### PR TITLE
Update core/model/modx/filters/modoutputfilter.class.php

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -619,6 +619,17 @@ class modOutputFilter {
                             $this->modx->regClientScript($output,$m_val);
                             break;
 
+                        case 'firstchild':
+    						$c = $this->modx->newQuery('modResource');
+							$c->select('`modResource`.`id`');
+							$c->where(array('parent' => $output, 'published' => true));
+							$c->sortby('menuindex', 'ASC');
+							$c->limit(1);
+							$child = $this->modx->getObject('modResource', $c);
+							if(!empty($child) && $child instanceof modResource) {
+								$output = $child->get('id');
+							}
+                            break;
 
                         /* Default, custom modifier (run snippet with modifier name) */
                         default:


### PR DESCRIPTION
Added "firstchild" output filter. Usefull to for forms. When having the "thank you" page below the form page.

Use: [[*id:firstchild]]
- Maybe the where should be better, but this is what always use
