### PR TITLE
[#9007] fix manager closing on file select

### DIFF
--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -348,10 +348,6 @@ Ext.extend(MODx.browser.Window,Ext.Window,{
                 var data = lookup[selNode.id];
                 Ext.callback(callback,scope || this,[data]);
                 this.fireEvent('select',data);
-                if (window.top.opener) {
-                    window.top.close();
-                    window.top.opener.focus();
-                }
             }
         },scope);
     }


### PR DESCRIPTION
Problem code seems to have originated from FCKEditor code in Evo.
Only use case for this that I can think of would be RTE opening a new browser window for a file dialog. It does not appear possible to configure TMCE this way anymore, despite there being a setting/plugin for it.
