### PR TITLE
Make MODx Manager ready for ajax page switching

### DIFF
--- a/manager/assets/modext/sections/context/list.js
+++ b/manager/assets/modext/sections/context/list.js
@@ -1,7 +1,3 @@
-Ext.onReady(function(){
-   MODx.load({ xtype: 'modx-page-contexts' }); 
-});
-
 /**
  * Loads the context management page
  * 

--- a/manager/assets/modext/sections/context/update.js
+++ b/manager/assets/modext/sections/context/update.js
@@ -1,10 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({
-        xtype: 'modx-page-context-update'
-        ,context: MODx.request.key
-    });
-});
-
 /** 
  * @class MODx.page.UpdateContext
  * @extends MODx.Component

--- a/manager/assets/modext/sections/context/view.js
+++ b/manager/assets/modext/sections/context/view.js
@@ -1,10 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({
-	   xtype: 'page-context-view'
-	   ,key: MODx.request.key
-	});
-});
-
 /**
  * @class MODx.page.ViewContext
  * @extends MODx.Component

--- a/manager/assets/modext/sections/element/propertyset/index.js
+++ b/manager/assets/modext/sections/element/propertyset/index.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-property-sets' });
-});
-
 /**
  * Loads the property sets page
  * 

--- a/manager/assets/modext/sections/fc/list.js
+++ b/manager/assets/modext/sections/fc/list.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.add('modx-page-form-customization');
-});
-
 MODx.page.FormCustomization = function(config) {
 	config = config || {};
 	Ext.applyIf(config,{

--- a/manager/assets/modext/sections/resource/schedule.js
+++ b/manager/assets/modext/sections/resource/schedule.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.add('modx-page-resource-schedule');
-});
-
 /**
  * Loads the Site Schedule page
  * 

--- a/manager/assets/modext/sections/security/access/list.js
+++ b/manager/assets/modext/sections/security/access/list.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'modx-page-access-permissions' });
-});
-
 /**
  * Loads the access permissions page
  * 

--- a/manager/assets/modext/sections/security/access/policy.js
+++ b/manager/assets/modext/sections/security/access/policy.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'modx-page-access-policies' });
-});
-
 /**
  * Loads the access policies page
  * 

--- a/manager/assets/modext/sections/security/message/list.js
+++ b/manager/assets/modext/sections/security/message/list.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-messages' });
-});
-
 /**
  * @class MODx.page.Messages
  * @extends MODx.Component

--- a/manager/assets/modext/sections/security/permissions/list.js
+++ b/manager/assets/modext/sections/security/permissions/list.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.add('modx-page-groups-roles');
-});
-
 /**
  * Loads the groups and roles page
  * 

--- a/manager/assets/modext/sections/security/resourcegroup/list.js
+++ b/manager/assets/modext/sections/security/resourcegroup/list.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-resource-groups' });
-});
-
 /**
  * Loads the groups and roles page
  * 

--- a/manager/assets/modext/sections/security/user/create.js
+++ b/manager/assets/modext/sections/security/user/create.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'modx-page-user-create' });
-});
-
 /**
  * Loads the create user page 
  * 

--- a/manager/assets/modext/sections/security/user/list.js
+++ b/manager/assets/modext/sections/security/user/list.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'modx-page-users' });
-});
-
 /**
  * Loads the users page
  * 

--- a/manager/assets/modext/sections/system/action.js
+++ b/manager/assets/modext/sections/system/action.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'modx-page-actions'});
-});
-
 /**
  * Loads the actions page
  * 

--- a/manager/assets/modext/sections/system/content.type.js
+++ b/manager/assets/modext/sections/system/content.type.js
@@ -1,6 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-content-type'});
-});
 /**
  * Loads the content type management page
  * 

--- a/manager/assets/modext/sections/system/help.js
+++ b/manager/assets/modext/sections/system/help.js
@@ -1,6 +1,3 @@
-Ext.onReady(function() {
-	MODx.load({ xtype: 'modx-page-help' });
-});
 /**
  * Loads the help page
  * 

--- a/manager/assets/modext/sections/system/import/html.js
+++ b/manager/assets/modext/sections/system/import/html.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-import-html' });
-});
-
 MODx.page.ImportHTML = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/assets/modext/sections/system/import/resource.js
+++ b/manager/assets/modext/sections/system/import/resource.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-import-resource' });
-});
-
 MODx.page.ImportResource = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/assets/modext/sections/system/logs.js
+++ b/manager/assets/modext/sections/system/logs.js
@@ -1,6 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-manager-log' });
-});
 /**
  * Loads the manager log page
  * 

--- a/manager/assets/modext/sections/system/settings.js
+++ b/manager/assets/modext/sections/system/settings.js
@@ -1,6 +1,3 @@
-Ext.onReady(function() {
-    MODx.add('modx-page-system-settings');
-});
 /**
  * Loads the configuration page
  * 

--- a/manager/assets/modext/workspace/index.js
+++ b/manager/assets/modext/workspace/index.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.add('modx-page-workspace');
-});
-
 /**
  * Loads the MODx Workspace environment
  * 

--- a/manager/assets/modext/workspace/lexicon/index.js
+++ b/manager/assets/modext/workspace/lexicon/index.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.add('modx-page-lexicon-management');
-});
-
 /**
  * @class MODx.page.LexiconManagement
  * @extends MODx.Component

--- a/manager/assets/modext/workspace/namespace/index.js
+++ b/manager/assets/modext/workspace/namespace/index.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-namespaces' });
-});
-
 /**
  * @class MODx.page.Namespaces
  * @extends MODx.Component

--- a/manager/assets/modext/workspace/package/index.js
+++ b/manager/assets/modext/workspace/package/index.js
@@ -1,7 +1,3 @@
-Ext.onReady(function() {
-    MODx.load({ xtype: 'modx-page-package' });
-});
-
 MODx.page.Package = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/controllers/default/context/index.class.php
+++ b/manager/controllers/default/context/index.class.php
@@ -25,6 +25,10 @@ class ContextManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.grid.context.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/context/list.js');
+        $this->addHtml("<script>
+            Ext.onReady(function(){
+                MODx.load({ xtype: 'modx-page-contexts' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/context/update.class.php
+++ b/manager/controllers/default/context/update.class.php
@@ -47,12 +47,18 @@ class ContextUpdateManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
-        $this->addHtml('<script type="text/javascript">
-        // <![CDATA[
-        MODx.onContextFormRender = "'.$this->onContextFormRender.'";
-        MODx.ctx = "'.$this->contextKey.'";
-        // ]]>
-        </script>');
+        $this->addHtml("<script>
+            // <![CDATA[
+            MODx.onContextFormRender = '".$this->onContextFormRender."';
+            MODx.ctx = '".$this->contextKey."';
+            Ext.onReady(function() {
+                MODx.load({
+                    xtype: 'modx-page-context-update'
+                    ,context: MODx.request.key
+                });
+            });
+            // ]]>
+            </script>");
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.access.context.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/core/modx.grid.settings.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.grid.context.settings.js');

--- a/manager/controllers/default/context/view.class.php
+++ b/manager/controllers/default/context/view.class.php
@@ -21,7 +21,13 @@ class ContextViewManagerController extends modManagerController {
      * @return void
      */
     public function loadCustomCssJs() {
-        
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({
+                   xtype: 'page-context-view'
+                   ,key: MODx.request.key
+                });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/element/propertyset/index.class.php
+++ b/manager/controllers/default/element/propertyset/index.class.php
@@ -24,6 +24,10 @@ class ElementPropertySetIndexManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.grid.element.properties.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.property.set.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/propertyset/index.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-property-sets' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/help.class.php
+++ b/manager/controllers/default/help.class.php
@@ -23,6 +23,10 @@ class HelpManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/help.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-help' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/resource/site_schedule.class.php
+++ b/manager/controllers/default/resource/site_schedule.class.php
@@ -22,6 +22,10 @@ class ResourceSiteScheduleManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.schedule.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/schedule.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.add('modx-page-resource-schedule');
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/security/forms/index.class.php
+++ b/manager/controllers/default/security/forms/index.class.php
@@ -22,6 +22,10 @@ class SecurityFormsManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.grid.fcprofile.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/fc/list.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.add('modx-page-form-customization');
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/security/message.class.php
+++ b/manager/controllers/default/security/message.class.php
@@ -22,6 +22,10 @@ class SecurityMessageManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.message.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/message/list.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-messages' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/security/permission.class.php
+++ b/manager/controllers/default/security/permission.class.php
@@ -30,6 +30,10 @@ class SecurityPermissionManagerController extends modManagerController {
         $canListPolicies = $this->modx->hasPermission('policy_view') ? 1 : 0;
         $canListPolicyTemplates = $this->modx->hasPermission('policy_template_view') ? 1 : 0;
         $this->addHtml('<script type="text/javascript">MODx.perm.usergroup_view = '.$canListUserGroups.';MODx.perm.view_role = '.$canListRoles.';MODx.perm.policy_view = '.$canListPolicies.';MODx.perm.policy_template_view = '.$canListPolicyTemplates.';</script>');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-groups-roles' });
+            });</script>");
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/permissions/list.js');
     }
 

--- a/manager/controllers/default/security/resourcegroup/index.class.php
+++ b/manager/controllers/default/security/resourcegroup/index.class.php
@@ -24,6 +24,10 @@ class SecurityResourceGroupIndexManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.tree.resource.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.resource.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/resourcegroup/list.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-resource-groups' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/security/user/create.class.php
+++ b/manager/controllers/default/security/user/create.class.php
@@ -27,6 +27,9 @@ class SecurityUserCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.user.js');
         $this->addHtml('<script type="text/javascript">
         // <![CDATA[
+        Ext.onReady(function() {
+            MODx.load({ xtype: "modx-page-user-create" });
+        });
         MODx.onUserFormRender = "'.$this->onUserFormRender.'";
         // ]]>
         </script>');

--- a/manager/controllers/default/security/user/index.class.php
+++ b/manager/controllers/default/security/user/index.class.php
@@ -22,6 +22,10 @@ class SecurityUserManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/user/list.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-users' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/system/action.class.php
+++ b/manager/controllers/default/system/action.class.php
@@ -27,6 +27,10 @@ class SystemActionManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.tree.menu.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.panel.actions.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/action.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-actions'});
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/system/contenttype.class.php
+++ b/manager/controllers/default/system/contenttype.class.php
@@ -19,6 +19,10 @@ class SystemContentTypeManagerController extends modManagerController {
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/system/modx.grid.content.type.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/content.type.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-content-type'});
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/system/import/html.class.php
+++ b/manager/controllers/default/system/import/html.class.php
@@ -23,6 +23,10 @@ class SystemImportHtmlManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.tree.resource.simple.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.panel.import.html.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/import/html.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-import-html' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/system/import/index.class.php
+++ b/manager/controllers/default/system/import/index.class.php
@@ -23,6 +23,10 @@ class SystemImportManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.tree.resource.simple.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.panel.import.resources.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/import/resource.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-import-resource' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/system/logs/index.class.php
+++ b/manager/controllers/default/system/logs/index.class.php
@@ -21,6 +21,10 @@ class SystemLogsIndexManagerController extends modManagerController {
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/system/modx.grid.manager.log.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/logs.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-manager-log' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -22,6 +22,9 @@ class SystemSettingsManagerController extends modManagerController {
     public function loadCustomCssJs() {
         $this->addHtml('<script type="text/javascript">
         // <[!CDATA[
+        Ext.onReady(function() {
+            MODx.add("modx-page-system-settings");
+        });
         MODx.onSiteSettingsRender = "'.$this->onSiteSettingsRender.'";
         // ]]>
         </script>');

--- a/manager/controllers/default/workspaces/index.class.php
+++ b/manager/controllers/default/workspaces/index.class.php
@@ -55,6 +55,10 @@ class WorkspacesManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/workspace/provider.grid.js');
         $this->addJavascript($mgrUrl.'assets/modext/workspace/workspace.panel.js');
         $this->addJavascript($mgrUrl.'assets/modext/util/lightbox.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.add('modx-page-workspace');
+            });</script>");
         $this->addHtml('<script type="text/javascript">MODx.defaultProvider = "'.$this->providerId.'";MODx.provider = "'.$this->providerId.'";MODx.providerName = "'.$this->providerName.'";MODx.curlEnabled = '.($this->curlEnabled ? 1 : 0).'; Ext.ux.Lightbox.register("a.lightbox");</script>');
         $this->addJavascript($mgrUrl.'assets/modext/workspace/index.js');
     }

--- a/manager/controllers/default/workspaces/index.class.php
+++ b/manager/controllers/default/workspaces/index.class.php
@@ -57,9 +57,9 @@ class WorkspacesManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/util/lightbox.js');
         $this->addHtml("<script>
             Ext.onReady(function() {
+                MODx.defaultProvider = '".$this->providerId."';MODx.provider = '".$this->providerId."';MODx.providerName = '".$this->providerName."';MODx.curlEnabled = ".(integer)$this->curlEnabled."; Ext.ux.Lightbox.register('a.lightbox');
                 MODx.add('modx-page-workspace');
             });</script>");
-        $this->addHtml('<script type="text/javascript">MODx.defaultProvider = "'.$this->providerId.'";MODx.provider = "'.$this->providerId.'";MODx.providerName = "'.$this->providerName.'";MODx.curlEnabled = '.($this->curlEnabled ? 1 : 0).'; Ext.ux.Lightbox.register("a.lightbox");</script>');
         $this->addJavascript($mgrUrl.'assets/modext/workspace/index.js');
     }
 

--- a/manager/controllers/default/workspaces/lexicon.class.php
+++ b/manager/controllers/default/workspaces/lexicon.class.php
@@ -25,6 +25,10 @@ class WorkspacesLexiconManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/workspace/lexicon/lexicon.grid.js');
         $this->addJavascript($mgrUrl.'assets/modext/workspace/lexicon/lexicon.panel.js');
         $this->addJavascript($mgrUrl.'assets/modext/workspace/lexicon/index.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.add('modx-page-lexicon-management');
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/workspaces/namespace.class.php
+++ b/manager/controllers/default/workspaces/namespace.class.php
@@ -25,6 +25,10 @@ class WorkspacesNamespaceManagerController extends modManagerController {
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/workspace/namespace/modx.namespace.panel.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/workspace/namespace/index.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-namespaces' });
+            });</script>");
     }
 
     /**

--- a/manager/controllers/default/workspaces/package/view.class.php
+++ b/manager/controllers/default/workspaces/package/view.class.php
@@ -24,6 +24,10 @@ class WorkspacesPackageViewManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/workspace/package/package.versions.grid.js');
         $this->addJavascript($mgrUrl.'assets/modext/workspace/package/package.panel.js');
         $this->addJavascript($mgrUrl.'assets/modext/workspace/package/index.js');
+        $this->addHtml("<script>
+            Ext.onReady(function() {
+                MODx.load({ xtype: 'modx-page-package' });
+            });</script>");
     }
 
     /**


### PR DESCRIPTION
This allows:
- Asynchronously load modext files (for that they should not contain Ext.onReady calls)
- Initialize panels dynamically, without dependence on external js files loading.
