### PR TITLE
Add class to body tag

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -40,7 +40,7 @@
 {$scr}
 {/foreach}
 </head>
-<body id="modx-body-tag">
+<body id="modx-body-tag" class="modx-2-3">
 
 <div id="modx-browser"></div>
 <div id="modx-container">


### PR DESCRIPTION
This can help addons that don't just use ExtJS widgets to progressively enhance their UI to match the restyled 2.3 by targeting the modx-2-3 class.
