### PR TITLE
Fix issues with the settings cache when running setup on systems running Zend OpCache

### DIFF
--- a/setup/index.php
+++ b/setup/index.php
@@ -27,6 +27,7 @@
 /* do a little bit of environment cleanup if possible */
 @ ini_set('magic_quotes_runtime', 0);
 @ ini_set('magic_quotes_sybase', 0);
+@ ini_set('opcache.revalidate_freq', 0);
 
 /* start session */
 session_start();


### PR DESCRIPTION
Fix issues with the settings cache when running setup on systems running Zend OpCache by ensuring opcache.revalidate_freq is set to 0 - i.e. revalidate files in the cache every request.
