### PR TITLE
Enhancement: Allow request() method to return curlinfo in modRestCurlClient

### DIFF
--- a/core/model/modx/rest/modrestcurlclient.class.php
+++ b/core/model/modx/rest/modrestcurlclient.class.php
@@ -45,6 +45,11 @@ class modRestCurlClient extends modRestClient {
 
         /* execute request */
         $result = trim(curl_exec($ch));
+
+        /* if returninfo option is set replace the response with curlinfo */
+        if ($options['returninfo']) {
+            $result = curl_getinfo($ch);
+        }
         
         /* make sure to close connection */
         curl_close($ch);


### PR DESCRIPTION
Very small change, but quite helpful when working with the modRestCurlClient. If the param "returninfo" is set to true via the $options array like

```
$this->modx->getService('getfile','rest.modRestCurlClient');
$response = $this->modx->getfile->request($options['url'], $options['path'], $options['method'], $options['params'], $options['options'] = array('returninfo' => 1));
```

the response contains all information about the request from curl_getinfo()
