### PR TITLE
[2.3] - Let browsers open resources/elements in new windows/tabs.

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -447,7 +447,6 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
         e.preventDefault();
 
         if (this.disableHref) {return true;}
-        if (e.ctrlKey) {return true;}
         if (n.attributes.page && n.attributes.page !== '') {
             if (e.button == 1 || e.shiftKey == 1) return window.open(n.attributes.page,'_blank');
             MODx.loadPage(n.attributes.page);


### PR DESCRIPTION
Could take care of #9953 (and possibly some others)

As stated in an other issue, opening "edition" in a new tab via JS could be tricky (to support all major browsers).
Better leave them open in new tab with keyboard shortcuts (ie. in Chrome/Linux ctrl+shift+click)
