### PR TITLE
Check ob_get_level() at ob_end_* calls where ob wasn't explicitly started

### DIFF
--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -186,7 +186,7 @@ class modResponse {
             }
             @session_write_close();
             echo $this->modx->resource->_output;
-            while (@ob_end_flush()) {}
+            while (ob_get_level() && @ob_end_flush()) {}
             flush();
             exit();
         }

--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -167,7 +167,7 @@ class modStaticResource extends modResource implements modResourceInterface {
                     }
                 }
                 @session_write_close();
-                while (@ob_end_clean()) {}
+                while (ob_get_level() && @ob_end_clean()) {}
                 readfile($file);
                 die();
             }

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1010,7 +1010,7 @@ class modX extends xPDO {
      */
     public function sendError($type = '', $options = array()) {
         if (!is_string($type) || empty($type)) $type = $this->getOption('error_type', $options, 'unavailable');
-        while (@ob_end_clean()) {}
+        while (ob_get_level() && @ob_end_clean()) {}
         if (!XPDO_CLI_MODE) {
             $errorPageTitle = $this->getOption('error_pagetitle', $options, 'Error 503: Service temporarily unavailable');
             $errorMessage = $this->getOption('error_message', $options, '<p>Site temporarily unavailable.</p>');
@@ -2455,7 +2455,7 @@ class modX extends xPDO {
             }
         } else {
             if ($level === modX::LOG_LEVEL_FATAL) {
-                while (@ob_end_clean()) {}
+                while (ob_get_level() && @ob_end_clean()) {}
                 if ($targetObj == 'FILE' && $cacheManager= $this->getCacheManager()) {
                     $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
                     $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;

--- a/core/model/modx/processors/system/errorlog/download.class.php
+++ b/core/model/modx/processors/system/errorlog/download.class.php
@@ -17,7 +17,7 @@ class modSystemErrorLogDownloadProcessor extends modProcessor {
         header('Content-Type: application/force-download');
         header('Content-Length: ' . filesize($f));
         header('Content-Disposition: attachment; filename="error.'.time().'.log');
-        @ob_end_flush();
+        ob_get_level() && @ob_end_flush();
         readfile($f);
         die();
     }

--- a/core/model/modx/xmlrpc/modxmlrpcresponse.class.php
+++ b/core/model/modx/xmlrpc/modxmlrpcresponse.class.php
@@ -54,8 +54,8 @@ class modXMLRPCResponse extends modResponse {
         }
 
         $this->server->service();
-        @ ob_end_flush();
-        while (@ ob_end_clean()) {}
+        ob_get_level() && @ob_end_flush();
+        while (ob_get_level() && @ob_end_clean()) {}
         exit();
     }
 

--- a/index.php
+++ b/index.php
@@ -53,7 +53,7 @@ ob_start();
 /* Create an instance of the modX class */
 $modx= new modX();
 if (!is_object($modx) || !($modx instanceof modX)) {
-    @ob_end_flush();
+    ob_get_level() && @ob_end_flush();
     $errorMessage = '<a href="setup/">MODX not installed. Install now?</a>';
     @include(MODX_CORE_PATH . 'error/unavailable.include.php');
     header('HTTP/1.1 503 Service Unavailable');

--- a/setup/includes/error/modinstalljsonerror.class.php
+++ b/setup/includes/error/modinstalljsonerror.class.php
@@ -71,7 +71,7 @@ class modInstallJSONError extends modInstallError {
     }
 
     public function failure($message = '', $object = null) {
-        while (@ ob_end_clean()) {}
+        while (ob_get_level() && @ob_end_clean()) {}
         die($this->process($message, false, $object));
     }
 


### PR DESCRIPTION
This check gives the current output buffer level, zero if there is no active output buffer, so it should prevent quite a few system notices, that so far just have been silenced with the @ operator.
