### PR TITLE
Add MODX-like support for separate 3rd party component setting topic to ...

### DIFF
--- a/core/model/modx/processors/system/settings/getareas.class.php
+++ b/core/model/modx/processors/system/settings/getareas.class.php
@@ -38,7 +38,7 @@ class modSystemSettingsGetAreasProcessor extends modProcessor {
                 $namespace = $r[1];
                 $count = $r[2];
                 if ($namespace != 'core') {
-                    $this->modx->lexicon->load($namespace.':default');
+                    $this->modx->lexicon->load($namespace.':default',$namespace.':setting');
                 }
                 $lex = 'area_'.$name;
                 if ($this->modx->lexicon->exists($lex)) {

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -82,8 +82,8 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
         $k = 'setting_'.$settingArray['key'];
 
         /* if 3rd party setting, load proper text, fallback to english */
-        $this->modx->lexicon->load('en:'.$object->get('namespace').':default');
-        $this->modx->lexicon->load($object->get('namespace').':default');
+        $this->modx->lexicon->load('en:'.$object->get('namespace').':default','en:'.$object->get('namespace').':setting');
+        $this->modx->lexicon->load($object->get('namespace').':default',$object->get('namespace').':setting');
 
         /* get translated area text */
         if ($this->modx->lexicon->exists('area_'.$object->get('area'))) {


### PR DESCRIPTION
...system settings processor.

Resolves #11098

This allows app developers to separate their system settings lexicon strings from the default topic into a separate setting topic, just like MODX does. This is handy for larger apps with many system settings. No need to load them everywhere, when they are only needed in the system settings panel.
