### PR TITLE
Add context param to modx.getParentIds

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Add context param to modx.getParentIds
 - [#3754] Ensure Resources can not have their parent set as one of their descendants
 - Add context param to modX.getChildIds
 - [#3612] Improve CDATA filter to not add spaces at beginning or end


### PR DESCRIPTION
- Also fixed a small issue in getChildIds where options array was being passed incorrectly in recursive calls
