### PR TITLE
Stripping query string from REQUEST_URI

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -313,7 +313,7 @@ class modRequest {
      */
     public function _cleanResourceIdentifier($identifier) {
         if (empty ($identifier)) {
-            if ($this->modx->getOption('base_url', null, MODX_BASE_URL) !== $_SERVER['REQUEST_URI']) {
+            if ($this->modx->getOption('base_url', null, MODX_BASE_URL) !== strtok($_SERVER["REQUEST_URI"],'?')) {
                 $this->modx->sendRedirect($this->modx->getOption('site_url', null, MODX_SITE_URL), array('responseCode' => 'HTTP/1.1 301 Moved Permanently'));
             }
             $identifier = $this->modx->getOption('site_start', null, 1);


### PR DESCRIPTION
Stripping query string from REQUEST_URI when comparing to base_url.

When using subfolders and contexts for a multilingual site, adding query string to the homepage results in a 301 redirect.
