### PR TITLE
[2.3] - Default theme tweaks

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -62,7 +62,7 @@ MODx.Layout = function(config){
             xtype: 'box'
             ,region: 'north'
             ,applyTo: 'modx-header'
-            ,height: 55
+            //,height: 55
         },{
              region: 'west'
             ,applyTo: 'modx-leftbar'
@@ -111,7 +111,7 @@ MODx.Layout = function(config){
             ,border: false
             ,autoScroll: true
         }/*,{
-            region: 'south' // ya, you're going south alright 
+            region: 'south' // ya, you're going south alright
             ,applyTo: 'modx-footer'
             ,border: false
             ,id: 'modx-footer'

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -7,7 +7,7 @@
 {if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
 
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
-<link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/index.css" />
+<link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/{$_config.manager_theme}/css/index.css" />
 
 {if $_config.ext_debug}
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>


### PR DESCRIPTION
Removed hard coded top nav height (from ExtJS, in favor of using CSS to ease the custom theme creation) +
Load appropriate theme index.css instead of forcing default one
