### PR TITLE
Fix cache cleanup for phpThumbOf-generated images

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -657,13 +657,11 @@ class phpthumb {
 			$CacheDirOldFilesSize = array();
 			$AllFilesInCacheDirectory = phpthumb_functions::GetAllFilesInSubfolders($this->config_cache_directory);
 			foreach ($AllFilesInCacheDirectory as $fullfilename) {
-				if (preg_match('/^phpThumb\_cache\_/i', basename($fullfilename)) && file_exists($fullfilename)) {
-					$CacheDirOldFilesAge[$fullfilename] = @fileatime($fullfilename);
-					if ($CacheDirOldFilesAge[$fullfilename] == 0) {
-						$CacheDirOldFilesAge[$fullfilename] = @filemtime($fullfilename);
-					}
-					$CacheDirOldFilesSize[$fullfilename] = @filesize($fullfilename);
+				$CacheDirOldFilesAge[$fullfilename] = @fileatime($fullfilename);
+				if ($CacheDirOldFilesAge[$fullfilename] == 0) {
+					$CacheDirOldFilesAge[$fullfilename] = @filemtime($fullfilename);
 				}
+				$CacheDirOldFilesSize[$fullfilename] = @filesize($fullfilename);
 			}
 			if (empty($CacheDirOldFilesSize)) {
 				return true;

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -861,6 +861,7 @@ class phpthumb_functions {
 					switch ($file) {
 						case '.':
 						case '..':
+						case 'index.html':  // leave out index.html too; don't want to delete it
 							break;
 
 						default:

--- a/manager/templates/default/css/xtheme-modx.css
+++ b/manager/templates/default/css/xtheme-modx.css
@@ -318,6 +318,9 @@ textarea.x-form-field, .x-form-textarea{
     border-bottom: 1px solid #d0d0d0;
     color: #434343;
 }
+.x-form-radio {
+    margin-left:1px;
+}
 
 .x-editor .x-form-check-wrap {
     background-color: #fff;

--- a/manager/templates/default/css/xtheme-modx.css
+++ b/manager/templates/default/css/xtheme-modx.css
@@ -318,9 +318,6 @@ textarea.x-form-field, .x-form-textarea{
     border-bottom: 1px solid #d0d0d0;
     color: #434343;
 }
-.x-form-radio {
-    margin-left:1px;
-}
 
 .x-editor .x-form-check-wrap {
     background-color: #fff;


### PR DESCRIPTION
Filenames for cached images created by phpThumbOf typically don't begin with 'phpThumb_cache', so [this line](https://github.com/modxcms/revolution/blob/develop/core/model/phpthumb/phpthumb.class.php#L660) in phpthumb.class.php prevents phpThumbOf's [cleanCache() method](https://github.com/splittingred/phpThumbOf/blob/develop/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php#L505-L507) from doing anything useful.  It just wastes time listing all the cache files without actually deleting any of them.

Also the phpThumbOf cache directory has a blank index.html file in it for security reasons which shouldn't be deleted.
