### PR TITLE
Update manager/assets/modext/widgets/core/modx.window.js

### DIFF
--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -24,7 +24,7 @@ MODx.Window = function(config) {
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')
             ,scope: this
-            ,handler: function() { this.hide(); }
+            ,handler: function() { config.closeAction !== 'close' ? this.hide() : this.close(); }
         },{
             text: config.saveBtnText || _('save')
             ,scope: this

--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -115,7 +115,7 @@ Ext.extend(MODx.Window,Ext.Window,{
                         Ext.callback(this.config.success,this.config.scope || this,[frm,a]);
                     }
                     this.fireEvent('success',{f:frm,a:a});
-                    if (close) { this.hide(); }
+                    if (close) { this.config.closeAction !== 'close' ? this.hide() : this.close(); }
                 }
             });
         }


### PR DESCRIPTION
This is a fix to allow the close button to follow the closeAction, this is currently leaving the DOM heavy in some of Mark Hamstra extras because even if he set closeAction: 'close', this is not actually fired unless the user presses ESC on the keyboard due to the close button only hiding the window.

There will be instances where the user will need to instantiate a new window each time rather than reusing the same one. Yet again if you have a look at Mark's bdListings and I am currently working on a website that had to use the same approach but had to call the close method inside the hide listener as a temporary measure.
