### PR TITLE
Enhancement: Add download() method to modFileHandler

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -501,7 +501,7 @@ class modFile extends modFileSystemResource {
      * 
      * @return downloadable file
      */
-    public function download($mimetype = 'application/octetstream') {
+    public function download($mimetype = 'application/octet-stream') {
         $output = $this->getContents();
 
         header('Content-type: ' . $mimetype);

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -382,7 +382,7 @@ class modFile extends modFileSystemResource {
     }
 
     /**
-     * Temporarly set (but not save) the content of the file
+     * Temporarily set (but not save) the content of the file
      * @param string $content The content
      */
     public function setContent($content) {
@@ -395,7 +395,13 @@ class modFile extends modFileSystemResource {
      * @return string The contents of the file
      */
     public function getContents() {
-        return @file_get_contents($this->path);
+        $content = @file_get_contents($this->path);
+
+        if ($content === false) {
+            $content = $this->content;
+        }
+
+        return $content;
     }
 
     /**
@@ -437,7 +443,17 @@ class modFile extends modFileSystemResource {
      * @return int The size of the file, in bytes
      */
     public function getSize() {
-        return filesize($this->path);
+        $size = @filesize($this->path);
+
+        if ($size === false) {
+            if ( function_exists('mb_strlen') ) {
+                $size = mb_strlen($this->content, '8bit');
+            } else {
+                $size = strlen($this->content);
+            }
+        }
+
+        return $size;
     }
 
     /**
@@ -476,6 +492,24 @@ class modFile extends modFileSystemResource {
      */
     public function getBaseName() {
         return ltrim(strrchr($this->path, '/'), '/');
+    }
+
+    /**
+     * Sends the file as a download
+     * 
+     * @param string $mimetype The mimetype of the file to download
+     * 
+     * @return downloadable file
+     */
+    public function download($mimetype = 'application/octetstream') {
+        $output = $this->getContents();
+
+        header('Content-type: ' . $mimetype);
+        header('Content-Disposition: attachment; filename=' . $this->getBasename());
+        header('Content-Length: ' . $this->getSize());
+        
+        echo $output;
+        die();
     }
 
     /**

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -497,15 +497,20 @@ class modFile extends modFileSystemResource {
     /**
      * Sends the file as a download
      * 
-     * @param string $mimetype The mimetype of the file to download
+     * @param array $options Optional configuration options like mimetype and filename
      * 
      * @return downloadable file
      */
-    public function download($mimetype = 'application/octet-stream') {
+    public function download($options = array()) {
+        $options = array_merge(array(
+            'mimetype' => 'application/octet-stream',
+            'filename' => $this->getBasename(),
+        ), $options);
+
         $output = $this->getContents();
 
-        header('Content-type: ' . $mimetype);
-        header('Content-Disposition: attachment; filename=' . $this->getBasename());
+        header('Content-type: ' . $options['mimetype']);
+        header('Content-Disposition: attachment; filename=' . $options['filename']);
         header('Content-Length: ' . $this->getSize());
         
         echo $output;

--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -1362,16 +1362,15 @@ abstract class modObjectExportProcessor extends modObjectGetProcessor {
      */
     public function download() {
         $file = $this->object->get($this->nameField).'.xml';
-        $f = $this->modx->getOption('core_path').'export/'.$this->objectType.'/'.$file;
-
+        $this->modx->getService('fileHandler', 'modFileHandler');
+        $fileobj = $this->modx->fileHandler->make($this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'export/' . $this->objectType . '/' . $file);
         $name = strtolower(str_replace(array(' ','/'),'-',$this->object->get($this->nameField)));
 
-        if (!is_file($f)) return $this->failure($f);
+        if (!$fileobj->exists()) return $this->failure($f);
 
-        $o = file_get_contents($f);
+        $o = $fileobj->getContents();
 
-        header('Content-Type: application/force-download');
-        header('Content-Disposition: attachment; filename="'.$name.'.'.$this->objectType.'.xml"');
+        $fileobj->download(array('filename' => $name . '.' . $this->objectType . '.xml'));
 
         return $o;
     }

--- a/core/model/modx/processors/browser/file/download.class.php
+++ b/core/model/modx/processors/browser/file/download.class.php
@@ -33,14 +33,9 @@ class modBrowserFileDownloadProcessor extends modProcessor {
     }
 
     public function download() {
-        $file = $this->getProperty('file');
-        $contents = $this->source->getObjectContents($file);
+        $fileobj = $this->source->fileHandler->make($this->source->getBasePath() . $this->getProperty('file'));
 
-        @session_write_close();
-        header("Content-Type: application/force-download");
-        header("Content-Disposition: attachment; filename=\"{$contents['basename']}\"");
-        echo $contents['content'];
-        die();
+        $fileobj->download();
     }
 
     /**

--- a/core/model/modx/processors/element/exportproperties.class.php
+++ b/core/model/modx/processors/element/exportproperties.class.php
@@ -39,7 +39,7 @@ class modElementExportPropertiesProcessor extends modProcessor {
 
         $fileName = strtolower(str_replace(' ', '-', $this->getProperty('id'))) . '.export.js';
 
-        $fileobj = $this->modx->fileHandler->make(MODX_CORE_PATH . 'export/properties/' . $fileName);
+        $fileobj = $this->modx->fileHandler->make($this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'export/properties/' . $fileName);
 
         $fileobj->setContent($data);
         $fileobj->download();

--- a/core/model/modx/processors/element/exportproperties.class.php
+++ b/core/model/modx/processors/element/exportproperties.class.php
@@ -14,62 +14,37 @@ class modElementExportPropertiesProcessor extends modProcessor {
     }
 
     public function process() {
+        $response = false;
         $download = $this->getProperty('download');
+
         if (!empty($download)) {
-            $o = $this->download($download);
-        } else {
-            $o = $this->export();
+            $response = $this->download();
         }
-        return $o;
+
+        return $response;
     }
 
     /**
-     * Download the file
+     * Create a temporary file object and serve as a download to the browser
      * 
-     * @param string $file
      * @return bool|string
      */
-    public function download($file) {
-        $fileName = $this->modx->getOption('core_path').'export/properties/'.$file;
-        if (!is_file($fileName)) return '';
-        $output = file_get_contents($fileName);
-        if (empty($output)) return '';
-
-        $id = $this->getProperty('id');
-        if (empty($id)) {
-            $name = 'default';
-        } else {
-            /** @var modPropertySet $propertySet */
-            $propertySet = $this->modx->getObject('modPropertySet',$id);
-            if (empty($propertySet)) {
-                $name = 'unknown';
-            } else {
-                $name = $propertySet->get('name');
-                $name = strtolower(str_replace(' ','-',$name));
-            }
-        }
-        header('Content-Type: application/force-download');
-        header('Content-Disposition: attachment; filename="'.$name.'.properties.js"');
-        return $output;
-    }
-
-    /**
-     * Export the properties into a temporary export file
-     * 
-     * @return mixed
-     */
-    public function export() {
+    public function download() {
         $data = $this->getProperty('data');
+
         if (empty($data)) return $this->failure($this->modx->lexicon('propertyset_err_ns'));
 
-        $f = 'export.js';
-        $fileName = $this->modx->getOption('core_path').'export/properties/'.$f;
+        /** @var modFileHandler $this->modx->fileHandler */
+        $this->modx->getService('fileHandler', 'modFileHandler');
 
-        /** @var modCacheManager $cacheManager */
-        $cacheManager = $this->modx->getCacheManager();
-        $cacheManager->writeFile($fileName,$data);
+        $fileName = strtolower(str_replace(' ', '-', $this->getProperty('id'))) . '.export.js';
 
-        return $this->success($f);
+        $fileobj = $this->modx->fileHandler->make(MODX_CORE_PATH . 'export/properties/' . $fileName);
+
+        $fileobj->setContent($data);
+        $fileobj->download();
+        
+        return true;
     }
 }
 return 'modElementExportPropertiesProcessor';

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -431,19 +431,7 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
 
     ,exportProperties: function (btn,e) {
         var id = Ext.getCmp('modx-combo-property-set').getValue();
-        MODx.Ajax.request({
-            url: MODx.config.connector_url
-            ,params: {
-                action: 'element/exportProperties'
-                ,data: this.encode()
-                ,id: id
-            }
-            ,listeners: {
-                'success': {fn:function(r) {
-                    location.href = MODx.config.connector_url+'?action=element/exportProperties&download='+r.message+'&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
-                },scope:this}
-            }
-        });
+        location.href = MODx.config.connectors_url+'element/index.php?action=exportProperties&download=1&id='+id+'&data='+this.encode()+'&HTTP_MODAUTH='+MODx.siteId;
     }
 
     ,importProperties: function (btn,e) {


### PR DESCRIPTION
This is a updated and properly branched version of this PR: https://github.com/modxcms/revolution/pull/680

As of @MarkH s comment from that PR

> Is this perhaps more appropriate/useful when added to media sources, so it's not limited to files? Speaking of which, I think it's already possible to download files from the Files tab, so this has to be implemented somewhere already..?

I did a bit of research and found a lot of repeating code which mostly does, what the new method download() does, e.g. setting headers etc. As already commented in the old PR: modMediaSource btw. modFileMediaSource already make use of the modFileHandler class, so it's easy to access this through the mediaSource as can be seen in the refactored download.class.php processor at core/processors/browser/ which handles the downloading of files from the file tree.

Together with the new method I also improved (hopefully) the two existing methods getSize() and getContents() to be able to return something, before a file really exists in the filesystem. This is helpful when  offering a download from data that is created on the fly but doesn't have to be saved somewhere in the filesystem, like a csv/json export etc. Like this we can set the file content via setContent($content) but never have to really save/create a physical file and can do:

```
$modx->getService('file', 'modFileHandler');

$fileobj = $modx->file->make('path/to/the/file.ext'); // in this case this just doesn't matter, this would be the path where the file was created if we do $fileobj->save()/$fileobj->create() though

$fileobj->setContent($content);
$fileobj->download();
// or
$fileobj->download(array('mimetype' => 'image/jpeg'));
// or
$fileobj->download(array('filename' => 'someotherfilename.jpg');
```

the changed getSize() method now also allows to return the size of temporarily set content which is not possible by filesize() alone.
