### PR TITLE
Update core/model/modx/sources/modfilemediasource.class.php

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -1004,9 +1004,9 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $properties = $this->getPropertyList();
         if (!empty($properties['baseUrl'])) {
             $value = $properties['baseUrl'].$value;
-            if (isset($properties['baseUrlRelative']) && !empty($properties['baseUrlRelative'])) {
+            /*if (isset($properties['baseUrlRelative']) && !empty($properties['baseUrlRelative'])) {
                 $value = $this->xpdo->context->getOption('base_url',null,MODX_BASE_URL).$value;
-            }
+            }*/
         }
         return $value;
     }


### PR DESCRIPTION
See http://tracker.modx.com/issues/8392

The base_url should not be prefixed when you setup a media source relative
