### PR TITLE
[REBUILD/UPGRADE REQUIRED] Fix Remove Locks functionality

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -225,12 +225,18 @@ $children[2]->fromArray(array (
 MODx.msg.confirm({
     title: _(\'remove_locks\')
     ,text: _(\'confirm_remove_locks\')
-    ,url: MODx.config.connectors_url+\'system/remove_locks.php\'
+    ,url: MODx.config.connectors_url
     ,params: {
-        action: \'remove\'
+        action: \'system/remove_locks\'
     }
     ,listeners: {
-        \'success\': {fn:function() { Ext.getCmp("modx-resource-tree").refresh(); },scope:this}
+        \'success\': {fn:function() {
+		var tree = Ext.getCmp(\'modx-resource-tree\');
+		if (tree) {
+		    Ext.getCmp(\'modx-leftbar-tabpanel\').setActiveTab(tree);
+                     tree.refresh();
+                 }
+	},scope:this}
     }
 });',
 ), '', true, true);


### PR DESCRIPTION
Fix Remove Locks functionality. It wasn't using the class-based processor and would error when the resource tree wasn't focussed upon refresh (resulting in all resource tree nodes being removed).
