### PR TITLE
Template based icons for resource tree in modx revo 2.3

### DIFF
--- a/core/lexicon/en/template.inc.php
+++ b/core/lexicon/en/template.inc.php
@@ -49,4 +49,5 @@ $_lang['template_untitled'] = 'Untitled Template';
 $_lang['templates'] = 'Templates';
 $_lang['tvt_err_nf'] = 'Template Variable does not have access to the specified Template.';
 $_lang['tvt_err_remove'] = 'An error occurred while trying to remove the template variable from the template.';
-$_lang['tvt_err_save'] = 'An error occurred while trying to attach the template variable to the template.';
+$_lang['template_icon'] = 'Icon';
+$_lang['template_icon_description'] = 'Optional. A custom icon class for all resources with this template.';

--- a/core/lexicon/en/template.inc.php
+++ b/core/lexicon/en/template.inc.php
@@ -6,6 +6,7 @@
  * @package modx
  * @subpackage lexicon
  */
+
 $_lang['access'] = 'Access';
 $_lang['filter_by_category'] = 'Filter by Category...';
 $_lang['rank'] = 'Rank';

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -429,7 +429,15 @@ class modResourceGetNodesProcessor extends modProcessor {
             }
         }
         
-        $iconCls = 'template_'.$resource->template;
+        
+        $tpl_id   = $resource->template;
+        $tpl      = $this->modx->getObject('modTemplate',$tpl_id);
+        /* grab icon field from template table */
+        $tpl_icon = $tpl->get('icon');       
+        
+        if(!empty($tpl_icon)){
+            $class[] = $tpl_icon;
+        }        
 
         $idNote = $this->modx->hasPermission('tree_show_resource_ids') ? ' <span dir="ltr">('.$resource->id.')</span>' : '';
         $itemArray = array(

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -147,6 +147,7 @@ class modResourceGetNodesProcessor extends modProcessor {
     public function getResourceQuery() {
         $resourceColumns = array(
             'id'
+            ,'template'
             ,'pagetitle'
             ,'longtitle'
             ,'alias'
@@ -210,6 +211,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         $c = $this->modx->newQuery('modResource');
         $c->select($this->modx->getSelectColumns('modResource','modResource','',array(
             'id'
+            ,'template'
             ,'pagetitle'
             ,'longtitle'
             ,'alias'
@@ -426,6 +428,8 @@ class modResourceGetNodesProcessor extends modProcessor {
                 $qtip .= ' - '.$this->modx->lexicon('locked_by',array('username' => $lockedBy->get('username')));
             }
         }
+        
+        $iconCls = 'template_'.$resource->template;
 
         $idNote = $this->modx->hasPermission('tree_show_resource_ids') ? ' <span dir="ltr">('.$resource->id.')</span>' : '';
         $itemArray = array(

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -399,7 +399,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         $defaultIcon = strlen($tplIcon) ? $tplIcon : $this->modx->getOption('mgr_tree_icon_'.$rsrcType, null,'tree-resource');
 
         if (strlen($tplIcon)) {
-            $class[] = $defaultIcon;
+            $iconCls[] = $defaultIcon;
         }
         elseif ($rsrcType === 'weblink') {
             $iconCls[] = $this->modx->getOption('mgr_tree_icon_weblink',null,'tree-weblink');

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -398,7 +398,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         $defaultIcon = strlen($tplIcon) ? $tplIcon : $this->modx->getOption('mgr_tree_icon_'.$rsrcType, null,'tree-resource');
 
         if (strlen($tplIcon)) {
-            $iconCls[] = $defaultIcon;
+            $class[] = $defaultIcon;
         }
         elseif ($rsrcType === 'weblink') {
             $iconCls[] = $this->modx->getOption('mgr_tree_icon_weblink',null,'tree-weblink');

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -5,6 +5,7 @@
  * @package modx
  * @subpackage processors.layout.tree.resource
  */
+
 class modResourceGetNodesProcessor extends modProcessor {
     /** @var int $defaultRootId */
     public $defaultRootId;

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -436,7 +436,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         $tpl_icon = $tpl->get('icon');       
         
         if(!empty($tpl_icon)){
-            $class[] = $tpl_icon;
+            $iconCls[] = $tpl_icon;
         }        
 
         $idNote = $this->modx->hasPermission('tree_show_resource_ids') ? ' <span dir="ltr">('.$resource->id.')</span>' : '';

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -93,6 +93,22 @@ MODx.panel.Template = function(config) {
                         ,html: _('template_desc_description')
                         ,cls: 'desc-under'
                     },{
+                        xtype: 'textfield'
+                        ,fieldLabel: _('template_icon')
+                        ,description: MODx.expandHelp ? '' : _('template_icon_description')
+                        ,name: 'icon'
+                        ,id: 'modx-template-icon'
+                        ,anchor: '100%'
+                        ,maxLength: 100
+                        ,enableKeyEvents: true
+                        ,allowBlank: true
+                        ,value: config.record.icon
+                    },{
+                        xtype: MODx.expandHelp ? 'label' : 'hidden'
+                        ,forId: 'modx-template-icon'
+                        ,html: _('template_icon_description')
+                        ,cls: 'desc-under'
+                    },{
                         xtype: 'modx-combo-browser'
                         ,browserEl: 'modx-browser'
                         ,fieldLabel: _('static_file')

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -6,6 +6,7 @@
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-template
  */
+
 MODx.panel.Template = function(config) {
     config = config || {record:{}};
     config.record = config.record || {};


### PR DESCRIPTION
This enables the icon field in the template manager. It has been there for years but never been enabled. Every fontawesome iconclass (v 3.2.1) added here will result in an icon that is displayed instead of the default icon.

Example: icon-heart for the "love" template.

![love](https://f.cloud.github.com/assets/667315/1784732/86d02892-68d7-11e3-8743-1305c55db52d.png)

A list of all available icons can e found here: http://fontawesome.io/3.2.1/icons/
