### PR TITLE
bugfix:  modx.console, js error on close

### DIFF
--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -34,7 +34,7 @@ MODx.Console = function(config) {
             ,itemId: 'okBtn'
             ,disabled: true
             ,scope: this
-            ,handler: this.hide
+            ,handler: this.hideConsole
         }]
         ,keys: [{
             key: Ext.EventObject.S
@@ -43,7 +43,7 @@ MODx.Console = function(config) {
             ,scope: this
         },{
             key: Ext.EventObject.ENTER
-            ,fn: this.hide
+            ,fn: this.hideConsole
             ,scope: this
         }]
     });


### PR DESCRIPTION
Fix regression caused by https://github.com/modxcms/revolution/commit/870f3bb5477fb134756df9a40c7750ca2f229883

On modx.console **close** via `ok` button -or- `<Enter>` key,   you'd get a JS error:  
_firefox_: `TypeError: h.apply is not a function`
_chrome_: `Uncaught TypeError: Object #<Object> has no method 'apply'`
