### PR TITLE
Prevent "core" namespace removal

### DIFF
--- a/core/model/modx/processors/workspace/namespace/remove.class.php
+++ b/core/model/modx/processors/workspace/namespace/remove.class.php
@@ -13,5 +13,9 @@ class modNamespaceRemoveProcessor extends modObjectRemoveProcessor {
     public $permission = 'namespaces';
     public $objectType = 'namespace';
     public $primaryKeyField = 'name';
+
+    public function beforeRemove() {
+        return 'core' != $this->getProperty('name');
+    }
 }
 return 'modNamespaceRemoveProcessor';


### PR DESCRIPTION
Just to make sure drunk people do not kill their installation :smile:
