### PR TITLE
Check for additional valid MIME types for zip files.

### DIFF
--- a/core/model/modx/processors/workspace/packages/upload.class.php
+++ b/core/model/modx/processors/workspace/packages/upload.class.php
@@ -45,7 +45,7 @@ class modBrowserPackageUploadProcessor extends modProcessor {
         $file =  array_shift($this->getProperty('files'));
 
         // Check MIME type of file
-        if(!in_array($file['type'], array('application/zip', 'application/x-zip-compressed', 'application/x-zip')))
+        if(!in_array(strtolower($file['type']), array('application/zip', 'application/x-zip-compressed', 'application/x-zip')))
             return $this->failure("1 This file does not appear to be a transport package"); //@TODO Lexiconize
 
         // Check valid name of file

--- a/core/model/modx/processors/workspace/packages/upload.class.php
+++ b/core/model/modx/processors/workspace/packages/upload.class.php
@@ -45,7 +45,7 @@ class modBrowserPackageUploadProcessor extends modProcessor {
         $file =  array_shift($this->getProperty('files'));
 
         // Check MIME type of file
-        if($file['type'] != 'application/zip')
+        if(!in_array($file['type'], array('application/zip', 'application/x-zip-compressed', 'application/x-zip')))
             return $this->failure("1 This file does not appear to be a transport package"); //@TODO Lexiconize
 
         // Check valid name of file


### PR DESCRIPTION
Wondered why my local transport packages aren't valid zip-files for MODx until I found out that Firefox is uploading them with MIME type 'application/x-zip-compressed'.
