### PR TITLE
[#4006] Show children count rather than IDs on categories in element tree to lessen id ambiguity

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- [#4006] Show children count rather than IDs on categories in element tree to lessen id ambiguity
 - Add UI for managing Resource uri and uri_override fields
 - Remove all deprecated methods and variables scheduled for removal in next minor release
 - Change modxcms.com references to modx.com

--- a/core/model/modx/processors/element/getnodes.incategory.php
+++ b/core/model/modx/processors/element/getnodes.incategory.php
@@ -39,7 +39,7 @@ foreach ($categories as $category) {
     if ($category->get('elementCount') <= 0) continue;
 
     $nodes[] = array(
-        'text' => strip_tags($category->get('category')) . ' (' . $category->get('id') . ')',
+        'text' => strip_tags($category->get('category')) . ' (' . $category->get('elementCount') . ')',
         'id' => 'n_'.$g[0].'_category_'.($category->get('id') != null ? $category->get('id') : 0),
         'pk' => $category->get('id'),
         'category' => $category->get('id'),

--- a/core/model/modx/processors/element/getnodes.type.php
+++ b/core/model/modx/processors/element/getnodes.type.php
@@ -37,12 +37,15 @@ $class .= $modx->hasPermission('delete_category') ? ' pdelcat' : '';
 /* loop through categories with elements in this type */
 foreach ($categories as $category) {
     if (!$category->checkPolicy('list')) continue;
-    if ($category->get('elementCount') == 0 && $category->get('childrenCount') <= 0 && $category->get('id') != 0) {
+    $elCount = (int)$category->get('elementCount');
+    $catCount = (int)$category->get('childrenCount');
+    if ($elCount < 1 && $catCount < 1 && $category->get('id') != 0) {
         continue;
     }
+    $cc = $elCount > 0 ? ' ('.$elCount.')' : '';
 
     $nodes[] = array(
-        'text' => strip_tags($category->get('category')) . ' (' . $category->get('id') . ')',
+        'text' => strip_tags($category->get('category')).$cc,
         'id' => 'n_'.$g[1].'_category_'.($category->get('id') != null ? $category->get('id') : 0),
         'pk' => $category->get('id'),
         'category' => $category->get('id'),


### PR DESCRIPTION
nt
