### PR TITLE
Adding error to modMail

### DIFF
--- a/core/model/modx/mail/modmail.class.php
+++ b/core/model/modx/mail/modmail.class.php
@@ -391,7 +391,7 @@ abstract class modMail {
      * @access public
      * @return null|modError
      */
-    public function getErrors() {
+    public function getError() {
         return $this->error;
     }
 }

--- a/core/model/modx/mail/modmail.class.php
+++ b/core/model/modx/mail/modmail.class.php
@@ -177,6 +177,12 @@ abstract class modMail {
      * @var array
      */
     public $files= array();
+    /**
+     * Error
+     * @access protected
+     * @var modError
+     */
+     protected $error = null;
 
     /**
      * Constructs a new instance of the modMail class.
@@ -367,5 +373,25 @@ abstract class modMail {
      */
     public function clearAttachments() {
         $this->files = array();
+    }
+    
+    /**
+     * Check if there is any error.
+     * 
+     * @access public
+     * @return boolean Indicates if there is error.
+     */
+    public function hasError() {
+        return $this->error !== null && $this->error instanceof modError && $this->error->hasError();
+    }
+    
+    /**
+     * Get error object
+     * 
+     * @access public
+     * @return null|modError
+     */
+    public function getErrors() {
+        return $this->error;
     }
 }

--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -179,6 +179,11 @@ class modPHPMailer extends modMail {
     public function send(array $attributes= array()) {
         $sent = parent :: send($attributes);
         $sent = $this->mailer->Send();
+        if ($send !== true) {
+            $this->modx->loadClass('error.modError');
+            $this->error = new modError($this->modx);
+            $this->error->addError($this->mailer->ErrorInfo);
+        }
         return $sent;
     }
 


### PR DESCRIPTION
An instance of modError added to modMail as a protected property and modPHPMailer::send instantiates on error
