### PR TITLE
Added replace closing php tag for inline php dashboard widget

### DIFF
--- a/core/model/modx/moddashboardwidget.class.php
+++ b/core/model/modx/moddashboardwidget.class.php
@@ -301,7 +301,7 @@ abstract class modDashboardWidgetInterface {
      */
     public function renderAsSnippet($content = '') {
         if (empty($content)) $content = $this->widget->get('content');
-        $content = str_replace('<?php','',$content);
+        $content = str_replace(array('<?php','?>'),'',$content);
         $closure = create_function('$scriptProperties','global $modx;if (is_array($scriptProperties)) {extract($scriptProperties, EXTR_SKIP);}'.$content);
         return $closure(array(
             'controller' => $this->controller,


### PR DESCRIPTION
Issue: [Inline Dashboard Widgets crash if closing ?> tag exists](https://github.com/modxcms/revolution/issues/781)

Replace opening and closing php tag from widget content
