### PR TITLE
[2.3] - Load menu lexicon for menu\getList

### DIFF
--- a/core/model/modx/processors/system/menu/getlist.php
+++ b/core/model/modx/processors/system/menu/getlist.php
@@ -31,9 +31,15 @@ $count = $modx->getCount('modMenu');
 
 $list = array();
 
+/** @type modMenu $menu */
 foreach ($menus as $menu) {
     $menuArray = $menu->toArray();
+    $namespace = $menu->get('namespace');
+    if (!in_array($namespace, array('core', '', null))) {
+        $modx->lexicon->load($namespace . ':default');
+    }
     $menuArray['text_lex'] = $modx->lexicon($menuArray['text']);
     $list[] = $menuArray;
 }
+
 return $this->outputArray($list,$count);


### PR DESCRIPTION
Just a quick fix.
I think we should provide a modMenu method to achieve so (to prevent repeating the check in multiple places)
