### PR TITLE
[2.3] - Added typeahead on system settings grid combos

### DIFF
--- a/core/model/modx/processors/system/settings/getareas.class.php
+++ b/core/model/modx/processors/system/settings/getareas.class.php
@@ -17,7 +17,7 @@ class modSystemSettingsGetAreasProcessor extends modProcessor {
     public function getLanguageTopics() {
         return array('setting','namespace');
     }
-    
+
     public function initialize() {
         $this->setDefaultProperties(array(
             'dir' => 'ASC',
@@ -62,6 +62,8 @@ class modSystemSettingsGetAreasProcessor extends modProcessor {
      */
     public function getQuery() {
         $namespace = $this->getProperty('namespace','core');
+        $query = $this->getProperty('query');
+
         $c = $this->modx->newQuery('modSystemSetting');
         $c->setClassAlias('settingsArea');
         $c->leftJoin('modSystemSetting', 'settingsCount', array(
@@ -70,6 +72,11 @@ class modSystemSettingsGetAreasProcessor extends modProcessor {
         if (!empty($namespace)) {
             $c->where(array(
                 'settingsArea.namespace' => $namespace,
+            ));
+        }
+        if (!empty($query)) {
+            $c->where(array(
+                'settingsArea.area:LIKE' => "%{$query}%"
             ));
         }
         $c->select(array(

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -25,6 +25,10 @@ MODx.grid.SettingsGrid = function(config) {
         ,emptyText: _('namespace_filter')
         ,value: MODx.request['namespace'] ? MODx.request['namespace'] : 'core'
         ,allowBlank: true
+        ,editable: true
+        ,typeAhead: true
+        ,forceSelection: true
+        ,queryParam: 'search'
         ,width: 150
         ,listeners: {
             'select': {fn: this.filterByNamespace, scope:this}
@@ -40,6 +44,9 @@ MODx.grid.SettingsGrid = function(config) {
         }
         ,width: 250
         ,allowBlank: true
+        ,editable: true
+        ,typeAhead: true
+        ,forceSelection: true
         ,listeners: {
             'select': {fn: this.filterByArea, scope:this}
         }


### PR DESCRIPTION
The idea is to provide as much as possible "type ahead" combos where it makes sense, to prevent "boring pagination" when there are a lot of results (ie. system settings with a lot of namespaces).
