### PR TITLE
[2.3] - Prevent browsing when clicking a "container" top menu

### DIFF
--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -179,7 +179,7 @@ class TopMenu
                 }
                 $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.$title.'>'.$label.$description.'</a>'."\n";
             } else {
-                $menuTpl .= '<a href="">'.$menu['text'].'</a>'."\n";
+                $menuTpl .= '<a href="javascript:;">'.$menu['text'].'</a>'."\n";
             }
 
             if (!empty($menu['children'])) {


### PR DESCRIPTION
After #11509 clicking on a top menu container causes navigation/browsing.
This PR just prevent that behavior
