### PR TITLE
[2.3] - Remove unnecessary shadow "DOM"

### DIFF
--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -9,11 +9,12 @@ MODx.SearchBar = function(config) {
         ,id: 'modx-uberbar'
         ,maxHeight: this.getViewPortSize()
         ,typeAhead: true
-        ,listAlign: [ 'tl-bl?', [0,0] ]
+        ,listAlign: [ 'tl-bl?', [0, 0] ]
         ,triggerConfig: {
             tag: 'span'
             ,cls: 'x-form-trigger icon icon-large icon-search'
         }
+        ,shadow: null
         //,triggerAction: 'query'
         ,minChars: 1
         ,displayField: 'name'


### PR DESCRIPTION
When displaying results from the search bar, some DOM elements are created to render/fake some [shadow](http://docs.sencha.com/extjs/3.4.0/#!/api/Ext.form.ComboBox-cfg-shadow) (unused/displayed, so no need)
