### PR TITLE
Issue #8556: regClient functions inject more than once

### DIFF
--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -88,12 +88,12 @@ class modResponse {
                 /* Insert Startup jscripts & CSS scripts into template - template must have a </head> tag */
                 if (($js= $this->modx->getRegisteredClientStartupScripts()) && (strpos($this->modx->resource->_output, '</head>') !== false)) {
                     /* change to just before closing </head> */
-                    $this->modx->resource->_output= preg_replace("/(<\/head>)/i", $js . "\n\\1", $this->modx->resource->_output);
+                    $this->modx->resource->_output= preg_replace("/(<\/head>)/i", $js . "\n\\1", $this->modx->resource->_output,1);
                 }
 
                 /* Insert jscripts & html block into template - template must have a </body> tag */
                 if ((strpos($this->modx->resource->_output, '</body>') !== false) && ($js= $this->modx->getRegisteredClientScripts())) {
-                    $this->modx->resource->_output= preg_replace("/(<\/body>)/i", $js . "\n\\1", $this->modx->resource->_output);
+                    $this->modx->resource->_output= preg_replace("/(<\/body>)/i", $js . "\n\\1", $this->modx->resource->_output,1);
                 }
             }
 


### PR DESCRIPTION
A simple fix, makes the substitution of /head just once using PHP function. On a "regular" HTML page, the head should appear on top of the page, before any body tags.

A more complicated fix would be to parse the whole page, build the DOM tree and insert the css/js there, but that seems overly complicated for a function which is eventually just a helper for HTML document (since it has no effect on other types of document -- unless they have a head-/head, which would be strange).
