### PR TITLE
[#2615] Fix issue with modx->user->getResourceGroups, set resource groups in "modx.user.{$id}.resourceGroups" session key

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,7 +2,8 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
-- [#3568] Fixed double error->failure reference in resource/create processor
+- [#2615] Fix issue with modx->user->getResourceGroups, set resource groups in "modx.user.{$id}.resourceGroups" session key
+- [#3568] Fix double error->failure reference in resource/create processor
 - [#3425] MODx.Browser now loads directory of TV's current value on load
 - [#3481], [#3571], [#3304], [#3569] Fix issue with filemanager_path in non-web contexts 
 - [#3009] Add ability to assign TVs to specific directories and base paths, limit file extensions shown

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -119,6 +119,9 @@ class modUser extends modPrincipal {
                             }
                         }
                         $_SESSION[$context . 'Docgroups']= array_values($legacyDocGroups);
+                        $_SESSION['modx.user.'.$this->get('id').'.resourceGroups'] = array(
+                            $context => array_values($legacyDocGroups),
+                         );
                         break;
                     case 'modAccessContext' :
                         $sql = "SELECT acl.target, acl.principal, mr.authority, acl.policy, p.data FROM {$accessTable} acl " .
@@ -196,6 +199,9 @@ class modUser extends modPrincipal {
                             }
                         }
                         $_SESSION[$context . 'Docgroups']= array_values($legacyDocGroups);
+                        $_SESSION['modx.user.'.$this->get('id').'.resourceGroups'] = array(
+                            $context => array_values($legacyDocGroups),
+                         );
                         break;
                     case 'modAccessContext' :
                         $sql = "SELECT acl.target, acl.principal, 0 AS authority, acl.policy, p.data FROM {$accessTable} acl " .
@@ -549,21 +555,17 @@ class modUser extends modPrincipal {
      * @access public
      * @return array An array of Resource Group names.
      */
-    public function getResourceGroups() {
+    public function getResourceGroups($ctx = '') {
+        if (empty($ctx)) $ctx = $this->xpdo->context->get('key');
+        
         $resourceGroups= array ();
-        if (isset($_SESSION["modx.user.{$this->id}.resourceGroups"])) {
-            $resourceGroups= $_SESSION["modx.user.{$this->id}.resourceGroups"];
+        if (isset($_SESSION["modx.user.{$this->id}.resourceGroups"][$ctx])) {
+            $resourceGroups= $_SESSION["modx.user.{$this->id}.resourceGroups"][$ctx];
         } else {
-            if ($memberships= $this->getMany('UserGroupMembers')) {
-                foreach ($memberships as $membership) {
-                    if ($documentGroupAccess= $membership->getMany('UserGroupResourceGroups')) {
-                        foreach ($documentGroupAccess as $dga) {
-                            $resourceGroups[]= $dga->get('documentgroup');
-                        }
-                    }
-                }
+            $this->loadAttributes('modAccessResourceGroup',$ctx,true);
+            if (isset($_SESSION["modx.user.{$this->id}.resourceGroups"][$ctx])) {
+                $resourceGroups= $_SESSION["modx.user.{$this->id}.resourceGroups"][$ctx];
             }
-            $_SESSION["modx.user.{$this->id}.resourceGroups"]= $resourceGroups;
         }
         return $resourceGroups;
     }


### PR DESCRIPTION
Now sets as:

<pre>'modx.user.1.resourceGroups' => 
    array
      'web' => 
        array
          0 => 5</pre>


This also fixes $modx->user->getResourceGroups(), which didn't work in 2.0.x.
