### PR TITLE
Fix fallback MODX_CORE_PATH in manager/min/index.php

### DIFF
--- a/manager/min/index.php
+++ b/manager/min/index.php
@@ -5,7 +5,7 @@
  * @subpackage minify
  */
 @include dirname(dirname(__FILE__)) . '/config.core.php';
-if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(dirname(dirname(__FILE__))) . '/core/');
 
 /* set the document_root */
 if(!isset($_SERVER['DOCUMENT_ROOT']) || empty($_SERVER['DOCUMENT_ROOT'])) {


### PR DESCRIPTION
Error: When `manager/config.core.php` doesn't exist, `MODX_CORE_PATH`
in manager/min becomes `%modx base%/manager/core` instead of `%modx
base%/core`
