### PR TITLE
 [rebuild] Add fallback for the resource tree node name 

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1459,6 +1459,15 @@ $settings['resource_tree_node_name']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
+$settings['resource_tree_node_name_fallback']= $xpdo->newObject('modSystemSetting');
+$settings['resource_tree_node_name_fallback']->fromArray(array (
+  'key' => 'resource_tree_node_name_fallback',
+  'value' => 'pagetitle',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 $settings['resource_tree_node_tooltip']= $xpdo->newObject('modSystemSetting');
 $settings['resource_tree_node_tooltip']->fromArray(array (
   'key' => 'resource_tree_node_tooltip',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -583,6 +583,9 @@ $_lang['setting_resolve_hostnames_desc'] = 'Do you want MODX to try to resolve y
 $_lang['setting_resource_tree_node_name'] = 'Resource Tree Node Field';
 $_lang['setting_resource_tree_node_name_desc'] = 'Specify the Resource field to use when rendering the nodes in the Resource Tree. Defaults to pagetitle, although any Resource field can be used, such as menutitle, alias, longtitle, etc.';
 
+$_lang['setting_resource_tree_node_name_fallback'] = 'Resource Tree Node Fallback Field';
+$_lang['setting_resource_tree_node_name_fallback_desc'] = 'Specify the Resource field to use as fallback when rendering the nodes in the Resource Tree. This will be used if the resource has an empty value for the configured Resource Tree Node Field.';
+
 $_lang['setting_resource_tree_node_tooltip'] = 'Resource Tree Tooltip Field';
 $_lang['setting_resource_tree_node_tooltip_desc'] = 'Specify the Resource field to use when rendering the nodes in the Resource Tree. Any Resource field can be used, such as menutitle, alias, longtitle, etc. If blank, will be the longtitle with a description underneath.';
 

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -30,6 +30,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             'noMenu' => false,
             'debug' => false,
             'nodeField' => $this->modx->getOption('resource_tree_node_name',null,'pagetitle'),
+            'nodeFieldFallback' => $this->modx->getOption('resource_tree_node_name_fallback',null,'pagetitle'),
             'qtipField' => $this->modx->getOption('resource_tree_node_tooltip',null,''),
             'currentResource' => false,
             'currentAction' => false,
@@ -360,6 +361,7 @@ class modResourceGetNodesProcessor extends modProcessor {
     public function prepareResourceNode(modResource $resource) {
         $qtipField = $this->getProperty('qtipField');
         $nodeField = $this->getProperty('nodeField');
+        $nodeFieldFallback = $this->getProperty('nodeFieldFallback');
         $noHref = $this->getProperty('noHref',false);
 
         $hasChildren = $resource->get('childrenCount') > 0 && !$resource->get('hide_children_in_tree');
@@ -465,8 +467,14 @@ class modResourceGetNodesProcessor extends modProcessor {
         if ($ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $resource->get('context_key'), 'key' => 'session_enabled'))) {
             $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
         }
+
+        $text = strip_tags($resource->get($nodeField));
+        if (empty($text)) {
+            $text = $resource->get($nodeFieldFallback);
+            $text = strip_tags($text);
+        }
         $itemArray = array(
-            'text' => strip_tags($resource->$nodeField).$idNote,
+            'text' => $text.$idNote,
             'id' => $resource->context_key . '_'.$resource->id,
             'pk' => $resource->id,
             'cls' => implode(' ',$class),


### PR DESCRIPTION
Fixes #11286. Requires a rebuild for the new setting. 
