### PR TITLE
Take care of modUserGroupMember rank upon creation

### DIFF
--- a/core/model/modx/processors/security/user/create.class.php
+++ b/core/model/modx/processors/security/user/create.class.php
@@ -88,6 +88,7 @@ class modUserCreateProcessor extends modObjectCreateProcessor {
         if ($groups !== null) {
             $groups = is_array($groups) ? $groups : $this->modx->fromJSON($groups);
             $groupsAdded = array();
+            $idx = 0;
             foreach ($groups as $group) {
                 if (in_array($group['usergroup'],$groupsAdded)) continue;
 
@@ -96,9 +97,11 @@ class modUserCreateProcessor extends modObjectCreateProcessor {
                 $membership->set('user_group',$group['usergroup']);
                 $membership->set('role',$group['role']);
                 $membership->set('member',$this->object->get('id'));
+                $membership->set('rank',isset($group['rank']) ? $group['rank'] : $idx);
                 $membership->save();
                 $memberships[] = $membership;
                 $groupsAdded[] = $group['usergroup'];
+                $idx++;
             }
         }
         return $memberships;

--- a/core/model/modx/processors/security/user/update.class.php
+++ b/core/model/modx/processors/security/user/update.class.php
@@ -29,7 +29,7 @@ class modUserUpdateProcessor extends modObjectUpdateProcessor {
     public $validator;
     /** @var string $newPassword */
     public $newPassword = '';
-    
+
 
     /**
      * Allow for Users to use derivative classes for their processors
@@ -169,18 +169,20 @@ class modUserUpdateProcessor extends modObjectUpdateProcessor {
             /* create user group links */
             $groupsAdded = array();
             $groups = is_array($groups) ? $groups : $this->modx->fromJSON($groups);
+            $idx = 0;
             foreach ($groups as $group) {
                 if (in_array($group['usergroup'],$groupsAdded)) continue;
                 $membership = $this->modx->newObject('modUserGroupMember');
                 $membership->set('user_group',$group['usergroup']);
                 $membership->set('role',$group['role']);
                 $membership->set('member',$this->object->get('id'));
-                $membership->set('rank',isset($group['rank']) ? $group['rank'] : 0);
+                $membership->set('rank',isset($group['rank']) ? $group['rank'] : $idx);
                 if (empty($group['rank'])) {
                     $primaryGroupId = $group['usergroup'];
                 }
                 $memberships[] = $membership;
                 $groupsAdded[] = $group['usergroup'];
+                $idx++;
             }
             $this->object->addMany($memberships,'UserGroupMembers');
             $this->object->set('primary_group',$primaryGroupId);


### PR DESCRIPTION
When creating a user and assigning multiples user groups, all groups' rank are set to 0.
This auto increments the rank in case no rank are specified
