### PR TITLE
XHTML support of manager

### DIFF
--- a/core/model/modx/modmanagerrequest.class.php
+++ b/core/model/modx/modmanagerrequest.class.php
@@ -56,10 +56,6 @@ class modManagerRequest extends modRequest {
      * @return boolean True if successful.
      */
     public function initialize() {
-        if (!defined('MODX_INCLUDES_PATH')) {
-            define('MODX_INCLUDES_PATH',$this->modx->getOption('manager_path').'includes/');
-        }
-
         /* load smarty template engine */
         $theme = $this->modx->getOption('manager_theme',null,'default');
         $templatePath = $this->modx->getOption('manager_path') . 'templates/' . $theme . '/';
@@ -82,7 +78,7 @@ class modManagerRequest extends modRequest {
         header('Cache-Control: post-check=0, pre-check=0', false);
         header('Pragma: no-cache');
         /* send the charset header */
-        header('Content-Type: text/html; charset='.$this->modx->getOption('modx_charset'));
+        header('Content-Type: '.$this->modx->getOption('manager_content_type', null, 'text/html').'; charset='.$this->modx->getOption('modx_charset'));
 
         /*
          * TODO: implement destroy active sessions if installing

--- a/core/model/modx/processors/system/config_check.inc.php
+++ b/core/model/modx/processors/system/config_check.inc.php
@@ -77,7 +77,7 @@ if ($errpage == null || !is_array($errpage)) {
 /* clear file info cache */
 clearstatcache();
 if (!empty($warnings)) {
-    $config_check_results = '<h4>' . $modx->lexicon('configcheck_notok') . '</h4><ul>';
+    $config_check_results = '<h4>' . $modx->lexicon('configcheck_notok') . '</h4><br /><ul>';
 
     for ($i = 0; $i < count($warnings); $i++) {
         switch ($warnings[$i][0]) {
@@ -120,12 +120,10 @@ if (!empty($warnings)) {
                             <p><strong>' . $modx->lexicon('configcheck_warning') . '</strong> ' . $warnings[$i][0] . '</p>
                             <p><em>' . $modx->lexicon('configcheck_what') . '</em></p>
                             <p>' . $warnings[$i][1] . ' </p>
+                            <br />
                             </li>';
-        if ($i != count($warnings) - 1) {
-            $config_check_results .= '<br />';
-        }
-        $config_check_results .= '</ul>';
     }
+    $config_check_results .= '</ul>';
     return false;
 } else {
     $config_check_results = $modx->lexicon('configcheck_ok');

--- a/manager/controllers/default/dashboard/widget.modx-news.php
+++ b/manager/controllers/default/dashboard/widget.modx-news.php
@@ -27,6 +27,8 @@ class modDashboardWidgetNewsFeed extends modDashboardWidgetInterface {
             $rss = $this->rss->parse($url);
             foreach (array_keys($rss->items) as $key) {
                 $item= &$rss->items[$key];
+                $item['title'] = str_replace('&', '&amp;', $item['title']);
+                $item['description'] = str_replace('&', '&amp;', $item['description']);
                 $item['pubdate'] = strftime('%c',$item['date_timestamp']);
                 $o[] = $this->getFileChunk('dashboard/rssitem.tpl',$item);
             }

--- a/manager/controllers/default/dashboard/widget.modx-security.php
+++ b/manager/controllers/default/dashboard/widget.modx-security.php
@@ -24,6 +24,8 @@ class modDashboardWidgetSecurityFeed extends modDashboardWidgetInterface {
             $rss = $this->rss->parse($url);
             foreach (array_keys($rss->items) as $key) {
                 $item= &$rss->items[$key];
+                $item['title'] = str_replace('&', '&amp;', $item['title']);
+                $item['description'] = str_replace('&', '&amp;', $item['description']);
                 $item['pubdate'] = strftime('%c',$item['date_timestamp']);
                 $o[] = $this->getFileChunk('dashboard/rssitem.tpl',$item);
             }

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -40,7 +40,7 @@ foreach ($menus as $menu) {
     if (!empty($menu['handler'])) {
         $menuTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'">'.$menu['text'].'</a>'."\n";
     } else if (!empty($menu['action'])) {
-        $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'">'.$menu['text'].'</a>'."\n";
+        $menuTpl .= '<a href="?a='.htmlentities($menu['action'].$menu['params']).'">'.$menu['text'].'</a>'."\n";
     } else {
         $menuTpl .= '<a>'.$menu['text'].'</a>'."\n";
     }
@@ -78,7 +78,7 @@ function _modProcessMenus(modX &$modx,&$output,$menus,&$childrenCt,$showDescript
             $smTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'">'.$menu['text'].($showDescriptions ? $description : '').'</a>'."\n";
         } else {
             $url = '?a='.$menu['action'].$menu['params'];
-            $smTpl .= '<a href="'.$url.'">'.$menu['text'].($showDescriptions ? $description : '').'</a>'."\n";
+            $smTpl .= '<a href="'.htmlentities($url).'">'.$menu['text'].($showDescriptions ? $description : '').'</a>'."\n";
         }
 
         if (!empty($menu['children'])) {

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -116,7 +116,7 @@ class SecurityLoginManagerController extends modManagerController {
         if (!empty($_SERVER['REQUEST_URI'])) {
             $chars = array("'",'"','(',')',';','>','<','!');
             $returnUrl = str_replace($chars,'',$_SERVER['REQUEST_URI']);
-            $this->setPlaceholder('returnUrl',$returnUrl);
+            $this->setPlaceholder('returnUrl',htmlentities($returnUrl));
         }
     }
     

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -20,8 +20,8 @@ class SystemSettingsManagerController extends modManagerController {
      * @return void
      */
     public function loadCustomCssJs() {
-        $this->addHtml('<script type="text/javascript">
-        // <[!CDATA[
+        $this->addHtml('<script>
+        // <![CDATA[
         MODx.onSiteSettingsRender = "'.$this->onSiteSettingsRender.'";
         // ]]>
         </script>');

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
 <title>MODX :: {$_lang.modx_resource_browser}</title>

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -1,9 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
+<html xmlns="http://www.w3.org/1999/xhtml" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
 <title>MODX :: {$_lang.modx_resource_browser}</title>
-<meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
-
 
 {if $_config.compress_css}
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
@@ -17,8 +15,8 @@
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
 <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
 <script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}layout/modx.config.js.php?action={$smarty.get.a|strip_tags}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&amp;topic=category,file,resource&amp;action={$smarty.get.a|strip_tags}" type="text/javascript"></script>
+<script src="{$_config.connectors_url}layout/modx.config.js.php?action={$smarty.get.a|strip_tags}{if $_ctx}&amp;wctx={$_ctx}{/if}" type="text/javascript"></script>
 
 {if $_config.compress_js_groups}
 <script src="{$_config.manager_url}min/index.php?g=coreJs1" type="text/javascript"></script>

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -1,11 +1,10 @@
-{if $_config.manager_html5_cache EQ 1}<!DOCTYPE HTML>{else}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">{/if}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}"{if $_config.manager_html5_cache EQ 1} manifest="{$_config.manager_url}cache.manifest.php"{/if}>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ext="http://www.sencha.com/products/extjs" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}"{if $_config.manager_html5_cache EQ 1} manifest="{$_config.manager_url}cache.manifest.php"{/if}>
 <head>
 <title>{if $_pagetitle}{$_pagetitle} | {/if}{$_config.site_name}</title>
-<meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
 
-{if $_config.manager_favicon_url}<link rel="shortcut icon" type="image/x-icon" href="{$_config.manager_favicon_url}" />{/if}
+{if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
 
 {if $_config.compress_css}
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
@@ -19,8 +18,8 @@
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
 <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
 <script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|strip_tags}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}layout/modx.config.js.php?action={$smarty.get.a|strip_tags}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&amp;topic=topmenu,file,resource,{$_lang_topics}&amp;action={$smarty.get.a|strip_tags}" type="text/javascript"></script>
+<script src="{$_config.connectors_url}layout/modx.config.js.php?action={$smarty.get.a|strip_tags}{if $_ctx}&amp;wctx={$_ctx}{/if}" type="text/javascript"></script>
 
 {if $_config.compress_js && $_config.compress_js_groups}
 <script src="{$_config.manager_url}min/index.php?g=coreJs1" type="text/javascript"></script>

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:ext="http://www.sencha.com/products/extjs" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}"{if $_config.manager_html5_cache EQ 1} manifest="{$_config.manager_url}cache.manifest.php"{/if}>
 <head>
 <title>{if $_pagetitle}{$_pagetitle} | {/if}{$_config.site_name}</title>

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
 	<title>{$_lang.login_title}</title>

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
+<html xmlns="http://www.w3.org/1999/xhtml" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
 	<title>{$_lang.login_title}</title>
-	<meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
-    {if $_config.manager_favicon_url}<link rel="shortcut icon" type="image/x-icon" href="{$_config.manager_favicon_url}" />{/if}
+
+    {if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
     
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
 	<link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/xtheme-modx.css" />

--- a/manager/templates/default/security/logout.tpl
+++ b/manager/templates/default/security/logout.tpl
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
     <title>MODx :: {$_lang.permission_denied}</title>

--- a/manager/templates/default/security/logout.tpl
+++ b/manager/templates/default/security/logout.tpl
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
+<html xmlns="http://www.w3.org/1999/xhtml" dir="{$_config.manager_direction}" lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
     <title>MODx :: {$_lang.permission_denied}</title>
-    <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
+
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all.css" />
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/xtheme-gray-extend.css" />
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/{$_config.manager_theme}/css/index.css" />


### PR DESCRIPTION
Fix http://tracker.modx.com/issues/8752

What is the purpose of `manager_lang_attribute setting` Since `manager_language` represents two-letter code, why don't use this for `lang` attribute ?
