### PR TITLE
Bring back backwards compatibility for the help window.

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -139,9 +139,6 @@ abstract class modManagerController {
         $this->setPlaceholder('_config',$this->modx->config);
         /* help url */
         $helpUrl = $this->getHelpUrl();
-        if (substr($helpUrl,0,4) != 'http') {
-            $helpUrl = $this->modx->getOption('base_help_url',null,'http://rtfm.modx.com/display/revolution20/').$helpUrl;
-        }
         $this->addHtml('<script type="text/javascript">MODx.helpUrl = "'.($helpUrl).'"</script>');
 
         $this->modx->invokeEvent('OnManagerPageBeforeRender',array('controller' => &$this));

--- a/core/model/modx/processors/system/config.js.php
+++ b/core/model/modx/processors/system/config.js.php
@@ -69,8 +69,7 @@ if (isset($scriptProperties['action']) && $scriptProperties['action'] != '' && i
         $c['namespace'] = $action['namespace'];
         $c['namespace_path'] = $action['namespace_path'];
         $c['namespace_assets_path'] = $action['namespace_assets_path'];
-        $baseHelpUrl = $modx->getOption('base_help_url',$scriptProperties,'http://rtfm.modx.com/display/revolution20/');
-        $c['help_url'] = $baseHelpUrl.ltrim($action['help_url'],'/');
+        $c['help_url'] = ltrim($action['help_url'],'/');
     } else {
         $namespace = $modx->getOption('namespace',$scriptProperties,'core');
         /** @var modNamespace $namespace */

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -230,8 +230,13 @@ Ext.extend(MODx,Ext.Component,{
 
     ,helpUrl: false
     ,loadHelpPane: function(b) {
-        var url = MODx.helpUrl;
-        if (!url) { return false; }
+        var url = MODx.helpUrl || MODx.config.help_url || '';
+        if (!url || !url.length) { return false; }
+
+        if (url.substring(0, 4) !== 'http') {
+            url = MODx.config.base_help_url + url;
+        }
+
         MODx.helpWindow = new Ext.Window({
             title: _('help')
             ,width: 850


### PR DESCRIPTION
In 2.2, overwriting MODx.config.help_url worked for loading a custom help url on CMPs. With this patch, that is once again possible. It prefers the new method (MODx.helpUrl, coming from the modManagerController.getHelpUrl() method) but checks the MODx.config.help_url for backwards compatibility.

It also prepends the base_help_url if the help url does not start with a protocol. Before this patch that was done on the server side (and stored in MODx.helpUrl), however that meant losing the ability to dynamically changing the help url in the manager. Putting that logic in the loadHelpPane method instead has the same result, but is more flexible.

**PS:** For some reason, all help buttons were removed in https://github.com/modxcms/revolution/commit/a84e038c7d26cf21094d075be523234ac42be72e - this seems a bit counterintuitive (why don't we want help buttons in the manager?) and I would suggest reverting that commit unless there's something I missed. @jpdevries 
