### PR TITLE
Enhancement: query string for postfields in modRestCurlClient

### DIFF
--- a/core/model/modx/rest/modrestcurlclient.class.php
+++ b/core/model/modx/rest/modrestcurlclient.class.php
@@ -86,7 +86,7 @@ class modRestCurlClient extends modRestClient {
                         break;
                     case 'string':
                         curl_setopt($ch,CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
-                        $string = implode('&', array_map(function ($v, $k) { return $k . '=' . $v; }, $params, array_keys($params)));
+                        $string = implode('&', array_map(create_function('$v, $k', 'return $k . "=" . $v;'), $params, array_keys($params)));
                         curl_setopt($ch,CURLOPT_POSTFIELDS,$string);
                         break;
                     default:

--- a/core/model/modx/rest/modrestcurlclient.class.php
+++ b/core/model/modx/rest/modrestcurlclient.class.php
@@ -84,6 +84,11 @@ class modRestCurlClient extends modRestClient {
                         $xml = modRestArrayToXML::toXML($params,!empty($options['rootNode']) ? $options['rootNode'] : 'request');
                         curl_setopt($ch,CURLOPT_POSTFIELDS,$xml);
                         break;
+                    case 'string':
+                        curl_setopt($ch,CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
+                        $string = implode('&', array_map(function ($v, $k) { return $k . '=' . $v; }, $params, array_keys($params)));
+                        curl_setopt($ch,CURLOPT_POSTFIELDS,$string);
+                        break;
                     default:
                         curl_setopt($ch,CURLOPT_POSTFIELDS,$params);
                         break;


### PR DESCRIPTION
Added possibility for the native REST cURL client to send postfields as query string for APIs (like Google Closure Compiler) that cannot handle a normal passed params array. Now when the contentType in the options array is set to string, the params/postfields array is transformed to param1=value&param2=http://www.url.tld/&param3=somethingelse. The array_map() stuff has to be done because http_build_query is not suitable here as it encodes special characters like slashes in a url etc., which are then also not understood by such APIs...so it has unfortunately to be done like that:

```
$this->modx->getService('getfile','rest.modRestCurlClient');

$url = 'http://www.apiurl.com/';
$path = null;
$method = 'POST';
$params = array(
    'param1' => 'value',
    'param2' => 'http://www.url.tld/',
    'param3' => 'somethingelse'
);
$options = array('contentType' => 'string');
$response = $this->modx->getfile->request($url, $path, $method, $params, $options);
```
