### PR TITLE
Make default grunt task lazy

### DIFF
--- a/_build/templates/default/gruntfile.js
+++ b/_build/templates/default/gruntfile.js
@@ -213,6 +213,6 @@ module.exports = function(grunt) {
 
 
 	// Tasks
-	grunt.registerTask('default', ['sass:map','growl:sass', 'growl:watch', 'watch:map']);
+	grunt.registerTask('default', ['growl:watch', 'watch:map']);
 	grunt.registerTask('build', ['clean:prebuild','bower', 'copy', 'sass:dist','autoprefixer', 'growl:prefixes', 'growl:sass','cssmin:compress','clean:postbuild']);
 };


### PR DESCRIPTION
Rather than compiling sass and then watching for changes, now just
watches for changes. so now:

``` bash
grunt sass:map #compile sass
grunt #watch for changes
```
