### PR TITLE
[#4054] Improve select binding to be able to use Resource fields via placeholders

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- [#4054] Improve select binding to be able to use Resource fields via placeholders
 - [#3511], [#2964], [#3601] Fix issues regarding form customization and Templates by removing ajax loading of TVs in Resource panels
 - Consolidate JS for derivative Resource panels to allow to inherit from main Resource panel
 - Add context param to modx.getParentIds

--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -651,6 +651,9 @@ class modTemplateVar extends modElement {
             case 'SELECT': /* selects a record from the cms database */
                 if ($preProcess) {
                     $dbtags = array();
+                    if ($modx->resource && $modx->resource instanceof modResource) {
+                        $dbtags = $modx->resource->toArray();
+                    }
                     $dbtags['DBASE'] = $this->xpdo->getOption('dbname');
                     $dbtags['PREFIX'] = $this->xpdo->getOption('table_prefix');
                     foreach($dbtags as $key => $pValue) {


### PR DESCRIPTION
Was fairly simple; data was already loaded, just needed to set dbtags array to use Resource fields in its placeholders.
