### PR TITLE
Fix caching of menu in manager

### DIFF
--- a/core/model/modx/modmenu.class.php
+++ b/core/model/modx/modmenu.class.php
@@ -53,7 +53,7 @@ class modMenu extends modAccessibleObject {
      */
     public function rebuildCache($start = '') {
         $menus = $this->getSubMenus($start);
-        $cached = $this->xpdo->cacheManager->set('menus/'.$this->xpdo->getOption('manager_language',null,$this->xpdo->getOption('cultureKey',null,'en')), $menus, 0, array(
+        $cached = $this->xpdo->cacheManager->set('mgr/menus/'.$this->xpdo->getOption('manager_language',null,$this->xpdo->getOption('cultureKey',null,'en')), $menus, 0, array(
             xPDO::OPT_CACHE_KEY => $this->xpdo->cacheManager->getOption('cache_menu_key', null, 'menu'),
             xPDO::OPT_CACHE_HANDLER => $this->xpdo->cacheManager->getOption('cache_menu_handler', null, $this->xpdo->getOption(xPDO::OPT_CACHE_HANDLER))
         ));


### PR DESCRIPTION
Until now probably manager menu never been cached by missing context key in path to cache file.

Take a look on **'mgr/menus/'** in https://github.com/modxcms/revolution/blob/release-2.2/manager/controllers/default/header.php#L12

``` php
$menus = $modx->cacheManager->get('mgr/menus/'.$modx->getOption('manager_language',null,$modx->getOption('cultureKey',null,'en')), array(
    xPDO::OPT_CACHE_KEY => $modx->getOption('cache_menu_key', null, 'menu'),
    xPDO::OPT_CACHE_HANDLER => $modx->getOption('cache_menu_handler', null, $modx->getOption(xPDO::OPT_CACHE_HANDLER)),
    xPDO::OPT_CACHE_FORMAT => (integer) $modx->getOption('cache_menu_format', null, $modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
));
```
