### PR TITLE
Added method for clearing cache of resource

### DIFF
--- a/core/lexicon/en/configcheck.inc.php
+++ b/core/lexicon/en/configcheck.inc.php
@@ -7,6 +7,10 @@
  * @subpackage lexicon
  */
 $_lang['configcheck_admin'] = 'Please contact a systems administrator and warn them about this message!';
+$_lang['configcheck_allowtagsinpost_context_enabled'] = 'allow_tags_in_post Context Setting Enabled outside `mgr`';
+$_lang['configcheck_allowtagsinpost_context_enabled_msg'] = 'The allow_tags_in_post Context Setting is enabled in your installation outside the mgr Context. MODX recommends this setting be disabled unless you need to explicitly allow users to submit MODX tags, numeric entities, or HTML script tags via the POST method to a form in your site. This should generally be disabled except in the mgr Context.';
+$_lang['configcheck_allowtagsinpost_system_enabled'] = 'allow_tags_in_post System Setting Enabled';
+$_lang['configcheck_allowtagsinpost_system_enabled_msg'] = 'The allow_tags_in_post System Setting is enabled in your installation. MODX recommends this setting be disabled unless you need to explicitly allow users to submit MODX tags, numeric entities, or HTML script tags via the POST method to a form in your site. It is better to enable this via Context Settings for specific Contexts.';
 $_lang['configcheck_cache'] = 'cache directory not writable';
 $_lang['configcheck_cache_msg'] = 'MODX cannot write to the cache directory. MODX will still function as expected, but no caching will take place. To solve this, make the /_cache/ directory writable.';
 $_lang['configcheck_configinc'] = 'Config file still writable!';

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -1214,4 +1214,22 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $properties[$namespace] = $merge ? array_merge($properties[$namespace],$newProperties) : $newProperties;
         return $this->set('properties',$properties);
     }
+
+    /**
+     * Clearing cache of this resource
+     * @param string $context Key of context for clearing
+     * @return void
+     */
+    public function clearCache($context = null) {
+        if (empty($context)) {
+            $context = $this->context_key;
+        }
+        $this->_contextKey = $context;
+
+        /** @var xPDOFileCache $cache */
+        $cache = $this->xpdo->cacheManager->getCacheProvider($this->xpdo->getOption('cache_resource_key', null, 'resource'));
+        $key = $this->getCacheKey();
+        $cache->delete($key, array('deleteTop' => true));
+        $cache->delete($key);
+	}
 }

--- a/core/model/modx/processors/system/config_check.inc.php
+++ b/core/model/modx/processors/system/config_check.inc.php
@@ -71,8 +71,21 @@ if ($errpage == null || !is_array($errpage)) {
     $warnings[] = array (
         $modx->lexicon('configcheck_errorpage_unpublished')
     );
-} 
+}
 
+/* warn if allow_tags_in_post is true in System Settings OR Context Settings other than mgr */
+$allowTagsInPostSystem = $modx->getCount('modSystemSetting', array('key' => 'allow_tags_in_post', 'value' => '1'));
+if ($allowTagsInPostSystem > 0) {
+    $warnings[] = array(
+        $modx->lexicon('configcheck_allowtagsinpost_system_enabled')
+    );
+}
+$allowTagsInPostContext = $modx->getCount('modContextSetting', array('context_key:!=' => 'mgr', 'key' => 'allow_tags_in_post', 'value' => '1'));
+if ($allowTagsInPostContext > 0) {
+    $warnings[] = array(
+        $modx->lexicon('configcheck_allowtagsinpost_context_enabled')
+    );
+}
 
 /* clear file info cache */
 clearstatcache();
@@ -111,6 +124,12 @@ if (!empty($warnings)) {
                 break;
             case $modx->lexicon('configcheck_errorpage_unavailable') :
                 $warnings[$i][1] = $modx->lexicon('configcheck_errorpage_unavailable_msg');
+                break;
+            case $modx->lexicon('configcheck_allowtagsinpost_context_enabled') :
+                $warnings[$i][1] = $modx->lexicon('configcheck_allowtagsinpost_context_enabled_msg');
+                break;
+            case $modx->lexicon('configcheck_allowtagsinpost_system_enabled') :
+                $warnings[$i][1] = $modx->lexicon('configcheck_allowtagsinpost_system_enabled_msg');
                 break;
             default :
                 $warnings[$i][1] = $modx->lexicon('configcheck_default_msg');

--- a/setup/includes/upgrades/common/2.2-disable-allowtagsinpost.php
+++ b/setup/includes/upgrades/common/2.2-disable-allowtagsinpost.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Common upgrade script for disabling allow_tags_in_post System Setting
+ *
+ * See issue #9080.
+ *
+ * @var modX $modx
+ * @package setup
+ */
+if ($object = $modx->getObject('modSystemSetting', array('key' => 'allow_tags_in_post', 'value' => '1'), false)) {
+    $object->set('value', '0');
+    $object->save();
+}

--- a/setup/includes/upgrades/mysql/2.2.6-pl.php
+++ b/setup/includes/upgrades/mysql/2.2.6-pl.php
@@ -1,0 +1,3 @@
+<?php
+/* disable allow_tags_in_post System Setting */
+include dirname(dirname(__FILE__)).'/common/2.2-disable-allowtagsinpost.php';

--- a/setup/includes/upgrades/sqlsrv/2.2.6-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.2.6-pl.php
@@ -1,0 +1,3 @@
+<?php
+/* disable allow_tags_in_post System Setting */
+include dirname(dirname(__FILE__)).'/common/2.2-disable-allowtagsinpost.php';


### PR DESCRIPTION
I think it is vary useful method, that is need for many developers.
I use it in my component and can do just

<pre>$res = $modx->getObject('modResource', 15);
$res->clearCache();
</pre>
