### PR TITLE
Implement auto-saving on Content Types grid

### DIFF
--- a/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
+++ b/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
@@ -29,32 +29,32 @@ class modContentTypeUpdateFromGridProcessor extends modProcessor {
     public function initialize() {
         $data = $this->getProperty('data');
         if (empty($data)) return $this->modx->lexicon('invalid_data');
-        $this->records = $this->modx->fromJSON($data);
-        if (empty($this->records)) return $this->modx->lexicon('invalid_data');
+        $this->record = $this->modx->fromJSON($data);
+        if (empty($this->record)) return $this->modx->lexicon('invalid_data');
         return true;
     }
 
     public function process() {
         $refresh = array();
-        foreach ($this->records as $fields) {
-            if (empty($fields['id'])) continue;
-            /** @var modContentType $contentType */
-            $contentType = $this->modx->getObject('modContentType',$fields['id']);
-            if (empty($contentType)) continue;
+        $field = $this->record;
+        if (empty($field['id'])) continue;
+        /** @var modContentType $contentType */
+        $contentType = $this->modx->getObject('modContentType',$field['id']);
+        if (empty($contentType)) continue;
 
-            /* save content type */
-            $fields['binary'] = !empty($fields['binary']) ? true : false;
-            $contentType->fromArray($fields);
+        /* save content type */
+        $field['binary'] = !empty($field['binary']) ? true : false;
+        $contentType->fromArray($field);
 
-            $refresh[] = $contentType->isDirty('file_extensions') && $this->modx->getCount('modResource', array('content_type' => $contentType->get('id')));
-            if ($contentType->save() == false) {
-                $this->modx->error->checkValidation($contentType);
-                return $this->failure($this->modx->lexicon('content_type_err_save'));
-            }
-
-            /* log manager action */
-            $this->modx->logManagerAction('content_type_save','modContentType',$contentType->get('id'));
+        $refresh[] = $contentType->isDirty('file_extensions') && $this->modx->getCount('modResource', array('content_type' => $contentType->get('id')));
+        if ($contentType->save() == false) {
+            $this->modx->error->checkValidation($contentType);
+            return $this->failure($this->modx->lexicon('content_type_err_save'));
         }
+
+        /* log manager action */
+        $this->modx->logManagerAction('content_type_save','modContentType',$contentType->get('id'));
+
         if (array_search(true, $refresh, true) !== false) {
             $this->modx->call('modResource', 'refreshURIs', array(&$this->modx));
         }

--- a/manager/assets/modext/sections/system/content.type.js
+++ b/manager/assets/modext/sections/system/content.type.js
@@ -7,31 +7,21 @@
  * @xtype modx-page-content-type
  */
 MODx.page.ContentType = function(config) {
-	config = config || {};
-	Ext.applyIf(config,{
+    config = config || {};
+    Ext.applyIf(config,{
         formpanel: 'modx-panel-content-type'
         ,buttons: [{
-            process: 'system/contenttype/updateFromGrid'
-            ,text: _('save')
-            ,method: 'remote'
-            ,id: 'save-type-btn'
-            ,disabled: true
-            ,keys: [{
-                key: MODx.config.keymap_save || 's'
-                ,ctrl: true
-            }]
-        },'-',{
             process: 'cancel', text: _('cancel'), params: {a:'welcome'}
         }/*,'-',{
-            text: _('help_ex')
-            ,handler: MODx.loadHelpPane
-        }*/]
-		,components: [{
+         text: _('help_ex')
+         ,handler: MODx.loadHelpPane
+         }*/]
+        ,components: [{
             xtype: 'modx-panel-content-type'
             ,title: ''
         }]
-	});
-	MODx.page.ContentType.superclass.constructor.call(this,config);
+    });
+    MODx.page.ContentType.superclass.constructor.call(this,config);
 };
 Ext.extend(MODx.page.ContentType,MODx.Component);
 Ext.reg('modx-page-content-type',MODx.page.ContentType);

--- a/manager/assets/modext/widgets/system/modx.grid.content.type.js
+++ b/manager/assets/modext/widgets/system/modx.grid.content.type.js
@@ -10,9 +10,6 @@ MODx.panel.ContentType = function(config) {
         id: 'modx-panel-content-type'
 		,cls: 'container'
         ,url: MODx.config.connector_url
-        ,baseParams: {
-            action: 'system/contenttype/updateFromGrid'
-        }
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
             html: '<h2>'+_('content_types')+'</h2>'
@@ -34,28 +31,10 @@ MODx.panel.ContentType = function(config) {
                 ,preventRender: true
             }]
         }]
-        ,listeners: {
-            'setup': {fn:this.setup,scope:this}
-            ,'success': {fn:this.success,scope:this}
-            ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
-        }
     });
     MODx.panel.ContentType.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.panel.ContentType,MODx.FormPanel,{
-    initialized: false
-    ,setup: function() {}
-    ,beforeSubmit: function(o) {
-        var g = this.getComponent('form').getComponent('grid');
-        Ext.apply(o.form.baseParams,{
-            data: g.encodeModified()
-        });
-    }
-    ,success: function(o) {
-        this.getComponent('form').getComponent('grid').getStore().commitChanges();
-        Ext.getCmp('save-type-btn').disable();
-    }
-});
+Ext.extend(MODx.panel.ContentType,MODx.FormPanel,{});
 Ext.reg('modx-panel-content-type',MODx.panel.ContentType);
 
 /**
@@ -80,6 +59,8 @@ MODx.grid.ContentType = function(config) {
         ,baseParams: {
             action: 'system/contenttype/getlist'
         }
+        ,autosave: true
+        ,save_action: 'system/contenttype/updatefromgrid'
         ,fields: ['id','name','mime_type','file_extensions','headers','binary','description']
         ,paging: true
         ,remoteSort: true
@@ -117,9 +98,6 @@ MODx.grid.ContentType = function(config) {
         }]
     });
     MODx.grid.ContentType.superclass.constructor.call(this,config);
-    this.on('afteredit', function() {
-        Ext.getCmp('save-type-btn').enable();
-    });
 };
 Ext.extend(MODx.grid.ContentType,MODx.grid.Grid,{
     getMenu: function() {


### PR DESCRIPTION
Implements auto-saving when editing Content Types inline.

Removes need for Save button on panel and the 'invalid data' error that can occur when using the ctrl+s keyboard shortcut if no data has been changed.
