### PR TITLE
Refactor remove combo paginator

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -455,7 +455,7 @@ MODx.combo.ContentDisposition = function(config) {
     });
     MODx.combo.ContentDisposition.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.combo.ContentDisposition,Ext.form.ComboBox);
+Ext.extend(MODx.combo.ContentDisposition,MODx.combo.ComboBox);
 Ext.reg('modx-combo-content-disposition',MODx.combo.ContentDisposition);
 
 MODx.combo.ClassMap = function(config) {

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -41,7 +41,45 @@ MODx.combo.ComboBox = function(config,getStore) {
     this.config = config;
     return this;
 };
-Ext.extend(MODx.combo.ComboBox,Ext.form.ComboBox);
+Ext.extend(MODx.combo.ComboBox,Ext.form.ComboBox, {
+    expand : function(){
+        if(this.isExpanded() || !this.hasFocus){
+            return;
+        }
+
+        if(this.title || this.pageSize){
+            this.assetHeight = 0;
+            if(this.title){
+                this.assetHeight += this.header.getHeight();
+            }
+            if(this.pageSize < this.store.getTotalCount()){
+                this.assetHeight += this.footer.getHeight();
+            } else {
+                this.list.setHeight(this.list.getHeight() - this.footer.getHeight());
+                this.pageTb.hide();
+            }
+        }
+
+        if(this.bufferSize){
+            this.doResize(this.bufferSize);
+            delete this.bufferSize;
+        }
+        this.list.alignTo.apply(this.list, [this.el].concat(this.listAlign));
+
+        // zindex can change, re-check it and set it if necessary
+        this.list.setZIndex(this.getZIndex());
+        this.list.show();
+        if(Ext.isGecko2){
+            this.innerList.setOverflow('auto'); // necessary for FF 2.0/Mac
+        }
+        this.mon(Ext.getDoc(), {
+            scope: this,
+            mousewheel: this.collapseIf,
+            mousedown: this.collapseIf
+        });
+        this.fireEvent('expand', this);
+    }
+});
 Ext.reg('modx-combo',MODx.combo.ComboBox);
 
 Ext.util.Format.comboRenderer = function (combo,val) {


### PR DESCRIPTION
When paginator is not necessary in combo box (number of items are lower or equal to page size) the paginator will not appear.
