### PR TITLE
[#54] Fix issues with phpThumb and DOCUMENT_ROOT by adding a custom phpthumb_document_root System Setting

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -927,6 +927,15 @@ $settings['phpthumb_cache_source_enabled']->fromArray(array (
   'area' => 'phpthumb',
   'editedon' => null,
 ), '', true, true);
+$settings['phpthumb_document_root']= $xpdo->newObject('modSystemSetting');
+$settings['phpthumb_document_root']->fromArray(array (
+  'key' => 'phpthumb_document_root',
+  'value' => '',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'phpthumb',
+  'editedon' => null,
+), '', true, true);
 $settings['phpthumb_error_bgcolor']= $xpdo->newObject('modSystemSetting');
 $settings['phpthumb_error_bgcolor']->fromArray(array (
   'key' => 'phpthumb_error_bgcolor',

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODx. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- [#54] Fix issues with phpThumb and DOCUMENT_ROOT by adding a custom phpthumb_document_root System Setting
 - [#4105] Add Spanish translation
 - Refactor duplicate alias checks into duplicate URI checks
 - Cleanup deprecated code in Resource templates

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -395,6 +395,9 @@ $_lang['setting_phpthumb_cache_maxfiles_desc'] = 'Delete least-recently-accessed
 $_lang['setting_phpthumb_cache_source_enabled'] = 'phpThumb Cache Source Files';
 $_lang['setting_phpthumb_cache_source_enabled_desc'] = 'Whether or not to cache source files as they are loaded. Recommended to off.';
 
+$_lang['setting_phpthumb_document_root'] = 'PHPThumb Document Root';
+$_lang['setting_phpthumb_document_root_desc'] = 'Set this if you are experiencing issues with the server variable DOCUMENT_ROOT, or getting errors with OutputThumbnail or !is_resource. Set it to the absolute document root path you would like to use. If this is empty, MODX will use the DOCUMENT_ROOT server variable.';
+
 $_lang['setting_phpthumb_error_bgcolor'] = 'phpThumb Error Background Color';
 $_lang['setting_phpthumb_error_bgcolor_desc'] = 'A hex value, without the #, indicating a background color for phpThumb error output.';
 

--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -54,6 +54,11 @@ class modPhpThumb extends phpThumb {
         $this->setParameter('far',$this->modx->getOption('far',$_REQUEST,$this->modx->getOption('phpthumb_far',$this->config,'C')));
         $this->setParameter('cache_directory_depth',4);
 
+        $documentRoot = $this->modx->getOption('phpthumb_document_root',$this->config,'');
+        if (!empty($documentRoot)) {
+            $this->setParameter('config_document_root',$documentRoot);
+        }
+
         /* iterate through properties */
         foreach ($this->config as $property => $value) {
             $this->setParameter($property,$value);


### PR DESCRIPTION
- This will fix issues with thumbnails not showing for users having their Apache public_html directories mapped with local symlinks; they can now override phpThumb's config_document_root setting with their own, proper, setting.
