### PR TITLE
Confirm Navigation Improvements

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -348,6 +348,15 @@ $settings['compress_js_groups']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
+$settings['confirm_navigation']= $xpdo->newObject('modSystemSetting');
+$settings['confirm_navigation']->fromArray(array (
+  'key' => 'confirm_navigation',
+  'value' => true,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 $settings['container_suffix']= $xpdo->newObject('modSystemSetting');
 $settings['container_suffix']->fromArray(array (
   'key' => 'container_suffix',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -193,8 +193,8 @@ $_lang['setting_compress_js_groups_desc'] = 'Group the core MODX manager JavaScr
 $_lang['setting_compress_js_max_files'] = 'Maximum JavaScript Files Compression Threshold';
 $_lang['setting_compress_js_max_files_desc'] = 'The maximum number of JavaScript files MODX will attempt to compress at once when compress_js is on. Set to a lower number if you are experiencing issues with Google Minify in the manager.';
 
-$_lang['setting_concat_js_desc'] = 'When this is enabled, MODX will use a concatenated version of its common JavaScript libraries in the manager interface. This greatly reduces load and execution time within the manager. Disable only if you are modifying core elements.';
 $_lang['setting_concat_js'] = 'Use Concatenated Javascript Libraries';
+$_lang['setting_concat_js_desc'] = 'When this is enabled, MODX will use a concatenated version of its common JavaScript libraries in the manager interface. This greatly reduces load and execution time within the manager. Disable only if you are modifying core elements.';
 
 $_lang['setting_confirm_navigation'] = 'Confirm Navigation with unsaved changes';
 $_lang['setting_confirm_navigation_desc'] = 'When this is enabled, the user will be prompted to confirm their intention if there are unsaved changes.';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -193,8 +193,11 @@ $_lang['setting_compress_js_groups_desc'] = 'Group the core MODX manager JavaScr
 $_lang['setting_compress_js_max_files'] = 'Maximum JavaScript Files Compression Threshold';
 $_lang['setting_compress_js_max_files_desc'] = 'The maximum number of JavaScript files MODX will attempt to compress at once when compress_js is on. Set to a lower number if you are experiencing issues with Google Minify in the manager.';
 
-$_lang['setting_concat_js'] = 'Use Concatenated Javascript Libraries';
 $_lang['setting_concat_js_desc'] = 'When this is enabled, MODX will use a concatenated version of its common JavaScript libraries in the manager interface. This greatly reduces load and execution time within the manager. Disable only if you are modifying core elements.';
+$_lang['setting_concat_js'] = 'Use Concatenated Javascript Libraries';
+
+$_lang['setting_confirm_navigation'] = 'Confirm Navigation with unsaved changes';
+$_lang['setting_confirm_navigation_desc'] = 'When this is enabled, the user will be prompted to confirm their intention if there are unsaved changes.';
 
 $_lang['setting_container_suffix'] = 'Container Suffix';
 $_lang['setting_container_suffix_desc'] = 'The suffix to append to Resources set as containers when using FURLs.';

--- a/core/lexicon/nl/setting.inc.php
+++ b/core/lexicon/nl/setting.inc.php
@@ -198,6 +198,9 @@ $_lang['setting_compress_js_max_files_desc'] = 'Het maximum aantal JavaScript be
 $_lang['setting_concat_js'] = 'Gebruik Samengevoegde Javascript Libraries';
 $_lang['setting_concat_js_desc'] = 'Indien ingeschakeld, MODX zal een samengevoegde versie gebruiken van zijn Javascript libraries in de manager interface. Dit reduceert de laadtijd enorm in de manager. Schakel deze alleen uit als je aanpassingen verricht aan core elementen.';
 
+$_lang['setting_confirm_navigation'] = 'Bevestig navigatie bij niet opgeslagen wijzigingen';
+$_lang['setting_confirm_navigation_desc'] = 'When this is enabled, the user will be prompted to confirm their intention if there are unsaved changes.';
+
 $_lang['setting_container_suffix'] = 'Container Achtervoegsel';
 $_lang['setting_container_suffix_desc'] = 'Het achtervoegsel voor documenten indien het containers zijn en als er gebruikt gemaakt wordt van FURLs.';
 

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -63,10 +63,12 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             }
 
             // Prevent accidental navigation when stuff has not been saved
-            var panel = this;
-            window.onbeforeunload = function() {
-                if (panel.isDirty()) return _('unsaved_changes');
-            };
+            if (MODx.config.confirm_navigation == 1) {
+                var panel = this;
+                window.onbeforeunload = function() {
+                    if (panel.isDirty()) return _('unsaved_changes');
+                };
+            }
 
             if (this.config.record.deleted) {
                 this.handlePreview('hide');

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -240,7 +240,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             },this);
         }
     }
-    ,onFieldChange: function() {
+    ,onFieldChange: function(o) {
+        if (o && o.field && o.field.name == 'syncsite') return;
+
         if (this.isReady || MODx.request.reload) {
             this.warnUnsavedChanges = true;
         }

--- a/pindex.php
+++ b/pindex.php
@@ -1,0 +1,9 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+define('MODX_API_MODE', 1);
+include 'index.php';
+
+$auth = $modx->user->getUserToken($modx->context->key);
+
+echo 'Auth: ' . $auth;

--- a/pindex.php
+++ b/pindex.php
@@ -1,9 +1,0 @@
-<?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-define('MODX_API_MODE', 1);
-include 'index.php';
-
-$auth = $modx->user->getUserToken($modx->context->key);
-
-echo 'Auth: ' . $auth;


### PR DESCRIPTION
This PR consists of two commits that work together to improve the confirm navigation popups in 2.2.11. _edit: and 2 commits to clean up my goofiness today._
#### Allow disabling the confirm navigation popup

Adds a new setting (confirm_navigation, in the Manager & Back-end area) that can be disabled to disable the check entirely. 
#### Improved "prevent navigation" alert by tracking field changes instead of using flawed isDirty() check.

The FormPanel.isDirty() check does a raw comparison between the original value and the current value of each of the fields. When using a rich text editor, there could be changes in the current content value of a resource due to changes in formatting (editors forcing a <p> root block) or encoding (& being turned into &amp;) which would result in the navigation popup. While yes, there are changes, no, the user did not make them so they should not be bothered with a popup. 

The commit changes from looking at FormPanel.isDirty() to tracking field changes through the changeField event and a local flag. 

This commit also resolves an issue where changing templates would show the warning during the reload.
