### PR TITLE
Fix incorrect sorting by rank in TV grid on template create/update screen

### DIFF
--- a/core/model/modx/mysql/modtemplate.class.php
+++ b/core/model/modx/mysql/modtemplate.class.php
@@ -22,7 +22,7 @@ class modTemplate_mysql extends modTemplate {
         if (!empty($conditions)) { $c->where($conditions); }
         $c->select(array(
             "IF(ISNULL(modTemplateVarTemplate.tmplvarid),0,1) AS access",
-            "IF(ISNULL(modTemplateVarTemplate.rank),'-',modTemplateVarTemplate.rank) AS tv_rank",
+            "IF(ISNULL(modTemplateVarTemplate.rank),0,modTemplateVarTemplate.rank) AS tv_rank",
             'category_name' => 'Category.category',
         ));
         foreach ($sort as $sortKey => $sortDir) {

--- a/core/model/modx/sqlsrv/modtemplate.class.php
+++ b/core/model/modx/sqlsrv/modtemplate.class.php
@@ -22,7 +22,7 @@ class modTemplate_sqlsrv extends modTemplate {
         if (!empty($conditions)) { $c->where($conditions); }
         $c->select(array(
             "CASE modTemplateVarTemplate.tmplvarid WHEN NULL THEN 0 ELSE 1 END AS access",
-            "ISNULL(modTemplateVarTemplate.rank, '-') AS tv_rank",
+            "ISNULL(modTemplateVarTemplate.rank, 0) AS tv_rank",
             'category_name' => 'Category.category',
         ));
         foreach ($sort as $sortKey => $sortDir) {


### PR DESCRIPTION
Fix incorrect sorting by rank in TV grid on template create/update screen - the IF() statements in the underlying query were forcing the sort to use alphanumeric sorting as opposed to natural sorting.

Fixes #6958.
