### PR TITLE
Fallback quoting style + logging

### DIFF
--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -2481,6 +2481,8 @@ class xPDO {
                 $quoted = (integer) trim($quoted, "'");
                 break;
             default:
+                $this->log(xPDO::LOG_LEVEL_ERROR, 'Unknown quote type', '', __METHOD__, __FILE__, __LINE__);
+                $quoted = trim($quoted);
                 break;
         }
         return $quoted;


### PR DESCRIPTION
Sorry, I branched from release-2.2

Only one function changed:

```
    public function quote($string, $parameter_type= PDO::PARAM_STR) {
        if (!$this->connect()) {
            return false;
        }
        $quoted = $this->pdo->quote($string, $parameter_type);
        switch ($parameter_type) {
            case PDO::PARAM_STR:
                $quoted = trim($quoted);
                break;
            case PDO::PARAM_INT:
                $quoted = trim($quoted);
                $quoted = (integer) trim($quoted, "'");
                break;
            default:
                $this->log(xPDO::LOG_LEVEL_ERROR, 'Unknown quote type', '', __METHOD__, __FILE__, __LINE__);
                $quoted = trim($quoted);
                break;
        }
        return $quoted;
    }
```
