### PR TITLE
Re-introduce MODx.action variable in manager to provide BC for actions

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -510,6 +510,37 @@ class modRequest {
             $key = ($action->get('namespace') == 'core' ? '' : $action->get('namespace').':').$action->get('controller');
             $actionList[$key] = $action->get('id');
         }
+
+        // Also add old core actions for backwards compatibility
+        $oldActions = array('browser', 'context',
+            'context/create', 'context/update', 'context/view',
+            'element', 'element/chunk', 'element/chunk/create', 'element/chunk/update',
+            'element/plugin', 'element/plugin/create', 'element/plugin/update:',
+            'element/propertyset/index', 'element/snippet', 'element/snippet/create',
+            'element/snippet/update', 'element/template', 'element/template/create',
+            'element/template/tvsort', 'element/template/update', 'element/tv',
+            'element/tv/create', 'element/tv/update', 'element/view', 'help',
+            'resource', 'resource/create', 'resource/data', 'resource/empty_recycle_bin',
+            'resource/site_schedule', 'resource/tvs', 'resource/update', 'search', 'security',
+            'security/access/policy/template/update', 'security/access/policy/update',
+            'security/forms', 'security/forms/profile/update', 'security/forms/set/update',
+            'security/login', 'security/message', 'security/permission', 'security/profile',
+            'security/resourcegroup/index', 'security/role', 'security/user', 'security/user/create',
+            'security/user/update', 'security/usergroup/create', 'security/usergroup/update',
+            'source/create', 'source/index', 'source/update', 'system', 'system/action',
+            'system/contenttype', 'system/dashboards', 'system/dashboards/create',
+            'system/dashboards/update', 'system/dashboards/widget/create',
+            'system/dashboards/widget/update', 'system/event', 'system/file', 'system/file/create',
+            'system/file/edit', 'system/import', 'system/import/html', 'system/info',
+            'system/logs/index', 'system/phpinfo', 'system/refresh_site', 'system/settings',
+            'welcome', 'workspaces', 'workspaces/lexicon',
+            'workspaces/namespace', 'workspaces/package/view');
+        if (empty($namespace) || $namespace ==  'core') {
+            foreach ($oldActions as $a) {
+                $actionList[$a] = $a;
+            }
+        }
+
         return $actionList;
     }
 

--- a/core/model/modx/processors/system/config.js.php
+++ b/core/model/modx/processors/system/config.js.php
@@ -84,6 +84,11 @@ unset($c['password'],$c['username'],$c['mail_smtp_pass'],$c['mail_smtp_user'],$c
 $o = "Ext.namespace('MODx'); MODx.config = ";
 $o .= $modx->toJSON($c);
 $o .= '; MODx.perm = {};';
+
+// Load actions for backwards compatibility (DEPRECATED)
+$actions = $modx->request->getAllActionIDs();
+$o .= 'MODx.action = ' . $modx->toJSON($actions) . ';';
+
 if ($modx->user) {
     if ($modx->hasPermission('directory_create')) { $o .= 'MODx.perm.directory_create = true;'; }
     if ($modx->hasPermission('resource_tree')) { $o .= 'MODx.perm.resource_tree = true;'; }


### PR DESCRIPTION
This is important for 3PCs that rely on MODx.action currently, making upgrades to 2.3 a lot smoother. 
