### PR TITLE
[#10007] Fix parser logic when processing elements via API

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- [#10007] Fix parser logic when processing elements via API
 - [#10087] Avoid stat warnings with missing static sources
 - [#9809] Remove empty ULs in topmenu
 - [#7569] Add bottom border to collapsed panels

--- a/core/model/modx/modchunk.class.php
+++ b/core/model/modx/modchunk.class.php
@@ -126,6 +126,7 @@ class modChunk extends modElement {
             $this->_processed= true;
         }
 
+        $this->xpdo->parser->setProcessingElement(false);
         /* finally, return the processed element content */
         return $this->_output;
     }

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -56,7 +56,7 @@ class modElement extends modAccessibleSimpleObject {
      * The source of the element.
      * @var string
      */
-    public $_source= null;    
+    public $_source= null;
     /**
      * The output of the element.
      * @var string
@@ -120,7 +120,7 @@ class modElement extends modAccessibleSimpleObject {
                 : null;
         }
         /* automatically translate lexicon descriptions */
-        if ($k == 'properties' && !empty($value) && is_array($value) 
+        if ($k == 'properties' && !empty($value) && is_array($value)
                && is_object($this->xpdo) && $this->xpdo instanceof modX && $this->xpdo->lexicon) {
             foreach ($value as &$property) {
                 if (!empty($property['lexicon'])) {
@@ -262,6 +262,7 @@ class modElement extends modAccessibleSimpleObject {
      */
     public function process($properties= null, $content= null) {
         $this->xpdo->getParser();
+        $this->xpdo->parser->setProcessingElement(true);
         $this->getProperties($properties);
         $this->getTag();
         if ($this->xpdo->getDebug() === true) $this->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "Processing Element: " . $this->get('name') . ($this->_tag ? "\nTag: {$this->_tag}" : "\n") . "\nProperties: " . print_r($this->_properties, true));
@@ -670,11 +671,11 @@ class modElement extends modAccessibleSimpleObject {
                         unset($option['menu'],$option['name']);
                     }
                 }
-                
+
                 if ($propertyArray['type'] == 'combo-boolean' && is_numeric($propertyArray['value'])) {
                     $propertyArray['value'] = (boolean)$propertyArray['value'];
                 }
-                
+
                 $propertiesArray[$key] = $propertyArray;
             }
 
@@ -773,7 +774,7 @@ class modElement extends modAccessibleSimpleObject {
     public function getSource($contextKey = '',$fallbackToDefault = true) {
         if (empty($contextKey)) $contextKey = $this->xpdo->context->get('key');
 
-        $source = $this->_source; 
+        $source = $this->_source;
 
         if (empty($source)) {
 
@@ -790,10 +791,10 @@ class modElement extends modAccessibleSimpleObject {
             }
             $this->setSource($source);
         }
-        
+
         return $source;
     }
-    
+
     /**
      * Setter method for the source class var.
      *
@@ -801,7 +802,7 @@ class modElement extends modAccessibleSimpleObject {
      */
     public function setSource($source) {
         $this->_source = $source;
-    }    
+    }
 
     /**
      * Get the stored sourceCache for a context

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -41,6 +41,11 @@ class modParser {
      */
     protected $_processingTag = false;
     /**
+     * If the parser is currently processing an element
+     * @var bool $_processingElement
+     */
+    protected $_processingElement = false;
+    /**
      * If the parser is currently processing an uncacheable tag
      * @var bool $_processingUncacheable
      */
@@ -64,7 +69,7 @@ class modParser {
      */
     public function isProcessingUncacheable() {
         $result = false;
-        if ($this->isProcessingTag()) $result = (boolean) $this->_processingUncacheable;
+        if ($this->isProcessingTag() || $this->isProcessingElement()) $result = (boolean) $this->_processingUncacheable;
         return $result;
     }
 
@@ -74,7 +79,7 @@ class modParser {
      */
     public function isRemovingUnprocessed() {
         $result = false;
-        if ($this->isProcessingTag()) $result = (boolean) $this->_removingUnprocessed;
+        if ($this->isProcessingTag() || $this->isProcessingElement()) $result = (boolean) $this->_removingUnprocessed;
         return $result;
     }
 
@@ -84,6 +89,24 @@ class modParser {
      */
     public function isProcessingTag() {
         return (boolean) $this->_processingTag;
+    }
+
+    /**
+     * Returns true if the parser is currently processing an element
+     * @return bool
+     */
+    public function isProcessingElement() {
+        return (boolean) $this->_processingElement;
+    }
+
+    public function setProcessingElement($arg = null) {
+        if (is_bool($arg)) {
+            $this->_processingElement = $arg;
+        } elseif ($arg === null) {
+            $this->_processingElement = !$this->_processingElement ? true : false;
+        } else {
+            $this->_processingElement = (boolean)$arg;
+        }
     }
 
     /**
@@ -780,6 +803,7 @@ abstract class modTag {
      */
     public function process($properties= null, $content= null) {
         $this->modx->getParser();
+        $this->modx->parser->setProcessingElement(true);
         $this->getProperties($properties);
         $this->getTag();
         $this->filterInput();

--- a/core/model/modx/modscript.class.php
+++ b/core/model/modx/modscript.class.php
@@ -86,7 +86,7 @@ class modScript extends modElement {
             }
         }
         $this->_processed= true;
-
+        $this->xpdo->parser->setProcessingElement(false);
         /* finally, return the processed element content */
         return $this->_output;
     }

--- a/core/model/modx/modtemplate.class.php
+++ b/core/model/modx/modtemplate.class.php
@@ -71,7 +71,7 @@ class modTemplate extends modElement {
             $msg = $isNew ? $this->xpdo->lexicon('template_err_create') : $this->xpdo->lexicon('template_err_save');
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$msg.$this->toArray());
         }
-        
+
         return $saved;
     }
 
@@ -122,6 +122,7 @@ class modTemplate extends modElement {
             $this->filterOutput();
             $this->_processed= true;
         }
+        $this->xpdo->parser->setProcessingElement(false);
         return $this->_output;
     }
 
@@ -188,7 +189,7 @@ class modTemplate extends modElement {
 
     /**
      * Check to see if this Template is assigned the specified Template Var
-     * 
+     *
      * @param mixed $tvPk Either the ID, name or object of the Template Var
      * @return boolean True if the TV is assigned to this Template
      */

--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -165,6 +165,7 @@ class modTemplateVar extends modElement {
 
             $this->_processed= true;
         }
+        $this->xpdo->parser->setProcessingElement(false);
         /* finally, return the processed element content */
         return $this->_output;
     }


### PR DESCRIPTION
Fixes inconsistencies in parsing logic with regard to processing non-cacheable/removing unprocessed tags.

See http://tracker.modx.com/issues/10007
