### PR TITLE
[2.3] - Put images base URL in a configurable variable

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -278,7 +278,7 @@
 }
 
 .x-btn em.x-btn-split {
-  /*background: transparent url(../images/modx-theme/button/s-arrow.gif) no-repeat right center;*/
+  /*background: transparent url($imgPath + 'modx-theme/button/s-arrow.gif') no-repeat right center;*/
   display: block;
   padding-right: 14px;
   position:relative;
@@ -293,7 +293,7 @@
 }
 
 .x-btn em.x-btn-arrow {
-  background: transparent url(../images/modx-theme/button/arrow.gif) no-repeat right center;
+  background: transparent url($imgPath + 'modx-theme/button/arrow.gif') no-repeat right center;
   display: block;
   padding-right: 20px;
 
@@ -313,23 +313,23 @@
 /* //end button style */
 
 .x-btn-over em.x-btn-split, .x-btn-click em.x-btn-split, .x-btn-menu-active em.x-btn-split, .x-btn-pressed em.x-btn-split {
-  /*background-image: url(../images/modx-theme/button/s-arrow-o.gif);*/
+  /*background-image: url($imgPath + 'modx-theme/button/s-arrow-o.gif');*/
 }
 
 .x-btn em.x-btn-arrow-bottom {
-  background-image: url(../images/modx-theme/button/s-arrow-b-noline.gif);
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-b-noline.gif');
 }
 
 .x-btn em.x-btn-split-bottom {
-  background-image: url(../images/modx-theme/button/s-arrow-b.gif);
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-b.gif');
 }
 
 .x-btn-over em.x-btn-split-bottom, .x-btn-click em.x-btn-split-bottom, .x-btn-menu-active em.x-btn-split-bottom, .x-btn-pressed em.x-btn-split-bottom {
-  background-image: url(../images/modx-theme/button/s-arrow-bo.gif);
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-bo.gif');
 }
 
 .x-btn-group-notitle .x-btn-group-tc {
-  background-image: url(../images/modx-theme/button/group-tb.gif);
+  background-image: url($imgPath + 'modx-theme/button/group-tb.gif');
 }
 
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -136,3 +136,5 @@ $gtTabletP: new-breakpoint(min-width 769px 12);
 $gtTabletL: new-breakpoint(min-width 1025px 12);
 $gtDesktop: new-breakpoint(min-width 961px 12);
 $gtCinema: new-breakpoint(min-width 1401px 12);
+
+$imgPath: '../images/';

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -62,13 +62,13 @@ input::-moz-focus-inner {
   font: $baseText;
 }
 
-textarea.x-form-field, 
+textarea.x-form-field,
 .x-form-textarea {
   font-family: $codefonts;
 }
 
 .x-form-text, /* this screws up clear cache modal #shame */
-textarea.x-form-field, 
+textarea.x-form-field,
 .x-form-textarea {
   background-color: #fbfbfb;
   background-image: none;
@@ -82,8 +82,8 @@ textarea.x-form-field,
   border-color: #c5c5c5;
 }
 
-.x-form-check-wrap, 
-.x-form-check-wrap label, 
+.x-form-check-wrap,
+.x-form-check-wrap label,
 .x-form-checkbox {
   cursor: pointer;
 }
@@ -110,7 +110,7 @@ textarea.x-form-field,
   background-color: #fff;
 }
 
-.ext-strict .x-form-field-trigger-wrap .x-form-text, 
+.ext-strict .x-form-field-trigger-wrap .x-form-text,
 .ext-strict .x-small-editor .x-form-field-trigger-wrap .x-form-text {
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
@@ -123,7 +123,7 @@ textarea.x-form-field,
 }
 
 .x-small-editor .x-form-field-wrap .x-form-trigger, .x-form-field-wrap .x-form-trigger {
-  background-image: url(../images/modx-theme/form/trigger.png);
+  background-image: url($imgPath + 'modx-theme/form/trigger.png');
   border-bottom-right-radius: 3px;
   border-top-right-radius: 3px;
   border: 1px solid #C5C5C5 !important;
@@ -132,7 +132,7 @@ textarea.x-form-field,
 
 /* fix combo on grid editor bug */
 .x-grid-editor .x-form-field-wrap {
-  background: #f6f2f7 url(../images/modx-theme/form/combo-bck.png) repeat-x scroll 0px 100%;
+  background: #f6f2f7 url($imgPath + 'modx-theme/form/combo-bck.png') repeat-x scroll 0px 100%;
 }
 
 .x-grid-editor .x-form-field-wrap input {
@@ -141,7 +141,7 @@ textarea.x-form-field,
 
 .x-grid-editor .x-form-field-wrap img {
   background-color: white;
-  background-image: url(../images/modx-theme/form/trigger.png);
+  background-image: url($imgPath + 'modx-theme/form/trigger.png');
 }
 
 .x-form-field-trigger-wrap {
@@ -175,7 +175,7 @@ textarea.x-form-field,
 }
 
 .x-form-field-wrap .x-form-arrow-trigger {
-  background: url("../images/modx-theme/form/trigger.png") no-repeat scroll left center transparent;
+  background: url($imgPath + 'modx-theme/form/trigger.png') no-repeat scroll left center transparent;
 }
 
 .x-form-field-wrap .x-form-trigger.x-form-trigger-over {
@@ -203,7 +203,7 @@ textarea.x-form-field,
 }
 
 .x-small-editor .x-form-field-wrap .x-form-arrow-trigger {
-  background: url("../images/modx-theme/form/trigger.png") no-repeat scroll left center transparent;
+  background: url($imgPath + 'modx-theme/form/trigger.png') no-repeat scroll left center transparent;
 }
 
 .x-small-editor .x-form-field-wrap .x-form-trigger.x-form-trigger-over {
@@ -215,15 +215,15 @@ textarea.x-form-field,
 }
 
 .x-form-field-wrap .x-form-date-trigger, .x-small-editor .x-form-field-wrap .x-form-date-trigger {
-  background-image: url(../images/modx-theme/form/calendar.png);
+  background-image: url($imgPath + 'modx-theme/form/calendar.png');
 }
 
 .x-form-field-wrap .x-form-clear-trigger {
-  background-image: url(../images/modx-theme/form/clear-trigger.gif);
+  background-image: url($imgPath + 'modx-theme/form/clear-trigger.gif');
 }
 
 .x-form-field-wrap .x-form-search-trigger {
-  background-image: url(../images/modx-theme/form/search-trigger.gif);
+  background-image: url($imgPath + 'modx-theme/form/search-trigger.gif');
 }
 
 .x-viewport .x-trigger-wrap-focus, .x-viewport input.x-form-focus, .x-viewport textarea.x-form-focus, .x-viewport .x-form-textarea.x-form-focus {
@@ -260,7 +260,7 @@ textarea.x-form-field,
 
 .x-form-inner-invalid, textarea.x-form-inner-invalid {
   background-color: #fff;
-  background-image: url(../images/modx-theme/grid/invalid_line.gif);
+  background-image: url($imgPath + 'modx-theme/grid/invalid_line.gif');
 }
 
 .x-form-grow-sizer {
@@ -268,7 +268,7 @@ textarea.x-form-field,
 }
 
 .x-form-invalid-msg {
-  /*background-image: url(../images/modx-theme/shared/warning.gif);*/
+  /*background-image: url($imgPath + 'modx-theme/shared/warning.gif');*/
   color: #c0272b;
   font: $fontSmall;
   margin-top:2px;
@@ -305,7 +305,7 @@ textarea.x-form-field,
 }
 
 .x-form-invalid-icon {
-  background-image: url(../images/modx-theme/form/exclamation.gif);
+  background-image: url($imgPath + 'modx-theme/form/exclamation.gif');
 }
 
 .x-fieldset {

--- a/_build/templates/default/sass/_help.scss
+++ b/_build/templates/default/sass/_help.scss
@@ -96,7 +96,7 @@
   min-height: 112px;
   background-repeat:no-repeat;
   background-position:right top;
-  @include image-set('../images/modx-help-logo.png','../images/modx-help-logo@2x.png');
+  @include image-set($imgPath + 'modx-help-logo.png', $imgPath + 'modx-help-logo@2x.png');
   #helpLogo {
     float: right;
     height: 76px;

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -51,7 +51,7 @@
   display: block;
   line-height: 55px;
   padding: 0 15px;
-  text-decoration: none; 
+  text-decoration: none;
 }
 
 #modx-topnav {
@@ -72,14 +72,14 @@
                     line-height:55px;
                     font-size:16px;
                 }
-            }    
+            }
         }
     }
     @include media($desktop) {
-        #limenu-site > a:after { content:$fa-var-file-text-o; /* "\f0f6" */ } 
+        #limenu-site > a:after { content:$fa-var-file-text-o; /* "\f0f6" */ }
         #limenu-media > a:after { content:$fa-var-picture-o; /* "\f03e" */ }
-        #limenu-components > a:after { content:$fa-var-cube; /* "\f1b2" */  } 
-        #limenu-manage > a:after { content:$fa-var-sliders; /* "\f1de" */ } 
+        #limenu-components > a:after { content:$fa-var-cube; /* "\f1b2" */  }
+        #limenu-manage > a:after { content:$fa-var-sliders; /* "\f1de" */ }
     }
 }
 
@@ -108,7 +108,7 @@
 }
 
 #modx-topnav > li.top > a, #modx-user-menu > li.top > a {
-  border-left:1px solid transparent; 
+  border-left:1px solid transparent;
   border-right:1px solid transparent;
 }
 
@@ -150,7 +150,7 @@
 }
 
 #modx-navbar #modx-home-dashboard {
-  background-image: url("../images/modx-logo@2x.png");
+  background-image: url($imgPath + 'modx-logo@2x.png');
   background-position:center center;
   background-repeat:no-repeat;
   background-size: 45px 45px;
@@ -217,7 +217,7 @@
 /*
 #modx-navbar ul.modx-subnav li a {
   border-top:1px solid $navbarDrop;
-  border-bottom:1px solid $navbarDrop;	
+  border-bottom:1px solid $navbarDrop;
 }
 */
 

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -96,7 +96,7 @@
 .x-tab-strip .x-tab-strip-closable a.x-tab-strip-close {
   right: 8px;
   top: 11px;
-  background-image: url(../images/modx-theme/tabs/tab-close.gif);
+  background-image: url($imgPath + 'modx-theme/tabs/tab-close.gif');
 }
 
 ul.x-tab-strip-top li:first-child {
@@ -109,18 +109,18 @@ ul.x-tab-strip-bottom {
   border-top-color: #dfdfdf;
 
   & .x-tab-right {
-    background-image: url(../images/modx-theme/tabs/tab-btm-inactive-right-bg.gif);
+    background-image: url($imgPath + 'modx-theme/tabs/tab-btm-inactive-right-bg.gif');
 
     & .x-tab-right {
-      background-image: url(../images/modx-theme/tabs/tab-btm-right-bg.gif);
+      background-image: url($imgPath + 'modx-theme/tabs/tab-btm-right-bg.gif');
     }
     & .x-tab-left {
-      background-image: url(../images/modx-theme/tabs/tab-btm-left-bg.gif);
+      background-image: url($imgPath + 'modx-theme/tabs/tab-btm-left-bg.gif');
     }
   }
 
   & .x-tab-left {
-    background-image: url(../images/modx-theme/tabs/tab-btm-inactive-left-bg.gif);
+    background-image: url($imgPath + 'modx-theme/tabs/tab-btm-inactive-left-bg.gif');
   }
 
 }
@@ -139,7 +139,7 @@ ul.x-tab-strip-bottom {
 }
 
 .x-tab-scroller-left {
-  background-image: url(../images/modx-theme/tabs/scroll-left.gif);
+  background-image: url($imgPath + 'modx-theme/tabs/scroll-left.gif');
   border-bottom-color: #dfdfdf;
 }
 
@@ -158,7 +158,7 @@ ul.x-tab-strip-bottom {
 }
 
 .x-tab-scroller-right {
-  background-image: url(../images/modx-theme/tabs/scroll-right.gif);
+  background-image: url($imgPath + 'modx-theme/tabs/scroll-right.gif');
   border-bottom-color: #dfdfdf;
 }
 

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -248,7 +248,7 @@
   display: inline-block;
 }
 .x-tree-node-loading .x-tree-node-icon {
-  background-image: url(../images/modx-theme/tree/loading.gif) !important;
+  background-image: url($imgPath + 'modx-theme/tree/loading.gif') !important;
 }
 .x-tree-node-loading a span {
   color: #444444;
@@ -291,16 +291,16 @@
   background-color: $selected;
 }
 .x-tree-drop-ok-append .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-add.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-add.gif');
 }
 .x-tree-drop-ok-above .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-over.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-over.gif');
 }
 .x-tree-drop-ok-below .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-under.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-under.gif');
 }
 .x-tree-drop-ok-between .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-between.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-between.gif');
 }
 
 
@@ -326,134 +326,134 @@
   }
 }
 .icon-rss {
-  background-image: url(../images/restyle/icons/feed.png) !important;
+  background-image: url($imgPath + 'restyle/icons/feed.png') !important;
   @include legacy-tree-icon;
 }
 .icon-cal {
-  background-image: url(../images/restyle/icons/calendar.png) !important;
+  background-image: url($imgPath + 'restyle/icons/calendar.png') !important;
   @include legacy-tree-icon;
 }
 .icon-sql {
-  background-image: url(../images/restyle/icons/database_table.png) !important;
+  background-image: url($imgPath + 'restyle/icons/database_table.png') !important;
   @include legacy-tree-icon;
 }
 .icon-db {
-  background-image: url(../images/restyle/icons/database.png) !important;
+  background-image: url($imgPath + 'restyle/icons/database.png') !important;
   @include legacy-tree-icon;
 }
 .icon-java, .icon-jar {
-  background-image: url(../images/restyle/icons/cup.png) !important;
+  background-image: url($imgPath + 'restyle/icons/cup.png') !important;
   @include legacy-tree-icon;
 }
 .icon-css {
-  background-image: url(../images/restyle/icons/css.png) !important;
+  background-image: url($imgPath + 'restyle/icons/css.png') !important;
   @include legacy-tree-icon;
 }
 .icon-zip, .icon-tar, .icon-tgz, .icon-gz {
-  background-image: url(../images/restyle/icons/compress.png) !important;
+  background-image: url($imgPath + 'restyle/icons/compress.png') !important;
   @include legacy-tree-icon;
 }
 .icon-jpg, .icon-jpeg, .icon-gif, .icon-png, .icon-bmp, .icon-tiff {
-  background-image: url(../images/restyle/icons/picture.png) !important;
+  background-image: url($imgPath + 'restyle/icons/picture.png') !important;
   @include legacy-tree-icon;
 }
 .icon-bat, .icon-scr {
-  background-image: url(../images/restyle/icons/application_osx_terminal.png) !important;
+  background-image: url($imgPath + 'restyle/icons/application_osx_terminal.png') !important;
   @include legacy-tree-icon;
 }
 .icon-log {
-  background-image: url(../images/restyle/icons/computer.png) !important;
+  background-image: url($imgPath + 'restyle/icons/computer.png') !important;
   @include legacy-tree-icon;
 }
 .icon-html, .icon-htm {
-  background-image: url(../images/restyle/icons/html_valid.png) !important;
+  background-image: url($imgPath + 'restyle/icons/html_valid.png') !important;
   @include legacy-tree-icon;
 }
 .icon-avi, .icon-mpg, .icon-mov {
-  background-image: url(../images/restyle/icons/film.png) !important;
+  background-image: url($imgPath + 'restyle/icons/film.png') !important;
   @include legacy-tree-icon;
 }
 .icon-rb {
-  background-image: url(../images/restyle/icons/ruby.png) !important;
+  background-image: url($imgPath + 'restyle/icons/ruby.png') !important;
   @include legacy-tree-icon;
 }
 .icon-doc {
-  background-image: url(../images/restyle/icons/page_white_word.png) !important;
+  background-image: url($imgPath + 'restyle/icons/page_white_word.png') !important;
   @include legacy-tree-icon;
 }
 .icon-ppt {
-  background-image: url(../images/restyle/icons/page_white_powerpoint.png) !important;
+  background-image: url($imgPath + 'restyle/icons/page_white_powerpoint.png') !important;
   @include legacy-tree-icon;
 }
 .icon-access, .icon-htaccess {
-  background-image: url(../images/restyle/icons/lock.png) !important;
+  background-image: url($imgPath + 'restyle/icons/lock.png') !important;
   @include legacy-tree-icon;
 }
 .icon-php {
-  background-image: url(../images/restyle/icons/page_white_php.png) !important;
+  background-image: url($imgPath + 'restyle/icons/page_white_php.png') !important;
   @include legacy-tree-icon;
 }
 .icon-flv, .icon-swf {
-  background-image: url(../images/restyle/icons/page_white_flash.png) !important;
+  background-image: url($imgPath + 'restyle/icons/page_white_flash.png') !important;
   @include legacy-tree-icon;
 }
 .icon-xls {
-  background-image: url(../images/restyle/icons/page_white_excel.png) !important;
+  background-image: url($imgPath + 'restyle/icons/page_white_excel.png') !important;
   @include legacy-tree-icon;
 }
 .icon-cfm {
-  background-image: url(../images/restyle/icons/page_white_coldfusion.png) !important;
+  background-image: url($imgPath + 'restyle/icons/page_white_coldfusion.png') !important;
   @include legacy-tree-icon;
 }
 .icon-pdf {
-  background-image: url(../images/restyle/icons/page_white_acrobat.png) !important;
+  background-image: url($imgPath + 'restyle/icons/page_white_acrobat.png') !important;
   @include legacy-tree-icon;
 }
 .icon-js {
-  background-image: url(../images/restyle/icons/javascript.png) !important;
+  background-image: url($imgPath + 'restyle/icons/javascript.png') !important;
   @include legacy-tree-icon;
 }
 
 
 .icon-action {
-  background-image: url(../images/restyle/icons/application_osx_terminal.png) !important;
+  background-image: url($imgPath + 'restyle/icons/application_osx_terminal.png') !important;
   @include legacy-tree-icon;
 }
 .icon-namespace {
-  background-image: url(../images/restyle/icons/computer.png) !important;
+  background-image: url($imgPath + 'restyle/icons/computer.png') !important;
   @include legacy-tree-icon;
 }
 /*.icon-propertyset {
-  background-image: url(../images/restyle/icons/property-set.png) !important;
+  background-image: url($imgPath + 'restyle/icons/property-set.png') !important;
   @extend %hide-font-icon;
 }*/
 /*.icon-resourcegroup {
-  background: url(../images/restyle/icons/application_cascade.png) no-repeat left top !important;
+  background: url($imgPath + 'restyle/icons/application_cascade.png') no-repeat left top !important;
   @extend %hide-font-icon;
 }*/
 .icon-list-new {
-  background-image: url(../images/restyle/icons/layout_add.png) !important;
+  background-image: url($imgPath + 'restyle/icons/layout_add.png') !important;
   @include legacy-tree-icon;
 }
 .icon-mark-active {
-  background-image: url(../images/restyle/icons/layout_edit.png) !important;
+  background-image: url($imgPath + 'restyle/icons/layout_edit.png') !important;
   @include legacy-tree-icon;
 }
 .icon-mark-complete {
-  background-image: url(../images/restyle/icons/layout_header.png) !important;
+  background-image: url($imgPath + 'restyle/icons/layout_header.png') !important;
   @include legacy-tree-icon;
 }
 .icon-package {
-  background-image: url(../images/restyle/icons/package.png) !important;
+  background-image: url($imgPath + 'restyle/icons/package.png') !important;
   padding-right: 5px !important;
   @include legacy-tree-icon;
 }
 .icon-locked {
-  background-image: url(../images/restyle/icons/lock_edit.png) !important;
+  background-image: url($imgPath + 'restyle/icons/lock_edit.png') !important;
   @include legacy-tree-icon;
 }
 .icon-lock {
-  background-image: url(../images/restyle/icons/lock.png) !important;
+  background-image: url($imgPath + 'restyle/icons/lock.png') !important;
   @include legacy-tree-icon;
 }
 #modx-resource-tree-panel .x-accordion-hd {
@@ -478,7 +478,7 @@
   display: inline-block;
 }
 .x-tree-node-loading .x-tree-node-icon {
-  background-image: url(../images/modx-theme/tree/loading.gif) !important;
+  background-image: url($imgPath + 'modx-theme/tree/loading.gif') !important;
 }
 .x-tree-node-loading a span {
   color: #444444;
@@ -590,14 +590,14 @@
   background-color: $selected;
 }
 .x-tree-drop-ok-append .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-add.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-add.gif');
 }
 .x-tree-drop-ok-above .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-over.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-over.gif');
 }
 .x-tree-drop-ok-below .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-under.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-under.gif');
 }
 .x-tree-drop-ok-between .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/tree/drop-between.gif);
+  background-image: url($imgPath + 'modx-theme/tree/drop-between.gif');
 }

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -43,7 +43,7 @@
 
 .x-mask-loading div {
   background-color: $actionable;
-  background-image: url(../images/modx-theme/grid/loading.gif);
+  background-image: url($imgPath + 'modx-theme/grid/loading.gif');
 }
 
 .x-item-disabled {
@@ -88,7 +88,7 @@
 }
 
 .loading-indicator {
-  background-image: url(../images/modx-theme/grid/loading.gif);
+  background-image: url($imgPath + 'modx-theme/grid/loading.gif');
   font-size: 11px;
 }
 
@@ -141,25 +141,25 @@
 }
 
 .x-toolbar em.x-btn-split {
-  background-image: url(../images/modx-theme/button/s-arrow-noline.gif);
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-noline.gif');
 }
 
-.x-toolbar .x-btn-over em.x-btn-split, 
+.x-toolbar .x-btn-over em.x-btn-split,
 .x-toolbar .x-btn-click em.x-btn-split,
-.x-toolbar .x-btn-menu-active em.x-btn-split, 
+.x-toolbar .x-btn-menu-active em.x-btn-split,
 .x-toolbar .x-btn-pressed em.x-btn-split {
- /* background-image: url(../images/modx-theme/button/s-arrow-o.gif);*/
+ /* background-image: url($imgPath + 'modx-theme/button/s-arrow-o.gif');*/
 }
 
 .x-toolbar em.x-btn-split-bottom {
-  background-image: url(../images/modx-theme/button/s-arrow-b-noline.gif);
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-b-noline.gif');
 }
 
-.x-toolbar .x-btn-over em.x-btn-split-bottom, 
+.x-toolbar .x-btn-over em.x-btn-split-bottom,
 .x-toolbar .x-btn-click em.x-btn-split-bottom,
-.x-toolbar .x-btn-menu-active em.x-btn-split-bottom, 
+.x-toolbar .x-btn-menu-active em.x-btn-split-bottom,
 .x-toolbar .x-btn-pressed em.x-btn-split-bottom {
-  background-image: url(../images/modx-theme/button/s-arrow-bo.gif);
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-bo.gif');
 }
 
 .ext-ie .x-toolbar-cell .x-form-field-wrap {
@@ -167,11 +167,11 @@
 }
 
 .x-tbar-page-first {
-  background-image: url(../images/modx-theme/grid/page-first.png) !important;
+  background-image: url($imgPath + 'modx-theme/grid/page-first.png') !important;
 }
 
 .x-tbar-loading {
-  background-image: url(../images/modx-theme/grid/refresh.png) !important;
+  background-image: url($imgPath + 'modx-theme/grid/refresh.png') !important;
 }
 
 .x-tbar-page-last {
@@ -240,11 +240,11 @@
 }
 
 .x-toolbar-more-icon {
-  background-image: url(../images/modx-theme/toolbar/more.gif) !important;
+  background-image: url($imgPath + 'modx-theme/toolbar/more.gif') !important;
 }
 
 .x-statusbar .x-status-busy {
-  background-image: url(../images/modx-theme/grid/loading.gif);
+  background-image: url($imgPath + 'modx-theme/grid/loading.gif');
 }
 
 .x-statusbar .x-status-text-panel {
@@ -262,32 +262,32 @@
 
 .x-resizable-over .x-resizable-handle-east, .x-resizable-pinned .x-resizable-handle-east,
 .x-resizable-over .x-resizable-handle-west, .x-resizable-pinned .x-resizable-handle-west {
-  background-image: url(../images/modx-theme/sizer/e-handle.gif);
+  background-image: url($imgPath + 'modx-theme/sizer/e-handle.gif');
 }
 
 .x-resizable-over .x-resizable-handle-south, .x-resizable-pinned .x-resizable-handle-south,
 .x-resizable-over .x-resizable-handle-north, .x-resizable-pinned .x-resizable-handle-north {
-  background-image: url(../images/modx-theme/sizer/s-handle.gif);
+  background-image: url($imgPath + 'modx-theme/sizer/s-handle.gif');
 }
 
 .x-resizable-over .x-resizable-handle-north, .x-resizable-pinned .x-resizable-handle-north {
-  background-image: url(../images/modx-theme/sizer/s-handle.gif);
+  background-image: url($imgPath + 'modx-theme/sizer/s-handle.gif');
 }
 
 .x-resizable-over .x-resizable-handle-southeast, .x-resizable-pinned .x-resizable-handle-southeast {
-  background-image: url(../images/modx-theme/sizer/se-handle.gif);
+  background-image: url($imgPath + 'modx-theme/sizer/se-handle.gif');
 }
 
 .x-resizable-over .x-resizable-handle-northwest, .x-resizable-pinned .x-resizable-handle-northwest {
-  background-image: url(../images/modx-theme/sizer/nw-handle.gif);
+  background-image: url($imgPath + 'modx-theme/sizer/nw-handle.gif');
 }
 
 .x-resizable-over .x-resizable-handle-northeast, .x-resizable-pinned .x-resizable-handle-northeast {
-  background-image: url(../images/modx-theme/sizer/ne-handle.gif);
+  background-image: url($imgPath + 'modx-theme/sizer/ne-handle.gif');
 }
 
 .x-resizable-over .x-resizable-handle-southwest, .x-resizable-pinned .x-resizable-handle-southwest {
-  background-image: url(../images/modx-theme/sizer/sw-handle.gif);
+  background-image: url($imgPath + 'modx-theme/sizer/sw-handle.gif');
 }
 
 .x-resizable-proxy {
@@ -333,7 +333,7 @@
 
 .x-grid-row-loading {
   background-color: #fff;
-  background-image: url(../images/modx-theme/shared/loading-balls.gif);
+  background-image: url($imgPath + 'modx-theme/shared/loading-balls.gif');
 }
 
 .x-grid3-row {
@@ -401,27 +401,27 @@
   border-left-color: #DFDFDF;
 }
 .x-grid3-header-pop-inner {
-  background-image: url(../images/modx-theme/grid/hd-pop.gif);
+  background-image: url($imgPath + 'modx-theme/grid/hd-pop.gif');
   border-left-color: #eee;
 }
-td.x-grid3-hd-over, 
-td.sort-desc, 
-td.sort-asc, 
+td.x-grid3-hd-over,
+td.sort-desc,
+td.sort-asc,
 td.x-grid3-hd-menu-open {
   border-left-color: $griddivider;
   background: $gridsorted;
 }
-td.x-grid3-hd-over .x-grid3-hd-inner, 
-td.sort-desc .x-grid3-hd-inner, 
-td.sort-asc .x-grid3-hd-inner, 
+td.x-grid3-hd-over .x-grid3-hd-inner,
+td.sort-desc .x-grid3-hd-inner,
+td.sort-asc .x-grid3-hd-inner,
 td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   color: $white;
 }
 .sort-asc .x-grid3-sort-icon {
-  background-image: url(../images/modx-theme/grid/sort_asc.gif);
+  background-image: url($imgPath + 'modx-theme/grid/sort_asc.gif');
 }
 .sort-desc .x-grid3-sort-icon {
-  background-image: url(../images/modx-theme/grid/sort_desc.gif);
+  background-image: url($imgPath + 'modx-theme/grid/sort_desc.gif');
 }
 .x-panel-body-noheader .x-grid3-body {
   background-color: #ffffff;
@@ -434,21 +434,21 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   color: #000;
 }
 .x-grid3-split {
-  background-image: url(../images/modx-theme/grid/grid-split.gif);
+  background-image: url($imgPath + 'modx-theme/grid/grid-split.gif');
 }
 .x-grid3-hd-text {
   color: #464646;
 }
 .x-dd-drag-proxy .x-grid3-hd-inner {
   background-color: #f2f2f2;
-  background-image: url(../images/modx-theme/grid/grid3-hrow-over.gif);
+  background-image: url($imgPath + 'modx-theme/grid/grid3-hrow-over.gif');
   border-color: #c8c8c8;
 }
 .col-move-top {
-  background-image: url(../images/modx-theme/grid/col-move-top.gif);
+  background-image: url($imgPath + 'modx-theme/grid/col-move-top.gif');
 }
 .col-move-bottom {
-  background-image: url(../images/modx-theme/grid/col-move-bottom.gif);
+  background-image: url($imgPath + 'modx-theme/grid/col-move-bottom.gif');
 }
 .x-grid3-row-selected {
   background-color: $gainsboro;
@@ -473,7 +473,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 }
 .x-grid3-locked td.x-grid3-row-marker, .x-grid3-locked .x-grid3-row-selected td.x-grid3-row-marker {
   background-color: #d7d9df !important;
-  background-image: url(../images/modx-theme/grid/grid-hrow.gif) !important;
+  background-image: url($imgPath + 'modx-theme/grid/grid-hrow.gif') !important;
   border-right-color: #9c9c9c !important;
   border-top-color: #fff;
   color: #000;
@@ -482,7 +482,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   color: #464646 !important;
 }
 .x-grid3-dirty-cell {
-  background-image: url(../images/modx-theme/grid/dirty.gif);
+  background-image: url($imgPath + 'modx-theme/grid/dirty.gif');
 }
 .x-grid3-topbar, .x-grid3-bottombar {
   font: $fontSmall;
@@ -491,7 +491,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   border-top-color: #bcbcbc;
 }
 .x-props-grid .x-grid3-td-name .x-grid3-cell-inner {
-  background-image: url(../images/modx-theme/grid/grid3-special-col-bg.gif) !important;
+  background-image: url($imgPath + 'modx-theme/grid/grid3-special-col-bg.gif') !important;
   color: #000 !important;
 }
 .x-grid3-hd-inner {
@@ -509,20 +509,20 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   border-right-color: #eee;
 }
 .xg-hmenu-sort-asc .x-menu-item-icon {
-  background-image: url(../images/modx-theme/grid/hmenu-asc.gif);
+  background-image: url($imgPath + 'modx-theme/grid/hmenu-asc.gif');
 }
 .xg-hmenu-sort-desc .x-menu-item-icon {
-  background-image: url(../images/modx-theme/grid/hmenu-desc.gif);
+  background-image: url($imgPath + 'modx-theme/grid/hmenu-desc.gif');
 }
 .xg-hmenu-lock .x-menu-item-icon {
-  background-image: url(../images/modx-theme/grid/hmenu-lock.gif);
+  background-image: url($imgPath + 'modx-theme/grid/hmenu-lock.gif');
 }
 .xg-hmenu-unlock .x-menu-item-icon {
-  background-image: url(../images/modx-theme/grid/hmenu-unlock.gif);
+  background-image: url($imgPath + 'modx-theme/grid/hmenu-unlock.gif');
 }
 .x-grid3-hd-btn {
   background-color: #d8d8d8;
-  background-image: url(../images/modx-theme/grid/grid3-hd-btn.gif);
+  background-image: url($imgPath + 'modx-theme/grid/grid3-hd-btn.gif');
 }
 .x-grid3-body .x-grid3-td-expander {
   background-image: none;
@@ -538,14 +538,14 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   margin-top: 6px;
 }
 .x-grid3-row-expander {
-  background-image: url("../images/modx-theme/grid/row-expand-sprite.png");
+  background-image: url($imgPath + 'modx-theme/grid/row-expand-sprite.png');
 }
 .x-grid3-body .x-grid3-td-checker {
   background-image: none;
   padding: 10px 0 0;
 }
 .x-grid3-row-checker, .x-grid3-hd-checker {
-  background-image: url(../images/modx-theme/grid/row-check-sprite.gif);
+  background-image: url($imgPath + 'modx-theme/grid/row-check-sprite.gif');
   cursor: pointer;
 }
 .x-grid3-body .x-grid3-td-numberer {
@@ -559,7 +559,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   padding-top: 10px !important;
 }
 .x-grid3-body .x-grid3-td-row-icon {
-  background-image: url(../images/modx-theme/grid/grid3-special-col-bg.gif);
+  background-image: url($imgPath + 'modx-theme/grid/grid3-special-col-bg.gif');
 }
 .x-grid3-body .x-grid3-row-selected .x-grid3-td-numberer,
 .x-grid3-body .x-grid3-row-selected .x-grid3-td-checker,
@@ -567,12 +567,12 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   background-image: none;
 }
 .x-grid3-check-col {
-  background-image: url(../images/modx-theme/menu/unchecked.gif);
+  background-image: url($imgPath + 'modx-theme/menu/unchecked.gif');
   cursor: pointer;
   margin-top: 10px;
 }
 .x-grid3-check-col-on {
-  background-image: url(../images/modx-theme/menu/checked.gif);
+  background-image: url($imgPath + 'modx-theme/menu/checked.gif');
   cursor: pointer;
   margin-top: 10px;
 }
@@ -583,23 +583,23 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   border-bottom-color: $darkNeutral;
 }
 .x-grid-group-hd div.x-grid-group-title {
-  background: transparent url(../images/modx-theme/grid/group-collapse.png) no-repeat scroll 3px 10px;
+  background: transparent url($imgPath + 'modx-theme/grid/group-collapse.png') no-repeat scroll 3px 10px;
   color: $darkNeutral;
   font: $fontSmall;
   font-weight: bold;
   padding: 10px 4px 6px 24px;
 }
 .x-grid-group-collapsed .x-grid-group-hd div.x-grid-group-title {
-  background-image: url("../images/modx-theme/grid/group-expand.png");
+  background-image: url($imgPath + 'modx-theme/grid/group-expand.png');
 }
 .x-group-by-icon {
-  background-image: url(../images/modx-theme/grid/group-by.gif);
+  background-image: url($imgPath + 'modx-theme/grid/group-by.gif');
 }
 .x-cols-icon {
-  background-image: url(../images/modx-theme/grid/columns.gif);
+  background-image: url($imgPath + 'modx-theme/grid/columns.gif');
 }
 .x-show-groups-icon {
-  background-image: url(../images/modx-theme/grid/group-by.gif);
+  background-image: url($imgPath + 'modx-theme/grid/group-by.gif');
 }
 .x-grid-empty {
   color: gray;
@@ -623,13 +623,13 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   font: $fontSmall;
 }
 .x-dd-drop-nodrop .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/dd/drop-no.gif);
+  background-image: url($imgPath + 'modx-theme/dd/drop-no.gif');
 }
 .x-dd-drop-ok .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/dd/drop-yes.gif);
+  background-image: url($imgPath + 'modx-theme/dd/drop-yes.gif');
 }
 .x-dd-drop-ok-add .x-dd-drop-icon {
-  background-image: url(../images/modx-theme/dd/drop-add.gif);
+  background-image: url($imgPath + 'modx-theme/dd/drop-add.gif');
 }
 .x-view-selector {
   background-color: #d8d8d8;
@@ -663,10 +663,10 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   font-weight: bold;
 }
 .x-date-right a {
-  background-image: url(../images/modx-theme/shared/right-btn.gif);
+  background-image: url($imgPath + 'modx-theme/shared/right-btn.gif');
 }
 .x-date-left a {
-  background-image: url(../images/modx-theme/shared/left-btn.gif);
+  background-image: url($imgPath + 'modx-theme/shared/left-btn.gif');
 }
 .x-date-inner th {
   background-color: #F5F5F5;
@@ -740,7 +740,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 }
 .x-date-mp-btns {
   background-color: #ebebeb;
-  background-image: url(../images/modx-theme/shared/glass-bg.gif);
+  background-image: url($imgPath + 'modx-theme/shared/glass-bg.gif');
 }
 .x-date-mp-btns td {
   border-top-color: #DFDFDF;
@@ -754,11 +754,11 @@ td.x-date-mp-month a:hover,td.x-date-mp-year a:hover {
 }
 td.x-date-mp-sel a {
   background-color: #ebebeb;
-  background-image: url(../images/modx-theme/shared/glass-bg.gif);
+  background-image: url($imgPath + 'modx-theme/shared/glass-bg.gif');
   border-color: #afafaf;
 }
 .x-date-mp-ybtn a {
-  background-image: url(../images/modx-theme/panel/tool-sprites.gif);
+  background-image: url($imgPath + 'modx-theme/panel/tool-sprites.gif');
 }
 td.x-date-mp-sep {
   border-right-color: #DFDFDF;
@@ -769,7 +769,7 @@ td.x-date-mp-sep {
   padding: 5px;
 }
 .x-tip .x-tip-close {
-  background-image: url(../images/modx-theme/qtip/close.gif);
+  background-image: url($imgPath + 'modx-theme/qtip/close.gif');
 }
 .x-tip .x-tip-tc, .x-tip .x-tip-tl, .x-tip .x-tip-tr, .x-tip .x-tip-bc, .x-tip .x-tip-bl, .x-tip .x-tip-br, .x-tip .x-tip-ml, .x-tip .x-tip-mr {
   background-image: none;
@@ -795,13 +795,13 @@ td.x-date-mp-sep {
 }
 .x-form-invalid-tip .x-tip-tc, .x-form-invalid-tip .x-tip-tl, .x-form-invalid-tip .x-tip-tr, .x-form-invalid-tip .x-tip-bc,
 .x-form-invalid-tip .x-tip-bl, .x-form-invalid-tip .x-tip-br, .x-form-invalid-tip .x-tip-ml, .x-form-invalid-tip .x-tip-mr {
-  background-image: url(../images/modx-theme/form/error-tip-corners.gif);
+  background-image: url($imgPath + 'modx-theme/form/error-tip-corners.gif');
 }
 .x-form-invalid-tip .x-tip-body {
-  background-image: url(../images/modx-theme/form/exclamation.gif);
+  background-image: url($imgPath + 'modx-theme/form/exclamation.gif');
 }
 .x-tip-anchor {
-  background-image: url(../images/modx-theme/qtip/tip-anchor-sprite.gif);
+  background-image: url($imgPath + 'modx-theme/qtip/tip-anchor-sprite.gif');
 }
 .x-menu-list {
   padding: 0;
@@ -816,7 +816,7 @@ td.x-date-mp-sep {
   font: $fontSmall;
 }
 .x-menu-item-arrow {
-  background-image: url(../images/modx-theme/menu/menu-parent.gif);
+  background-image: url($imgPath + 'modx-theme/menu/menu-parent.gif');
 }
 .x-menu-sep {
   background-color: $subnavSepBorder;
@@ -839,13 +839,13 @@ a.x-menu-item {
   margin: 0;
 }
 .x-menu-check-item .x-menu-item-icon {
-  background-image: url(../images/modx-theme/menu/unchecked.gif);
+  background-image: url($imgPath + 'modx-theme/menu/unchecked.gif');
 }
 .x-menu-item-checked .x-menu-item-icon {
-  background-image: url(../images/modx-theme/menu/checked.gif);
+  background-image: url($imgPath + 'modx-theme/menu/checked.gif');
 }
 .x-menu-item-checked .x-menu-group-item .x-menu-item-icon {
-  background-image: url(../images/modx-theme/menu/group-checked.gif);
+  background-image: url($imgPath + 'modx-theme/menu/group-checked.gif');
 }
 .x-menu-group-item .x-menu-item-icon {
   background-image: none;
@@ -861,10 +861,10 @@ a.x-menu-item {
   border-color: #b9b9b9 !important;
 }
 .x-menu-scroller-top {
-  background-image: url(../images/modx-theme/layout/mini-top.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-top.gif');
 }
 .x-menu-scroller-bottom {
-  background-image: url(../images/modx-theme/layout/mini-bottom.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-bottom.gif');
 }
 .x-box-tl ,.x-box-ml {
   background-color: #fafafa;
@@ -903,7 +903,7 @@ a.x-menu-item {
   background-image: none;
 }
 .x-box-blue .x-box-bc, .x-box-blue .x-box-mc, .x-box-blue .x-box-tc {
-  background-image: url(../images/modx-theme/box/tb-gray.gif);
+  background-image: url($imgPath + 'modx-theme/box/tb-gray.gif');
 }
 .x-box-blue .x-box-mc {
   background-color: #d8d8d8;
@@ -912,10 +912,10 @@ a.x-menu-item {
   color: #363636;
 }
 .x-box-blue .x-box-ml {
-  background-image: url(../images/modx-theme/box/l-gray.gif);
+  background-image: url($imgPath + 'modx-theme/box/l-gray.gif');
 }
 .x-box-blue .x-box-mr {
-  background-image: url(../images/modx-theme/box/r-gray.gif);
+  background-image: url($imgPath + 'modx-theme/box/r-gray.gif');
 }
 #x-debug-browser .x-tree .x-tree-node a span {
   color: #333333;
@@ -950,7 +950,7 @@ a.x-menu-item {
   background-color: $dropdownBg;
 }
 .x-combo-list-hd {
-  background-image: url(../images/modx-theme/layout/panel-title-light-bg.gif);
+  background-image: url($imgPath + 'modx-theme/layout/panel-title-light-bg.gif');
   border-bottom-color: #bcbcbc;
   color: #464646;
 }
@@ -1089,19 +1089,19 @@ a.x-menu-item {
   padding-bottom: 8px;
 }
 .x-window-dlg .x-msg-box-wait {
-  background-image: url(../images/modx-theme/grid/loading.gif);
+  background-image: url($imgPath + 'modx-theme/grid/loading.gif');
 }
 .x-window-dlg .ext-mb-info {
-  background-image: url(../images/modx-theme/window/icon-info.gif);
+  background-image: url($imgPath + 'modx-theme/window/icon-info.gif');
 }
 .x-window-dlg .ext-mb-warning {
-  background-image: url(../images/modx-theme/window/icon-warning.gif);
+  background-image: url($imgPath + 'modx-theme/window/icon-warning.gif');
 }
 .x-window-dlg .ext-mb-question {
-  background-image: url(../images/modx-theme/window/icon-question.gif);
+  background-image: url($imgPath + 'modx-theme/window/icon-question.gif');
 }
 .x-window-dlg .ext-mb-error {
-  background-image: url(../images/modx-theme/window/icon-error.gif);
+  background-image: url($imgPath + 'modx-theme/window/icon-error.gif');
 }
 .x-panel-ml {
   border-left: 1px solid #E3E3E3;
@@ -1114,7 +1114,7 @@ a.x-menu-item {
   background-color: #f7f7f7;
 }
 .x-tool {
-  background-image: url(../images/modx-theme/panel/tool-sprites.png);
+  background-image: url($imgPath + 'modx-theme/panel/tool-sprites.png');
   height: 16px;
   margin: 1px 2px 0 0;
   width: 16px;
@@ -1287,7 +1287,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
   border-radius: 3px;
 }
 .x-html-editor-tb .x-btn-text {
-  background-image: url(../images/modx-theme/editor/tb-sprite.gif);
+  background-image: url($imgPath + 'modx-theme/editor/tb-sprite.gif');
 }
 .x-panel-noborder .x-panel-header-noborder {
   border-bottom-color: transparent;
@@ -1303,7 +1303,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
   background-color: #FAFAFA;
 }
 .x-accordion-hd {
-  background-image: url(../images/modx-theme/panel/light-hd.gif);
+  background-image: url($imgPath + 'modx-theme/panel/light-hd.gif');
   color: #222;
   font-weight: normal;
 }
@@ -1316,39 +1316,39 @@ body.x-body-masked .x-window-plain .x-window-mc {
   background-color: #e6e6e6;
 }
 .x-layout-split-west .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-left.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-left.gif');
 }
 .x-layout-split-east .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-right.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-right.gif');
 }
 .x-layout-split-north .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-top.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-top.gif');
 }
 .x-layout-split-south .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-bottom.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-bottom.gif');
 }
 .x-layout-cmini-west .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-right.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-right.gif');
 }
 .x-layout-cmini-east .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-left.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-left.gif');
 }
 .x-layout-cmini-north .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-bottom.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-bottom.gif');
 }
 .x-layout-cmini-south .x-layout-mini {
-  background-image: url(../images/modx-theme/layout/mini-top.gif);
+  background-image: url($imgPath + 'modx-theme/layout/mini-top.gif');
 }
 .x-progress-wrap {
   border-color: #8f8f8f;
 }
 .x-progress-inner {
   background-color: #e7e7e7;
-  background-image: url(../images/modx-theme/qtip/bg.gif);
+  background-image: url($imgPath + 'modx-theme/qtip/bg.gif');
 }
 .x-progress-bar {
   background-color: #bcbcbc;
-  background-image: url(../images/modx-theme/progress/progress-bg.gif);
+  background-image: url($imgPath + 'modx-theme/progress/progress-bg.gif');
   border-bottom-color: #a6a6a6;
   border-right-color: #a6a6a6;
   border-top-color: #e2e2e2;
@@ -1363,7 +1363,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
 }
 .x-list-header {
   background-color: #f9f9f9;
-  background-image: url(../images/modx-theme/grid/grid3-hrow.gif);
+  background-image: url($imgPath + 'modx-theme/grid/grid3-hrow.gif');
 }
 .x-list-header-inner div em {
   border-left-color: #ddd;
@@ -1383,20 +1383,20 @@ body.x-body-masked .x-window-plain .x-window-mc {
   border-right-color: #555;
 }
 .x-list-header-inner em.sort-asc, .x-list-header-inner em.sort-desc {
-  background-image: url(../images/modx-theme/grid/sort-hd.gif);
+  background-image: url($imgPath + 'modx-theme/grid/sort-hd.gif');
   border-color: #DFDFDF;
 }
 .x-slider-horz, .x-slider-horz .x-slider-end, .x-slider-horz .x-slider-inner {
-  background-image: url(../images/modx-theme/slider/slider-bg.png);
+  background-image: url($imgPath + 'modx-theme/slider/slider-bg.png');
 }
 .x-slider-horz .x-slider-thumb {
-  background-image: url(../images/modx-theme/slider/slider-thumb.png);
+  background-image: url($imgPath + 'modx-theme/slider/slider-thumb.png');
 }
 .x-slider-vert, .x-slider-vert .x-slider-end, .x-slider-vert .x-slider-inner {
-  background-image: url(../images/modx-theme/slider/slider-v-bg.png);
+  background-image: url($imgPath + 'modx-theme/slider/slider-v-bg.png');
 }
 .x-slider-vert .x-slider-thumb {
-  background-image: url(../images/modx-theme/slider/slider-v-thumb.png);
+  background-image: url($imgPath + 'modx-theme/slider/slider-v-thumb.png');
 }
 /* portal */
 .x-portal .x-panel-tl .x-panel-header {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -105,7 +105,7 @@ hr {
 }
 
 .wait {
-  background: transparent url('../images/style/wait.gif') no-repeat scroll center 55px;
+  background: transparent url($imgPath + 'style/wait.gif') no-repeat scroll center 55px;
   color: $darkNeutral;
   font-size: 15px;
   font-weight: bold;
@@ -462,7 +462,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 }
 
 .ux-row-action-item span {
-  background: transparent url(../images/style/go-next.png) no-repeat scroll 1px 4px;
+  background: transparent url($imgPath + 'style/go-next.png') no-repeat scroll 1px 4px;
   display: inline !important;
   line-height: 24px;
   margin: 0 5px;
@@ -471,19 +471,19 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 }
 
 .icon-uninstall span {
-  background: url("../images/style/delete.png") no-repeat scroll 1px 4px transparent;
+  background: url($imgPath + 'style/delete.png') no-repeat scroll 1px 4px transparent;
 }
 
 .package-details span {
-  background: url("../images/style/info.png") no-repeat scroll 1px 4px transparent;
+  background: url($imgPath + 'style/info.png') no-repeat scroll 1px 4px transparent;
 }
 
 .package-download span {
-  background: url("../images/style/download.png") no-repeat scroll 1px 4px transparent;
+  background: url($imgPath + 'style/download.png') no-repeat scroll 1px 4px transparent;
 }
 
 .package-installed span {
-  background: url("../images/style/accept.png") no-repeat scroll 1px 4px transparent;
+  background: url($imgPath + 'style/accept.png') no-repeat scroll 1px 4px transparent;
 }
 
 .ext-ie .ux-row-action-item span {
@@ -666,7 +666,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 }
 
 .x-rbtn td {
-  background-image: url(../images/restyle/icons/rbtn.gif);
+  background-image: url($imgPath + 'restyle/icons/rbtn.gif');
   background-repeat: no-repeat;
   border: 0 none;
   height: 21px;
@@ -864,33 +864,33 @@ ul.modx-tag-list li.modx-tag-checked {
 
 /* file upload */
 .ext-ux-uploaddialog-addbtn {
-  background: url("../images/restyle/fileup/file-add.gif") no-repeat left center !important;
+  background: url($imgPath + 'restyle/fileup/file-add.gif') no-repeat left center !important;
 }
 
 .ext-ux-uploaddialog-removebtn {
-  background: url("../images/restyle/fileup/file-remove.gif") no-repeat left center !important;
+  background: url($imgPath + 'restyle/fileup/file-remove.gif') no-repeat left center !important;
 }
 
 .ext-ux-uploaddialog-resetbtn {
-  background: url("../images/restyle/fileup/reset.gif") no-repeat left center !important;
+  background: url($imgPath + 'restyle/fileup/reset.gif') no-repeat left center !important;
 }
 
 .ext-ux-uploaddialog-uploadstartbtn {
-  background: url("../images/restyle/fileup/upload-start.gif") no-repeat left center !important;
+  background: url($imgPath + 'restyle/fileup/upload-start.gif') no-repeat left center !important;
 }
 
 .ext-ux-uploaddialog-uploadstopbtn {
-  background: url("../images/restyle/fileup/upload-stop.gif") no-repeat left center !important;
+  background: url($imgPath + 'restyle/fileup/upload-stop.gif') no-repeat left center !important;
 }
 
 .ext-ux-uploaddialog-indicator-stoped {
-  background: url("../images/restyle/fileup/done.gif") no-repeat center center;
+  background: url($imgPath + 'restyle/fileup/done.gif') no-repeat center center;
   height: 16px;
   width: 16px;
 }
 
 .ext-ux-uploaddialog-indicator-processing {
-  background: url("../images/restyle/fileup/loading.gif") no-repeat center center;
+  background: url($imgPath + 'restyle/fileup/loading.gif') no-repeat center center;
   height: 16px;
   width: 16px;
 }
@@ -902,19 +902,19 @@ ul.modx-tag-list li.modx-tag-checked {
 }
 
 .ext-ux-uploaddialog-state-0 {
-  background-image: url("../images/restyle/fileup/uncheck.gif");
+  background-image: url($imgPath + 'restyle/fileup/uncheck.gif');
 }
 
 .ext-ux-uploaddialog-state-1 {
-  background-image: url("../images/restyle/fileup/check.gif");
+  background-image: url($imgPath + 'restyle/fileup/check.gif');
 }
 
 .ext-ux-uploaddialog-state-2 {
-  background-image: url("../images/restyle/fileup/failed.gif");
+  background-image: url($imgPath + 'restyle/fileup/failed.gif');
 }
 
 .ext-ux-uploaddialog-state-3 {
-  background-image: url("../images/restyle/fileup/file-uploading.gif");
+  background-image: url($imgPath + 'restyle/fileup/file-uploading.gif');
 }
 
 .ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-bar .x-progress-text div {
@@ -995,11 +995,11 @@ ul.modx-tag-list li.modx-tag-checked {
 }
 
 .x-superboxselect-btn-clear {
-  background: url(../images/restyle/icons/sb_clear.png) no-repeat scroll left 0;
+  background: url($imgPath + 'restyle/icons/sb_clear.png') no-repeat scroll left 0;
 }
 
 .x-superboxselect-btn-expand {
-  background: url(../images/restyle/icons/sb_expand.png) no-repeat scroll left 0;
+  background: url($imgPath + 'restyle/icons/sb_expand.png') no-repeat scroll left 0;
 }
 
 .x-superboxselect-btn-over {
@@ -1060,7 +1060,7 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .x-superboxselect-item-close {
-  background: url(../images/restyle/icons/sb_close.png) no-repeat scroll left 0;
+  background: url($imgPath + 'restyle/icons/sb_close.png') no-repeat scroll left 0;
   border: none;
   cursor: pointer;
   display: block;
@@ -1309,7 +1309,7 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .modx-tv-reset {
-  background: url(../images/restyle/icons/arrow_rotate_anticlockwise.png) top right no-repeat;
+  background: url($imgPath + 'restyle/icons/arrow_rotate_anticlockwise.png') top right no-repeat;
   cursor: pointer;
   float: left;
   height: 16px;
@@ -1334,7 +1334,7 @@ body.ext-ie7 .x-superboxselect-item {
   padding-top: 4px;
 }
 
-#modx-resource-settings .modx-tv-label, 
+#modx-resource-settings .modx-tv-label,
 #modx-page-settings .modx-tv-label {
   width: 216px;
 }
@@ -1398,7 +1398,7 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .crumbs li {
-  background: url("../images/style/crumbs-bg.png") no-repeat scroll right center transparent;
+  background: url($imgPath + 'style/crumbs-bg.png') no-repeat scroll right center transparent;
   color: $darkNeutral;
   float: left;
   font-size: 12px;
@@ -1420,7 +1420,7 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .crumbs li .root {
-  background: url("../images/style/home.png") no-repeat scroll center top transparent;
+  background: url($imgPath + 'style/home.png') no-repeat scroll center top transparent;
   display: block;
   height: 16px;
   margin: 10px 0 9px;
@@ -1476,7 +1476,7 @@ body.ext-ie7 .x-superboxselect-item {
   padding: 10px;
 }
 #ux-lightbox-loading {
-  background: url("../images/style/loading.gif") no-repeat scroll center 15% transparent;
+  background: url($imgPath + 'style/loading.gif') no-repeat scroll center 15% transparent;
   height: 25%;
   left: 0;
   line-height: 0;
@@ -1549,7 +1549,7 @@ body.ext-ie7 .x-superboxselect-item {
   padding-bottom: 1em;
 }
 #ux-lightbox-data #ux-lightbox-navClose {
-  background: transparent url('../images/style/close.png') no-repeat scroll 0 0;
+  background: transparent url($imgPath + 'style/close.png') no-repeat scroll 0 0;
   float: right;
   height: 16px;
   outline: medium none;
@@ -1634,7 +1634,7 @@ body.ext-ie7 .x-superboxselect-item {
   text-decoration: none;
 }
 .home-panel ol li:hover button {
-  background: transparent url('../images/style/search.png') no-repeat scroll right center;
+  background: transparent url($imgPath + 'style/search.png') no-repeat scroll right center;
   color: #3D4349;
 }
 .home-panel ol li .highlighted {

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -12,7 +12,7 @@ html {
 }
 
 body {
-  background: #eeeeee url(../images/restyle/manager-loginscreen-bg.png) center -90px repeat-x;
+  background: #eeeeee url($imgPath + 'restyle/manager-loginscreen-bg.png') center -90px repeat-x;
   font-size: 75%;
   /* 12px 62.5% for 10px*/
   height: 100%;
@@ -86,7 +86,7 @@ img.loginCaptcha {
 .login-form-bwrap-padding {
   -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
-  background: black url(../images/restyle/manager-loginscreen-form-bg.png) bottom left no-repeat;
+  background: black url($imgPath + 'restyle/manager-loginscreen-form-bg.png') bottom left no-repeat;
   border-radius: 5px;
   padding-bottom: 10px;
 }
@@ -229,7 +229,7 @@ label {
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
   background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
   background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  background: url(../images/modx-theme/form/button-bg.png) repeat-x scroll 0 bottom gainsboro;
+  background: url($imgPath + 'modx-theme/form/button-bg.png') repeat-x scroll 0 bottom gainsboro;
   border-radius: 3px;
   border: 2px solid #ddd;
   box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
@@ -240,7 +240,7 @@ label {
 }
 #modx-login-btn {
   float: right;
-  
+
   &:hover {
     background: #ddd;
   }

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -1,3 +1,6 @@
+@charset "UTF-8";
+@import "colors-and-vars";
+
 html {
   color: #111;
   /* http://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/ */


### PR DESCRIPTION
The main idea driving this PR is to ease the use of original images without having to ship them with the custom manager theme.

This would allow to `@import` default theme scss and override some bits.
