### PR TITLE
Enhancement: Added OnResourceAutoPublish system event

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -396,6 +396,12 @@ $events['OnResourceTVFormRender']->fromArray(array (
   'service' => 1,
   'groupname' => 'Resources',
 ), '', true, true);
+$events['OnResourceAutoPublish']= $xpdo->newObject('modEvent');
+$events['OnResourceAutoPublish']->fromArray(array (
+  'name' => 'OnResourceAutoPublish',
+  'service' => 1,
+  'groupname' => 'Resources',
+), '', true, true);
 $events['OnResourceDelete']= $xpdo->newObject('modEvent');
 $events['OnResourceDelete']->fromArray(array (
   'name' => 'OnResourceDelete',

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -661,6 +661,12 @@ class modCacheManager extends xPDOCacheManager {
         if (!$this->set('auto_publish', $nextevent, 0, $options)) {
             $this->modx->log(modX::LOG_LEVEL_ERROR, "Error caching time of next auto publishing event");
             $publishingResults['errors'][]= $this->modx->lexicon('cache_sitepublishing_file_error');
+        } else {
+            if ($publishingResults['published'] !== 0 || $publishingResults['unpublished'] !== 0) {
+                $this->modx->invokeEvent('OnResourceAutoPublish', array(
+                    'results' => $publishingResults
+                ));
+            }
         }
 
         return $publishingResults;


### PR DESCRIPTION
This additional system event is fired when the cache manager auto publishes a resource. This is helpful in advanced caching scenarios where you have to clean up other cache partitions when a resource is automatically published/unpublished based on pub_date or unpub_date.

Like this you can just hook in a plugin to that event to do the further cleanup instead of having to check what needs to be refreshed on every request.

unfortunately I couldn't find a way to pass the resource(s) that were published/unpublished to the event, but this is better than nothing =)
