### PR TITLE
[2.2] - Only execute handlePreview if the "deleted" value changed

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -97,7 +97,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     /**
      * Handle the preview button visibility according to the resource "deleted" status
      *
-     * @param {String} action The action to perform on the preview button (hide/show)
+     * @param {string} action The action to perform on the preview button (hide/show)
      */
     ,handlePreview: function(action) {
         var previewBtn = Ext.getCmp('modx-abtn-preview');
@@ -174,12 +174,15 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         if (this.config.resource && object.parent !== undefined && (object.class_key != this.defaultClassKey || object.parent != this.defaultValues.parent)) {
             MODx.loadPage(location.href);
         } else {
-            if (object.deleted) {
-                var action = 'hide';
-            } else {
-                action = 'show';
+            if (object.deleted !== this.record.deleted) {
+                if (object.deleted) {
+                    var action = 'hide';
+                } else {
+                    action = 'show';
+                }
+                this.handlePreview(action);
             }
-            this.handlePreview(action);
+            this.record = object;
             this.getForm().setValues(object);
             Ext.getCmp('modx-page-update-resource').config.preview_url = object.preview_url;
         }


### PR DESCRIPTION
For now we were executing hide/show methods on the preview button on every save.

With this PR the methods are only executed if the deleted value of the resource changed.
