### PR TITLE
Add margin to input fields

### DIFF
--- a/setup/assets/css/layout.css
+++ b/setup/assets/css/layout.css
@@ -12,6 +12,7 @@ div.labelHolder {
 }
 
 div.labelHolder input {
+    margin: 2px 0;
     width: 200px;
 }
 


### PR DESCRIPTION
In Firefox, the input fields don't have margins.
