### PR TITLE
Fix minify issue when DOCUMENT_ROOT is a symlink and suhosin test is failed

### DIFF
--- a/setup/includes/test/modinstalltest.class.php
+++ b/setup/includes/test/modinstalltest.class.php
@@ -338,9 +338,6 @@ abstract class modInstallTest {
         if (empty($documentRoot)) {
             $this->install->settings->set('compress_js',0);
             $this->install->settings->set('compress_css',0);
-        } else {
-            $this->install->settings->set('compress_js',1);
-            $this->install->settings->set('compress_css',1);
         }
         $this->install->settings->store();
     }


### PR DESCRIPTION
Remove unnecessary routine in the _checkDocumentRoot() function that may lead to minify issue when setup failed the suhosin test but pass the checkDocumentRoot check.
