### PR TITLE
Enhancement: Allow drag and drop reordering of TVs in Template TV grid

### DIFF
--- a/core/model/modx/processors/element/template/tv/getlist.php
+++ b/core/model/modx/processors/element/template/tv/getlist.php
@@ -52,6 +52,11 @@ $list = array();
 foreach ($tvs as $tv) {
     $tvArray = $tv->get(array('id','name','description','tv_rank','category_name'));
     $tvArray['access'] = (boolean)$tv->get('access');
+
+    $tvArray['perm'] = array();
+    if ($modx->hasPermission('edit_tv')) {
+        $tvArray['perm'][] = 'pedit';
+    }
     
     $list[] = $tvArray;
 }

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -101,20 +101,25 @@ MODx.grid.TemplateTV = function(config) {
         var store = this.getStore();
         var ddrow = new Ext.dd.DropTarget(grid.getView().mainBody, {
             ddGroup : 'template-tvs-dd'
-            notifyDrop : function(dd, e, data) {
+            ,notifyDrop : function(dd, e, data) {
                 var sm = grid.getSelectionModel();
-                var rows = sm.getSelections();
+                var row = sm.getSelections();
                 var cindex = dd.getDragData(e).rowIndex;
                 if (sm.hasSelection()) {
-                    for (i = 0; i < rows.length; i++) {
-                        store.remove(store.getById(rows[i].id));
-                        store.insert(cindex,rows[i]);
+                    for (i = 0; i < row.length; i++) {
+                        store.remove(store.getById(row[i].id));
+                        store.insert(cindex,row[i]);
                     }
-                    sm.selectRecords(rows);
+                    sm.selectRecords(row);
                 }
                 
                 Ext.each(store.data.items, function(item, index, allItems) {
-                    item.set('tv_rank', index);
+                    // take pagination into account by recalculating the index based on the currently viewed page
+                    index = grid.config.bbar.cursor !== 0 ? ((grid.config.bbar.cursor - 1) * grid.config.bbar.pageSize) + index : index;
+
+                    if (row[0].data.category_name === item.data.category_name) {
+                        item.set('tv_rank', index);
+                    }
                 }, this);
             }
         });

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -18,7 +18,7 @@ MODx.grid.TemplateTV = function(config) {
         title: _('template_assignedtv_tab')
         ,id: 'modx-grid-template-tv'
         ,url: MODx.config.connector_url
-        ,fields: ['id','name','description','tv_rank','access','category_name','category']
+        ,fields: ['id','name','description','tv_rank','access','perm','category_name','category']
         ,baseParams: {
             action: 'element/template/tv/getlist'
             ,template: config.template
@@ -110,8 +110,23 @@ MODx.grid.TemplateTV = function(config) {
     this.on('render', this.prepareDDSort, this);
 };
 Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
+    getMenu: function() {
+        var r = this.getSelectionModel().getSelected();
+        var p = r.data.perm;
+        var m = [];
 
-    filterByCategory: function(cb,rec,ri) {
+        if (p.indexOf('pedit') != -1) {
+            m.push({
+                text: _('edit_tv')
+                ,handler: this.updateTV
+            });
+        }
+        return m;
+    }
+    ,updateTV: function(itm,e) {
+        MODx.loadPage('element/tv/update', 'id='+this.menu.record.id);
+    }
+    ,filterByCategory: function(cb,rec,ri) {
         this.getStore().baseParams['category'] = cb.getValue();
         this.getBottomToolbar().changePage(1);
         this.refresh();

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -22,6 +22,7 @@ MODx.grid.TemplateTV = function(config) {
         ,baseParams: {
             action: 'element/template/tv/getlist'
             ,template: config.template
+            ,sort: 'tv_rank'
         }
         ,saveParams: {
             template: config.template
@@ -30,6 +31,9 @@ MODx.grid.TemplateTV = function(config) {
         ,paging: true
         ,plugins: tt
         ,remoteSort: true
+        ,enableDragDrop: true
+        ,ddGroup : 'template-tvs-dd'
+        ,sm: new Ext.grid.RowSelectionModel({singleSelect:false})
         ,columns: [{
             header: _('name')
             ,dataIndex: 'name'
@@ -91,6 +95,30 @@ MODx.grid.TemplateTV = function(config) {
         }]
     });
     MODx.grid.TemplateTV.superclass.constructor.call(this,config);
+
+    this.on('render',function() {
+        var grid = this;
+        var store = this.getStore();
+        var ddrow = new Ext.dd.DropTarget(grid.getView().mainBody, {
+            ddGroup : 'template-tvs-dd'
+            notifyDrop : function(dd, e, data) {
+                var sm = grid.getSelectionModel();
+                var rows = sm.getSelections();
+                var cindex = dd.getDragData(e).rowIndex;
+                if (sm.hasSelection()) {
+                    for (i = 0; i < rows.length; i++) {
+                        store.remove(store.getById(rows[i].id));
+                        store.insert(cindex,rows[i]);
+                    }
+                    sm.selectRecords(rows);
+                }
+                
+                Ext.each(store.data.items, function(item, index, allItems) {
+                    item.set('tv_rank', index);
+                }, this);
+            }
+        });
+    },this);
 };
 Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
 

--- a/manager/controllers/default/element/template/create.class.php
+++ b/manager/controllers/default/element/template/create.class.php
@@ -119,7 +119,7 @@ class ElementTemplateCreateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('template','category','propertyset','element');
+        return array('template','category','propertyset','element','tv');
     }
 
     /**

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -169,7 +169,7 @@ class ElementTemplateUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('template','category','system_events','propertyset','element');
+        return array('template','category','system_events','propertyset','element','tv');
     }
 
     /**


### PR DESCRIPTION
This is the first attempt to solve the annoying "not-being-able-to-reorder-TVs-by-drag-and-drop"-problem existing since Revo was released (and that functionality existed in Evo), so far it seems to work quite well, but as I'm far from even little skilled with extJS, I don't know if my approach is even a valid one...

Related issues (maybe there are more, but these I could find with a quick search):
#9410 #9698 #5095 #11120 #4592 #11102

with the proposed changes it works like this:
![modx templatetvs dd](https://cloud.githubusercontent.com/assets/445501/3357870/55659818-fad7-11e3-9c62-5b8d1f9d3c13.gif)
