### PR TITLE
Fix: RegisterLogging "clear" variable handles "false" (string)

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -422,7 +422,7 @@ class modRequest {
                 $register = $this->modx->registry->getRegister($options['register'], $register_class);
                 if ($register) {
                     $level = isset($options['log_level']) ? $options['log_level'] : modX::LOG_LEVEL_INFO;
-                    $clear = (!empty($options['clear']));
+                    $clear = (!empty($options['clear']) && $options['clear'] !== 'false');
                     $this->modx->registry->setLogging($register, $options['topic'], $level, $clear);
                 }
             }


### PR DESCRIPTION
Small (but important!!) fix for https://github.com/modxcms/revolution/pull/566
It wrongly took "false" (string) as true.   
