### PR TITLE
MODx:beforeLoadPage javascript event

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -296,7 +296,7 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
             }
         } else { /* if just doing a URL redirect */
             Ext.applyIf(itm.params || {},o.baseParams || {});
-            location.href = '?'+Ext.urlEncode(itm.params);
+            MODx.loadPage('?'+Ext.urlEncode(itm.params));
         }
         return false;
     }
@@ -347,7 +347,7 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     } else if (itm.process === 'delete') {
                         itm.params.a = o.actions.cancel;
                         url = Ext.urlEncode(itm.params);
-                        location.href = '?'+url;
+                        MODx.loadPage('?'+url);
                     }
                 }
                 break;

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -325,8 +325,8 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     if (MODx.request.parent) { itm.params.parent = MODx.request.parent; }
                     if (MODx.request.context_key) { itm.params.context_key = MODx.request.context_key; }
                     if (MODx.request.class_key) { itm.params.class_key = MODx.request.class_key; }
-                    var a = Ext.urlEncode(itm.params);
-                    location.href = '?a='+o.actions['new']+'&'+a;
+                    var params = Ext.urlEncode(itm.params);
+                    MODx.loadPage(o.actions['new'], params);
                 }
                 break;
             case 'stay':
@@ -337,12 +337,12 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     /* if Continue Editing, then don't reload the page - just hide the Progress bar
                        unless the user is on a 'Create' page...if so, then redirect
                        to the proper Edit page */
-                    if ((itm.process === 'create' || itm.process === 'duplicate' || itm.reload) && res.object.id && res.object.id !== null) {
+                    if ((itm.process === 'create' || itm.process === 'duplicate' || itm.reload) && res.object.id) {
                         itm.params.id = res.object.id;
                         if (MODx.request.parent) { itm.params.parent = MODx.request.parent; }
                         if (MODx.request.context_key) { itm.params.context_key = MODx.request.context_key; }
                         url = Ext.urlEncode(itm.params);
-                        location.href = '?a='+o.actions.edit+'&'+url;
+                        MODx.loadPage(o.actions.edit, url);
 
                     } else if (itm.process === 'delete') {
                         itm.params.a = o.actions.cancel;
@@ -355,7 +355,7 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                 if (o.form.hasListener('actionClose')) {
                     o.form.fireEvent('actionClose',itm.params);
                 } else if (o.actions) {
-                    location.href = '?a='+o.actions.cancel+'&'+Ext.encode(itm.params);
+                    MODx.loadPage(o.actions.cancel, Ext.encode(itm.params));
                 }
                 break;
         }

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -48,6 +48,7 @@ Ext.extend(MODx,Ext.Component,{
             beforeClearCache: true
             ,beforeLogout: true
             ,beforeReleaseLocks: true
+            ,beforeLoadPage: true
             ,afterClearCache: true
             ,afterLogout: true
             ,afterReleaseLocks: true

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -208,7 +208,7 @@ MODx.LayoutMgr = function() {
     var _activeMenu = 'menu0';
     return {
         loadPage: function(a,p) {
-            location.href = '?a='+a+'&'+(p || '');
+            location.href = '?a=' + a + (p ? '&' + p : '');
             return false;
         }
         ,changeMenu: function(a,sm) {

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -207,9 +207,22 @@ Ext.reg('modx-layout',MODx.Layout);
 MODx.LayoutMgr = function() {
     var _activeMenu = 'menu0';
     return {
-        loadPage: function(a,p) {
-            location.href = '?a=' + a + (p ? '&' + p : '');
-            return false;
+        loadPage: function(action, parameters) {
+            var url = '';
+            // Handles url, passed as first argument
+            if (isNaN(action)) {
+                url = action;
+            } else {
+                var parts = [];
+                if (action) {
+                    parts.push('a=' + action);
+                }
+                if (parameters) {
+                    parts.push(parameters);
+                }
+                url = '?' + parts.join('&');
+            }
+            location.href = url;
         }
         ,changeMenu: function(a,sm) {
             if (sm === _activeMenu) return false;

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -222,7 +222,9 @@ MODx.LayoutMgr = function() {
                 }
                 url = '?' + parts.join('&');
             }
-            location.href = url;
+            if (MODx.fireEvent('beforeLoadPage', url)) {
+                location.href = url;
+            }
         }
         ,changeMenu: function(a,sm) {
             if (sm === _activeMenu) return false;

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -62,10 +62,10 @@ Ext.extend(MODx.page.ResourceData,MODx.Component,{
         return false;
     }
     ,editResource: function() {
-        location.href = '?a='+MODx.action['resource/update']+'&id='+this.config.record.id;
+        MODx.loadPage(MODx.action['resource/update'], 'id='+this.config.record.id);
     }
     ,cancel: function() {
-        location.href = '?a='+MODx.action['welcome'];
+        MODx.loadPage(MODx.action['welcome']);
     }
 });
 Ext.reg('modx-page-resource-data',MODx.page.ResourceData);

--- a/manager/assets/modext/sections/resource/static/update.js
+++ b/manager/assets/modext/sections/resource/static/update.js
@@ -56,7 +56,7 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -72,7 +72,7 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -85,12 +85,12 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     ,getButtons: function(cfg) {

--- a/manager/assets/modext/sections/resource/symlink/update.js
+++ b/manager/assets/modext/sections/resource/symlink/update.js
@@ -52,7 +52,7 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -68,7 +68,7 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -81,12 +81,12 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -71,7 +71,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -87,7 +87,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -100,12 +100,12 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     

--- a/manager/assets/modext/sections/resource/weblink/update.js
+++ b/manager/assets/modext/sections/resource/weblink/update.js
@@ -52,7 +52,7 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -68,7 +68,7 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    location.href = '?a='+MODx.action['resource/update']+'&id='+r.object.id;
+                    MODx.loadPage(MODx.action['resource/update'], 'id='+r.object.id);
                 },scope:this}
             }
         });
@@ -81,12 +81,12 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    location.href = '?a='+MODx.action['welcome'];                    
+                    MODx.loadPage(MODx.action['welcome']);
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            location.href = '?a='+MODx.action['welcome'];
+            MODx.loadPage(MODx.action['welcome']);
         }
     }
     

--- a/manager/assets/modext/sections/security/user/update.js
+++ b/manager/assets/modext/sections/security/user/update.js
@@ -54,9 +54,9 @@ Ext.extend(MODx.page.UpdateUser,MODx.Component,{
                 ,id: this.config.user
             }
             ,listeners: {
-            	'success': {fn:function(r) {
-            	    location.href = '?a='+MODx.action['security/user'];
-            	},scope:this}
+                'success': {fn:function(r) {
+                    MODx.loadPage(MODx.action['security/user']);
+                },scope:this}
             }
         });
     }

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -131,7 +131,7 @@ Ext.extend(MODx.panel.CreateFile,MODx.FormPanel,{
         return true;
     }
     ,success: function(r) {
-        location.href = 'index.php?a='+MODx.action['system/file/edit']+'&file='+r.result.object.file+'&source='+MODx.request.source;
+        MODx.loadPage(MODx.action['system/file/edit'], 'file='+r.result.object.file+'&source='+MODx.request.source);
     }
     ,beforeSubmit: function(o) {
         this.cleanupEditor();

--- a/manager/assets/modext/widgets/core/modx.tree.js
+++ b/manager/assets/modext/widgets/core/modx.tree.js
@@ -408,7 +408,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
         if (this.disableHref) {return true;}
         if (e.ctrlKey) {return true;}
         if (n.attributes.page && n.attributes.page !== '') {
-            location.href = n.attributes.page;
+            MODx.loadPage(n.attributes.page);
         } else {
             n.toggle();
         }
@@ -504,7 +504,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
      * @param {String} loc The URL to direct to.
      */
     ,redirect: function(loc) {
-        location.href = loc;
+        MODx.loadPage(loc);
     }
 	
     ,loadAction: function(p) {
@@ -513,7 +513,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
             var pid = this.cm.activeNode.id.split('_');
             id = 'id='+pid[1];
         }
-        location.href = 'index.php?'+id+'&'+p;
+        MODx.loadPage('?'+id+'&'+p);
     }
     /**
      * Loads the default toolbar for the tree.

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -178,7 +178,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                     this.cm.activeNode.remove();
                     /* if editing the element being removed */
                     if (MODx.request.a == MODx.action['element/'+oar[0]+'/update'] && MODx.request.id == oar[2]) {
-                        location.href = 'index.php?a='+MODx.action['welcome'];
+                        MODx.loadPage(MODx.action['welcome']);
                     }
                 },scope:this}
             }
@@ -391,9 +391,8 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                 ,type: a.type
                 ,pk: a.pk
                 ,handler: function(itm,e) {
-                    location.href = 'index.php?a='
-                        + MODx.action['element/'+itm.type+'/update']
-                        + '&id='+itm.pk;
+                    MODx.loadPage(MODx.action['element/'+itm.type+'/update'],
+                        'id='+itm.pk);
                 }
             });
             m.push({

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -129,8 +129,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             }
         }
         var object = o.result.object;
-        if (this.config.resource && (object.class_key != this.defaultClassKey || object.parent != this.defaultValues.parent)) {
-            MODx.loadPage(object.action, 'id=' + object.id);
+        // object.parent is undefined on template changing.
+        if (this.config.resource && object.parent !== undefined && (object.class_key != this.defaultClassKey || object.parent != this.defaultValues.parent)) {
+            MODx.loadPage(location.href);
         } else {
             this.getForm().setValues(object);
             Ext.getCmp('modx-page-update-resource').config.preview_url = object.preview_url;

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -128,13 +128,12 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 t.refreshNode(v,true);
             }
         }
-        if (o.result.object.class_key != this.defaultClassKey && this.config.resource != '' && this.config.resource != 0) {
-            location.href = location.href;
-        } else if (o.result.object['parent'] != this.defaultValues['parent'] && this.config.resource != '' && this.config.resource != 0) {
-            location.href = location.href;
+        var object = o.result.object;
+        if (this.config.resource && (object.class_key != this.defaultClassKey || object.parent != this.defaultValues.parent)) {
+            MODx.loadPage(object.action, 'id=' + object.id);
         } else {
-            this.getForm().setValues(o.result.object);
-            Ext.getCmp('modx-page-update-resource').config.preview_url = o.result.object.preview_url;
+            this.getForm().setValues(object);
+            Ext.getCmp('modx-page-update-resource').config.preview_url = object.preview_url;
         }
     }
     ,failure: function(o) {
@@ -165,7 +164,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     f.config.action = 'reload';
                     MODx.activePage.submitForm({
                         success: {fn:function(r) {
-                            location.href = '?a='+MODx.action[r.result.object.action]+'&class_key='+ r.result.object.class_key+'&id='+r.result.object.id+'&reload='+r.result.object.reload;
+                            MODx.loadPage(MODx.action[r.result.object.action], 'id='+r.result.object.id+'&reload='+r.result.object.reload + '&class_key='+ r.result.object.class_key);
                         },scope:this}
                     },{
                         bypassValidCheck: true

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -136,7 +136,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
     }
 
     ,editPolicy: function(itm,e) {
-        location.href = '?a='+MODx.action['security/access/policy/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['security/access/policy/update'], 'id='+this.menu.record.id);
     }
     
     ,createPolicy: function(btn,e) {

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -138,7 +138,7 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
         this.refresh();
     }
     ,editPolicyTemplate: function(itm,e) {
-        location.href = '?a='+MODx.action['security/access/policy/template/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['security/access/policy/template/update'], 'id='+this.menu.record.id);
     }
     
     ,createPolicyTemplate: function(btn,e) {

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -198,7 +198,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
 
     ,createUser: function() {
-        location.href = 'index.php?a='+MODx.action['security/user/create'];
+        MODx.loadPage(MODx.action['security/user/create']);
     }
 
     ,activateSelected: function() {
@@ -290,7 +290,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
     
     ,updateUser: function() {
-        location.href = 'index.php?a='+MODx.action['security/user/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['security/user/update'], 'id='+this.menu.record.id);
     }
     				
     ,rendGender: function(d,c) {

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -100,14 +100,14 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                 ,buttons: Ext.Msg.OK
                 ,fn: function(btn) {
                     if (userId == 0) {
-                        location.href = '?a='+MODx.action['security/user']+'&id='+o.result.object.id;
+                        MODx.loadPage(MODx.action['security/user'], 'id='+o.result.object.id);
                     }
                     return false;
                 }
             });
             this.clearDirty();
         } else if (userId == 0) {
-            location.href = '?a='+MODx.action['security/user']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['security/user'], 'id='+o.result.object.id);
         }
     }
     

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -78,9 +78,7 @@ Ext.extend(MODx.tree.UserGroup,MODx.tree.Tree,{
         var n = this.cm.activeNode;
         var id = n.id.substr(2).split('_');id = id[1];
         
-        location.href = 'index.php'
-            + '?a=' + MODx.action['security/usergroup/update']
-            + '&id=' + id;
+        MODx.loadPage(MODx.action['security/usergroup/update'], 'id=' + id);
     }
 
     ,getMenu: function() {

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -208,7 +208,7 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
     }
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            location.href = '?a='+MODx.action['source/update']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['source/update'], 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-btn-save').setDisabled(false);
             var wg = Ext.getCmp('modx-grid-source-properties');

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -164,7 +164,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         });
     }
     ,createSource: function() {
-        location.href = 'index.php?a='+MODx.action['system/source/create'];
+        MODx.loadPage(MODx.action['system/source/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -204,7 +204,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
     }
 
     ,updateSource: function() {
-        location.href = 'index.php?a='+MODx.action['source/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['source/update'], 'id='+this.menu.record.id);
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
@@ -335,7 +335,7 @@ Ext.extend(MODx.grid.SourceTypes,MODx.grid.Grid,{
     }
 
     ,createSourceType: function() {
-        location.href = 'index.php?a='+MODx.action['system/source/type/create'];
+        MODx.loadPage(MODx.action['system/source/type/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -375,7 +375,7 @@ Ext.extend(MODx.grid.SourceTypes,MODx.grid.Grid,{
     }
 
     ,updateSourceType: function() {
-        location.href = 'index.php?a='+MODx.action['source/type/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['source/type/update'], 'id='+this.menu.record.id);
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -59,7 +59,7 @@ MODx.grid.Context = function(config) {
 };
 Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
     updateContext: function(itm,e) {
-        location.href = 'index.php?a='+MODx.action['context/update']+'&key='+this.menu.record.key;
+        MODx.loadPage(MODx.action['context/update'], 'key='+this.menu.record.key);
     }
     ,getMenu: function() {
         var r = this.getSelectionModel().getSelected();

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -107,7 +107,7 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
     }
 
     ,createDashboard: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/widget/create'];
+        MODx.loadPage(MODx.action['system/dashboards/widget/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -147,7 +147,7 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
     }
 
     ,updateWidget: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/widget/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['system/dashboards/widget/update'], 'id='+this.menu.record.id);
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -170,7 +170,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
     }
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            location.href = '?a='+MODx.action['system/dashboards/update']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['system/dashboards/update'], 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-btn-save').setDisabled(false);
             var wg = Ext.getCmp('modx-grid-dashboard-widget-placements');

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -259,7 +259,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
     }
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            location.href = '?a='+MODx.action['system/dashboards/widget/update']+'&id='+o.result.object.id;
+            MODx.loadPage(MODx.action['system/dashboards/widget/update'], 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-btn-save').setDisabled(false);
             var g = Ext.getCmp('modx-grid-dashboard-widget-dashboards');

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -170,7 +170,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
     }
 
     ,createDashboard: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/create'];
+        MODx.loadPage(MODx.action['system/dashboards/create']);
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -223,7 +223,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
     }
 
     ,updateDashboard: function() {
-        location.href = 'index.php?a='+MODx.action['system/dashboards/update']+'&id='+this.menu.record.id;
+        MODx.loadPage(MODx.action['system/dashboards/update'], 'id='+this.menu.record.id);
     }
     
     ,filterUsergroup: function(cb,nv,ov) {

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -279,7 +279,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 	
 	/* Go to package details @TODO : Stay on the same page */
     ,viewPackage: function(btn,e) {
-        location.href = 'index.php?a='+MODx.action['workspaces/package/view']+'&signature='+this.menu.record.signature;
+        MODx.loadPage(MODx.action['workspaces/package/view'], 'signature='+this.menu.record.signature);
     }
     
 	/* Search for a package update - only for installed package */

--- a/manager/assets/modext/workspace/package/index.js
+++ b/manager/assets/modext/workspace/package/index.js
@@ -25,7 +25,7 @@ MODx.page.Package = function(config) {
             process: 'cancel'
             ,text: _('cancel')
             ,handler: function() {
-                location.href= '?a='+MODx.action['workspaces'];
+                MODx.loadPage(MODx.action['workspaces']);
             }
         },'-',{
             text: _('help_ex')


### PR DESCRIPTION
Less changes = less head ache.
I replaced almost all direct location changes by MODx.loadPage proxy to allow to handle page loading. This is used by http://modx.com/extras/package/ajaxmanager
My last three patches add ability of ajax page reloading (via plugin) to MODx Manager.

Later, we can build ajax page switching in MODx itself.
