### PR TITLE
Prevent 'PHP Catchable fatal error:  Argument 1 passed to xPDOObject::load()' error on fetching thumbnail from cache

### DIFF
--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -186,6 +186,7 @@ class modPhpThumb extends phpThumb {
             } else {
                 @readfile($this->cache_filename);
             }
+            session_write_close();
             exit;
 
         }


### PR DESCRIPTION
Prevent modPhpThumb causing an error when the session hasn't been written/closed prior to the exit() when fetching a thumbnail from the cache.
