### PR TITLE
[2.3] - Welcome action

### DIFF
--- a/core/model/modx/modmanagerrequest.class.php
+++ b/core/model/modx/modmanagerrequest.class.php
@@ -76,8 +76,8 @@ class modManagerRequest extends modRequest {
         $this->modx->smarty->assignByRef('modx',$this->modx);
 
         if (!array_key_exists('a', $_REQUEST)) {
-            $this->action = $this->modx->getOption('welcome_action', null, $this->defaultAction);
-            $_REQUEST['namespace'] = $this->modx->getOption('welcome_namespace', null, 'core');
+            $_REQUEST[$this->actionVar] = $this->modx->getOption('welcome_action', null, $this->defaultAction);
+            $_REQUEST[$this->namespaceVar] = $this->modx->getOption('welcome_namespace', null, 'core');
         }
 
         /* send anti caching headers */

--- a/core/model/modx/modmanagerrequest.class.php
+++ b/core/model/modx/modmanagerrequest.class.php
@@ -75,6 +75,11 @@ class modManagerRequest extends modRequest {
         $this->modx->smarty->assign('_config',$this->modx->config);
         $this->modx->smarty->assignByRef('modx',$this->modx);
 
+        if (!array_key_exists('a', $_REQUEST)) {
+            $this->action = $this->modx->getOption('welcome_action', null, $this->defaultAction);
+            $_REQUEST['namespace'] = $this->modx->getOption('welcome_namespace', null, 'core');
+        }
+
         /* send anti caching headers */
         header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
         header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -288,9 +288,11 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
             } else {
                 Ext.Msg.alert(_('error'),_('correct_errors'));
             }
-        } else { /* if just doing a URL redirect */
-            Ext.applyIf(itm.params || {},o.baseParams || {});
-            MODx.loadPage('?'+Ext.urlEncode(itm.params));
+        } else {
+            // if just doing a URL redirect
+            var params = itm.params || {};
+            Ext.applyIf(params, o.baseParams || {});
+            MODx.loadPage('?' + Ext.urlEncode(params));
         }
         return false;
     }

--- a/manager/assets/modext/sections/element/chunk/create.js
+++ b/manager/assets/modext/sections/element/chunk/create.js
@@ -1,20 +1,15 @@
 /**
  * Loads the chunk create page
- * 
+ *
  * @class MODx.page.CreateChunk
  * @extends MODx.Component
  * @param {Object} config An object of config properties
  * @xtype modx-page-chunk-create
  */
 MODx.page.CreateChunk = function(config) {
-	config = config || {};	
+	config = config || {};
 	Ext.applyIf(config,{
 		formpanel: 'modx-panel-chunk'
-        ,actions: {
-            'new': 'element/chunk/create'
-            ,'edit': 'element/chunk/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/chunk/create'
             ,text: _('save')
@@ -26,9 +21,7 @@ MODx.page.CreateChunk = function(config) {
                 ,ctrl: true
             }]
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -10,11 +10,6 @@ MODx.page.UpdateChunk = function(config) {
 	config = config || {};
 	Ext.applyIf(config,{
 	    formpanel: 'modx-panel-chunk'
-        ,actions: {
-            'new': 'element/chunk/create'
-            ,'edit': 'element/chunk/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/chunk/update'
             ,text: _('save')
@@ -29,9 +24,7 @@ MODx.page.UpdateChunk = function(config) {
             ,handler: this.duplicate
             ,scope: this
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/plugin/create.js
+++ b/manager/assets/modext/sections/element/plugin/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create plugin page
- * 
+ *
  * @class MODx.page.CreatePlugin
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -10,11 +10,6 @@ MODx.page.CreatePlugin = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-plugin'
-        ,actions: {
-            'new': 'element/plugin/create'
-            ,'edit': 'element/plugin/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/plugin/create'
             ,text: _('save')
@@ -26,9 +21,7 @@ MODx.page.CreatePlugin = function(config) {
                 ,ctrl: true
             }]
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         },'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -10,11 +10,6 @@ MODx.page.UpdatePlugin = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-plugin'
-        ,actions: {
-            'new': 'element/plugin/create'
-            ,'edit': 'element/plugin/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/plugin/update'
             ,text: _('save')
@@ -29,9 +24,7 @@ MODx.page.UpdatePlugin = function(config) {
             ,handler: this.duplicate
             ,scope: this
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/snippet/create.js
+++ b/manager/assets/modext/sections/element/snippet/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create snippet page
- * 
+ *
  * @class MODx.page.CreateSnippet
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -10,11 +10,6 @@ MODx.page.CreateSnippet = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-snippet'
-        ,actions: {
-            'new': 'element/snippet/create'
-            ,'edit': 'element/snippet/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/snippet/create'
             ,text: _('save')
@@ -26,9 +21,7 @@ MODx.page.CreateSnippet = function(config) {
                 ,ctrl: true
             }]
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -10,11 +10,6 @@ MODx.page.UpdateSnippet = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-snippet'
-        ,actions: {
-            'new': 'element/snippet/create'
-            ,'edit': 'element/snippet/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/snippet/update'
             ,text: _('save')
@@ -29,9 +24,7 @@ MODx.page.UpdateSnippet = function(config) {
             ,handler: this.duplicate
             ,scope: this
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params:{a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/template/create.js
+++ b/manager/assets/modext/sections/element/template/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create template page
- * 
+ *
  * @class MODx.page.CreateTemplate
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -10,11 +10,6 @@ MODx.page.CreateTemplate = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-template'
-        ,actions: {
-            'new': 'element/template/create'
-            ,'edit': 'element/template/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/template/create'
             ,text: _('save')
@@ -26,9 +21,7 @@ MODx.page.CreateTemplate = function(config) {
                 ,ctrl: true
             }]
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -25,9 +25,7 @@ MODx.page.UpdateTemplate = function(config) {
             ,handler: this.duplicate
             ,scope: this
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/tv/create.js
+++ b/manager/assets/modext/sections/element/tv/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the TV creation page
- * 
+ *
  * @class MODx.page.CreateTV
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -10,11 +10,6 @@ MODx.page.CreateTV = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-tv'
-        ,actions: {
-            'new': 'element/tv/create'
-            ,edit: 'element/tv/update'
-            ,cancel: 'welcome'
-        }
         ,buttons: [{
             process: 'element/tv/create'
             ,text: _('save')
@@ -26,9 +21,7 @@ MODx.page.CreateTV = function(config) {
                 ,ctrl: true
             }]
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -10,11 +10,6 @@ MODx.page.UpdateTV = function(config) {
 	config = config || {};
 	Ext.applyIf(config,{
 		formpanel: 'modx-panel-tv'
-        ,actions: {
-            'new': 'element/tv/create'
-            ,'edit': 'element/tv/update'
-            ,'cancel': 'welcome'
-        }
         ,buttons: [{
             process: 'element/tv/update'
             ,text: _('save')
@@ -29,9 +24,7 @@ MODx.page.UpdateTV = function(config) {
             ,handler: this.duplicate
             ,scope: this
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/resource/create.js
+++ b/manager/assets/modext/sections/resource/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create resource page
- * 
+ *
  * @class MODx.page.CreateResource
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -14,11 +14,6 @@ MODx.page.CreateResource = function(config) {
         ,id: 'modx-page-update-resource'
         ,which_editor: 'none'
         ,action: 'resource/create'
-    	,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,cancel: 'welcome'
-        }
     	,buttons: this.getButtons(config)
         ,components: [{
             xtype: config.panelXType || 'modx-panel-resource'
@@ -54,10 +49,8 @@ Ext.extend(MODx.page.CreateResource,MODx.Component,{
             btns.push('-');
         }
         btns.push({
-            process: 'cancel'
-            ,text: _('cancel')
+            text: _('cancel')
             ,id: 'modx-abtn-cancel'
-            ,params: { a: 'welcome' }
         });
         /*btns.push('-');
         btns.push({

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -1,6 +1,6 @@
 /**
  * Loads the resource data page
- * 
+ *
  * @class MODx.page.ResourceData
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -28,17 +28,10 @@ MODx.page.ResourceData = function(config) {
     btns.push('-');
     btns.push({
         text: _('cancel')
-        ,handler: this.cancel
-        ,scope: this
         ,id: 'modx-abtn-cancel'
     });
     Ext.applyIf(config,{
         form: 'modx-resource-data'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,cancel: 'welcome'
-        }
         ,buttons: btns
         ,components: [{
             xtype: 'modx-panel-resource-data'
@@ -60,9 +53,6 @@ Ext.extend(MODx.page.ResourceData,MODx.Component,{
     }
     ,editResource: function() {
         MODx.loadPage('resource/update', 'id='+this.config.record.id);
-    }
-    ,cancel: function() {
-        MODx.loadPage('welcome');
     }
 });
 Ext.reg('modx-page-resource-data',MODx.page.ResourceData);

--- a/manager/assets/modext/sections/resource/static/create.js
+++ b/manager/assets/modext/sections/resource/static/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create static resource page
- * 
+ *
  * @class MODx.page.CreateStatic
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -14,11 +14,6 @@ MODx.page.CreateStatic = function(config) {
         ,id: 'modx-page-update-resource'
         ,which_editor: 'none'
         ,action: 'resource/create'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,cancel: 'welcome'
-        }
         ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-static'
@@ -53,9 +48,7 @@ Ext.extend(MODx.page.CreateStatic,MODx.Component,{
             btns.push('-');
         }
         btns.push({
-            process: 'cancel'
-            ,text: _('cancel')
-            ,params: { a: 'welcome' }
+            text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
         /*btns.push('-');

--- a/manager/assets/modext/sections/resource/static/update.js
+++ b/manager/assets/modext/sections/resource/static/update.js
@@ -19,12 +19,6 @@ MODx.page.UpdateStatic = function(config) {
         ,formpanel: 'modx-panel-resource'
         ,id: 'modx-page-update-resource'
         ,action: 'resource/update'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,preview: 'resource/preview'
-            ,cancel: 'welcome'
-        }
         ,components: [{
             xtype: 'modx-panel-static'
             ,renderTo: 'modx-panel-static-div'
@@ -84,12 +78,12 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    MODx.loadPage('welcome');
+                    MODx.loadPage('?');
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            MODx.loadPage('welcome');
+            MODx.loadPage('?');
         }
     }
     ,getButtons: function(cfg) {

--- a/manager/assets/modext/sections/resource/symlink/create.js
+++ b/manager/assets/modext/sections/resource/symlink/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create resource page
- * 
+ *
  * @class MODx.page.CreateSymLink
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -14,11 +14,6 @@ MODx.page.CreateSymLink = function(config) {
         ,id: 'modx-page-update-resource'
         ,which_editor: 'none'
         ,action: 'resource/create'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,cancel: 'welcome'
-        }
         ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-symlink'
@@ -53,9 +48,7 @@ Ext.extend(MODx.page.CreateSymLink,MODx.Component,{
             btns.push('-');
         }
         btns.push({
-            process: 'cancel'
-            ,text: _('cancel')
-            ,params: { a: 'welcome' }
+            text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
         /*btns.push('-');

--- a/manager/assets/modext/sections/resource/symlink/update.js
+++ b/manager/assets/modext/sections/resource/symlink/update.js
@@ -15,12 +15,6 @@ MODx.page.UpdateSymLink = function(config) {
         ,formpanel: 'modx-panel-resource'
         ,id: 'modx-page-update-resource'
         ,action: 'resource/update'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,preview: 'resource/preview'
-            ,cancel: 'welcome'
-        }
         ,components: [{
             xtype: 'modx-panel-symlink'
             ,renderTo: 'modx-panel-symlink-div'
@@ -80,12 +74,12 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    MODx.loadPage('welcome');
+                    MODx.loadPage('?');
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            MODx.loadPage('welcome');
+            MODx.loadPage('?');
         }
     }
 

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -18,12 +18,6 @@ MODx.page.UpdateResource = function(config) {
         ,formpanel: 'modx-panel-resource'
         ,id: 'modx-page-update-resource'
         ,action: 'edit'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,preview: 'resource/preview'
-            ,cancel: 'welcome'
-        }
         ,components: [{
             xtype: config.panelXType || 'modx-panel-resource'
             ,renderTo: config.panelRenderTo || 'modx-panel-resource-div'
@@ -99,12 +93,12 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                     fp.warnUnsavedChanges = false;
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    MODx.loadPage('welcome');
+                    MODx.loadPage('?');
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            MODx.loadPage('welcome');
+            MODx.loadPage('?');
         }
     }
 

--- a/manager/assets/modext/sections/resource/weblink/create.js
+++ b/manager/assets/modext/sections/resource/weblink/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create resource page
- * 
+ *
  * @class MODx.page.CreateWebLink
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -14,11 +14,6 @@ MODx.page.CreateWebLink = function(config) {
         ,id: 'modx-page-update-resource'
         ,which_editor: 'none'
         ,action: 'resource/create'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,cancel: 'welcome'
-        }
         ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-weblink'
@@ -28,7 +23,7 @@ MODx.page.CreateWebLink = function(config) {
             ,publish_document: config.publish_document
             ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
-            ,url: config.url       
+            ,url: config.url
         }]
     });
     MODx.page.CreateWebLink.superclass.constructor.call(this,config);
@@ -53,10 +48,8 @@ Ext.extend(MODx.page.CreateWebLink,MODx.Component,{
             btns.push('-');
         }
         btns.push({
-            process: 'cancel'
-            ,text: _('cancel')
+            text: _('cancel')
             ,id: 'modx-abtn-cancel'
-            ,params: { a: 'welcome' }
         });
         /*btns.push('-');
         btns.push({

--- a/manager/assets/modext/sections/resource/weblink/update.js
+++ b/manager/assets/modext/sections/resource/weblink/update.js
@@ -14,12 +14,6 @@ MODx.page.UpdateWebLink = function(config) {
         ,formpanel: 'modx-panel-resource'
         ,id: 'modx-page-update-resource'
         ,action: 'resource/update'
-        ,actions: {
-            'new': 'resource/create'
-            ,edit: 'resource/update'
-            ,preview: 'resource/preview'
-            ,cancel: 'welcome'
-        }
         ,components: [{
             xtype: 'modx-panel-weblink'
             ,renderTo: 'modx-panel-weblink-div'
@@ -79,12 +73,12 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
                 if (e == 'yes') {
                     MODx.releaseLock(MODx.request.id);
                     MODx.sleep(400);
-                    MODx.loadPage('welcome');
+                    MODx.loadPage('?');
                 }
             },this);
         } else {
             MODx.releaseLock(MODx.request.id);
-            MODx.loadPage('welcome');
+            MODx.loadPage('?');
         }
     }
 

--- a/manager/assets/modext/sections/security/role/list.js
+++ b/manager/assets/modext/sections/security/role/list.js
@@ -1,10 +1,10 @@
 Ext.onReady(function() {
-	MODx.load({ xtype: 'page-roles' });	
+	MODx.load({ xtype: 'page-roles' });
 });
 
 /**
  * Loads the Role management page
- * 
+ *
  * @class MODx.page.ListRoles
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -14,9 +14,13 @@ MODx.page.ListRoles = function(config) {
 	config = config || {};
 	Ext.applyIf(config,{
 		buttons: [{
-            process: 'new', text: _('new'), params: {a:'security/role/create'}
+            process: 'new'
+            ,text: _('new')
+            ,params: {
+                a:'security/role/create'
+            }
         },'-',{
-            process: 'cancel', text: _('cancel'), params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
             text: _('help_ex')
             ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/system/content.type.js
+++ b/manager/assets/modext/sections/system/content.type.js
@@ -11,7 +11,7 @@ MODx.page.ContentType = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-content-type'
         ,buttons: [{
-            process: 'cancel', text: _('cancel'), params: {a:'welcome'}
+            text: _('cancel')
         }/*,'-',{
          text: _('help_ex')
          ,handler: MODx.loadHelpPane

--- a/manager/assets/modext/sections/system/error.log.js
+++ b/manager/assets/modext/sections/system/error.log.js
@@ -1,6 +1,6 @@
 /**
  * Loads the error log page
- * 
+ *
  * @class MODx.page.ErrorLog
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -21,9 +21,7 @@ MODx.page.ErrorLog = function(config) {
             ,scope: this
             ,hidden: config.record.tooLarge
         },'-',{
-            process: 'welcome'
-            ,text: _('cancel')
-            ,params: {a:'welcome'}
+            text: _('cancel')
         }]
         ,components: [{
             xtype: 'modx-panel-error-log'

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -20,9 +20,7 @@ MODx.page.CreateFile = function(config) {
     });
     btns.push('-');
     btns.push({
-        process: 'cancel'
-        ,text: _('cancel')
-        ,params: {a:'welcome'}
+        text: _('cancel')
     });
 
     Ext.applyIf(config,{

--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -22,9 +22,7 @@ MODx.page.EditFile = function(config) {
         btns.push('-');
     }
     btns.push({
-        process: 'cancel'
-        ,text: _('cancel')
-        ,params: {a:'welcome'}
+        text: _('cancel')
     });
 
     Ext.applyIf(config,{

--- a/manager/assets/modext/sections/system/import/html.js
+++ b/manager/assets/modext/sections/system/import/html.js
@@ -3,9 +3,12 @@ MODx.page.ImportHTML = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-import-html'
         ,buttons: [{
-            process: 'system/import/html', text: _('import_site'), method: 'remote', cls:'primary-button'
+            process: 'system/import/html'
+            ,text: _('import_site')
+            ,method: 'remote'
+            ,cls:'primary-button'
         },{
-            process: 'cancel', text: _('cancel'), params: {a:'welcome'}
+            text: _('cancel')
         }]
         ,components: [{
             xtype: 'modx-panel-import-html'

--- a/manager/assets/modext/sections/system/import/resource.js
+++ b/manager/assets/modext/sections/system/import/resource.js
@@ -3,9 +3,11 @@ MODx.page.ImportResource = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-import-resources'
         ,buttons: [{
-            process: 'system/import/index', text: _('import_resources'), method: 'remote'
+            process: 'system/import/index'
+            ,text: _('import_resources')
+            ,method: 'remote'
         },{
-            process: 'cancel', text: _('cancel'), params: {a:'welcome'}
+            text: _('cancel')
         }]
         ,components: [{
             xtype: 'modx-panel-import-resources'

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -63,8 +63,9 @@
                 </li>
             </ul>
             <ul id="modx-topnav">
+                {assign var='action' value=$_config.welcome_action|default:'welcome'}
                 <li id="modx-home-dashboard">
-                    <a href="?a=welcome" title="{$_lang.dashboard}">{$_lang.dashboard}</a>
+                    <a href="?a={$action}{if $_config.welcome_namespace}&namespace={$_config.welcome_namespace}{/if}" title="{$_lang.dashboard}">{$_lang.dashboard}</a>
                 </li>
                 <li id="modx-manager-search"></li>
                 {$navb}

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -63,9 +63,8 @@
                 </li>
             </ul>
             <ul id="modx-topnav">
-                {assign var='action' value=$_config.welcome_action|default:'welcome'}
                 <li id="modx-home-dashboard">
-                    <a href="?a={$action}{if $_config.welcome_namespace}&namespace={$_config.welcome_namespace}{/if}" title="{$_lang.dashboard}">{$_lang.dashboard}</a>
+                    <a href="?" title="{$_lang.dashboard}">{$_lang.dashboard}</a>
                 </li>
                 <li id="modx-manager-search"></li>
                 {$navb}


### PR DESCRIPTION
This allows to use system settings to define the "home" action.
This means a user could land on a CMP when logging in (this could be "overridable" per user, using user settings).

Makes use of 2 system settings : 
- `welcome_action` to define the action "controller" (defaulting to "welcome")
- `welcome_namespace` to define the namespace the "controller" belongs to (defaulting to "core")
