### PR TITLE
Disable OPcache during MODX setup to prevent issues with new installs ...

### DIFF
--- a/setup/index.php
+++ b/setup/index.php
@@ -27,6 +27,7 @@
 /* do a little bit of environment cleanup if possible */
 @ ini_set('magic_quotes_runtime', 0);
 @ ini_set('magic_quotes_sybase', 0);
+@ ini_set('opcache.enable', 0);
 
 /* start session */
 session_start();


### PR DESCRIPTION
... or updates when OPcache is enabled. This PR addresses #9037.
