### PR TITLE
[9152] - See http://tracker.modx.com/issues/9152

### DIFF
--- a/core/model/modx/processors/resource/gettoolbar.class.php
+++ b/core/model/modx/processors/resource/gettoolbar.class.php
@@ -30,34 +30,36 @@ class modResourceGetToolbarProcessor extends modProcessor {
             'handler' => 'this.collapseAll',
         );
         $items[] = '-';
+        $context = '&context_key=' . $this->modx->getOption('default_context');
         if ($this->modx->hasPermission('new_document')) {
             $items[] = array(
                 'icon' => $p.'folder_page_add.png',
                 'tooltip' => $this->modx->lexicon('document_new'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&context_key='. $this->modx->getOption('default_context') .'\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create']. $context .'\");");',
             );
         }
         if ($this->modx->hasPermission('new_weblink')) {
             $items[] = array(
                 'icon' => $p.'page_white_link.png',
                 'tooltip' => $this->modx->lexicon('add_weblink'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modWebLink&context_key='. $this->modx->getOption('default_context') .'\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modWebLink'. $context .'\");");',
             );
         }
         if ($this->modx->hasPermission('new_symlink')) {
             $items[] = array(
                 'icon' => $p.'page_white_copy.png',
                 'tooltip' => $this->modx->lexicon('add_symlink'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modSymLink&context_key='. $this->modx->getOption('default_context') .'\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modSymLink'. $context .'\");");',
             );
         }
         if ($this->modx->hasPermission('new_static_resource')) {
             $items[] = array(
                 'icon' => $p.'page_white_gear.png',
                 'tooltip' => $this->modx->lexicon('static_resource_new'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modStaticResource&context_key='. $this->modx->getOption('default_context') .'\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modStaticResource'. $context .'\");");',
             );
         }
+        unset($context);
         $items[] = '-';
 
         $items[] = array(

--- a/core/model/modx/processors/resource/gettoolbar.class.php
+++ b/core/model/modx/processors/resource/gettoolbar.class.php
@@ -7,7 +7,7 @@
  */
 class modResourceGetToolbarProcessor extends modProcessor {
     public function checkPermissions() {
-        return $this->modx->hasPermission('resource_tree'); 
+        return $this->modx->hasPermission('resource_tree');
     }
 
     public function getLanguageTopics() {
@@ -34,28 +34,28 @@ class modResourceGetToolbarProcessor extends modProcessor {
             $items[] = array(
                 'icon' => $p.'folder_page_add.png',
                 'tooltip' => $this->modx->lexicon('document_new'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&context_key='. $this->modx->getOption('default_context') .'\");");',
             );
         }
         if ($this->modx->hasPermission('new_weblink')) {
             $items[] = array(
                 'icon' => $p.'page_white_link.png',
                 'tooltip' => $this->modx->lexicon('add_weblink'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modWebLink\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modWebLink&context_key='. $this->modx->getOption('default_context') .'\");");',
             );
         }
         if ($this->modx->hasPermission('new_symlink')) {
             $items[] = array(
                 'icon' => $p.'page_white_copy.png',
                 'tooltip' => $this->modx->lexicon('add_symlink'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modSymLink\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modSymLink&context_key='. $this->modx->getOption('default_context') .'\");");',
             );
         }
         if ($this->modx->hasPermission('new_static_resource')) {
             $items[] = array(
                 'icon' => $p.'page_white_gear.png',
                 'tooltip' => $this->modx->lexicon('static_resource_new'),
-                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modStaticResource\");");',
+                'handler' => 'new Function("this.redirect(\"index.php?a='.$actions['resource/create'].'&class_key=modStaticResource&context_key='. $this->modx->getOption('default_context') .'\");");',
             );
         }
         $items[] = '-';
@@ -85,6 +85,6 @@ class modResourceGetToolbarProcessor extends modProcessor {
 
         return $this->modx->error->success('',$items);
     }
-    
+
 }
 return 'modResourceGetToolbarProcessor';


### PR DESCRIPTION
Pass the context key with default context setting when creating a new resource (from the tree toolbar).
Mostly useful only when user do not have access to default (web) context
