### PR TITLE
Ff autofocus delay

### DIFF
--- a/manager/assets/modext/widgets/core/modx.panel.js
+++ b/manager/assets/modext/widgets/core/modx.panel.js
@@ -115,7 +115,7 @@ Ext.extend(MODx.FormPanel,Ext.FormPanel,{
     ,focusFirstField: function() {
         if(this.getForm().items.getCount() > 0) {
             var fld = this.findFirstTextField();
-            if (fld) { fld.focus(false,30); }
+            if (fld) { fld.focus(false,200); }
         }
     }
     ,findFirstTextField: function(i) {

--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -83,7 +83,7 @@ Ext.extend(MODx.Window,Ext.Window,{
 
     ,focusFirstField: function() {
         var fld = this.findFirstTextField();
-        if (fld) { fld.focus(false,20); }
+        if (fld) { fld.focus(false,200); }
     }
     ,findFirstTextField: function(i) {
         i = i || 0;


### PR DESCRIPTION
New autofocus was not working for me in Firefox .. I would sometimes see the focus go to the field and very quickly go away. I could not find another solution than increasing the delay time. It may be that FF4 on my particular OS and machine is running slowly, but it therefore gives a good baseline. 200ms may seem a large increase, but even 150ms did not work for me. I don't feel that a delay of 1/5 of a second on a focus will be noticeable (or distracting) to users.
