### PR TITLE
Fix browser listing in root after media source change

### DIFF
--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -183,6 +183,7 @@ MODx.browser.Window = function(config) {
                 this.config.source = s;
                 this.view.config.source = s;
                 this.view.baseParams.source = s;
+                this.view.dir = '/';
                 this.view.run();
             },scope:this}
             ,'nodeclick': {fn:function(n,e) {


### PR DESCRIPTION
Force root folder after change of media source from Media source combo.
