### PR TITLE
Bug 3693

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- [#3693] Fix reversed content-disposition logic on static resources
 - [#3427] Fix issue where User Settings were not respected with filemanager_path/url
 - [#3702] Ensure file/image TVs can have files drag/dropped onto them
 - [#3465] Add sanity check for non-object to log call in modAccessibleObject::_loadInstance

--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -147,7 +147,7 @@ class modStaticResource extends modResource {
                 }
                 $header= 'Cache-Control: public';
                 header($header);
-                $header= 'Content-Disposition: ' . ($this->get('content_dispo') ? 'inline' : 'attachment' . '; filename=' . $name);
+                $header= 'Content-Disposition: ' . ($this->get('content_dispo') ? 'attachment; filename=' . $name : 'inline');
                 header($header);
                 $header= 'Vary: User-Agent';
                 header($header);


### PR DESCRIPTION
The content-disposition logic on modStaticResource was reversed so that attachment was loading them inline and vice versa. This shall fix it.
