### PR TITLE
[2.3] - Fix issue introduced in aa0cab2856efbf13b4c0598e97456f076f5e3b6c

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -316,7 +316,15 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
             if (MODx.request.parent) { itm.params.parent = MODx.request.parent; }
             if (MODx.request.context_key) { itm.params.context_key = MODx.request.context_key; }
             url = Ext.urlEncode(itm.params);
-            MODx.loadPage(o.actions.edit, url);
+            var action;
+            if (o.actions && o.actions.edit) {
+                // If an edit action is given, use it (BC)
+                action = o.actions.edit;
+            } else {
+                // Else assume we want the 'update' controller
+                action = itm.process.replace('create', 'update');
+            }
+            MODx.loadPage(action, url);
 
         } else if (process === 'delete') {
             itm.params.a = o.actions.cancel;


### PR DESCRIPTION
In aa0cab2856efbf13b4c0598e97456f076f5e3b6c, i removed the `actions` attribute of some `MODx.FormPanel` derivate, assuming it was used only to process actions, thus being redundant/duplicate with the buttons `process` attribute.

Seems like i was wrong.

This PR intend to fix my error, as well as provide some BC (`actions` are now optional -- & working "nicely" without it -- while still being supported).
