### PR TITLE
Fixtimeoffset

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -527,7 +527,7 @@ class modCacheManager extends xPDOCacheManager {
         $publishingResults= array();
         /* publish and unpublish resources using pub_date and unpub_date checks */
         $tblResource= $this->modx->getTableName('modResource');
-        $timeNow= time() + $this->modx->getOption('server_offset_time', null, 0);
+        $timeNow= time();
         $publishingResults['published']= $this->modx->exec("UPDATE {$tblResource} SET published=1, publishedon=pub_date, pub_date=0 WHERE pub_date IS NOT NULL AND pub_date < {$timeNow} AND pub_date > 0");
         $publishingResults['unpublished']= $this->modx->exec("UPDATE $tblResource SET published=0, publishedon=0, pub_date=0, unpub_date=0 WHERE unpub_date IS NOT NULL AND unpub_date < {$timeNow} AND unpub_date > 0");
 

--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -480,7 +480,7 @@ class modRequest {
             xPDO::OPT_CACHE_HANDLER => $this->modx->getOption('cache_auto_publish_handler', null, $this->modx->getOption(xPDO::OPT_CACHE_HANDLER))
         ));
         if ($cacheRefreshTime > 0) {
-            $timeNow= time() + $this->modx->getOption('server_offset_time', null, 0);
+            $timeNow= time();
             if ($cacheRefreshTime <= $timeNow) {
                 $this->modx->cacheManager->refresh();
             }

--- a/core/model/modx/processors/resource/data.class.php
+++ b/core/model/modx/processors/resource/data.class.php
@@ -78,7 +78,7 @@ class modResourceDataProcessor extends modProcessor {
         $resourceArray['unpub_date'] = !empty($resourceArray['unpub_date']) && $resourceArray['unpub_date'] != $emptyDate ? $resourceArray['unpub_date'] : $this->modx->lexicon('none');
         $resourceArray['status'] = $resourceArray['published'] ? $this->modx->lexicon('resource_published') : $this->modx->lexicon('resource_unpublished');
         
-        $server_offset_time= intval($this->modx->getOption('server_offset_time',null,0));
+        $server_offset_time= floatval($this->modx->getOption('server_offset_time',null,0)) * 3600;
         $resourceArray['createdon_adjusted'] = strftime('%c', strtotime($this->resource->get('createdon')) + $server_offset_time);
         $resourceArray['createdon_by'] = $this->resource->get('creator');
         if (!empty($resourceArray['editedon']) && $resourceArray['editedon'] != $emptyDate) {

--- a/core/model/modx/processors/resource/event/getlist.class.php
+++ b/core/model/modx/processors/resource/event/getlist.class.php
@@ -26,7 +26,7 @@ class modResourceEventGetListProcessor extends modProcessor {
             'mode' => 'pub_date',
             'dir' => 'ASC',
             'timeFormat' => '%a %b %d, %Y',
-            'offset' => $this->modx->getOption('server_offset_time',null,0) * 60 * 60,
+            'offset' => floatval($this->modx->getOption('server_offset_time',null,0)) * 3600,
         ));
         return true;
     }

--- a/core/model/modx/processors/system/info.class.php
+++ b/core/model/modx/processors/system/info.class.php
@@ -14,7 +14,7 @@ class modSystemInfoProcessor extends modProcessor {
         $data = array();
 
         $this->modx->getVersionData();
-        $serverOffset = $this->modx->getOption('server_offset_time',null,0) * 60 * 60;
+        $serverOffset = floatval($this->modx->getOption('server_offset_time',null,0)) * 3600;
 
         /* general */
         $data['modx_version'] = $this->modx->version['full_appname'];

--- a/manager/assets/modext/util/datetime.js
+++ b/manager/assets/modext/util/datetime.js
@@ -468,7 +468,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      */
     ,setDate:function(date) {
         if (date && this.offset_time != 0) {
-            date = date.add(Date.HOUR, new Number(this.offset_time));
+            date = date.add(Date.MINUTE, 60 * new Number(this.offset_time));
         }
         this.df.setValue(date);
     } // eo function setDate
@@ -479,7 +479,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      */
     ,setTime:function(date) {
         if (date && this.offset_time != 0) {
-            date = date.add(Date.HOUR, new Number(this.offset_time));
+            date = date.add(Date.MINUTE, 60 * new Number(this.offset_time));
         }
         this.tf.setValue(date);
     } // eo function setTime
@@ -643,7 +643,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         if(this.isRendered) {
             var value = '';
             if (this.dateValue instanceof Date) {
-                value = this.dateValue.add(Date.HOUR, 0 - new Number(this.offset_time)).format(this.hiddenFormat);
+                value = this.dateValue.add(Date.MINUTE, 0 - 60 * new Number(this.offset_time)).format(this.hiddenFormat);
             }
             this.el.dom.value = value;
         }

--- a/manager/assets/modext/util/datetime.js
+++ b/manager/assets/modext/util/datetime.js
@@ -79,6 +79,11 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         // call parent initComponent
         Ext.ux.form.DateTime.superclass.initComponent.call(this);
 
+        // offset time
+        if (!this.hasOwnProperty('offset_time') || isNaN(this.offset_time)) {
+            this.offset_time = 0;
+        }
+
         // create DateField
         var dateConfig = Ext.apply({}, {
              id:this.id + '-date'
@@ -462,6 +467,9 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      * @private Sets the value of DateField
      */
     ,setDate:function(date) {
+        if (date && this.offset_time != 0) {
+            date = date.add(Date.HOUR, new Number(this.offset_time));
+        }
         this.df.setValue(date);
     } // eo function setDate
     // }}}
@@ -470,6 +478,9 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      * @private Sets the value of TimeField
      */
     ,setTime:function(date) {
+        if (date && this.offset_time != 0) {
+            date = date.add(Date.HOUR, new Number(this.offset_time));
+        }
         this.tf.setValue(date);
     } // eo function setTime
     // }}}
@@ -630,7 +641,10 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      */
     ,updateHidden:function() {
         if(this.isRendered) {
-            var value = this.dateValue instanceof Date ? this.dateValue.format(this.hiddenFormat) : '';
+            var value = '';
+            if (this.dateValue instanceof Date) {
+                value = this.dateValue.add(Date.HOUR, 0 - new Number(this.offset_time)).format(this.hiddenFormat);
+            }
             this.el.dom.value = value;
         }
     }

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -581,6 +581,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,startDay: parseInt(MODx.config.manager_week_start)
             ,dateWidth: 120
             ,timeWidth: 120
+            ,offset_time: MODx.config.server_offset_time
             ,value: config.record.publishedon
         },{
             xtype: MODx.config.publish_document ? 'xdatetime' : 'hidden'
@@ -594,6 +595,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,startDay: parseInt(MODx.config.manager_week_start)
             ,dateWidth: 120
             ,timeWidth: 120
+            ,offset_time: MODx.config.server_offset_time
             ,value: config.record.pub_date
         },{
             xtype: MODx.config.publish_document ? 'xdatetime' : 'hidden'
@@ -607,6 +609,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,startDay: parseInt(MODx.config.manager_week_start)
             ,dateWidth: 120
             ,timeWidth: 120
+            ,offset_time: MODx.config.server_offset_time
             ,value: config.record.unpub_date
         },{
             xtype: 'fieldset'

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -9,21 +9,24 @@
  */
 class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
     public function render() {
-        $timetocheck = (time()-(60*20))+$this->modx->getOption('server_offset_time',null,0);
-        $c = $this->modx->newQuery('modManagerLog');
-        $c->innerJoin('modUser','User');
+        $timetocheck = (time()-(60*20));
 
         $c = $this->modx->newQuery('modManagerLog');
         $c->innerJoin('modUser','User');
         $c->where(array(
             'occurred:>' => strftime('%Y-%m-%d, %H:%M:%S',$timetocheck),
         ));
+        $c->where(
+            "occurred = (SELECT MAX(`occurred`)
+                    FROM {$this->modx->getTableName('modManagerLog')} AS log2
+                    WHERE `log2`.`user` = `modManagerLog`.`user`
+                    GROUP BY `user`)"
+        );
         $data['total'] = $this->modx->getCount('modManagerLog',$c);
 
         $c->select($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
         $c->select($this->modx->getSelectColumns('modUser','User','',array('username')));
         $c->sortby('occurred','DESC');
-        $c->groupby('user');
         $ausers = $this->modx->getIterator('modManagerLog',$c);
 
         $users = array();
@@ -33,14 +36,14 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
         foreach ($ausers as $user) {
             $userArray = $user->toArray();
             $userArray['currentAction'] = $user->get('action');
-            $userArray['occurred'] = strftime('%b %d, %Y - %I:%M %p',strtotime($user->get('occurred')));
+            $userArray['occurred'] = strftime('%b %d, %Y - %I:%M %p',strtotime($user->get('occurred'))+floatval($this->modx->getOption('server_offset_time',null,0)) * 3600);
             $userArray['class'] = $alt ? 'alt' : '';
             $users[] = $this->getFileChunk('dashboard/onlineusers.row.tpl',$userArray);
         }
         
         $output = $this->getFileChunk('dashboard/onlineusers.tpl',array(
             'users' => implode("\n",$users),
-            'curtime' => strftime('%I:%M %p',time()+$this->modx->getOption('server_offset_time',null,0)),
+            'curtime' => strftime('%I:%M %p',time()+floatval($this->modx->getOption('server_offset_time',null,0)) * 3600),
         ));
         return $output;
     }


### PR DESCRIPTION
- server_offset_time always treated as hours value
- resource publish timestamps stored without offset
- auto_publish cache timestamp stored without offset
- server_offset_time added to view only, on resource edit, resource overview and "who's online" dashboard widget
- "who's online" widget fixed to display most recent activity of each user within last 20 min (was displaying oldest activity within 20 minutes)
