### PR TITLE
Return nothing when toPlaceholder output filter is used.

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -609,6 +609,7 @@ class modOutputFilter {
 
                         case 'toPlaceholder':
                             $this->modx->toPlaceholder($m_val,$output);
+                            $output = '';
                             break;
                         case 'cssToHead':
                             $this->modx->regClientCSS($output);


### PR DESCRIPTION
Not sure if this is a bug or not, however when I used the toPlaceholder filter I expected no output from the variable.

I found this old bug request where someone had expected a similar output.
http://bugs.modx.com/issues/8468
