### PR TITLE
Fix tooltip bg images

### DIFF
--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -2107,3 +2107,9 @@ span.required {
 	padding: 5px;
 	font-size: 13px;
 }
+
+.x-tip img {
+    min-width:240px;
+    max-width:100%;
+    max-width:66vw;
+}


### PR DESCRIPTION
Closes modxcms/revolution#818

prevents tooltip images from being larger than 66% of the viewport
width. falls back to 100% off the tooltip container. the min-width
prevents Ext from collapsing the tooltip in on itself
