### PR TITLE
Update sort.class.php

### DIFF
--- a/core/model/modx/processors/resource/sort.class.php
+++ b/core/model/modx/processors/resource/sort.class.php
@@ -25,7 +25,7 @@ class modResourceSortProcessor extends modProcessor {
         $data = $this->modx->fromJSON($data);
         if (empty($data)) $this->failure($this->modx->lexicon('invalid_data'));
 
-        $this->getNodesFormatted($data,0);
+        $this->getNodesFormatted($data,$this->getProperty('parent', 0));
 
         $this->fireBeforeSort();
 


### PR DESCRIPTION
Allow to influence the parent node. This can be useful for sorting options in compontents that uses a sub-grid view of child resources instead using the tree (like Articles). Without this option it's necessary to include all parents untill the context-node (web/0) is reached.
