### PR TITLE
Enhancement: Added isMember() method to modResource

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -1089,18 +1089,15 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
             /** @var modResourceGroup $resourceGroup */
             $resourceGroup = $this->xpdo->getObject('modResourceGroup',$c);
             if (empty($resourceGroup) || !is_object($resourceGroup) || !($resourceGroup instanceof modResourceGroup)) {
-                $this->xpdo->log(modX::LOG_LEVEL_ERROR,'modResource::joinGroup - No resource group: '.$resourceGroupPk);
+                $this->xpdo->log(modX::LOG_LEVEL_ERROR, __METHOD__ . ' - No resource group: ' . $resourceGroupPk);
                 return false;
             }
         } else {
             $resourceGroup =& $resourceGroupPk;
         }
-        $resourceGroupResource = $this->xpdo->getObject('modResourceGroupResource',array(
-            'document' => $this->get('id'),
-            'document_group' => $resourceGroup->get('id'),
-        ));
-        if ($resourceGroupResource) {
-            $this->xpdo->log(modX::LOG_LEVEL_ERROR,'modResource::joinGroup - Resource '.$this->get('id').' already in resource group: '.$resourceGroupPk);
+
+        if ($this->isMember($resourceGroup->get('name'))) {
+            $this->xpdo->log(modX::LOG_LEVEL_ERROR, __METHOD__ . ' - Resource '.$this->get('id') . ' already in resource group: ' . $resourceGroupPk);
             return false;
         }
         /** @var modResourceGroupResource $resourceGroupResource */
@@ -1125,21 +1122,23 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
             /** @var modResourceGroup $resourceGroup */
             $resourceGroup = $this->xpdo->getObject('modResourceGroup',$c);
             if (empty($resourceGroup) || !is_object($resourceGroup) || !($resourceGroup instanceof modResourceGroup)) {
-                $this->xpdo->log(modX::LOG_LEVEL_ERROR,'modResource::leaveGroup - No resource group: '.(is_object($resourceGroupPk) ? $resourceGroupPk->get('name') : $resourceGroupPk));
+                $this->xpdo->log(modX::LOG_LEVEL_ERROR, __METHOD__ . ' - No resource group: ' . (is_object($resourceGroupPk) ? $resourceGroupPk->get('name') : $resourceGroupPk));
                 return false;
             }
         } else {
             $resourceGroup =& $resourceGroupPk;
+        }
+        
+        if (!$this->isMember($resourceGroup->get('name'))) {
+            $this->xpdo->log(modX::LOG_LEVEL_ERROR, __METHOD__ . ' - Resource ' . $this->get('id') . ' is not in resource group: ' . (is_object($resourceGroupPk) ? $resourceGroupPk->get('name') : $resourceGroupPk));
+            return false;
         }
         /** @var modResourceGroupResource $resourceGroupResource */
         $resourceGroupResource = $this->xpdo->getObject('modResourceGroupResource',array(
             'document' => $this->get('id'),
             'document_group' => $resourceGroup->get('id'),
         ));
-        if (!$resourceGroupResource) {
-            $this->xpdo->log(modX::LOG_LEVEL_ERROR,'modResource::leaveGroup - Resource '.$this->get('id').' is not in resource group: '.(is_object($resourceGroupPk) ? $resourceGroupPk->get('name') : $resourceGroupPk));
-            return false;
-        }
+
         return $resourceGroupResource->remove();
     }
 

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -1156,6 +1156,52 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     }
 
     /**
+     * States whether a resource is a member of a resource group or groups. You may specify
+     * either a string name of the resource group, or an array of names.
+     *
+     * @access public
+     * @param string|array $groups Either a string of a resource group name or an array
+     * of names.
+     * @param boolean $matchAll If true, requires the resource to be a member of all
+     * the resource groups specified. If false, the resource can be a member of only one to
+     * pass. Defaults to false.
+     * @return boolean True if the resource is a member of any of the resource groups
+     * specified.
+     */
+    public function isMember($groups, $matchAll = false) {
+        $isMember = false;
+        $resourceGroupNames = array();
+        $resourceGroupList = $this->getGroupsList();
+
+        foreach ($resourceGroupList['collection'] as $resourceGroup) {
+            /** @var modResourceGroupResource $resourceGroupResource */
+            $resourceGroupResource = $this->xpdo->getObject('modResourceGroupResource', array(
+                'document' => $this->get('id'),
+                'document_group' => $resourceGroup->get('id'),
+            ));
+
+            if ($resourceGroupResource) {
+                $resourceGroupNames[] = $resourceGroup->get('name');
+            }
+        }
+        
+        if ($resourceGroupNames) {
+            if (is_array($groups)) {
+                if ($matchAll) {
+                    $matches = array_diff($groups, $resourceGroupNames);
+                    $isMember = empty($matches);
+                } else {
+                    $matches = array_intersect($groups, $resourceGroupNames);
+                    $isMember = !empty($matches);
+                }
+            } else {
+                $isMember = (array_search($groups, $resourceGroupNames) !== false);
+            }
+        }
+        return $isMember;
+    }
+
+    /**
      * Determine the controller path for this Resource class
      * @static
      * @param xPDO $modx A reference to the modX object


### PR DESCRIPTION
This method is the equivalent of isMember() for modUser but this time for modResource. With this it can be checked if a resource is member of one or multiple resource groups as it can be done with a user for user groups. 

This is handy for example when having a plugin automatically joining resources to resource groups OnDocFormSave. Right now, there is no elegant way (basically you have to implement this method yourself or I'm not aware of how to do this in a one liner =D) to check if a resource is already member of a resource group and if so don't try to join the resource group (which then throws an error to the log each time the plugin is running)...like that:

```
$robj = $modx->getObject('modResource', array('alias' => 'somepage'));

if (!$robj->isMember('resourcegroupname') && $robj->joinGroup('resourcegroupname')) {
    echo 'added resource to resource group "resourcegroupname"';
}
```

if this would be accepted for merging, I can also change the joinGroup() / leaveGroup() to make use of this new method (and maybe improve them a bit to support multiple groups at once...)
