### PR TITLE
Update core/model/modx/modx.class.php

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -357,7 +357,7 @@ class modX extends xPDO {
      */
     public function sanitizeString($str,$chars = array('/',"'",'"','(',')',';','>','<'),$allowedTags = '') {
         $str = str_replace($chars,'',strip_tags($str,$allowedTags));
-        return preg_replace("/[^A-Za-z0-9_\-\.\/]/",'',$str);
+        return preg_replace("/[^A-Za-z0-9_\-\.\/\\p{L}[\p{L} _.-]/u",'',$str);
     }
 
     /**


### PR DESCRIPTION
Adding unicode capacity to the regexp.
To allow unicode-specific characters pass the filter.

Bug Report:
http://tracker.modx.com/issues/9364
