### PR TITLE
Removed condition for no children elements

### DIFF
--- a/core/model/modx/processors/element/getnodes.class.php
+++ b/core/model/modx/processors/element/getnodes.class.php
@@ -322,10 +322,10 @@ class modElementGetNodesProcessor extends modProcessor {
         /** @var modCategory $category */
         foreach ($categories as $category) {
             if (!$category->checkPolicy('list')) continue;
-            if ($category->get('elementCount') <= 0) continue;
-        
+
+            $cc = ($category->get('elementCount') > 0) ? ' (' . $category->get('elementCount') . ')' : '';
             $nodes[] = array(
-                'text' => strip_tags($category->get('category')) . ' (' . $category->get('elementCount') . ')',
+                'text' => strip_tags($category->get('category')) . $cc,
                 'id' => 'n_'.$map[0].'_category_'.($category->get('id') != null ? $category->get('id') : 0),
                 'pk' => $category->get('id'),
                 'category' => $category->get('id'),


### PR DESCRIPTION
I removed condition that checks if category has any elements under it. It checked only first level.

Probably better would be check if any child category has elements, but it would be more time consuming while opening the tree, so I choosed this way.

Issue: http://bugs.modx.com/issues/9951
