### PR TITLE
Fixes Installer for PHP versions above 5.5.0

### DIFF
--- a/core/model/modx/mysql/modcontextsetting.map.inc.php
+++ b/core/model/modx/mysql/modcontextsetting.map.inc.php
@@ -70,6 +70,7 @@ $xpdo_meta_map['modContextSetting']= array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
       'null' => false,
+      'default' => 'CURRENT_TIMESTAMP',
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/modx/mysql/modlexiconentry.map.inc.php
+++ b/core/model/modx/mysql/modlexiconentry.map.inc.php
@@ -73,6 +73,7 @@ $xpdo_meta_map['modLexiconEntry']= array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
       'null' => false,
+      'default' => 'CURRENT_TIMESTAMP',
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/modx/mysql/modmanagerlog.map.inc.php
+++ b/core/model/modx/mysql/modmanagerlog.map.inc.php
@@ -11,7 +11,7 @@ $xpdo_meta_map['modManagerLog']= array (
   'fields' => 
   array (
     'user' => 0,
-    'occurred' => '0000-00-00 00:00:00',
+    'occurred' => '',
     'action' => '',
     'classKey' => '',
     'item' => '0',
@@ -32,7 +32,6 @@ $xpdo_meta_map['modManagerLog']= array (
       'dbtype' => 'datetime',
       'phptype' => 'datetime',
       'null' => true,
-      'default' => '0000-00-00 00:00:00',
     ),
     'action' => 
     array (

--- a/core/model/modx/mysql/modsystemsetting.map.inc.php
+++ b/core/model/modx/mysql/modsystemsetting.map.inc.php
@@ -64,6 +64,7 @@ $xpdo_meta_map['modSystemSetting']= array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
       'null' => false,
+      'default' => 'CURRENT_TIMESTAMP',
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/modx/mysql/modusergroupsetting.map.inc.php
+++ b/core/model/modx/mysql/modusergroupsetting.map.inc.php
@@ -71,6 +71,7 @@ $xpdo_meta_map['modUserGroupSetting']= array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
       'null' => false,
+      'default' => 'CURRENT_TIMESTAMP',
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/modx/mysql/modusersetting.map.inc.php
+++ b/core/model/modx/mysql/modusersetting.map.inc.php
@@ -72,6 +72,7 @@ $xpdo_meta_map['modUserSetting']= array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
       'null' => false,
+      'default' => 'CURRENT_TIMESTAMP',
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -667,7 +667,7 @@
 
     <object class="modManagerLog" table="manager_log" extends="xPDOSimpleObject">
         <field key="user" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
-        <field key="occurred" dbtype="datetime" phptype="datetime" null="true" default="0000-00-00 00:00:00" />
+        <field key="occurred" dbtype="datetime" phptype="datetime" null="true" />
         <field key="action" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="classKey" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="item" dbtype="varchar" precision="255" phptype="string" null="false" default="0" />

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -453,7 +453,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
             <column key="context_key" collation="A" null="false" />
@@ -647,7 +647,7 @@
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" index="index" />
         <field key="language" dbtype="varchar" precision="20" phptype="string" null="false" default="en" index="index" />
         <field key="createdon" dbtype="datetime" phptype="datetime" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="name" name="name" primary="false" unique="false" type="BTREE">
             <column key="name" length="" collation="A" null="false" />
@@ -1063,7 +1063,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="key" length="" collation="A" null="false" />
@@ -1308,7 +1308,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="group" length="" collation="A" null="false" />
@@ -1374,7 +1374,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="CURRENT_TIMESTAMP" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="user" length="" collation="A" null="false" />

--- a/setup/includes/drivers/modinstalldriver_mysql.class.php
+++ b/setup/includes/drivers/modinstalldriver_mysql.class.php
@@ -139,8 +139,7 @@ class modInstallDriver_mysql extends modInstallDriver {
      * {@inheritDoc}
      */
     public function verifyServerVersion() {
-        $handler = @mysql_connect($this->install->settings->get('database_server'),$this->install->settings->get('database_user'),$this->install->settings->get('database_password'));
-        $mysqlVersion = @mysql_get_server_info($handler);
+        $mysqlVersion = $this->xpdo->pdo->getAttribute(PDO::ATTR_SERVER_VERSION);
         $mysqlVersion = $this->_sanitizeVersion($mysqlVersion);
         if (empty($mysqlVersion)) {
             return array('result' => 'warning', 'message' => $this->install->lexicon('mysql_version_server_nf'),'version' => $mysqlVersion);
@@ -164,7 +163,7 @@ class modInstallDriver_mysql extends modInstallDriver {
      * {@inheritDoc}
      */
     public function verifyClientVersion() {
-        $mysqlVersion = @mysql_get_client_info();
+        $mysqlVersion = $this->xpdo->pdo->getAttribute(PDO::ATTR_CLIENT_VERSION);
         $mysqlVersion = $this->_sanitizeVersion($mysqlVersion);
         if (empty($mysqlVersion)) {
             return array('result' => 'warning','message' => $this->install->lexicon('mysql_version_client_nf'),'version' => $mysqlVersion);


### PR DESCRIPTION
Fixes Installer for PHP versions above 5.5.0 and for MySQL versions above 5.6 in strict mode

Targets these bug reports
http://tracker.modx.com/issues/10244 -- confirmed
http://tracker.modx.com/issues/10174 -- partially confirmed
