### PR TITLE
Removing Bower from Listed Dependencies

### DIFF
--- a/_build/templates/default/README.md
+++ b/_build/templates/default/README.md
@@ -41,20 +41,19 @@ First, clone a copy of this git repo by running:
 git clone -b develop git://github.com/modxcms/revolution.git
 ```
 
-Install the [grunt-cli](http://gruntjs.com/getting-started#installing-the-cli) and [bower](http://bower.io/) packages if you haven't before. These should be done as global installs:
+Install the [grunt-cli](http://gruntjs.com/getting-started#installing-the-cli) package if you haven't before. This should be done as global install:
 
 ```bash
-npm install -g grunt-cli bower
+npm install -g grunt-cli
 ```
 
-Make sure you have `grunt` and `bower` installed by testing:
+Make sure you have `grunt`installed by testing:
 
 ```bash
 grunt --version
-bower --version
 ```
 
-Enter the default template directory and install the Node and Bower dependencies, this time *without* specifying a global(-g) install:
+Enter the default template directory and install the Node dependencies, this time *without* specifying a global(-g) install:
 
 ```bash
 cd revolution/_build/templates/default


### PR DESCRIPTION
Bower doesn't needed to be installed through npm to use grunt-bower
