### PR TITLE
Update update.class.php

### DIFF
--- a/core/model/modx/processors/security/user/update.class.php
+++ b/core/model/modx/processors/security/user/update.class.php
@@ -63,7 +63,6 @@ class modUserUpdateProcessor extends modObjectUpdateProcessor {
         $this->setDefaultProperties(array(
             'class_key' => $this->classKey,
         ));
-        $this->classKey = $this->getProperty('class_key');
         return parent::initialize();
     }
 


### PR DESCRIPTION
Removed setting $this->classKey to avoid error when trying to change the class_key of a user. The inheritance to modUser of a custom user class will make it load modUser record anyway
