### PR TITLE
[2.3] - Clear menus cache

### DIFF
--- a/core/model/modx/processors/system/menu/create.php
+++ b/core/model/modx/processors/system/menu/create.php
@@ -49,4 +49,7 @@ if ($menu->save() == false) {
 /* log manager action */
 $modx->logManagerAction('menu_create','modMenu',$menu->get('text'));
 
+$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
+$modx->cacheManager->deleteTree($path);
+
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/create.php
+++ b/core/model/modx/processors/system/menu/create.php
@@ -50,6 +50,6 @@ if ($menu->save() == false) {
 $modx->logManagerAction('menu_create','modMenu',$menu->get('text'));
 
 $path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->deleteTree($path);
+$modx->cacheManager->delete($path);
 
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/create.php
+++ b/core/model/modx/processors/system/menu/create.php
@@ -49,7 +49,9 @@ if ($menu->save() == false) {
 /* log manager action */
 $modx->logManagerAction('menu_create','modMenu',$menu->get('text'));
 
-$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->delete($path);
+$modx->getCacheManager();
+$modx->cacheManager->refresh(array(
+    'menu' => array(),
+));
 
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/remove.php
+++ b/core/model/modx/processors/system/menu/remove.php
@@ -23,7 +23,9 @@ if ($menu->remove() == false) {
 /* log manager action */
 $modx->logManagerAction('menu_delete','modMenu',$menu->get('text'));
 
-$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->delete($path);
+$modx->getCacheManager();
+$modx->cacheManager->refresh(array(
+    'menu' => array(),
+));
 
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/remove.php
+++ b/core/model/modx/processors/system/menu/remove.php
@@ -24,6 +24,6 @@ if ($menu->remove() == false) {
 $modx->logManagerAction('menu_delete','modMenu',$menu->get('text'));
 
 $path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->deleteTree($path);
+$modx->cacheManager->delete($path);
 
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/remove.php
+++ b/core/model/modx/processors/system/menu/remove.php
@@ -23,4 +23,7 @@ if ($menu->remove() == false) {
 /* log manager action */
 $modx->logManagerAction('menu_delete','modMenu',$menu->get('text'));
 
+$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
+$modx->cacheManager->deleteTree($path);
+
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/sort.php
+++ b/core/model/modx/processors/system/menu/sort.php
@@ -35,8 +35,10 @@ foreach ($nodes as $node) {
     $menu->save();
 }
 
-$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->delete($path);
+$modx->getCacheManager();
+$modx->cacheManager->refresh(array(
+    'menu' => array(),
+));
 
 return $modx->error->success();
 

--- a/core/model/modx/processors/system/menu/sort.php
+++ b/core/model/modx/processors/system/menu/sort.php
@@ -34,6 +34,10 @@ foreach ($nodes as $node) {
     $menu->set('menuindex',$node['order']);
     $menu->save();
 }
+
+$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
+$modx->cacheManager->deleteTree($path);
+
 return $modx->error->success();
 
 function getNodesFormatted(&$ar_nodes,$cur_level,$parent = '') {

--- a/core/model/modx/processors/system/menu/sort.php
+++ b/core/model/modx/processors/system/menu/sort.php
@@ -36,7 +36,7 @@ foreach ($nodes as $node) {
 }
 
 $path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->deleteTree($path);
+$modx->cacheManager->delete($path);
 
 return $modx->error->success();
 

--- a/core/model/modx/processors/system/menu/update.php
+++ b/core/model/modx/processors/system/menu/update.php
@@ -69,6 +69,6 @@ if (!empty($scriptProperties['new_text']) && $scriptProperties['new_text'] != $m
 $modx->logManagerAction('menu_update','modMenu',$menu->get('text'));
 
 $path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->deleteTree($path);
+$modx->cacheManager->delete($path);
 
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/update.php
+++ b/core/model/modx/processors/system/menu/update.php
@@ -68,4 +68,7 @@ if (!empty($scriptProperties['new_text']) && $scriptProperties['new_text'] != $m
 /* log manager action */
 $modx->logManagerAction('menu_update','modMenu',$menu->get('text'));
 
+$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
+$modx->cacheManager->deleteTree($path);
+
 return $modx->error->success('',$menu);

--- a/core/model/modx/processors/system/menu/update.php
+++ b/core/model/modx/processors/system/menu/update.php
@@ -68,7 +68,9 @@ if (!empty($scriptProperties['new_text']) && $scriptProperties['new_text'] != $m
 /* log manager action */
 $modx->logManagerAction('menu_update','modMenu',$menu->get('text'));
 
-$path = $modx->getOption('cache_path') . $modx->getOption('cache_menu_key', null, 'menu') .'/menus/';
-$modx->cacheManager->delete($path);
+$modx->getCacheManager();
+$modx->cacheManager->refresh(array(
+    'menu' => array(),
+));
 
 return $modx->error->success('',$menu);


### PR DESCRIPTION
Lazy method to refresh the menus cache after creation/edition/sort.

Might not work if the cache handler is something different than `xPDOFileCache`
