### PR TITLE
(feature) "clear" flag for registerLogging request using register&topic

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -407,6 +407,7 @@ class modRequest {
      * <li>topic: the topic to record to (required)</li>
      * <li>register_class: the modRegister class (defaults to modFileRegister)</li>
      * <li>log_level: the logging level (defaults to MODX_LOG_LEVEL_INFO)</li>
+     * <li>clear: set flag to clear register before logging new messages into it  (optional)</li>
      * </ul>
      *
      * @param array $options An array containing all the options required to
@@ -419,7 +420,8 @@ class modRequest {
                 $register = $this->modx->registry->getRegister($options['register'], $register_class);
                 if ($register) {
                     $level = isset($options['log_level']) ? $options['log_level'] : modX::LOG_LEVEL_INFO;
-                    $this->modx->registry->setLogging($register, $options['topic'], $level);
+                    $clear = (!empty($options['clear']));
+                    $this->modx->registry->setLogging($register, $options['topic'], $level, $clear);
                 }
             }
         }

--- a/core/model/modx/registry/modregistry.class.php
+++ b/core/model/modx/registry/modregistry.class.php
@@ -172,9 +172,10 @@ class modRegistry {
      * @param modRegister &$register
      * @param string $topic
      * @param int $level
+     * @param boolean $clear Clear the register before subscribing to it
      * @return boolean True if successful.
      */
-    public function setLogging(modRegister &$register, $topic, $level = modX::LOG_LEVEL_ERROR) {
+    public function setLogging(modRegister &$register, $topic, $level = modX::LOG_LEVEL_ERROR, $clear = false) {
         $set = false;
         $this->_loggingRegister = &$register;
         if (isset($topic) && !empty($topic)) {
@@ -182,6 +183,7 @@ class modRegistry {
             if ($this->_loggingRegister->connect()) {
                 $this->_prevLogTarget = $this->modx->getLogTarget();
                 $this->_prevLogLevel = $this->modx->getLogLevel();
+                if ($clear) $this->_loggingRegister->clear($topic);
                 $this->_loggingRegister->subscribe($topic);
                 $this->_loggingRegister->setCurrentTopic($topic);
                 $this->modx->setLogTarget($this->_loggingRegister);

--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -82,6 +82,7 @@ Ext.extend(MODx.Console,Ext.Window,{
                 action: 'console'
                 ,register: this.config.register || ''
                 ,topic: this.config.topic || ''
+                ,clear: false
                 ,show_filename: this.config.show_filename || 0
                 ,format: this.config.format || 'html_log'
             }


### PR DESCRIPTION
Notes:
1. This depends on  https://github.com/modxcms/revolution/pull/565
2. Although optional, modx.console.js was set to "clear=false".  this is just in case you decide to set the "clear" flag by default to "true".     this modx-console should never have clear=true.
