### PR TITLE
Static file is required while creating/updating an element that have static checkbox checked

### DIFF
--- a/core/lexicon/en/element.inc.php
+++ b/core/lexicon/en/element.inc.php
@@ -36,3 +36,4 @@ $_lang['tv_default'] = 'Default Value';
 $_lang['tv_type'] = 'Input Type';
 $_lang['tv_output_type'] = 'Output Type';
 $_lang['tv_output_type_properties'] = 'Output Type Properties';
+$_lang['static_file_ns'] = 'You have to specify a static file.';

--- a/core/model/modx/processors/element/chunk/create.class.php
+++ b/core/model/modx/processors/element/chunk/create.class.php
@@ -21,5 +21,19 @@ class modChunkCreateProcessor extends modElementCreateProcessor {
     public $objectType = 'chunk';
     public $beforeSaveEvent = 'OnBeforeChunkFormSave';
     public $afterSaveEvent = 'OnChunkFormSave';
+
+    public function beforeSave() {
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
+        return parent::beforeSave();
+    }
 }
 return 'modChunkCreateProcessor';

--- a/core/model/modx/processors/element/chunk/update.class.php
+++ b/core/model/modx/processors/element/chunk/update.class.php
@@ -23,6 +23,20 @@ class modChunkUpdateProcessor extends modElementUpdateProcessor {
     public $beforeSaveEvent = 'OnBeforeChunkFormSave';
     public $afterSaveEvent = 'OnChunkFormSave';
 
+    public function beforeSave() {
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
+        return parent::beforeSave();
+    }
+
     public function cleanup() {
         return $this->success('',array_merge($this->object->get(array('id', 'name', 'description', 'locked', 'category', 'snippet')), array('previous_category' => $this->previousCategory)));
     }

--- a/core/model/modx/processors/element/plugin/create.class.php
+++ b/core/model/modx/processors/element/plugin/create.class.php
@@ -26,6 +26,20 @@ class modPluginCreateProcessor extends modElementCreateProcessor {
     public $beforeSaveEvent = 'OnBeforePluginFormSave';
     public $afterSaveEvent = 'OnPluginFormSave';
 
+    public function beforeSave() {
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
+        return parent::beforeSave();
+    }
+
     public function afterSave() {
         $this->saveEvents();
         return parent::afterSave();

--- a/core/model/modx/processors/element/plugin/update.class.php
+++ b/core/model/modx/processors/element/plugin/update.class.php
@@ -31,6 +31,16 @@ class modPluginUpdateProcessor extends modElementUpdateProcessor {
         $disabled = (boolean)$this->getProperty('disabled',false);
         $this->object->set('disabled',$disabled);
 
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
         return parent::beforeSave();
     }
 

--- a/core/model/modx/processors/element/snippet/create.class.php
+++ b/core/model/modx/processors/element/snippet/create.class.php
@@ -22,5 +22,19 @@ class modSnippetCreateProcessor extends modElementCreateProcessor {
     public $objectType = 'snippet';
     public $beforeSaveEvent = 'OnBeforeSnipFormSave';
     public $afterSaveEvent = 'OnSnipFormSave';
+
+    public function beforeSave() {
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
+        return parent::beforeSave();
+    }
 }
 return 'modSnippetCreateProcessor';

--- a/core/model/modx/processors/element/snippet/update.class.php
+++ b/core/model/modx/processors/element/snippet/update.class.php
@@ -24,6 +24,20 @@ class modSnippetUpdateProcessor extends modElementUpdateProcessor {
     public $beforeSaveEvent = 'OnBeforeSnipFormSave';
     public $afterSaveEvent = 'OnSnipFormSave';
 
+    public function beforeSave() {
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
+        return parent::beforeSave();
+    }
+
     public function cleanup() {
         return $this->success('',array_merge($this->object->get(array('id', 'name', 'description', 'locked', 'category', 'snippet')), array('previous_category' => $this->previousCategory)));
     }

--- a/core/model/modx/processors/element/template/create.class.php
+++ b/core/model/modx/processors/element/template/create.class.php
@@ -24,6 +24,20 @@ class modTemplateCreateProcessor extends modElementCreateProcessor {
     public $beforeSaveEvent = 'OnBeforeTempFormSave';
     public $afterSaveEvent = 'OnTempFormSave';
 
+    public function beforeSave() {
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
+        return parent::beforeSave();
+    }
+
     public function afterSave() {
         $this->saveTemplateVariables();
         return parent::afterSave();

--- a/core/model/modx/processors/element/template/update.class.php
+++ b/core/model/modx/processors/element/template/update.class.php
@@ -25,6 +25,20 @@ class modTemplateUpdateProcessor extends modElementUpdateProcessor {
     public $beforeSaveEvent = 'OnBeforeTempFormSave';
     public $afterSaveEvent = 'OnTempFormSave';
 
+    public function beforeSave() {
+        $isStatic = intval($this->getProperty('static', 0));
+
+        if ($isStatic == 1) {
+            $staticFile = $this->getProperty('static_file');
+
+            if (empty($staticFile)) {
+                $this->addFieldError('static_file', $this->modx->lexicon('static_file_ns'));
+            }
+        }
+
+        return parent::beforeSave();
+    }
+
     public function afterSave() {
         $this->setTemplateVariables();
         return parent::afterSave();

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -104,6 +104,17 @@ MODx.panel.Chunk = function(config) {
                         ,value: config.record.static_file || ''
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
+                        ,validator: function(value){
+                            if (Ext.getCmp('modx-chunk-static').getValue() === true) {
+                                if (Ext.util.Format.trim(value) != '') {
+                                    return true;
+                                } else {
+                                    return _('static_file_ns');
+                                }
+                            }
+
+                            return true;
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-chunk-static-file'

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -105,6 +105,17 @@ MODx.panel.Plugin = function(config) {
                         ,value: config.record.static_file || ''
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
+                        ,validator: function(value){
+                            if (Ext.getCmp('modx-plugin-static').getValue() === true) {
+                                if (Ext.util.Format.trim(value) != '') {
+                                    return true;
+                                } else {
+                                    return _('static_file_ns');
+                                }
+                            }
+
+                            return true;
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-plugin-static-file'

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -104,6 +104,17 @@ MODx.panel.Snippet = function(config) {
                         ,value: config.record.static_file || ''
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
+                        ,validator: function(value){
+                            if (Ext.getCmp('modx-snippet-static').getValue() === true) {
+                                if (Ext.util.Format.trim(value) != '') {
+                                    return true;
+                                } else {
+                                    return _('static_file_ns');
+                                }
+                            }
+
+                            return true;
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-snippet-static-file'

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -106,6 +106,17 @@ MODx.panel.Template = function(config) {
                         ,value: config.record.static_file || ''
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
+                        ,validator: function(value){
+                            if (Ext.getCmp('modx-template-static').getValue() === true) {
+                                if (Ext.util.Format.trim(value) != '') {
+                                    return true;
+                                } else {
+                                    return _('static_file_ns');
+                                }
+                            }
+
+                            return true;
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-template-static-file'


### PR DESCRIPTION
Proper error message appear when you tries to save static element without providing a static file.

Implemented JS and PHP validator.
