### PR TITLE
dynamic Mediasources with autocreate Directory option for image and file-TV

### DIFF
--- a/core/lexicon/en/tv_widget.inc.php
+++ b/core/lexicon/en/tv_widget.inc.php
@@ -125,3 +125,6 @@ $_lang['upper_case'] = 'Upper Case';
 $_lang['url'] = 'URL';
 $_lang['url_display_text'] = 'Display Text';
 $_lang['width'] = 'Width';
+$_lang['width'] = 'Width';
+$_lang['autoResourceFolders'] = 'Auto Resource Folders';
+$_lang['autoResourceFolders_desc'] = 'Autocreate File-System-Directory for generated path from mediaSource. Only useful, with placeholder [[+mediasource.res_id]] or other dynamic tags in mediasource-path';

--- a/core/lexicon/en/tv_widget.inc.php
+++ b/core/lexicon/en/tv_widget.inc.php
@@ -125,6 +125,5 @@ $_lang['upper_case'] = 'Upper Case';
 $_lang['url'] = 'URL';
 $_lang['url_display_text'] = 'Display Text';
 $_lang['width'] = 'Width';
-$_lang['width'] = 'Width';
 $_lang['autoResourceFolders'] = 'Auto Resource Folders';
 $_lang['autoResourceFolders_desc'] = 'Autocreate File-System-Directory for generated path from mediaSource. Only useful, with placeholder [[+mediasource.res_id]] or other dynamic tags in mediasource-path';

--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -266,7 +266,7 @@ class modTemplateVar extends modElement {
         }
 
         /* run prepareOutput to allow for custom overriding */
-        $value = $this->prepareOutput($value);
+        $value = $this->prepareOutput($value,$resourceId);
 
         /* find the render */
         $outputRenderPaths = $this->getRenderDirectories('OnTVOutputRenderList','output');
@@ -278,7 +278,7 @@ class modTemplateVar extends modElement {
      * @param string $value
      * @return string
      */
-    public function prepareOutput($value) {
+    public function prepareOutput($value,$resourceId = false) {
         /* Allow custom source types to manipulate the output URL for image/file tvs */
         $mTypes = $this->xpdo->getOption('manipulatable_url_tv_output_types',null,'image,file');
         $mTypes = explode(',',$mTypes);
@@ -293,6 +293,9 @@ class modTemplateVar extends modElement {
                     $source = $this->xpdo->newObject($classKey);
                     if ($source) {
                         $source->fromArray($sourceCache,'',true,true);
+                        if ($resourceId){
+                            $this->xpdo->setPlaceholder('mediasource.res_id',$resourceId);
+                        }                        
                         $value = $source->prepareOutputUrl($value);
                     }
                 }

--- a/core/model/modx/processors/browser/directory/chmod.class.php
+++ b/core/model/modx/processors/browser/directory/chmod.class.php
@@ -37,7 +37,7 @@ class modBrowserFolderChmodProcessor extends modProcessor {
         }
         $this->source->setRequestProperties($this->getProperties());
         $this->source->initialize();
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $this->source->chmodContainer($this->getProperty('dir'),$this->getProperty('mode'));
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/directory/create.class.php
+++ b/core/model/modx/processors/browser/directory/create.class.php
@@ -36,7 +36,7 @@ class modBrowserFolderCreateProcessor extends modProcessor {
         }
         $this->source->setRequestProperties($this->getProperties());
         $this->source->initialize();
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $this->source->createContainer($this->getProperty('name'),$this->getProperty('parent'));
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/directory/getfiles.class.php
+++ b/core/model/modx/processors/browser/directory/getfiles.class.php
@@ -63,9 +63,11 @@ class modBrowserFolderGetFilesProcessor extends modProcessor {
     
     public function autoFolder()
     {
+        
         if ($this->getProperty('autoCreateFolder') == 'true'){
-            $bases = $this->source->getBases();
+            $bases = $this->source->getBases('');
             $targetDir = $bases['pathAbsolute'];
+            //$this->modx->log(modX::LOG_LEVEL_ERROR, $bases['pathAbsolute']);
             $cacheManager = $this->modx->getCacheManager();
             /* if directory doesnt exist, create it */
             if (!file_exists($targetDir) || !is_dir($targetDir)) {

--- a/core/model/modx/processors/browser/directory/getfiles.class.php
+++ b/core/model/modx/processors/browser/directory/getfiles.class.php
@@ -42,7 +42,8 @@ class modBrowserFolderGetFilesProcessor extends modProcessor {
         }
         $this->source->setRequestProperties($this->getProperties());
         $this->source->initialize();
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
+        $this->autoFolder();
         $list = $this->source->getObjectsInContainer($this->getProperty('dir'));
         return $this->outputArray($list);
     }
@@ -59,5 +60,22 @@ class modBrowserFolderGetFilesProcessor extends modProcessor {
         }
         return $this->source;
     }
+    
+    public function autoFolder()
+    {
+        if ($this->getProperty('autoCreateFolder') == 'true'){
+            $bases = $this->source->getBases();
+            $targetDir = $bases['pathAbsolute'];
+            $cacheManager = $this->modx->getCacheManager();
+            /* if directory doesnt exist, create it */
+            if (!file_exists($targetDir) || !is_dir($targetDir)) {
+                if (!$cacheManager->writeTree($targetDir)) {
+                    $this->modx->log(modX::LOG_LEVEL_ERROR, '[MIGX] Could not create directory: ' . $targetDir);
+                    //return $modx->error->failure('Could not create directory: ' . $targetDir);
+                }
+            }
+        }
+        return true;
+    }    
 }
 return 'modBrowserFolderGetFilesProcessor';

--- a/core/model/modx/processors/browser/directory/getlist.class.php
+++ b/core/model/modx/processors/browser/directory/getlist.class.php
@@ -47,7 +47,7 @@ class modBrowserFolderGetListProcessor extends modProcessor {
         }
         $this->source->setRequestProperties($this->getProperties());
         $this->source->initialize();
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $list = $this->source->getContainerList($this->getProperty('dir'));
         return $this->modx->toJSON($list);
     }

--- a/core/model/modx/processors/browser/directory/remove.class.php
+++ b/core/model/modx/processors/browser/directory/remove.class.php
@@ -41,7 +41,7 @@ class modBrowserFolderRemoveProcessor extends modProcessor {
         }
         $this->source->setRequestProperties($this->getProperties());
         $this->source->initialize();
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $this->source->removeContainer($this->getProperty('dir'));
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/directory/rename.class.php
+++ b/core/model/modx/processors/browser/directory/rename.class.php
@@ -45,7 +45,7 @@ class modBrowserFolderRenameProcessor extends modProcessor {
         if (!$this->validate($fields)) {
             return $this->failure();
         }
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $response = $this->source->renameContainer($fields['path'],$fields['name']);
         return $this->handleResponse($response);
     }

--- a/core/model/modx/processors/browser/directory/sort.class.php
+++ b/core/model/modx/processors/browser/directory/sort.class.php
@@ -31,6 +31,7 @@ class modBrowserFolderSortProcessor extends modProcessor {
         }
         $source->setRequestProperties($this->getProperties());
         $source->initialize();
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $source->moveObject($from,$to);
         if (!$success) {
             $errors = $source->getErrors();

--- a/core/model/modx/processors/browser/directory/update.class.php
+++ b/core/model/modx/processors/browser/directory/update.class.php
@@ -34,6 +34,7 @@ class modBrowserFolderUpdateProcessor extends modProcessor {
         }
         $source->setRequestProperties($this->getProperties());
         $source->initialize();
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $source->renameContainer($this->getProperty('dir'),$this->getProperty('name'));
 
         if (!$success) {

--- a/core/model/modx/processors/browser/file/create.class.php
+++ b/core/model/modx/processors/browser/file/create.class.php
@@ -30,7 +30,7 @@ class modBrowserFileCreateProcessor extends modProcessor {
         if (!($this->source instanceof modMediaSource)) {
             return $loaded;
         }
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id')); 
         $path = $this->source->createObject($directory,$name,$this->getProperty('content'));
         if (empty($path)) {
             $msg = '';

--- a/core/model/modx/processors/browser/file/download.class.php
+++ b/core/model/modx/processors/browser/file/download.class.php
@@ -14,7 +14,7 @@ class modBrowserFileDownloadProcessor extends modProcessor {
         if ($source !== true) {
             return $source;
         }
-        
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         if ($this->getProperty('download',false)) {
             return $this->download();
         } else {

--- a/core/model/modx/processors/browser/file/get.class.php
+++ b/core/model/modx/processors/browser/file/get.class.php
@@ -28,6 +28,7 @@ class modBrowserFileGetProcessor extends modProcessor {
         }
         
         $this->source = $this->getProperty('source',1);
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $fileArray = $this->source->getObjectContents($file);
 
         if (empty($fileArray)) {

--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -27,6 +27,7 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (!($this->source instanceof modMediaSource)) {
             return $loaded;
         }
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $this->source->removeObject($file);
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/file/rename.class.php
+++ b/core/model/modx/processors/browser/file/rename.class.php
@@ -27,7 +27,7 @@ class modBrowserFileRenameProcessor extends modProcessor {
         if (!($this->source instanceof modMediaSource)) {
             return $loaded;
         }
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $this->source->renameObject($oldFile,$this->getProperty('name'));
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/file/update.class.php
+++ b/core/model/modx/processors/browser/file/update.class.php
@@ -26,7 +26,7 @@ class modBrowserFileUpdateProcessor extends modProcessor {
         if (!($this->source instanceof modMediaSource)) {
             return $loaded;
         }
-
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $path = $this->source->updateObject($filePath,$this->getProperty('content'));
         if (empty($path)) {
             $msg = '';

--- a/core/model/modx/processors/browser/file/upload.class.php
+++ b/core/model/modx/processors/browser/file/upload.class.php
@@ -33,6 +33,7 @@ class modBrowserFileUploadProcessor extends modProcessor {
         }
         $this->source->setRequestProperties($this->getProperties());
         $this->source->initialize();
+        $this->modx->setPlaceholder('mediasource.res_id',$this->getProperty('res_id'));
         $success = $this->source->uploadObjectsToContainer($this->getProperty('path'),$_FILES);
 
         if (empty($success)) {

--- a/core/model/modx/processors/element/tv/renders/mgr/input/file.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/file.class.php
@@ -21,8 +21,9 @@ class modTemplateVarInputRenderFile extends modTemplateVarInputRender {
         $source->initialize();
         $this->modx->controller->setPlaceholder('source',$source->get('id'));
         $params = array_merge($source->getPropertyList(),$params);
+        $res_id = $this->modx->resource->get('id');
 
-        if (!$source->checkPolicy('view')) {
+        if (!$source->checkPolicy('view') || ($params['autoResourceFolders'] == 'true' && empty($res_id))) {
             $this->modx->controller->setPlaceholder('disabled',true);
             $this->tv->set('disabled',true);
             $this->tv->set('relativeValue',$this->tv->get('value'));
@@ -38,6 +39,7 @@ class modTemplateVarInputRenderFile extends modTemplateVarInputRender {
 
         $this->setPlaceholder('params',$params);
         $this->setPlaceholder('tv',$this->tv);
+        $this->setPlaceholder('res_id',$res_id);        
     }
     public function getTemplate() {
         return 'element/tv/renders/input/file.tpl';

--- a/core/model/modx/processors/element/tv/renders/mgr/input/image.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/image.class.php
@@ -21,8 +21,9 @@ class modTemplateVarInputRenderImage extends modTemplateVarInputRender {
         $source->initialize();
         $this->modx->controller->setPlaceholder('source',$source->get('id'));
         $params = array_merge($source->getPropertyList(),$params);
-        
-        if (!$source->checkPolicy('view')) {
+        $res_id = $this->modx->resource->get('id');
+
+        if (!$source->checkPolicy('view') || ($params['autoResourceFolders'] == 'true' && empty($res_id))) {
             $this->setPlaceholder('disabled',true);
             $this->tv->set('disabled',true);
             $this->tv->set('relativeValue',$this->tv->get('value'));
@@ -38,6 +39,7 @@ class modTemplateVarInputRenderImage extends modTemplateVarInputRender {
         
         $this->setPlaceholder('params',$params);
         $this->setPlaceholder('tv',$this->tv);
+        $this->setPlaceholder('res_id',$res_id);
     }
     public function getTemplate() {
         return 'element/tv/renders/input/image.tpl';

--- a/core/model/modx/processors/system/phpthumb.class.php
+++ b/core/model/modx/processors/system/phpthumb.class.php
@@ -37,7 +37,10 @@ class modSystemPhpThumbProcessor extends modProcessor {
 
         $this->getSource($this->getProperty('source'));
         if (empty($this->source)) $this->failure($this->modx->lexicon('source_err_nf'));
-
+        $res_id = $this->getProperty('res_id');
+        if (!empty($res_id)){
+            $this->modx->setPlaceholder('mediasource.res_id',$res_id);
+        }
         $src = $this->source->prepareSrcForThumb($src);
         if (empty($src)) return '';
 

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -49,6 +49,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         } else {
             $bases['pathAbsolute'] = $bases['path'];
         }
+        //$this->xpdo->log(modX::LOG_LEVEL_ERROR, print_r('$bases',1));
         $bases['path'] = $this->processPlaceholders(null,$bases['path']);
         $bases['pathAbsolute'] = $this->processPlaceholders(null,$bases['pathAbsolute']);     
         $bases['pathAbsoluteWithPath'] = $bases['pathAbsolute'].$path;
@@ -107,6 +108,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
         $imagesExts = explode(',',$imagesExts);
         $skipFiles = $this->getOption('skipFiles',$properties,'.svn,.git,_notes,.DS_Store,nbproject,.idea');
+        $skipFiles = $this->processPlaceholders(null,$skipFiles);//line added
+        //$this->xpdo->log(modX::LOG_LEVEL_ERROR, $skipFiles); 
         $skipFiles = explode(',',$skipFiles);
         $skipFiles[] = '.';
         $skipFiles[] = '..';
@@ -118,11 +121,14 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         /* iterate through directories */
         /** @var DirectoryIterator $file */
         foreach (new DirectoryIterator($fullPath) as $file) {
+            
             if (in_array($file,$skipFiles)) continue;
             if (!$file->isReadable()) continue;
 
             $fileName = $file->getFilename();
+            //$this->xpdo->log(modX::LOG_LEVEL_ERROR, $fullPath.$fileName); 
             if (in_array(trim($fileName,'/'),$skipFiles)) continue;
+            if (in_array($fullPath.$fileName,$skipFiles)) continue;
             $filePathName = $file->getPathname();
             $octalPerms = substr(sprintf('%o', $file->getPerms()), -4);
 

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -49,7 +49,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         } else {
             $bases['pathAbsolute'] = $bases['path'];
         }
-        
+        $bases['path'] = $this->processPlaceholders(null,$bases['path']);
+        $bases['pathAbsolute'] = $this->processPlaceholders(null,$bases['pathAbsolute']);     
         $bases['pathAbsoluteWithPath'] = $bases['pathAbsolute'].$path;
         if (is_dir($bases['pathAbsoluteWithPath'])) {
             $bases['pathAbsoluteWithPath'] = $this->fileHandler->postfixSlash($bases['pathAbsoluteWithPath']);
@@ -65,7 +66,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         } else {
             $bases['urlAbsolute'] = $bases['url'];
         }
-
+        $bases['urlAbsolute'] = $this->processPlaceholders(null,$bases['urlAbsolute']);
+        $bases['url'] = $this->processPlaceholders(null,$bases['url']);
         $bases['urlAbsoluteWithPath'] = $bases['urlAbsolute'].ltrim($path,'/');
         $bases['urlRelative'] = ltrim($path,'/');
         return $bases;
@@ -816,6 +818,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         'HTTP_MODAUTH' => $modAuth,
                         'wctx' => $this->ctx->get('key'),
                         'source' => $this->get('id'),
+                        'res_id' => $this->xpdo->getPlaceholder('mediasource.res_id'),
                     ));
                     $imageQuery = http_build_query(array(
                         'src' => $url,
@@ -826,6 +829,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         'q' => $thumbnailQuality,
                         'wctx' => $this->ctx->get('key'),
                         'source' => $this->get('id'),
+                        'res_id' => $this->xpdo->getPlaceholder('mediasource.res_id'),
                     ));
                     $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                     $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
@@ -976,6 +980,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
     public function prepareOutputUrl($value) {
         $properties = $this->getPropertyList();
         if (!empty($properties['baseUrl'])) {
+            $properties['baseUrl'] = $this->processPlaceholders(null,$properties['baseUrl']);            
             $value = $properties['baseUrl'].$value;
             if (isset($properties['baseUrlRelative']) && !empty($properties['baseUrlRelative'])) {
                 $value = $this->xpdo->context->getOption('base_url',null,MODX_BASE_URL).$value;

--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -541,6 +541,7 @@ class modMediaSource extends modAccessibleSimpleObject implements modMediaSource
         if (substr($src,0,4) != 'http') {
             if (strpos($src,'/') !== 0) {
                 $properties = $this->getPropertyList();
+                $properties['basePath'] = $this->processPlaceholders(null,$properties['basePath']);
                 $src = $properties['basePath'].$src;
                 if (!empty($properties['basePathRelative'])) {
                     $src = $this->ctx->getOption('base_path',null,MODX_BASE_PATH).$src;
@@ -560,6 +561,13 @@ class modMediaSource extends modAccessibleSimpleObject implements modMediaSource
         }
         return $src;
     }
+
+    public function processPlaceholders($placeholders,$content){
+        $chunk = $this->xpdo->newObject('modChunk');
+        $chunk->setCacheable(false);
+        $chunk->setContent($content);
+        return $chunk->process($placeholders);        
+    }     
 
     /**
      * Prepares the output URL when the Source is being used in an Element. Can be overridden to provide prefixing/post-

--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -135,6 +135,8 @@ MODx.Browser = function(config) {
         onSelect: function(data) {}
         ,scope: this
         ,source: config.source || 1
+        ,res_id: config.res_id || false
+        ,autoCreateFolder: config.autoCreateFolder || false        
         ,cls: 'modx-browser'
     });
     MODx.Browser.superclass.constructor.call(this,config);
@@ -165,6 +167,8 @@ MODx.browser.Window = function(config) {
         ,prependPath: config.prependPath || null
         ,prependUrl: config.prependUrl || null
         ,source: config.source || MODx.config.default_media_source
+        ,res_id: config.res_id || false
+        ,autoCreateFolder: config.autoCreateFolder || false        
         ,allowedFileTypes: config.allowedFileTypes || ''
         ,wctx: config.wctx || 'web'
         ,openTo: config.openTo || ''
@@ -176,6 +180,7 @@ MODx.browser.Window = function(config) {
         ,onUpload: function() { this.view.run(); }
         ,scope: this
         ,source: config.source || MODx.config.default_media_source
+        ,res_id: config.res_id || false        
         ,hideFiles: config.hideFiles || false
         ,openTo: config.openTo || ''
         ,ident: this.ident
@@ -278,6 +283,8 @@ Ext.extend(MODx.browser.Window,Ext.Window,{
         this.view.run({
             dir: dir
             ,source: this.config.source
+            ,res_id: this.config.res_id || false
+            ,autoCreateFolder: this.config.autoCreateFolder || false                        
             ,allowedFileTypes: this.config.allowedFileTypes || ''
             ,wctx: this.config.wctx || 'web'
         });
@@ -380,6 +387,8 @@ MODx.browser.View = function(config) {
             ,prependPath: config.prependPath || null
             ,prependUrl: config.prependUrl || null
             ,source: config.source || 1
+            ,res_id: config.res_id || false
+            ,autoCreateFolder: config.autoCreateFolder || false                
             ,allowedFileTypes: config.allowedFileTypes || ''
             ,wctx: config.wctx || 'web'
             ,dir: config.openTo || ''
@@ -408,6 +417,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
                 action: 'remove'
                 ,file: d+'/'+node.id
                 ,source: this.config.source
+                ,res_id: this.config.res_id || false                
                 ,wctx: this.config.wctx || 'web'
             }
             ,listeners: {
@@ -425,6 +435,8 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             action: 'getFiles'
             ,dir: this.dir
             ,source: this.config.source || MODx.config.default_media_source
+            ,res_id: this.config.res_id || false
+            ,autoCreateFolder: this.config.autoCreateFolder || false            
         });
         this.store.load({
             params: p

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -460,6 +460,8 @@ MODx.combo.Browser = function(config) {
        width: 300
        ,triggerAction: 'all'
        ,source: config.source || 1
+       ,res_id: config.res_id || false
+       ,autoCreateFolder: config.autoCreateFolder || false       
     });
     MODx.combo.Browser.superclass.constructor.call(this,config);
     this.config = config;
@@ -478,6 +480,8 @@ Ext.extend(MODx.combo.Browser,Ext.form.TriggerField,{
                 ,id: Ext.id()
                 ,multiple: true
                 ,source: this.config.source || 1
+                ,res_id: this.config.res_id || false
+                ,autoCreateFolder: this.config.autoCreateFolder || false                
                 ,hideFiles: this.config.hideFiles || false
                 ,rootVisible: this.config.rootVisible || false
                 ,allowedFileTypes: this.config.allowedFileTypes || ''

--- a/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
@@ -31,6 +31,8 @@ MODx.panel.ImageTV = function(config) {
             ,value: config.relativeValue
             ,hideFiles: true
             ,source: config.source || 1
+            ,res_id: config.res_id || false
+            ,autoCreateFolder: config.autoCreateFolder || false            
             ,allowedFileTypes: config.allowedFileTypes || ''
             ,openTo: config.openTo || ''
             ,listeners: {
@@ -80,6 +82,8 @@ MODx.panel.FileTV = function(config) {
             ,value: config.relativeValue
             ,hideFiles: true
             ,source: config.source || 1
+            ,res_id: config.res_id || false
+            ,autoCreateFolder: config.autoCreateFolder || false                   
             ,allowedFileTypes: config.allowedFileTypes || ''
             ,wctx: config.wctx || 'web'
             ,openTo: config.openTo || ''

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -25,6 +25,7 @@ MODx.tree.Directory = function(config) {
             ,currentAction: MODx.request.a || 0
             ,currentFile: MODx.request.file || ''
             ,source: config.source || 0
+            ,res_id: config.res_id || false            
         }
         ,action: 'getList'
         ,primaryKey: 'dir'
@@ -138,6 +139,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             url: this.config.url
             ,params: {
                 source: this.config.baseParams.source
+                ,res_id: this.config.baseParams.res_id                
                 ,from: from
                 ,to: to
                 ,action: this.config.sortAction || 'sort'
@@ -231,6 +233,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,file: this.treeEditor.editNode.id
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
+                ,res_id: this.config.res_id || false                
             }
             ,listeners: {
                'success': {fn:this.refreshActiveNode,scope:this}
@@ -245,6 +248,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             ,name: node.text
             ,path: node.attributes.pathRelative
             ,source: this.getSource()
+            ,res_id: this.config.res_id || false            
         };
         if (!this.windows.renameDirectory) {
             this.windows.renameDirectory = MODx.load({
@@ -266,6 +270,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             ,name: node.text
             ,path: node.attributes.pathRelative
             ,source: this.getSource()
+            ,res_id: this.config.res_id || false            
         };
         if (!this.windows.renameFile) {
             this.windows.renameFile = MODx.load({
@@ -285,6 +290,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         var r = {
             'parent': node && node.attributes.type == 'dir' ? node.attributes.pathRelative : '/'
             ,source: this.getSource()
+            ,res_id: this.config.res_id || false             
         };
         if (!this.windows.create) {
             this.windows.create = MODx.load({
@@ -307,6 +313,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             dir: node.attributes.path
             ,mode: node.attributes.perms
             ,source: this.getSource()
+            ,res_id: this.config.res_id || false            
         };
         if (!this.windows.chmod) {
             this.windows.chmod = MODx.load({
@@ -334,6 +341,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,prependPath: this.config.prependPath || null
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
+                ,res_id: this.config.res_id || false                
             }
             ,listeners: {
                 'success':{fn:this.refreshParentNode,scope:this}
@@ -351,6 +359,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,file: node.attributes.id
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
+                ,res_id: this.config.res_id || false
             }
             ,listeners: {
                 'success':{fn:this.refreshParentNode,scope:this}
@@ -367,11 +376,12 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,file: node.attributes.id
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
+                ,res_id: this.config.res_id || false
             }
             ,listeners: {
                 'success':{fn:function(r) {
                     if (!Ext.isEmpty(r.object.url)) {
-                        location.href = MODx.config.connectors_url+'browser/file.php?action=download&download=1&file='+node.attributes.id+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.getSource()+'&wctx='+MODx.ctx;
+                        location.href = MODx.config.connectors_url+'browser/file.php?action=download&download=1&file='+node.attributes.id+'&HTTP_MODAUTH='+MODx.siteId+'&res_id='+this.config.res_id+'&source='+this.getSource()+'&wctx='+MODx.ctx;
                     }
                 },scope:this}
             }
@@ -396,6 +406,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                     ,baseUrlRelative: this.config.baseUrlRelative || null
                     ,wctx: MODx.ctx || ''
                     ,source: this.getSource()
+                    ,res_id: this.config.res_id || false                     
                 }
                 ,reset_on_hide: true
                 ,width: 550
@@ -450,6 +461,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             ,path: path
             ,wctx: MODx.ctx || ''
             ,source: this.getSource()
+            ,res_id: this.config.res_id || false
         });
         this.fireEvent('beforeUpload',this.cm.activeNode);
     }
@@ -479,6 +491,9 @@ MODx.window.CreateDirectory = function(config) {
         },{
             xtype: 'hidden'
             ,name: 'source'
+        },{
+            xtype: 'hidden'
+            ,name: 'res_id'
         },{
             xtype: 'hidden'
             ,name: 'prependPath'
@@ -526,6 +541,9 @@ MODx.window.ChmodDirectory = function(config) {
             ,name: 'source'
         },{
             xtype: 'hidden'
+            ,name: 'res_id'
+        },{
+            xtype: 'hidden'
             ,name: 'prependPath'
             ,value: config.prependPath || null
         },{
@@ -563,6 +581,9 @@ MODx.window.RenameDirectory = function(config) {
         },{
             xtype: 'hidden'
             ,name: 'source'
+        },{
+            xtype: 'hidden'
+            ,name: 'res_id'
         },{
             xtype: 'hidden'
             ,name: 'prependPath'
@@ -606,6 +627,9 @@ MODx.window.RenameFile = function(config) {
         },{
             xtype: 'hidden'
             ,name: 'source'
+        },{
+            xtype: 'hidden'
+            ,name: 'res_id'
         },{
             xtype: 'hidden'
             ,name: 'prependPath'

--- a/manager/templates/default/element/tv/renders/input/file.tpl
+++ b/manager/templates/default/element/tv/renders/input/file.tpl
@@ -36,6 +36,8 @@ Ext.onReady(function() {
         ,msgTarget: 'under'
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         ,source: '{$source}'
+        ,res_id: '{$res_id}'
+        ,autoCreateFolder: {if $params.autoResourceFolders == 1 || $params.autoResourceFolders == 'true'}true{else}false{/if}        
         
         {if $params.allowedFileTypes},allowedFileTypes: '{$params.allowedFileTypes}'{/if}
         ,wctx: '{if $params.wctx}{$params.wctx}{else}web{/if}'

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,7 +1,7 @@
 <div id="tvbrowser{$tv->id}"></div>
 <div id="tv-image-{$tv->id}" style="width: 97%"></div>
 <div id="tv-image-preview-{$tv->id}">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?h=150&w=150&src={$tv->value}&source={$source}" alt="" />{/if}
+    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?h=150&w=150&src={$tv->value}&res_id={$res_id}&source={$source}" alt="" />{/if}    
 </div>
 {if $disabled}
 <script type="text/javascript">
@@ -39,6 +39,8 @@ Ext.onReady(function() {
         ,wctx: '{if $params.wctx}{$params.wctx}{else}web{/if}'
         {if $params.openTo},openTo: '{$params.openTo}'{/if}
         ,source: '{$source}'
+        ,res_id: '{$res_id}'
+        ,autoCreateFolder: {if $params.autoResourceFolders == 1 || $params.autoResourceFolders == 'true'}true{else}false{/if}        
     {literal}
         ,msgTarget: 'under'
         ,listeners: {
@@ -49,7 +51,7 @@ Ext.onReady(function() {
                     d.update('');
                 } else {
                     {/literal}
-                    d.update('<img src="'+MODx.config.connectors_url+'system/phpthumb.php?h=150&w=150&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
+                    d.update('<img src="'+MODx.config.connectors_url+'system/phpthumb.php?h=150&w=150&src='+data.url+'&wctx={$ctx}&res_id={$res_id}&source={$source}" alt="" />');
                     {literal}
                 }
             }}

--- a/manager/templates/default/element/tv/renders/inputproperties/file.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/file.tpl
@@ -16,7 +16,22 @@ MODx.load({
     ,cls: 'form-with-labels'
     ,labelAlign: 'top'
     ,border: false
-    ,items: []
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('autoResourceFolders')
+        ,description: MODx.expandHelp ? '' : _('autoResourceFolders_desc')
+        ,name: 'inopt_autoResourceFolders'
+        ,hiddenName: 'inopt_autoResourceFolders'
+        ,id: 'inopt_autoResourceFolders{/literal}{$tv}{literal}'
+        ,value: params['autoResourceFolders'] == 0 || params['autoResourceFolders'] == 'true' ? true : false
+        ,width: 300
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_autoResourceFolders{/literal}{$tv}{literal}'
+        ,html: _('autoResourceFolders_desc')
+        ,cls: 'desc-under'
+    }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv}{literal}'
 });
 // ]]>

--- a/manager/templates/default/element/tv/renders/inputproperties/image.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/image.tpl
@@ -16,7 +16,22 @@ MODx.load({
     ,cls: 'form-with-labels'
     ,labelAlign: 'top'
     ,border: false
-    ,items: []
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('autoResourceFolders')
+        ,description: MODx.expandHelp ? '' : _('autoResourceFolders_desc')
+        ,name: 'inopt_autoResourceFolders'
+        ,hiddenName: 'inopt_autoResourceFolders'
+        ,id: 'inopt_autoResourceFolders{/literal}{$tv}{literal}'
+        ,value: params['autoResourceFolders'] == 0 || params['autoResourceFolders'] == 'true' ? true : false
+        ,width: 300
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_autoResourceFolders{/literal}{$tv}{literal}'
+        ,html: _('autoResourceFolders_desc')
+        ,cls: 'desc-under'
+    }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv}{literal}'
 });
 // ]]>


### PR DESCRIPTION
Signed-off-by: Bruno Perner b.perner@gmx.de

now again, a clean pull request.

Signed-off-by: Bruno17 b.perner@gmx.de

Would be nice, when we could have something like this.
Dynamic Mediasources.

For Example different filepathes for each resource.

I added a function 'processPlaceholders' to modMediaSource and added the resource-id as placeholder to processors, which are using mediaSources.

modified the image-TV and file-TV (and MIGX) to try this functionality, which seems to work well.

With this we can have mediaSource-pathes like:

```
assets/images/[[+mediasource.res_id]]/
```

or

```
assets/files/[[+mediasource.res_id]]/images
assets/files/[[+mediasource.res_id]]/pdfs
```

Also using snippets like ultimateParent or getResourceField for example or outputFilters to manipulate the mediaSource-pathes depending on the resource should work (didn't test that yet).

Added also an option to file- and image-TVs where they create resourcefolders automatically, depending on its dynamic mediasource - of course only possible, once the resource was created.

Hopefully something like this will make it to the pl.

Thanks! 
