### PR TITLE
Proposal for issue 9607 (http://tracker.modx.com/issues/9607)

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -805,6 +805,12 @@ $events['OnSiteSettingsRender']->fromArray(array (
   'service' => 1,
   'groupname' => 'Settings',
 ), '', true, true);
+$events['OnBeforeConfigSet']= $xpdo->newObject('modEvent');
+$events['OnBeforeConfigSet']->fromArray(array (
+  'name' => 'OnBeforeConfigSet',
+  'service' => 1,
+  'groupname' => 'Settings',
+), '', true, true);
 
 
 /* Internationalization */

--- a/core/model/modx/processors/system/config.js.php
+++ b/core/model/modx/processors/system/config.js.php
@@ -81,6 +81,21 @@ $c = array_merge($modx->config,$workingContext->config,$modx->_userConfig,$c);
 
 unset($c['password'],$c['username'],$c['mail_smtp_pass'],$c['mail_smtp_user'],$c['proxy_password'],$c['proxy_username'],$c['connections'],$c['connection_init'],$c['connection_mutable'],$c['dbname'],$c['database'],$c['driverOptions'],$c['dsn'],$c['session_name']);
 
+$config = $modx->invokeEvent('OnBeforeConfigSet', array(
+    'config' => $c,
+));
+if (!empty($config) && is_array($config)) {
+    foreach ($config as $key) {
+        if (is_array($key)) {
+            foreach ($key as $keyName) {
+                unset($c[$keyName]);
+            }
+        } else {
+            unset($c[$key]);
+        }
+    }
+}
+
 $o = "Ext.namespace('MODx'); MODx.config = ";
 $o .= $modx->toJSON($c);
 $o .= '; MODx.perm = {};';


### PR DESCRIPTION
You should be able to hook multiple plugins on `OnBeforeConfigSet` event and either output a key or an array of keys to be unset : 

``` php
$modx->event->_output = array('access_resource_group_enabled', 'access_category_enabled');
return true;
```

or

``` php
$modx->event->output('access_resource_group_enabled');
return true;
```
