### PR TITLE
Added saveCSV() method to modFileHandler class

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -431,6 +431,29 @@ class modFile extends modFileSystemResource {
         return $result;
     }
 
+     /**
+     * Writes a csv file.
+     *
+     * @param array $csvlines This holds all the csv lines in one array, each key is a line!
+     * @param string $mode The mode in which to write
+     * @return boolean The result of the fputcsv (will return number of written characters, not true or false)
+     */
+    public function saveCSV($csvlines = array(), $mode = 'w+') {
+        $result = false;
+
+        $fp = @fopen($this->path, $mode);
+        if ($fp) {
+            foreach ($csvlines as $csvline) {
+                if ( fputcsv($fp, $csvline) ) {
+                    $result = true;
+                }
+            }
+            @fclose($fp);
+        }
+
+        return $result;
+    }
+
     /**
      * Gets the size of the file
      *


### PR DESCRIPTION
Additional modFileHandler method that allows easy saving of array elements as CSV
I don't know if you find this a helpful addition or not, just thought I share if so. I really like the modFileHandler and use it a lot and this method is something I find quite convenient when generating an export of any data that can be stored in an array (ie . Collections of MODx objects or whatever objects etc.). Actually it involves a bit more than just this method (need to generate headers, catch encoding issues etc.), but when the data is prepared nicely in an array, this just needs to be passed to this method and voila...
