### PR TITLE
Add parameter for skipping cache clear on settings save.

### DIFF
--- a/core/lexicon/ru/login.inc.php
+++ b/core/lexicon/ru/login.inc.php
@@ -18,7 +18,7 @@ $_lang['login_cannot_locate_account'] = 'Учётная запись не най
 $_lang['login_copyright'] = '&copy; 2005-2013 by <a href="http://modx.com/about/" target="_blank">MODX, LLC</a>. <strong>MODX</strong> &trade; распространяется под лицензией GPLv2 или по более поздней версии этой лицензии.';
 $_lang['login_email_label'] = 'Электронная почта аккаунта:';
 $_lang['login_err_unknown'] = 'При попытке авторизации произошла неизвестная ошибка.';
-$_lang['login_forget_your_login'] = 'Забыли своё имя пользователя?';
+$_lang['login_forget_your_login'] = 'Забыли пароль';
 $_lang['login_hostname_error'] = 'Ваше имя хоста не указывает на ваш IP-адрес.';
 $_lang['login_message'] = 'Для входа в панель управления введите имя пользователя и пароль. Будьте внимательны, они чувствительны к регистру! ';
 $_lang['login_password'] = 'Пароль: ';

--- a/core/model/modx/modsystemsetting.class.php
+++ b/core/model/modx/modsystemsetting.class.php
@@ -18,17 +18,17 @@
 class modSystemSetting extends xPDOObject {
 
 
-    public function save($cacheFlag= null) {
+    public function save($cacheFlag= null, $skipCacheClear=false) {
         $saved = parent::save($cacheFlag);
-        if ($saved) {
+        if ($saved && !$skipCacheClear) {
             $this->clearCache();
         }
         return $saved;
     }
 
-    public function remove(array $ancestors = array()) {
+    public function remove(array $ancestors = array(), $skipCacheClear=false) {
         $removed = parent::remove();
-        if ($removed) {
+        if ($removed && !$skipCacheClear) {
             $this->clearCache();
         }
         return $removed;
@@ -56,7 +56,7 @@ class modSystemSetting extends xPDOObject {
      */
     public function updateTranslation($key,$value = '',array $options = array()) {
         if (!is_array($options) || empty($options)) return false;
-        
+
         $options['namespace'] = $this->xpdo->getOption('namespace',$options,'core');
         $options['cultureKey'] = $this->xpdo->getOption('cultureKey',$options,'en');
         $options['topic'] = $options['namespace'] == 'core' ? 'setting' : 'default';


### PR DESCRIPTION
Add parameter "skipCacheClear" to skip cache clear in modxsystemsettings
usefull for massive settings change in user components.

Fixed russian translation on login page.

Signed-off-by: Indomian egor.b@fabricasaitov.ru
