### PR TITLE
fix critical issue with utf-8 urls - infinity 301 redirects

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -336,7 +336,7 @@ class modRequest {
                 $this->modx->sendRedirect($this->modx->getOption('site_url', null, MODX_SITE_URL), array('responseCode' => 'HTTP/1.1 301 Moved Permanently'));
             } else {
                 $requestUri = preg_replace('/\?.*/', '', $_SERVER['REQUEST_URI']);
-                if ($this->modx->getOption('base_url', null, MODX_BASE_URL) . $identifier !== $requestUri) {
+                if ($this->modx->getOption('base_url', null, MODX_BASE_URL) . $identifier !== urldecode ($requestUri)) {
                     $parameters = $this->getParameters();
                     unset($parameters[$this->modx->getOption('request_param_alias')]);
                     $url = $this->modx->makeUrl($this->modx->aliasMap[$identifier], '', $parameters, 'full');


### PR DESCRIPTION
 string  $identifier containing symbols newer be compare with  urlencoded string $requestUri
