### PR TITLE
Fixed help message strings to correct URLs

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the 
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Fixed help message strings to correct URLs
 - [#2545] Added setting resource_tree_node_name to allow users to specify the field used for the node text on the Resource Tree
 - [#2639] Prevent user from specifying a FC rule with Action of none
 - [#2641] Fixed issue where template was reset incorrectly when canceled on template change

--- a/core/lexicon/en/about.inc.php
+++ b/core/lexicon/en/about.inc.php
@@ -14,5 +14,5 @@ $_lang['credits_php'] = 'MODx is powered by  <a href="http://www.php.net" target
 $_lang['credits_sencha'] = 'MODx uses <a href="http://www.sencha.com/" target="_blank">Sencha (ExtJS)</a> in its default manager UI.';
 $_lang['credits_smarty'] = 'MODx uses <a href="http://www.smarty.net/" target="_blank">Smarty</a> in its default manager UI.';
 $_lang['credits_xpdo'] = 'MODx uses the database ORM <a href="http://www.xpdo.org/" target="_blank">xPDO</a>.';
-$_lang['help_msg'] = '<p>You can obtain free community support by <a href="http://modxcms.com/forums/" target="_blank">visiting the MODx Forums</a>. There is also a growing body of <a href="http://docs.modxcms.com/display/revolution" target="_blank">MODx Revolution documentation</a>.</p><p>For bugs, please go to <a href="http://bugs.modxcms.com/" target="_blank">MODx\'s JIRA Issue Tracker</a>.</p>';
+$_lang['help_msg'] = '<p>You can obtain free community support by <a href="http://modxcms.com/forums/" target="_blank">visiting the MODx Forums</a>. There is also a growing body of <a href="http://rtfm.modx.com/display/revolution20/Home" target="_blank">MODx Revolution documentation</a>.</p><p>For bugs, please go to <a href="http://bugs.modx.com/projects/revo" target="_blank">MODx\'s JIRA Issue Tracker</a>.</p>';
 $_lang['help_title'] = 'Help';


### PR DESCRIPTION
Just some minor updates to the URLs in the about lexicon
