### PR TITLE
HIGH PRIORITY :: Changed the message_limit

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -653,7 +653,7 @@ MODx.HttpProvider = function(config) {
             ,poll_limit: 1
             ,poll_interval: 1
             ,time_limit: 10
-            ,message_limit: 200
+            ,message_limit: 1000
             ,remove_read: 0
             ,show_filename: 0
             ,include_keys: 1


### PR DESCRIPTION
This will fix the annoying tree problem. 

If there are more than 200 cache files modx won't load the tree position cache file (modx-resource-tree.msg.php). 
The cache files are inside the core/cache/registry/state/ys/user.. directory.
