### PR TITLE
[#9825] Revert "Increase width of file and image TVs"

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
@@ -25,7 +25,6 @@ MODx.panel.ImageTV = function(config) {
             ,value: config.value
         },{
             xtype: 'modx-combo-browser'
-            ,anchor: '100%'
             ,browserEl: 'tvbrowser'+config.tv
             ,name: 'tvbrowser'+config.tv
             ,id: 'tvbrowser'+config.tv
@@ -76,7 +75,6 @@ MODx.panel.FileTV = function(config) {
             ,value: config.value
         },{
             xtype: 'modx-combo-browser'
-            ,anchor: '100%'
             ,browserEl: 'tvbrowser'+config.tv
             ,name: 'tvbrowser'+config.tv
             ,id: 'tvbrowser'+config.tv

--- a/manager/templates/default/element/tv/renders/input/file.tpl
+++ b/manager/templates/default/element/tv/renders/input/file.tpl
@@ -12,7 +12,7 @@ Ext.onReady(function() {
         ,tv: '{$tv->id}'
         ,renderTo: 'tvpanel{$tv->id}'
         ,value: '{$tv->value|escape}'
-        ,anchor: '100%'
+        ,width: '99%'
         ,msgTarget: 'under'
     {literal}
     });
@@ -32,7 +32,7 @@ Ext.onReady(function() {
         ,tv: '{$tv->id}'
         ,value: '{$tv->value|escape}'
         ,relativeValue: '{$tv->value|escape}'
-        ,width: '100%'
+        ,width: '97%'
         ,msgTarget: 'under'
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         ,source: '{$source}'

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -14,7 +14,7 @@ Ext.onReady(function() {
         ,tv: '{$tv->id}'
         ,renderTo: 'tv-image-{$tv->id}'
         ,value: '{$tv->value|escape}'
-        ,anchor: '100%'
+        ,width: 400
         ,msgTarget: 'under'
     {literal}
     });
@@ -34,7 +34,7 @@ Ext.onReady(function() {
         ,tv: '{$tv->id}'
         ,value: '{$tv->value|escape}'
         ,relativeValue: '{$tv->value|escape}'
-        ,width: '100%'
+        ,width: '97%'
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         ,wctx: '{if $params.wctx}{$params.wctx}{else}web{/if}'
         {if $params.openTo},openTo: '{$params.openTo}'{/if}


### PR DESCRIPTION
This reverts commit dbd36390a4070f29319db81186fe8f66155fdb60 which is causing issues with MIGX and TVs below the content. I've not yet been able of finding a patch that provides the increased width, without creating the problem.

http://tracker.modx.com/issues/9825
