### PR TITLE
modFileHandler: Added method unpack() to extract ZIP files

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -111,7 +111,7 @@ class modFileHandler {
      * @return string The sanitized path
      */
     public function sanitizePath($path) {
-        return preg_replace(array('/\.*[\/|\\\]/i', '/[\/|\\\]+/i'), array('/', '/'), $path);
+        return preg_replace(array("/\.*[\/|\\\]/i", "/[\/|\\\]+/i"), array('/', '/'), $path);
     }
 
     /**
@@ -195,11 +195,13 @@ abstract class modFileSystemResource {
     }
 
     /**
-     * Get the path of the fs resource.
-     * @return string The path of the fs resource
+     * Parses a string mode into octal format
+     *
+     * @param string $mode The octal to parse
+     * @return octal The new mode in octal format
      */
-    public function getPath() {
-        return $this->path;
+    protected function parseMode($mode = '') {
+        return octdec($mode);
     }
 
     /**
@@ -297,28 +299,11 @@ abstract class modFileSystemResource {
     }
 
     /**
-     * Renames the file/folder
-     *
-     * @param string $newPath The new path for the fs resource
-     * @return boolean True if successful
+     * Get the path of the fs resource.
+     * @return string The path of the fs resource
      */
-    public function rename($newPath) {
-        $newPath = $this->fileHandler->sanitizePath($newPath);
-
-        if (!$this->isWritable()) return false;
-        if (file_exists($newPath)) return false;
-
-        return @rename($this->path, $newPath);
-    }
-
-    /**
-     * Parses a string mode into octal format
-     *
-     * @param string $mode The octal to parse
-     * @return octal The new mode in octal format
-     */
-    protected function parseMode($mode = '') {
-        return octdec($mode);
+    public function getPath() {
+        return $this->path;
     }
 
     /**
@@ -336,6 +321,21 @@ abstract class modFileSystemResource {
 
         $directory = $this->fileHandler->make($ppath,array(),'modDirectory');
         return $directory;
+    }
+
+    /**
+     * Renames the file/folder
+     *
+     * @param string $newPath The new path for the fs resource
+     * @return boolean True if successful
+     */
+    public function rename($newPath) {
+        $newPath = $this->fileHandler->sanitizePath($newPath);
+
+        if (!$this->isWritable()) return false;
+        if (file_exists($newPath)) return false;
+
+        return @rename($this->path, $newPath);
     }
 }
 
@@ -361,27 +361,6 @@ class modFile extends modFileSystemResource {
     }
 
     /**
-     * Actually create the file on the file system
-     *
-     * @param string $content The content of the file to write
-     * @param string $mode The perms to write with the file
-     * @return boolean True if successful
-     */
-    public function create($content = '', $mode = 'w+') {
-        if ($this->exists()) return false;
-        $result = false;
-
-        $fp = @fopen($this->path, 'w+');
-        if ($fp) {
-            @fwrite($fp, $content);
-            @fclose($fp);
-
-            $result = file_exists($this->path);
-        }
-        return $result;
-    }
-
-    /**
      * Temporarly set (but not save) the content of the file
      * @param string $content The content
      */
@@ -396,39 +375,6 @@ class modFile extends modFileSystemResource {
      */
     public function getContents() {
         return @file_get_contents($this->path);
-    }
-
-    /**
-     * Alias for save()
-     *
-     * @see modDirectory::write
-     * @param string $content
-     * @param string $mode
-     * @return boolean
-     */
-    public function write($content = null, $mode = 'w+') {
-        return $this->save($content, $mode);
-    }
-
-    /**
-     * Writes the content of the modFile object to the actual file.
-     *
-     * @param string $content Optional. If not using setContent, this will set
-     * the content to write.
-     * @param string $mode The mode in which to write
-     * @return boolean The result of the fwrite
-     */
-    public function save($content = null, $mode = 'w+') {
-        if ($content !== null) $this->content = $content;
-        $result = false;
-
-        $fp = @fopen($this->path, $mode);
-        if ($fp) {
-            $result = @fwrite($fp, $this->content);
-            @fclose($fp);
-        }
-
-        return $result;
     }
 
     /**
@@ -479,6 +425,60 @@ class modFile extends modFileSystemResource {
     }
 
     /**
+     * Actually create the file on the file system
+     *
+     * @param string $content The content of the file to write
+     * @param string $mode The perms to write with the file
+     * @return boolean True if successful
+     */
+    public function create($content = '', $mode = 'w+') {
+        if ($this->exists()) return false;
+        $result = false;
+
+        $fp = @fopen($this->path, 'w+');
+        if ($fp) {
+            @fwrite($fp, $content);
+            @fclose($fp);
+
+            $result = file_exists($this->path);
+        }
+        return $result;
+    }
+
+    /**
+     * Alias for save()
+     *
+     * @see modDirectory::write
+     * @param string $content
+     * @param string $mode
+     * @return boolean
+     */
+    public function write($content = null, $mode = 'w+') {
+        return $this->save($content, $mode);
+    }
+
+    /**
+     * Writes the content of the modFile object to the actual file.
+     *
+     * @param string $content Optional. If not using setContent, this will set
+     * the content to write.
+     * @param string $mode The mode in which to write
+     * @return boolean The result of the fwrite
+     */
+    public function save($content = null, $mode = 'w+') {
+        if ($content !== null) $this->content = $content;
+        $result = false;
+
+        $fp = @fopen($this->path, $mode);
+        if ($fp) {
+            $result = @fwrite($fp, $this->content);
+            @fclose($fp);
+        }
+
+        return $result;
+    }
+
+    /**
      * Deletes the file from the filesystem
      *
      * @return boolean True if successful
@@ -486,6 +486,99 @@ class modFile extends modFileSystemResource {
     public function remove() {
         if (!$this->exists()) return false;
         return @unlink($this->path);
+    }
+
+    /**
+     * Unpack a zip archive to a specified location.
+     *
+     * @uses compression.xPDOZip OR compression.PclZip
+     *
+     * @param string $this->getPath() An absolute file system location to a valid zip archive.
+     * @param string $to A file system location to extract the contents of the archive to.
+     * @param array $options an array of optional options, primarily for the xPDOZip class
+     * @return array|string|boolean An array of unpacked files, a string in case of cli functions or false on failure.
+     */
+    public function unpack($to = '', $options = array()) {
+
+        $results = false;
+
+        // extract the archive in the same directory if no $to path is specified
+        if (empty($to)) {
+            $to = $this->getParentDirectory(true);
+        }
+
+        if (class_exists('ZipArchive') && $this->fileHandler->modx->getService('zip', 'compression.xPDOZip', XPDO_CORE_PATH, array_merge($options, array('file' => $this->path)))) {
+
+            $results = $this->fileHandler->modx->zip->unpack($to);
+            $this->fileHandler->modx->zip->close();
+        } else if (class_exists('PclZip') || include_once(XPDO_CORE_PATH . 'compression/pclzip.lib.php')) {
+
+            $archive = new PclZip($this->path);
+
+            if ($archive) {
+                $results = array_map('current', $archive->extract(PCLZIP_OPT_PATH, $to));
+            }
+        } else if (is_callable('zip_open')) {
+
+            $archive = zip_open($this->path);
+
+            if (!is_dir($to)) {
+                $this->fileHandler->modx->cacheManager->writeTree($to);
+            }
+
+            while ($zip_entry = zip_read($archive)) {
+                $filename = zip_entry_name($zip_entry);
+                $target = $to . DIRECTORY_SEPARATOR . substr($filename, 0, strrpos($filename, '/'));
+                $filesize = zip_entry_filesize($zip_entry);
+
+                if (file_exists($target) || mkdir($target)) {
+                    $results[] = $to . DIRECTORY_SEPARATOR . $filename;
+
+                    if ($filesize > 0) {
+                        $contents = zip_entry_read($zip_entry, $filesize);
+                        file_put_contents($to . DIRECTORY_SEPARATOR . $filename, $contents);
+                    }
+                }
+            }
+        } else {
+            // check for windows systems running PHP, as they do not seem to have a native unzip functionality
+            if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
+                $sysfns = array(
+                    'shell_exec' => false,
+                    'system' => false,
+                    'exec' => false,
+                );
+
+                $disabled = array_map('trim', explode(',', ini_get('disable_functions')));
+
+                foreach ($sysfns as $func => $value) {
+                    $sysfns[$func] = !in_array($func, $disabled);
+                }
+
+                $sysfns = array_filter($sysfns); // remove not available system functions
+
+                if (!empty($sysfns)) {
+                    $sysfn = key($sysfns); // get the first available system function
+                    $command = implode(' ', array(
+                        'unzip',
+                        $this->path
+                    ));
+                    
+                    // sanitize and escape command
+                    $command = escapeshellcmd(preg_replace('#(\s){2,}#is', ' ', str_replace(array("\n", "'"), array('', '"'), $command)));
+
+                    if (!is_dir($to)) {
+                        $this->fileHandler->modx->cacheManager->writeTree($to);
+                    }
+
+                    chdir($to); // switch to target directory
+
+                    $results = $sysfn($command); // execute command
+                }
+            }
+        }
+
+        return $results;
     }
 }
 
@@ -495,6 +588,17 @@ class modFile extends modFileSystemResource {
  * @package modx
  */
 class modDirectory extends modFileSystemResource {
+    /**
+     * @see modFileSystemResource::parseMode
+     *
+     * @param string $mode
+     * @return boolean
+     */
+    protected function parseMode($mode = '') {
+        if (empty($mode)) $mode = $this->fileHandler->context->getOption('new_folder_permissions', '0755', $this->fileHandler->config);
+        return parent::parseMode($mode);
+    }
+
     /**
      * Actually creates the new directory on the file system.
      *
@@ -511,17 +615,6 @@ class modDirectory extends modFileSystemResource {
         return $this->fileHandler->modx->cacheManager->writeTree($this->path,array(
             'new_folder_permissions' => $mode,
         ));
-    }
-
-    /**
-     * @see modFileSystemResource::parseMode
-     *
-     * @param string $mode
-     * @return boolean
-     */
-    protected function parseMode($mode = '') {
-        if (empty($mode)) $mode = $this->fileHandler->context->getOption('new_folder_permissions', '0755', $this->fileHandler->config);
-        return parent::parseMode($mode);
     }
 
     /**


### PR DESCRIPTION
I know the changes look f'd up...sorry...the only thing I really changed/added is the new unpack() method, the rest is cosmetic cleanup stuff, I just moved around the methods in a more organized way (in my opinion) + I fixed the very annoying syntax-highlighting bug in my editor (sublimetext, don't know if others have this too) which causes everything after that regex in sanitizePath() to be "unhighlighted", I just replaced single quotes with double ones...

the added method unpack is basically thought as outsourcing/replacement for the _unpack method here: https://github.com/modxcms/revolution/blob/develop/core/xpdo/transport/xpdotransport.class.php#L746 which has a @todo to be outsourced...@opengeek as it is part of xPDO I'm not so sure this is gonna work (PR which actually works coming soon) when it relies on something from MODX??

anyways, the unpack method basically does the same as the "old" _unpack() method by choosing from xPDOZip (which uses ZipArchive(), actually the new one (https://github.com/modxcms/revolution/pull/11354) or the pclzip library in case ZipArchive() is not available...BUT, it also falls back further to zip functions (like zip_open etc.) and finally looks for active system functions (shell_exec, system, exec) and if one is found it tries to unzip via cli...I tested all 4 approaches successfully on a LAMP server / MODX 2.2.14pl, including arbitrary zip files and also the package manager zip extraction...seems to work! Just to make sure: Does anybody know of other parts of MODX/XPDO where zip archives get extracted (other than in xpdo/xpdotransport.class.php)?

For testing / copy&pasting the method with debug loggers (to test the different approaches, just add some arbitrary string to classname/libname/functionname so it doesn't work)

```
    /**
     * Unpack a zip archive to a specified location.
     *
     * @uses compression.xPDOZip OR compression.PclZip
     *
     * @param string $this->getPath() An absolute file system location to a valid zip archive.
     * @param string $to A file system location to extract the contents of the archive to.
     * @param array $options an array of optional options, primarily for the xPDOZip class
     * @return array|string|boolean An array of unpacked files, a string in case of cli functions or false on failure.
     */
    public function unpack($to = '', $options = array()) {

        $results = false;

        // extract the archive in the same directory if no $to path is specified
        if (empty($to)) {
            $to = $this->getParentDirectory(true);
        }

        if (class_exists('ZipArchive') && $this->fileHandler->modx->getService('zip', 'compression.xPDOZip', XPDO_CORE_PATH, array_merge($options, array('file' => $this->path)))) {
            $this->fileHandler->modx->log(modX::LOG_LEVEL_ERROR, '[' . __METHOD__ . '] Using xPDOZip to extract ' . $this->path . ' to ' . $to);
            $results = $this->fileHandler->modx->zip->unpack($to);
            $this->fileHandler->modx->zip->close();
        } else if (class_exists('PclZip') || include_once(XPDO_CORE_PATH . 'compression/pclzip.lib.php')) {
            $this->fileHandler->modx->log(modX::LOG_LEVEL_ERROR, '[' . __METHOD__ . '] Using pclzip to extract ' . $this->path . ' to ' . $to);
            $archive = new PclZip($this->path);

            if ($archive) {
                $results = array_map('current', $archive->extract(PCLZIP_OPT_PATH, $to));
            }
        } else if (is_callable('zip_open')) {
            $this->fileHandler->modx->log(modX::LOG_LEVEL_ERROR, '[' . __METHOD__ . '] Using zip functions to extract ' . $this->path . ' to ' . $to);
            $archive = zip_open($this->path);

            if (!is_dir($to)) {
                $this->fileHandler->modx->cacheManager->writeTree($to);
            }

            while ($zip_entry = zip_read($archive)) {
                $filename = zip_entry_name($zip_entry);
                $target = $to . DIRECTORY_SEPARATOR . substr($filename, 0, strrpos($filename, '/'));
                $filesize = zip_entry_filesize($zip_entry);

                if (file_exists($target) || mkdir($target)) {
                    $results[] = $to . DIRECTORY_SEPARATOR . $filename;

                    if ($filesize > 0) {
                        $contents = zip_entry_read($zip_entry, $filesize);
                        file_put_contents($to . DIRECTORY_SEPARATOR . $filename, $contents);
                    }
                }
            }
        } else {
            // check for windows systems running PHP, as they do not seem to have a native unzip functionality
            if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
                $sysfns = array(
                    'shell_exec' => false,
                    'system' => false,
                    'exec' => false,
                );

                $disabled = array_map('trim', explode(',', ini_get('disable_functions')));

                foreach ($sysfns as $func => $value) {
                    $sysfns[$func] = !in_array($func, $disabled);
                }

                $sysfns = array_filter($sysfns); // remove not available system functions

                $this->fileHandler->modx->log(modX::LOG_LEVEL_ERROR, '[' . __METHOD__ . '] Available system functions ' . print_r($sysfns,1));

                if (!empty($sysfns)) {
                    $sysfn = key($sysfns); // get the first available system function
                    $this->fileHandler->modx->log(modX::LOG_LEVEL_ERROR, '[' . __METHOD__ . '] Using command line ' . $sysfn . ' to extract ' . $this->path . ' to ' . $to);
                    $command = implode(' ', array(
                        'unzip',
                        $this->path
                    ));

                    // sanitize and escape command
                    $command = escapeshellcmd(preg_replace('#(\s){2,}#is', ' ', str_replace(array("\n", "'"), array('', '"'), $command)));

                    if (!is_dir($to)) {
                        $this->fileHandler->modx->cacheManager->writeTree($to);
                    }

                    chdir($to); // switch to target directory

                    $results = $sysfn($command); // execute command
                }
            }
        }

        return $results;
    }
```

Also related to PR https://github.com/modxcms/revolution/pull/11356
