### PR TITLE
xPDOTransport: Use new modFileHandler unpack() method

### DIFF
--- a/core/xpdo/transport/xpdotransport.class.php
+++ b/core/xpdo/transport/xpdotransport.class.php
@@ -746,7 +746,7 @@ class xPDOTransport {
     public static function _unpack(& $xpdo, $from, $to) {
         $resources = false;
 
-        if ($xpdo->getService('fileHandler', 'modFilehandler', MODX_CORE_PATH . 'model/modx/')) {
+        if ($xpdo->getService('fileHandler', 'modFileHandler', MODX_CORE_PATH . 'model/modx/')) {
             $fileobj = $xpdo->fileHandler->make($from);
             $resources = $fileobj->unpack($to);
         } else {

--- a/core/xpdo/transport/xpdotransport.class.php
+++ b/core/xpdo/transport/xpdotransport.class.php
@@ -741,20 +741,26 @@ class xPDOTransport {
      * @param xPDO &$xpdo A reference to an xPDO instance.
      * @param string $from An absolute file system location to a valid zip archive.
      * @param string $to A file system location to extract the contents of the archive to.
-     * @return array|boolean An array of unpacked resources or false on failure.
+     * @return array|string|boolean An array of unpacked resources, a string in case it was unpackt via cli or false on failure.
      */
     public static function _unpack(& $xpdo, $from, $to) {
         $resources = false;
-        if ($xpdo->getOption(xPDOTransport::ARCHIVE_WITH, null, 0) != xPDOTransport::ARCHIVE_WITH_PCLZIP && class_exists('ZipArchive', true) && $xpdo->loadClass('compression.xPDOZip', XPDO_CORE_PATH, true, true)) {
-            $archive = new xPDOZip($xpdo, $from);
-            if ($archive) {
-                $resources = $archive->unpack($to);
-                $archive->close();
-            }
-        } elseif (class_exists('PclZip') || include(XPDO_CORE_PATH . 'compression/pclzip.lib.php')) {
-            $archive = new PclZip($from);
-            if ($archive) {
-                $resources = $archive->extract(PCLZIP_OPT_PATH, $to);
+
+        if ($xpdo->getService('fileHandler', 'modFilehandler', MODX_CORE_PATH . 'model/modx/')) {
+            $fileobj = $xpdo->fileHandler->make($from);
+            $resources = $fileobj->unpack($to);
+        } else {
+            if ($xpdo->getOption(xPDOTransport::ARCHIVE_WITH, null, 0) != xPDOTransport::ARCHIVE_WITH_PCLZIP && class_exists('ZipArchive', true) && $xpdo->loadClass('compression.xPDOZip', XPDO_CORE_PATH, true, true)) {
+                $archive = new xPDOZip($xpdo, $from);
+                if ($archive) {
+                    $resources = $archive->unpack($to);
+                    $archive->close();
+                }
+            } elseif (class_exists('PclZip') || include(XPDO_CORE_PATH . 'compression/pclzip.lib.php')) {
+                $archive = new PclZip($from);
+                if ($archive) {
+                    $resources = $archive->extract(PCLZIP_OPT_PATH, $to);
+                }
             }
         }
         return $resources;


### PR DESCRIPTION
This is just an implementation of the method proposed here: https://github.com/modxcms/revolution/pull/11355

Tested with the package manager on a LAMP server with MODX 2.2.14pl, all 4 approaches of the new unpack() method (see PR above) worked for me.

@opengeek I didn't remove the "legacy" code as I'm not sure if an xpdo class should/is allowed to make use of modx classes...

This PR is also related to https://github.com/modxcms/revolution/pull/11354
