### PR TITLE
Updated processor instantiation via modProcessor::getInstance call

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1674,8 +1674,7 @@ class modX extends xPDO {
                     $className = $this->processors[$processorFile];
                 }
                 if (!empty($className)) {
-                    $c = new $className($this,$scriptProperties);
-                    $processor = call_user_func_array(array($c,'getInstance'),array($this,$className,$scriptProperties));
+                    $processor = call_user_func_array(array($className,'getInstance'),array(&$this,$className,$scriptProperties));
                 }
             }
             if (empty($processor)) {


### PR DESCRIPTION
When instantiating processor, instance of `$className` is created twice. This also does not allow to have abstract class as a "processor-router" which will accept different requests and return corresponding processor instance using `getInstance` method.
Similar situation has place when instantiating manager controllers.
