### PR TITLE
Removing :map tasks from gruntfile

### DIFF
--- a/_build/templates/default/gruntfile.js
+++ b/_build/templates/default/gruntfile.js
@@ -74,24 +74,14 @@ module.exports = function(grunt) {
 			dev: {
 				options: {
 					style: 'expanded',
-					compass: false
+					compass: false,
+                    sourcemap: true
 				},
 				files: {
 					'<%= dirs.css %>index.css': 'sass/index.scss',
 					'<%= dirs.css %>login.css': 'sass/login.scss'
 				}
-			},
-            map: {
-                options: {
-                    style: 'expanded',
-                    compass: false,
-                    sourcemap: true
-                },
-				files: {
-					'<%= dirs.css %>index.css': 'sass/index.scss',
-					'<%= dirs.css %>login.css': 'sass/login.scss'
-				}
-            }
+			}
 		},
 		autoprefixer: { /* this expands the css so it needs to get compressed with cssmin afterwards */
 			options: {
@@ -120,12 +110,8 @@ module.exports = function(grunt) {
 		},
 		watch: { /* trigger tasks on save */
 			scss: {
-				files: ['<%= dirs.scss %>*','<%= dirs.scss %>components/**/*'],
-				tasks: ['sass:dist', 'autoprefixer', 'cssmin:compress', 'growl:sass']
-			},
-			map: {
-				files: ['<%= dirs.scss %>*','<%= dirs.scss %>components/**/*'],
-				tasks: ['sass:map', 'growl:map']
+				files: ['<%= dirs.scss %>/**/*'],
+				tasks: ['sass:dev', 'growl:sass']
 			},
             css: {
                 options: {
@@ -220,6 +206,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-imageoptim');
 
     // Tasks
-    grunt.registerTask('default', ['growl:watch', 'watch:map']);
+    grunt.registerTask('default', ['growl:watch', 'watch']);
     grunt.registerTask('build', ['clean:prebuild','bower', 'copy', 'sass:dev','autoprefixer', 'growl:prefixes', 'growl:sass','cssmin:compress','clean:postbuild']);
 };

--- a/_build/templates/default/package.json
+++ b/_build/templates/default/package.json
@@ -5,17 +5,16 @@
   "repository": "https://github.com/modxcms/revolution",
   "devDependencies": {
     "grunt": "^0.4.3",
-    "grunt-bower-task": "^0.3.4",
-    "grunt-rename": "^0.1.3",
-    "grunt-contrib-watch": "^0.5.3",
-    "grunt-contrib-clean": "^0.5.0",
-    "grunt-grunticon": "^1.0.0",
-    "grunt-growl": "^0.1.5",
-    "grunt-contrib-sass": "^0.7.3",
     "grunt-autoprefixer": "^0.7.2",
+    "grunt-bower-task": "^0.3.4",
+    "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",
-    "grunt-contrib-csslint": "~0.1.2",
+    "grunt-contrib-csslint": "^0.1.2",
     "grunt-contrib-cssmin": "^0.9.0",
-    "grunt-imageoptim": "^1.4.1"
+    "grunt-contrib-sass": "^0.7.3",
+    "grunt-contrib-watch": "^0.5.3",
+    "grunt-growl": "^0.1.5",
+    "grunt-imageoptim": "^1.4.1",
+    "grunt-rename": "^0.1.3"
   }
 }


### PR DESCRIPTION
To allow for a seamless transition between Sass 3.2 and Sass 3.3 which
is required for source maps separate watch and sass tasks were used for
backwards compatibility.
Sass 3.3 will now be required to run
`grunt sass:dev`
