### PR TITLE
Manager Log now properly shows the classKey of custom XPDO classes.

### DIFF
--- a/core/model/modx/processors/system/log/getlist.class.php
+++ b/core/model/modx/processors/system/log/getlist.class.php
@@ -103,14 +103,16 @@ class modSystemLogGetListProcessor extends modProcessor {
     public function prepareLog(modManagerLog $log) {
         $logArray = $log->toArray();
         if (!empty($logArray['classKey']) && !empty($logArray['item'])) {
+            $logArray['name'] = $logArray['classKey'] . ' (' . $logArray['item'] . ')';
             /** @var xPDOObject $obj */
             $obj = $this->modx->getObject($logArray['classKey'],$logArray['item']);
             if ($obj) {
                 $nameField = $this->getNameField($logArray['classKey']);
-                $pk = $obj->get('id');
-                $logArray['name'] = $obj->get($nameField).(!empty($pk) ? ' ('.$pk.')' : '');
-            } else {
-                $logArray['name'] = $logArray['classKey'] . ' (' . $logArray['item'] . ')';
+                $k = $obj->getField($nameField, true);
+                if (!empty($k)) {
+                    $pk = $obj->get('id');
+                    $logArray['name'] = $obj->get($nameField).(!empty($pk) ? ' ('.$pk.')' : '');
+                }
             }
         } else {
             $logArray['name'] = $log->get('item');

--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -87,22 +87,25 @@ Ext.extend(MODx.Console,Ext.Window,{
             }
         });
         Ext.Direct.addProvider(this.provider);
-        Ext.Direct.on('message', function(e,p) {
-            var out = this.getComponent('body');
-            if (out) {
-                out.el.insertHtml('beforeEnd',e.data);
-                e.data = '';
-                out.el.scroll('b', out.el.getHeight(), true);
-            }
-            if (e.complete) {
-                this.fireEvent('complete');
-            }
-            delete e;
-        },this);
+        Ext.Direct.on('message', this.onMessage, this);
+    }
+
+    ,onMessage: function(e,p) {
+        var out = this.getComponent('body');
+        if (out) {
+            out.el.insertHtml('beforeEnd',e.data);
+            e.data = '';
+            out.el.scroll('b', out.el.getHeight(), true);
+        }
+        if (e.complete) {
+            this.fireEvent('complete');
+        }
+        delete e;
     }
 
     ,onComplete: function() {
         this.provider.disconnect();
+        Ext.Direct.un('message', this.onMessage);
         this.fbar.setDisabled(false);
         this.keyMap.setDisabled(false);
     }


### PR DESCRIPTION
Basically, I just added the $obj->getField($nameField, true),  to see if this field really exists.
Previously, custom XPDO classes's key was sometimes missing from the manager log, because function getNameField() has hardcoded modx core objects.
