### PR TITLE
[REBUILD] Prevent Reports menu item from navigating to non-existant action

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -292,7 +292,7 @@ $children[5]->fromArray(array (
   'description' => 'reports_desc',
   'parent' => 'manage',
   'permissions' => 'menu_reports',
-  'action' => 'reports',
+  'action' => '',
 ), '', true, true);
 
 /* site schedule */


### PR DESCRIPTION
Per #768. Requires a rebuild and re-running setup. 
