### PR TITLE
return the error when listing the packages is false

### DIFF
--- a/core/model/modx/processors/workspace/packages/rest/getlist.class.php
+++ b/core/model/modx/processors/workspace/packages/rest/getlist.class.php
@@ -41,7 +41,7 @@ class modPackageRemoteGetListProcessor extends modProcessor {
     public function process() {
         $data = $this->getData();
         if (!is_array($data)) {
-            $this->failure($data);
+            return $this->failure($data);
         }
 
         $list = array();


### PR DESCRIPTION
The false message will be written on the grid, and this will suppress error 

```
[2013-10-25 18:32:04] (ERROR @ /home/..../core/model/modx/processors/workspace/packages/rest/getlist.class.php : 48) PHP warning: Invalid argument supplied for foreach()
```
