### PR TITLE
Prevent navigation if there are unsaved changes on the resource panel

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -500,6 +500,7 @@ $_lang['untitled_template'] = 'Untitled template';
 $_lang['untitled_tv'] = 'Untitled tv';
 $_lang['untitled_weblink'] = 'Untitled weblink';
 $_lang['untitled_symlink'] = 'Untitled symlink';
+$_lang['unsaved_changes'] = 'There are unsaved changes. Are you sure you want to leave this page?';
 $_lang['update'] = 'Update';
 $_lang['updated'] = 'Updated';
 $_lang['upload'] = 'Upload';

--- a/core/lexicon/nl/default.inc.php
+++ b/core/lexicon/nl/default.inc.php
@@ -503,6 +503,7 @@ $_lang['untitled_symlink'] = 'Naamloze symlink';
 $_lang['update'] = 'Bewerken';
 $_lang['updated'] = 'Bewerkt';
 $_lang['upload'] = 'Upload';
+$_lang['unsaved_changes'] = 'Er zijn wijzigingen die nog niet zijn opgeslagen. Weet je zeker dat je deze pagina wilt verlaten?';
 $_lang['username'] = 'Gebruikersnaam';
 $_lang['value'] = 'Waarde';
 $_lang['version'] = 'Versie';

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -61,6 +61,12 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             if ((this.config.record && this.config.record.richtext) || MODx.request.reload || MODx.request.activeSave == 1) {
                 this.markDirty();
             }
+
+            // Prevent accidental navigation when stuff has not been saved
+            var panel = this;
+            window.onbeforeunload = function() {
+                if (panel.isDirty()) return _('unsaved_changes');
+            };
         }
         if (MODx.config.use_editor && MODx.loadRTE) {
             var f = this.getForm().findField('richtext');


### PR DESCRIPTION
After losing yet another half-way finished blog post by an accidental click, I cracked. Four freaking lines of code. 

![image](https://f.cloud.github.com/assets/312944/1866139/9bbac702-7828-11e3-88ab-2a51b3dffac8.png)
