### PR TITLE
Prevent Element ACL queries from always firing

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Prevent Category ACL queries on Elements if no entries for current context
 - [#3350] Improvements to bugfix for PHP bug 53632
 - [#4054] Improve select binding to be able to use Resource fields via placeholders
 - [#142] Add modResource.setTVValue API method

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -70,6 +70,11 @@ class modCacheManager extends xPDOCacheManager {
                 }
             }
 
+            /* check for category ACLs in this context and set contextConfig option */
+            $catACLCount = $this->modx->getCount('modAccessCategory', array('context_key' => $key));
+            $results['config']['access_category_enabled'] = $catACLCount > 0 ? '1' : '0';
+            $contextConfig['access_category_enabled'] = $catACLCount > 0 ? '1' : '0';
+
             /* generate the aliasMap and resourceMap */
             $tblResource= $this->modx->getTableName('modResource');
             $tblContextResource= $this->modx->getTableName('modContextResource');

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -342,36 +342,47 @@ class modElement extends modAccessibleSimpleObject {
      */
     public function findPolicy($context = '') {
         $policy = array();
+        $enabled = true;
         $context = !empty($context) ? $context : $this->xpdo->context->get('key');
-        if (empty($this->_policies) || !isset($this->_policies[$context])) {
-            $accessTable = $this->xpdo->getTableName('modAccessCategory');
-            $policyTable = $this->xpdo->getTableName('modAccessPolicy');
-            $categoryClosureTable = $this->xpdo->getTableName('modCategoryClosure');
-            $sql = "SELECT Acl.target, Acl.principal, Acl.authority, Acl.policy, Policy.data FROM {$accessTable} Acl " .
-                    "LEFT JOIN {$policyTable} Policy ON Policy.id = Acl.policy " .
-                    "JOIN {$categoryClosureTable} CategoryClosure ON CategoryClosure.descendant = :category " .
-                    "AND Acl.principal_class = 'modUserGroup' " .
-                    "AND CategoryClosure.ancestor = Acl.target " .
-                    "AND (Acl.context_key = :context OR Acl.context_key IS NULL OR Acl.context_key = '') " .
-                    "GROUP BY target, principal, authority, policy " .
-                    "ORDER BY CategoryClosure.depth DESC, authority ASC";
-            $bindings = array(
-                ':category' => $this->get('category'),
-                ':context' => $context,
-            );
-            $query = new xPDOCriteria($this->xpdo, $sql, $bindings);
-            if ($query->stmt && $query->stmt->execute()) {
-                while ($row = $query->stmt->fetch(PDO::FETCH_ASSOC)) {
-                    $policy['modAccessCategory'][$row['target']][] = array(
-                        'principal' => $row['principal'],
-                        'authority' => $row['authority'],
-                        'policy' => $row['data'] ? $this->xpdo->fromJSON($row['data'], true) : array(),
-                    );
+        if ($context === $this->xpdo->context->get('key')) {
+            $enabled = (boolean) $this->xpdo->getOption('access_category_enabled', null, false);
+        } elseif ($this->xpdo->getContext($context)) {
+            $enabled = (boolean) $this->xpdo->contexts[$context]->getOption('access_category_enabled', false);
+        }
+        if ($enabled) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Checking category ACLs for element ' . get_class($this) . ':' . $this->get('name'));
+            if (empty($this->_policies) || !isset($this->_policies[$context])) {
+                $accessTable = $this->xpdo->getTableName('modAccessCategory');
+                $policyTable = $this->xpdo->getTableName('modAccessPolicy');
+                $categoryClosureTable = $this->xpdo->getTableName('modCategoryClosure');
+                $sql = "SELECT Acl.target, Acl.principal, Acl.authority, Acl.policy, Policy.data FROM {$accessTable} Acl " .
+                        "LEFT JOIN {$policyTable} Policy ON Policy.id = Acl.policy " .
+                        "JOIN {$categoryClosureTable} CategoryClosure ON CategoryClosure.descendant = :category " .
+                        "AND Acl.principal_class = 'modUserGroup' " .
+                        "AND CategoryClosure.ancestor = Acl.target " .
+                        "AND (Acl.context_key = :context OR Acl.context_key IS NULL OR Acl.context_key = '') " .
+                        "GROUP BY target, principal, authority, policy " .
+                        "ORDER BY CategoryClosure.depth DESC, authority ASC";
+                $bindings = array(
+                    ':category' => $this->get('category'),
+                    ':context' => $context,
+                );
+                $query = new xPDOCriteria($this->xpdo, $sql, $bindings);
+                if ($query->stmt && $query->stmt->execute()) {
+                    while ($row = $query->stmt->fetch(PDO::FETCH_ASSOC)) {
+                        $policy['modAccessCategory'][$row['target']][] = array(
+                            'principal' => $row['principal'],
+                            'authority' => $row['authority'],
+                            'policy' => $row['data'] ? $this->xpdo->fromJSON($row['data'], true) : array(),
+                        );
+                    }
                 }
+                $this->_policies[$context] = $policy;
+            } else {
+                $policy = $this->_policies[$context];
             }
-            $this->_policies[$context] = $policy;
         } else {
-            $policy = $this->_policies[$context];
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Skipping category ACLs for element ' . get_class($this) . ':' . $this->get('name'));
         }
         return $policy;
     }


### PR DESCRIPTION
This prevents category ACL queries from firing if no ACL entries exist for a specific Context.
