### PR TITLE
Fix: JSON Content Type has file extension .js

### DIFF
--- a/_build/data/transport.core.content_types.php
+++ b/_build/data/transport.core.content_types.php
@@ -65,7 +65,7 @@ $collection['7']->fromArray(array (
   'name' => 'JSON',
   'description' => 'JSON',
   'mime_type' => 'application/json',
-  'file_extensions' => '.js',
+  'file_extensions' => '.json',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);


### PR DESCRIPTION
Not sure if this is intentional (will probably work), but the Resource content type JSON results in a file extension / url extension of .js and not as I would expect in .json (if I want .js I would choose the JavaScript content type, I guess...)

This was implemented here: https://github.com/modxcms/revolution/commit/08090b3f2ea39f2eab5eaf4d3c710e674a7e7518
