### PR TITLE
Update manager/controllers/default/resource/symlink/update.class.php

### DIFF
--- a/manager/controllers/default/resource/symlink/update.class.php
+++ b/manager/controllers/default/resource/symlink/update.class.php
@@ -42,6 +42,8 @@ class SymlinkUpdateManagerController extends ResourceUpdateManagerController {
         });
         // ]]>
         </script>');
+        /* load RTE */
+        $this->loadRichTextEditor();
     }
     
     /**


### PR DESCRIPTION
Symlinks also should load RTE because you can have template variables assigned with this feature. Otherwise it will be a normal textarea.
