### PR TITLE
Fix for custom help URL not working properly

### DIFF
--- a/core/model/modx/processors/system/config.js.php
+++ b/core/model/modx/processors/system/config.js.php
@@ -56,7 +56,8 @@ if (isset($scriptProperties['action']) && $scriptProperties['action'] != '' && i
     $c['namespace'] = $action['namespace'];
     $c['namespace_path'] = $action['namespace_path'];
     $baseHelpUrl = $modx->getOption('base_help_url',$scriptProperties,'http://rtfm.modx.com/display/revolution20/');
-    $c['help_url'] = $baseHelpUrl.ltrim($action['help_url'],'/');
+    //$c['help_url'] = $baseHelpUrl.ltrim($action['help_url'],'/');
+    $c['help_url'] = $baseHelpUrl === 'http://rtfm.modx.com/display/revolution20/' ? $baseHelpUrl.ltrim($action['help_url'],'/') : $baseHelpUrl;
 }
 
 $actions = $modx->request->getAllActionIDs();


### PR DESCRIPTION
If the base_help_url is set to something other than the standard RTFM URL, the help button doesn't work properly because something (couldn't find out where/what) is adding a postfix (like "/Resources") to the URL, which of course does only work on the RTFM Site.

I think that it is the $action['help_url'], but I'm not deep enough into the code to understand what it exactly does^^.

So what I did here is to check if the base_help_url system setting was changed to a not "standard" URL, and if it was changed, just don't do the $action['help_url'] postfix thing to make the custom URL work properly. I commented out the original line, if pulled into the master branch, this should be removed.

The whole issue was also filed here http://tracker.modx.com/issues/7786 but closed prematurely (in my opinion)

Problem: The URL is hard-coded twice in this file...don't know how severe it is, but if the URL changes, somebody would have to remember it =), any way around this?

Dependency: MODx.loadHelpPane Method (http://rtfm.modx.com/display/revolution20/MODExt+MODx+Object#MODExtMODxObject-MODx.loadHelpPane) which gets the $url param from this file.

Related Issue: If I set a context setting "base_help_url", it isn't respected, only the system setting is taken.
