### PR TITLE
Fix Manager radio buttons so the left 1px isn't clipped

### DIFF
--- a/manager/templates/default/sass/_xtheme-modx.scss
+++ b/manager/templates/default/sass/_xtheme-modx.scss
@@ -137,6 +137,9 @@ textarea.x-form-field, .x-form-textarea{
     border-bottom: 1px solid #d0d0d0;
     color: #434343;
 }
+.x-form-radio {
+    margin-left:1px;
+}
 
 .x-editor .x-form-check-wrap {
     background-color: #fff;


### PR DESCRIPTION
The issue:
![clipped-radio-buttons](https://f.cloud.github.com/assets/1202764/1025995/17849482-0e55-11e3-98c3-150970474da1.png)
