### PR TITLE
http://bugs.modx.com/issues/10267

### DIFF
--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -149,17 +149,17 @@ class modResponse {
                     } elseif ($this->modx->resource->get('alias')) {
                         $name= $this->modx->resource->get('alias');
                         if ($ext= $this->contentType->getExtension()) {
-                            $name .= ".{$ext}";
+                            $name .= "{$ext}";
                         }
                     } elseif ($name= $this->modx->resource->get('pagetitle')) {
                         $name= $this->modx->resource->cleanAlias($name);
                         if ($ext= $this->contentType->getExtension()) {
-                            $name .= ".{$ext}";
+                            $name .= "{$ext}";
                         }
                     } else {
                         $name= 'download';
                         if ($ext= $this->contentType->getExtension()) {
-                            $name .= ".{$ext}";
+                            $name .= "{$ext}";
                         }
                     }
                     $header= 'Cache-Control: public';


### PR DESCRIPTION
Content Disposition „Attachement“ -> Filename shows two dots (e.g. file..txt).
