### PR TITLE
[2.3] - Should take care of resources duplication/reordering when a custom ...

### DIFF
--- a/core/model/modx/processors/resource/create.class.php
+++ b/core/model/modx/processors/resource/create.class.php
@@ -112,7 +112,7 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
     public function beforeSet() {
         /* default settings */
         $this->prepareParent();
-        if ($this->getProperty('parent') === 0 && !$this->modx->hasPermission('new_document_in_root')) {
+        if ($this->getProperty('parent') === (int) $this->modx->getOption('tree_root_id') && !$this->modx->hasPermission('new_document_in_root')) {
             return $this->modx->lexicon('permission_denied');
         }
         $set = $this->checkParentPermissions();

--- a/core/model/modx/processors/resource/duplicate.class.php
+++ b/core/model/modx/processors/resource/duplicate.class.php
@@ -37,7 +37,7 @@ class modResourceDuplicateProcessor extends modProcessor {
         if (!$this->oldResource->checkPolicy('copy')) {
             return $this->modx->lexicon('permission_denied');
         }
-        if ($this->oldResource->parent < 1 && !$this->modx->hasPermission('new_document_in_root')) {
+        if ($this->oldResource->parent === (int) $this->modx->getOption('tree_root_id') && !$this->modx->hasPermission('new_document_in_root')) {
             return $this->modx->lexicon('permission_denied');
         }
         return true;

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -376,7 +376,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         if (!empty($this->permissions['view_document'])) $class[] = $this->permissions['view_document'];
         if (!empty($this->permissions['edit_document'])) $class[] = $this->permissions['edit_document'];
         if (!empty($this->permissions['resource_duplicate'])) {
-            if ($resource->parent != 0 || $this->modx->hasPermission('new_document_in_root')) {
+            if ($resource->parent != $this->defaultRootId || $this->modx->hasPermission('new_document_in_root')) {
                 $class[] = $this->permissions['resource_duplicate'];
             }
         }

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -127,7 +127,8 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
 
         $this->trimPageTitle();
         $this->handleParent();
-        if ($this->object->parent != 0 && $this->getProperty('parent') === 0 && !$this->modx->hasPermission('new_document_in_root')) {
+        $root = (int) $this->modx->getOption('tree_root_id');
+        if ($this->object->parent != $root && $this->getProperty('parent') === $root && !$this->modx->hasPermission('new_document_in_root')) {
             return $this->modx->lexicon('permission_denied');
         }
         $this->checkParentContext();

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -126,7 +126,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             });
             btns.push('-');
         }
-        if (cfg.canDuplicate == 1 && (cfg.record.parent !== 0 || cfg.canCreateRoot == 1)) {
+        if (cfg.canDuplicate == 1 && (cfg.record.parent !== parseInt(MODx.config.tree_root_id) || cfg.canCreateRoot == 1)) {
             btns.push({
                 text: _('duplicate')
                 ,handler: this.duplicateResource


### PR DESCRIPTION
`tree_root_id` is defined (never ending fix!)

See #11343

There are too much places to affect this (and we event did not consider a `tree_root_id` could be defined in a context setting (not sure how it would behave).
Shouldn't we perform the check in `modResource::save` instead ?
