### PR TITLE
Adding Assets to Groups Config

### DIFF
--- a/manager/min/groupsConfig.php
+++ b/manager/min/groupsConfig.php
@@ -30,7 +30,6 @@ $externals3[] = $managerUrl.'assets/modext/widgets/core/modx.tree.asynctreenode.
 $externals3[] = $managerUrl.'assets/modext/widgets/resource/modx.tree.resource.js';
 $externals3[] = $managerUrl.'assets/modext/widgets/element/modx.tree.element.js';
 $externals3[] = $managerUrl.'assets/modext/widgets/system/modx.tree.directory.js';
-$externals3[] = $managerUrl.'assets/modext/widgets/system/modx.tree.directory.js';
 $externals3[] = $managerUrl.'assets/modext/widgets/system/modx.panel.filetree.js';
 $externals3[] = $managerUrl.'assets/modext/core/modx.view.js';
 $externals3[] = $managerUrl.'assets/modext/core/modx.layout.js';

--- a/manager/min/groupsConfig.php
+++ b/manager/min/groupsConfig.php
@@ -6,26 +6,35 @@ $managerUrl = '../';
 $externals = array();
 $externals[] = $managerUrl.'assets/modext/core/modx.localization.js';
 $externals[] = $managerUrl.'assets/modext/util/utilities.js';
+$externals[] = $managerUrl.'assets/modext/util/uploaddialog.js';
+$externals[] = $managerUrl.'assets/modext/widgets/core/modx.button.js';
 $externals[] = $managerUrl.'assets/modext/core/modx.component.js';
 $externals[] = $managerUrl.'assets/modext/widgets/core/modx.panel.js';
 $externals[] = $managerUrl.'assets/modext/widgets/core/modx.tabs.js';
 $externals[] = $managerUrl.'assets/modext/widgets/core/modx.window.js';
+$externals[] = $managerUrl.'assets/modext/widgets/core/modx.combo.js';
 
 $externals2 = array();
-$externals2[] = $managerUrl.'assets/modext/widgets/core/modx.tree.js';
-$externals2[] = $managerUrl.'assets/modext/widgets/core/modx.combo.js';
 $externals2[] = $managerUrl.'assets/modext/widgets/core/modx.grid.js';
 $externals2[] = $managerUrl.'assets/modext/widgets/core/modx.console.js';
 $externals2[] = $managerUrl.'assets/modext/widgets/core/modx.portal.js';
+$externals2[] = $managerUrl.'assets/modext/widgets/windows.js';
+$externals2[] = $managerUrl.'assets/fileapi/FileAPI.js';
+$externals2[] = $managerUrl.'assets/modext/util/multiuploaddialog.js';
+$externals2[] = $managerUrl.'assets/modext/widgets/core/tree/modx.tree.js';
+$externals2[] = $managerUrl.'assets/modext/widgets/core/tree/modx.tree.treeloader.js';
 $externals2[] = $managerUrl.'assets/modext/widgets/modx.treedrop.js';
 
 $externals3 = array();
-$externals3[] = $managerUrl.'assets/modext/widgets/windows.js';
+$externals3[] = $managerUrl.'assets/modext/widgets/core/modx.tree.asynctreenode.js';
 $externals3[] = $managerUrl.'assets/modext/widgets/resource/modx.tree.resource.js';
 $externals3[] = $managerUrl.'assets/modext/widgets/element/modx.tree.element.js';
 $externals3[] = $managerUrl.'assets/modext/widgets/system/modx.tree.directory.js';
+$externals3[] = $managerUrl.'assets/modext/widgets/system/modx.tree.directory.js';
+$externals3[] = $managerUrl.'assets/modext/widgets/system/modx.panel.filetree.js';
 $externals3[] = $managerUrl.'assets/modext/core/modx.view.js';
 $externals3[] = $managerUrl.'assets/modext/core/modx.layout.js';
+$externals3[] = $managerUrl.'templates/default/js/layout.js';
 
 return array(
     'coreJs1' => $externals,


### PR DESCRIPTION
I noticed in the latest nightly that if setting compress_js and compress_js_groups to true the manager broke. After some investigating and comparing what is loaded globally with and without the settings enabled, it looks like some assets were missing.

This PR ensures same assets are loaded in same order regardless of compress_js
and compress_js_groups settings.

Steps to reproduce issue in modxcms/revolution#11515

Closes modxcms/revolution#11515
