### PR TITLE
Fix deprecated returnValue

### DIFF
--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -1,6 +1,6 @@
 /**
  * Loads the resource update page
- * 
+ *
  * @class MODx.page.UpdateResource
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -43,7 +43,7 @@ MODx.page.UpdateResource = function(config) {
         Ext.EventManager.on(window, 'beforeunload',function(e) {
             MODx.releaseLock(this.config.resource);
             MODx.sleep(400);
-            e.browserEvent.returnValue = '';
+            e.preventDefault();
             return false;
         }, this);
     }
@@ -60,7 +60,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
         window.open(this.config.preview_url);
         return false;
     }
-    
+
     ,duplicateResource: function(btn,e) {
         MODx.msg.confirm({
             text: _('resource_duplicate_confirm')
@@ -108,7 +108,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             MODx.loadPage(MODx.action['welcome']);
         }
     }
-    
+
     ,getButtons: function(cfg) {
         var btns = [];
         if (cfg.canSave == 1) {


### PR DESCRIPTION
Since Chrome 32.0.1700.77 (Linux), every time you leave an "update resource panel", we are asked to make "confirm navigation".

Changing returnValue to preventDefault() fixes the issue.

**Note** : This has not been tested on other browsers/OS
