### PR TITLE
Enhancement: Sort the last edited resources grid desc instead of asc

### DIFF
--- a/core/model/modx/processors/system/activeresource/getlist.class.php
+++ b/core/model/modx/processors/system/activeresource/getlist.class.php
@@ -18,6 +18,7 @@ class modActiveResourceListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('resource');
     public $permission = 'view_document';
     public $defaultSortField = 'editedon';
+    public $defaultSortDirection = 'DESC';
 
     public function checkPermissions() {
         return $this->modx->hasPermission('view_document');


### PR DESCRIPTION
When you go to Reports > System info > recent documents, the grid is sorted ascending by default, which means it shows the resources that were edited the longest ago on top...this doesn't really make sense to me so I propose to change the default sort order to descending to show the most recent changed documents.
