### PR TITLE
Plugin Event Output Fixes (for OnBeforeWebLogin and such)

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2512,7 +2512,12 @@ class modSystemEvent {
      * @param string $output The output to render.
      */
     public function output($output) {
-        $this->_output .= $output;
+        if ($this->_output === '') {
+            $this->_output = $output;
+        }
+        else {
+            $this->_output .= $output;
+        }
     }
 
     /**


### PR DESCRIPTION
Trying to deal with issue described http://forums.modx.com/thread/32541/modx-revo-event-output-issue-in-plugin#dis-post-437548 so now modEvent::output() can be used for setting the output, instead of "semi-private" modEvent::_output, which should generally be used only for internal interactions.
