### PR TITLE
Fixed transparent input boxes on manager login page.

### DIFF
--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -181,6 +181,7 @@ label {
   .x-form-text {
     padding: 8px;
     width: 181px;
+    background: #FFF;
   }
 }
 


### PR DESCRIPTION
Somehow I think this slipped through the fold. In current revision, the background of the login boxes (user/pass) are transparent, and reflect the background image. Simply added the background: #FFF; to the x-form-text class fixes this.
