### PR TITLE
Fix: Preserve order of selected values in multiselect / listbox (multiple) TVs

### DIFF
--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -1640,3 +1640,23 @@ body.x-body-masked .x-window-plain .x-window-mc {
   padding-left: 0;
   padding-right: 0;
 }
+.x-superboxselect,
+.x-superboxselect-btns {
+  overflow: visible;
+}
+.x-superboxselect-input input {
+  background: transparent;
+}
+.x-superboxselect-btn-expand {
+  margin-top: 9px !important; margin-right: 6px;
+}
+.x-superboxselect-btn-clear {
+  background-color: #fbfbfb;
+  height: 17px !important;
+  top: -4px;
+  outline: 1px solid #e4e4e4;
+  border: 12px solid #fbfbfb;
+  position: absolute;
+  right: -42px;
+  display: block;
+}

--- a/core/model/modx/processors/element/tv/renders/mgr/input/listbox-multiple.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/listbox-multiple.class.php
@@ -22,6 +22,23 @@ class modTemplateVarInputRenderListboxMultiple extends modTemplateVarInputRender
             );
         }
 
+        // preserve the order of selected values
+        $orderedItems = array();
+        // loop trough the selected values
+        foreach ($value as $val) {
+            // find the corresponding option in the items array
+            foreach ($items as $item => $values) {
+                // if found, add it in the right order to the $orderItems array
+                if ($values['value'] == $val) {
+                    $orderedItems[] = $values;
+                    // and remove it from the original $items array
+                    unset($items[$item]);
+                }
+            }
+        }
+        // merge the correctly ordered items with the unselected remaining ones
+        $items = array_merge($orderedItems, $items);
+
         $this->setPlaceholder('opts',$items);
     }
 }

--- a/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
@@ -24,7 +24,7 @@ Ext.onReady(function() {
         ,triggerAction: 'all'
         ,mode: 'local'
         ,extraItemCls: 'x-tag'
-        ,width: 400
+        ,width: 359
         ,displayField: "text"
         ,valueField: "value"
         ,resizable: true


### PR DESCRIPTION
Fixes issue: https://github.com/modxcms/revolution/issues/9206

before:
![bildschirmfoto 2014-06-24 um 18 50 20](https://cloud.githubusercontent.com/assets/445501/3374556/d0eba49e-fbbf-11e3-959d-746381d4c4c2.png)

after:
![bildschirmfoto 2014-06-24 um 19 50 31](https://cloud.githubusercontent.com/assets/445501/3375277/18258304-fbc8-11e3-9050-05dc1bc8ff39.png)
