### PR TITLE
some es, fr and th localisation files contains UTF8 BOM

### DIFF
--- a/core/lexicon/country/fr.inc.php
+++ b/core/lexicon/country/fr.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
 * Country List Language File - French Version
 * Version: 1.0

--- a/core/lexicon/country/th.inc.php
+++ b/core/lexicon/country/th.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Country List Language File(Thai)
  *

--- a/core/lexicon/es/about.inc.php
+++ b/core/lexicon/es/about.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * About Spanish lexicon topic
  *

--- a/core/lexicon/es/access.inc.php
+++ b/core/lexicon/es/access.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Access Spanish lexicon topic
  *

--- a/core/lexicon/es/action.inc.php
+++ b/core/lexicon/es/action.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Action Spanish lexicon topic
  *

--- a/core/lexicon/es/category.inc.php
+++ b/core/lexicon/es/category.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Category Spanish lexicon topic
  *

--- a/core/lexicon/es/chunk.inc.php
+++ b/core/lexicon/es/chunk.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Chunk Spanish lexicon topic
  *

--- a/core/lexicon/es/configcheck.inc.php
+++ b/core/lexicon/es/configcheck.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Config Check Spanish lexicon topic
  *

--- a/core/lexicon/es/content_type.inc.php
+++ b/core/lexicon/es/content_type.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Content Type Spanish lexicon topic
  *

--- a/core/lexicon/es/context.inc.php
+++ b/core/lexicon/es/context.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Context Spanish lexicon topic
  *

--- a/core/lexicon/es/dashboard.inc.php
+++ b/core/lexicon/es/dashboard.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Welcome Page Spanish lexicon topic
  *

--- a/core/lexicon/es/default.inc.php
+++ b/core/lexicon/es/default.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Default Spanish lexicon topic
  *

--- a/core/lexicon/es/element.inc.php
+++ b/core/lexicon/es/element.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Spanish language strings for Elements
  *

--- a/core/lexicon/es/export.inc.php
+++ b/core/lexicon/es/export.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Export Spanish lexicon topic
  *

--- a/core/lexicon/es/file.inc.php
+++ b/core/lexicon/es/file.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * File Spanish lexicon topic
  *

--- a/core/lexicon/es/filters.inc.php
+++ b/core/lexicon/es/filters.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Custom Filters Spanish lexicon topic
  *

--- a/core/lexicon/es/formcustomization.inc.php
+++ b/core/lexicon/es/formcustomization.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Form Customization Spanish lexicon topic
  *

--- a/core/lexicon/es/import.inc.php
+++ b/core/lexicon/es/import.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Import Spanish lexicon entries
  *

--- a/core/lexicon/es/lexicon.inc.php
+++ b/core/lexicon/es/lexicon.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Lexicon Spanish lexicon topic
  *

--- a/core/lexicon/es/login.inc.php
+++ b/core/lexicon/es/login.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Login Spanish lexicon topic
  *

--- a/core/lexicon/es/mail.inc.php
+++ b/core/lexicon/es/mail.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Mail Spanish lexicon topic
  *

--- a/core/lexicon/es/manager_log.inc.php
+++ b/core/lexicon/es/manager_log.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Manager Log Spanish lexicon topic
  *

--- a/core/lexicon/es/menu.inc.php
+++ b/core/lexicon/es/menu.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Menu Spanish lexicon topic
  *

--- a/core/lexicon/es/messages.inc.php
+++ b/core/lexicon/es/messages.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Messages Spanish lexicon topic
  *

--- a/core/lexicon/es/namespace.inc.php
+++ b/core/lexicon/es/namespace.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Namespace Spanish lexicon topic
  *

--- a/core/lexicon/es/package_builder.inc.php
+++ b/core/lexicon/es/package_builder.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Package Builder Spanish lexicon topic
  *

--- a/core/lexicon/es/permissions.inc.php
+++ b/core/lexicon/es/permissions.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Permissions Spanish lexicon topic
  *

--- a/core/lexicon/es/plugin.inc.php
+++ b/core/lexicon/es/plugin.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Plugin Spanish lexicon topic
  *

--- a/core/lexicon/es/policy.inc.php
+++ b/core/lexicon/es/policy.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Access Policy Spanish lexicon topic
  *

--- a/core/lexicon/es/propertyset.inc.php
+++ b/core/lexicon/es/propertyset.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Property Set Spanish lexicon topic
  *

--- a/core/lexicon/es/resource.inc.php
+++ b/core/lexicon/es/resource.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Resource Spanish lexicon topic
  *

--- a/core/lexicon/es/setting.inc.php
+++ b/core/lexicon/es/setting.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Setting Spanish lexicon topic
  *

--- a/core/lexicon/es/snippet.inc.php
+++ b/core/lexicon/es/snippet.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Snippet Spanish lexicon topic
  *

--- a/core/lexicon/es/system_events.inc.php
+++ b/core/lexicon/es/system_events.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * System Events Spanish lexicon topic
  *

--- a/core/lexicon/es/system_info.inc.php
+++ b/core/lexicon/es/system_info.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * System Info Spanish lexicon topic
  *

--- a/core/lexicon/es/template.inc.php
+++ b/core/lexicon/es/template.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Template Spanish lexicon topic
  *

--- a/core/lexicon/es/topmenu.inc.php
+++ b/core/lexicon/es/topmenu.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Top Menu Spanish lexicon topic
  *

--- a/core/lexicon/es/tv.inc.php
+++ b/core/lexicon/es/tv.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * TV Spanish lexicon topic
  *

--- a/core/lexicon/es/tv_input_types.inc.php
+++ b/core/lexicon/es/tv_input_types.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * TV Input Types Spanish lexicon topic
  *

--- a/core/lexicon/es/tv_widget.inc.php
+++ b/core/lexicon/es/tv_widget.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * TV Widget Spanish lexicon topic
  *

--- a/core/lexicon/es/user.inc.php
+++ b/core/lexicon/es/user.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * User Spanish lexicon topic
  *

--- a/core/lexicon/es/welcome.inc.php
+++ b/core/lexicon/es/welcome.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Welcome Spanish lexicon topic
  *

--- a/core/lexicon/es/workspace.inc.php
+++ b/core/lexicon/es/workspace.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Workspace Spanish lexicon topic
  *

--- a/core/lexicon/th/about.inc.php
+++ b/core/lexicon/th/about.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * About Thai lexicon topic
  *

--- a/core/lexicon/th/access.inc.php
+++ b/core/lexicon/th/access.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Access Thai lexicon topic
  *

--- a/core/lexicon/th/action.inc.php
+++ b/core/lexicon/th/action.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Action Thai lexicon topic
  *

--- a/core/lexicon/th/category.inc.php
+++ b/core/lexicon/th/category.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Category Thai lexicon topic
  *

--- a/core/lexicon/th/chunk.inc.php
+++ b/core/lexicon/th/chunk.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Chunk Thai lexicon topic
  *

--- a/core/lexicon/th/configcheck.inc.php
+++ b/core/lexicon/th/configcheck.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Config Check Thai lexicon topic
  *

--- a/core/lexicon/th/content_type.inc.php
+++ b/core/lexicon/th/content_type.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Content Type Thai lexicon topic
  *

--- a/core/lexicon/th/context.inc.php
+++ b/core/lexicon/th/context.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Context Thai lexicon topic
  *

--- a/core/lexicon/th/dashboard.inc.php
+++ b/core/lexicon/th/dashboard.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Welcome Page Thai lexicon topic
  *

--- a/core/lexicon/th/dashboards.inc.php
+++ b/core/lexicon/th/dashboards.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Thai language strings for Dashboards
  *

--- a/core/lexicon/th/default.inc.php
+++ b/core/lexicon/th/default.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Default Thai lexicon topic
  *

--- a/core/lexicon/th/element.inc.php
+++ b/core/lexicon/th/element.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Thai language strings for Elements
  *

--- a/core/lexicon/th/export.inc.php
+++ b/core/lexicon/th/export.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Export Thai lexicon topic
  *

--- a/core/lexicon/th/file.inc.php
+++ b/core/lexicon/th/file.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * File Thai lexicon topic
  *

--- a/core/lexicon/th/filters.inc.php
+++ b/core/lexicon/th/filters.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Custom Filters Thai lexicon topic
  *

--- a/core/lexicon/th/formcustomization.inc.php
+++ b/core/lexicon/th/formcustomization.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Form Customization Thai lexicon topic
  *

--- a/core/lexicon/th/import.inc.php
+++ b/core/lexicon/th/import.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Import Thai lexicon entries
  *

--- a/core/lexicon/th/lexicon.inc.php
+++ b/core/lexicon/th/lexicon.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Lexicon Thai lexicon topic
  *

--- a/core/lexicon/th/login.inc.php
+++ b/core/lexicon/th/login.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Login Thai lexicon topic
  *

--- a/core/lexicon/th/mail.inc.php
+++ b/core/lexicon/th/mail.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Mail Thai lexicon topic
  *

--- a/core/lexicon/th/manager_log.inc.php
+++ b/core/lexicon/th/manager_log.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Manager Log Thai lexicon topic
  *

--- a/core/lexicon/th/menu.inc.php
+++ b/core/lexicon/th/menu.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Menu Thai lexicon topic
  *

--- a/core/lexicon/th/messages.inc.php
+++ b/core/lexicon/th/messages.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Messages Thai lexicon topic
  *

--- a/core/lexicon/th/namespace.inc.php
+++ b/core/lexicon/th/namespace.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Namespace Thai lexicon topic
  *

--- a/core/lexicon/th/package_builder.inc.php
+++ b/core/lexicon/th/package_builder.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Package Builder Thai lexicon topic
  *

--- a/core/lexicon/th/permissions.inc.php
+++ b/core/lexicon/th/permissions.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Permissions Thai lexicon topic
  *

--- a/core/lexicon/th/plugin.inc.php
+++ b/core/lexicon/th/plugin.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Plugin Thai lexicon topic
  *

--- a/core/lexicon/th/policy.inc.php
+++ b/core/lexicon/th/policy.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Access Policy Thai lexicon topic
  *

--- a/core/lexicon/th/propertyset.inc.php
+++ b/core/lexicon/th/propertyset.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Property Set Thai lexicon topic
  *

--- a/core/lexicon/th/resource.inc.php
+++ b/core/lexicon/th/resource.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Resource Thai lexicon topic
  *

--- a/core/lexicon/th/setting.inc.php
+++ b/core/lexicon/th/setting.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Setting Thai lexicon topic
  *

--- a/core/lexicon/th/snippet.inc.php
+++ b/core/lexicon/th/snippet.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Snippet Thai lexicon topic
  *

--- a/core/lexicon/th/source.inc.php
+++ b/core/lexicon/th/source.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Sources Thai lexicon topic
  *

--- a/core/lexicon/th/system_events.inc.php
+++ b/core/lexicon/th/system_events.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * System Events Thai lexicon topic
  *

--- a/core/lexicon/th/system_info.inc.php
+++ b/core/lexicon/th/system_info.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * System Info Thai lexicon topic
  *

--- a/core/lexicon/th/template.inc.php
+++ b/core/lexicon/th/template.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Template Thai lexicon topic
  *

--- a/core/lexicon/th/topmenu.inc.php
+++ b/core/lexicon/th/topmenu.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Top Menu Thai lexicon topic
  *

--- a/core/lexicon/th/tv.inc.php
+++ b/core/lexicon/th/tv.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * TV Thai lexicon topic
  *

--- a/core/lexicon/th/tv_input_types.inc.php
+++ b/core/lexicon/th/tv_input_types.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * TV Input Types Thai lexicon topic
  *

--- a/core/lexicon/th/tv_widget.inc.php
+++ b/core/lexicon/th/tv_widget.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * TV Widget Thai lexicon topic
  *

--- a/core/lexicon/th/user.inc.php
+++ b/core/lexicon/th/user.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * User Thai lexicon topic
  *

--- a/core/lexicon/th/welcome.inc.php
+++ b/core/lexicon/th/welcome.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Welcome Thai lexicon topic
  *

--- a/core/lexicon/th/workspace.inc.php
+++ b/core/lexicon/th/workspace.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Workspace Thai lexicon topic
  *

--- a/setup/lang/es/default.inc.php
+++ b/setup/lang/es/default.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Spanish language files for Revolution 2.0.7 setup
  *

--- a/setup/lang/es/drivers.inc.php
+++ b/setup/lang/es/drivers.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Spanish Drivers Lexicon Topic for Revolution setup
  *

--- a/setup/lang/es/preload.inc.php
+++ b/setup/lang/es/preload.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Spanish Preload Lexicon Topic for Revolution setup
  *

--- a/setup/lang/es/upgrades.inc.php
+++ b/setup/lang/es/upgrades.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Spanish Upgrades Lexicon Topic for Revolution setup.
  *


### PR DESCRIPTION
Some es, fr and th localisation files contains UTF8 BOM bytes
(http://en.wikipedia.org/wiki/Byte_order_mark), this creates mysterious
errors because this BOM bytes are returned to browser when these
localisation files are included (only whe MODX cache is empty). Special
problems this makes on custom FormIt validators, because this BOM bytes
are returned in custom validator response! I spend hours to find this
mysterious problem. I discussed this error by jan.tezner@coex.cz.

Best way to reduce this errors in next MODX relases is to add UTF8 BOM filter to batch which makes ZIP archive or sometime scan Github repository. This UTF8 BOM problem contains some MODX extras :(

Jiri Pavlicek
