### PR TITLE
Fix loading of plugin events on Create Plugin screen

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -240,7 +240,7 @@ MODx.panel.Plugin = function(config) {
                 xtype: 'modx-grid-plugin-event'
 				,cls:'main-wrapper'
                 ,preventRender: true
-                ,plugin: config.plugin
+                ,plugin: config.record.id || 0
                 ,listeners: {
                     'updateEvent': {fn:this.markDirty,scope:this}
                     ,'rowclick': {fn:this.markDirty,scope:this}


### PR DESCRIPTION
Plugin events are not loading into the grid when creating a new plugin. This PR fixes the issue.
