### PR TITLE
Fix warnings (LOG_LEVEL_WARN) about alias not found for deleted resources

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -39,7 +39,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return mixed
      */
     public function process() {
@@ -103,7 +103,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
     /**
      * Determine the context and root and start nodes for the tree
-     * 
+     *
      * @return void
      */
     public function getRootNode() {
@@ -191,7 +191,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
     /**
      * Add search results to tree nodes
-     * 
+     *
      * @param string $query
      * @return void
      */
@@ -265,7 +265,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
     /**
      * Iterate across the collection of items from the query
-     * 
+     *
      * @param array $collection
      * @return void
      */
@@ -297,7 +297,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
     /**
      * Prepare a Context for being shown in the tree
-     * 
+     *
      * @param modContext $context
      * @return array
      */
@@ -338,7 +338,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
     /**
      * Prepare a Resource for being shown in the tree
-     * 
+     *
      * @param modResource $resource
      * @return array
      */
@@ -410,7 +410,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             'ctx' => $resource->context_key,
             'hide_children_in_tree' => $resource->hide_children_in_tree,
             'qtip' => $qtip,
-            'preview_url' => $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), '', 'full'),
+            'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), '', 'full') : '',
             'page' => empty($noHref) ? '?a='.(!empty($this->permissions['edit_document']) ? $this->actions['resource/update'] : $this->actions['resource/data']).'&id='.$resource->id : '',
             'allowDrop' => true,
         );

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -700,7 +700,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         $this->workingContext->prepare(true);
         $returnArray['preview_url'] = '';
         if (!$this->object->get('deleted')) {
-            $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');
+            $returnArray['preview_url'] = $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');
         }
 
         return $this->success('',$returnArray);

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -93,7 +93,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         /** @var modResource $object */
         $object = $modx->getObject('modResource',$properties['id']);
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : ($object ? $object->get('class_key') : 'modDocument');
-        
+
         if (!in_array($classKey,array('modDocument','modResource',''))) {
             $className = $classKey.'UpdateProcessor';
             if (!class_exists($className)) {
@@ -141,7 +141,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         $this->checkDeletedStatus();
         $this->handleResourceProperties();
         $this->unsetProperty('variablesmodified');
-        
+
         return parent::beforeSet();
     }
 
@@ -280,7 +280,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         $this->isSiteStart = ($this->object->get('id') == $this->workingContext->getOption('site_start') || $this->object->get('id') == $this->modx->getOption('site_start'));
         $pageTitle = $this->getProperty('pagetitle',null);
         $alias = $this->getProperty('alias');
-        
+
         if ($this->workingContext->getOption('friendly_urls', false) && (!$this->getProperty('reloadOnly',false) || (!empty($pageTitle) || $this->isSiteStart))) {
 
             /* auto assign alias */
@@ -479,7 +479,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
      * Set the parents isfolder status based upon remaining children
      *
      * @TODO Debate whether or not this should be default functionality
-     * 
+     *
      * @return void
      */
     public function fixParents() {
@@ -698,7 +698,11 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         }
         $returnArray['class_key'] = $this->object->get('class_key');
         $this->workingContext->prepare(true);
-        $returnArray['preview_url'] = $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');
+        $returnArray['preview_url'] = '';
+        if (!$this->object->get('deleted')) {
+            $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');
+        }
+
         return $this->success('',$returnArray);
     }
 

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -164,13 +164,15 @@ class ResourceUpdateManagerController extends ResourceManagerController {
      * @return string
      */
     public function getPreviewUrl() {
-        $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'),'','full');
+        if (!$this->resource->get('deleted')) {
+            $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'),'','full');
+        }
         return $this->previewUrl;
     }
 
     /**
      * Check for locks on the Resource
-     * 
+     *
      * @return bool
      */
     public function checkForLocks() {
@@ -189,7 +191,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
         }
         return $this->locked;
     }
-    
+
     /**
      * Check for any permissions or requirements to load page
      * @return bool


### PR DESCRIPTION
This just prevent trying to makeUrl for deleted resources.

Edit : while being there, we might want to remove the preview button in the action bar, as well as the contextual menu...
