### PR TITLE
First attempt to make multilanguage TVs (in Backend) possible

### DIFF
--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -377,6 +377,16 @@ abstract class ResourceManagerController extends modManagerController {
             $this->setPlaceholder('showCheckbox',1);
         }
 
+        if ($namespace = stristr($tv->get('caption'), '.', true)) {
+            $this->modx->lexicon->load($namespace . ':default');
+            if ($this->modx->lexicon(ltrim(stristr($tv->get('caption'), '.'), '.'))) {
+                $tv->set('caption', $this->modx->lexicon(ltrim(stristr($tv->get('caption'), '.'), '.')));
+            }
+            if ($this->modx->lexicon(ltrim(stristr($tv->get('description'), '.'), '.'))) {
+                $tv->set('description', $this->modx->lexicon(ltrim(stristr($tv->get('description'), '.'), '.')));
+            }
+        }
+
         $tvOutput = $this->fetchTemplate('resource/sections/tvs.tpl');
         if (!empty($this->tvCounts)) {
             $this->setPlaceholder('tvOutput',$tvOutput);

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -339,6 +339,16 @@ abstract class ResourceManagerController extends modManagerController {
                     } else {
                         $hidden[] = $tv;
                     }
+
+                    if ($namespace = strstr($tv->get('caption'), '.', true)) {
+                        $this->modx->lexicon->load($namespace . ':default');
+                        if ($this->modx->lexicon->exists(ltrim(strstr($tv->get('caption'), '.'), '.'))) {
+                            $tv->set('caption', $this->modx->lexicon(ltrim(strstr($tv->get('caption'), '.'), '.')));
+                        }
+                        if ($this->modx->lexicon->exists(ltrim(strstr($tv->get('description'), '.'), '.'))) {
+                            $tv->set('description', $this->modx->lexicon(ltrim(strstr($tv->get('description'), '.'), '.')));
+                        }
+                    }
                 }
             }
         }
@@ -375,16 +385,6 @@ abstract class ResourceManagerController extends modManagerController {
 
         if (!empty($this->scriptProperties['showCheckbox'])) {
             $this->setPlaceholder('showCheckbox',1);
-        }
-
-        if ($namespace = stristr($tv->get('caption'), '.', true)) {
-            $this->modx->lexicon->load($namespace . ':default');
-            if ($this->modx->lexicon(ltrim(stristr($tv->get('caption'), '.'), '.'))) {
-                $tv->set('caption', $this->modx->lexicon(ltrim(stristr($tv->get('caption'), '.'), '.')));
-            }
-            if ($this->modx->lexicon(ltrim(stristr($tv->get('description'), '.'), '.'))) {
-                $tv->set('description', $this->modx->lexicon(ltrim(stristr($tv->get('description'), '.'), '.')));
-            }
         }
 
         $tvOutput = $this->fetchTemplate('resource/sections/tvs.tpl');


### PR DESCRIPTION
This was inspired by the forum threads here:

http://forums.modx.com/thread/90958/lexicon-setting-of-the-template-variables-transport-package#dis-post-498390

and subsequently here:

http://forums.modx.com/thread/31482/multi-language-tv

This could come in handy in some scenarios (especially with the envato marketplace available now...so authors could submit multilanguage themes, but in a multilanguage manager...!)

I took @MarkH s idea of making it work like it does for action lexicon entries, e.g. namespace.lexiconkey, so if you do something like that in a TV setup:

![bildschirmfoto 2014-05-22 um 03 08 55](https://cloud.githubusercontent.com/assets/445501/3048772/997b2786-e14e-11e3-96de-b61fe2f406d0.png)

and add the appropriate lexicon files under core/components/namespace/lexicons/CULTUREKEY/default.inc.php + a namespace with core path value of {core_path}components/namespace/ in the manager...

an example lexicon file at core/components/tplstrings/lexicon/en/default.inc.php (english) for the image above could look like:

```
/**
 * Custom English language file for manager TVs
 */

$_lang['tv.tvname'] = 'TV Name';
$_lang['tv.tvname.desc'] = 'That\'s a TV description';
```

I'm not sure about the performance hit of something like this (as the $modx->lexicon->load() method doesn't return something I could check in an if statement...which then unavoidably triggers a debug message in the if check on $modx->lexicon()...but yeah, if you set log_level_debug you get many of exactly these messages anyway...see this as an idea, improvements and discussions are very welcome!

for the more visual people, this is how it works...

![modx multilangtvs](https://cloud.githubusercontent.com/assets/445501/3048903/76799256-e151-11e3-921c-4ba89bca4b05.gif)
