### PR TITLE
Fix the gap in topnav's dropdown.

### DIFF
--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -734,7 +734,7 @@ table.classy tr.odd td {
     position: absolute;
     z-index: 23 !important;
     left: 0;
-    top: 41px;
+    top: 40px;
     background: #444;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
The gap was causing dropdown to close it self if you don't move mouse fast enough.
