### PR TITLE
Modified getTree() to support options (like context) as getChildIds()/getParentIds()

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -487,6 +487,21 @@ class modFile extends modFileSystemResource {
         if (!$this->exists()) return false;
         return @unlink($this->path);
     }
+
+    /**
+     * Sends download headers
+     * 
+     * Can also be used by just setting the content of the fileobject with setContent()
+     * 
+     * @return file
+     */
+    public function makeDownload() {
+        $output = $this->getContents();
+        header('Content-type: application/octetstream');
+        header('Content-Disposition: attachment; filename=' . $this->getBasename());
+        header('Content-Length: ' . $this->getSize());
+        return $output;
+    }
 }
 
 /**

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -758,17 +758,22 @@ class modX extends xPDO {
      * @param int $depth The maximum depth to build the tree (default 10).
      * @return array An array containing the tree structure.
      */
-    public function getTree($id= null, $depth= 10) {
+    public function getTree($id= null, $depth= 10, array $options = array()) {
         $tree= array ();
+        $context = '';
+        if (!empty($options['context'])) {
+            $this->getContext($options['context']);
+            $context = $options['context'];
+        }
         if ($id !== null) {
             if (is_array ($id)) {
                 foreach ($id as $k => $v) {
-                    $tree[$v]= $this->getTree($v, $depth);
+                    $tree[$v]= $this->getTree($v, $depth, $options);
                 }
             }
-            elseif ($branch= $this->getChildIds($id, 1)) {
+            elseif ($branch= $this->getChildIds($id, 1, $options)) {
                 foreach ($branch as $key => $child) {
-                    if ($depth > 0 && $leaf= $this->getTree($child, $depth--)) {
+                    if ($depth > 0 && $leaf= $this->getTree($child, $depth--, $options)) {
                         $tree[$child]= $leaf;
                     } else {
                         $tree[$child]= $child;


### PR DESCRIPTION
This is just for convenience that we don't have to set a context via `$modx->switchContext('contextname')` before using `$modx->getTree()`
