### PR TITLE
[2.2] - FormPanel in dashboard widgets

### DIFF
--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -1,6 +1,6 @@
 /**
  * @class MODx.panel.Welcome
- * @extends MODx.FormPanel
+ * @extends MODx.Panel
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-welcome
  */

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -9,8 +9,13 @@ MODx.panel.Welcome = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-welcome'
-		,cls: 'container'
-        ,defaults: { collapsible: false ,autoHeight: true }
+        ,cls: 'container'
+        ,baseCls: 'modx-formpanel'
+        ,layout: 'form'
+        ,defaults: {
+            collapsible: false
+            ,autoHeight: true
+        }
         ,items: [{
             html: '<h2>'+dashboardName+'</h2>'
             ,id: 'modx-welcome-header'
@@ -24,7 +29,7 @@ MODx.panel.Welcome = function(config) {
     MODx.panel.Welcome.superclass.constructor.call(this,config);
     this.setup();
 };
-Ext.extend(MODx.panel.Welcome,MODx.FormPanel,{
+Ext.extend(MODx.panel.Welcome, MODx.Panel,{
     setup: function() {
         if (this.config.dashboard && this.config.dashboard.hide_trees) {
             Ext.getCmp('modx-layout').hideLeftbar(false);
@@ -32,4 +37,4 @@ Ext.extend(MODx.panel.Welcome,MODx.FormPanel,{
         MODx.fireEvent('ready');
     }
 });
-Ext.reg('modx-panel-welcome',MODx.panel.Welcome);
+Ext.reg('modx-panel-welcome', MODx.panel.Welcome);

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -5,13 +5,14 @@
  */
 /**
  * Renders a grid of recently edited resources by the active user
- * 
+ *
  * @package modx
  * @subpackage dashboard
  */
 class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterface {
     public function render() {
-        $this->modx->controller->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->controller->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/security/modx.grid.user.recent.resource.js');
+        $this->controller->addHtml('<script type="text/javascript">Ext.onReady(function() {
     MODx.load({
         xtype: "modx-grid-user-recent-resource"
         ,user: "'.$this->modx->user->get('id').'"

--- a/manager/controllers/default/welcome.class.php
+++ b/manager/controllers/default/welcome.class.php
@@ -17,7 +17,7 @@
      * @var null|modDashboard $dashboard
      */
     public $dashboard = null;
-    
+
     /**
      * Check for any permissions or requirements to load page
      * @return bool
@@ -31,7 +31,6 @@
      * @return void
      */
     public function loadCustomCssJs() {
-        $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/security/modx.grid.user.recent.resource.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/modx.panel.welcome.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/welcome.js');
         $this->addHtml('<script type="text/javascript">
@@ -58,7 +57,7 @@ Ext.onReady(function() { MODx.loadWelcomePanel("'.$url.'"); });
      */
     public function process(array $scriptProperties = array()) {
         $placeholders = array();
-        
+
         $this->checkForWelcomeScreen();
 
         $this->dashboard = $this->modx->user->getDashboard();


### PR DESCRIPTION
### Problem

The original panel (the container of all widgets) initially was a FormPanel (thus created a form).
Any "subsequent" form were considered as "div", resulting in being always empty when submitted.
### Proposed solution

I changed the panel to `MODx.Panel` (without form) and added appropriate classes to get a similar look.

In addition, i saw the "recently edited resources" grid was always loaded, no matter if the widget was visible or not. Now the grid is loaded via the widget "script"
