### PR TITLE
Updated phpThumb to its current GitHub status, (1.7.12-pre).

### DIFF
--- a/core/model/phpthumb/phpthumb.filters.php
+++ b/core/model/phpthumb/phpthumb.filters.php
@@ -1,7 +1,8 @@
 <?php
 //////////////////////////////////////////////////////////////
-///  phpThumb() by James Heinrich <info@silisoftware.com>   //
-//        available at http://phpthumb.sourceforge.net     ///
+//   phpThumb() by James Heinrich <info@silisoftware.com>   //
+//        available at http://phpthumb.sourceforge.net      //
+//         and/or https://github.com/JamesHeinrich/phpThumb //
 //////////////////////////////////////////////////////////////
 ///                                                         //
 // phpthumb.filters.php - image processing filter functions //
@@ -16,7 +17,16 @@ class phpthumb_filters {
 		return true;
 	}
 
-	function ApplyMask(&$gdimg_mask, &$gdimg_image) {
+	function DebugMessage($message, $file='', $line='') {
+		if (is_object($this->phpThumbObject)) {
+			return $this->phpThumbObject->DebugMessage($message, $file, $line);
+		}
+		return false;
+	}
+
+
+
+	public function ApplyMask(&$gdimg_mask, &$gdimg_image) {
 		if (phpthumb_functions::gd_version() < 2) {
 			$this->DebugMessage('Skipping ApplyMask() because gd_version is "'.phpthumb_functions::gd_version().'"', __FILE__, __LINE__);
 			return false;
@@ -85,7 +95,7 @@ class phpthumb_filters {
     }
 
 
-	function Blur(&$gdimg, $radius=0.5) {
+	public function Blur(&$gdimg, $radius=0.5) {
 		// Taken from Torstein Hønsi's phpUnsharpMask (see phpthumb.unsharp.php)
 
 		$radius = round(max(0, min($radius, 50)) * 2);
@@ -121,7 +131,7 @@ class phpthumb_filters {
 	}
 
 
-	function BlurGaussian(&$gdimg) {
+	public function BlurGaussian(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (ImageFilter($gdimg, IMG_FILTER_GAUSSIAN_BLUR)) {
 				return true;
@@ -134,7 +144,7 @@ class phpthumb_filters {
 	}
 
 
-	function BlurSelective(&$gdimg) {
+	public function BlurSelective(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (ImageFilter($gdimg, IMG_FILTER_SELECTIVE_BLUR)) {
 				return true;
@@ -148,7 +158,7 @@ class phpthumb_filters {
 	}
 
 
-	function Brightness(&$gdimg, $amount=0) {
+	public function Brightness(&$gdimg, $amount=0) {
 		if ($amount == 0) {
 			return true;
 		}
@@ -178,7 +188,7 @@ class phpthumb_filters {
 	}
 
 
-	function Contrast(&$gdimg, $amount=0) {
+	public function Contrast(&$gdimg, $amount=0) {
 		if ($amount == 0) {
 			return true;
 		}
@@ -212,7 +222,7 @@ class phpthumb_filters {
 	}
 
 
-	function Colorize(&$gdimg, $amount, $targetColor) {
+	public function Colorize(&$gdimg, $amount, $targetColor) {
 		$amount      = (is_numeric($amount)                          ? $amount      : 25);
 		$amountPct   = $amount / 100;
 		$targetColor = (phpthumb_functions::IsHexColor($targetColor) ? $targetColor : 'gray');
@@ -260,7 +270,7 @@ class phpthumb_filters {
 	}
 
 
-	function Crop(&$gdimg, $left=0, $right=0, $top=0, $bottom=0) {
+	public function Crop(&$gdimg, $left=0, $right=0, $top=0, $bottom=0) {
 		if (!$left && !$right && !$top && !$bottom) {
 			return true;
 		}
@@ -288,7 +298,7 @@ class phpthumb_filters {
 	}
 
 
-	function Desaturate(&$gdimg, $amount, $color='') {
+	public function Desaturate(&$gdimg, $amount, $color='') {
 		if ($amount == 0) {
 			return true;
 		}
@@ -296,7 +306,7 @@ class phpthumb_filters {
 	}
 
 
-	function DropShadow(&$gdimg, $distance, $width, $hexcolor, $angle, $alpha) {
+	public function DropShadow(&$gdimg, $distance, $width, $hexcolor, $angle, $alpha) {
 		if (phpthumb_functions::gd_version() < 2) {
 			return false;
 		}
@@ -378,7 +388,7 @@ class phpthumb_filters {
 	}
 
 
-	function EdgeDetect(&$gdimg) {
+	public function EdgeDetect(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (ImageFilter($gdimg, IMG_FILTER_EDGEDETECT)) {
 				return true;
@@ -392,7 +402,7 @@ class phpthumb_filters {
 	}
 
 
-	function Elipse($gdimg) {
+	public function Elipse($gdimg) {
 		if (phpthumb_functions::gd_version() < 2) {
 			return false;
 		}
@@ -419,7 +429,7 @@ class phpthumb_filters {
 	}
 
 
-	function Emboss(&$gdimg) {
+	public function Emboss(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (ImageFilter($gdimg, IMG_FILTER_EMBOSS)) {
 				return true;
@@ -433,7 +443,7 @@ class phpthumb_filters {
 	}
 
 
-	function Flip(&$gdimg, $x=false, $y=false) {
+	public function Flip(&$gdimg, $x=false, $y=false) {
 		if (!$x && !$y) {
 			return false;
 		}
@@ -456,7 +466,7 @@ class phpthumb_filters {
 	}
 
 
-	function Frame(&$gdimg, $frame_width, $edge_width, $hexcolor_frame, $hexcolor1, $hexcolor2) {
+	public function Frame(&$gdimg, $frame_width, $edge_width, $hexcolor_frame, $hexcolor1, $hexcolor2) {
 		$frame_width    = ($frame_width    ? $frame_width    : 5);
 		$edge_width     = ($edge_width     ? $edge_width     : 1);
 		$hexcolor_frame = ($hexcolor_frame ? $hexcolor_frame : 'CCCCCC');
@@ -488,7 +498,7 @@ class phpthumb_filters {
 	}
 
 
-	function Gamma(&$gdimg, $amount) {
+	public function Gamma(&$gdimg, $amount) {
 		if (number_format($amount, 4) == '1.0000') {
 			return true;
 		}
@@ -496,7 +506,7 @@ class phpthumb_filters {
 	}
 
 
-	function Grayscale(&$gdimg) {
+	public function Grayscale(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (ImageFilter($gdimg, IMG_FILTER_GRAYSCALE)) {
 				return true;
@@ -508,7 +518,7 @@ class phpthumb_filters {
 	}
 
 
-	function HistogramAnalysis(&$gdimg, $calculateGray=false) {
+	public function HistogramAnalysis(&$gdimg, $calculateGray=false) {
 		$ImageSX = ImageSX($gdimg);
 		$ImageSY = ImageSY($gdimg);
 		for ($x = 0; $x < $ImageSX; $x++) {
@@ -535,7 +545,7 @@ class phpthumb_filters {
 	}
 
 
-	function HistogramStretch(&$gdimg, $band='*', $method=0, $threshold=0.1) {
+	public function HistogramStretch(&$gdimg, $band='*', $method=0, $threshold=0.1) {
 		// equivalent of "Auto Contrast" in Adobe Photoshop
 		// method 0 stretches according to RGB colors. Gives a more conservative stretch.
 		// method 1 band stretches according to grayscale which is color-biased (59% green, 30% red, 11% blue). May give a punchier / more aggressive stretch, possibly appearing over-saturated
@@ -616,7 +626,7 @@ class phpthumb_filters {
 	}
 
 
-	function HistogramOverlay(&$gdimg, $bands='*', $colors='', $width=0.25, $height=0.25, $alignment='BR', $opacity=50, $margin_x=5, $margin_y=null) {
+	public function HistogramOverlay(&$gdimg, $bands='*', $colors='', $width=0.25, $height=0.25, $alignment='BR', $opacity=50, $margin_x=5, $margin_y=null) {
 		$margin_y = (is_null($margin_y) ? $margin_x : $margin_y);
 
 		$Analysis = phpthumb_filters::HistogramAnalysis($gdimg, true);
@@ -666,7 +676,7 @@ class phpthumb_filters {
 	}
 
 
-	function ImageBorder(&$gdimg, $border_width, $radius_x, $radius_y, $hexcolor_border) {
+	public function ImageBorder(&$gdimg, $border_width, $radius_x, $radius_y, $hexcolor_border) {
 		$border_width = ($border_width ? $border_width : 1);
 		$radius_x     = ($radius_x     ? $radius_x     : 0);
 		$radius_y     = ($radius_y     ? $radius_y     : 0);
@@ -743,7 +753,7 @@ class phpthumb_filters {
 	}
 
 
-	function ImprovedImageRotate(&$gdimg_source, $rotate_angle=0, $config_background_hexcolor='FFFFFF', $bg=null) {
+	public function ImprovedImageRotate(&$gdimg_source, $rotate_angle=0, $config_background_hexcolor='FFFFFF', $bg=null) {
 		while ($rotate_angle < 0) {
 			$rotate_angle += 360;
 		}
@@ -838,7 +848,7 @@ class phpthumb_filters {
 	}
 
 
-	function MeanRemoval(&$gdimg) {
+	public function MeanRemoval(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (ImageFilter($gdimg, IMG_FILTER_MEAN_REMOVAL)) {
 				return true;
@@ -852,7 +862,7 @@ class phpthumb_filters {
 	}
 
 
-	function Negative(&$gdimg) {
+	public function Negative(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (ImageFilter($gdimg, IMG_FILTER_NEGATE)) {
 				return true;
@@ -873,7 +883,7 @@ class phpthumb_filters {
 	}
 
 
-	function RoundedImageCorners(&$gdimg, $radius_x, $radius_y) {
+	public function RoundedImageCorners(&$gdimg, $radius_x, $radius_y) {
 		// generate mask at twice desired resolution and downsample afterwards for easy antialiasing
 		// mask is generated as a white double-size elipse on a triple-size black background and copy-paste-resampled
 		// onto a correct-size mask image as 4 corners due to errors when the entire mask is resampled at once (gray edges)
@@ -907,7 +917,7 @@ class phpthumb_filters {
 	}
 
 
-	function Saturation(&$gdimg, $amount, $color='') {
+	public function Saturation(&$gdimg, $amount, $color='') {
 		if ($amount == 0) {
 			return true;
 		} elseif ($amount > 0) {
@@ -919,7 +929,7 @@ class phpthumb_filters {
 	}
 
 
-	function Sepia(&$gdimg, $amount, $targetColor) {
+	public function Sepia(&$gdimg, $amount, $targetColor) {
 		$amount      = (is_numeric($amount) ? max(0, min(100, $amount)) : 50);
 		$amountPct   = $amount / 100;
 		$targetColor = (phpthumb_functions::IsHexColor($targetColor) ? $targetColor : 'A28065');
@@ -975,7 +985,7 @@ class phpthumb_filters {
 	}
 
 
-	function Smooth(&$gdimg, $amount=6) {
+	public function Smooth(&$gdimg, $amount=6) {
 		$amount = min(25, max(0, $amount));
 		if ($amount == 0) {
 			return true;
@@ -993,7 +1003,7 @@ class phpthumb_filters {
 	}
 
 
-	function SourceTransparentColorMask(&$gdimg, $hexcolor, $min_limit=5, $max_limit=10) {
+	public function SourceTransparentColorMask(&$gdimg, $hexcolor, $min_limit=5, $max_limit=10) {
 		$width  = ImageSX($gdimg);
 		$height = ImageSY($gdimg);
 		if ($gdimg_mask = ImageCreateTrueColor($width, $height)) {
@@ -1017,7 +1027,7 @@ class phpthumb_filters {
 	}
 
 
-	function Threshold(&$gdimg, $cutoff) {
+	public function Threshold(&$gdimg, $cutoff) {
 		$width  = ImageSX($gdimg);
 		$height = ImageSY($gdimg);
 		$cutoff = min(255, max(0, ($cutoff ? $cutoff : 128)));
@@ -1037,7 +1047,7 @@ class phpthumb_filters {
 	}
 
 
-	function ImageTrueColorToPalette2(&$image, $dither, $ncolors) {
+	public function ImageTrueColorToPalette2(&$image, $dither, $ncolors) {
 		// http://www.php.net/manual/en/function.imagetruecolortopalette.php
 		// zmorris at zsculpt dot com (17-Aug-2004 06:58)
 		$width  = ImageSX($image);
@@ -1051,7 +1061,7 @@ class phpthumb_filters {
 		return true;
 	}
 
-	function ReduceColorDepth(&$gdimg, $colors=256, $dither=true) {
+	public function ReduceColorDepth(&$gdimg, $colors=256, $dither=true) {
 		$colors = max(min($colors, 256), 2);
 		// ImageTrueColorToPalette usually makes ugly colors, the replacement is a bit better
 		//ImageTrueColorToPalette($gdimg, $dither, $colors);
@@ -1060,7 +1070,7 @@ class phpthumb_filters {
 	}
 
 
-	function WhiteBalance(&$gdimg, $targetColor='') {
+	public function WhiteBalance(&$gdimg, $targetColor='') {
 		if (phpthumb_functions::IsHexColor($targetColor)) {
 			$targetPixel = array(
 				'red'   => hexdec(substr($targetColor, 0, 2)),
@@ -1097,7 +1107,7 @@ class phpthumb_filters {
 	}
 
 
-	function WatermarkText(&$gdimg, $text, $size, $alignment, $hex_color='000000', $ttffont='', $opacity=100, $margin=5, $angle=0, $bg_color=false, $bg_opacity=0, $fillextend='') {
+	public function WatermarkText(&$gdimg, $text, $size, $alignment, $hex_color='000000', $ttffont='', $opacity=100, $margin=5, $angle=0, $bg_color=false, $bg_opacity=0, $fillextend='') {
 		// text watermark requested
 		if (!$text) {
 			return false;
@@ -1380,9 +1390,13 @@ class phpthumb_filters {
 
 						case 'BR':
 						default:
-							$x_offset = $text_width - (ImageFontWidth($size) * strlen($line));
-							$originOffsetX = ImageSX($gdimg) - ImageSX($img_watermark) - $margin;
-							$originOffsetY = ImageSY($gdimg) - ImageSY($img_watermark) - $margin;
+							if (!empty($originOffsetX) || !empty($originOffsetY)) {
+								// absolute pixel positioning
+							} else {
+								$x_offset = $text_width - (ImageFontWidth($size) * strlen($line));
+								$originOffsetX = ImageSX($gdimg) - ImageSX($img_watermark) - $margin;
+								$originOffsetY = ImageSY($gdimg) - ImageSY($img_watermark) - $margin;
+							}
 							break;
 					}
 					$this->DebugMessage('WatermarkText() calling ImageString($img_watermark, '.$size.', '.$x_offset.', '.($key * ImageFontHeight($size)).', '.$line.', $text_color_watermark)', __FILE__, __LINE__);
@@ -1409,7 +1423,7 @@ class phpthumb_filters {
 	}
 
 
-	function WatermarkOverlay(&$gdimg_dest, &$img_watermark, $alignment='*', $opacity=50, $margin_x=5, $margin_y=null) {
+	public function WatermarkOverlay(&$gdimg_dest, &$img_watermark, $alignment='*', $opacity=50, $margin_x=5, $margin_y=null) {
 
 		if (is_resource($gdimg_dest) && is_resource($img_watermark)) {
 			$watermark_source_x        = 0;
@@ -1534,13 +1548,4 @@ class phpthumb_filters {
 		return false;
 	}
 
-
-	function DebugMessage($message, $file='', $line='') {
-		if (is_object($this->phpThumbObject)) {
-			return $this->phpThumbObject->DebugMessage($message, $file, $line);
-		}
-		return false;
-	}
 }
-
-?>

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -1,7 +1,8 @@
 <?php
 //////////////////////////////////////////////////////////////
-///  phpThumb() by James Heinrich <info@silisoftware.com>   //
-//        available at http://phpthumb.sourceforge.net     ///
+//   phpThumb() by James Heinrich <info@silisoftware.com>   //
+//        available at http://phpthumb.sourceforge.net      //
+//         and/or https://github.com/JamesHeinrich/phpThumb //
 //////////////////////////////////////////////////////////////
 ///                                                         //
 // phpthumb.functions.php - general support functions       //

--- a/core/model/phpthumb/phpthumb.ico.php
+++ b/core/model/phpthumb/phpthumb.ico.php
@@ -1,7 +1,8 @@
 <?php
 //////////////////////////////////////////////////////////////
-///  phpThumb() by James Heinrich <info@silisoftware.com>   //
-//        available at http://phpthumb.sourceforge.net     ///
+//   phpThumb() by James Heinrich <info@silisoftware.com>   //
+//        available at http://phpthumb.sourceforge.net      //
+//         and/or https://github.com/JamesHeinrich/phpThumb //
 //////////////////////////////////////////////////////////////
 ///                                                         //
 // phpthumb.ico.php - .ICO output format functions          //

--- a/core/model/phpthumb/phpthumb.unsharp.php
+++ b/core/model/phpthumb/phpthumb.unsharp.php
@@ -8,13 +8,14 @@
 ////               Please leave this notice.
 ////
 //////////////////////////////////////////////////////////////
-/// From: http://vikjavev.no/computing/ump.php              //
+//  From: http://vikjavev.no/computing/ump.php              //
 //                                                          //
 //  Reformatted by James Heinrich <info@silisoftware.com>   //
 //    for use in phpThumb() on 3 February 2003.             //
 //    updated to v2.1.1 on 24 April 2011                    //
 //                                                          //
-//  phpThumb() is found at http://phpthumb.sourceforge.net ///
+//  phpThumb() is found at http://phpthumb.sourceforge.net  //
+//         and/or https://github.com/JamesHeinrich/phpThumb //
 //////////////////////////////////////////////////////////////
 
 /*
@@ -42,7 +43,7 @@ and the roundoff errors in the Gaussian blur process, are welcome.
 
 class phpUnsharpMask {
 
-	function applyUnsharpMask(&$img, $amount, $radius, $threshold) {
+	static function applyUnsharpMask(&$img, $amount, $radius, $threshold) {
 
 		// $img is an image that is already created within php using
 		// imgcreatetruecolor. No url! $img must be a truecolor image.


### PR DESCRIPTION
The version of phpThumb that MODX currently ships, generates distorted thumbnails in some cases (e.g. when generating a horizontal thumbnail for a vertical image, with far=C). I figured out this can be fixed by updating phpThumb to v1.7.11 final.

Then I discovered that this library now lives in GitHub and the lines that concerned me (aspect ratio calculation) have been relocated once again after 1.7.11 (see JamesHeinrich/phpThumb@1603c41105ea88572cd9bc24a953df8415f76241), so I thought it might be better to update straight to their GitHub status instead.

If this change is too big however, I can make a new pull request which updates to 1.7.11 instead (or you can update the library yourself, that changeset is really small).
