### PR TITLE
(bug fix)  clear the register before cache clear.

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -136,6 +136,7 @@ Ext.extend(MODx,Ext.Component,{
                xtype: 'modx-console'
                ,register: 'mgr'
                ,topic: topic
+               ,clear: true
                ,show_filename: 0
                ,listeners: {
                     'shutdown': {fn:function() {


### PR DESCRIPTION
Seems that all those "clear cache" problems were all related to stuck messages in the register.

Depends on: 
https://github.com/modxcms/revolution/pull/565
https://github.com/modxcms/revolution/pull/566

Solves long standing bugs on this:
http://tracker.modx.com/issues/413
http://tracker.modx.com/issues/3090
http://tracker.modx.com/issues/919
Solves an unreported bug:     Clear cache always show the last run's report,  not the current.
