### PR TITLE
(bug fix) Removed console.fireEvent('complete') after clearCache.

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -155,11 +155,6 @@ Ext.extend(MODx,Ext.Component,{
         MODx.Ajax.request({
             url: MODx.config.connectors_url+'system/index.php'
             ,params: { action: 'clearCache',register: 'mgr' ,topic: topic }
-            ,listeners: {
-                'success':{fn:function() {
-                    this.console.fireEvent('complete');
-                },scope:this}
-            }
         });
         return true;
     }


### PR DESCRIPTION
This causes a timing issue where it fires a "complete" event **before** modx-console has finished digesting all messages.   This seems as (one of) the source for the "clear cache" issues.     Anyway, this fireEvent is **not** needed.
