### PR TITLE
Restores color highlighting to selected Resource in tree

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -95,7 +95,7 @@ $tabInactiveText: #757575;
 $tabHoverText: darken($colorSplash, 20%);
 
 /* text colors and font stacks */
-$selected:lighten(desaturate($colorSplash,45%),50%);
+$selected:lighten(desaturate($colorSplash,40%),40%);
 $over: rgb(250, 250, 250);
 
 $bodyfonts: 'Helvetica Neue', Helvetica, arial, tahoma, sans-serif;


### PR DESCRIPTION
Minor adjustment since #11406 to SASS lighten/desaturate levels for `$selected` to prevent returning pure white `#fff`. This PR brings back the highlighting of selected Resources in the tree.

Here's an example of the tree when editing the Home page:

**BEFORE:**

``` sass
$selected:lighten(desaturate($colorSplash,45%),50%);
```

![tree_no_highlight](https://cloud.githubusercontent.com/assets/352182/3094202/bbd48d12-e5b9-11e3-9961-705b0878ec9d.jpg)

**AFTER:**

``` sass
$selected:lighten(desaturate($colorSplash,40%),40%);
```

![tree_highlighted](https://cloud.githubusercontent.com/assets/352182/3094217/d918da36-e5b9-11e3-84a2-74549d23fe6e.jpg)
