### PR TITLE
Update core/model/phpthumb/phpthumb.class.php

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -1363,7 +1363,7 @@ class phpthumb {
 								$commandline .= ' -'.$IMresizeParameter.' x'.$thumbnailH;
 							}
 
-							switch (strtoupper($this->far)) {
+							switch (strtoupper($this->zc)) {
 								case 'T':
 									$commandline .= ' -gravity north';
 									break;


### PR DESCRIPTION
This reverts the changes introduced in cc1fee261694cd9e73e281492246026b112ad7f3 which causes phpThumb's zoom-crop to fail. Reverting the change fixes splittingred/phpThumbOf#19
