### PR TITLE
Modify Grunt Build Task

### DIFF
--- a/_build/templates/default/gruntfile.js
+++ b/_build/templates/default/gruntfile.js
@@ -214,5 +214,5 @@ module.exports = function(grunt) {
 
 	// Tasks
 	grunt.registerTask('default', ['sass:map','growl:sass', 'growl:watch', 'watch:map']);
-	grunt.registerTask('build', ['clean:prebuild','bower', 'copy', 'sass:dist','autoprefixer', 'growl:prefixes', 'growl:sass','cssmin:compress','clean:postbuild']);
+	grunt.registerTask('build', ['clean:prebuild','bower', 'copy', 'sass:dev','autoprefixer', 'growl:prefixes', 'growl:sass','cssmin:compress','clean:postbuild']);
 };


### PR DESCRIPTION
No point in compiling the Sass into compressed CSS since it has to run
through autoprefixer and then cssmin
