### PR TITLE
Replace most window.location changes by MODx.loadPage calls

### DIFF
--- a/core/model/modx/processors/resource/gettoolbar.class.php
+++ b/core/model/modx/processors/resource/gettoolbar.class.php
@@ -34,28 +34,28 @@ class modResourceGetToolbarProcessor extends modProcessor {
             $items[] = array(
                 'icon' => $p.'folder_page_add.png',
                 'tooltip' => $this->modx->lexicon('document_new'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'\");");',
+                'handler' => '(function(){ this.createResource() })',
             );
         }
         if ($this->modx->hasPermission('new_weblink')) {
             $items[] = array(
                 'icon' => $p.'page_white_link.png',
                 'tooltip' => $this->modx->lexicon('add_weblink'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modWebLink\");");',
+                'handler' => '(function(){ this.createResource("modWebLink") })',
             );
         }
         if ($this->modx->hasPermission('new_symlink')) {
             $items[] = array(
                 'icon' => $p.'page_white_copy.png',
                 'tooltip' => $this->modx->lexicon('add_symlink'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modSymLink\");");',
+                'handler' => '(function(){ this.createResource("modSymLink") })',
             );
         }
         if ($this->modx->hasPermission('new_static_resource')) {
             $items[] = array(
                 'icon' => $p.'page_white_gear.png',
                 'tooltip' => $this->modx->lexicon('static_resource_new'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modStaticResource\");");',
+                'handler' => '(function(){ this.createResource("modStaticResource") })',
             );
         }
         $items[] = '-';

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -325,8 +325,8 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     if (MODx.request.parent) { itm.params.parent = MODx.request.parent; }
                     if (MODx.request.context_key) { itm.params.context_key = MODx.request.context_key; }
                     if (MODx.request.class_key) { itm.params.class_key = MODx.request.class_key; }
-                    var a = Ext.urlEncode(itm.params);
-                    location.href = '?a='+o.actions['new']+'&'+a;
+                    var params = Ext.urlEncode(itm.params);
+                    MODx.loadPage(o.actions['new'], params);
                 }
                 break;
             case 'stay':
@@ -337,12 +337,12 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     /* if Continue Editing, then don't reload the page - just hide the Progress bar
                        unless the user is on a 'Create' page...if so, then redirect
                        to the proper Edit page */
-                    if ((itm.process === 'create' || itm.process === 'duplicate' || itm.reload) && res.object.id && res.object.id !== null) {
+                    if ((itm.process === 'create' || itm.process === 'duplicate' || itm.reload) && res.object.id) {
                         itm.params.id = res.object.id;
                         if (MODx.request.parent) { itm.params.parent = MODx.request.parent; }
                         if (MODx.request.context_key) { itm.params.context_key = MODx.request.context_key; }
                         url = Ext.urlEncode(itm.params);
-                        location.href = '?a='+o.actions.edit+'&'+url;
+                        MODx.loadPage(o.actions.edit, url);
 
                     } else if (itm.process === 'delete') {
                         itm.params.a = o.actions.cancel;
@@ -355,7 +355,7 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                 if (o.form.hasListener('actionClose')) {
                     o.form.fireEvent('actionClose',itm.params);
                 } else if (o.actions) {
-                    location.href = '?a='+o.actions.cancel+'&'+Ext.encode(itm.params);
+                    MODx.loadPage(o.actions.cancel, Ext.encode(itm.params));
                 }
                 break;
         }

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -208,7 +208,7 @@ MODx.LayoutMgr = function() {
     var _activeMenu = 'menu0';
     return {
         loadPage: function(a,p) {
-            location.href = '?a='+a+'&'+(p || '');
+            location.href = '?a=' + a + (p ? '&' + p : '');
             return false;
         }
         ,changeMenu: function(a,sm) {

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -62,10 +62,10 @@ Ext.extend(MODx.page.ResourceData,MODx.Component,{
         return false;
     }
     ,editResource: function() {
-        location.href = '?a='+MODx.action['resource/update']+'&id='+this.config.record.id;
+        MODx.loadPage(MODx.action['resource/update'], 'id='+this.config.record.id);
     }
     ,cancel: function() {
-        location.href = '?a='+MODx.action['welcome'];
+        MODx.loadPage(MODx.action['welcome']);
     }
 });
 Ext.reg('modx-page-resource-data',MODx.page.ResourceData);

--- a/manager/assets/modext/sections/resource/static/update.js
+++ b/manager/assets/modext/sections/resource/static/update.js
@@ -56,7 +56,7 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -72,7 +72,7 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -85,12 +85,12 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     ,getButtons: function(cfg) {

--- a/manager/assets/modext/sections/resource/symlink/update.js
+++ b/manager/assets/modext/sections/resource/symlink/update.js
@@ -52,7 +52,7 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -68,7 +68,7 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -81,12 +81,12 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -71,7 +71,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -87,7 +87,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -100,12 +100,12 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     

--- a/manager/assets/modext/sections/resource/weblink/update.js
+++ b/manager/assets/modext/sections/resource/weblink/update.js
@@ -52,7 +52,7 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -68,7 +68,7 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -81,12 +81,12 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     

--- a/manager/assets/modext/sections/security/user/update.js
+++ b/manager/assets/modext/sections/security/user/update.js
@@ -54,9 +54,9 @@ Ext.extend(MODx.page.UpdateUser,MODx.Component,{
                 ,id: this.config.user
             }
             ,listeners: {
-            	'success': {fn:function(r) {
-            	    location.href = '?a='+MODx.action['security/user'];
-            	},scope:this}
+                'success': {fn:function(r) {
+                    MODx.loadPage(MODx.action['security/user']);
+                },scope:this}
             }
         });
     }

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -131,7 +131,7 @@ Ext.extend(MODx.panel.CreateFile,MODx.FormPanel,{
         return true;
     }
     ,success: function(r) {
-        location.href = 'index.php?a='+MODx.action['system/file/edit']+'&file='+r.result.object.file+'&source='+MODx.request.source;
+        MODx.loadPage(MODx.action['system/file/edit'], 'file='+r.result.object.file+'&source='+MODx.request.source);
     }
     ,beforeSubmit: function(o) {
         this.cleanupEditor();

--- a/manager/assets/modext/widgets/core/modx.tree.js
+++ b/manager/assets/modext/widgets/core/modx.tree.js
@@ -506,8 +506,17 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
     ,redirect: function(loc) {
         location.href = loc;
     }
-	
+
+    /**
+     * Redirects the page to the given action for the selected active node
+     * @param {Number} action Action to redirect to
+     * @param {String} parameters Optional query parameters
+     */
     ,loadAction: function(a,p) {
+        // Handles deprecated calls when first argument is a query string
+        if (isNaN(a)) {
+            p = a.replace(/&?a=([^&]*)/, function(match, capture) {a = capture; return ''});
+        }
         p = p || '';
         if (this.cm.activeNode && this.cm.activeNode.id) {
             var pid = this.cm.activeNode.id.split('_');

--- a/manager/assets/modext/widgets/core/modx.tree.js
+++ b/manager/assets/modext/widgets/core/modx.tree.js
@@ -507,13 +507,13 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
         location.href = loc;
     }
 	
-    ,loadAction: function(p) {
-        var id = '';
+    ,loadAction: function(a,p) {
+        p = p || '';
         if (this.cm.activeNode && this.cm.activeNode.id) {
             var pid = this.cm.activeNode.id.split('_');
-            id = 'id='+pid[1];
+            p += (p ? '&' : '') + 'id='+pid[1];
         }
-        location.href = 'index.php?'+id+'&'+p;
+        MODx.loadPage(a, p);
     }
     /**
      * Loads the default toolbar for the tree.

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -178,7 +178,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                     this.cm.activeNode.remove();
                     /* if editing the element being removed */
                     if (MODx.request.a == MODx.action['element/'+oar[0]+'/update'] && MODx.request.id == oar[2]) {
-                        location.href = 'index.php?a='+MODx.action['welcome'];
+                        MODx.loadPage(MODx.action['welcome']);
                     }
                 },scope:this}
             }
@@ -391,9 +391,8 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                 ,type: a.type
                 ,pk: a.pk
                 ,handler: function(itm,e) {
-                    location.href = 'index.php?a='
-                        + MODx.action['element/'+itm.type+'/update']
-                        + '&id='+itm.pk;
+                    MODx.loadPage(MODx.action['element/'+itm.type+'/update'],
+                        'id='+itm.pk);
                 }
             });
             m.push({

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -24,7 +24,7 @@ MODx.tree.Element = function(config) {
             ,cls: 'x-btn-icon'
             ,tooltip: {text: _('new')+' '+_('template')}
             ,handler: function() {
-                this.redirect('index.php?a='+MODx.action['element/template/create']);
+                this._createElement('template');
             }
             ,scope: this
             ,hidden: MODx.perm.new_template ? false : true
@@ -33,7 +33,7 @@ MODx.tree.Element = function(config) {
             ,cls: 'x-btn-icon'
             ,tooltip: {text: _('new')+' '+_('tv')}
             ,handler: function() {
-                this.redirect('index.php?a='+MODx.action['element/tv/create']);
+                this._createElement('tv');
             }
             ,scope: this
             ,hidden: MODx.perm.new_tv ? false : true
@@ -42,7 +42,7 @@ MODx.tree.Element = function(config) {
             ,cls: 'x-btn-icon'
             ,tooltip: {text: _('new')+' '+_('chunk')}
             ,handler: function() {
-                this.redirect('index.php?a='+MODx.action['element/chunk/create']);
+                this._createElement('chunk');
             }
             ,scope: this
             ,hidden: MODx.perm.new_chunk ? false : true
@@ -51,7 +51,7 @@ MODx.tree.Element = function(config) {
             ,cls: 'x-btn-icon'
             ,tooltip: {text: _('new')+' '+_('snippet')}
             ,handler: function() {
-                this.redirect('index.php?a='+MODx.action['element/snippet/create']);
+                this._createElement('snippet');
             }
             ,scope: this
             ,hidden: MODx.perm.new_snippet ? false : true
@@ -60,7 +60,7 @@ MODx.tree.Element = function(config) {
             ,cls: 'x-btn-icon'
             ,tooltip: {text: _('new')+' '+_('plugin')}
             ,handler: function() {
-                this.redirect('index.php?a='+MODx.action['element/plugin/create']);
+                this._createElement('plugin');
             }
             ,scope: this
             ,hidden: MODx.perm.new_plugin ? false : true
@@ -261,15 +261,8 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         });
     }
 	
-    ,_createElement: function(itm,e,type) {
-        var id = this.cm.activeNode.id.substr(2);
-        var oar = id.split('_');
-        var type = oar[0] == 'type' ? oar[1] : oar[0];
-        var cat_id = oar[0] == 'type' ? 0 : (oar[1] == 'category' ? oar[2] : oar[3]);
-        var a = MODx.action['element/'+type+'/create'];
-        this.redirect('index.php?a='+a+'&category='+cat_id);
-        this.cm.hide();
-        return false;
+    ,_createElement: function(type, category) {
+        MODx.loadPage(MODx.action['element/'+type+'/create'], category ? '&category=' + category : '');
     }
     
     ,afterSort: function(o) {
@@ -438,7 +431,9 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         if (ui.hasClass('pnew')) {
             m.push({
                 text: _('add_to_category_'+a.type)
-                ,handler: this._createElement
+                ,handler: function(){
+                    this._createElement(a.type, a.category);
+                }
             });
         }
         if (ui.hasClass('pnewcat')) {
@@ -478,7 +473,9 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         if (a.elementType) {
             m.push({
                 text: _('add_to_category_'+a.type)
-                ,handler: this._createElement
+                ,handler: function() {
+                    this._createElement(a.type, a.category);
+                }
             });
         }
         this._getQuickCreateMenu(n,m);
@@ -501,7 +498,9 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         if (ui.hasClass('pnew')) {
             m.push({
                 text: _('new_'+a.type)
-                ,handler: this._createElement
+                ,handler: function(){
+                    this._createElement(a.type);
+                }
             });
             m.push({
                 text: _('quick_create_'+a.type)

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -128,13 +128,12 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 t.refreshNode(v,true);
             }
         }
-        if (o.result.object.class_key != this.defaultClassKey && this.config.resource != '' && this.config.resource != 0) {
-            location.href = location.href;
-        } else if (o.result.object['parent'] != this.defaultValues['parent'] && this.config.resource != '' && this.config.resource != 0) {
-            location.href = location.href;
+        var object = o.result.object;
+        if (this.config.resource && (object.class_key != this.defaultClassKey || object.parent != this.defaultValues.parent)) {
+            MODx.loadPage(object.action, 'id=' + object.id);
         } else {
-            this.getForm().setValues(o.result.object);
-            Ext.getCmp('modx-page-update-resource').config.preview_url = o.result.object.preview_url;
+            this.getForm().setValues(object);
+            Ext.getCmp('modx-page-update-resource').config.preview_url = object.preview_url;
         }
     }
     ,failure: function(o) {
@@ -165,7 +164,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     f.config.action = 'reload';
                     MODx.activePage.submitForm({
                         success: {fn:function(r) {
-                            location.href = '?a='+MODx.action[r.result.object.action]+'&id='+r.result.object.id+'&reload='+r.result.object.reload;
+                            MODx.loadPage(MODx.action[r.result.object.action], 'id='+r.result.object.id+'&reload='+r.result.object.reload);
                         },scope:this}
                     },{
                         bypassValidCheck: true

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -558,7 +558,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
 
     ,overviewResource: function() {this.loadAction(MODx.action['resource/data'])}
     ,quickUpdateResource: function(itm,e) {
-        Ext.getCmp("modx-resource-tree").quickUpdate(itm,e,itm.classKey);
+        this.quickUpdate(itm,e,itm.classKey);
     }
     ,editResource: function() {this.loadAction(MODx.action['resource/update']);}
 
@@ -647,19 +647,24 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         this.refreshNode(this.cm.activeNode.id);
     }
 
+    ,createResource: function(classKey) {
+        MODx.loadPage(MODx.action['resource/create'], classKey ? 'class_key=' + classKey : '');
+    }
+
     ,createResourceHere: function(itm) {
         var at = this.cm.activeNode.attributes;
         var p = itm.usePk ? itm.usePk : at.pk;
-        Ext.getCmp('modx-resource-tree').loadAction(
+        this.loadAction(
             MODx.action['resource/create'],
             'class_key=' + itm.classKey + '&parent=' + p
             + (at.ctx ? '&context_key=' + at.ctx : '')
         );
     }
-    ,createResource: function(itm,e) {
+
+    ,quickCreateResource: function(itm,e) {
         var at = this.cm.activeNode.attributes;
         var p = itm.usePk ? itm.usePk : at.pk;
-        Ext.getCmp('modx-resource-tree').quickCreate(itm,e,itm.classKey,at.ctx,p);
+        this.quickCreate(itm,e,itm.classKey,at.ctx,p);
     }
 
     ,_getCreateMenus: function(m,pk,ui) {
@@ -688,7 +693,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 qct.push({
                     text: types[k]['text_create']
                     ,classKey: k
-                    ,handler: this.createResource
+                    ,handler: this.quickCreateResource
                     ,scope: this
                 });
             }

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -526,7 +526,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 text: _('edit_context')
                 ,handler: function() {
                     var at = this.cm.activeNode.attributes;
-                    this.loadAction('a='+MODx.action['context/update']+'&key='+at.pk);
+                    this.loadAction(MODx.action['context/update'], 'key='+at.pk);
                 }
             });
         }
@@ -556,11 +556,11 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         return m;
     }
 
-    ,overviewResource: function() {this.loadAction('a='+MODx.action['resource/data'])}
+    ,overviewResource: function() {this.loadAction(MODx.action['resource/data'])}
     ,quickUpdateResource: function(itm,e) {
         Ext.getCmp("modx-resource-tree").quickUpdate(itm,e,itm.classKey);
     }
-    ,editResource: function() {this.loadAction('a='+MODx.action['resource/update']);}
+    ,editResource: function() {this.loadAction(MODx.action['resource/update']);}
 
     ,_getModResourceMenu: function(n) {
         var a = n.attributes;
@@ -651,10 +651,9 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         var at = this.cm.activeNode.attributes;
         var p = itm.usePk ? itm.usePk : at.pk;
         Ext.getCmp('modx-resource-tree').loadAction(
-            'a='+MODx.action['resource/create']
-            + '&class_key='+itm.classKey
-            + '&parent='+p
-            + (at.ctx ? '&context_key='+at.ctx : '')
+            MODx.action['resource/create'],
+            'class_key=' + itm.classKey + '&parent=' + p
+            + (at.ctx ? '&context_key=' + at.ctx : '')
         );
     }
     ,createResource: function(itm,e) {

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -136,7 +136,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
     }
 
     ,editPolicy: function(itm,e) {
-        location.href = '?a='+MODx.action['security/access/policy/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['security/access/policy/update'], 'id='+this.menu.record.id);
     }
     
     ,createPolicy: function(btn,e) {

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -138,7 +138,7 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
         this.refresh();
     }
     ,editPolicyTemplate: function(itm,e) {
-        location.href = '?a='+MODx.action['security/access/policy/template/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['security/access/policy/template/update'], 'id='+this.menu.record.id);
     }
     
     ,createPolicyTemplate: function(btn,e) {

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -198,7 +198,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
 
     ,createUser: function() {
-        location.href = 'index.php?a='+MODx.action['security/user/create'];
+        MODx.loadPage(MODx.action['security/user/create']);
     }
 
     ,activateSelected: function() {
@@ -290,7 +290,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
     
     ,updateUser: function() {
-        location.href = 'index.php?a='+MODx.action['security/user/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['security/user/update'], 'id='+this.menu.record.id);
     }
     				
     ,rendGender: function(d,c) {

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -100,14 +100,14 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                 ,buttons: Ext.Msg.OK
                 ,fn: function(btn) {
                     if (userId == 0) {
-                        location.href = '?a='+MODx.action['security/user']+'&id='+o.result.object.id;
+                        MODx.loadPage(MODx.action['security/user'], 'id='+o.result.object.id);
                     }
                     return false;
                 }
             });
             this.clearDirty();
         } else if (userId == 0) {
-            location.href = '?a='+MODx.action['security/user']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['security/user'], 'id='+o.result.object.id);
         }
     }
     

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -78,9 +78,7 @@ Ext.extend(MODx.tree.UserGroup,MODx.tree.Tree,{
         var n = this.cm.activeNode;
         var id = n.id.substr(2).split('_');id = id[1];
         
-        location.href = 'index.php'
-            + '?a=' + MODx.action['security/usergroup/update']
-            + '&id=' + id;
+        MODx.loadPage(MODx.action['security/usergroup/update'], 'id=' + id);
     }
 
     ,getMenu: function() {

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -208,7 +208,7 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
     }
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            location.href = '?a='+MODx.action['source/update']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['source/update'], 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-btn-save').setDisabled(false);
             var wg = Ext.getCmp('modx-grid-source-properties');

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -164,7 +164,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         });
     }
     ,createSource: function() {
-        location.href = 'index.php?a='+MODx.action['system/source/create'];
+        MODx.loadPage(MODx.action['system/source/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -204,7 +204,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
     }
 
     ,updateSource: function() {
-        location.href = 'index.php?a='+MODx.action['source/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['source/update'], 'id='+this.menu.record.id);
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
@@ -335,7 +335,7 @@ Ext.extend(MODx.grid.SourceTypes,MODx.grid.Grid,{
     }
 
     ,createSourceType: function() {
-        location.href = 'index.php?a='+MODx.action['system/source/type/create'];
+        MODx.loadPage(MODx.action['system/source/type/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -375,7 +375,7 @@ Ext.extend(MODx.grid.SourceTypes,MODx.grid.Grid,{
     }
 
     ,updateSourceType: function() {
-        location.href = 'index.php?a='+MODx.action['source/type/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['source/type/update'], 'id='+this.menu.record.id);
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -59,7 +59,7 @@ MODx.grid.Context = function(config) {
 };
 Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
     updateContext: function(itm,e) {
-        location.href = 'index.php?a='+MODx.action['context/update']+'&key='+this.menu.record.key;
+        MODx.loadPage(MODx.action['context/update'], 'key='+this.menu.record.key);
     }
     ,getMenu: function() {
         var r = this.getSelectionModel().getSelected();

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -107,7 +107,7 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
     }
 
     ,createDashboard: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/widget/create'];
+        MODx.loadPage(MODx.action['system/dashboards/widget/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -147,7 +147,7 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
     }
 
     ,updateWidget: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/widget/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['system/dashboards/widget/update'], 'id='+this.menu.record.id);
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -170,7 +170,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
     }
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            location.href = '?a='+MODx.action['system/dashboards/update']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['system/dashboards/update'], 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-btn-save').setDisabled(false);
             var wg = Ext.getCmp('modx-grid-dashboard-widget-placements');

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -259,7 +259,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
     }
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            location.href = '?a='+MODx.action['system/dashboards/widget/update']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['system/dashboards/widget/update'], 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-btn-save').setDisabled(false);
             var g = Ext.getCmp('modx-grid-dashboard-widget-dashboards');

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -170,7 +170,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
     }
 
     ,createDashboard: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/create'];
+        MODx.loadPage(MODx.action['system/dashboards/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -223,7 +223,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
     }
 
     ,updateDashboard: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['system/dashboards/update'], 'id='+this.menu.record.id);
     }
     
     ,filterUsergroup: function(cb,nv,ov) {

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -197,7 +197,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
     }
 
     ,editFile: function(itm,e) {
-        this.loadAction('a='+MODx.action['system/file/edit']+'&file='+this.cm.activeNode.attributes.id+'&source='+this.config.source);
+        this.loadAction(MODx.action['system/file/edit'], 'file='+this.cm.activeNode.attributes.id+'&source='+this.config.source);
     }
 
     ,quickUpdateFile: function(itm,e) {
@@ -234,7 +234,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
 
     ,createFile: function(itm,e) {
         var d = this.cm.activeNode && this.cm.activeNode.attributes ? this.cm.activeNode.attributes.id : '';
-        this.loadAction('a='+MODx.action['system/file/create']+'&directory='+d+'&source='+this.getSource());
+        this.loadAction(MODx.action['system/file/create'], 'directory='+d+'&source='+this.getSource());
     }
 
     ,quickCreateFile: function(itm,e) {

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -279,7 +279,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 	
 	/* Go to package details @TODO : Stay on the same page */
     ,viewPackage: function(btn,e) {
-        location.href = 'index.php?a='+MODx.action['workspaces/package/view']+'&signature='+this.menu.record.signature;
+        MODx.loadPage(MODx.action['workspaces/package/view'], 'signature='+this.menu.record.signature);
     }
     
 	/* Search for a package update - only for installed package */

--- a/manager/assets/modext/workspace/package/index.js
+++ b/manager/assets/modext/workspace/package/index.js
@@ -25,7 +25,7 @@ MODx.page.Package = function(config) {
             process: 'cancel'
             ,text: _('cancel')
             ,handler: function() {
-                location.href= '?a='+MODx.action['workspaces'];
+                MODx.loadPage(MODx.action['workspaces']);
             }
         },'-',{
             text: _('help_ex')


### PR DESCRIPTION
I replaced almost all direct location changes by MODx.loadPage proxy to allow to handle page loading.
There are still issues with remote toolbars and tree node clicks.

Currently tree click handler is defined in https://github.com/modxcms/revolution/blob/release-2.2/manager/assets/modext/widgets/core/modx.tree.js#L411 and it uses `page` attribute of node. We need the way to url params instead of url itself. Maybe to store params into another attribute in JSON format ? Or override click handler in each Tree class ancestor?

The another issue is remote toolbar. Currently, toolbar button click handler is defined such way:
https://github.com/modxcms/revolution/blob/release-2.2/core/model/modx/processors/resource/gettoolbar.class.php#L37

I propose to use this:

``` php
'handler' => '(function(){ MODx.loadPage(MODx.action["resource/create"]) })'
```

Anyway eval is evil. Do we really need "remote toolbar" feature?
