### PR TITLE
Added additional CSS rules to avoid 3rd party override with action buttons

### DIFF
--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -1694,8 +1694,12 @@ span.required {
     padding: 10px 5px 35px;
 }
 .x-grid3-cell-inner.x-grid3-col-main h3{
-	font-size: 16px;
-    margin: 0 0 2px;
+	font-family: arial,Helvetica,sans-serif;
+	font-size: 20px;
+	letter-spacing: -1px;
+	color: #555555;
+	line-height: 1;
+    margin: 0 0 2px;	
 }
 .x-grid3-cell-inner.x-grid3-col-main  .not-installed{
 	color: #999999;

--- a/manager/templates/default/css/xtheme-modx.css
+++ b/manager/templates/default/css/xtheme-modx.css
@@ -1142,13 +1142,13 @@ td.x-grid3-hd-over .x-grid3-hd-inner, td.sort-desc .x-grid3-hd-inner, td.sort-as
 .x-grid3-row-collapsed .x-grid3-row-expander {
     background-position:5px 10px;
     height:30px;
-    margin-top:4px;
+    margin-top:6px;
 }
 
 .x-grid3-row-expanded .x-grid3-row-expander  {
     background-position:-31px 10px;
     height:30px;
-    margin-top:4px;
+    margin-top:6px;
 }
 
 .x-grid3-row-expander {


### PR DESCRIPTION
This will allow Articles (or any other 3rd party package) to not use override for styling which could break the package manager actions buttons.
