### PR TITLE
phpThumb's CleanUpCacheDirectory() only deletes thumbnails named phpThumb_cache*

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -657,13 +657,11 @@ class phpthumb {
 			$CacheDirOldFilesSize = array();
 			$AllFilesInCacheDirectory = phpthumb_functions::GetAllFilesInSubfolders($this->config_cache_directory);
 			foreach ($AllFilesInCacheDirectory as $fullfilename) {
-				if (preg_match('/^phpThumb\_cache\_/i', basename($fullfilename)) && file_exists($fullfilename)) {
-					$CacheDirOldFilesAge[$fullfilename] = @fileatime($fullfilename);
-					if ($CacheDirOldFilesAge[$fullfilename] == 0) {
-						$CacheDirOldFilesAge[$fullfilename] = @filemtime($fullfilename);
-					}
-					$CacheDirOldFilesSize[$fullfilename] = @filesize($fullfilename);
+				$CacheDirOldFilesAge[$fullfilename] = @fileatime($fullfilename);
+				if ($CacheDirOldFilesAge[$fullfilename] == 0) {
+					$CacheDirOldFilesAge[$fullfilename] = @filemtime($fullfilename);
 				}
+				$CacheDirOldFilesSize[$fullfilename] = @filesize($fullfilename);
 			}
 			if (empty($CacheDirOldFilesSize)) {
 				return true;

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -861,6 +861,7 @@ class phpthumb_functions {
 					switch ($file) {
 						case '.':
 						case '..':
+						case 'index.html':  // leave out index.html too; don't want to delete it
 							break;
 
 						default:


### PR DESCRIPTION
Filenames for cached images created by phpThumbOf typically don't begin with 'phpThumb_cache', so [this line](https://github.com/modxcms/revolution/blob/release-2.2/core/model/phpthumb/phpthumb.class.php#L660) in phpthumb.class.php prevents phpThumbOf's [cleanCache()](https://github.com/splittingred/phpThumbOf/blob/develop/core/components/phpthumbof/model/phpthumbof/phpthumbof.class.php#L505-L507) method from doing anything useful. It just wastes time listing all the cache files without actually deleting any of them.

Also the phpThumbOf cache directory has a blank index.html file in it for security reasons which shouldn't be deleted.
