### PR TITLE
[2.2] - Packages (versions) order

### DIFF
--- a/core/model/modx/transport/mysql/modtransportpackage.class.php
+++ b/core/model/modx/transport/mysql/modtransportpackage.class.php
@@ -22,11 +22,11 @@ class modTransportPackage_mysql extends modTransportPackage {
               FROM {$modx->getTableName('modTransportPackage')} AS `latestPackage`
               WHERE `latestPackage`.`package_name` = `modTransportPackage`.`package_name`
               ORDER BY
-                 `latestPackage`.`version_major` DESC,
-                 `latestPackage`.`version_minor` DESC,
-                 `latestPackage`.`version_patch` DESC,
-                 IF(`release` = '' OR `release` = 'ga' OR `release` = 'pl','z',`release`) DESC,
-                 `latestPackage`.`release_index` DESC
+                `latestPackage`.`version_major` DESC,
+                `latestPackage`.`version_minor` DESC,
+                `latestPackage`.`version_patch` DESC,
+                IF(`release` = '' OR `release` = 'ga' OR `release` = 'pl','z',IF(`release` = 'dev','a',`release`)) DESC,
+                `latestPackage`.`release_index` DESC
               LIMIT 1) = `modTransportPackage`.`signature`",
         ));
         if (!empty($search)) {
@@ -57,7 +57,7 @@ class modTransportPackage_mysql extends modTransportPackage {
         $c->sortby('modTransportPackage.version_major', 'DESC');
         $c->sortby('modTransportPackage.version_minor', 'DESC');
         $c->sortby('modTransportPackage.version_patch', 'DESC');
-        $c->sortby('IF(modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl","z",modTransportPackage.release) DESC','');
+        $c->sortby('IF(modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl","z",IF(modTransportPackage.release = "dev","a",modTransportPackage.release)) DESC','');
         $c->sortby('modTransportPackage.release_index', 'DESC');
         if((int)$limit > 0) {
             $c->limit((int)$limit, (int)$offset);


### PR DESCRIPTION
### What does it do ?

Consider `-dev` packages lower than `-alpha`
### Why is it needed ?

Having a package tagged `-alpha` (or `-beta`) after `-dev` one (using the same version number) "marks" the package as "upgradable" since "dev" is alphabetically higher than "alpha" or "beta"
### To do before merge
- [ ] Port to MsSQL since i have no idea if it should be different
### Related issue(s)/PR(s)
- #5263 
