### PR TITLE
Add a template based class to each node in the resource tree.

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -379,7 +379,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             $class[] = 'active-node';
         }
         
-        $class = $resource->get('template');
+        $class[] = $resource->get('template');
 
         $qtip = '';
         if (!empty($qtipField)) {

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -149,6 +149,7 @@ class modResourceGetNodesProcessor extends modProcessor {
     public function getResourceQuery() {
         $resourceColumns = array(
             'id'
+            ,'template'
             ,'pagetitle'
             ,'longtitle'
             ,'alias'
@@ -212,6 +213,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         $c = $this->modx->newQuery('modResource');
         $c->select($this->modx->getSelectColumns('modResource','modResource','',array(
             'id'
+            ,'template'
             ,'pagetitle'
             ,'longtitle'
             ,'alias'
@@ -376,6 +378,8 @@ class modResourceGetNodesProcessor extends modProcessor {
         if ($this->getProperty('currentResource') == $resource->id && $this->getProperty('currentAction') == $this->actions['resource/update']) {
             $class[] = 'active-node';
         }
+        
+        $class = $resource->get('template');
 
         $qtip = '';
         if (!empty($qtipField)) {


### PR DESCRIPTION
**This pull request has been updated in another pull request:** https://github.com/modxcms/revolution/pull/757

Pattern: class="template_xx" (x is the id of the current template)

By adding a few lines of code to manager/templates/default/css/index.css you can add a custom icon to each resource with a specific template.

Lets say we have 3 templates

Simple Text page (ID:5)
Gallery (ID:6)
Event (ID 7)

**Example css:**
div.template_5 .x-tree-node-icon {
    background-image: url("../images/restyle/icons/text_dropcaps.png")!important;
}
div.template_6 .x-tree-node-icon {
    background-image: url("../images/restyle/icons/picture.png")!important;
}
div.template_7 .x-tree-node-icon {
    background-image: url("../images/restyle/icons/calendar.png")!important;
}

**The screenshot shows the benefits:**
![Template based resource icons](https://dl.dropboxusercontent.com/u/1840535/Download.png)
