### PR TITLE
MODx.combo:   Notify on error while loading store

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -31,6 +31,12 @@ MODx.combo.ComboBox = function(config,getStore) {
             ,baseParams: config.baseParams || {}
             ,remoteSort: config.remoteSort || false
             ,autoDestroy: true
+            ,listeners: {
+                'loadexception': {fn: function(o,trans,resp) {
+                    var status = _('code') + ': ' + resp.status + ' ' + resp.statusText + '<br/>';
+                    MODx.msg.alert(_('error'), status + resp.responseText);
+                }}
+            }
         })
     });
     if (getStore === true) {


### PR DESCRIPTION
Currently,  if the store loading fails nothing happens.    The user has no way to know why (_unless they open dev-tools and try to find the response..._).    This patch will pop-up a notification.

In our case,  we have a combo which is populated via third-party API endpoint.   with  apikey, authentication token and so on.. many things can "normally" go wrong.
