### PR TITLE
[2.3] Restores Menu/Action tree icons

### DIFF
--- a/core/model/modx/processors/system/menu/getnodes.php
+++ b/core/model/modx/processors/system/menu/getnodes.php
@@ -54,6 +54,7 @@ foreach ($menus as $menu) {
         'text' => $text.($controller != '' ? ' <i>('.$namespace.':'.$controller.')</i>' : ''),
         'id' => 'n_'.$menu->get('text'),
         'cls' => 'icon-menu',
+        'iconCls' => 'icon icon-' . ( $menu->get('childrenCount') > 0 ? ( $menu->get('parent') === '' ? 'navicon' : 'folder' ) : 'terminal' ),
         'type' => 'menu',
         'pk' => $menu->get('text'),
         'leaf' => $menu->get('childrenCount') > 0 ? false : true,


### PR DESCRIPTION
Brings back icons for managing MODX Menus:

![topnav_icons](https://cloud.githubusercontent.com/assets/352182/3123411/96bfa6d2-e772-11e3-932b-e9b52dac3ca0.jpg)
