### PR TITLE
Fix bug in modConnectorResponse with runProcessor

### DIFF
--- a/connectors/index.php
+++ b/connectors/index.php
@@ -28,12 +28,10 @@ if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(dirname(__FILE_
 if (!include_once(MODX_CORE_PATH . 'model/modx/modx.class.php')) die();
 
 $modx= new modX();
-
 /* set debugging/logging options */
 $modx->setDebug(E_ALL | E_STRICT);
 $modx->setLogLevel(modX::LOG_LEVEL_ERROR);
 $modx->setLogTarget('FILE');
-
 /* initialize the proper context */
 $ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';
 $modx->initialize($ctx);

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- [#3568] Fixed double error->failure reference in resource/create processor
 - [#3425] MODx.Browser now loads directory of TV's current value on load
 - [#3481], [#3571], [#3304], [#3569] Fix issue with filemanager_path in non-web contexts 
 - [#3009] Add ability to assign TVs to specific directories and base paths, limit file extensions shown

--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -77,7 +77,7 @@ class modConnectorResponse extends modResponse {
             }
 
             /* run processor */
-            $this->response = $this->modx->runProcessor($target,$scriptProperties);
+            $this->response = $this->modx->runProcessor($target,$scriptProperties,$options);
             if (!$this->response) {
                 $this->body = $this->modx->error->failure($this->modx->lexicon('processor_err_nf',array(
                     'target' => $target,

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1435,8 +1435,8 @@ class modX extends xPDO {
 
         /* calculate processor file path from options and action */
         $processorFile = isset($options['processors_path']) && !empty($options['processors_path']) ? $options['processors_path'] : $this->config['processors_path'];
-        if (isset($options['location']) && !empty($options['location'])) $processorFile .= $options['location'] . '/';
-        $processorFile .= str_replace('../', '', $action . '.php');
+        if (isset($options['location']) && !empty($options['location'])) $processorFile .= ltrim($options['location'],'/') . '/';
+        $processorFile .= ltrim(str_replace('../', '', $action . '.php'),'/');
 
         if (file_exists($processorFile)) {
             if (!isset($this->lexicon)) $this->getService('lexicon', 'modLexicon');

--- a/core/model/modx/processors/resource/create.php
+++ b/core/model/modx/processors/resource/create.php
@@ -67,7 +67,7 @@ $wctx = $scriptProperties['context_key'];
 if (!empty($wctx)) {
     $workingContext = $modx->getContext($wctx);
     if (!$workingContext) {
-        return $modx->error->failure($modx->error->failure($modx->lexicon('access_denied')));
+        return $modx->error->failure($modx->lexicon('access_denied'));
     }
 } else {
     $workingContext =& $modx->context;


### PR DESCRIPTION
Fix issue with runProcessor not loading processors_path in modConnectorResponse.
