### PR TITLE
Fatal error

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/text.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/text.class.php
@@ -3,9 +3,11 @@
  * @package modx
  * @subpackage processors.element.tv.renders.mgr.input
  */
-class modTemplateVarInputRenderText extends modTemplateVarInputRender {
-    public function getTemplate() {
-        return 'element/tv/renders/input/textbox.tpl';
+if(!class_exists('modTemplateVarInputRenderText')){
+    class modTemplateVarInputRenderText extends modTemplateVarInputRender {
+        public function getTemplate() {
+            return 'element/tv/renders/input/textbox.tpl';
+        }
     }
-}
+} 
 return 'modTemplateVarInputRenderText';


### PR DESCRIPTION
Fatal error: Cannot redeclare class modTemplateVarInputRenderText in /var/www/evakuator.ru/public_html/core/model/modx/processors/element/tv/renders/mgr/input/text.class.php on line 10

OR add if(class_exists) here: https://github.com/modxcms/revolution/blob/develop/core/model/modx/modtemplatevar.class.php#L420
like here: https://github.com/modxcms/revolution/blob/develop/core/model/modx/modtemplatevar.class.php#L445
