### PR TITLE
#2510 Refactor Resource tree processor to preload active items in one request

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -451,7 +451,10 @@ class modResourceGetNodesProcessor extends modProcessor {
             $itemArray['expanded'] = true;
         } else {
             $itemArray['hasChildren'] = true;
-            $itemArray['children'] = $this->getChildrenNodes($itemArray);
+            $children = $this->getChildrenNodes($itemArray);
+            if (is_array($children)) {
+                $itemArray['children'] = $children;
+            }
         }
         $itemArray = $resource->prepareTreeNode($itemArray);
         return $itemArray;
@@ -473,7 +476,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
             return $children;
         }
-        return array();
+        return false;
     }
 }
 return 'modResourceGetNodesProcessor';


### PR DESCRIPTION
Requested & details here: http://tracker.modx.com/issues/2510

Basically this pull request checks the current state of the resource tree from the Registry, and when the processor is looping over resource nodes it checks if the current resource exists in that state. If it does, it recursively runs itself (processor), and adds the results as children nodes. 

The processor takes a bit longer to complete when having many levels open, however it saves a bunch of AJAX requests and instantly makes the tree usable again after the load, contrary to it being enabled and disabled again when the next request hits. 
- I'm thinking it may be convenient to add a system setting to toggle the preloading behavior. It may be less desirable to preload everything that was opened when having a huge amount of resources. 
- Perhaps it should be limited to a certain amount of levels?
- When there's a parent-child loop (resource 2 has resource 1 as parent, while resource 1 has resource 2 as parent) which somehow make it into the tree's active state this preloading probably screws up the processor.
