### PR TITLE
Added type-check for variable $entries, should be an array, but can be a 

### DIFF
--- a/core/model/modx/processors/workspace/lexicon/getlist.php
+++ b/core/model/modx/processors/workspace/lexicon/getlist.php
@@ -46,6 +46,7 @@ foreach ($results as $r) {
 
 /* first get file-based lexicon */
 $entries = $modx->lexicon->getFileTopic($language,$namespace,$topic);
+$entries = is_array($entries)?$entries:array();
 
 /* if searching */
 if (!empty($scriptProperties['search'])) {


### PR DESCRIPTION
Added type-check for variable $entries, should be an array, but can be a boolean "false" which breaks the array-functions. Bug-Ticket: http://bugs.modx.com/issues/5421
