### PR TITLE
Fixed inline add button in tree

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -673,7 +673,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
                     node: node,
                     handler: function(btn,evt){
                         evt.stopPropagation(evt);
-                        node.reload();
+                        node.getOwnerTree().handleCreateClick(node);
                     },
                     iconCls: 'icon-plus-sign',
                     renderTo: elId
@@ -707,6 +707,14 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
             node.el.appendChild(btn);
         }
     }
+
+    /**
+     * Handled inline add button click
+     * Need to be extended in MODx.tree.Tree instances to work properly
+     *
+     * @param Ext.tree.AsyncTreeNode node
+     */
+    ,handleCreateClick: function(node){}
 
 });
 Ext.reg('modx-tree',MODx.tree.Tree);

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -525,7 +525,12 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
 
     ,handleCreateClick: function(node){
         this.cm.activeNode = node;
-        this._createElement();
+        var type = this.cm.activeNode.id.substr(2).split('_');
+        if (type[0] != 'category') {
+            this._createElement(null, null, null);
+        } else {
+            this.createCategory(null, {target: this});
+        }
     }
 });
 Ext.reg('modx-tree-element',MODx.tree.Element);

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -522,6 +522,11 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         
         return m;
     }
+
+    ,handleCreateClick: function(node){
+        this.cm.activeNode = node;
+        this._createElement();
+    }
 });
 Ext.reg('modx-tree-element',MODx.tree.Element);
 

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -706,6 +706,15 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         return m;
     }
 
+    ,handleCreateClick: function(node){
+        this.cm.activeNode = node;
+        var itm = {
+            usePk: '0'
+            ,classKey: 'modDocument'
+        };
+
+        this.createResourceHere(itm);
+    }
 });
 Ext.reg('modx-tree-resource',MODx.tree.Resource);
 


### PR DESCRIPTION
Added methods to create child after clicking on inline tree add button.
