### PR TITLE
[2.3] - Added ability to "wipe" a user session data without killing the session

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -837,4 +837,24 @@ class modUser extends modPrincipal {
         }
         return $dashboard;
     }
+
+    /**
+     * Refresh the current "active" session
+     */
+    public function refreshSession()
+    {
+        $sessionID = $this->Profile->get('sessionid');
+        if (!$sessionID || empty($sessionID)) {
+            return;
+        }
+        /** @var modSession $session */
+        $session = $this->xpdo->getObject('modSession', array(
+            'id' => $sessionID,
+        ));
+        if (!$session) {
+            return;
+        }
+
+        $session->refresh();
+    }
 }


### PR DESCRIPTION
Since i'm far from being a session master, feedback are more than welcome.
### What does it do ?

Adds ability to "refresh" a user session without logging-out the user.
### Why is it needed ?

Session data (ie. contexts accesses) being stored at "logging", a user must log-out first to regenerate the data.
This could potentially be used when some changes are made to user/group settings.
### Related issue(s)/PR(s)

Should fix #11247
