### PR TITLE
Fix leftbar rendering issues

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -31,58 +31,24 @@ MODx.Layout = function(config){
     if (MODx.perm.resource_tree) {
        tabs.push({
             title: _('resources')
-            ,id: 'modx-resource-tree-ct'
-            ,listeners: {
-              activate : function(panel){
-                if (Ext.get('modx-resource-tree') == null){
-                  Ext.get(Ext.query('#'+panel.id+' div.x-panel-bwrap')).item(0).remove();
-                  MODx.load({
-                      xtype: 'modx-tree-resource'
-                      ,id: 'modx-resource-tree'
-                      ,renderTo: panel.id
-                  });
-                }
-              }
-            }
+            ,xtype: 'modx-tree-resource'
+            ,id: 'modx-resource-tree'
         });
         showTree = true;
     }
     if (MODx.perm.element_tree) {
         tabs.push({
             title: _('elements')
-            ,id: 'modx-element-tree-ct'
-            ,listeners: {
-              activate : function(panel){
-                if (Ext.get('modx-element-tree') == null){
-                  Ext.get(Ext.query('#'+panel.id+' div.x-panel-bwrap')).item(0).remove();
-                  MODx.load({
-                      xtype: 'modx-tree-element'
-                      ,id: 'modx-element-tree'
-                      ,renderTo: panel.id
-                  });
-                }
-              }
-            }
+            ,xtype: 'modx-tree-element'
+            ,id: 'modx-tree-element'
         });
         showTree = true;
     }
     if (MODx.perm.file_tree) {
         tabs.push({
             title: _('files')
-            ,id: 'modx-file-tree-ct'
-            ,hideFiles: false
-            ,listeners: {
-              activate : function(panel){
-                if (Ext.get('modx-file-tree') == null){
-                  Ext.get(Ext.query('#'+panel.id+' div.x-panel-bwrap')).item(0).remove();
-                  MODx.load({
-                      xtype: 'modx-tree-directory'
-                      ,id: 'modx-file-tree'
-                      ,renderTo: panel.id
-                  });
-                }
-              }
-            }
+            ,xtype: 'modx-tree-directory'
+            ,id: 'modx-file-tree'
         });
         showTree = true;
     }
@@ -110,13 +76,10 @@ MODx.Layout = function(config){
             ,collapseMode: 'mini'
             ,useSplitTips: true
             ,monitorResize: true
-            ,forceLayout: true
             ,layout: 'anchor'
             ,items: [{
                  xtype: 'modx-tabs'
                 ,plain: true
-                ,forceLayout: true
-                ,deferredRender: false
                 ,defaults: {
                      autoScroll: true
                     ,fitToFrame: true
@@ -223,24 +186,13 @@ Ext.extend(MODx.Layout,Ext.Viewport,{
             if (!wrap.isVisible()) {
                 // Set the "masking div" to visible
                 wrap.setVisible(true);
-                this.reDrawWest();
+                Ext.getCmp('modx-leftbar-tabpanel').expand(true);
             }
         }
         if(panelState && !this.saveState){
             Ext.state.Manager.set('modx-leftbar-tabs', {collapsed: false});
             this.saveState = true;
         }
-    }
-    ,reDrawWest: function() {
-        // Resize the topToolbar
-        var rTree = Ext.getCmp('modx-resource-tree');
-        rTree.getTopToolbar().setWidth(298);
-        // Redraw the search toolbar (because of bad size)
-        Ext.get('modx-resource-tree-tbar').setWidth(298);
-        Ext.get('modx-resource-searchbar').remove();
-        rTree.addSearchToolbar();
-        // Now expand the tabPanel
-        Ext.getCmp('modx-leftbar-tabpanel').expand(true);
     }
     ,showLeftbar: function(anim) {
         Ext.getCmp('modx-leftbar-tabs').expand(anim);

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -32,10 +32,10 @@ MODx.tree.Resource = function(config) {
         var el = Ext.get('modx-resource-tree');
         el.createChild({tag: 'div', id: 'modx-resource-tree_tb'});
         el.createChild({tag: 'div', id: 'modx-resource-tree_filter'});
+        this.addSearchToolbar();
     },this);
     this.addEvents('loadCreateMenus');
     this.on('afterSort',this._handleAfterDrop,this);
-    this.addSearchToolbar();
 };
 Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     forms: {}
@@ -89,6 +89,9 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         tb.add(tf);
         tb.doLayout();
         this.searchBar = tb;
+        this.on('resize', function(){
+            tf.setWidth(this.getWidth() - 12);
+        }, this);
     }
 
     ,search: function(nv) {

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -116,6 +116,9 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             tb.doLayout();
         }
         this.searchBar = tb;
+        this.on('resize', function(){
+            this.sourceCombo.setWidth(this.getWidth() - 12);
+        }, this);
     }
     ,changeSource: function(sel) {
         var s = sel.getValue();


### PR DESCRIPTION
Fix for http://tracker.modx.com/issues/9097
No need for implementing deferred rendering of inactive tabs since it is already impemented by ExtJS.
Custom search field and source dropdown should monitor resizing of its tbar.

We should not use applyTo everywhere because it disables some of ExtJS features (anchors for example) 

Initially, the tab content rendering was deferred, but  it was disabled later by Shaun (https://github.com/modxcms/revolution/commit/297a7ab6e385bb24ac905726493d9b499657ce92). But this was replaced by current code in https://github.com/modxcms/revolution/commit/acef9382df3d9dca7c88e4bda3b0e6362e2734ff
