### PR TITLE
Changed message_limit and delay

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -625,7 +625,7 @@ MODx.HttpProvider = function(config) {
     );
     MODx.HttpProvider.superclass.constructor.call(this,config);
     Ext.apply(this, config, {
-        delay: 1000
+        delay: 500
         ,dirty: false
         ,started: false
         ,autoStart: true
@@ -653,7 +653,7 @@ MODx.HttpProvider = function(config) {
             ,poll_limit: 1
             ,poll_interval: 1
             ,time_limit: 10
-            ,message_limit: 200
+            ,message_limit: 1000
             ,remove_read: 0
             ,show_filename: 0
             ,include_keys: 1


### PR DESCRIPTION
This will fix the annoying tree problem. 

If there are more than 200 cache files modx won't load the tree position cache file (modx-resource-tree.msg.php). 
The cache files are inside the core/cache/registry/state/ys/user.. directory.

I reduced the delay so the level of the tree will be saved faster.
