### PR TITLE
#8401~#8414 

### DIFF
--- a/core/model/modx/mysql/modaccesspermission.map.inc.php
+++ b/core/model/modx/mysql/modaccesspermission.map.inc.php
@@ -34,7 +34,7 @@ $xpdo_meta_map['modAccessPermission']= array (
       'phptype' => 'string',
       'null' => false,
       'default' => '',
-      'index' => 'index',
+      'index' => 'pk',
     ),
     'description' => 
     array (

--- a/core/model/modx/processors/security/access/permission/getlist.class.php
+++ b/core/model/modx/processors/security/access/permission/getlist.class.php
@@ -20,7 +20,7 @@ class modAccessPermissionGetListProcessor extends modObjectGetListProcessor {
 
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $c->leftJoin('modAccessPolicyTemplate','Template');
-        $c->query['DISTINCT'] = 'DISTINCT';
+        $c->query['distinct'] = 'DISTINCT';
         $query = $this->getProperty('query','');
         if (!empty($query)) {
             $c->where(array(

--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -997,7 +997,8 @@ class xPDO {
                 $expr= $this->getSelectColumns($className, $query->getAlias(), '', $pk);
             }
             if (isset($query->query['columns'])) $query->query['columns'] = array();
-            $query->select(array ("COUNT(DISTINCT {$expr})"));
+            $exprs = explode(',',$expr);            
+            $query->select(array ("COUNT(DISTINCT {$exprs[count($exprs)-1]})"));
             if ($stmt= $query->prepare()) {
                 if ($stmt->execute()) {
                     if ($results= $stmt->fetchAll(PDO::FETCH_COLUMN)) {

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -163,6 +163,10 @@ class ResourceUpdateManagerController extends ResourceManagerController {
      * @return string
      */
     public function getPreviewUrl() {
+        if(($this->modx->getOption('friendly_urls') == 1)&&($this->resourceArray['uri']!='')) {                      
+            $alias = array_search($this->resourceArray['id'], $this->context->aliasMap);
+            if(!$alias)$this->context->aliasMap[$this->resourceArray['uri']] = $this->resourceArray['id'];            
+        }
         $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'),'','full');
         return $this->previewUrl;
     }


### PR DESCRIPTION
08-13-12:
BUGFIX+BADHACK - In the action "add permission to template" the "MODx.combo.Permission" Object, overflows and crashes the application js on the client side,

I have been researching and I found the problem, in the rule xPDO, are referred SQL DISTINCT only the fields with index equal to "pk" (primary key)

In the case of the table "modx_access_permissions" the index "pk", correctly  is assigned to the field "id" 
but the correct distinction of unique field can only be obtained in the field "name"

I posted a "commit" in my git with the method to FIX the problem,
but in my opinion should consider an alternative solution, to expand the rules xPDO for "sql DISTINCT"

08-16-12:
BUGFIX-#8414 user: ya ma
~Not working preview button after the saving new resource.~

The arrangement adds temporarily a ghost record in the "aliasMap" 
as long as the alias of the resource is not listed, 
when the system FURL enabled, and when there is a valid uri.

Thus allowing that the getPreviewUrl method returns a "previewUrl" 
in the first save of the resources.

Regards.
