### PR TITLE
[8327] - See http://tracker.modx.com/issues/8327

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -696,13 +696,13 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         }
         m.push({
             text: _('create')
-            ,handler: Ext.emptyFn
+            ,handler: function() {return false;}
             ,menu: {items: ct}
         });
         if (ui && ui.hasClass('pqcreate')) {
             m.push({
                text: _('quick_create')
-               ,handler: Ext.emptyFn
+                ,handler: function() {return false;}
                ,menu: {items: qct}
             });
         }


### PR DESCRIPTION
Make sure the contextual menu is not closed when clicking on an entry (with no action) with sub menus
