### PR TITLE
Fix #6695 - close sessions before min scripts terminate

### DIFF
--- a/manager/min/index.php
+++ b/manager/min/index.php
@@ -72,6 +72,9 @@ $min_uploaderHoursBehind = 0;
 $min_libPath = dirname(__FILE__) . '/lib';
 @ini_set('zlib.output_compression', (int)$modx->getOption('manager_js_zlib_output_compression',null,0));
 
+// MODX session no longer required
+@session_write_close();
+
 // setup include path
 @set_include_path($min_libPath . PATH_SEPARATOR . get_include_path());
 @set_time_limit(0);

--- a/manager/min/lib/Minify.php
+++ b/manager/min/lib/Minify.php
@@ -438,6 +438,8 @@ class Minify {
         list(, $code) = explode(' ', $header, 3);
         header($header, true, $code);
         header('Content-Type: text/html; charset=utf-8');
+        // MODX session no longer required
+        @session_write_close();
         echo "<h1>$h1</h1>";
         echo "<p>Please see <a href='$url'>$url</a>.</p>";
         exit();


### PR DESCRIPTION
http://tracker.modx.com/issues/6695

min script terminating without closing MODX session causes problems
in some environments, notably those where APC is employed.
