### PR TITLE
Fix "Snippet name is invalid" error on mysql database

### DIFF
--- a/core/model/modx/mysql/modsnippet.map.inc.php
+++ b/core/model/modx/mysql/modsnippet.map.inc.php
@@ -159,7 +159,7 @@ $xpdo_meta_map['modSnippet']= array (
         'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff_-\\s]+(?!\\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?!\\s)$/',
           'message' => 'snippet_err_invalid_name',
         ),
       ),


### PR DESCRIPTION
Fix validation error when create a new snippet on mysql database
