### PR TITLE
Allow filtering of namespace by request on lexicon page

### DIFF
--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -14,7 +14,7 @@ MODx.grid.Lexicon = function(config) {
         ,fields: ['name','value','namespace','topic','language','editedon','overridden']
         ,baseParams: {
             action: 'workspace/lexicon/getList'
-            ,'namespace': 'core'
+            ,'namespace': MODx.request['namespace'] ? MODx.request['namespace'] : 'core'
             ,topic: ''
             ,language: MODx.config.manager_language || 'en'
         }
@@ -47,7 +47,7 @@ MODx.grid.Lexicon = function(config) {
             xtype: 'modx-combo-namespace'
             ,id: 'modx-lexicon-filter-namespace'
             ,itemId: 'namespace'
-            ,value: 'core'
+            ,value: MODx.request['namespace'] ? MODx.request['namespace'] : 'core'
             ,width: 120
             ,listeners: {
                 'select': {fn: this.changeNamespace,scope:this}

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -14,7 +14,7 @@ MODx.grid.Lexicon = function(config) {
         ,fields: ['name','value','namespace','topic','language','editedon','overridden']
         ,baseParams: {
             action: 'workspace/lexicon/getList'
-            ,'namespace': MODx.request['namespace'] ? MODx.request['namespace'] : 'core'
+            ,'namespace': MODx.request['ns'] ? MODx.request['ns'] : 'core'
             ,topic: ''
             ,language: MODx.config.manager_language || 'en'
         }
@@ -47,7 +47,7 @@ MODx.grid.Lexicon = function(config) {
             xtype: 'modx-combo-namespace'
             ,id: 'modx-lexicon-filter-namespace'
             ,itemId: 'namespace'
-            ,value: MODx.request['namespace'] ? MODx.request['namespace'] : 'core'
+            ,value: MODx.request['ns'] ? MODx.request['ns'] : 'core'
             ,width: 120
             ,listeners: {
                 'select': {fn: this.changeNamespace,scope:this}


### PR DESCRIPTION
Like https://github.com/modxcms/revolution/commit/58ed1e52057ba71d020ffc4019778860958395e0 this enables users to filter on namespaces by request on the lexicon grid

Something like http://domain.com/manager/index.php?a=71&namespace=babel

This is useful since you can share a link to a specific lexicon e.g. from the dashboard, so clients can easily find it.
