### PR TITLE
[#9690] ensure server_offset_time always handled as hours

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -522,7 +522,7 @@ class modCacheManager extends xPDOCacheManager {
         $publishingResults= array();
         /* publish and unpublish resources using pub_date and unpub_date checks */
         $tblResource= $this->modx->getTableName('modResource');
-        $timeNow= time() + $this->modx->getOption('server_offset_time', null, 0);
+        $timeNow= time() + floatval($this->modx->getOption('server_offset_time', null, 0)) * 3600;
         $publishingResults['published']= $this->modx->exec("UPDATE {$tblResource} SET published=1, publishedon=pub_date, pub_date=0 WHERE pub_date IS NOT NULL AND pub_date < {$timeNow} AND pub_date > 0");
         $publishingResults['unpublished']= $this->modx->exec("UPDATE $tblResource SET published=0, publishedon=0, pub_date=0, unpub_date=0 WHERE unpub_date IS NOT NULL AND unpub_date < {$timeNow} AND unpub_date > 0");
 

--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -480,7 +480,7 @@ class modRequest {
             xPDO::OPT_CACHE_HANDLER => $this->modx->getOption('cache_auto_publish_handler', null, $this->modx->getOption(xPDO::OPT_CACHE_HANDLER))
         ));
         if ($cacheRefreshTime > 0) {
-            $timeNow= time() + $this->modx->getOption('server_offset_time', null, 0);
+            $timeNow= time() + floatval($this->modx->getOption('server_offset_time', null, 0)) * 3600;
             if ($cacheRefreshTime <= $timeNow) {
                 $this->modx->cacheManager->refresh();
             }

--- a/core/model/modx/processors/resource/data.class.php
+++ b/core/model/modx/processors/resource/data.class.php
@@ -78,18 +78,18 @@ class modResourceDataProcessor extends modProcessor {
         $resourceArray['unpub_date'] = !empty($resourceArray['unpub_date']) && $resourceArray['unpub_date'] != $emptyDate ? $resourceArray['unpub_date'] : $this->modx->lexicon('none');
         $resourceArray['status'] = $resourceArray['published'] ? $this->modx->lexicon('resource_published') : $this->modx->lexicon('resource_unpublished');
         
-        $server_offset_time= intval($this->modx->getOption('server_offset_time',null,0));
-        $resourceArray['createdon_adjusted'] = strftime('%c', strtotime($this->resource->get('createdon')) + $server_offset_time);
+        $server_offset_time_seconds = floatval($this->modx->getOption('server_offset_time',null,0)) * 3600 ;
+        $resourceArray['createdon_adjusted'] = strftime('%c', strtotime($this->resource->get('createdon')) + $server_offset_time_seconds);
         $resourceArray['createdon_by'] = $this->resource->get('creator');
         if (!empty($resourceArray['editedon']) && $resourceArray['editedon'] != $emptyDate) {
-            $resourceArray['editedon_adjusted'] = strftime('%c', strtotime($this->resource->get('editedon')) + $server_offset_time);
+            $resourceArray['editedon_adjusted'] = strftime('%c', strtotime($this->resource->get('editedon')) + $server_offset_time_seconds);
             $resourceArray['editedon_by'] = $this->resource->get('editor');
         } else {
             $resourceArray['editedon_adjusted'] = $this->modx->lexicon('none');
             $resourceArray['editedon_by'] = $this->modx->lexicon('none');
         }
         if (!empty($resourceArray['publishedon']) && $resourceArray['publishedon'] != $emptyDate) {
-            $resourceArray['publishedon_adjusted'] = strftime('%c', strtotime($this->resource->get('editedon')) + $server_offset_time);
+            $resourceArray['publishedon_adjusted'] = strftime('%c', strtotime($this->resource->get('editedon')) + $server_offset_time_seconds);
             $resourceArray['publishedon_by'] = $this->resource->get('publisher');
         } else {
             $resourceArray['publishedon_adjusted'] = $this->modx->lexicon('none');

--- a/core/model/modx/processors/resource/event/getlist.class.php
+++ b/core/model/modx/processors/resource/event/getlist.class.php
@@ -26,7 +26,7 @@ class modResourceEventGetListProcessor extends modProcessor {
             'mode' => 'pub_date',
             'dir' => 'ASC',
             'timeFormat' => '%a %b %d, %Y',
-            'offset' => $this->modx->getOption('server_offset_time',null,0) * 60 * 60,
+            'offset' => floatval($this->modx->getOption('server_offset_time',null,0)) * 3600,
         ));
         return true;
     }

--- a/core/model/modx/processors/system/info.class.php
+++ b/core/model/modx/processors/system/info.class.php
@@ -14,7 +14,7 @@ class modSystemInfoProcessor extends modProcessor {
         $data = array();
 
         $this->modx->getVersionData();
-        $serverOffset = $this->modx->getOption('server_offset_time',null,0) * 60 * 60;
+        $serverOffset = floatval($this->modx->getOption('server_offset_time',null,0)) * 3600;
 
         /* general */
         $data['modx_version'] = $this->modx->version['full_appname'];

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -9,7 +9,7 @@
  */
 class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
     public function render() {
-        $timetocheck = (time()-(60*20))+$this->modx->getOption('server_offset_time',null,0);
+        $timetocheck = (time()-(60*20))+floatval($this->modx->getOption('server_offset_time',null,0)) * 3600;
         $c = $this->modx->newQuery('modManagerLog');
         $c->innerJoin('modUser','User');
 
@@ -40,7 +40,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
         
         $output = $this->getFileChunk('dashboard/onlineusers.tpl',array(
             'users' => implode("\n",$users),
-            'curtime' => strftime('%I:%M %p',time()+$this->modx->getOption('server_offset_time',null,0)),
+            'curtime' => strftime('%I:%M %p',time()+floatval($this->modx->getOption('server_offset_time',null,0)) * 3600),
         ));
         return $output;
     }

--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -66,9 +66,9 @@ class ResourceDataManagerController extends ResourceManagerController {
         $this->resource->getOne('EditedBy');
         $this->resource->getOne('Template');
 
-        $server_offset_time= intval($this->modx->getOption('server_offset_time',null,0));
-        $this->resource->set('createdon_adjusted',strftime('%c', $this->resource->get('createdon') + $server_offset_time));
-        $this->resource->set('editedon_adjusted',strftime('%c', $this->resource->get('editedon') + $server_offset_time));
+        $server_offset_time_seconds = floatval($this->modx->getOption('server_offset_time',null,0)) * 3600;
+        $this->resource->set('createdon_adjusted',strftime('%c', $this->resource->get('createdon') + $server_offset_time_seconds));
+        $this->resource->set('editedon_adjusted',strftime('%c', $this->resource->get('editedon') + $server_offset_time_seconds));
 
         $this->resource->_contextKey= $this->resource->get('context_key');
         $buffer = $this->modx->cacheManager->get($this->resource->getCacheKey(), array(


### PR DESCRIPTION
Cursory testing shows auto publishing working now when there is a server_offset_time. Auto-publishing behaves according to users' "local time".
