### PR TITLE
Bug 9964

### DIFF
--- a/core/model/modx/processors/system/import/html.php
+++ b/core/model/modx/processors/system/import/html.php
@@ -37,6 +37,7 @@ if (!function_exists('importFiles')) {
             return;
         if ($parent > 0) {
             if ($parentResource= $modx->getObject('modResource', $parent)) {
+                $context = $parentResource->get('context_key');
                 $parentResource->set('isfolder', true);
                 $parentResource->save();
             } else {

--- a/core/model/modx/processors/system/import/index.php
+++ b/core/model/modx/processors/system/import/index.php
@@ -24,11 +24,17 @@ $class= 'modStaticResource';
 if (isset ($scriptProperties['import_resource_class'])) {
     $class= $modx->loadClass($scriptProperties['import_resource_class']);
 }
+// is import_context being used anywhere? It isn't in the manager form...
 if (isset ($scriptProperties['import_context'])) {
     $context= $scriptProperties['import_context'];
 }
 if (isset ($scriptProperties['import_parent'])) {
     $parent= intval($scriptProperties['import_parent']);
+}
+if ($parentRes = $modx->getObject('modResource', $parent)) {
+    if ($context_key = $parentRes->get('context_key')) {
+        $context= $context_key;
+    }
 }
 $filepath= $modx->getOption('core_path') . 'import/';
 $basefilepath= $filepath;


### PR DESCRIPTION
Fixes bug where context_key is always set to 'web' on new resources created by "Import Resources" or "Import HTML". Now checks the context_key of the parent resource the user specifies. 

Also added a comment regarding the "import_context" value - that doesn't seem to be an option in the input form anywhere. (And the concept doesn't really make sense when a parent resource is already being specified, because children will always be in the same context as the parent, right?). I think this block is obsolete and can be removed(?)
