### PR TITLE
[#325] PBKDF2 Secure User Password Storage

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Refactor password reset not to send password hash as activation key
 - [#325] Allow configurable user password hashing with PBKDF2 default implementation
 - [#3111] Fix bug causing unnecessary writes to Resource cache files
 - Update xPDO to v2.1.1-pl2

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- [#325] Allow configurable user password hashing with PBKDF2 default implementation
 - [#3111] Fix bug causing unnecessary writes to Resource cache files
 - Update xPDO to v2.1.1-pl2
 - Add modResource.uri_override to allow a uri to be manually set and locked per Resource

--- a/core/model/modx/hashing/modhashing.class.php
+++ b/core/model/modx/hashing/modhashing.class.php
@@ -1,0 +1,172 @@
+<?php
+/*
+ * MODx Revolution
+ *
+ * Copyright 2006-2011 by the MODx Team.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+
+/**
+ * This file contains the modHashing service class definition and the modHash abstract implementation class.
+ * @package modx
+ * @subpackage hashing
+ */
+/**
+ * The modX hashing service class.
+ *
+ * @package modx
+ * @subpackage hashing
+ */
+class modHashing {
+    /**
+     * A reference to an xPDO instance communicating with this service instance.
+     *
+     * Though this is typically a modX instance, an xPDO instance must work for new installs.
+     * @var xPDO
+     */
+    public $modx= null;
+    /**
+     * An array of options for the hashing service.
+     * @var array
+     */
+    public $options= array();
+    /**
+     * An array of loaded modHash implementations.
+     * @var array
+     */
+    protected $_hashes= array();
+
+    /**
+     * Constructs a new instance of the modHashing service class.
+     *
+     * @param xPDO &$modx A reference to an modX (or xPDO) instance.
+     * @param array $options An array of options for the hashing service.
+     */
+    function __construct(xPDO &$modx, array $options= array()) {
+        $this->modx= & $modx;
+        $this->options = $options;
+    }
+
+    /**
+     * Get an option for the MODX hashing service.
+     *
+     * Searches for local options and then prefixes keys with encrypt_ to look for
+     * MODX System Settings.
+     *
+     * @param string $key The option key to get a value for.
+     * @param array|null $options An optional array of options to look in first.
+     * @param mixed $default An optional default value to return if no value is set.
+     * @return mixed The option value or the specified default if not found.
+     */
+    public function getOption($key, $options = null, $default = null) {
+        if (is_array($options) && array_key_exists($key, $options)) {
+            $option = $options[$key];
+        } elseif (array_key_exists($key, $this->options)) {
+            $option = $this->options[$key];
+        } else {
+            $option = $this->modx->getOption('hashing_' . $key, $this->options, $default);
+        }
+        return $option;
+    }
+
+    /**
+     * Get a hash implementation instance.
+     *
+     * The implementation is made available as a member variable of the modHashing service.
+     *
+     * @param string $key A key string identifying the instance; must be a valid PHP variable name.
+     * @param string $class A valid fully-qualified modHash derivative class name
+     * @param array $options
+     * @return array|null
+     */
+    public function getHash($key, $class, array $options = array()) {
+        $className = $this->modx->loadClass($class, '', false, true);
+        if ($className) {
+            if (empty($key)) $key = strtolower(str_replace('mod', '', $className));
+            if (!array_key_exists($key, $this->_hashes)) {
+                $hash = new $className($this);
+                if ($hash instanceof $className) {
+                    $this->_hashes[$key] = $hash;
+                    $this->$key =& $this->_hashes[$key];
+                }
+            }
+            if (array_key_exists($key, $this->_hashes)) {
+                return $this->_hashes[$key];
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * Defines the interface for a modHash implementation.
+ *
+ * @abstract Implement a derivative of this class to define an actual hash algorithm implementation.
+ * @package modx
+ * @subpackage hashing
+ */
+abstract class modHash {
+    /**
+     * A reference to the modHashing service hosting this modHash instance.
+     * @var modHashing
+     */
+    public $host= null;
+    /**
+     * An array of options for the modHash implementation.
+     * @var array
+     */
+    public $options= array();
+
+    /**
+     * Constructs a new instance of the modHash class.
+     */
+    function __construct(modHashing &$host, array $options= array()) {
+        $this->host =& $host;
+        $this->options = $options;
+
+    }
+
+    /**
+     * Get an option for this modHash implementation
+     *
+     * Searches for local options and then prefixes keys with hashing_ to look for
+     * MODX System Settings.
+     *
+     * @param string $key The option key to get a value for.
+     * @param array|null $options An optional array of options to look in first.
+     * @param mixed $default An optional default value to return if no value is set.
+     * @return mixed The option value or the specified default if not found.
+     */
+    public function getOption($key, $options = null, $default = null) {
+        if (is_array($options) && array_key_exists($key, $options)) {
+            $option = $options[$key];
+        } else {
+            $option = $this->host->getOption($key, $this->options, $default);
+        }
+        return $option;
+    }
+
+    /**
+     * Generate a hash of the given string using the provided options.
+     *
+     * @abstract
+     * @param string $string A string to generate a secure hash from.
+     * @param array $options An array of options to be passed to the hash implementation.
+     * @return mixed The hash result or false on failure.
+     */
+    public abstract function hash($string, array $options = array());
+}

--- a/core/model/modx/hashing/modmd5.class.php
+++ b/core/model/modx/hashing/modmd5.class.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file contains an MD5 modHash implementation.
+ * @package modx
+ * @subpackage hashing
+ */
+
+/**
+ * An MD5 implementation of modHash.
+ *
+ * {@inheritdoc}
+ */
+class modMD5 extends modHash {
+    /**
+     * Generate an MD5 hash of the provided string.
+     *
+     * Options are ignored in this implementation.
+     *
+     * {@inheritdoc}
+     */
+    public function hash($string, array $options = array()) {
+        return md5($string);
+    }
+}

--- a/core/model/modx/hashing/modpbkdf2.class.php
+++ b/core/model/modx/hashing/modpbkdf2.class.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file contains a modHash implementation of RSA PDKDF2.
+ * @package modx
+ * @subpackage hashing
+ */
+
+/**
+ * A PBKDF2 implementation of modHash.
+ *
+ * {@inheritdoc}
+ */
+class modPBKDF2 extends modHash {
+    /**
+     * Generate a hash of a string using the RSA PBKDFA2 specification.
+     *
+     * The following options are available:
+     *  - salt (required): a valid, non-empty string to salt the hashes
+     *  - iterations: the number of iterations per block, default is 1000 (< 1000 not recommended)
+     *  - derived_key_length: the size of the derived key to generate, default is 32
+     *  - algorithm: the hash algorithm to use, default is sha256
+     *  - raw_output: if true, returns binary output, otherwise derived key is base64_encode()'d; default is false
+     *
+     * {@inheritdoc}
+     */
+    public function hash($string, array $options = array()) {
+        $derivedKey = false;
+        $salt = $this->getOption('salt', $options, false);
+        if (is_string($salt) && strlen($salt) > 0) {
+            $iterations = (integer) $this->getOption('iterations', $options, 1000);
+            $derivedKeyLength = (integer) $this->getOption('derived_key_length', $options, 32);
+            $algorithm = $this->getOption('algorithm', $options, 'sha256');
+
+            $hashLength = strlen(hash($algorithm, null, true));
+            $keyBlocks = ceil($derivedKeyLength / $hashLength);
+            $derivedKey = '';
+            for ($block = 1; $block <= $keyBlocks; $block++) {
+                $hashBlock = $hb = hash_hmac($algorithm, $salt . pack('N', $block), $string, true);
+                for ($blockIteration = 1; $blockIteration < $iterations; $blockIteration++) {
+                    $hashBlock ^= ($hb = hash_hmac($algorithm, $hb, $string, true));
+                }
+                $derivedKey .= $hashBlock;
+            }
+            $derivedKey = substr($derivedKey, 0, $derivedKeyLength);
+            if (!$this->getOption('raw_output', $options, false)) {
+                $derivedKey = base64_encode($derivedKey);
+            }
+        } else {
+            $this->host->modx->log(modX::LOG_LEVEL_ERROR, "PBKDF2 requires a valid salt string.", '', __METHOD__, __FILE__, __LINE__);
+        }
+        return $derivedKey;
+    }
+}

--- a/core/model/modx/mysql/moduser.map.inc.php
+++ b/core/model/modx/mysql/moduser.map.inc.php
@@ -16,6 +16,8 @@ $xpdo_meta_map['modUser']= array (
     'active' => 1,
     'remote_key' => NULL,
     'remote_data' => NULL,
+    'hash_class' => 'hashing.modPBKDF2',
+    'salt' => '',
   ),
   'fieldMeta' => 
   array (
@@ -75,6 +77,22 @@ $xpdo_meta_map['modUser']= array (
       'dbtype' => 'text',
       'phptype' => 'json',
       'null' => true,
+    ),
+    'hash_class' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'hashing.modPBKDF2',
+    ),
+    'salt' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
     ),
   ),
   'indexes' => 

--- a/core/model/modx/processors/security/login.php
+++ b/core/model/modx/processors/security/login.php
@@ -136,7 +136,7 @@ if ($mgrEvents) {
 /* check if plugin authenticated the user */
 if (!$rt || (is_array($rt) && !in_array(true, $rt))) {
     /* check user password - local authentication */
-    if ($user->get('password') != md5($givenPassword)) {
+    if (!$user->passwordMatches($givenPassword)) {
         $flc = ((int)$up->get('failedlogincount'))+1;
         $up->set('failedlogincount',$flc);
         $up->save();

--- a/core/model/modx/processors/security/profile/changepassword.php
+++ b/core/model/modx/processors/security/profile/changepassword.php
@@ -15,7 +15,7 @@ if (!$modx->hasPermission('change_password')) return $modx->error->failure($modx
 $modx->lexicon->load('user');
 
 /* if changing the password */
-if (md5($scriptProperties['password_old']) != $modx->user->get('password')) {
+if (!$modx->user->passwordMatches($scriptProperties['password_old'])) {
     return $modx->error->failure($modx->lexicon('user_err_password_invalid_old'));
 }
 if (empty($scriptProperties['password_new']) || strlen($scriptProperties['password_new']) < $modx->getOption('password_min_length',null,8)) {

--- a/core/model/modx/processors/security/user/_validation.php
+++ b/core/model/modx/processors/security/user/_validation.php
@@ -24,7 +24,7 @@ if (isset($scriptProperties['newpassword']) && $scriptProperties['newpassword'] 
     if ($scriptProperties['passwordgenmethod'] == 'g') {
     $len = $modx->getOption('password_generated_length',null,8);
             $autoPassword = generate_password($len);
-            $user->set('password', $user->encode($autoPassword));
+            $user->set('password', $autoPassword);
             $newPassword= $autoPassword;
     } else {
         if (empty($scriptProperties['specifiedpassword'])) {
@@ -34,7 +34,7 @@ if (isset($scriptProperties['newpassword']) && $scriptProperties['newpassword'] 
         } elseif (strlen($scriptProperties['specifiedpassword']) < $modx->getOption('password_min_length',null,6)) {
                 $modx->error->addField('password',$modx->lexicon('user_err_password_too_short'));
         } else {
-                $user->set('password',$user->encode($scriptProperties['specifiedpassword']));
+                $user->set('password', $scriptProperties['specifiedpassword']);
                 $newPassword= $scriptProperties['specifiedpassword'];
         }
     }

--- a/core/model/modx/rest/modrestserver.class.php
+++ b/core/model/modx/rest/modrestserver.class.php
@@ -151,7 +151,7 @@ class modRestServer {
         ));
         if (empty($user)) return $this->deny($this->modx->lexicon('user_err_nf'));
 
-        if ($user->get('password') != md5($_REQUEST[$this->config[modRestServer::OPT_AUTH_PASS_VAR]])) {
+        if (!$user->passwordMatches($_REQUEST[$this->config[modRestServer::OPT_AUTH_PASS_VAR]])) {
             return $this->deny($this->modx->lexicon('user_err_password'));
         }
         return true;

--- a/core/model/modx/sqlsrv/moduser.map.inc.php
+++ b/core/model/modx/sqlsrv/moduser.map.inc.php
@@ -16,6 +16,8 @@ $xpdo_meta_map['modUser']= array (
     'active' => 1,
     'remote_key' => NULL,
     'remote_data' => NULL,
+    'hash_class' => 'hashing.modPBKDF2',
+    'salt' => '',
   ),
   'fieldMeta' => 
   array (
@@ -74,6 +76,22 @@ $xpdo_meta_map['modUser']= array (
       'precision' => 'max',
       'phptype' => 'json',
       'null' => true,
+    ),
+    'hash_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'hashing.modPBKDF2',
+    ),
+    'salt' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
     ),
   ),
   'indexes' => 

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1100,7 +1100,9 @@
         <field key="active" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="false" default="1" />
         <field key="remote_key" dbtype="varchar" precision="255" phptype="string" null="true" index="index" />
         <field key="remote_data" dbtype="text" phptype="json" null="true" />
-        
+        <field key="hash_class" dbtype="varchar" precision="100" phptype="string" null="false" default="hashing.modPBKDF2" />
+        <field key="salt" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+
         <index alias="username" name="username" primary="false" unique="true" type="BTREE">
             <column key="username" length="" collation="A" null="false" />
         </index>

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -1100,7 +1100,9 @@
         <field key="active" dbtype="bit" phptype="boolean" null="false" default="1" />
         <field key="remote_key" dbtype="nvarchar" precision="255" phptype="string" null="true" index="index" />
         <field key="remote_data" dbtype="nvarchar" precision="max" phptype="json" null="true" />
-        
+        <field key="hash_class" dbtype="nvarchar" precision="100" phptype="string" null="false" default="hashing.modPBKDF2" />
+        <field key="salt" dbtype="nvarchar" precision="100" phptype="string" null="false" default="" />
+
         <index alias="username" name="username" primary="false" unique="true" type="BTREE">
             <column key="username" length="" collation="A" null="false" />
         </index>

--- a/manager/controllers/default/security/login.php
+++ b/manager/controllers/default/security/login.php
@@ -40,12 +40,9 @@ if (!empty($_POST)) {
         ));
         /* first if there's an activation hash, process that */
         if ($user) {
-            $cachepwd = $user->get('cachepwd');
-            if (!empty($_REQUEST['modahsh']) && !empty($cachepwd)) {
-                if ($_REQUEST['modahsh'] == $cachepwd) {
-                    /* correct hash and pwd specified, so reset actual pwd to new one */
-                    $user->activatePassword();
-                } else {
+            if (array_key_exists('modahsh', $_REQUEST) && !empty($_REQUEST['modahsh'])) {
+                $activated = $user->activatePassword($_REQUEST['modahsh']);
+                if ($activated === false) {
                     $modx->smarty->assign('error_message',$modx->lexicon('login_activation_key_err'));
                     $validated = false;
                 }
@@ -84,12 +81,15 @@ if (!empty($_POST)) {
         ));
         $user = $modx->getObject('modUser',$c);
         if ($user) {
+            $activationHash = md5(uniqid(md5($user->get('email') . '/' . $user->get('id')), true));
+
+            $modx->getService('registry', 'registry.modRegistry');
+            $modx->registry->getRegister('user', 'registry.modDbRegister');
+            $modx->registry->user->connect();
+            $modx->registry->user->subscribe('/pwd/reset/');
+            $modx->registry->user->send('/pwd/reset/', array(md5($user->get('username')) => $activationHash), array('ttl' => 86400));
 
             $newPassword = $user->generatePassword();
-
-            $modx->getService('hashing', 'hashing.modHashing');
-            $hashOptions = array('salt' => $user->get('salt'));
-            $newPasswordHash = $modx->hashing->getHash('', $user->get('hash_class'))->hash($newPassword, $hashOptions);
 
             $user->set('cachepwd', $newPassword);
             $user->save();
@@ -100,7 +100,7 @@ if (!empty($_POST)) {
             $placeholders['url_scheme'] = $modx->getOption('url_scheme');
             $placeholders['http_host'] = $modx->getOption('http_host');
             $placeholders['manager_url'] = $modx->getOption('manager_url');
-            $placeholders['hash'] = $newPasswordHash;
+            $placeholders['hash'] = $activationHash;
             $placeholders['password'] = $newPassword;
             foreach ($placeholders as $k => $v) {
                 $message = str_replace('[[+'.$k.']]',$v,$message);

--- a/manager/controllers/default/security/login.php
+++ b/manager/controllers/default/security/login.php
@@ -42,11 +42,9 @@ if (!empty($_POST)) {
         if ($user) {
             $cachepwd = $user->get('cachepwd');
             if (!empty($_REQUEST['modahsh']) && !empty($cachepwd)) {
-                if ($_REQUEST['modahsh'] == md5($cachepwd)) {
+                if ($_REQUEST['modahsh'] == $cachepwd) {
                     /* correct hash and pwd specified, so reset actual pwd to new one */
-                    $user->set('password',md5($cachepwd));
-                    $user->set('cachepwd','');
-                    $user->save();
+                    $user->activatePassword();
                 } else {
                     $modx->smarty->assign('error_message',$modx->lexicon('login_activation_key_err'));
                     $validated = false;
@@ -88,9 +86,12 @@ if (!empty($_POST)) {
         if ($user) {
 
             $newPassword = $user->generatePassword();
-            $newPasswordHash = md5($newPassword);
 
-            $user->set('cachepwd',$newPassword);
+            $modx->getService('hashing', 'hashing.modHashing');
+            $hashOptions = array('salt' => $user->get('salt'));
+            $newPasswordHash = $modx->hashing->getHash('', $user->get('hash_class'))->hash($newPassword, $hashOptions);
+
+            $user->set('cachepwd', $newPassword);
             $user->save();
 
             /* send activation email */

--- a/setup/includes/new.install.php
+++ b/setup/includes/new.install.php
@@ -27,7 +27,7 @@ $settings_distro->save();
 /* add default admin user */
 $user = $this->xpdo->newObject('modUser');
 $user->set('username', $this->settings->get('cmsadmin'));
-$user->set('password', md5($this->settings->get('cmspassword')));
+$user->set('password', $this->settings->get('cmspassword'));
 $saved = $user->save();
 
 if ($saved) {

--- a/setup/includes/upgrades/mysql/2.1.0-rc-1.php
+++ b/setup/includes/upgrades/mysql/2.1.0-rc-1.php
@@ -99,3 +99,18 @@ $modx->exec($sql);
 if ($uriAdded && $modx->getOption('friendly_urls')) {
     $modx->call('modResource', 'refreshURIs', array(&$modx));
 }
+
+/* add hash_class and salt to modUser */
+$class = 'modUser';
+$table = $modx->getTableName($class);
+$description = $this->install->lexicon('add_column',array('column' => 'hash_class','table' => $table));
+$sql = "ALTER TABLE {$table} ADD COLUMN {$modx->escape('hash_class')} VARCHAR(100) NOT NULL DEFAULT 'hashing.modPBKDF2' AFTER {$modx->escape('remote_data')}";
+$hashClassAdded = $this->processResults($class,$description,$sql);
+
+$description = $this->install->lexicon('add_column',array('column' => 'salt','table' => $table));
+$sql = "ALTER TABLE {$table} ADD COLUMN {$modx->escape('salt')} VARCHAR(100) NOT NULL DEFAULT '' AFTER {$modx->escape('hash_class')}";
+$this->processResults($class,$description,$sql);
+
+if ($hashClassAdded) {
+    $modx->exec("UPDATE {$table} SET {$modx->escape('hash_class')} = 'hashing.modMD5'");
+}

--- a/setup/includes/upgrades/sqlsrv/2.1.0-rc-1.php
+++ b/setup/includes/upgrades/sqlsrv/2.1.0-rc-1.php
@@ -35,3 +35,18 @@ $modx->exec($sql);
 if ($uriAdded && $modx->getOption('friendly_urls')) {
     $modx->call('modResource', 'refreshURIs', array(&$modx));
 }
+
+/* add hash_class and salt to modUser */
+$class = 'modUser';
+$table = $modx->getTableName($class);
+$description = $this->install->lexicon('add_column',array('column' => 'hash_class','table' => $table));
+$sql = "ALTER TABLE {$table} ADD COLUMN {$modx->escape('hash_class')} NVARCHAR(100) NOT NULL DEFAULT 'hashing.modPBKDF2'"; // AFTER {$modx->escape('remote_data')}
+$hashClassAdded = $this->processResults($class,$description,$sql);
+
+$description = $this->install->lexicon('add_column',array('column' => 'salt','table' => $table));
+$sql = "ALTER TABLE {$table} ADD COLUMN {$modx->escape('salt')} NVARCHAR(100) NOT NULL DEFAULT ''"; // AFTER {$modx->escape('hash_class')}
+$this->processResults($class,$description,$sql);
+
+if ($hashClassAdded) {
+    $modx->exec("UPDATE {$table} SET {$modx->escape('hash_class')} = 'hashing.modMD5'");
+}


### PR DESCRIPTION
This implements configurable password hashing and storage, including PBKDF2 as a default, and MD5 to support legacy user accounts. Plugins will be provided as Extras to automatically convert existing users to PBKDF2 or another hashing implementation of their choice.

Also refactored the password reset process to never store the unhashed password, or pass the hashed password around, as both could potentially be a serious security problem for those who reuse their passwords.
