### PR TITLE
Small fix that clears errors on sites with mupltiple contexts. 

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -724,7 +724,7 @@ class modX extends xPDO {
                 $context = $options['context'];
             }
             $resourceMap = !empty($context) && !empty($this->contexts[$context]->resourceMap) ? $this->contexts[$context]->resourceMap : $this->resourceMap;
-            
+
             if (isset ($resourceMap["{$id}"])) {
                 if ($children= $resourceMap["{$id}"]) {
                     foreach ($children as $child) {
@@ -2209,6 +2209,9 @@ class modX extends xPDO {
             if (!$this->context->prepare((boolean) $regenerate, is_array($options) ? $options : array())) {
                 $this->log(modX::LOG_LEVEL_ERROR, 'Could not prepare context: ' . $contextKey);
             } else {
+                //This fixes error with multiple contexts
+                $this->contexts[$contextKey]=$this->context;
+
                 if ($this->context->checkPolicy('load')) {
                     $this->aliasMap= & $this->context->aliasMap;
                     $this->resourceMap= & $this->context->resourceMap;


### PR DESCRIPTION
Sometimes array $modx->contexts get wrong key=>object assigment cause of switchContext don't fill $this->contexts array, but links it to $this->context.

Signed-off-by: Indomian blade39@yandex.ru
