### PR TITLE
Release 2.2 - fix #6695 and #8341

### DIFF
--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -1,11 +1,12 @@
 <?php
+require_once dirname(__FILE__).'/resource.class.php';
 /**
  * Loads the resource data page
  *
  * @package modx
  * @subpackage manager.controllers
  */
-class ResourceDataManagerController extends modManagerController {
+class ResourceDataManagerController extends ResourceManagerController {
     /** @var modResource $resource */
     public $resource;
     /** @var string $previewUrl */

--- a/manager/controllers/default/resource/staticresource/data.class.php
+++ b/manager/controllers/default/resource/staticresource/data.class.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @package modx
+ * @subpackage manager.controllers
+ */
+class StaticResourceDataManagerController extends ResourceDataManagerController {}

--- a/manager/controllers/default/resource/symlink/data.class.php
+++ b/manager/controllers/default/resource/symlink/data.class.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @package modx
+ * @subpackage manager.controllers
+ */
+class SymlinkDataManagerController extends ResourceDataManagerController {}

--- a/manager/controllers/default/resource/weblink/data.class.php
+++ b/manager/controllers/default/resource/weblink/data.class.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @package modx
+ * @subpackage manager.controllers
+ */
+class WebLinkDataManagerController extends ResourceDataManagerController {}

--- a/manager/min/index.php
+++ b/manager/min/index.php
@@ -72,6 +72,9 @@ $min_uploaderHoursBehind = 0;
 $min_libPath = dirname(__FILE__) . '/lib';
 @ini_set('zlib.output_compression', (int)$modx->getOption('manager_js_zlib_output_compression',null,0));
 
+// MODX session no longer required
+@session_write_close();
+
 // setup include path
 @set_include_path($min_libPath . PATH_SEPARATOR . get_include_path());
 @set_time_limit(0);

--- a/manager/min/lib/Minify.php
+++ b/manager/min/lib/Minify.php
@@ -438,6 +438,8 @@ class Minify {
         list(, $code) = explode(' ', $header, 3);
         header($header, true, $code);
         header('Content-Type: text/html; charset=utf-8');
+        // MODX session no longer required
+        @session_write_close();
         echo "<h1>$h1</h1>";
         echo "<p>Please see <a href='$url'>$url</a>.</p>";
         exit();


### PR DESCRIPTION
#6695 - close sessions before min scripts terminate

http://tracker.modx.com/issues/6695

min script terminating without closing MODX session causes problems
in some environments, notably those where APC is employed.

---
#8341 - Allow Resource data pages to be extended by CRCs

http://tracker.modx.com/issues/8341
