### PR TITLE
Various light manager interface fixes and additions

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -239,11 +239,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         'text' => $this->xpdo->lexicon('file_edit'),
                         'handler' => 'this.editFile',
                     );
+                    $menu[] = array(
+                        'text' => $this->xpdo->lexicon('quick_update_file'),
+                        'handler' => 'this.quickUpdateFile',
+                    );
                 }
-                $menu[] = array(
-                    'text' => $this->xpdo->lexicon('quick_update_file'),
-                    'handler' => 'this.quickUpdateFile',
-	            );
                 $menu[] = array(
                     'text' => $this->xpdo->lexicon('rename'),
                     'handler' => 'this.renameFile',

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -226,7 +226,9 @@ Ext.extend(MODx,Ext.Component,{
             title: _('help')
             ,width: 850
             ,height: 500
-            ,modal: Ext.isIE ? false : true
+            ,resizable: true
+            ,maximizable: true
+            ,modal: false
             ,layout: 'fit'
             ,html: '<iframe src="' + url + '" width="100%" height="100%" frameborder="0"></iframe>'
         });

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -111,6 +111,7 @@ MODx.Layout = function(config){
             ,useSplitTips: true
             ,monitorResize: true
             ,forceLayout: true
+            ,layout: 'anchor'
             ,items: [{
                  xtype: 'modx-tabs'
                 ,plain: true
@@ -122,6 +123,7 @@ MODx.Layout = function(config){
                 }
                 ,id: 'modx-leftbar-tabpanel'
                 ,border: false
+                ,anchor: '100%'
                 ,activeTab: activeTab
                 ,stateful: true
                 ,stateId: 'modx-leftbar-tabs'

--- a/manager/assets/modext/widgets/core/modx.tabs.js
+++ b/manager/assets/modext/widgets/core/modx.tabs.js
@@ -7,8 +7,7 @@ MODx.Tabs = function(config) {
         ,deferredRender: true
         ,hideMode: 'offsets'
 		,defaults: {
-			autoScroll: true
-			,autoHeight: true
+			autoHeight: true
             ,hideMode: 'offsets'
             ,border: true
             ,autoWidth: true
@@ -16,6 +15,7 @@ MODx.Tabs = function(config) {
 		}
 	    ,activeTab: 0
         ,border: false
+        ,autoScroll: true
         ,autoHeight: true
         ,cls: 'modx-tabs'
 	});

--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -122,15 +122,22 @@ Ext.extend(MODx.Window,Ext.Window,{
     }
 	
     ,createForm: function(config) {
+        Ext.applyIf(this.config,{
+            formFrame: true
+            ,border: false
+            ,bodyBorder: false
+            ,autoHeight: true
+        });
         config = config || {};
         Ext.applyIf(config,{
             labelAlign: this.config.labelAlign || 'top'
             ,labelWidth: this.config.labelWidth || 100
             ,labelSeparator: this.config.labelSeparator || ''
-            ,frame: this.config.formFrame || true
-            ,border: this.config.border || false
-            ,bodyBorder: this.config.bodyBorder || false
-            ,autoHeight: this.config.autoHeight || true
+            ,frame: this.config.formFrame
+            ,border: this.config.border
+            ,bodyBorder: this.config.bodyBorder
+            ,autoHeight: this.config.autoHeight
+            ,anchor: '100% 100%'
             ,errorReader: MODx.util.JSONReader
             ,defaults: this.config.formDefaults || {
                 msgTarget: this.config.msgTarget || 'under'

--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -270,6 +270,7 @@ Ext.extend(MODx.window.InsertElement,MODx.Window,{
         });
     }
     ,onPropFormLoad: function(el,s,r) {
+        this.mask.hide();
         var vs = Ext.decode(r.responseText);
         if (!vs || vs.length <= 0) { return false; }
         for (var i=0;i<vs.length;i++) {
@@ -288,7 +289,6 @@ Ext.extend(MODx.window.InsertElement,MODx.Window,{
             ,items: vs
             ,renderTo: 'modx-iprops-form'
         });
-        this.mask.hide();
     }
     ,submit: function() {
         var v = '[[';

--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -229,13 +229,18 @@ MODx.window.InsertElement = function(config) {
             ,autoScroll: true
             ,items: [{
                 html: '<div id="modx-iprops-form"></div>'
+                ,id: 'modx-iprops-container'
                 ,height: 400
                 ,autoScroll: true
             }]
         }]
     });
     MODx.window.InsertElement.superclass.constructor.call(this,config);
-    this.on('show',function() { this.center(); },this);
+    this.on('show',function() {
+        this.center();
+        this.mask = new Ext.LoadMask(Ext.get('modx-iprops-container'), {msg:_('loading')});
+        this.mask.show();
+    },this);
 };
 Ext.extend(MODx.window.InsertElement,MODx.Window,{
     changePropertySet: function(cb) {
@@ -256,6 +261,7 @@ Ext.extend(MODx.window.InsertElement,MODx.Window,{
             ,scope: this
         });
         this.modps = [];
+        this.mask.show();
     }
     ,createStore: function(data) {
         return new Ext.data.SimpleStore({
@@ -282,6 +288,7 @@ Ext.extend(MODx.window.InsertElement,MODx.Window,{
             ,items: vs
             ,renderTo: 'modx-iprops-form'
         });
+        this.mask.hide();
     }
     ,submit: function() {
         var v = '[[';

--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -173,6 +173,8 @@ MODx.window.InsertElement = function(config) {
         title: _('select_el_opts')
         ,id: 'modx-window-insert-element' 
         ,width: 600
+        ,labelAlign: 'left'
+        ,labelWidth: 160
         ,url: MODx.config.connectors_url+'element/template.php'
         ,action: 'create'
         ,fields: [{

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -253,8 +253,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         }
         if (MODx.config.tvs_below_content == 1) {
             var tvs = this.getTemplateVariablesPanel(config);
-            tvs.style = 'margin-top: 10px';
-            tvs.border = false;
             its.push(tvs);
         }
         return its;
@@ -281,6 +279,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,template: config.record.template
             ,anchor: '100%'
             ,border: true
+            ,bodyStyle: 'display: none'
         };
     }
 

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -254,6 +254,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         if (MODx.config.tvs_below_content == 1) {
             var tvs = this.getTemplateVariablesPanel(config);
             tvs.style = 'margin-top: 10px';
+            tvs.border = false;
             its.push(tvs);
         }
         return its;

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -717,20 +717,27 @@ MODx.window.QuickCreateResource = function(config) {
         title: _('quick_create_resource')
         ,id: this.ident
         ,width: 700
+        ,height: ['modResource', 'modDocument'].indexOf(config.record.class_key) == -1 ? 498 : 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'resource/index.php'
         ,action: 'create'
         ,shadow: false
         ,fields: [{
             xtype: 'modx-tabs'
             ,bodyStyle: { background: 'transparent' }
+            ,border: true
             ,deferredRender: false
-            ,autoHeight: true
+            ,autoHeight: false
+            ,autoScroll: false
+            ,anchor: '100% 100%'
             ,items: [{
                 title: _('resource')
                 ,layout: 'form'
                 ,cls: 'modx-panel'
                 ,bodyStyle: { background: 'transparent', padding: '10px' }
-                ,autoHeight: true
+                ,autoHeight: false
+                ,anchor: '100% 100%'
                 ,labelWidth: 100
                 ,items: [{
                     layout: 'column'
@@ -848,21 +855,27 @@ MODx.window.QuickUpdateResource = function(config) {
         title: _('quick_update_resource')
         ,id: this.ident
         ,width: 700
+        ,height: ['modResource', 'modDocument'].indexOf(config.record.class_key) == -1 ? 498 : 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'resource/index.php'
         ,action: 'update'
-        ,autoHeight: true
         ,shadow: false
         ,fields: [{
             xtype: 'modx-tabs'
             ,bodyStyle: { background: 'transparent' }
-            ,autoHeight: true
+            ,border: true
+            ,autoHeight: false
+            ,autoScroll: false
+            ,anchor: '100% 100%'
             ,deferredRender: false
             ,items: [{
                 title: _('resource')
                 ,layout: 'form'
                 ,cls: 'modx-panel'
-                ,bodyStyle: { background: 'transparent', padding: '10px' }
-                ,autoHeight: true
+                ,bodyStyle: { background: 'transparent', padding: '10px', overflow: 'hidden' }
+                ,autoHeight: false
+                ,anchor: '100% 100%'
                 ,labelWidth: 100
                 ,items: [{
                     xtype: 'hidden'
@@ -1047,8 +1060,7 @@ MODx.getQRContentField = function(id,cls) {
                 ,id: 'modx-'+id+'-content'
                 ,hideLabel: true
                 ,labelSeparator: ''
-                ,anchor: '100%'
-                ,height: dm.height <= 768 ? 200 : 280
+                ,anchor: '100% -274'
             };
             break;
     }

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -717,7 +717,7 @@ MODx.window.QuickCreateResource = function(config) {
         title: _('quick_create_resource')
         ,id: this.ident
         ,width: 700
-        ,height: ['modResource', 'modDocument'].indexOf(config.record.class_key) == -1 ? 498 : 640
+        ,height: ['modSymLink', 'modWebLink', 'modStaticResource'].indexOf(config.record.class_key) == -1 ? 640 : 498
         ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'resource/index.php'
@@ -855,7 +855,7 @@ MODx.window.QuickUpdateResource = function(config) {
         title: _('quick_update_resource')
         ,id: this.ident
         ,width: 700
-        ,height: ['modResource', 'modDocument'].indexOf(config.record.class_key) == -1 ? 498 : 640
+        ,height: ['modSymLink', 'modWebLink', 'modStaticResource'].indexOf(config.record.class_key) == -1 ? 640 : 498
         ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'resource/index.php'

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -682,6 +682,9 @@ MODx.window.QuickUpdateFile = function(config) {
     Ext.applyIf(config,{
         title: _('file_quick_update')
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'browser/file.php'
         ,action: 'update'
         ,fields: [{
@@ -708,8 +711,7 @@ MODx.window.QuickUpdateFile = function(config) {
             fieldLabel: _('content')
             ,xtype: 'textarea'
             ,name: 'content'
-            ,anchor: '100%'
-            ,grow: true, growMax: 380
+            ,anchor: '100% -118'
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER
@@ -749,6 +751,9 @@ MODx.window.QuickCreateFile = function(config) {
     Ext.applyIf(config,{
         title: _('file_quick_create')
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'browser/file.php'
         ,action: 'create'
         ,fields: [{
@@ -774,8 +779,7 @@ MODx.window.QuickCreateFile = function(config) {
             fieldLabel: _('content')
             ,xtype: 'textarea'
             ,name: 'content'
-            ,anchor: '100%'
-            ,grow: true, growMax: 380
+            ,anchor: '100% -120'
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -194,6 +194,9 @@ MODx.window.QuickCreateChunk = function(config) {
         title: _('quick_create_chunk')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/chunk.php'
         ,action: 'create'
         ,fields: [{
@@ -220,8 +223,7 @@ MODx.window.QuickCreateChunk = function(config) {
             ,name: 'snippet'
             ,id: 'modx-'+this.ident+'-snippet'
             ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true, growMax: 380
+            ,anchor: '100% -216'
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER
@@ -242,6 +244,9 @@ MODx.window.QuickUpdateChunk = function(config) {
         title: _('quick_update_chunk')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/chunk.php'
         ,action: 'update'
         ,fields: [{
@@ -268,20 +273,20 @@ MODx.window.QuickUpdateChunk = function(config) {
             ,anchor: '100%'
             ,rows: 2
         },{
-            xtype: 'xcheckbox'
-            ,name: 'clearCache'
-            ,id: 'modx-'+this.ident+'-clearcache'
-            ,fieldLabel: _('clear_cache_on_save')
-            ,description: _('clear_cache_on_save_msg')
-            ,inputValue: 1
-            ,checked: true
-        },{
             xtype: 'textarea'
             ,name: 'snippet'
             ,id: 'modx-'+this.ident+'-snippet'
             ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true             ,growMax: Ext.getBody().getViewSize().height <= 768 ? 300 : 380
+            ,anchor: '100% -246'
+        },{
+            xtype: 'xcheckbox'
+            ,name: 'clearCache'
+            ,id: 'modx-'+this.ident+'-clearcache'
+            ,hideLabel: true
+            ,boxLabel: _('clear_cache_on_save')
+            ,description: _('clear_cache_on_save_msg')
+            ,inputValue: 1
+            ,checked: true
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER
@@ -315,6 +320,9 @@ MODx.window.QuickCreateTemplate = function(config) {
         title: _('quick_create_template')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/template.php'
         ,action: 'create'
         ,fields: [{
@@ -341,9 +349,7 @@ MODx.window.QuickCreateTemplate = function(config) {
             ,name: 'content'
             ,id: 'modx-'+this.ident+'-content'
             ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true
-            ,growMax: Ext.getBody().getViewSize().height <= 768 ? 300 : 380
+            ,anchor: '100% -216'
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER
@@ -364,6 +370,9 @@ MODx.window.QuickUpdateTemplate = function(config) {
         title: _('quick_update_template')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/template.php'
         ,action: 'update'
         ,fields: [{
@@ -394,9 +403,7 @@ MODx.window.QuickUpdateTemplate = function(config) {
             ,name: 'content'
             ,id: 'modx-'+this.ident+'-content'
             ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true
-            ,growMax: Ext.getBody().getViewSize().height <= 768 ? 300 : 380
+            ,anchor: '100% -246'
         },{
             xtype: 'xcheckbox'
             ,name: 'clearCache'
@@ -440,6 +447,9 @@ MODx.window.QuickCreateSnippet = function(config) {
         title: _('quick_create_snippet')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/snippet.php'
         ,action: 'create'
         ,fields: [{
@@ -466,9 +476,7 @@ MODx.window.QuickCreateSnippet = function(config) {
             ,name: 'snippet'
             ,id: 'modx-'+this.ident+'-snippet'
             ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true
-            ,growMax: Ext.getBody().getViewSize().height <= 768 ? 300 : 380
+            ,anchor: '100% -216'
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER
@@ -489,6 +497,9 @@ MODx.window.QuickUpdateSnippet = function(config) {
         title: _('quick_update_snippet')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/snippet.php'
         ,action: 'update'
         ,fields: [{
@@ -519,9 +530,7 @@ MODx.window.QuickUpdateSnippet = function(config) {
             ,name: 'snippet'
             ,id: 'modx-'+this.ident+'-snippet'
             ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true
-            ,growMax: Ext.getBody().getViewSize().height <= 768 ? 300 : 380
+            ,anchor: '100% -246'
         },{
             xtype: 'xcheckbox'
             ,name: 'clearCache'
@@ -566,6 +575,9 @@ MODx.window.QuickCreatePlugin = function(config) {
         title: _('quick_create_plugin')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/plugin.php'
         ,action: 'create'
         ,fields: [{
@@ -588,20 +600,19 @@ MODx.window.QuickCreatePlugin = function(config) {
             ,anchor: '100%'
             ,rows: 2
         },{
-            xtype: 'xcheckbox'
-            ,name: 'disabled'
-            ,id: 'modx-'+this.ident+'-disabled'
-            ,fieldLabel: _('disabled')
-            ,inputValue: 1
-            ,checked: false
-        },{
             xtype: 'textarea'
             ,name: 'plugincode'
             ,id: 'modx-'+this.ident+'-plugincode'
             ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true
-            ,growMax: Ext.getBody().getViewSize().height <= 768 ? 300 : 380
+            ,anchor: '100% -246'
+        },{
+            xtype: 'xcheckbox'
+            ,name: 'disabled'
+            ,id: 'modx-'+this.ident+'-disabled'
+            ,boxLabel: _('disabled')
+            ,hideLabel: true
+            ,inputValue: 1
+            ,checked: false
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER
@@ -622,6 +633,9 @@ MODx.window.QuickUpdatePlugin = function(config) {
         title: _('quick_update_plugin')
         ,id: this.ident
         ,width: 600
+        ,height: 640
+        ,autoHeight: false
+        ,layout: 'anchor'
         ,url: MODx.config.connectors_url+'element/plugin.php'
         ,action: 'update'
         ,fields: [{
@@ -648,6 +662,12 @@ MODx.window.QuickUpdatePlugin = function(config) {
             ,anchor: '100%'
             ,rows: 2
         },{
+            xtype: 'textarea'
+            ,name: 'plugincode'
+            ,id: 'modx-'+this.ident+'-plugincode'
+            ,fieldLabel: _('code')
+            ,anchor: '100% -270'
+        },{
             xtype: 'xcheckbox'
             ,name: 'disabled'
             ,id: 'modx-'+this.ident+'-disabled'
@@ -664,14 +684,6 @@ MODx.window.QuickUpdatePlugin = function(config) {
             ,description: _('clear_cache_on_save_msg')
             ,inputValue: 1
             ,checked: true
-        },{
-            xtype: 'textarea'
-            ,name: 'plugincode'
-            ,id: 'modx-'+this.ident+'-plugincode'
-            ,fieldLabel: _('code')
-            ,anchor: '100%'
-            ,grow: true
-            ,growMax: Ext.getBody().getViewSize().height <= 768 ? 300 : 380
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -1496,8 +1496,7 @@ span.required {
 }
 
 #modx-resource-tvs-div {
-    border-top: 0;
-    border-bottom: 0;
+    border: 1px solid #999;
 }
 #modx-tv-tabs .x-tab-panel-header {
     border-top: 1px solid #999;

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -65,8 +65,8 @@ hr {
     border-radius: 4px;
     background: none repeat scroll 0 0 transparent;
     border: 0;
-    margin: 20px 0 10px 10px;
-    padding: 0;
+    margin: 20px 0 10px 0;
+    padding: 0 0 0 10px;
 }
 
 #modx-leftbar .x-tab-panel-noborder .x-tab-panel-body-noborder {

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -1494,16 +1494,12 @@ span.required {
     color: #777;
     padding: 0 0 10px;
 }
-
-#modx-resource-tvs-div {
-    border-top: none;
-    border-bottom: none;
+#modx-resource-tvs-div{
+    border-top-width: 0;
 }
-#modx-resource-content ~ #modx-resource-tvs-div {
-    border: 1px solid #999;
-}
-#modx-tv-tabs .x-tab-panel-header {
-    border-top: 1px solid #999;
+#modx-resource-tvs-div.below-content{
+    border-top-width: 1px;
+    margin-top: 10px;
 }
 
 /* for selectability in ext grids */

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -1496,6 +1496,10 @@ span.required {
 }
 
 #modx-resource-tvs-div {
+    border-top: none;
+    border-bottom: none;
+}
+#modx-resource-content ~ #modx-resource-tvs-div {
     border: 1px solid #999;
 }
 #modx-tv-tabs .x-tab-panel-header {

--- a/manager/templates/default/css/xtheme-modx.css
+++ b/manager/templates/default/css/xtheme-modx.css
@@ -244,8 +244,7 @@ ul.x-tab-strip-bottom {
 .x-tab-strip-bottom .x-tab-strip-active .x-tab-right { background-image:url(../images/modx-theme/tabs/tab-btm-right-bg.gif); }
 .x-tab-strip-bottom .x-tab-strip-active .x-tab-left { background-image:url(../images/modx-theme/tabs/tab-btm-left-bg.gif); }
 .x-tab-panel-body {
-	border-left: 1px solid #999;
-	border-right: 1px solid #999;
+	border: 1px solid #999;
 	background-color:#ffffff;
 }
 .x-tab-panel-body-top { border-top:0 none; }
@@ -1843,6 +1842,10 @@ a.x-menu-item {
     background-color:#fff;
 }
 
+.x-panel-noborder{
+    border: none;
+}
+
 .x-panel-body-noheader{
 
 }
@@ -2373,7 +2376,6 @@ body.x-body-masked .x-window-plain .x-window-mc {
 	border: 1px solid #C0C0C0;
 	padding:0;
 	overflow:hidden;
-	z-index: 10000 !important;
 }
 .x-window .desc-under .warning { color:#df8d00; }
 .x-window h2 {
@@ -2383,12 +2385,6 @@ body.x-body-masked .x-window-plain .x-window-mc {
 	padding: 8px 15px;
 	border-bottom: 1px solid #D6DFC3;
 	text-shadow: 0 1px 1px #FFFFFF;
-}
-.x-window .x-form-text,
-.x-window .x-form.textarea {
-	height: 20px !important;
-	padding: 5px;
-	font-size: 13px;
 }
 .x-window .x-panel-tl,
 .x-window .x-panel-ml,

--- a/manager/templates/default/css/xtheme-modx.css
+++ b/manager/templates/default/css/xtheme-modx.css
@@ -125,7 +125,7 @@ ul.x-tab-strip-top li {
 	border-style:solid solid none;
 	border-width:1px 1px 0;
 	margin:1px 0 1px 2px;
-	padding:2px;	
+	padding:2px 0;
 	background:#658F1A;
     background:-moz-linear-gradient(center bottom,#658F1A 0%,#8BAF4C 100%) repeat scroll 0 0 transparent;
     background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#8BAF4C),color-stop(100%,#658F1A));

--- a/manager/templates/default/css/xtheme-modx.css
+++ b/manager/templates/default/css/xtheme-modx.css
@@ -2587,3 +2587,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
 	padding:8px;
 }
 .x-window .x-dlg-mask { background-color:#cccccc; }
+.x-window-maximized .x-window-tc {
+	padding-left: 0;
+	padding-right: 0;
+}

--- a/manager/templates/default/css/xtheme-modx.css
+++ b/manager/templates/default/css/xtheme-modx.css
@@ -217,9 +217,9 @@ ul.x-tab-strip-bottom {
 	border-width: 0 1px 0 !important;
 	border-color: #999;
 	border-top: 1px solid #999 !important;
-    -moz-border-radius-topright: 3px;
-    -webkit-border-top-right-radius: 3px;
-    border-top-right-radius: 3px;
+    -moz-border-radius: 0 4px 0 0;
+    -webkit-border-radius: 0 4px 0 0;
+    border-radius: 0 4px 0 0;
 
 }
 
@@ -245,6 +245,9 @@ ul.x-tab-strip-bottom {
 .x-tab-strip-bottom .x-tab-strip-active .x-tab-left { background-image:url(../images/modx-theme/tabs/tab-btm-left-bg.gif); }
 .x-tab-panel-body {
 	border: 1px solid #999;
+    -moz-border-radius: 0 0 4px 4px;
+    -webkit-border-radius: 0 0 4px 4px;
+    border-radius: 0 0 4px 4px;
 	background-color:#ffffff;
 }
 .x-tab-panel-body-top { border-top:0 none; }

--- a/manager/templates/default/help.tpl
+++ b/manager/templates/default/help.tpl
@@ -1,7 +1,7 @@
 <div class="modx-page" style="padding-top: 15px;">
+<h2>{$_lang.about_title}</h2>
 <div id="tabs_div"></div>
 <div id="modx-tab-about" class="padding x-hide-display">
-    <h2>{$_lang.about_title}</h2>
     <p>{$_lang.about_msg}</p>
 
     <h2>{$_lang.help}</h2>


### PR DESCRIPTION
This patch:
- Removes Quick Edit menu entry for binary files;
- Fixes insertElement window property fields, adds loading mask while loading properties.
- Makes help window maximizable
- Fixes issue with resized leftbar (removed hscrollbar after page reload) - good for third-party components, wich wants to add it's own tree tab to leftbar.
- Fixes other little issues.
