### PR TITLE
Back-button hides during install, fixing #11259

### DIFF
--- a/setup/assets/js/sections/summary.js
+++ b/setup/assets/js/sections/summary.js
@@ -7,6 +7,7 @@ MODx.Summary = function() {
         init: function() {
             Ext.get('install').on('submit',function() {
                 Ext.get('modx-next').setVisible(false);
+                Ext.get('modx-back').setVisible(false);
             });
         }
     }


### PR DESCRIPTION
Title says it all.

Back-button is now hidden once the user clicks 'Install'.
