### PR TITLE
Prevent requests from failing becaus of unnecessary ampersand

### DIFF
--- a/core/model/modx/rest/modrestcurlclient.class.php
+++ b/core/model/modx/rest/modrestcurlclient.class.php
@@ -90,8 +90,8 @@ class modRestCurlClient extends modRestClient {
                 }
                 break;
         }
-        /* prevent invalid xhtml ampersands in request path */
-        $url = str_replace('&amp;', '&', $host.$path);
+        /* prevent invalid xhtml ampersands in request path and strip unneccessary ampersands from the end of the url */
+        $url = rtrim(str_replace('&amp;', '&', $host.$path), '&');
         return curl_setopt($ch, CURLOPT_URL,$url);
     }
 


### PR DESCRIPTION
The following line further up in the method adds an ampersand (even when no params specified)

```
$path .= (strpos($host,'?') === false ? '?' : '&').$q;
```

In the actual case of

```
https://fbcdn-sphotos-g-a.akamaihd.net/hphotos-ak-prn1/v/t1.0-9/s720x720/69570_680329172009398_751285058_n.jpg?oh=30c89675265d26ac6d7124894f3d9b45&oe=53C9EEB5&__gda__=1405254992_b6d95f7913abf7f3b62a56c3aa7dd2f2
```

the $url becomes (notice the ampersand at the end)

```
https://fbcdn-sphotos-g-a.akamaihd.net/hphotos-ak-prn1/v/t1.0-9/s720x720/69570_680329172009398_751285058_n.jpg?oh=30c89675265d26ac6d7124894f3d9b45&oe=53C9EEB5&__gda__=1405254992_b6d95f7913abf7f3b62a56c3aa7dd2f2&
```

which in turn then returns an error from facebook...(you can try this yourself, the above urls should work)
I'm quite sure this is a very edge case as Facebook acts very sensitive here...but the only way to get the image back correctly was to not have that last ampersand in the URL and as it doesn't hurt to remove them (I guess, correct me if I'm wrong!) I propose the change made in the PR.
