### PR TITLE
Enhancement: Manager - Prevent data loss trough HTML5 localStorage

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -39,6 +39,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     ,warnUnsavedChanges: false
     ,setup: function() {
         if (!this.initialized) {
+
+            this.checkLocalStorage(); // exside: if a local storage object is present this.config.record is replaced with these values
+
             this.getForm().setValues(this.config.record);
             var pcmb = this.getForm().findField('parent-cmb');
             if (pcmb && Ext.isEmpty(this.config.record.parent_pagetitle)) {
@@ -91,10 +94,57 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         this.fireEvent('ready');
         this.initialized = true;
 
+        this.handleCancel(); // exside: when cancel is clicked, the local storage should be cleared (will be the only way to intentionally lose changes =D)
+
         MODx.fireEvent('ready');
         MODx.sleep(4); /* delay load event to allow FC rules to move before loading RTE */
         if (MODx.afterTVLoad) { MODx.afterTVLoad(); }
         this.fireEvent('load');
+    }
+
+    // exside
+    ,cancel: function() {
+        this.clearLocalStorage('cancel');
+    }
+    // exside
+    ,supportsLocalStorage: function() {
+        // has to be implemented yet, important is the case where a user disables localStorage, that's a bit tricky to catch
+    }
+    // exside
+    ,checkLocalStorage: function() {
+        if (localStorage.getItem('resource-' + this.config.record.id) !== null) {
+            console.log('from ls: ' + localStorage.getItem('resource-' + this.config.record.id));
+            this.config.record = JSON.parse(localStorage.getItem('resource-' + this.config.record.id));
+        } else {
+            console.log('checkLocalStorage was null');
+        }
+    }
+    // exside
+    ,setLocalStorage: function(o) {
+        console.log('setLocalStorage triggered');
+        console.log(o);
+        var field = o.field;
+        if (field !== undefined && field.name !== undefined) {
+            // console.log(field.field);
+            console.log('field (' + field.name + ') changed, dumping object to local storage, xtype = ' + field.xtype);
+
+            var fieldObj = {};
+            fieldObj[field.name] = ( field.xtype === 'textfield' || field.xtype === 'textarea' ) ? field.getValue() : ( field.el.dom.checked ? field.el.getValue(true) : 0 );
+            this.tempObj = Ext.apply(this.config.record, fieldObj);
+            console.log(this.tempObj);
+            localStorage.setItem('resource-' + this.config.record.id, JSON.stringify(this.tempObj));
+        } else {
+            console.log('field was undefined');
+        }
+    }
+    // exside
+    ,clearLocalStorage: function(trigger) {
+        if (localStorage.getItem('resource-' + this.config.record.id) !== null){
+            console.log('ls object found, wiping it, triggered from ' + trigger);
+            localStorage.removeItem('resource-' + this.config.record.id);
+        } else {
+            console.log('no ls object found, triggered from ' + trigger);
+        }
     }
 
     /**
@@ -116,6 +166,22 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             // Do the desired action on the button and its sibling (a spacer)
             previewBtn[action]();
             toolBar.items.get(btnIndex + 1)[action]();
+        }
+    }
+    // exside: I want to wipe the local storage when the cancel button in the toolbar is clicked
+    ,handleCancel: function() {
+        console.log('handleCancel');
+
+        var cancelBtn = Ext.getCmp('modx-abtn-cancel');
+
+        if (cancelBtn == undefined) {
+            console.log('waiting');
+            // Button not found, let's try again in a few ms
+            Ext.defer(function() {
+                this.handleCancel();
+            }, 200, this);
+        } else {
+            cancelBtn.on('click', function(e) { this.cancel(); }, this);
         }
     }
 
@@ -175,6 +241,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             }
         }
         var object = o.result.object;
+
+        this.clearLocalStorage('success'); // exside: when the resource was successfully saved, we can wipe the local storage
+
         // object.parent is undefined on template changing.
         if (this.config.resource && object.parent !== undefined && (object.class_key != this.defaultClassKey || object.parent != this.defaultValues.parent)) {
             MODx.loadPage(location.href);
@@ -240,6 +309,8 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
 
         if (this.isReady || MODx.request.reload) {
             this.warnUnsavedChanges = true;
+            this.setLocalStorage(o); // exside: like this on each change a new "dump" is made, I had it trottled, 
+            // but didn't recognize any performance issues when doing this on every change...
         }
     }
 


### PR DESCRIPTION
From the discussion here: https://github.com/modxcms/revolution/issues/3382#issuecomment-43333686

Couldn't leave it and had to try, even with extJS...(god I lost hair...)...and it actually works already pretty well on my test setup...I implemented it that way that the Cancel button forces the localStorage to be cleared.

This very alpha...I definitely need somebody with actual knowledge in ExtJS to have a look at what I did...probably a lot not "how it should be done" things...maybe @rtripault?

There are several things that should be done to make this "real":
1. implement the check if browser supports localStorage and also make sure to catch those users, that manually disable it for whatever reason (this is the tricky part)
2. It doesn't work with TVs...when I change a TV (just tried with an image TV) the onFieldChange method/function sends an "undefined" as object...don't know why...hints on what's wrong btw. how I can get and set the TV field values are highly appreciated
3. It just works for resources...for now, but I think this is where most of unintentional data loss happens...

To see what this actually is supposed to do, a quick screencast:

![modx manager html5localstorage](https://cloud.githubusercontent.com/assets/445501/3001564/010cf378-dd32-11e3-9ee5-e39e43a6a36b.gif)
