### PR TITLE
[2.3] - "Component-ize" the filetree panel

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -1,65 +1,96 @@
+/**
+ * Light container with all available media sources trees
+ *
+ * @class MODx.panel.FileTree
+ * @extends Ext.Container
+ * @param {Object} config
+ * @xtype modx-panel-filetree
+ */
 MODx.panel.FileTree = function(config) {
     config = config || {};
-    Ext.applyIf(config,{
-        border:0,
-        padding:0,
-        margin:0,
-        id: 'modx-leftbar-filetree',
-        listeners: {
-            render: {fn: this.getSourceList,scope:this}
+    Ext.applyIf(config, {
+        _treePrefix: 'source-tree-'
+        ,id: 'modx-leftbar-filetree'
+        ,autoHeight: true
+        ,defaults: {
+            autoHeight: true
+            ,border: false
         }
     });
-    MODx.panel.FileTree.superclass.constructor.call(this,config);
-
- //   this.on('render',this.o)
+    MODx.panel.FileTree.superclass.constructor.call(this, config);
+    this.on('render', this.getSourceList, this);
 };
-Ext.extend(MODx.panel.FileTree,MODx.FormPanel,{
-    sourceTrees: []
-
-    ,getSourceList: function(){
+Ext.extend(MODx.panel.FileTree, Ext.Container, {
+    /**
+     * Query the media sources list
+     */
+    getSourceList: function() {
         MODx.Ajax.request({
             url: MODx.config.connectors_url
             ,params: {
                 action: 'source/getList'
             }
             ,listeners: {
-                success: {fn: function(data){
-                    console.log('data received');
-                    this.onSourceListReceived(data.results);
-                },scope:this},
-                failure: {fn: function(data){
-                    // Check if this really is an error
-                    if(data.total > 0 && data.results != undefined){
+                success: {
+                    fn: function(data) {
                         this.onSourceListReceived(data.results);
                     }
-                    return false;
-                },scope: this}
+                    ,scope:this
+                }
+                ,failure: {
+                    fn: function(data) {
+                        // Check if this really is an error
+                        if (data.total > 0 && data.results != undefined) {
+                            this.onSourceListReceived(data.results);
+                        }
+                        return false;
+                    }
+                    ,scope: this
+                }
             }
         })
     }
 
-    ,onSourceListReceived: function(sources){
-        for(var k=0;k<sources.length;k++){
-            var source = sources[k];
-            if(!this.sourceTrees[source.name]){
-                this.sourceTrees[source.name] = MODx.load({
-                    xtype: 'modx-tree-directory'
-                    ,id: 'source-tree-' + source.id
-                    ,rootName: source.name
-                    ,hideSourceCombo: true
-                    ,source: source.id
-                    ,tbar: false
-                    ,tbarCfg: {
-                        hidden: true
-                    }
-                })
+    /**
+     * Iterate over the given media sources list to add their trees
+     *
+     * @param {Array} sources
+     */
+    ,onSourceListReceived: function(sources) {
+        for (var k = 0; k < sources.length; k++) {
+            var source = sources[k]
+                ,exists = this.getComponent(this._treePrefix + source.id);
+
+            if (!exists) {
+                var tree = this.loadTree(source);
             }
 
-            this.add(this.sourceTrees[source.name]);
+            this.add(tree);
+            tree = exists = void 0;
         }
         this.doLayout();
-      //  this.render();
+    }
+
+    /**
+     * Load the tree configuration for the given media source
+     *
+     * @param {Object} source
+     * @returns {Object}
+     */
+    ,loadTree: function(source) {
+        return MODx.load({
+            xtype: 'modx-tree-directory'
+            ,itemId: this._treePrefix + source.id
+            ,stateId: this._treePrefix + source.id
+            ,rootName: source.name
+            ,hideSourceCombo: true
+            ,source: source.id
+            ,tbar: false
+            ,tbarCfg: {
+                hidden: true
+            }
+        });
     }
 });
-Ext.reg('modx-panel-filetree',MODx.panel.FileTree);
+Ext.reg('modx-panel-filetree', MODx.panel.FileTree);
 


### PR DESCRIPTION
This PR aims to ease the reuse of the media sources tree panel.

In the process, it ended up extending `Ext.Container` instead of `MODx.FormPanel` to prevent the unnecessary features (top/bottom bars, form...), resulting in a slightly lighter DOM
