### PR TITLE
Extending #458 'open in new window' feature with optional Shift modifier...

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -444,7 +444,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
         if (this.disableHref) {return true;}
         if (e.ctrlKey) {return true;}
         if (n.attributes.page && n.attributes.page !== '') {
-            if (e.button == 1) return window.open(n.attributes.page,'_blank');
+            if (e.button == 1 || e.shiftKey == 1) return window.open(n.attributes.page,'_blank');
             MODx.loadPage(n.attributes.page);
         } else {
             n.toggle();


### PR DESCRIPTION
.... Shift + click in resource tree to edit in new window for users with no middle mouse button (e.g. Apple magic mouse, trackpads, etc)
