### PR TITLE
Update manager/templates/default/header.tpl

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -2,7 +2,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}"{if $_config.manager_html5_cache EQ 1} manifest="{$_config.manager_url}cache.manifest.php"{/if}>
 <head>
-<title>{$_config.site_name}{if $_pagetitle} :: {$_pagetitle}{/if}</title>
+<title>{if $_pagetitle}{$_pagetitle} | {/if}{$_config.site_name}</title>
 <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
 
 {if $_config.manager_favicon_url}<link rel="shortcut icon" type="image/x-icon" href="{$_config.manager_favicon_url}" />{/if}


### PR DESCRIPTION
Changed content of title tag so it will be easier to guess the content of each individual tab.

If your homepage has a title like "supercalifragilisticexplialigotious.com" (or any other domain with a total of 20 characters or more) all open tabs will look the same, so you don't know which one of them was your preview or which one of them was the template, chunk or snippet you were working on. 

Its much better to have a tab displaying the actual content of the tab:

Instead of:

supercalifragilist...

you can read:

chunk: navigation wf...

or

edit: welcome :: supercal

which is MUCH better.

I suppose most of us are working in multiple tabs at once, so this would be a great benefit for all of us.
