### PR TITLE
[2.2] Fix css overflow issues

### DIFF
--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -148,7 +148,6 @@ input::-moz-focus-inner {
 
 #modx-content {
     padding: 0 0 0 15px;
-    height: 100%;
     overflow: auto;
 }
 
@@ -574,7 +573,6 @@ table.classy tr.odd td {
 #modx-topnav-div {
     background: transparent;
     margin-left: 8px;
-    width: 100%;
 }
 #modx-topnav {
     width: 100%;


### PR DESCRIPTION
This patch fixes a bug with the CKEditor (and sometimes with the Codemirror) in the Google Chrome, when top menu disappears. This is already fixed in the 2.3 branch.
