### PR TITLE
"Fix" toQueryString not handling nested array (using core PHP5 http_buil...

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -384,11 +384,7 @@ class modX extends xPDO {
      * @return string A valid query string representing the parameters.
      */
     public static function toQueryString(array $parameters = array()) {
-        $qs = array();
-        foreach ($parameters as $paramKey => $paramVal) {
-            $qs[] = urlencode($paramKey) . '=' . urlencode($paramVal);
-        }
-        return implode('&', $qs);
+        return http_build_query($qs);
     }
 
     /**


### PR DESCRIPTION
modX::toQueryString does not handle nested array properly. Say you pass:

Array(
    'param' => Array (
            'sortby' => 'sortorder'
            ,'sortdir' => 'ASC'
         )
)

The query generated will be:
param=

When it is meant to be (without the encoding for readability):
param[sortby]=sortorder&param[sortdir]=ASC

The php function http_build_query seems to do that perfectly and is available in PHP5. It might have been a choice to not use it in the first place (and not support this kind of query with modx), but this is a problem I encountered notably with getPage, which "loses" the search parameter for a pretty complicated form when moving to the next page.
