### PR TITLE
[2.3] - Fix "treestate_id"

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -82,6 +82,7 @@ Ext.extend(MODx.panel.FileTree, Ext.Container, {
             xtype: 'modx-tree-directory'
             ,itemId: this._treePrefix + source.id
             ,stateId: this._treePrefix + source.id
+            ,id: this._treePrefix + source.id
             ,rootName: source.name
             ,hideSourceCombo: true
             ,source: source.id


### PR DESCRIPTION
Sorry, i forgot to add this fix for #11476 (don't ask me why `treestate_id` is used in [`MODx.tree.Tree`](https://github.com/modxcms/revolution/blob/develop/manager/assets/modext/widgets/core/tree/modx.tree.js#L200) instead of default [`stateId`](http://docs.sencha.com/extjs/3.4.0/#!/api/Ext.Component-cfg-stateId))
