### PR TITLE
Move fax field near other telephone related fields

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -309,6 +309,13 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,width: 200
                     ,maxLength: 255
                 },{
+                    id: 'modx-user-fax'
+                    ,name: 'fax'
+                    ,fieldLabel: _('user_fax')
+                    ,xtype: 'textfield'
+                    ,width: 200
+                    ,maxLength: 255
+                },{
                     id: 'modx-user-address'
                     ,name: 'address'
                     ,fieldLabel: _('address')
@@ -321,13 +328,6 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,fieldLabel: _('city')
                     ,xtype: 'textfield'
                     ,anchor: '100%'
-                    ,maxLength: 255
-                },{
-                    id: 'modx-user-fax'
-                    ,name: 'fax'
-                    ,fieldLabel: _('user_fax')
-                    ,xtype: 'textfield'
-                    ,width: 200
                     ,maxLength: 255
                 },{
                     id: 'modx-user-state'


### PR DESCRIPTION
It has always seemed odd to me that the "Fax" field shows up _between_ the City and State fields. This PR simply moves Fax near the other telephone related fields.

**BEFORE:**

![user__bsod_revo4___body_shapers_on_demand](https://cloud.githubusercontent.com/assets/352182/3047086/021d738e-e131-11e3-8ccb-4ae52442314d.jpg)

**AFTER:**

![user__bsod_revo4___body_shapers_on_demand](https://cloud.githubusercontent.com/assets/352182/3047095/31f9b478-e131-11e3-840e-d2eb2d28aac2.jpg)
