### PR TITLE
Added href attribute for modx-topnav to work on iOS

### DIFF
--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -179,7 +179,7 @@ class TopMenu
                 }
                 $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.$title.'>'.$label.$description.'</a>'."\n";
             } else {
-                $menuTpl .= '<a>'.$menu['text'].'</a>'."\n";
+                $menuTpl .= '<a href="">'.$menu['text'].'</a>'."\n";
             }
 
             if (!empty($menu['children'])) {


### PR DESCRIPTION
without the href attribute the menu won't drop on iOS devices. neither mobile safari nor chrome.
