### PR TITLE
Fix login processor to use absolute url redirects for mgr

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,8 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Fix login processor to use absolute url redirects for mgr
+
 MODX Revolution 2.2.8-pl (June 4, 2013)
 ====================================
 - Prevent empty HTTP_MODAUTH from succeeding

--- a/core/model/modx/processors/security/login.php
+++ b/core/model/modx/processors/security/login.php
@@ -196,7 +196,9 @@ $response = array(
 );
 switch ($loginContext) {
     case 'mgr':
-        $manager_login_startup_url = $modx->getOption('manager_url', null, $returnUrl);
+        $manager_login_startup_url = !empty($returnUrl)
+            ? $returnUrl
+            : $modx->getOption('url_scheme') . $modx->getOption('http_host') . $modx->getOption('manager_url', null, MODX_MANAGER_URL);
         if (!empty($manager_login_startup)) {
             $manager_login_startup= intval($manager_login_startup);
             if ($manager_login_startup) $manager_login_startup_url .= '?id=' . $manager_login_startup;


### PR DESCRIPTION
Allows mgr deployments on subdomains, https-only configurations, etc. - uses url_scheme+http_host+manager_url
