### PR TITLE
Fixes #8992, ResourceGroup save dialog not closing

### DIFF
--- a/core/model/modx/processors/security/resourcegroup/create.class.php
+++ b/core/model/modx/processors/security/resourcegroup/create.class.php
@@ -12,8 +12,8 @@ class modResourceGroupCreateProcessor extends modObjectCreateProcessor {
     public $languageTopics = array('access');
     public $permission = 'resourcegroup_new';
     public $objectType = 'resource_group';
-    public $beforeSaveEvent = 'OnBeforeChunkFormSave';
-    public $afterSaveEvent = 'OnChunkFormSave';
+    public $beforeSaveEvent = 'OnResourceGroupBeforeSave';
+    public $afterSaveEvent = 'OnResourceGroupSave';
 
     public function initialize() {
         $this->setDefaultProperties(array(


### PR DESCRIPTION
This problem seems (at least in my case) only to occur because of VersionX but the cause is a bug in the core...that is the create resource group processor mistakenly is calling OnChunkFormSave instead of OnResourceGroupSave which then triggers the VersionX plugin and then calls ->toArray() on a non-object, which let the whole thing fail...the fix is very simple, but I think this should not be delayed till 2.3 (which is the target version for #8992)!

Fix also provided for VersionX (for older MODX versions in case of merge)
