### PR TITLE
Enhancing isloggedin/isnotloggedin output filters

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -587,14 +587,16 @@ class modOutputFilter {
                             break;
 
                         case 'isloggedin':
-                            /* returns true if user is logged in */
-                            $output= $this->modx->user->isAuthenticated($this->modx->context->get('key'));
+                            /* returns true if user is logged in to the specified context or by default the current context */
+                            $ctxkey = (!empty($m_val)) ? $m_val : $this->modx->context->get('key');
+                            $output= $this->modx->user->isAuthenticated($ctxkey);
                             $output= $output ? true : false;
                             break;
 
                         case 'isnotloggedin':
-                            /* returns true if user is not logged in */
-                            $output= $this->modx->user->isAuthenticated($this->modx->context->get('key'));
+                            /* returns true if user is not logged in to the specified context or by default the current context */
+                            $ctxkey = (!empty($m_val)) ? $m_val : $this->modx->context->get('key');
+                            $output= $this->modx->user->isAuthenticated($ctxkey);
                             $output= $output ? false : true;
                             break;
 


### PR DESCRIPTION
Allow to specify a context for the isloggedin/isnotloggedin output filters, the default is still the current context, so it shouldn't break old implementations or implementations where no context is specified.

with that change it is possible to do something like that:

```
[[!+modx.user.id:isloggedin=`mgr`:eq=`1`:then=`class="loggedin"`:else=``]]
```

when before just the current context was checked (as far as I understand)
