### PR TITLE
Enhancement: Add saveCSV() method to modFileHandler

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -431,6 +431,37 @@ class modFile extends modFileSystemResource {
         return $result;
     }
 
+     /**
+     * Writes a CSV file.
+     *
+     * @param array $content An array that holds one csv line per key, each column is a sub-array item
+     * @param string $mode The mode in which to write
+     * @param array $options Optional options for fputcsv, here you can specify custom delimiter and enclosure
+     * @return boolean true when the operation was successful
+     */
+    public function saveCSV($content = array(), $mode = 'w+', $options = array()) {
+        $options = array_merge(array(
+            'delimiter' => ',',
+            'enclosure' => '"',
+        ), $options);
+
+        $result = false;
+
+        if (!empty($content)) {
+            $fp = @fopen($this->path, $mode);
+            if ($fp) {
+                foreach($content as $line) {
+                    if (fputcsv($fp, $line, $options['delimiter'], $options['enclosure']) !== false) {
+                        $result = true;
+                    }
+                }
+                @fclose($fp);
+            }
+        }
+
+        return $result;
+    }
+
     /**
      * Gets the size of the file
      *


### PR DESCRIPTION
This is an updated and properly branched version of this PR: https://github.com/modxcms/revolution/pull/681

The added method allows easy saving of a multidimensional array as CSV file, which is very handy when generating an export of any data that can be stored in an array (ie . Collections of MODx objects or whatever objects etc.).
Actually it involves a bit more than just this method (need to generate headers if desired, catch encoding issues etc.), but when the data is prepared nicely in a multidimensional array, it can just be passed to this method and voila...

As an example let's say we have (ya, i know) very simple data like this:

```
$data = array(
    array(
        'name' => 'Name 1',
        'email' => 'email@test.com',
        'address' => 'Test Street 3',
        'mobile' => '240024040420',
    ),
    array(
        'name' => 'Name 2',
        'email' => 'spam@test.com',
        'address' => 'Test Alley 5',
        'mobile' => '058028948220',
    ),
);

// what we can do now to save this (without any further processing etc.)

$modx->getService('file', 'modFileHandler');

$fileobj = $modx->file->make(MODX_ASSETS_PATH . 'test.csv');

$fileobj->saveCSV($data);
```

and now we have a nice csv file at assets/test.csv
