### PR TITLE
clear:both layout fix for @INHERIT TVs

### DIFF
--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -20,7 +20,7 @@
             {/if}
         </label>
         {if $tv->inherited}<span class="modx-tv-inherited">{$_lang.tv_value_inherited}</span>{/if}
-        <div class="x-form-clear-left"></div>
+        <div class="x-form-clear"></div>
         <div class="x-form-element modx-tv-form-element">
             <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
             {$tv->get('formElement')}


### PR DESCRIPTION
Simple `clear: both` CSS fix in `manager/templates/default/resource/sections/tvs.tpl` to fix the following layout issue:

![editing__home___body_shapers_on_demand](https://cloud.githubusercontent.com/assets/352182/3095941/ec9d6360-e5cd-11e3-836b-dcad2a68fbcf.jpg)

I believe this was introduced with the new [2.3] manager theme updates.
