### PR TITLE
Add Context Name field [old]

### DIFF
--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -499,6 +499,7 @@ unset ($policies,$policy,$idx,$ct,$attributes);
 $c = $xpdo->newObject('modContext');
 $c->fromArray(array (
     'key' => 'web',
+    'name' => 'Website',
     'description' => 'The default front-end context for your web site.',
 ), '', true, true);
 $attributes = array (
@@ -529,6 +530,7 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in web context.'); flush();
 $c = $xpdo->newObject('modContext');
 $c->fromArray(array (
     'key' => 'mgr',
+    'name' => 'Manager',
     'description' => 'The default manager or administration context for content management activity.',
 ), '', true, true);
 $attributes = array (

--- a/core/model/modx/mysql/modcontext.map.inc.php
+++ b/core/model/modx/mysql/modcontext.map.inc.php
@@ -11,6 +11,7 @@ $xpdo_meta_map['modContext']= array (
   'fields' => 
   array (
     'key' => NULL,
+    'name' => NULL,
     'description' => NULL,
     'rank' => 0,
   ),
@@ -23,6 +24,12 @@ $xpdo_meta_map['modContext']= array (
       'phptype' => 'string',
       'null' => false,
       'index' => 'pk',
+    ),
+    'name' =>
+    array (
+        'dbtype' => 'varchar',
+        'precision' => '100',
+        'phptype' => 'string',
     ),
     'description' => 
     array (

--- a/core/model/modx/processors/context/remove.class.php
+++ b/core/model/modx/processors/context/remove.class.php
@@ -15,8 +15,8 @@ class modContextRemoveProcessor extends modObjectRemoveProcessor {
     public $primaryKeyField = 'key';
 
     public function beforeRemove() {
-        /* prevent removing of mgr/web contexts */
-        if ($this->object->get('key') == 'web' || $this->object->get('key') == 'mgr') {
+        /* prevent removing of mgr context */
+        if ($this->object->get('key') == 'mgr') {
             return $this->modx->lexicon('permission_denied');
         }
         return true;

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -315,7 +315,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
         $context->prepare();
         return array(
-            'text' => $context->get('key'),
+            'text' => $context->get('name') != '' ? $context->get('name') : $context->get('key'),
             'id' => $context->get('key') . '_0',
             'pk' => $context->get('key'),
             'ctx' => $context->get('key'),

--- a/core/model/modx/sqlsrv/modcontext.map.inc.php
+++ b/core/model/modx/sqlsrv/modcontext.map.inc.php
@@ -11,6 +11,7 @@ $xpdo_meta_map['modContext']= array (
   'fields' => 
   array (
     'key' => NULL,
+    'name' => NULL,
     'description' => NULL,
     'rank' => 0,
   ),
@@ -23,6 +24,12 @@ $xpdo_meta_map['modContext']= array (
       'phptype' => 'string',
       'null' => false,
       'index' => 'pk',
+    ),
+    'name' =>
+    array (
+        'dbtype' => 'nvarchar',
+        'precision' => '100',
+        'phptype' => 'string',
     ),
     'description' => 
     array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -422,6 +422,7 @@
     
     <object class="modContext" table="context" extends="modAccessibleObject">
         <field key="key" dbtype="varchar" precision="100" phptype="string" null="false" index="pk" />
+        <field key="name" dbtype="varchar" precision="100" phptype="string" />
         <field key="description" dbtype="tinytext" phptype="string" />
         <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
         

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -11,16 +11,22 @@ MODx.grid.Context = function(config) {
     Ext.applyIf(config,{
         title: _('contexts')
         ,url: MODx.config.connectors_url+'context/index.php'
-        ,fields: ['key','description','perm']
+        ,fields: ['key','name','description','perm']
         ,paging: true
         ,autosave: true
         ,remoteSort: true
         ,primaryKey: 'key'
         ,columns: [{
-            header: _('context_key')
+            header: _('key')
             ,dataIndex: 'key'
+            ,width: 100
+            ,sortable: true
+        },{
+            header: _('name')
+            ,dataIndex: 'name'
             ,width: 150
             ,sortable: true
+            ,editor: { xtype: 'textfield' }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -118,6 +124,12 @@ MODx.window.CreateContext = function(config) {
             xtype: 'textfield'
             ,fieldLabel: _('context_key')
             ,name: 'key'
+            ,anchor: '100%'
+            ,maxLength: 100
+        },{
+            xtype: 'textfield'
+            ,fieldLabel: _('name')
+            ,name: 'name'
             ,anchor: '100%'
             ,maxLength: 100
         },{

--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -34,11 +34,17 @@ MODx.panel.Context = function(config) {
 					,fieldLabel: _('key')
 					,name: 'key'
 					,width: 300
-					,maxLength: 255
+					,maxLength: 100
 					,enableKeyEvents: true
 					,allowBlank: true
 					,value: config.context
 					,submitValue: true
+				},{
+					xtype: 'textfield'
+					,fieldLabel: _('name')
+					,name: 'name'
+					,width: 300
+					,maxLength: 100
 				},{
 					xtype: 'textarea'
 					,fieldLabel: _('description')

--- a/setup/includes/upgrades/sqlsrv/2.2.5-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.2.5-pl.php
@@ -14,12 +14,6 @@ if (!empty($classes)) {
 }
 unset($classes);
 
-/* Add cache_refresh_idx to modResource table (MySQL-specific) */
-$class = 'modResource';
-$table = $modx->getTableName('modResource');
-$description = $this->install->lexicon('add_index',array('index' => 'cache_refresh_idx', 'table' => $table));
-$this->processResults($class, $description, array($modx->manager, 'addIndex'), array($class, 'cache_refresh_idx'));
-
 /* Add name field to modContext */
 $class = 'modContext';
 $table = $modx->getTableName($class);


### PR DESCRIPTION
http://tracker.modx.com/issues/7788

When `name` field is empty, resourse tree shows `key` field (like now)

Additionally I have removed prevention of `web` context removing since we have default_context setting
