### PR TITLE
Bugfix in package name validation code on local upload

### DIFF
--- a/core/model/modx/processors/workspace/packages/upload.class.php
+++ b/core/model/modx/processors/workspace/packages/upload.class.php
@@ -49,7 +49,7 @@ class modBrowserPackageUploadProcessor extends modProcessor {
             return $this->failure("1 This file does not appear to be a transport package"); //@TODO Lexiconize
 
         // Check valid name of file
-        if(preg_match("/.+\\.transport\\.zip$/",$file['name'])===false)
+        if(!preg_match("/.+\\.transport\\.zip$/",$file['name']))
             return $this->failure("2 This file [{$file['name']}] does not appear to be a transport package"); //@TODO Lexiconize
 
         // Return response

--- a/core/model/modx/processors/workspace/packages/upload.class.php
+++ b/core/model/modx/processors/workspace/packages/upload.class.php
@@ -49,7 +49,7 @@ class modBrowserPackageUploadProcessor extends modProcessor {
             return $this->failure("1 This file does not appear to be a transport package"); //@TODO Lexiconize
 
         // Check valid name of file
-        if(!preg_match("/.+\\.transport\\.zip$/",$file['name']))
+        if(!preg_match("/.+\\.transport\\.zip$/i",$file['name']))
             return $this->failure("2 This file [{$file['name']}] does not appear to be a transport package"); //@TODO Lexiconize
 
         // Return response


### PR DESCRIPTION
According to the docs (http://php.net/preg_match) preg_match() only returns a boolean false, when an error occurs, but not for valid searches without a result.
This change covers both cases.
