### PR TITLE
Filtered error messages so they don't crash the javascript modals.

### DIFF
--- a/core/model/modx/error/moderror.class.php
+++ b/core/model/modx/error/moderror.class.php
@@ -176,7 +176,8 @@ class modError {
         $objarray = $this->toArray($object);
         return array (
             'success' => $status,
-            'message' => $this->message,
+            // See http://tracker.modx.com/issues/6294
+            'message' => htmlspecialchars($this->message),
             'total' => isset ($this->total) && $this->total != 0 ? $this->total : count($this->errors),
             'errors' => $this->errors,
             'object' => $objarray,


### PR DESCRIPTION
This is the quick fix: htmlspecialchars to filter error messages to make them compatible with MODExt's failure alert box.

A more thorough solution here would be to tackle this: http://tracker.modx.com/issues/9982
