### PR TITLE
Fixed loading modResource derivatives listing (class_key dropdown)

### DIFF
--- a/core/model/modx/modjsonrpcresource.class.php
+++ b/core/model/modx/modjsonrpcresource.class.php
@@ -10,6 +10,7 @@
  * @subpackage jsonrpc
  */
 class modJSONRPCResource extends modResource {
+	public $allowListingInClassKeyDropdown = false;
     /**
      * Overrides the modResource constructor to set the response class and class_key for this Resource type
      * @param xPDO $xpdo

--- a/core/model/modx/processors/system/derivatives/getlist.class.php
+++ b/core/model/modx/processors/system/derivatives/getlist.class.php
@@ -35,7 +35,6 @@ class modSystemDerivativesGetListProcessor extends modProcessor {
             $obj = $this->modx->newObject($descendant);
             if (!$obj) continue;
 
-            if ($class == 'modResource' && !$obj->showInContextMenu) continue;
             if ($class == 'modResource' && !$obj->allowListingInClassKeyDropdown) continue;
             if ($class == 'modResource') {
                 $name = $obj->getResourceTypeName();


### PR DESCRIPTION
based on $allowListingInClassKeyDropdown setting, not using $showInContextMenu for that
Editted modJSONRPCResource to set not to show up in that menu by setting $allowListingInClassKeyDropdown = false;
