### PR TITLE
add icon class to tree-node based on context, id, and parent

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -352,6 +352,8 @@ class modResourceGetNodesProcessor extends modProcessor {
         $class = array();
         $class[] = 'icon-'.strtolower(str_replace('mod','',$resource->get('class_key')));
         $class[] = $resource->isfolder ? 'icon-folder' : 'x-tree-node-leaf icon-resource';
+        $class[] = 'icon-' . $resource->get('context_key') . '-' . $resource->get('id');
+        $class[] = 'icon-parent-' . $resource->get('context_key') . '-'  . $resource->get('parent');
         if (!$resource->get('published')) $class[] = 'unpublished';
         if ($resource->get('deleted')) $class[] = 'deleted';
         if ($resource->get('hidemenu')) $class[] = 'hidemenu';


### PR DESCRIPTION
add icon class to tree-node based on context, id, and parent

case: https://github.com/goldsky/GridClassKey/issues/72
![tree-node-icons](https://cloud.githubusercontent.com/assets/308524/2739055/4e850e54-c6a0-11e3-97b7-eac597044f8c.png)

``` css
div.icon-web-82 .x-tree-node-icon {
    background-image: url(../icons/shop.png) !important;
    background-repeat: no-repeat;
}

div.icon-web-83 .x-tree-node-icon {
    background-image: url(../icons/cart.png) !important;
    background-repeat: no-repeat;
}

div.icon-web-84 .x-tree-node-icon {
    background-image: url(../icons/box.png) !important;
    background-repeat: no-repeat;
}

div.icon-web-85 .x-tree-node-icon {
    background-image: url(../icons/factory.png) !important;
    background-repeat: no-repeat;
}
```

Btw,
I'm bringing this pull request to master, because the develop branch has this file way a lot different and I don't want to break any new changes.
