### PR TITLE
Bring back color to deleted resource icon

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -175,6 +175,12 @@
 }
 .deleted {
   color: $deleted;
+
+  i.icon,
+  i.icon-large {
+      color: $deleted;
+      font-style: normal;
+  }
 }
 .deleted a span {
   color: $deleted;


### PR DESCRIPTION
Restores red color to the icon of a deleted resource, missed in #11489
