### PR TITLE
Corrected misplaced modProcessor comments

### DIFF
--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -675,13 +675,13 @@ abstract class modObjectCreateProcessor extends modObjectProcessor {
     public function beforeSet() { return !$this->hasErrors(); }
 
     /**
-     * Override in your derivative class to do functionality after save() is run
+     * Override in your derivative class to do functionality before save() is run
      * @return boolean
      */
     public function beforeSave() { return !$this->hasErrors(); }
 
     /**
-     * Override in your derivative class to do functionality before save() is run
+     * Override in your derivative class to do functionality after save() is run
      * @return boolean
      */
     public function afterSave() { return true; }


### PR DESCRIPTION
This documentation correction will be reflected on api.modx.com -- See http://api.modx.com/revolution/2.2/db_core_model_modx_modprocessor.class.html#\modObjectCreateProcessor::afterSave()
