### PR TITLE
[ReUp][#8489] add a new index in the site_tmplvar_contentvalues table

### DIFF
--- a/core/model/modx/mysql/modtemplatevarresource.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevarresource.map.inc.php
@@ -75,6 +75,28 @@ $xpdo_meta_map['modTemplateVarResource']= array (
         ),
       ),
     ),
+    'tv_cnt' => 
+    array (
+      'alias' => 'tv_cnt',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'tmplvarid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'contentid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
   ),
   'aggregates' => 
   array (

--- a/core/model/modx/sqlsrv/modtemplatevarresource.map.inc.php
+++ b/core/model/modx/sqlsrv/modtemplatevarresource.map.inc.php
@@ -74,6 +74,28 @@ $xpdo_meta_map['modTemplateVarResource']= array (
         ),
       ),
     ),
+    'tv_cnt' => 
+    array (
+      'alias' => 'tv_cnt',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'tmplvarid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'contentid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
   ),
   'aggregates' => 
   array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1119,6 +1119,10 @@
         <index alias="contentid" name="contentid" primary="false" unique="false" type="BTREE">
             <column key="contentid" length="" collation="A" null="false" />
         </index>
+        <index alias="tv_cnt" name="tv_cnt" primary="false" unique="false" type="BTREE">
+            <column key="contentid" length="" collation="A" null="false" />
+            <column key="tmplvarid" length="" collation="A" null="false" />
+        </index>
 
         <aggregate alias="TemplateVar" class="modTemplateVar" local="tmplvarid" foreign="id" cardinality="one" owner="foreign" />
         <aggregate alias="Resource" class="modResource" local="contentid" foreign="id" cardinality="one" owner="foreign" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -1106,6 +1106,10 @@
         <index alias="contentid" name="contentid" primary="false" unique="false" type="BTREE">
             <column key="contentid" length="" collation="A" null="false" />
         </index>
+        <index alias="tv_cnt" name="tv_cnt" primary="false" unique="false" type="BTREE">
+            <column key="contentid" length="" collation="A" null="false" />
+            <column key="tmplvarid" length="" collation="A" null="false" />
+        </index>
 
         <aggregate alias="TemplateVar" class="modTemplateVar" local="tmplvarid" foreign="id" cardinality="one" owner="foreign" />
         <aggregate alias="Resource" class="modResource" local="contentid" foreign="id" cardinality="one" owner="foreign" />


### PR DESCRIPTION
Fix for unoptimal MySQL behavior (prior to 5.1).

This behavior appears on sites with large amount (more than 1000) of resources and corresponding TVs while using getResources to display some pages. Seems that MySQL < 5.1 can't merge indexes on complex queries with LEFT JOINs, eg.:

``` sql
SELECT
COUNT(DISTINCT modResource.id)
FROM
modx_site_content modResource
JOIN
modx_site_tmplvar_templates tv_tmpl
ON
modResource.template = tv_tmpl.templateid
JOIN
modx_site_tmplvars tv
ON
tv.id = tv_tmpl.tmplvarid
LEFT JOIN
modx_site_tmplvar_contentvalues tvr
ON
tvr.tmplvarid = tv_tmpl.tmplvarid
AND tvr.contentid = modResource.id
```

Also this commit closes ticket http://tracker.modx.com/issues/8489
