### PR TITLE
Changed logic of using "Blocked" and "Blocked till" user field.

### DIFF
--- a/core/model/modx/processors/security/login.php
+++ b/core/model/modx/processors/security/login.php
@@ -100,13 +100,13 @@ if ($user->Profile->get('blockeduntil') != 0 && $user->Profile->get('blockedunti
     $user->Profile->save();
 }
 if ($user->Profile->get('blocked')) {
-    return $modx->error->failure($modx->lexicon('login_blocked_admin'));
+	return $modx->error->failure($modx->lexicon('login_blocked_admin'));
 }
-if ($user->Profile->get('blockeduntil') > time()) {
-    return $modx->error->failure($modx->lexicon('login_blocked_error'));
+if ($user->Profile->get('blocked') && $user->Profile->get('blockeduntil') > time()) {
+	return $modx->error->failure($modx->lexicon('login_blocked_error'));
 }
-if ($user->Profile->get('blockedafter') > 0 && $user->Profile->get('blockedafter') < time()) {
-    return $modx->error->failure($modx->lexicon('login_blocked_error'));
+if ($user->Profile->get('blocked') && $user->Profile->get('blockedafter') > 0 && $user->Profile->get('blockedafter') < time()) {
+	return $modx->error->failure($modx->lexicon('login_blocked_error'));
 }
 
 if (isset ($allowed_ip) && $allowed_ip) {


### PR DESCRIPTION
Change logic to more comfortable when system checks both fields:
- "Blocked"
- "Blocked till/from"
  Because now when field block is not marked but field blocked till field, user
  still stays blocked. It's pretty unlogical.

Signed-off-by: Indomian egor.b@fabricasaitov.ru
