### PR TITLE
Another version of improved widget of active users

### DIFF
--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -12,21 +12,18 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
         $timetocheck = (time()-(60*20));
 
         $c = $this->modx->newQuery('modManagerLog');
-        $c->innerJoin('modUser','User');
-        $c->where(array(
-            'occurred:>' => strftime('%Y-%m-%d, %H:%M:%S',$timetocheck),
-        ));
-        $c->where(
-            "occurred = (SELECT MAX(`occurred`)
-                    FROM {$this->modx->getTableName('modManagerLog')} AS log2
-                    WHERE `log2`.`user` = `modManagerLog`.`user`
-                    GROUP BY `user`)"
-        );
-        $data['total'] = $this->modx->getCount('modManagerLog',$c);
-
+        $c->leftJoin('modUser','User');
+            $tmp = $this->modx->newQuery('modManagerLog');
+            $tmp->setClassAlias('tmp');
+            $tmp->select($this->modx->getSelectColumns('modManagerLog','tmp'));
+            $tmp->where(array('tmp.occurred:>' => strftime('%Y-%m-%d, %H:%M:%S',$timetocheck)));
+            $tmp->sortby('occurred','DESC');
+            $tmp->prepare();
+            $c->query['from']['tables'][0]['table'] = '('.$tmp->toSQL().')';
         $c->select($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
         $c->select($this->modx->getSelectColumns('modUser','User','',array('username')));
         $c->sortby('occurred','DESC');
+        $c->groupby('user');
         $ausers = $this->modx->getIterator('modManagerLog',$c);
 
         $users = array();
@@ -38,6 +35,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
             $userArray['currentAction'] = $user->get('action');
             $userArray['occurred'] = strftime('%b %d, %Y - %I:%M %p',strtotime($user->get('occurred'))+floatval($this->modx->getOption('server_offset_time',null,0)) * 3600);
             $userArray['class'] = $alt ? 'alt' : '';
+            if (!$userArray['username']) {$userArray['username'] = 'anonymous';}
             $users[] = $this->getFileChunk('dashboard/onlineusers.row.tpl',$userArray);
         }
         

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -23,8 +23,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
         $c->select($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
         $c->select($this->modx->getSelectColumns('modUser','User','',array('username')));
         $c->sortby('occurred','DESC');
-        $c->groupby($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
-        $c->groupby($this->modx->getSelectColumns('modUser','User','',array('username')));
+        $c->groupby('user');
         $ausers = $this->modx->getIterator('modManagerLog',$c);
 
         $users = array();

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -12,18 +12,19 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
         $timetocheck = (time()-(60*20));
 
         $c = $this->modx->newQuery('modManagerLog');
+        $c->setClassAlias('lastlog');
+        $c->innerJoin('modManagerLog','modManagerLog', array('`lastlog`.`id` = `modManagerLog`.`id`'));
         $c->leftJoin('modUser','User');
             $tmp = $this->modx->newQuery('modManagerLog');
             $tmp->setClassAlias('tmp');
-            $tmp->select($this->modx->getSelectColumns('modManagerLog','tmp'));
+            $tmp->select(array('MAX(`id`) AS `id`', '`user`'));
             $tmp->where(array('tmp.occurred:>' => strftime('%Y-%m-%d, %H:%M:%S',$timetocheck)));
-            $tmp->sortby('occurred','DESC');
+            $tmp->groupby('user');
             $tmp->prepare();
             $c->query['from']['tables'][0]['table'] = '('.$tmp->toSQL().')';
         $c->select($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
         $c->select($this->modx->getSelectColumns('modUser','User','',array('username')));
         $c->sortby('occurred','DESC');
-        $c->groupby('user');
         $ausers = $this->modx->getIterator('modManagerLog',$c);
 
         $users = array();

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -23,7 +23,8 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
         $c->select($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
         $c->select($this->modx->getSelectColumns('modUser','User','',array('username')));
         $c->sortby('occurred','DESC');
-        $c->groupby('user');
+        $c->groupby($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
+        $c->groupby($this->modx->getSelectColumns('modUser','User','',array('username')));
         $ausers = $this->modx->getIterator('modManagerLog',$c);
 
         $users = array();


### PR DESCRIPTION
This is the new commit for issue #11107
Now it uses subquery with nested sorting and must work on any type of database.

I have table with 45000 records and when I select last actions for 50 hours this query takes only 0.0287 sec.
