### PR TITLE
Make modx.layout.js theme specific

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -388,6 +388,26 @@ abstract class modManagerController {
     }
 
     /**
+     * Get an array of possible URLs to the template's directory.
+     * Override this to point to a custom directory.
+     *
+     * @param bool $specificThemeOnly Return URL only to theme specified in system settings
+     * @return array
+     */
+    public function getTemplatesUrls($specificThemeOnly = false) {
+        $urls = array();
+        $managerUrl = $this->modx->getOption('manager_url', null, MODX_MANAGER_URL);
+
+        $urls[] = $managerUrl . 'templates/'.$this->theme.'/';
+
+        if ($specificThemeOnly === false) {
+            $urls[] = $managerUrl . 'templates/default/';
+        }
+
+        return $urls;
+    }
+
+    /**
      * Do permission checking in this method. Returning false will present a "permission denied" message.
      * 
      * @abstract
@@ -509,6 +529,12 @@ abstract class modManagerController {
             $siteId = $this->modx->user->getUserToken('mgr');
 
             $externals[] = $managerUrl.'assets/modext/core/modx.layout.js';
+
+            $urls = $this->getTemplatesUrls(true);
+
+            foreach($urls as $url) {
+                $externals[] = $url . 'js/layout.js';
+            }
 
             $o = '';
             $compressJs = (boolean)$this->modx->getOption('compress_js',null,true);

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -206,7 +206,6 @@ Ext.extend(MODx.Layout,Ext.Viewport,{
         Ext.getCmp('modx-leftbar-tabs').expand(anim);
     }
 });
-Ext.reg('modx-layout',MODx.Layout);
 
 /**
  * Handles layout functions. In module format for easier privitization.

--- a/manager/templates/default/js/layout.js
+++ b/manager/templates/default/js/layout.js
@@ -1,0 +1,10 @@
+MODx.Layout.Default = function(config,getStore) {
+    config = config || {};
+    Ext.applyIf(config,{
+    });
+
+    MODx.Layout.Default.superclass.constructor.call(this,config);
+    return this;
+};
+Ext.extend(MODx.Layout.Default,MODx.Layout);
+Ext.reg('modx-layout',MODx.Layout.Default);


### PR DESCRIPTION
Each manager template must include layout.js file that extends MODx.Layout and register modx-layout xtype.
