### PR TITLE
Bugfix: Prevent Modx.console callback accumulating

### DIFF
--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -87,20 +87,22 @@ Ext.extend(MODx.Console,Ext.Window,{
             }
         });
         Ext.Direct.addProvider(this.provider);
-        Ext.Direct.on('message', function(e,p) {
-            var out = this.getComponent('body');
-            if (out) {
-                out.el.insertHtml('beforeEnd',e.data);
-                e.data = '';
-                out.el.scroll('b', out.el.getHeight(), true);
-            }
-            if (e.complete) {
-                this.fireEvent('complete');
-            }
-            delete e;
-        },this);
+        Ext.Direct.on('message',  this.onMessage, this);
     }
 
+    ,onMessage: function(e,p) {
+        var out = this.getComponent('body');
+        if (out) {
+            out.el.insertHtml('beforeEnd',e.data);
+            e.data = '';
+            out.el.scroll('b', out.el.getHeight(), true);
+        }
+        if (e.complete) {
+            this.fireEvent('complete');
+        }
+        delete e;
+    }
+    
     ,onComplete: function() {
         this.provider.disconnect();
         this.fbar.setDisabled(false);


### PR DESCRIPTION
Previously, if you'd run modx.console X times,  the onMessage callback would be called X times, instead of only once. Resolved by changing from anonymous JS function to named one.
