### PR TITLE
[2.3] Bring back missing uberbar icons

### DIFF
--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -25,14 +25,14 @@ MODx.SearchBar = function(config) {
             '<tpl exec="this.type = values.type; values.label = this.getLabel(values.type)"></tpl>',
                 '<h3>{label}</h3>',
             '</tpl>',
-                '<p class="item"><a><tpl exec="values.icon = this.getClass(values)"><i class="icon-{icon}"></i></tpl>{name}<tpl if="description"><em> – {description}</em></tpl></a></p>',
+                '<p class="item"><a><tpl exec="values.icon = this.getClass(values)"><i class="icon icon-{icon}"></i></tpl>{name}<tpl if="description"><em> – {description}</em></tpl></a></p>',
             '</div >',
             '</tpl>', {
                 getClass: function(values) {
                     //console.log('in test!', values);
                     switch (values.type) {
                         case 'resources':
-                            return 'file-alt';
+                            return 'file-o';
                         case 'chunks':
                             return 'th';
                         case 'templates':


### PR DESCRIPTION
Brings back the missing icons in [2.3] uberbar search results:

![uberbar_icons](https://cloud.githubusercontent.com/assets/352182/3045202/6db2d6aa-e11a-11e3-80e3-3dde4252a0b6.jpg)
