### PR TITLE
Update core/model/modx/processors/resource/update.class.php

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -541,6 +541,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
                         if (is_array($value)) {
                             $featureInsert = array();
                             while (list($featureValue, $featureItem) = each($value)) {
+                                if(empty($featureItem)) { continue; }
                                 $featureInsert[count($featureInsert)] = $featureItem;
                             }
                             $value = implode('||',$featureInsert);


### PR DESCRIPTION
SHOULD BE TESTED MORE!

---

This fix will take care of mutliple-tv-value which are empty.
Let's say; a checkboxgroup without any value set will save a record with the famous || in it..
With this fix the record isn't saved
