### PR TITLE
New plugin event 'OnMODXInit'

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -754,6 +754,12 @@ $events['OnHandleRequest']->fromArray(array (
   'service' => 5,
   'groupname' => 'System',
 ), '', true, true);
+$events['OnMODXInit']= $xpdo->newObject('modEvent');
+$events['OnMODXInit']->fromArray(array (
+  'name' => 'OnMODXInit',
+  'service' => 5,
+  'groupname' => 'System',
+), '', true, true);
 
 
 /* Settings */

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -479,6 +479,8 @@ class modX extends xPDO {
 
             $this->getService('registry', 'registry.modRegistry');
 
+            $this->invokeEvent('OnMODXInit');
+
             if (is_array ($this->config)) {
                 $this->setPlaceholders($this->config, '+');
             }


### PR DESCRIPTION
This event fired in $modx->initialize().
All request hit this event.

For example, the MODX Manager with Multi language runs on Opera browser in following codes. 

check event:OnMODXInit

``` php
if( $modx->event->name == 'OnMODXInit'
  && stripos($_SERVER['HTTP_USER_AGENT'],'Opera') !== false
  && stripos($_SERVER['CONTENT_TYPE'],'x-www-form-urlencoded') !== false
  && strcasecmp($_SERVER['HTTP_CONTENT_TRANSFER_ENCODING'],'binary') == 0 ){
    foreach($_POST as $key => $val){
      $_POST[$key] = urldecode($val);
      $_REQUEST[$key] = $_POST[$key];
    }
}
```
