### PR TITLE
add modElement->setSource for explicit setting the source before processing

### DIFF
--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -53,6 +53,11 @@ class modElement extends modAccessibleSimpleObject {
      */
     public $_content= '';
     /**
+     * The source of the element.
+     * @var string
+     */
+    public $_source= null;    
+    /**
      * The output of the element.
      * @var string
      */
@@ -767,19 +772,35 @@ class modElement extends modAccessibleSimpleObject {
     public function getSource($contextKey = '',$fallbackToDefault = true) {
         if (empty($contextKey)) $contextKey = $this->xpdo->context->get('key');
 
-        $c = $this->xpdo->newQuery('sources.modMediaSource');
-        $c->innerJoin('sources.modMediaSourceElement','SourceElement');
-        $c->where(array(
-            'SourceElement.object' => $this->get('id'),
-            'SourceElement.object_class' => $this->_class,
-            'SourceElement.context_key' => $contextKey,
-        ));
-        $source = $this->xpdo->getObject('sources.modMediaSource',$c);
-        if (!$source && $fallbackToDefault) {
-            $source = modMediaSource::getDefaultSource($this->xpdo);
+        $source = $this->_source; 
+
+        if (empty($source)) {
+
+            $c = $this->xpdo->newQuery('sources.modMediaSource');
+            $c->innerJoin('sources.modMediaSourceElement','SourceElement');
+            $c->where(array(
+                'SourceElement.object' => $this->get('id'),
+                'SourceElement.object_class' => $this->_class,
+                'SourceElement.context_key' => $contextKey,
+            ));
+            $source = $this->xpdo->getObject('sources.modMediaSource',$c);
+            if (!$source && $fallbackToDefault) {
+                $source = modMediaSource::getDefaultSource($this->xpdo);
+            }
+            $this->setSource($source);
         }
+        
         return $source;
     }
+    
+    /**
+     * Setter method for the source class var.
+     *
+     * @param string $source The source to use for this element.
+     */
+    public function setSource($source) {
+        $this->_source = $source;
+    }    
 
     /**
      * Get the stored sourceCache for a context


### PR DESCRIPTION
Signed-off-by: Bruno Perner b.perner@gmx.de

Need to change the TV-id in MIGX before running $tv->getRender.
To get the correct media-source I have to set the media-source before changing the id and before running $tv->getRender

I could do:

```
//set default_media_source for this TV before changing the id
$mediasource = $tv->getSource($modx->resource->get('context_key'));
$modx->setOption('default_media_source',$mediasource->get('id'));

$tv->set('id', $field['tv_id']);

/*some more code*/

$inputForm = $tv->getRender($params, $value, $inputRenderPaths, 'input', $resourceId, $tv->get('type')); 
```

Not sure if it is a good idea to do it this way, so with this pull request it would be enough todo:

```
//get and set media_source for this TV before changing the id
$mediasource = $tv->getSource($modx->resource->get('context_key'));

$tv->set('id', $field['tv_id']);

/*some more code*/

$inputForm = $tv->getRender($params, $value, $inputRenderPaths, 'input', $resourceId, $tv->get('type')); 
```

With this it would also be possible for example to use a global mediasource for all in MIGX included TVs or use different configurable mediasources for each field undependend on its inputTV
