### PR TITLE
Make preview possible if session_enabled = 0

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2379,7 +2379,7 @@ class modX extends xPDO {
      */
     protected function _initSession($options = null) {
         $contextKey= $this->context instanceof modContext ? $this->context->get('key') : null;
-        if ($this->getOption('session_enabled', $options, true)) {
+        if ($this->getOption('session_enabled', $options, true) || isset($_GET['preview'])) {
             if (!in_array($this->getSessionState(), array(modX::SESSION_STATE_INITIALIZED, modX::SESSION_STATE_EXTERNAL, modX::SESSION_STATE_UNAVAILABLE), true)) {
                 $sh= false;
                 if ($sessionHandlerClass = $this->getOption('session_handler_class', $options)) {

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -458,7 +458,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             'ctx' => $resource->context_key,
             'hide_children_in_tree' => $resource->hide_children_in_tree,
             'qtip' => $qtip,
-            'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), $sessionEnabled, 'full') : '',
+            'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), $sessionEnabled, 'full', array('xhtml_urls' => false)) : '',
             'page' => empty($noHref) ? '?a='.(!empty($this->permissions['edit_document']) ? 'resource/update' : 'resource/data').'&id='.$resource->id : '',
             'allowDrop' => true,
         );

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -442,6 +442,10 @@ class modResourceGetNodesProcessor extends modProcessor {
         }
 
         $idNote = $this->modx->hasPermission('tree_show_resource_ids') ? ' <span dir="ltr">('.$resource->id.')</span>' : '';
+        $sessionEnabled = '';
+        if ($ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $resource->get('context_key'), 'key' => 'session_enabled'))) {
+            $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
+        }
         $itemArray = array(
             'text' => strip_tags($resource->$nodeField).$idNote,
             'id' => $resource->context_key . '_'.$resource->id,
@@ -454,7 +458,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             'ctx' => $resource->context_key,
             'hide_children_in_tree' => $resource->hide_children_in_tree,
             'qtip' => $qtip,
-            'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), '', 'full') : '',
+            'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), $sessionEnabled, 'full') : '',
             'page' => empty($noHref) ? '?a='.(!empty($this->permissions['edit_document']) ? 'resource/update' : 'resource/data').'&id='.$resource->id : '',
             'allowDrop' => true,
         );

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -165,7 +165,11 @@ class ResourceUpdateManagerController extends ResourceManagerController {
      */
     public function getPreviewUrl() {
         if (!$this->resource->get('deleted')) {
-            $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'),'','full');
+            $sessionEnabled = '';
+            if ($ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $this->resource->get('context_key'), 'key' => 'session_enabled'))) {
+                $sessionEnabled = $ctxSetting->get('value') == 0 ? 'preview' : '';
+            }
+            $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'),$sessionEnabled,'full');
         }
         return $this->previewUrl;
     }

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -167,7 +167,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
         if (!$this->resource->get('deleted')) {
             $sessionEnabled = '';
             if ($ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $this->resource->get('context_key'), 'key' => 'session_enabled'))) {
-                $sessionEnabled = $ctxSetting->get('value') == 0 ? 'preview' : '';
+                $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
             }
             $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'),$sessionEnabled,'full');
         }

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -169,7 +169,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
             if ($ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $this->resource->get('context_key'), 'key' => 'session_enabled'))) {
                 $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
             }
-            $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'),$sessionEnabled,'full');
+            $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'), $this->resource->get('context_key'), $sessionEnabled, 'full', array('xhtml_urls' => false));
         }
         return $this->previewUrl;
     }


### PR DESCRIPTION
For many sites sessions_enabled = 0 (set in the context!) can speed up load times dramatically if no user sessions, e.g. personalization, are needed. The problem that comes with this context setting is, that editors that are logged into the manager are not able to preview unpublished resources anymore, which makes this nice option useless in real world website management.

This PR fixes the issue by 1. adjusting the preview URL in the manager if a sessions_enabled context setting is detected > setting get param ?preview and 2. checking for that get param in the initSession() method of the modx core class and forcing a session if the preview param is set.

I thought about making some more security checks, but I couldn't load an unpublished resource from a not logged in browser, so this seemed to be unnecessary, but if somebody sees a potential security issue here, please comment and/or improve this PR!
