### PR TITLE
Processor properties overwriting

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1663,7 +1663,9 @@ class modX extends xPDO {
                 $processor = new modDeprecatedProcessor($this);
             }
             $processor->setPath($processorFile);
-            $processor->setProperties($scriptProperties);
+            if (empty($className)) {
+                $processor->setProperties($scriptProperties);
+            }
             $response = $processor->run();
         } else {
             $this->log(modX::LOG_LEVEL_ERROR, "Processor {$processorFile} does not exist; " . print_r($options, true));


### PR DESCRIPTION
If executed classs-based processor, we already have $this->properties:
$processor = call_user_func_array(array($c,'getInstance'),array($this,$className,$scriptProperties));
And we may return another processor and overwrite $properties via getInstance method.
But then modX set $properties again and overwrite our $properties.
$processor->setProperties($scriptProperties);

It`s really not good.
