### PR TITLE
various design improvements per #11540

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -551,25 +551,3 @@
   @extend %pseudo-font;
   content:$fa-var-folder;
 }
-
-
-/* accordion header row icons */
-#modx-leftbar .icon,
-.x-tree-node /*.modx-tree-node-tool-ct*/ .icon {
-  background: none;
-  border: 0;
-  display: inline-block;
-  opacity: 0.6;
-  margin: 0;
-  padding: 3px;
-  text-align: center;
-  i {
-    font-style: normal;
-  }
-  button {
-    display: none;
-  }
-  &:hover {
-    opacity: 1 !important;
-  }
-}

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -63,13 +63,13 @@ $headerText: #555555;
 $treeColor: #556C88;
 $treeColor_2: #728DA7;
 $treePseudoRootBg: $lightBg;
-$treePseudoRootColor: #4D82A5;
+$treePseudoRootColor: #447996;
 $treePseudoRootOverBg: $brandHover;
-$treePseudoRootOverColor: $colorSplash;
+$treePseudoRootOverColor: #1A7FB8;
 
 /* Tree menus */
 $iconColor: $treeText;
-$unpublished: lighten($treeText, 20%) !important;
+$unpublished: lighten($treeText, 10%) !important;
 $disabled: $unpublished;
 $hidden: $unpublished;
 $unpubText: italic;
@@ -114,9 +114,9 @@ $tabStripBg: transparent;
 $tabInactiveBg: $navbarBg;
 $tabHoverBg: $navbarHover;
 $tabText: $colorSplash;
-$tabInactiveText: #757575;
+$tabInactiveText: $colorSplash;
 $tabHoverText: darken($colorSplash, 20%);
-$tabActiveText: #297EAD;
+$tabActiveText: #1A7FB8;
 
 /* text colors and font stacks */
 $selected: lighten(desaturate($colorSplash,40%),40%);

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -64,8 +64,8 @@ $treeColor: #556C88;
 $treeColor_2: #728DA7;
 $treePseudoRootBg: $lightBg;
 $treePseudoRootColor: #447996;
-$treePseudoRootOverBg: $brandHover;
-$treePseudoRootOverColor: #1A7FB8;
+$treePseudoRootOverBg: $lightBg; /* $brandHover; */
+$treePseudoRootOverColor: #447996; /* #1A7FB8; */
 
 /* Tree menus */
 $iconColor: $treeText;

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -347,7 +347,7 @@ textarea.x-form-field,
   padding: 0;
 }
 .form-with-labels .x-form-label-top .x-form-item label.x-form-item-label {
-  color: #707070;
+  color: #555;
   font-size: 13px;
   font-weight: bold;
   margin-bottom: 0;

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -57,7 +57,7 @@
   font: $tabFont;
   line-height: 2.2;
   margin: 1px 0 1px 2px;
-  padding: 0 13px;
+  padding: 0 12px;
   position: relative;
   z-index: 5;
 
@@ -72,7 +72,6 @@
     cursor: default;
     margin: 0 0 0 2px;
     padding-bottom: 2px;
-    border-radius: 2px 2px 0 0;
 
     .vertical-tabs-header & {
       border-radius: 0;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -66,7 +66,7 @@
 }
 
 .modx-tree {
-  padding: 0 0 5px;
+  padding: 0;
   #modx-file-tree & {
     &:first-child {
       padding-top: 5px;
@@ -268,6 +268,7 @@
   }
   + .x-tree-node-ct {
     margin-left: -16px;
+    padding: 5px 0;
   }
   &:hover .modx-tree-node-tool-ct {
     opacity: 1;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -8,7 +8,7 @@
   }
   /* the toolbars just below the tabs */
   & .x-toolbar {
-    padding: 4px 5px 5px;
+    padding: 6px 5px 0px;
   }
   /* root box contaiing a context or category */
   & .x-tree-root-ct {
@@ -17,6 +17,11 @@
   /* just the actual nodes */
   & .x-tree .x-panel-body {
     backgroud: $white;
+  }
+  
+  .x-tab-panel-bwrap {
+	  position: relative;
+	  z-index: 1;
   }
 }
 
@@ -61,7 +66,7 @@
 }
 
 .modx-tree {
-  padding: 0 5px 5px 5px;
+  padding: 0 0 5px;
   #modx-file-tree & {
     &:first-child {
       padding-top: 5px;
@@ -228,12 +233,11 @@
 
 .tree-pseudoroot-node.x-tree-node-el {
   background-color: $treePseudoRootBg;
-  border-radius: 4px;
   font: $treePseudoRootFont;
   position:relative;
   padding: 0 0 0 4px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  margin-top: 2px;
+  margin-bottom: 2px;
 
   a span {
     color: $treePseudoRootColor;
@@ -249,11 +253,12 @@
 
   .modx-tree-node-tool-ct {
     line-height: 35px;
+    opacity: .5;
     .x-btn {
       margin-left: 2px;
     }
   }
-  &.x-tree-node-expanded, &.x-tree-node-expanded span {
+  &.x-tree-node-expanded, &.x-tree-node-expanded span, &.x-tree-node-expanded > .icon {
     color: $treePseudoRootOverColor;
     background-color: $treePseudoRootOverBg;
   }
@@ -263,6 +268,9 @@
   }
   + .x-tree-node-ct {
     margin-left: -16px;
+  }
+  &:hover .modx-tree-node-tool-ct {
+    opacity: 1;
   }
 }
 
@@ -289,6 +297,30 @@
 .ext-ie .x-tree-node-el input {
   height: 15px;
   width: 15px;
+}
+
+/* accordion header row icons */
+#modx-leftbar .icon,
+.x-tree-node /*.modx-tree-node-tool-ct*/ .icon {
+  background: none;
+  border: 0;
+  display: inline-block;
+  margin: 0;
+  padding: 3px;
+  text-align: center;
+  opacity: 0.8;
+  i {
+    font-style: normal;
+  }
+  button {
+    display: none;
+  }
+}
+
+.x-tree-node-ct .x-tree-node .icon {
+	position: relative;
+	top: -1px;
+	left: 1px;
 }
 
 

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -5773,7 +5773,7 @@ ul.x-tab-strip-bottom .x-tab-left {
 }
 
 .modx-tree {
-  padding: 0 0 5px;
+  padding: 0;
 }
 #modx-file-tree .modx-tree:first-child {
   padding-top: 5px;
@@ -5972,6 +5972,7 @@ ul.x-tab-strip-bottom .x-tab-left {
 }
 .tree-pseudoroot-node.x-tree-node-el + .x-tree-node-ct {
   margin-left: -16px;
+  padding: 5px 0;
 }
 .tree-pseudoroot-node.x-tree-node-el:hover .modx-tree-node-tool-ct {
   opacity: 1;

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -1,21 +1,9022 @@
 /*!
-* 
-* Copyright (C) 2014 MODX LLC
-* 
-* This file is part of MODX Revolution and was compiled using Grunt.
-* 
-* MODX Revolution is free software: you can redistribute it and/or modify it under the terms of the
-* GNU General Public License as published by the Free Software Foundation, either version 2 of the
-* License, or (at your option) any later version.
-* 
-* MODX Revolution is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* 
-* See the GNU General Public License for more details. You should have received a copy of the GNU
-* General Public License along with MODX Revolution. If not, see <http://www.gnu.org/licenses/>.
-* 
-*/
-/*!
  *  Font Awesome 4.1.0 by @davegandy - http://fontawesome.io - @fontawesome
  *  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
- */@font-face{font-family:FontAwesome;src:url(../fonts/fontawesome-webfont.eot?v=4.1.0);src:url(../fonts/fontawesome-webfont.eot?#iefix&v=4.1.0) format("embedded-opentype"),url(../fonts/fontawesome-webfont.woff?v=4.1.0) format("woff"),url(../fonts/fontawesome-webfont.ttf?v=4.1.0) format("truetype"),url(../fonts/fontawesome-webfont.svg?v=4.1.0#fontawesomeregular) format("svg");font-weight:400;font-style:normal}.icon{display:inline-block;font-family:FontAwesome;font-style:normal;font-weight:400;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.icon-large,.icon-lg{font-size:1.33333em;line-height:.75em;vertical-align:-15%}.icon-2x{font-size:2em}.icon-3x{font-size:3em}.icon-4x{font-size:4em}.icon-5x{font-size:5em}.icon-fw{width:1.28571em;text-align:center}.icon-ul{padding-left:0;margin-left:2.14286em;list-style-type:none}.icon-ul>li{position:relative}.icon-li{position:absolute;left:-2.14286em;width:2.14286em;top:.14286em;text-align:center}.icon-li.icon-large,.icon-li.icon-lg{left:-1.85714em}.icon-border{padding:.2em .25em .15em;border:solid .08em #eee;border-radius:.1em}.pull-right{float:right}.pull-left{float:left}.icon.pull-left{margin-right:.3em}.icon.pull-right{margin-left:.3em}.icon-spin{-webkit-animation:spin 2s infinite linear;animation:spin 2s infinite linear}@-webkit-keyframes spin{0%{-webkit-transform:rotate(0deg)}100%{-webkit-transform:rotate(359deg)}}@keyframes spin{0%{-webkit-transform:rotate(0deg);-ms-transform:rotate(0deg);transform:rotate(0deg)}100%{-webkit-transform:rotate(359deg);-ms-transform:rotate(359deg);transform:rotate(359deg)}}.icon-rotate-90{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=1);-webkit-transform:rotate(90deg);-ms-transform:rotate(90deg);transform:rotate(90deg)}.icon-rotate-180{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);-webkit-transform:rotate(180deg);-ms-transform:rotate(180deg);transform:rotate(180deg)}.icon-rotate-270{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=3);-webkit-transform:rotate(270deg);-ms-transform:rotate(270deg);transform:rotate(270deg)}.icon-flip-horizontal{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=0);-webkit-transform:scale(-1,1);-ms-transform:scale(-1,1);transform:scale(-1,1)}.icon-flip-vertical{filter:progid:DXImageTransform.Microsoft.BasicImage(rotation=2);-webkit-transform:scale(1,-1);-ms-transform:scale(1,-1);transform:scale(1,-1)}.icon-stack{position:relative;display:inline-block;width:2em;height:2em;line-height:2em;vertical-align:middle}.icon-stack-1x,.icon-stack-2x{position:absolute;left:0;width:100%;text-align:center}.icon-stack-1x{line-height:inherit}.icon-stack-2x{font-size:2em}.icon-inverse{color:#fff}.icon-glass:before{content:"\f000"}.icon-music:before{content:"\f001"}.icon-search:before{content:"\f002"}.icon-envelope-o:before{content:"\f003"}.icon-heart:before{content:"\f004"}.icon-star:before{content:"\f005"}.icon-star-o:before{content:"\f006"}.icon-user:before{content:"\f007"}.icon-film:before{content:"\f008"}.icon-th-large:before{content:"\f009"}.icon-th:before{content:"\f00a"}.icon-th-list:before{content:"\f00b"}.icon-check:before{content:"\f00c"}.icon-times:before{content:"\f00d"}.icon-search-plus:before{content:"\f00e"}.icon-search-minus:before{content:"\f010"}.icon-power-off:before{content:"\f011"}.icon-signal:before{content:"\f012"}.icon-cog:before,.icon-gear:before{content:"\f013"}.icon-trash-o:before{content:"\f014"}.icon-home:before{content:"\f015"}.icon-file-o:before{content:"\f016"}.icon-clock-o:before{content:"\f017"}.icon-road:before{content:"\f018"}.icon-download:before{content:"\f019"}.icon-arrow-circle-o-down:before{content:"\f01a"}.icon-arrow-circle-o-up:before{content:"\f01b"}.icon-inbox:before{content:"\f01c"}.icon-play-circle-o:before{content:"\f01d"}.icon-repeat:before,.icon-rotate-right:before{content:"\f01e"}.icon-refresh:before{content:"\f021"}.icon-list-alt:before{content:"\f022"}.icon-lock:before{content:"\f023"}.icon-flag:before{content:"\f024"}.icon-headphones:before{content:"\f025"}.icon-volume-off:before{content:"\f026"}.icon-volume-down:before{content:"\f027"}.icon-volume-up:before{content:"\f028"}.icon-qrcode:before{content:"\f029"}.icon-barcode:before{content:"\f02a"}.icon-tag:before{content:"\f02b"}.icon-tags:before{content:"\f02c"}.icon-book:before{content:"\f02d"}.icon-bookmark:before{content:"\f02e"}.icon-print:before{content:"\f02f"}.icon-camera:before{content:"\f030"}.icon-font:before{content:"\f031"}.icon-bold:before{content:"\f032"}.icon-italic:before{content:"\f033"}.icon-text-height:before{content:"\f034"}.icon-text-width:before{content:"\f035"}.icon-align-left:before{content:"\f036"}.icon-align-center:before{content:"\f037"}.icon-align-right:before{content:"\f038"}.icon-align-justify:before{content:"\f039"}.icon-list:before{content:"\f03a"}.icon-dedent:before,.icon-outdent:before{content:"\f03b"}.icon-indent:before{content:"\f03c"}.icon-video-camera:before{content:"\f03d"}.icon-image:before,.icon-photo:before,.icon-picture-o:before{content:"\f03e"}.icon-pencil:before{content:"\f040"}.icon-map-marker:before{content:"\f041"}.icon-adjust:before{content:"\f042"}.icon-tint:before{content:"\f043"}.icon-edit:before,.icon-pencil-square-o:before{content:"\f044"}.icon-share-square-o:before{content:"\f045"}.icon-check-square-o:before{content:"\f046"}.icon-arrows:before{content:"\f047"}.icon-step-backward:before{content:"\f048"}.icon-fast-backward:before{content:"\f049"}.icon-backward:before{content:"\f04a"}.icon-play:before{content:"\f04b"}.icon-pause:before{content:"\f04c"}.icon-stop:before{content:"\f04d"}.icon-forward:before{content:"\f04e"}.icon-fast-forward:before{content:"\f050"}.icon-step-forward:before{content:"\f051"}.icon-eject:before{content:"\f052"}.icon-chevron-left:before{content:"\f053"}.icon-chevron-right:before{content:"\f054"}.icon-plus-circle:before{content:"\f055"}.icon-minus-circle:before{content:"\f056"}.icon-times-circle:before{content:"\f057"}.icon-check-circle:before{content:"\f058"}.icon-question-circle:before{content:"\f059"}.icon-info-circle:before{content:"\f05a"}.icon-crosshairs:before{content:"\f05b"}.icon-times-circle-o:before{content:"\f05c"}.icon-check-circle-o:before{content:"\f05d"}.icon-ban:before{content:"\f05e"}.icon-arrow-left:before{content:"\f060"}.icon-arrow-right:before{content:"\f061"}.icon-arrow-up:before{content:"\f062"}.icon-arrow-down:before{content:"\f063"}.icon-mail-forward:before,.icon-share:before{content:"\f064"}.icon-expand:before{content:"\f065"}.icon-compress:before{content:"\f066"}.icon-plus:before{content:"\f067"}.icon-minus:before{content:"\f068"}.icon-asterisk:before{content:"\f069"}.icon-exclamation-circle:before{content:"\f06a"}.icon-gift:before{content:"\f06b"}.icon-leaf:before{content:"\f06c"}.icon-fire:before{content:"\f06d"}.icon-eye:before{content:"\f06e"}.icon-eye-slash:before{content:"\f070"}.icon-exclamation-triangle:before,.icon-warning:before{content:"\f071"}.icon-plane:before{content:"\f072"}.icon-calendar:before{content:"\f073"}.icon-random:before{content:"\f074"}.icon-comment:before{content:"\f075"}.icon-magnet:before{content:"\f076"}.icon-chevron-up:before{content:"\f077"}.icon-chevron-down:before{content:"\f078"}.icon-retweet:before{content:"\f079"}.icon-shopping-cart:before{content:"\f07a"}.icon-folder:before{content:"\f07b"}.icon-folder-open:before{content:"\f07c"}.icon-arrows-v:before{content:"\f07d"}.icon-arrows-h:before{content:"\f07e"}.icon-bar-chart-o:before{content:"\f080"}.icon-twitter-square:before{content:"\f081"}.icon-facebook-square:before{content:"\f082"}.icon-camera-retro:before{content:"\f083"}.icon-key:before{content:"\f084"}.icon-cogs:before,.icon-gears:before{content:"\f085"}.icon-comments:before{content:"\f086"}.icon-thumbs-o-up:before{content:"\f087"}.icon-thumbs-o-down:before{content:"\f088"}.icon-star-half:before{content:"\f089"}.icon-heart-o:before{content:"\f08a"}.icon-sign-out:before{content:"\f08b"}.icon-linkedin-square:before{content:"\f08c"}.icon-thumb-tack:before{content:"\f08d"}.icon-external-link:before{content:"\f08e"}.icon-sign-in:before{content:"\f090"}.icon-trophy:before{content:"\f091"}.icon-github-square:before{content:"\f092"}.icon-upload:before{content:"\f093"}.icon-lemon-o:before{content:"\f094"}.icon-phone:before{content:"\f095"}.icon-square-o:before{content:"\f096"}.icon-bookmark-o:before{content:"\f097"}.icon-phone-square:before{content:"\f098"}.icon-twitter:before{content:"\f099"}.icon-facebook:before{content:"\f09a"}.icon-github:before{content:"\f09b"}.icon-unlock:before{content:"\f09c"}.icon-credit-card:before{content:"\f09d"}.icon-rss:before{content:"\f09e"}.icon-hdd-o:before{content:"\f0a0"}.icon-bullhorn:before{content:"\f0a1"}.icon-bell:before{content:"\f0f3"}.icon-certificate:before{content:"\f0a3"}.icon-hand-o-right:before{content:"\f0a4"}.icon-hand-o-left:before{content:"\f0a5"}.icon-hand-o-up:before{content:"\f0a6"}.icon-hand-o-down:before{content:"\f0a7"}.icon-arrow-circle-left:before{content:"\f0a8"}.icon-arrow-circle-right:before{content:"\f0a9"}.icon-arrow-circle-up:before{content:"\f0aa"}.icon-arrow-circle-down:before{content:"\f0ab"}.icon-globe:before{content:"\f0ac"}.icon-wrench:before{content:"\f0ad"}.icon-tasks:before{content:"\f0ae"}.icon-filter:before{content:"\f0b0"}.icon-briefcase:before{content:"\f0b1"}.icon-arrows-alt:before{content:"\f0b2"}.icon-group:before,.icon-users:before{content:"\f0c0"}.icon-chain:before,.icon-link:before{content:"\f0c1"}.icon-cloud:before{content:"\f0c2"}.icon-flask:before{content:"\f0c3"}.icon-cut:before,.icon-scissors:before{content:"\f0c4"}.icon-copy:before,.icon-files-o:before{content:"\f0c5"}.icon-paperclip:before{content:"\f0c6"}.icon-floppy-o:before,.icon-save:before{content:"\f0c7"}.icon-square:before{content:"\f0c8"}.icon-bars:before,.icon-navicon:before,.icon-reorder:before{content:"\f0c9"}.icon-list-ul:before{content:"\f0ca"}.icon-list-ol:before{content:"\f0cb"}.icon-strikethrough:before{content:"\f0cc"}.icon-underline:before{content:"\f0cd"}.icon-table:before{content:"\f0ce"}.icon-magic:before{content:"\f0d0"}.icon-truck:before{content:"\f0d1"}.icon-pinterest:before{content:"\f0d2"}.icon-pinterest-square:before{content:"\f0d3"}.icon-google-plus-square:before{content:"\f0d4"}.icon-google-plus:before{content:"\f0d5"}.icon-money:before{content:"\f0d6"}.icon-caret-down:before{content:"\f0d7"}.icon-caret-up:before{content:"\f0d8"}.icon-caret-left:before{content:"\f0d9"}.icon-caret-right:before{content:"\f0da"}.icon-columns:before{content:"\f0db"}.icon-sort:before,.icon-unsorted:before{content:"\f0dc"}.icon-sort-desc:before,.icon-sort-down:before{content:"\f0dd"}.icon-sort-asc:before,.icon-sort-up:before{content:"\f0de"}.icon-envelope:before{content:"\f0e0"}.icon-linkedin:before{content:"\f0e1"}.icon-rotate-left:before,.icon-undo:before{content:"\f0e2"}.icon-gavel:before,.icon-legal:before{content:"\f0e3"}.icon-dashboard:before,.icon-tachometer:before{content:"\f0e4"}.icon-comment-o:before{content:"\f0e5"}.icon-comments-o:before{content:"\f0e6"}.icon-bolt:before,.icon-flash:before{content:"\f0e7"}.icon-sitemap:before{content:"\f0e8"}.icon-umbrella:before{content:"\f0e9"}.icon-clipboard:before,.icon-paste:before{content:"\f0ea"}.icon-lightbulb-o:before{content:"\f0eb"}.icon-exchange:before{content:"\f0ec"}.icon-cloud-download:before{content:"\f0ed"}.icon-cloud-upload:before{content:"\f0ee"}.icon-user-md:before{content:"\f0f0"}.icon-stethoscope:before{content:"\f0f1"}.icon-suitcase:before{content:"\f0f2"}.icon-bell-o:before{content:"\f0a2"}.icon-coffee:before{content:"\f0f4"}.icon-cutlery:before{content:"\f0f5"}.icon-file-text-o:before{content:"\f0f6"}.icon-building-o:before{content:"\f0f7"}.icon-hospital-o:before{content:"\f0f8"}.icon-ambulance:before{content:"\f0f9"}.icon-medkit:before{content:"\f0fa"}.icon-fighter-jet:before{content:"\f0fb"}.icon-beer:before{content:"\f0fc"}.icon-h-square:before{content:"\f0fd"}.icon-plus-square:before{content:"\f0fe"}.icon-angle-double-left:before{content:"\f100"}.icon-angle-double-right:before{content:"\f101"}.icon-angle-double-up:before{content:"\f102"}.icon-angle-double-down:before{content:"\f103"}.icon-angle-left:before{content:"\f104"}.icon-angle-right:before{content:"\f105"}.icon-angle-up:before{content:"\f106"}.icon-angle-down:before{content:"\f107"}.icon-desktop:before{content:"\f108"}.icon-laptop:before{content:"\f109"}.icon-tablet:before{content:"\f10a"}.icon-mobile-phone:before,.icon-mobile:before{content:"\f10b"}.icon-circle-o:before{content:"\f10c"}.icon-quote-left:before{content:"\f10d"}.icon-quote-right:before{content:"\f10e"}.icon-spinner:before{content:"\f110"}.icon-circle:before{content:"\f111"}.icon-mail-reply:before,.icon-reply:before{content:"\f112"}.icon-github-alt:before{content:"\f113"}.icon-folder-o:before{content:"\f114"}.icon-folder-open-o:before{content:"\f115"}.icon-smile-o:before{content:"\f118"}.icon-frown-o:before{content:"\f119"}.icon-meh-o:before{content:"\f11a"}.icon-gamepad:before{content:"\f11b"}.icon-keyboard-o:before{content:"\f11c"}.icon-flag-o:before{content:"\f11d"}.icon-flag-checkered:before{content:"\f11e"}.icon-terminal:before{content:"\f120"}.icon-code:before{content:"\f121"}.icon-mail-reply-all:before,.icon-reply-all:before{content:"\f122"}.icon-star-half-empty:before,.icon-star-half-full:before,.icon-star-half-o:before{content:"\f123"}.icon-location-arrow:before{content:"\f124"}.icon-crop:before{content:"\f125"}.icon-code-fork:before{content:"\f126"}.icon-chain-broken:before,.icon-unlink:before{content:"\f127"}.icon-question:before{content:"\f128"}.icon-info:before{content:"\f129"}.icon-exclamation:before{content:"\f12a"}.icon-superscript:before{content:"\f12b"}.icon-subscript:before{content:"\f12c"}.icon-eraser:before{content:"\f12d"}.icon-puzzle-piece:before{content:"\f12e"}.icon-microphone:before{content:"\f130"}.icon-microphone-slash:before{content:"\f131"}.icon-shield:before{content:"\f132"}.icon-calendar-o:before{content:"\f133"}.icon-fire-extinguisher:before{content:"\f134"}.icon-rocket:before{content:"\f135"}.icon-maxcdn:before{content:"\f136"}.icon-chevron-circle-left:before{content:"\f137"}.icon-chevron-circle-right:before{content:"\f138"}.icon-chevron-circle-up:before{content:"\f139"}.icon-chevron-circle-down:before{content:"\f13a"}.icon-html5:before{content:"\f13b"}.icon-css3:before{content:"\f13c"}.icon-anchor:before{content:"\f13d"}.icon-unlock-alt:before{content:"\f13e"}.icon-bullseye:before{content:"\f140"}.icon-ellipsis-h:before{content:"\f141"}.icon-ellipsis-v:before{content:"\f142"}.icon-rss-square:before{content:"\f143"}.icon-play-circle:before{content:"\f144"}.icon-ticket:before{content:"\f145"}.icon-minus-square:before{content:"\f146"}.icon-minus-square-o:before{content:"\f147"}.icon-level-up:before{content:"\f148"}.icon-level-down:before{content:"\f149"}.icon-check-square:before{content:"\f14a"}.icon-pencil-square:before{content:"\f14b"}.icon-external-link-square:before{content:"\f14c"}.icon-share-square:before{content:"\f14d"}.icon-compass:before{content:"\f14e"}.icon-caret-square-o-down:before,.icon-toggle-down:before{content:"\f150"}.icon-caret-square-o-up:before,.icon-toggle-up:before{content:"\f151"}.icon-caret-square-o-right:before,.icon-toggle-right:before{content:"\f152"}.icon-eur:before,.icon-euro:before{content:"\f153"}.icon-gbp:before{content:"\f154"}.icon-dollar:before,.icon-usd:before{content:"\f155"}.icon-inr:before,.icon-rupee:before{content:"\f156"}.icon-cny:before,.icon-jpy:before,.icon-rmb:before,.icon-yen:before{content:"\f157"}.icon-rouble:before,.icon-rub:before,.icon-ruble:before{content:"\f158"}.icon-krw:before,.icon-won:before{content:"\f159"}.icon-bitcoin:before,.icon-btc:before{content:"\f15a"}.icon-file:before{content:"\f15b"}.icon-file-text:before{content:"\f15c"}.icon-sort-alpha-asc:before{content:"\f15d"}.icon-sort-alpha-desc:before{content:"\f15e"}.icon-sort-amount-asc:before{content:"\f160"}.icon-sort-amount-desc:before{content:"\f161"}.icon-sort-numeric-asc:before{content:"\f162"}.icon-sort-numeric-desc:before{content:"\f163"}.icon-thumbs-up:before{content:"\f164"}.icon-thumbs-down:before{content:"\f165"}.icon-youtube-square:before{content:"\f166"}.icon-youtube:before{content:"\f167"}.icon-xing:before{content:"\f168"}.icon-xing-square:before{content:"\f169"}.icon-youtube-play:before{content:"\f16a"}.icon-dropbox:before{content:"\f16b"}.icon-stack-overflow:before{content:"\f16c"}.icon-instagram:before{content:"\f16d"}.icon-flickr:before{content:"\f16e"}.icon-adn:before{content:"\f170"}.icon-bitbucket:before{content:"\f171"}.icon-bitbucket-square:before{content:"\f172"}.icon-tumblr:before{content:"\f173"}.icon-tumblr-square:before{content:"\f174"}.icon-long-arrow-down:before{content:"\f175"}.icon-long-arrow-up:before{content:"\f176"}.icon-long-arrow-left:before{content:"\f177"}.icon-long-arrow-right:before{content:"\f178"}.icon-apple:before{content:"\f179"}.icon-windows:before{content:"\f17a"}.icon-android:before{content:"\f17b"}.icon-linux:before{content:"\f17c"}.icon-dribbble:before{content:"\f17d"}.icon-skype:before{content:"\f17e"}.icon-foursquare:before{content:"\f180"}.icon-trello:before{content:"\f181"}.icon-female:before{content:"\f182"}.icon-male:before{content:"\f183"}.icon-gittip:before{content:"\f184"}.icon-sun-o:before{content:"\f185"}.icon-moon-o:before{content:"\f186"}.icon-archive:before{content:"\f187"}.icon-bug:before{content:"\f188"}.icon-vk:before{content:"\f189"}.icon-weibo:before{content:"\f18a"}.icon-renren:before{content:"\f18b"}.icon-pagelines:before{content:"\f18c"}.icon-stack-exchange:before{content:"\f18d"}.icon-arrow-circle-o-right:before{content:"\f18e"}.icon-arrow-circle-o-left:before{content:"\f190"}.icon-caret-square-o-left:before,.icon-toggle-left:before{content:"\f191"}.icon-dot-circle-o:before{content:"\f192"}.icon-wheelchair:before{content:"\f193"}.icon-vimeo-square:before{content:"\f194"}.icon-try:before,.icon-turkish-lira:before{content:"\f195"}.icon-plus-square-o:before{content:"\f196"}.icon-space-shuttle:before{content:"\f197"}.icon-slack:before{content:"\f198"}.icon-envelope-square:before{content:"\f199"}.icon-wordpress:before{content:"\f19a"}.icon-openid:before{content:"\f19b"}.icon-bank:before,.icon-institution:before,.icon-university:before{content:"\f19c"}.icon-graduation-cap:before,.icon-mortar-board:before{content:"\f19d"}.icon-yahoo:before{content:"\f19e"}.icon-google:before{content:"\f1a0"}.icon-reddit:before{content:"\f1a1"}.icon-reddit-square:before{content:"\f1a2"}.icon-stumbleupon-circle:before{content:"\f1a3"}.icon-stumbleupon:before{content:"\f1a4"}.icon-delicious:before{content:"\f1a5"}.icon-digg:before{content:"\f1a6"}.icon-pied-piper-square:before,.icon-pied-piper:before{content:"\f1a7"}.icon-pied-piper-alt:before{content:"\f1a8"}.icon-drupal:before{content:"\f1a9"}.icon-joomla:before{content:"\f1aa"}.icon-language:before{content:"\f1ab"}.icon-fax:before{content:"\f1ac"}.icon-building:before{content:"\f1ad"}.icon-child:before{content:"\f1ae"}.icon-paw:before{content:"\f1b0"}.icon-spoon:before{content:"\f1b1"}.icon-cube:before{content:"\f1b2"}.icon-cubes:before{content:"\f1b3"}.icon-behance:before{content:"\f1b4"}.icon-behance-square:before{content:"\f1b5"}.icon-steam:before{content:"\f1b6"}.icon-steam-square:before{content:"\f1b7"}.icon-recycle:before{content:"\f1b8"}.icon-automobile:before,.icon-car:before{content:"\f1b9"}.icon-cab:before,.icon-taxi:before{content:"\f1ba"}.icon-tree:before{content:"\f1bb"}.icon-spotify:before{content:"\f1bc"}.icon-deviantart:before{content:"\f1bd"}.icon-soundcloud:before{content:"\f1be"}.icon-database:before{content:"\f1c0"}.icon-file-pdf-o:before{content:"\f1c1"}.icon-file-word-o:before{content:"\f1c2"}.icon-file-excel-o:before{content:"\f1c3"}.icon-file-powerpoint-o:before{content:"\f1c4"}.icon-file-image-o:before,.icon-file-photo-o:before,.icon-file-picture-o:before{content:"\f1c5"}.icon-file-archive-o:before,.icon-file-zip-o:before{content:"\f1c6"}.icon-file-audio-o:before,.icon-file-sound-o:before{content:"\f1c7"}.icon-file-movie-o:before,.icon-file-video-o:before{content:"\f1c8"}.icon-file-code-o:before{content:"\f1c9"}.icon-vine:before{content:"\f1ca"}.icon-codepen:before{content:"\f1cb"}.icon-jsfiddle:before{content:"\f1cc"}.icon-life-bouy:before,.icon-life-ring:before,.icon-life-saver:before,.icon-support:before{content:"\f1cd"}.icon-circle-o-notch:before{content:"\f1ce"}.icon-ra:before,.icon-rebel:before{content:"\f1d0"}.icon-empire:before,.icon-ge:before{content:"\f1d1"}.icon-git-square:before{content:"\f1d2"}.icon-git:before{content:"\f1d3"}.icon-hacker-news:before{content:"\f1d4"}.icon-tencent-weibo:before{content:"\f1d5"}.icon-qq:before{content:"\f1d6"}.icon-wechat:before,.icon-weixin:before{content:"\f1d7"}.icon-paper-plane:before,.icon-send:before{content:"\f1d8"}.icon-paper-plane-o:before,.icon-send-o:before{content:"\f1d9"}.icon-history:before{content:"\f1da"}.icon-circle-thin:before{content:"\f1db"}.icon-header:before{content:"\f1dc"}.icon-paragraph:before{content:"\f1dd"}.icon-sliders:before{content:"\f1de"}.icon-share-alt:before{content:"\f1e0"}.icon-share-alt-square:before{content:"\f1e1"}.icon-bomb:before{content:"\f1e2"}.tree-context:before,.tree-folder:before,.tree-new-category>em>button:before,.tree-new-chunk>em>button:before,.tree-new-plugin>em>button:before,.tree-new-resource>em>button:before,.tree-new-snippet>em>button:before,.tree-new-static-resource>em>button:before,.tree-new-symlink>em>button:before,.tree-new-template>em>button:before,.tree-new-tv>em>button:before,.tree-new-weblink>em>button:before,.tree-resource:before,.tree-static-resource:before,.tree-symlink:before,.tree-trash>em>button:before,.tree-weblink:before,.x-btn em.x-btn-split:before,.x-btn-icon.arrow_down button:before,.x-btn-icon.arrow_up button:before,.x-btn-icon.refresh button:before,.x-form-invalid-msg:before,.x-tbar-loading:before,.x-tbar-page-first:before,.x-tbar-page-last:before,.x-tbar-page-next:before,.x-tbar-page-prev:before,.x-tree-arrows .x-tree-elbow-end-minus:before,.x-tree-arrows .x-tree-elbow-end-plus:before,.x-tree-arrows .x-tree-elbow-minus:before,.x-tree-arrows .x-tree-elbow-plus:before,.x-tree-node-collapsed .tree-folder:before,.x-tree-node-expanded .tree-folder:before{display:inline-block;font-family:FontAwesome;font-style:normal;font-weight:400;line-height:1;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.x-btn-icon.arrow_down button:before,.x-btn-icon.arrow_up button:before,.x-btn-icon.refresh button:before,.x-tbar-loading:before,.x-tbar-page-first:before,.x-tbar-page-last:before,.x-tbar-page-next:before,.x-tbar-page-prev:before{position:absolute;top:0;left:0;right:0;bottom:0;line-height:100%;width:100%;height:100%;font-size:14px;color:inherit;text-align:center}#modx-tv-tabs .lt-ie8{*zoom:1}#modx-tv-tabs:after,#modx-tv-tabs:before{content:" ";display:table}#modx-tv-tabs:after{clear:both}.ext-el-mask{background-color:silver;z-index:10}.ext-el-mask-msg{-webkit-box-shadow:0 1px 3px #575757;box-shadow:0 1px 3px #575757;background-color:#FAFAFA;background-image:none;border-color:#A7A7A7;border-radius:5px;padding:5px;z-index:10}.ext-el-mask-msg div{background-color:transparent;border:0 none;color:#444;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-mask-loading div{background-color:#fbfbfb;background-image:url(../images/modx-theme/grid/loading.gif)}.x-item-disabled{color:gray}.x-item-disabled *{color:gray!important}.x-splitbar-proxy{background-color:#aaa}.x-color-palette a{border-color:#fff}.x-color-palette a.x-color-palette-sel,.x-color-palette a:hover{background-color:#ebebeb;border-color:#b4b4b4}.x-color-palette em{border-color:#aca899}.x-ie-shadow{background-color:#777}.x-shadow .xsbc,.x-shadow .xsbl,.x-shadow .xsbr,.x-shadow .xsmc,.x-shadow .xsml,.x-shadow .xsmr,.x-shadow .xstc,.x-shadow .xstl,.x-shadow .xstr{background-image:none}.loading-indicator{background-image:url(../images/modx-theme/grid/loading.gif);font-size:11px}.x-spotlight{background-color:#ccc}.x-panel-bbar .x-toolbar,.x-panel-tbar .x-toolbar{overflow:hidden}.x-panel-bbar{padding-top:10px}.x-panel-tbar{padding-bottom:2px}.ext-ie7 .x-plain-body{position:relative}.ext-ie7 .x-toolbar-ct{width:auto}.x-toolbar{background-color:#F7F7F7;background-image:none;border-color:#DFDFDF}.x-toolbar div,.x-toolbar input,.x-toolbar label,.x-toolbar select,.x-toolbar span,.x-toolbar td{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-toolbar .x-item-disabled,.x-toolbar .x-item-disabled *{color:gray}.x-toolbar em.x-btn-split{background-image:url(../images/modx-theme/button/s-arrow-noline.gif)}.x-toolbar em.x-btn-split-bottom{background-image:url(../images/modx-theme/button/s-arrow-b-noline.gif)}.x-toolbar .x-btn-click em.x-btn-split-bottom,.x-toolbar .x-btn-menu-active em.x-btn-split-bottom,.x-toolbar .x-btn-over em.x-btn-split-bottom,.x-toolbar .x-btn-pressed em.x-btn-split-bottom{background-image:url(../images/modx-theme/button/s-arrow-bo.gif)}.ext-ie .x-toolbar-cell .x-form-field-wrap{height:30px}.x-tbar-page-last{background:none!important;position:relative}.x-tbar-page-last:before{content:"\f04e";top:1px;left:1px;right:auto}.x-tbar-page-next{background:none!important;position:relative}.x-tbar-page-next:before{content:"\f0da";font-size:18px;line-height:110%;left:1px;right:auto}.x-tbar-page-prev{background:none!important;position:relative}.x-tbar-page-prev:before{content:"\f0d9";font-size:18px;line-height:110%;left:auto;right:1px}.x-tbar-loading{background:none!important;position:relative}.x-tbar-loading:before{content:"\f01e";top:1px;bottom:auto}.x-tbar-page-first{background:none!important;position:relative}.x-tbar-page-first:before{content:"\f04a";top:1px;left:auto;right:1px}.x-paging-info{color:#444}.x-toolbar-more-icon{background-image:url(../images/modx-theme/toolbar/more.gif)!important}.x-statusbar .x-status-busy{background-image:url(../images/modx-theme/grid/loading.gif)}.x-statusbar .x-status-text-panel{border-color:#DFDFDF #fff #fff #DFDFDF}.x-resizable-handle-southeast{bottom:1px;right:1px}.x-resizable-over .x-resizable-handle-east,.x-resizable-over .x-resizable-handle-west,.x-resizable-pinned .x-resizable-handle-east,.x-resizable-pinned .x-resizable-handle-west{background-image:url(../images/modx-theme/sizer/e-handle.gif)}.x-resizable-over .x-resizable-handle-north,.x-resizable-over .x-resizable-handle-south,.x-resizable-pinned .x-resizable-handle-north,.x-resizable-pinned .x-resizable-handle-south{background-image:url(../images/modx-theme/sizer/s-handle.gif)}.x-resizable-over .x-resizable-handle-southeast,.x-resizable-pinned .x-resizable-handle-southeast{background-image:url(../images/modx-theme/sizer/se-handle.gif)}.x-resizable-over .x-resizable-handle-northwest,.x-resizable-pinned .x-resizable-handle-northwest{background-image:url(../images/modx-theme/sizer/nw-handle.gif)}.x-resizable-over .x-resizable-handle-northeast,.x-resizable-pinned .x-resizable-handle-northeast{background-image:url(../images/modx-theme/sizer/ne-handle.gif)}.x-resizable-over .x-resizable-handle-southwest,.x-resizable-pinned .x-resizable-handle-southwest{background-image:url(../images/modx-theme/sizer/sw-handle.gif)}.x-resizable-proxy{border-color:#575757}.x-resizable-overlay{background-color:#fff}.x-grid3{background-color:transparent;background-image:none;border-radius:3px;overflow:hidden;padding:0}.x-grid-panel .x-panel-mc .x-panel-body{border:0 none}.x-grid3-hd-row td,.x-grid3-row td,.x-grid3-summary-row td{font:400 12px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-grid3-row td,.x-grid3-summary-row td{padding-left:0}.x-grid3-hd-row td{border-left:1px solid #e4e9ee;border-right:none}.x-grid3-hd-row td.x-grid3-cell-first{border-left:0 none}.x-grid3-hd-row td.x-grid3-cell-last{border-right:0 none}.x-grid-row-loading{background-color:#fff;background-image:url(../images/modx-theme/shared/loading-balls.gif)}.x-grid3-row{border-color:#FFF #FFF #EFEFEF}.x-grid3-row-expanded .x-grid3-row-body{color:#888;margin:0 2px 0 -20px;padding:0 25px 15px;word-wrap:break-word}.x-grid3-row-expanded .x-grid3-row-body .desc{word-wrap:break-word}.x-grid3-row-alt{background-color:#f5f6f9}.x-panel-body-noheader .x-grid3-row{border-color:transparent}.x-panel-body-noheader .x-grid3-row-alt{border-bottom:1px solid #EAEAEA;border-top:1px solid #EAEAEA}.x-panel-body-noheader .x-grid3-row-alt .x-grid3-row-table{border-top:1px solid transparent}.x-grid3-row-over{background-color:#E0E8EF;background-image:0 none;border-bottom:1px solid #D1D9DF}.x-grid3-resize-marker,.x-grid3-resize-proxy{background-color:#777}.x-grid3-header{background:#c9d4e0;border-bottom:1px solid #444;padding:0}.x-panel-body-noheader .x-grid3-header{border:none}.x-grid3-header-offset{padding-left:0}.x-grid3-header .x-grid3-hd-row td{color:#696969;font-weight:700}.x-grid3-header-pop{border-left-color:#DFDFDF}.x-grid3-header-pop-inner{background-image:url(../images/modx-theme/grid/hd-pop.gif);border-left-color:#eee}td.sort-asc,td.sort-desc,td.x-grid3-hd-menu-open,td.x-grid3-hd-over{border-left-color:#e4e9ee;background:#9fb4c8}td.sort-asc .x-grid3-hd-inner,td.sort-desc .x-grid3-hd-inner,td.x-grid3-hd-menu-open .x-grid3-hd-inner,td.x-grid3-hd-over .x-grid3-hd-inner{color:#fff}.sort-asc .x-grid3-sort-icon{background-image:url(../images/modx-theme/grid/sort_asc.gif)}.sort-desc .x-grid3-sort-icon{background-image:url(../images/modx-theme/grid/sort_desc.gif)}.x-panel-body-noheader .x-grid3-body{background-color:#fff}.x-grid3-cell-text,.x-grid3-hd-text{color:#000}.x-grid3-split{background-image:url(../images/modx-theme/grid/grid-split.gif)}.x-grid3-hd-text{color:#464646}.x-dd-drag-proxy .x-grid3-hd-inner{background-color:#f2f2f2;background-image:url(../images/modx-theme/grid/grid3-hrow-over.gif);border-color:#c8c8c8}.col-move-top{background-image:url(../images/modx-theme/grid/col-move-top.gif)}.col-move-bottom{background-image:url(../images/modx-theme/grid/col-move-bottom.gif)}.x-grid3-row-selected{background-color:#f0f0f0;background-image:none;border-bottom:1px solid #e4e4e4!important;border-top:1px solid #e4e4e4!important;color:#565550}.x-grid3-cell-selected{background-color:#E0EAEF!important;color:#000}.x-grid3-cell-selected span{color:#000!important}.x-grid3-cell-selected .x-grid3-cell-text{color:#000}.x-grid3-locked .x-grid3-row-selected td.x-grid3-row-marker,.x-grid3-locked td.x-grid3-row-marker{background-color:#d7d9df!important;background-image:url(../images/modx-theme/grid/grid-hrow.gif)!important;border-right-color:#9c9c9c!important;border-top-color:#fff;color:#000}.x-grid3-locked .x-grid3-row-selected td.x-grid3-row-marker div,.x-grid3-locked td.x-grid3-row-marker div{color:#464646!important}.x-grid3-dirty-cell{background-image:url(../images/modx-theme/grid/dirty.gif)}.x-grid3-bottombar,.x-grid3-topbar{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-grid3-bottombar .x-toolbar{border-top-color:#bcbcbc}.x-props-grid .x-grid3-td-name .x-grid3-cell-inner{background-image:url(../images/modx-theme/grid/grid3-special-col-bg.gif)!important;color:#000!important}.x-grid3-hd-inner{font-weight:700}.ext-ie .x-grid3-hd-inner{width:auto}.x-grid3-cell-inner,.x-grid3-hd-inner{padding:13px 18px 13px 5px}.x-props-grid .x-grid3-body .x-grid3-td-name{background-color:#fff!important;border-right-color:#eee}.xg-hmenu-sort-asc .x-menu-item-icon{background-image:url(../images/modx-theme/grid/hmenu-asc.gif)}.xg-hmenu-sort-desc .x-menu-item-icon{background-image:url(../images/modx-theme/grid/hmenu-desc.gif)}.xg-hmenu-lock .x-menu-item-icon{background-image:url(../images/modx-theme/grid/hmenu-lock.gif)}.xg-hmenu-unlock .x-menu-item-icon{background-image:url(../images/modx-theme/grid/hmenu-unlock.gif)}.x-grid3-hd-btn{background-color:#d8d8d8;background-image:url(../images/modx-theme/grid/grid3-hd-btn.gif)}.x-grid3-body .x-grid3-td-expander{background-image:none}.x-grid3-row-collapsed .x-grid3-row-expander{background-position:5px 10px;height:30px;margin-top:6px}.x-grid3-row-expanded .x-grid3-row-expander{background-position:-31px 10px;height:30px;margin-top:6px}.x-grid3-row-expander{background-image:url(../images/modx-theme/grid/row-expand-sprite.png)}.x-grid3-body .x-grid3-td-checker{padding:10px 0 0}.x-grid3-hd-checker,.x-grid3-row-checker{background-image:url(../images/modx-theme/grid/row-check-sprite.gif);cursor:pointer}.x-grid3-body .x-grid3-td-numberer{background-color:#E5E5E5;border-bottom:1px solid #DADADA;border-right:1px solid #DADADA!important}.x-grid3-body .x-grid3-td-numberer .x-grid3-cell-inner{color:#444;padding-left:10px;padding-top:10px!important}.x-grid3-body .x-grid3-td-row-icon{background-image:url(../images/modx-theme/grid/grid3-special-col-bg.gif)}.x-grid3-body .x-grid3-row-selected .x-grid3-td-checker,.x-grid3-body .x-grid3-row-selected .x-grid3-td-expander,.x-grid3-body .x-grid3-row-selected .x-grid3-td-numberer{background-image:none}.x-grid3-check-col{background-image:url(../images/modx-theme/menu/unchecked.gif);cursor:pointer;margin-top:10px}.x-grid3-check-col-on{background-image:url(../images/modx-theme/menu/checked.gif);cursor:pointer;margin-top:10px}.x-grid-group,.x-grid-group-body,.x-grid-group-hd{zoom:1}.x-grid-group-hd{border-bottom-color:#53595f}.x-grid-group-hd div.x-grid-group-title{background:transparent url(../images/modx-theme/grid/group-collapse.png) no-repeat scroll 3px 10px;color:#53595f;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700;padding:10px 4px 6px 24px}.x-grid-group-collapsed .x-grid-group-hd div.x-grid-group-title{background-image:url(../images/modx-theme/grid/group-expand.png)}.x-group-by-icon{background-image:url(../images/modx-theme/grid/group-by.gif)}.x-cols-icon{background-image:url(../images/modx-theme/grid/columns.gif)}.x-show-groups-icon{background-image:url(../images/modx-theme/grid/group-by.gif)}.x-grid-empty{color:gray;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;text-align:center}.x-grid-with-col-lines .x-grid3-row td.x-grid3-cell{border-right-color:#ededed}.x-grid-with-col-lines .x-grid3-row{border-left:0 none;border-top:0 none}.x-grid-with-col-lines .x-grid3-row-selected{border-top-color:#e4e4e4}.x-dd-drag-ghost{background-color:#fff;border-color:#ddd #bbb #bbb #ddd;color:#000;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-dd-drop-nodrop .x-dd-drop-icon{background-image:url(../images/modx-theme/dd/drop-no.gif)}.x-dd-drop-ok .x-dd-drop-icon{background-image:url(../images/modx-theme/dd/drop-yes.gif)}.x-dd-drop-ok-add .x-dd-drop-icon{background-image:url(../images/modx-theme/dd/drop-add.gif)}.x-view-selector{background-color:#d8d8d8;border-color:#8d8d8d}.x-date-picker{background-color:#F5F5F5;border-color:#E4E4E4}.x-date-left,.x-date-middle,.x-date-right{background-image:none;color:#fff;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700}.x-date-middle .x-btn{-moz-box-shadow:none;background-color:transparent;background-image:none;border:0 none;-webkit-box-shadow:none;box-shadow:none;color:#575757}.x-date-middle .x-btn-over{border:0 none}.x-date-middle .x-btn .x-btn-text{color:#575757;font-weight:700}.x-date-right a{background-image:url(../images/modx-theme/shared/right-btn.gif)}.x-date-left a{background-image:url(../images/modx-theme/shared/left-btn.gif)}.x-date-inner th{background-color:#F5F5F5;background-image:none;border-bottom-color:#DFDFDF;color:#676767;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700}.x-date-inner td{background-color:#FAFAFA;border:0 none;padding:1px}.x-date-inner a{color:#878787;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700}.x-date-inner .x-date-active{color:#000}.x-date-inner .x-date-selected a{background-color:#717F37;background-image:none;border-color:#fff}.x-date-inner .x-date-today a{border-color:#717F37}.x-date-inner .x-date-active span,.x-date-inner .x-date-selected span{font-weight:700}.x-date-inner .x-date-selected span{color:#FAFAFA}.x-date-inner .x-date-nextday a,.x-date-inner .x-date-prevday a{color:#D0D0D0}.x-date-bottom{background-color:#f5f5f5;background-image:none;border-top-color:#DFDFDF}.x-date-inner .x-date-disabled a:hover,.x-date-inner a:hover{background-color:#DFDFDF;color:#000}.x-date-inner .x-date-disabled a{background-color:#eee;color:#bbb}.x-date-mmenu{background-color:#eee!important}.x-date-mmenu .x-menu-item{color:#000;font-size:11px}.x-date-mp{background-color:#fff}.x-date-mp td{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-date-mp-btns button{background-color:#373737;border-color:#686868 #101010 #101010 #686868;color:#fff;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-date-mp-btns{background-color:#ebebeb;background-image:url(../images/modx-theme/shared/glass-bg.gif)}.x-date-mp-btns td{border-top-color:#DFDFDF}td.x-date-mp-month a,td.x-date-mp-year a{color:#464646}td.x-date-mp-month a:hover,td.x-date-mp-year a:hover{background-color:#DFDFDF;color:#464646}td.x-date-mp-sel a{background-color:#ebebeb;background-image:url(../images/modx-theme/shared/glass-bg.gif);border-color:#afafaf}.x-date-mp-ybtn a{background-image:url(../images/modx-theme/panel/tool-sprites.gif)}td.x-date-mp-sep{border-right-color:#DFDFDF}.x-tip{background:#575757;border-radius:3px;padding:5px}.x-tip .x-tip-close{background-image:url(../images/modx-theme/qtip/close.gif)}.x-tip .x-tip-bc,.x-tip .x-tip-bl,.x-tip .x-tip-br,.x-tip .x-tip-ml,.x-tip .x-tip-mr,.x-tip .x-tip-tc,.x-tip .x-tip-tl,.x-tip .x-tip-tr{background-image:none}.x-tip .x-tip-mc{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-tip .x-tip-ml{background-color:transparent}.x-tip .x-tip-header-text{color:#f0f0f0;font:400 13px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-tip .x-tip-body{color:#f0f0f0;font:400 12px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-tip img{min-width:240px;max-width:100%;max-width:66vw}.x-form-invalid-tip .x-tip-bc,.x-form-invalid-tip .x-tip-bl,.x-form-invalid-tip .x-tip-br,.x-form-invalid-tip .x-tip-ml,.x-form-invalid-tip .x-tip-mr,.x-form-invalid-tip .x-tip-tc,.x-form-invalid-tip .x-tip-tl,.x-form-invalid-tip .x-tip-tr{background-image:url(../images/modx-theme/form/error-tip-corners.gif)}.x-form-invalid-tip .x-tip-body{background-image:url(../images/modx-theme/form/exclamation.gif)}.x-tip-anchor{background-image:url(../images/modx-theme/qtip/tip-anchor-sprite.gif)}.x-menu{background-color:#fff;border:1px solid #bbb;border-radius:3px;-webkit-box-shadow:0 0 5px rgba(0,0,0,.25);box-shadow:0 0 5px rgba(0,0,0,.25)}.x-menu-list{padding:0}.x-menu-list li{border:0;margin:0;padding:0}.x-menu-list li:first-child{margin-top:3px}.x-menu-list li:last-child{margin-bottom:3px}.x-menu-list li a.x-menu-item{color:#555;font-size:13px;padding:5px 20px 5px 15px}.x-menu-list li.x-menu-item-active{background-color:#30759c}.x-menu-list li.x-menu-item-active a{color:#fff}.x-menu-floating{border-color:#C7C7C7}.x-menu-nosep{background-image:none}.x-menu-list-item{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-menu-item-arrow{background-image:url(../images/modx-theme/menu/menu-parent.gif)}.x-menu-sep{background-color:#ccc;border-bottom:none;margin:2px 0}.x-menu-item-active a.x-menu-item{border:0 none;margin:0}.x-menu-check-item .x-menu-item-icon{background-image:url(../images/modx-theme/menu/unchecked.gif)}.x-menu-item-checked .x-menu-item-icon{background-image:url(../images/modx-theme/menu/checked.gif)}.x-menu-item-checked .x-menu-group-item .x-menu-item-icon{background-image:url(../images/modx-theme/menu/group-checked.gif)}.x-menu-group-item .x-menu-item-icon{background-image:none}.x-menu-plain{background-color:#fff!important}.x-menu .x-date-picker{border-color:#DFDFDF}.x-cycle-menu .x-menu-item-checked{background-color:#DFDFDF;border-color:#b9b9b9!important}.x-menu-scroller-top{background-image:url(../images/modx-theme/layout/mini-top.gif)}.x-menu-scroller-bottom{background-image:url(../images/modx-theme/layout/mini-bottom.gif)}.x-box-ml,.x-box-tl{background-image:none;color:#393939;font:400 13px/1.4 "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700}.x-box-mc p{font-weight:400;margin-bottom:5px}.x-box-tl{background-color:rgba(250,250,250,.8);border-left:1px solid #DEDEDE;border-right:1px solid #DEDEDE;border-top:1px solid #DEDEDE}.x-box-ml{background-color:rgba(250,250,250,.8);border-left:1px solid #DEDEDE;border-right:1px solid #DEDEDE}.x-box-bl{background-color:#eee;background-color:rgba(230,230,230,.8);border-bottom:1px solid #DEDEDE;border-left:1px solid #DEDEDE;border-right:1px solid #DEDEDE}.x-box-mc h3{font-size:14px;font-weight:700}.x-box-bc,.x-box-bl,.x-box-blue .x-box-bl,.x-box-blue .x-box-br,.x-box-blue .x-box-tl,.x-box-blue .x-box-tr,.x-box-br,.x-box-mr{background-image:none}.x-box-blue .x-box-bc,.x-box-blue .x-box-mc,.x-box-blue .x-box-tc{background-image:url(../images/modx-theme/box/tb-gray.gif)}.x-box-blue .x-box-mc{background-color:#d8d8d8}.x-box-blue .x-box-mc h3{color:#363636}.x-box-blue .x-box-ml{background-image:url(../images/modx-theme/box/l-gray.gif)}.x-box-blue .x-box-mr{background-image:url(../images/modx-theme/box/r-gray.gif)}#x-debug-browser .x-tree .x-tree-node a span{color:#333;font-family:"Courier New",Courier,monospace;font-size:11px}#x-debug-browser .x-tree a i{color:#ff4545;font-style:normal}#x-debug-browser .x-tree a em{color:#999}#x-debug-browser .x-tree .x-tree-node .x-tree-selected a span{background-color:#d8d8d8}.x-combo-list{background-color:#fff;border-color:#e4e4e4;border-radius:0 0 5px 5px}.x-combo-list-inner{background-color:#fff}.x-combo-list-hd{background-image:url(../images/modx-theme/layout/panel-title-light-bg.gif);border-bottom-color:#bcbcbc;color:#464646}.x-resizable-pinned .x-combo-list-inner{border-bottom-color:transparent}.x-combo-list-item{border:none;padding:5px;color:#444}.x-combo-list .x-combo-selected{background-color:#e1ecf1;border:0 none!important}.x-combo-list .x-toolbar{border-top-color:#bcbcbc}.x-combo-list-small{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-panel-bwrap{overflow:visible}.x-panel-body{background-color:#fff;border:0;overflow:visible}.x-panel-noborder{border:none}.x-panel-bbar .x-toolbar{background-color:transparent;border:0 none}.x-panel-mc .x-panel-tbar .x-toolbar,.x-panel-tbar-noheader .x-toolbar{border:0 none}.x-panel-tbar .x-toolbar{background-color:transparent;border:0 none;padding:5px 4px}.x-panel-mc .x-panel-tbar .x-toolbar{background-image:none}.x-panel-tbar-noheader .x-toolbar{background-color:transparent;background-image:none;border:0 none;padding:5px 0}.x-panel-mc .x-panel-tbar .x-toolbar{background-color:#F5F5F5;border-bottom:0 none;padding:5px 0}.x-grid-panel .x-panel-body{background-color:#F5F5F5;border:0 none}.x-grid-panel .x-panel-body-noheader{background-color:transparent;border:0 none;padding:0!important}.x-panel-tl .x-panel-header{color:#6A6A6A;font:400 12px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700;text-shadow:0 1px 0 #FAFAFA}.x-panel-tl .x-panel-icon,.x-window-tl .x-panel-icon{background-position:0 8px}.x-panel-tc{background-image:none}.x-panel-bl,.x-panel-br,.x-panel-tl,.x-panel-tr{background-image:none;border-bottom-color:#DFDFDF}.x-panel-bc{background-image:none}.x-panel-tc{background-color:#F5F5F5}.x-panel-tl{border-color:#E3E3E3;border-style:solid solid none;border-width:1px 1px 0}.x-panel-tl .x-panel-header{border-bottom:1px solid #E4E4E4;padding:10px 0}.x-panel-bc .x-panel-footer{padding-bottom:0}.x-panel-btns{background-color:transparent;border-top:1px solid #FAFAFA}.x-panel-mc{background-color:#F5F5F5;border-bottom:1px solid #DFDFDF;border-top:1px solid #FAFAFA;padding:10px 5px}.x-panel-bl,.x-panel-ml,.x-panel-tl{background-color:#F5F5F5;padding-left:8px}.x-panel-ml,.x-panel-mr{background-image:none}.x-panel-bl{border-color:#E3E3E3;border-style:none solid solid;border-width:0 1px 1px;padding-bottom:8px}.x-window-dlg .x-msg-box-wait{background-image:url(../images/modx-theme/grid/loading.gif)}.x-window-dlg .ext-mb-info{background-image:url(../images/modx-theme/window/icon-info.gif)}.x-window-dlg .ext-mb-warning{background-image:url(../images/modx-theme/window/icon-warning.gif)}.x-window-dlg .ext-mb-question{background-image:url(../images/modx-theme/window/icon-question.gif)}.x-window-dlg .ext-mb-error{background-image:url(../images/modx-theme/window/icon-error.gif)}.x-panel-ml{border-left:1px solid #E3E3E3;border-right:1px solid #E3E3E3}.x-panel-mr{padding-right:8px}.x-panel-br,.x-panel-mr,.x-panel-tr{background-color:#f7f7f7}.x-tool{background-image:url(../images/modx-theme/panel/tool-sprites.png);height:16px;margin:1px 2px 0 0;width:16px}.x-accordion-hd .x-tool-toggle,.x-tool-toggle{background-position:left -48px}.x-accordion-hd .x-tool-toggle-over,.x-tool-toggle-over{background-position:right -48px}.x-panel-collapsed .x-tool-toggle{background-position:left -96px}.x-panel-collapsed .x-tool-toggle-over{background-position:right -96px}.x-tool-close{background-position:left 0}.x-tool-close-over{background-position:right 0}.x-tool-minimize{background-position:left -16px}.x-tool-minimize-over{background-position:right -16px}.x-tool-maximize{background-position:left -32px}.x-tool-maximize-over{background-position:right -32px}.x-tool-restore{background-position:left -112px}.x-tool-restore-over{background-position:right -112px}.x-tool-gear{background-position:left -200px}.x-tool-gear-over{background-position:right -200px}.x-tool-pin{background-position:left -200px}.x-tool-pin-over{background-position:right -200px}.x-tool-unpin{background-position:left -200px}.x-tool-unpin-over{background-position:right -200px}.x-tool-expand-west,.x-tool-right{background-position:left -80px}.x-tool-expand-west-over,.x-tool-right-over{background-position:right -80px}.x-tool-expand-east,.x-tool-left{background-position:left -64px}.x-tool-expand-east-over,.x-tool-left-over{background-position:right -64px}.x-tool-up{background-position:left -48px}.x-tool-up-over{background-position:right -48px}.x-tool-down{background-position:left -96px}.x-tool-down-over{background-position:right -96px}.x-tool-minus{background-position:left -224px}.x-tool-minus-over{background-position:right -224px}.x-tool-plus{background-position:left -208px}.x-tool-plus-over{background-position:right -208px}.x-panel-fbar div,.x-panel-fbar input,.x-panel-fbar label,.x-panel-fbar select,.x-panel-fbar span,.x-panel-fbar td{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-window-proxy{background-color:#dcdcdc;border-color:#d0d0d0}.x-panel-header,.x-window-tl .x-window-header{color:#5E5E5E;font:400 13px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700}.x-panel-header{border-radius:2px 2px 0 0;border-top-left-radius:2px;border-top-right-radius:2px;font-weight:700;text-shadow:0 1px 1px #fff}.x-portal-space{border-bottom:1px solid #afafaf;padding:0}.x-column{margin:0 15px 0 0;overflow:visible}.x-column-inner{overflow:visible}.x-panel-nofooter .x-panel-bc{background-image:none;height:0}.x-panel-ghost .x-window-tl{border-bottom-color:#d0d0d0}.x-panel-ghost{background-color:#dbdbdb}.x-panel-dd-spacer,.x-panel-ghost ul{border-color:#d0d0d0}.x-dlg-mask{background-color:#ccc}body.x-body-masked .x-window-plain .x-window-mc{background-color:#e2e2e2}.x-html-editor-wrap{background-color:#fff;border-color:#bcbcbc}.x-toolbar div,.x-toolbar input,.x-toolbar label,.x-toolbar select,.x-toolbar span,.x-toolbar td{border-radius:3px}.x-html-editor-tb .x-btn-text{background-image:url(../images/modx-theme/editor/tb-sprite.gif)}.x-panel-noborder .x-panel-header-noborder{border-bottom-color:transparent}.x-panel-noborder .x-panel-tbar-noborder .x-toolbar{background-color:transparent;border-bottom-color:transparent}.x-panel-noborder .x-panel-bbar-noborder .x-toolbar{border-top-color:transparent}.x-border-layout-ct{background-color:#FAFAFA}.x-accordion-hd{background-image:url(../images/modx-theme/panel/light-hd.gif);color:#222;font-weight:400}.x-layout-collapsed{background-color:#E4E4E4;border-color:#DFDFDF;width:7px!important}.x-layout-collapsed-over{background-color:#e6e6e6}.x-layout-split-west .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-left.gif)}.x-layout-split-east .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-right.gif)}.x-layout-split-north .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-top.gif)}.x-layout-split-south .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-bottom.gif)}.x-layout-cmini-west .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-right.gif)}.x-layout-cmini-east .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-left.gif)}.x-layout-cmini-north .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-bottom.gif)}.x-layout-cmini-south .x-layout-mini{background-image:url(../images/modx-theme/layout/mini-top.gif)}.x-progress-wrap{border-color:#8f8f8f}.x-progress-inner{background-color:#e7e7e7;background-image:url(../images/modx-theme/qtip/bg.gif)}.x-progress-bar{background-color:#bcbcbc;background-image:url(../images/modx-theme/progress/progress-bg.gif);border-bottom-color:#a6a6a6;border-right-color:#a6a6a6;border-top-color:#e2e2e2}.x-progress-text{color:#fff;font-size:11px;font-weight:700}.x-progress-text-back{color:#396095}.x-list-header{background-color:#f9f9f9;background-image:url(../images/modx-theme/grid/grid3-hrow.gif)}.x-list-header-inner div em{border-left-color:#ddd;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-list-body dt em{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-list-over{background-color:#eee}.x-list-selected{background-color:#e7e7e7}.x-list-resizer{border-left-color:#555;border-right-color:#555}.x-list-header-inner em.sort-asc,.x-list-header-inner em.sort-desc{background-image:url(../images/modx-theme/grid/sort-hd.gif);border-color:#DFDFDF}.x-slider-horz,.x-slider-horz .x-slider-end,.x-slider-horz .x-slider-inner{background-image:url(../images/modx-theme/slider/slider-bg.png)}.x-slider-horz .x-slider-thumb{background-image:url(../images/modx-theme/slider/slider-thumb.png)}.x-slider-vert,.x-slider-vert .x-slider-end,.x-slider-vert .x-slider-inner{background-image:url(../images/modx-theme/slider/slider-v-bg.png)}.x-slider-vert .x-slider-thumb{background-image:url(../images/modx-theme/slider/slider-v-thumb.png)}.x-portal .x-panel-tl .x-panel-header{background:0 0;font-size:14px;padding:8px 0}.x-portal .x-tool{margin-top:0}.x-portal .x-panel-body{font-weight:400;margin-bottom:5px;padding:0;text-transform:none}.x-portal-space{margin-bottom:5px}.x-grid3-body .x-grid3-td-checker{background-image:none!important}.modx-combo-desc{color:gray;font-size:.9em;font-style:italic}.modx-combo-title{font-weight:700}.modx-grid-draggable .x-grid3-row{cursor:move}.x-window .desc-under .warning{color:#df8d00}.x-window h2{border-bottom:1px solid #D6DFC3;color:#5e5e5e;font:700 15px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-size:18px;margin:0 0 11px;padding:8px 15px;text-shadow:0 1px 1px #FFF}.x-window .x-panel-bl,.x-window .x-panel-br,.x-window .x-panel-mc,.x-window .x-panel-ml,.x-window .x-panel-mr,.x-window .x-panel-tl,.x-window .x-panel-tr{background-color:#f8f8f8}.x-window .x-tab-panel-body-top{background:#fff!important}.x-window .modx-tabs{background:#f0f0f0}.x-window .modx-tabs .x-tab-strip-wrap{border:1px solid #e4e4e4;border-bottom-width:0}.x-window .x-tab-strip{margin-left:0}.x-window .x-form-item label.x-form-item-label{padding:0}.x-window .x-form-label-top .x-form-element{padding-top:0}.x-window .x-form-cb-label{color:#707070;font-weight:700}.x-window .x-panel-mc,.x-window .x-panel-ml{border:0 none}.x-window .x-panel-bl.x-panel-nofooter,.x-window .x-panel-tl{background-color:transparent;background-image:none;border:0 none;padding:0}.x-window .x-window-plain .x-panel-btns{border-top:0 none}.x-window .x-window-plain .x-window-mc{background-color:#f5f5f5;border-color:0 none!important}.x-window-plain .x-window-body{border:0 none}.x-window-body{background-color:#fff;border-bottom:1px solid #D0D0D0;border-top:1px solid #F7F7F7}.x-window-dlg .x-window-body{background:none repeat scroll 0 0 #F4F4F4!important;padding:15px 15px 5px}.x-window .x-window-bc .x-panel-btns{background:#dfdfdf;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#f4f4f4),color-stop(100%,#dfdfdf));background:-webkit-linear-gradient(center bottom,#dfdfdf 0,#f4f4f4 100%);background:-webkit-gradient(linear,,from(#dfdfdf),to(#f4f4f4));background:linear-gradient(center bottom,#dfdfdf 0,#f4f4f4 100%);border-bottom:1px solid #dfdfdf;border-top:1px solid #fff;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#f4f4f4, endColorstr=#dfdfdf, GradientType=0);padding:8px}.x-window-dlg .x-window-bc .x-panel-btns{border-top:0 none}.x-window .x-window-bc .x-window-footer{margin-bottom:0}.x-window .x-window-proxy{background-color:#dcdcdc;border-color:#dfdfdf}.x-window .x-window-tl{background-color:#fff;border-radius:3px 3px 0 0;overflow:hidden}.x-window .x-window-tl .x-window-header{background:#d0d0d0;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#eee),color-stop(100%,#d0d0d0));background:-webkit-linear-gradient(center bottom,#d0d0d0 0,#eee 100%);background:-webkit-gradient(linear,,from(#d0d0d0),to(#eee));background:linear-gradient(center bottom,#d0d0d0 0,#eee 100%);border-bottom:1px solid #ababab;border-radius:3px 3px 0 0;color:#5e5e5e;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#eeeeee, endColorstr=#d0d0d0, GradientType=0);margin-top:0;padding:8px;text-align:center;text-shadow:0 1px 0 #fff}.x-window .x-window-bl{background-color:#fff;background-image:none;border-radius:0 0 3px 3px;overflow:hidden;padding-left:0}.x-window .x-panel-nofooter{background:#dfdfdf;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#f4f4f4),color-stop(100%,#dfdfdf));background:-webkit-linear-gradient(center bottom,#dfdfdf 0,#f4f4f4 100%);background:-webkit-gradient(linear,,from(#dfdfdf),to(#f4f4f4));background:linear-gradient(center bottom,#dfdfdf 0,#f4f4f4 100%);border-bottom:1px solid #dfdfdf;border-top:1px solid #fff;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#f4f4f4, endColorstr=#dfdfdf, GradientType=0)}.x-window .x-window-header-text{color:#666}.x-window .x-window-dlg .ext-mb-text{font-size:12px}.x-window .x-window-dlg .x-window-header-text{font-size:14px}.x-window .x-window-dlg .x-window-body{padding:15px}.x-window .x-window-dlg .x-panel-btns{border-top:0 none}.x-window .x-window-bc,.x-window .x-window-tc{background-image:none}.x-window .x-window-br,.x-window .x-window-mr,.x-window .x-window-tr{background-image:none;padding-right:0}.x-window .x-window-ml,.x-window .x-window-tl{background-image:none;padding-left:0}.x-window .x-window-mc{background-color:#fff;border-radius:0 0 3px 3px;border:0 none}.x-window .x-window-maximized .x-window-tc{background-color:#fff}.x-window .x-window-bbar .x-toolbar,.x-window .x-window-bbar-noborder .x-toolbar{background:#d5dade;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#eff0f4),color-stop(100%,#d5dade));background:-webkit-linear-gradient(center bottom,#d5dade 0,#eff0f4 100%);background:-webkit-gradient(linear,,from(#d5dade),to(#eff0f4));background:linear-gradient(center bottom,#d5dade 0,#eff0f4 100%);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#eff0f4, endColorstr=#d5dade, GradientType=0);border-radius:0 0 3px 3px;border-bottom:0 none;border-top:1px solid #d4d9df;padding:8px}.x-window .x-dlg-mask{background-color:#ccc}.x-window-maximized .x-window-tc{padding-left:0;padding-right:0}.x-superboxselect-input input{background:0 0}.x-superboxselect-btn-expand{margin-top:9px!important;margin-right:6px}.x-superboxselect-btn-clear{height:17px!important;top:-4px;outline:1px solid #e4e4e4;border:12px solid #fbfbfb;position:absolute;right:-42px;display:block}textarea{overflow:auto}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}.modx-form .x-form-text,.modx-form .x-form-textarea{font-size:14px}.modx-form .x-form-text{height:20px!important;padding:5px}.modx-form .x-form-item label{color:#505050;font-size:14px}.x-form-check-wrap{height:auto!important}.x-form-check-wrap .x-form-cb-label{color:#777;font-weight:400}.inline-form{border:0 none;padding:15px 15px 0}.inline-form label{color:#777;display:block;font-weight:700;margin-bottom:2px}.inline-form input[type=text],.inline-form textarea{background-color:#fbfbfb;background-image:none;border-radius:2px;border:1px solid #CCC;position:relative;width:97%}.inline-form input[type=text]{font-size:13px;height:20px!important;padding:5px}.x-form-field{font:400 13px/1.4 "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-form-textarea,textarea.x-form-field{font-family:"Courier New",Courier,monospace}.x-form-text,.x-form-textarea,textarea.x-form-field{background-color:#fbfbfb;background-image:none;border-radius:3px;border:1px solid #e4e4e4;position:relative}.x-form-select-one{background-color:#fff;border-color:#c5c5c5}.x-form-check-wrap,.x-form-check-wrap label,.x-form-checkbox{cursor:pointer}.x-form-checkbox{margin:0 2px}.x-form-checkbox:focus{outline-offset:1px;outline:1px solid #648c32!important}.x-form-check-group-label{border-bottom:1px solid #d0d0d0;color:#434343}.x-form-radio{margin-left:1px}.x-editor .x-form-check-wrap{background-color:#fff}.ext-strict .x-form-field-trigger-wrap .x-form-text,.ext-strict .x-small-editor .x-form-field-trigger-wrap .x-form-text{border-bottom-right-radius:0;border-top-right-radius:0;border-right:0 none;color:#606060;font-weight:700;height:20px;padding:6px;text-shadow:1px -1px 0 #fff}.x-form-field-wrap .x-form-trigger,.x-small-editor .x-form-field-wrap .x-form-trigger{background-image:url(../images/modx-theme/form/trigger.png);border-bottom-right-radius:3px;border-top-right-radius:3px}.x-grid-editor .x-form-field-wrap{background:#f6f2f7 url(../images/modx-theme/form/combo-bck.png) repeat-x scroll 0 100%}.x-grid-editor .x-form-field-wrap input{background-color:transparent!important}.x-grid-editor .x-form-field-wrap img{background-color:#fff;background-image:url(../images/modx-theme/form/trigger.png)}.x-form-field-trigger-wrap{border-color:#D0D0D0 #CCC #BEBEBE;border-style:solid;border-width:1px;height:30px;margin-right:1px}.x-form-field-trigger-wrap .x-form-text{background-color:transparent;border:0 none}.x-form-field-wrap{background:#fbfbfb;border-radius:2px}.x-form-field-wrap .x-form-trigger{background-position:left center;background-repeat:no-repeat;border:0 none!important;height:30px;width:32px}.x-form-field-wrap .x-form-trigger-over{background-position:right}.x-form-field-wrap .x-form-arrow-trigger{background:url(../images/modx-theme/form/trigger.png) no-repeat scroll left center transparent}.x-form-field-wrap .x-form-trigger.x-form-trigger-over{background-position:center center}.x-form-field-wrap .x-form-trigger.x-form-trigger-click{background-position:right center}.x-small-editor .x-form-field-wrap{background:#f0f0f0;border-radius:2px}.x-small-editor .x-form-field-wrap .x-form-trigger{border:0 none!important;height:32px;width:32px}.x-small-editor .x-form-field-wrap .x-form-trigger-over{background-color:#f3f3f3;background-position:right}.x-small-editor .x-form-field-wrap .x-form-arrow-trigger{background:url(../images/modx-theme/form/trigger.png) no-repeat scroll left center transparent}.x-small-editor .x-form-field-wrap .x-form-trigger.x-form-trigger-over{background-position:center center}.x-small-editor .x-form-field-wrap .x-form-trigger.x-form-trigger-click{background-position:right center}.x-form-field-wrap .x-form-date-trigger,.x-small-editor .x-form-field-wrap .x-form-date-trigger{background-image:url(../images/modx-theme/form/calendar.png)}.x-form-field-wrap .x-form-clear-trigger{background-image:url(../images/modx-theme/form/clear-trigger.gif)}.x-form-field-wrap .x-form-search-trigger{background-image:url(../images/modx-theme/form/search-trigger.gif)}.x-viewport .x-form-textarea.x-form-focus,.x-viewport .x-trigger-wrap-focus,.x-viewport input.x-form-focus,.x-viewport textarea.x-form-focus{border-radius:0;outline-offset:0;outline:1px solid #ddd!important}.x-viewport .x-trigger-wrap-focus .x-form-focus{outline:0!important}.x-datetime-wrap{background:0 0}.x-form-invalid,textarea.x-form-invalid{border-color:red!important}.ext-strict .x-small-editor .x-form-text{border-radius:2px;height:20px!important}.ext-gecko .x-form-text,.ext-ie8 .x-form-text{padding:5px}.ext-safari .x-form-invalid{background-color:#fee;border-color:#ff7870}.x-form-inner-invalid,textarea.x-form-inner-invalid{background-color:#fff;background-image:url(../images/modx-theme/grid/invalid_line.gif)}.x-form-grow-sizer{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-form-invalid-msg{color:#c0272b;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;margin-top:2px;position:relative}.x-form-invalid-msg:before{content:"\f071";position:absolute;top:3px;left:3px;color:inherit}.x-form-empty-field{color:gray}.x-grid3 .x-small-editor .x-form-field-wrap,.x-grid3 .x-small-editor .x-form-text{font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;margin-top:5px}.x-grid3 .x-small-editor .x-form-field-wrap{overflow:hidden}.x-grid3 .x-small-editor .x-form-field-wrap .x-form-text{margin-top:0}.ext-safari .x-small-editor .x-form-field{font:400 13px/1.4 "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.x-form-invalid-icon{background-image:url(../images/modx-theme/form/exclamation.gif)}.x-fieldset{border-color:#C5C5C5}.x-fieldset legend{color:#434343;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700}.ext-gecko .x-window-body .x-form-item{overflow:hidden}.x-form-item-label{color:#777;font-weight:700}.x-form fieldset{border:1px solid #dedede}.x-form fieldset legend{color:#606060;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700}.x-fieldset-body{font-size:12px}.x-form-text{min-height:20px;padding:5px}.form-with-labels .x-form-label-top .x-form-element{padding:0}.form-with-labels .x-form-label-top .x-form-item label.x-form-item-label{color:#707070;font-size:13px;font-weight:700;margin-bottom:0;display:block;padding:7px 5px 4px 3px}.form-with-labels .desc-under,.x-window .desc-under{color:#aaa;display:block;font-size:11px;font-style:italic;margin:-8px 0 16px}.form-with-labels .desc-under.desc-checkbox,.x-window .desc-under.desc-checkbox{margin:-2px 0 4px}.form-with-labels .desc-under .warning,.x-window{-moz-box-shadow:0 0 5px #A0A0A0;-o-box-shadow:0 0 5px #A0A0A0;border-radius:3px;border:1px solid silver;-webkit-box-shadow:0 0 5px #A0A0A0;box-shadow:0 0 5px #A0A0A0;overflow:hidden;padding:0}#modx-resource-tabs #modx-tv-tabs .x-tab-panel-header,#modx-resource-tabs .x-tab-panel-bwrap .x-tab-panel-bwrap{border-width:0!important}#modx-action-buttons .x-btn#modx-abtn-save,.primary-button,.x-btn.primary-button{background-image:-webkit-linear-gradient(left top,#58a598,#3c8e8b);background-image:-webkit-gradient(linear,,from(#58a598),to(#3c8e8b));background-image:linear-gradient(to right bottom,#58a598,#3c8e8b);background-color:#58a598;color:#fff}#modx-action-buttons .x-item-disabled.x-btn#modx-abtn-save,.x-item-disabled.primary-button{opacity:1;background:#b4b4b4}#modx-action-buttons .x-btn#modx-abtn-save button,.primary-button button,.x-btn.primary-button button{color:#fff}#modx-action-buttons .x-item-disabled.x-btn#modx-abtn-save *,.x-item-disabled.primary-button *{color:#455a6e!important}#modx-action-buttons .x-btn-over.x-btn#modx-abtn-save,.x-btn-over.primary-button{background:#7fbbb1}#modx-action-buttons{position:fixed;top:55px;right:10px;z-index:9;left:auto;background:#f2f2f2;padding:10px 2px 7px 7px;border:0;font-family:"Helvetica Neue",Helvetica,arial,tahoma,sans-serif;border-radius:0 0 0 5px}#modx-action-buttons .x-toolbar-left{width:auto!important;zoom:1}.x-btn{*display:inline;background:-webkit-linear-gradient(270deg,#e4e9ee 0,#d2dbe2 100%) no-repeat;background:linear-gradient(180deg,#e4e9ee 0,#d2dbe2 100%) no-repeat;border-radius:4px;line-height:1;cursor:pointer;display:inline-block;margin:0 1px;padding:10px 15px;position:relative;text-decoration:none;zoom:1;border:1px solid #c8d2dc}.x-btn button{font-size:13px;color:#707070;cursor:pointer;height:16px;min-width:100%;vertical-align:middle}#modx-leftbar .x-btn{background:#fff;border-radius:3px;padding:13px 20px;border:none}#modx-leftbar .x-btn button{color:#728da7}#modx-action-buttons .x-btn{background:#fff;border-radius:3px;padding:13px 20px;border:none;-webkit-box-shadow:0 1px 0 0 #CCC;box-shadow:0 1px 0 rgba(0,0,0,.025),-1px 0 0 rgba(0,0,0,.025),1px 0 0 rgba(0,0,0,.025)}#modx-action-buttons .x-btn button{color:#728da7}#modx-action-buttons .x-btn.x-btn-over{border-color:#fbfbfb;background-color:#fbfbfb}.x-toolbar .x-form-field-trigger-wrap{background:-webkit-linear-gradient(270deg,#e4e9ee 0,#d2dbe2 100%);background:linear-gradient(180deg,#e4e9ee 0,#d2dbe2 100%);border-radius:4px;line-height:1;cursor:pointer;display:inline-block;margin:0 1px;position:relative;text-decoration:none;zoom:1;border:1px solid #c8d2dc;-webkit-transition:background-color .2s;transition:background-color .2s;padding:3px 23px 3px 0}.x-toolbar .x-form-field-trigger-wrap input.x-form-text{font-weight:400!important;padding-left:13px!important}.x-toolbar .x-form-field-trigger-wrap .x-form-trigger{padding-top:2px}.x-toolbar .x-form-field-trigger-wrap.x-trigger-wrap-focus{outline:0!important;border-color:#8a8a8a}.x-toolbar .x-toolbar-cell input.x-form-text{padding:8px 13px;border-radius:4px;font-size:13px!important}.x-btn-over{border-color:#8a8a8a;background-color:#f0f0f0}.x-btn-icon button{height:16px;width:16px}.x-btn-icon.arrow_up button{background:none!important;position:relative}.x-btn-icon.arrow_up button:before{content:"\f148";top:1px;bottom:auto}.x-btn-icon.arrow_down button{background:none!important;position:relative}.x-btn-icon.arrow_down button:before{content:"\f149";top:1px;bottom:auto}.x-btn-icon.refresh button{background:none!important;position:relative}.x-btn-icon.refresh button:before{content:"\f021";top:1px;bottom:auto}.x-btn-text-icon button{padding-left:20px!important}.x-html-editor-tb .x-btn{-moz-box-shadow:none;-o-box-shadow:none;background-color:transparent;background-image:none;border:0 none;-webkit-box-shadow:none;box-shadow:none;margin:0}.x-html-editor-tb .x-btn-over{border:0 none}.x-btn-click{-o-box-shadow:0 0 3px #aaa inset;-webkit-box-shadow:0 0 3px #aaa inset;box-shadow:0 0 3px #aaa inset;margin:0 1px}.x-btn-focus{border:1px solid #53595f}.x-btn-group{border-radius:3px;border:1px solid #dbe0e4;margin-right:2px;padding:0}.x-btn-group .x-btn{-moz-box-shadow:transparent 0 0 1px;-o-box-shadow:transparent 0 0 1px;background-color:transparent;background-image:none;border:1px solid transparent;-webkit-box-shadow:transparent 0 0 1px;box-shadow:transparent 0 0 1px}.x-btn-group .x-btn button{color:#868b8f;height:auto!important}.x-btn-group .x-btn-over{background:#dfdfdf;background:#f0f0f0;border:1px solid #dbe0e4}.x-btn-group .x-btn-over button{color:#5b7a98}.x-btn-group .x-btn-click{background-color:#fff;background-image:none;-webkit-box-shadow:0 0 3px #aaa inset;box-shadow:0 0 3px #aaa inset;margin:0 2px 0 0}.x-btn-click .x-btn-text,.x-btn-menu-active .x-btn-text,.x-btn-pressed .x-btn-text{color:#73797f}.x-btn-disabled *{color:gray!important}.x-btn-group-bwrap{padding:1px 0 0}.x-btn-group-header{background-color:#dbe0e4;color:#73797f;text-shadow:0 1px 0 #fafafa}.x-btn-group-tl,.x-btn-group-tr{background-image:none;padding:0}.x-btn-group-bc,.x-btn-group-bl,.x-btn-group-br,.x-btn-group-tc{background-image:none}.x-btn-group-ml{background-image:none;padding-left:1px}.x-btn-group-mr{background-image:none;padding-right:1px}.x-btn em.x-btn-split{display:block;padding-right:14px;position:relative}.x-btn em.x-btn-split:before{content:"\f0d7";position:absolute;top:4px;right:0;color:inherit}.x-btn em.x-btn-arrow{background:transparent url(../images/modx-theme/button/arrow.gif) no-repeat right center;display:block;padding-right:20px}.x-btn em.x-btn-arrow button{padding-right:10px!important;border-right:1px solid #fff}.x-btn-menu-active{background:#fff}.x-btn-menu-active button{color:#444}.x-btn em.x-btn-arrow-bottom{background-image:url(../images/modx-theme/button/s-arrow-b-noline.gif)}.x-btn em.x-btn-split-bottom{background-image:url(../images/modx-theme/button/s-arrow-b.gif)}.x-btn-click em.x-btn-split-bottom,.x-btn-menu-active em.x-btn-split-bottom,.x-btn-over em.x-btn-split-bottom,.x-btn-pressed em.x-btn-split-bottom{background-image:url(../images/modx-theme/button/s-arrow-bo.gif)}.x-btn-group-notitle .x-btn-group-tc{background-image:url(../images/modx-theme/button/group-tb.gif)}.actions{bottom:8px;margin:0;overflow:hidden;position:absolute}.actions li{float:left;line-height:.7;margin-right:2px}.actions button,.inline-button{background:#dcdcdc;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fcfcfc),color-stop(100%,#dcdcdc));background:-webkit-linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);background:-webkit-gradient(linear,,from(#dcdcdc),to(#fcfcfc));background:linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);border-radius:3px;border:1px solid #ccc;color:#888;cursor:pointer;display:block;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc, endColorstr=#dcdcdc, GradientType=0);font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700;padding:3px 5px;text-decoration:none}.actions button:hover,.inline-button:hover{background:#e0e0e0;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fcfcfc),color-stop(100%,#e0e0e0));background:-webkit-linear-gradient(center bottom,#e0e0e0 0,#fcfcfc 100%);background:-webkit-gradient(linear,,from(#e0e0e0),to(#fcfcfc));background:linear-gradient(center bottom,#e0e0e0 0,#fcfcfc 100%);color:#565550;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc, endColorstr=#e0e0e0, GradientType=0)}.actions button:active,.inline-button:active{background-color:#fff;background-image:none;-webkit-box-shadow:0 0 3px #aaa inset;box-shadow:0 0 3px #aaa inset}.actions button.orange{background:#febb4a;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#feda71),color-stop(100%,#febb4a));background:-webkit-linear-gradient(center bottom,#febb4a 0,#feda71 100%);background:-webkit-gradient(linear,,from(#febb4a),to(#feda71));background:linear-gradient(center bottom,#febb4a 0,#feda71 100%);border-color:#f5b74e #e7a93f #dfa138;color:#963;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#feda71, endColorstr=#febb4a, GradientType=0)}.actions button.orange:hover{background:#fec95b;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fee1a0),color-stop(100%,#fec95b));background:-webkit-linear-gradient(center bottom,#fec95b 0,#fee1a0 100%);background:-webkit-gradient(linear,,from(#fec95b),to(#fee1a0));background:linear-gradient(center bottom,#fec95b 0,#fee1a0 100%);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#fee1a0, endColorstr=#fec95b, GradientType=0)}.inline-button.green{background:#9fcb57;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#d7e9a4),color-stop(100%,#9fcb57));background:-webkit-linear-gradient(center bottom,#9fcb57 0,#d7e9a4 100%);background:-webkit-gradient(linear,,from(#9fcb57),to(#d7e9a4));background:linear-gradient(center bottom,#9fcb57 0,#d7e9a4 100%);border:1px solid #85a948;color:#556f14!important;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#d7e9a4, endColorstr=#9fcb57, GradientType=0)}.inline-button.green:hover{background:#9fcb57;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#e6efd1),color-stop(100%,#9fcb57));background:-webkit-linear-gradient(center bottom,#9fcb57 0,#e6efd1 100%);background:-webkit-gradient(linear,,from(#9fcb57),to(#e6efd1));background:linear-gradient(center bottom,#9fcb57 0,#e6efd1 100%);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#e6efd1, endColorstr=#9fcb57, GradientType=0)}#modx-leftbar .x-toolbar-ct .x-btn{margin:0 3px;padding:0;width:25px;height:30px;border:none;-webkit-box-shadow:none;box-shadow:none;opacity:1;display:inline-block;position:relative}#modx-leftbar .x-toolbar-ct .x-btn>em>button{font-size:18px;text-shadow:0!important;overflow:visible;position:absolute;height:24px;top:4px;left:2px;color:#728da7}#modx-leftbar .x-toolbar-ct .x-btn button:hover,#modx-leftbar .x-toolbar-ct .x-btn:hover{color:#3697cd}#modx-leftbar .x-toolbar-ct .x-btn span{vertical-align:middle}#modx-leftbar .x-toolbar-ct .x-toolbar-right .x-btn>em>button{color:#96A9BB}#modx-leftbar #emptifier.x-item-disabled{opacity:.4!important}.tree-new-resource>em>button:before{content:"\f15b"}.tree-new-weblink>em>button:before{content:"\f0c1"}.tree-new-symlink>em>button:before{content:"\f0c5"}.tree-new-static-resource>em>button:before{content:"\f0f6"}.tree-trash>em>button:before{content:"\f014"}#modx-leftbar .x-toolbar-ct .x-btn.tree-new-symlink>em>button{top:4px;left:2px}#modx-leftbar .x-toolbar-ct .x-btn.tree-new-weblink>em>button{left:2px}.tree-new-template>em>button:before{content:"\f0db"}.tree-new-tv>em>button:before{content:"\f022"}.tree-new-chunk>em>button:before{content:"\f009"}.tree-new-snippet>em>button:before{content:"\f121"}.tree-new-plugin>em>button:before{content:"\f085"}.tree-new-category>em>button:before{content:"\f07b"}#modx-leftbar .icon,.x-tree-node .icon{background:0 0;border:0;display:inline-block;opacity:.6;margin:0;padding:3px;text-align:center}#modx-leftbar .icon i,.x-tree-node .icon i{font-style:normal}#modx-leftbar .icon button,.x-tree-node .icon button{display:none}#modx-leftbar .icon:hover,.x-tree-node .icon:hover{opacity:1!important}.x-tab-panel-noborder{border:1px solid #E2E3DE;margin:20px 0 10px;overflow:visible}#modx-leftbar .x-tab-panel-noborder .x-tab-panel-body-noborder,.x-tab-panel-noborder .x-tab-panel-body-noborder{background-color:#fff}.x-tab-panel-footer,.x-tab-panel-header{border:0}.x-tab-panel-header ul.x-tab-strip-top{border-bottom-color:#fff;margin:0;width:auto;background-color:transparent!important;position:relative;top:1px}.x-tab-panel-footer-plain .x-tab-strip-spacer,.x-tab-panel-header-plain .x-tab-strip-spacer{background-color:#fff;border:none;height:0}.x-tab-panel-header,.x-tab-strip{padding-left:0}.x-tab-panel-bwrap{-webkit-box-shadow:0 0 5px rgba(0,0,0,.1);box-shadow:0 0 5px rgba(0,0,0,.1);border-radius:3px}.x-tab-strip li{color:#757575;cursor:pointer;font:14px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;line-height:2.2;margin:1px 0 1px 2px;padding:0 13px;position:relative;z-index:5}.x-tab-strip li:hover{color:#1f5c7e}.x-tab-strip li.x-tab-strip-active{color:#297ead;background-color:#fff;-webkit-box-shadow:0 -3px 0 #3697cd,-1px 0 0 transparent;box-shadow:0 -3px 0 #3697cd,-1px 0 0 transparent;cursor:default;margin:0 0 0 2px;padding-bottom:2px;border-radius:2px 2px 0 0}.vertical-tabs-header .x-tab-strip li.x-tab-strip-active{border-radius:0}.x-tab-strip li.x-tab-strip-active:after{content:"";display:block;position:absolute;top:-3px;right:0;bottom:1px;left:0;-webkit-box-shadow:0 0 5px rgba(0,0,0,.1);box-shadow:0 0 5px rgba(0,0,0,.1);z-index:-1;border-radius:3px}.x-tab-strip li.x-tab-strip-active:before{content:"";display:block;position:absolute;top:90%;right:0;bottom:-4px;left:0;background:#fff}.x-tab-panel,.x-tab-panel-header,.x-tab-strip-wrap{overflow:visible;border:none}.x-tab-strip-closable{padding-right:15px!important}.x-tab-strip .x-tab-strip-closable a.x-tab-strip-close{right:8px;top:11px;background-image:url(../images/modx-theme/tabs/tab-close.gif)}ul.x-tab-strip-top li:first-child{margin-left:0}ul.x-tab-strip-bottom{background-color:#f4f4f4;border-top-color:#dfdfdf}ul.x-tab-strip-bottom .x-tab-right{background-image:url(../images/modx-theme/tabs/tab-btm-inactive-right-bg.gif)}ul.x-tab-strip-bottom .x-tab-right .x-tab-right{background-image:url(../images/modx-theme/tabs/tab-btm-right-bg.gif)}ul.x-tab-strip-bottom .x-tab-right .x-tab-left{background-image:url(../images/modx-theme/tabs/tab-btm-left-bg.gif)}ul.x-tab-strip-bottom .x-tab-left{background-image:url(../images/modx-theme/tabs/tab-btm-inactive-left-bg.gif)}.x-tab-panel-body{background-color:#fff;border:none}.x-tab-panel-body-top{border-top:0 none}.x-tab-panel-body-bottom{border-bottom:0 none}.x-tab-scroller-left{background-image:url(../images/modx-theme/tabs/scroll-left.gif);border-bottom-color:#dfdfdf}.x-tab-scroller-left-over{background-position:0 0}.x-tab-scroller-left-disabled{-khtml-opacity:.5;-moz-opacity:.5;-ms-filter:"alpha(Opacity=50)";background-position:-18px 0;cursor:default;filter:alpha(Opacity=50);opacity:.5}.x-tab-scroller-right{background-image:url(../images/modx-theme/tabs/scroll-right.gif);border-bottom-color:#dfdfdf}.x-tab-panel-bbar .x-toolbar,.x-tab-panel-tbar .x-toolbar{border-color:#dfdfdf}.x-tab-panel-body-noborder .x-panel-body-noheader:first-child{border-top:0 none}.x-tab-panel-bbar-noborder .x-toolbar{border-top-color:transparent}.x-tab-panel-tbar-noborder .x-toolbar{border-bottom-color:transparent}.vertical-tabs-panel{background:#f8f8f8}.vertical-tabs-panel.wrapped{border:1px solid #e0e0e0}.vertical-tabs-header{background-color:#f8f8f8!important;float:left;margin-left:0;padding:13px 0!important;width:150px!important}.vertical-tabs-header ul{border-top:1px solid transparent;width:auto;border-bottom-color:transparent}.vertical-tabs-header .vertical-tabs-header li{background:none repeat scroll 0 0 transparent!important;border-color:transparent transparent #E0E0E0!important;border-radius:0!important;border-style:none none solid!important;border-width:1px 1px 1px 0!important;float:none!important;margin:0!important;overflow:hidden;padding:5px!important;white-space:nowrap;color:#555;line-height:1.3;text-shadow:0 1px 0 #fff}.vertical-tabs-header .vertical-tabs-header li:first-child{border-top:0 none!important}.vertical-tabs-header h4{margin-left:15px}.vertical-tabs-header ul.x-tab-strip-top{border-bottom:none;background:#f8f8f8!important}.window-vtabs .x-panel-mr{padding-right:0}.window-vtabs .vertical-tabs-panel{width:100%!important;margin:0}.vertical-tabs-header ul.x-tab-strip-top li{width:100%}.vertical-tabs-header ul.x-tab-strip-top li .x-tab-strip-active{background:#fff!important;color:#555;text-shadow:none}.vertical-tabs-header .x-tab-edge{height:0}.vertical-tabs-header .x-tab-strip-spacer{display:none}.vertical-tabs-body{padding:20px 30px 20px 25px}#modx-header{background:#3f4850;min-height:55px}#modx-navbar{background-image:-webkit-linear-gradient(left,#3f4850 0,#365462 46%,#3e5554 60%,#42554d 68%,#573d4e 100%);background-image:-webkit-gradient(linear,left top,right top,from(#3f4850),color-stop(46%,#365462),color-stop(60%,#3e5554),color-stop(68%,#42554d),to(#573d4e));background-image:-webkit-linear-gradient(left,#3f4850 0,#365462 46%,#3e5554 60%,#42554d 68%,#573d4e 100%);background-image:linear-gradient(to right,#3f4850 0,#365462 46%,#3e5554 60%,#42554d 68%,#573d4e 100%);-webkit-box-shadow:0 2px 0 rgba(0,0,0,.025);box-shadow:0 2px 0 rgba(0,0,0,.025);height:100%;position:relative;z-index:10}#modx-user-menu{float:right;margin-right:15px}#modx-navbar{font:normal 13px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}#modx-topnav{float:left;list-style:none;margin:0;padding:0}#modx-topnav li{border-right:1px solid #2f4150}#modx-navbar a,#modx-navbar li{background:0 0;float:left;margin:0;padding:0;position:relative}#modx-navbar li:hover{z-index:10000}#modx-navbar a{color:#fff;cursor:pointer;display:block;line-height:55px;padding:0 15px;text-decoration:none}@media screen and (max-width:960px){#modx-topnav>li:not(#modx-home-dashboard)>a{text-indent:-99999em;display:block;height:100%;position:relative;width:1em}#modx-topnav>li:not(#modx-home-dashboard)>a:after{position:absolute;top:0;left:0;right:0;bottom:0;font-family:FontAwesome;font-style:normal;font-weight:400;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-indent:0;display:block;text-align:center;line-height:55px;font-size:16px}}@media screen and (max-width:960px){#modx-topnav #limenu-site>a:after{content:"\f0f6"}#modx-topnav #limenu-media>a:after{content:"\f03e"}#modx-topnav #limenu-components>a:after{content:"\f1b2"}#modx-topnav #limenu-manage>a:after{content:"\f1de"}}@media screen and (max-width:960px){#user-username{display:none}}#modx-navbar .top{padding-right:15px}#modx-navbar .top:after{border-left:5px solid transparent;border-right:5px solid transparent;border-top:5px solid #60727c;position:absolute;content:' ';right:12px;top:26px}#modx-topnav li.top>a{cursor:default}#modx-topnav>li.top>a,#modx-user-menu>li.top>a{border-left:1px solid transparent;border-right:1px solid transparent}#modx-topnav>li.top:hover>a,#modx-user-menu>li.top:hover>a{padding-bottom:1px;z-index:10001}#modx-navbar li:hover a:hover.modx-help{color:#3697cd}#modx-navbar #limenu-admin ul.modx-subnav,#modx-navbar #limenu-user ul.modx-subnav{left:auto;right:0}#modx-navbar ul.modx-subnav{float:left;left:0;line-height:1.1;list-style:none;margin:0;padding:0;position:absolute;top:54px;z-index:10000;opacity:0;visibility:hidden}#modx-navbar ul.modx-subnav,#modx-navbar ul.modx-subsubnav{border-radius:0 0 2px 2px;border:1px solid #2f4150;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.025),-1px 0 0 rgba(0,0,0,.025),1px 0 0 rgba(0,0,0,.025);box-shadow:0 1px 0 rgba(0,0,0,.025),-1px 0 0 rgba(0,0,0,.025),1px 0 0 rgba(0,0,0,.025)}#modx-navbar #modx-home-dashboard{background-image:url(../images/modx-logo@2x.png);background-position:center center;background-repeat:no-repeat;-webkit-background-size:45px 45px;background-size:45px 45px;width:50px;border-right:none;margin-left:21px}#user-avatar img{border-radius:20px;margin:8px 10px 0 0;height:40px;width:40px;display:block;float:left}#modx-navbar #modx-home-dashboard a{overflow:hidden;padding:0;text-indent:-9999px;width:100%}#modx-navbar #modx-home-dashboard:hover a{background-color:transparent}#modx-navbar li:hover ul.modx-subnav{visibility:visible;opacity:1;-webkit-transition:all .15s ease;transition:all .15s ease;-webkit-transition-delay:.2s;transition-delay:.2s}#modx-navbar ul.modx-subnav li{background:#2b3948;border-bottom:1px solid #192b3e;clear:both;margin:0;padding:0}#modx-navbar ul.modx-subnav li a{background-color:#2b3948;color:#c9d4e1;float:left;font-weight:700;line-height:1.5;margin:0;padding:8px 15px;text-shadow:none;width:240px}#modx-navbar ul.modx-subnav li a:hover{background:#182028;border-top-color:#3f4850;border-bottom-color:#3f4850;color:#fff}#modx-navbar ul.modx-subnav li a:hover .description{color:#a0d9f0}#modx-navbar ul.modx-subnav li:first-child a{border-top-width:0}#modx-navbar ul.modx-subnav li:last-child a{border-bottom-width:0}#modx-navbar ul.modx-subnav li a span{color:#5abce5;display:block;float:none;font-size:12px;font-weight:400;line-height:1.3;margin-top:6px;width:100%}#modx-navbar ul.modx-subnav ul{display:none;left:270px;list-style:none;padding-left:0;position:absolute;top:2px;z-index:24}#modx-navbar ul.modx-subnav ul li:first-child,#modx-navbar ul.modx-subnav ul li:first-child a{border-radius:0 2px 0 0}#modx-navbar ul.modx-subnav ul li:last-child,#modx-navbar ul.modx-subnav ul li:last-child a{border-radius:0 0 2px}#modx-navbar ul.modx-subnav ul ul li:last-child,#modx-navbar ul.modx-subnav ul ul li:last-child a{border-radius:0 0 2px 2px}#modx-navbar ul.modx-subnav li:hover ul ul,#modx-navbar ul.modx-subnav ul li:hover ul ul,#modx-navbar ul.modx-subnav ul ul li:hover ul ul{display:none}#modx-navbar ul.modx-subnav li:hover ul,#modx-navbar ul.modx-subnav ul li:hover ul,#modx-navbar ul.modx-subnav ul ul li:hover ul,#modx-navbar ul.modx-subnav ul ul ul li:hover ul{display:block}.ext-ie7 #modx-header{position:relative;z-index:10}#modx-navbar #modx-manager-search{padding:11px 8px 5px 10px;height:38px;min-width:120px}@media screen and (min-width:961px){#modx-navbar #modx-manager-search{min-width:194px}}@media screen and (max-width:960px){#modx-navbar #modx-manager-search>.x-form-field-trigger-wrap{max-width:120px!important}}#modx-navbar #modx-manager-search:hover{background:0 0}#modx-manager-search .x-form-trigger{color:rgba(255,255,255,.25);cursor:default;height:16px;right:0;border-radius:0;border:none;padding:9px 5px;width:17px;background-image:none}#modx-manager-search .x-form-field-wrap{background:rgba(0,0,0,.25);border:0;border-radius:4px;overflow:hidden;color:#565353;font-size:12px;outline:0!important;text-shadow:none;-webkit-box-shadow:rgba(0,0,0,.05)0 0 3px 0 inset;box-shadow:rgba(0,0,0,.05)0 0 3px 0 inset}#modx-manager-search .x-form-field-trigger-wrap{border-width:0;height:auto;background-image:none}#modx-manager-search .x-form-field-trigger-wrap .x-form-text{text-shadow:none;font-weight:400;color:#C9D3E0;letter-spacing:0}#modx-manager-search .x-form-field-trigger-wrap .x-form-empty-field{color:#5a6a79}#modx-manager-search .x-form-field-wrap:hover,#modx-manager-search .x-trigger-wrap-focus{background-color:rgba(0,0,0,.5)}#modx-uberbar{margin-right:20px}.modx-manager-search-results{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;background:0 0;border-radius:0 0 2px 2px;border:#e4e4e4;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.025),-1px 0 0 rgba(0,0,0,.025),1px 0 0 rgba(0,0,0,.025);box-shadow:0 1px 0 rgba(0,0,0,.025),-1px 0 0 rgba(0,0,0,.025),1px 0 0 rgba(0,0,0,.025);height:auto!important;position:relative;width:450px!important}.modx-manager-search-results:before{content:"";display:block;position:absolute;top:-7px;left:12px;border:8px solid transparent;border-bottom:8px solid #2a3949}.modx-manager-search-results .x-combo-list-inner{background:#2a3949;width:100%!important;border-top:none;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;overflow:scroll;margin-top:9px}.modx-manager-search-results .section{border-left:1px solid #1d2732;font-size:13px;margin-left:116px;position:relative}.modx-manager-search-results .x-combo-selected h3{left:0}.modx-manager-search-results h3,.modx-manager-search-results p{line-height:17px;margin:0;padding:4px 8px}.modx-manager-search-results p{color:#C9D3E0}.modx-manager-search-results h3{color:#55bbe7;font-size:13px;font-weight:400;left:-116px;position:absolute;text-align:right;top:0;width:95px}.modx-manager-search-results a{cursor:pointer;display:inline-block;padding-left:18px;position:relative;color:inherit;text-decoration:none}.modx-manager-search-results i{color:#3697cd;left:0;position:absolute;top:2px}.modx-manager-search-results em{font-style:normal;opacity:.5}.modx-manager-search-results .x-combo-selected h3,.modx-manager-search-results .x-combo-selected i,.modx-manager-search-results .x-combo-selected p{color:#fff}.modx-manager-search-results .x-combo-selected p{border-left-color:transparent}.modx-manager-search-results .x-combo-selected{border:none;color:#fff!important;background-color:#3e5268;margin-left:0;z-index:10}.modx-manager-search-results .icon-user{background-image:none!important}#modx-leftbar .x-tab-panel-noborder{margin:25px 10px 25px 25px}#modx-leftbar .x-toolbar{padding:4px 5px 5px}#modx-leftbar .x-tree-root-ct{padding:6px}#modx-leftbar .x-tree .x-panel-body{backgroud:#fff}#modx-resource-tree-tbar .x-toolbar-left .x-btn.tree-new-resource,#modx-tree-element .x-toolbar-left .x-btn.tree-new-template{margin-left:16px}.x-layout-split{width:8px;z-index:0}.x-layout-split:hover{background:#dcdcdc}.x-layout-split .x-layout-mini{left:-11px;background-color:#fff;width:10px;height:50px;background-image:none;background-repeat:no-repeat;background-position:center left;border-radius:0 4px 4px 0;opacity:1}.x-layout-split .x-layout-mini:after{border-top:5px solid transparent;border-bottom:5px solid transparent;border-right:5px solid #3697cd;position:absolute;content:' ';right:4px;top:21px}.modx-tree{padding:0 5px 5px}#modx-file-tree .modx-tree:first-child{padding-top:5px}#modx-file-tree .modx-tree .tree-pseudoroot-node{margin-top:0;margin-bottom:0}.x-tree-node-collapsed .tree-folder:before{content:"\f07b"}.x-tree-node-el{color:#556c88;font:400 13px/22px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;padding-left:6px;background-repeat:no-repeat;background-position:5px}.x-tree-node-el .x-btn{-webkit-box-shadow:none;box-shadow:none}.x-tree-node-el .icon{display:inline-block;width:1em;font-size:1.15em;line-height:.75em;vertical-align:-15%}.x-tree-node-el a span{line-height:1.7;padding-left:7px}.x-tree-node-el a span span{padding-left:0}.unpublished,.unpublished a span{color:#b0c0ce!important;font-style:italic}.unpublished a span i.icon,.unpublished a span i.icon-large,.unpublished i.icon,.unpublished i.icon-large{color:#b0c0ce!important;font-style:normal}.hidemenu,.hidemenu a span{color:#b0c0ce!important}.hidemenu a span i.icon,.hidemenu a span i.icon-large,.hidemenu i.icon,.hidemenu i.icon-large{color:#b0c0ce!important;font-style:normal}.deleted{color:#b42260!important}.deleted i.icon,.deleted i.icon-large{color:#b42260!important;font-style:normal}.deleted a span{color:#b42260!important;text-decoration:line-through;font-style:normal}.element-node-disabled a span{color:#b0c0ce!important}.element-node-locked a span{font-style:italic}.x-tree-node{position:relative}.modx-tree-node-tool-ct{position:absolute;top:0;right:6px;bottom:0;line-height:1.8}.tree-pseudoroot-node.x-tree-node-el{background-color:#f0f0f0;border-radius:4px;font:400 14px/35px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;position:relative;padding:0 0 0 4px;margin-top:5px;margin-bottom:5px}.tree-pseudoroot-node.x-tree-node-el a span{color:#4d82a5}.tree-pseudoroot-node.x-tree-node-el>.icon{font-weight:400;color:#4d82a5;font-size:1.33333em;line-height:.75em;vertical-align:-15%}.tree-pseudoroot-node.x-tree-node-el .modx-tree-node-tool-ct{line-height:35px}.tree-pseudoroot-node.x-tree-node-el .modx-tree-node-tool-ct .x-btn{margin-left:2px}.tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded,.tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded span{color:#3697cd;background-color:#e8f0f8}.tree-pseudoroot-node.x-tree-node-el.x-tree-node-over{background-color:#e8f0f8;color:#3697cd}.tree-pseudoroot-node.x-tree-node-el+.x-tree-node-ct{margin-left:-16px}.x-tree-elbow,.x-tree-elbow-end{display:inline-block}.x-tree-node .x-tree-expanded{color:#3697cd;background-color:#e8f0f8}.x-tree-node .x-tree-expanded a,.x-tree-node .x-tree-expanded a span{color:#3697cd}.icon-rss{background-image:url(../images/restyle/icons/feed.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-rss.x-tree-node-el{background-position:5px 5px!important}.icon-rss::before{content:' '}.icon-cal{background-image:url(../images/restyle/icons/calendar.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-cal.x-tree-node-el{background-position:5px 5px!important}.icon-cal::before{content:' '}.icon-sql{background-image:url(../images/restyle/icons/database_table.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-sql.x-tree-node-el{background-position:5px 5px!important}.icon-sql::before{content:' '}.icon-db{background-image:url(../images/restyle/icons/database.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-db.x-tree-node-el{background-position:5px 5px!important}.icon-db::before{content:' '}.icon-jar,.icon-java{background-image:url(../images/restyle/icons/cup.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-jar.x-tree-node-el,.icon-java.x-tree-node-el{background-position:5px 5px!important}.icon-jar::before,.icon-java::before{content:' '}.icon-css{background-image:url(../images/restyle/icons/css.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-css.x-tree-node-el{background-position:5px 5px!important}.icon-css::before{content:' '}.icon-gz,.icon-tar,.icon-tgz,.icon-zip{background-image:url(../images/restyle/icons/compress.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-gz.x-tree-node-el,.icon-tar.x-tree-node-el,.icon-tgz.x-tree-node-el,.icon-zip.x-tree-node-el{background-position:5px 5px!important}.icon-gz::before,.icon-tar::before,.icon-tgz::before,.icon-zip::before{content:' '}.icon-bmp,.icon-gif,.icon-jpeg,.icon-jpg,.icon-png,.icon-tiff{background-image:url(../images/restyle/icons/picture.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-bmp.x-tree-node-el,.icon-gif.x-tree-node-el,.icon-jpeg.x-tree-node-el,.icon-jpg.x-tree-node-el,.icon-png.x-tree-node-el,.icon-tiff.x-tree-node-el{background-position:5px 5px!important}.icon-bmp::before,.icon-gif::before,.icon-jpeg::before,.icon-jpg::before,.icon-png::before,.icon-tiff::before{content:' '}.icon-bat,.icon-scr{background-image:url(../images/restyle/icons/application_osx_terminal.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-bat.x-tree-node-el,.icon-scr.x-tree-node-el{background-position:5px 5px!important}.icon-bat::before,.icon-scr::before{content:' '}.icon-log{background-image:url(../images/restyle/icons/computer.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-log.x-tree-node-el{background-position:5px 5px!important}.icon-log::before{content:' '}.icon-htm,.icon-html{background-image:url(../images/restyle/icons/html_valid.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-htm.x-tree-node-el,.icon-html.x-tree-node-el{background-position:5px 5px!important}.icon-htm::before,.icon-html::before{content:' '}.icon-avi,.icon-mov,.icon-mpg{background-image:url(../images/restyle/icons/film.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-avi.x-tree-node-el,.icon-mov.x-tree-node-el,.icon-mpg.x-tree-node-el{background-position:5px 5px!important}.icon-avi::before,.icon-mov::before,.icon-mpg::before{content:' '}.icon-rb{background-image:url(../images/restyle/icons/ruby.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-rb.x-tree-node-el{background-position:5px 5px!important}.icon-rb::before{content:' '}.icon-doc{background-image:url(../images/restyle/icons/page_white_word.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-doc.x-tree-node-el{background-position:5px 5px!important}.icon-doc::before{content:' '}.icon-ppt{background-image:url(../images/restyle/icons/page_white_powerpoint.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-ppt.x-tree-node-el{background-position:5px 5px!important}.icon-ppt::before{content:' '}.icon-access,.icon-htaccess{background-image:url(../images/restyle/icons/lock.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-access.x-tree-node-el,.icon-htaccess.x-tree-node-el{background-position:5px 5px!important}.icon-access::before,.icon-htaccess::before{content:' '}.icon-php{background-image:url(../images/restyle/icons/page_white_php.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-php.x-tree-node-el{background-position:5px 5px!important}.icon-php::before{content:' '}.icon-flv,.icon-swf{background-image:url(../images/restyle/icons/page_white_flash.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-flv.x-tree-node-el,.icon-swf.x-tree-node-el{background-position:5px 5px!important}.icon-flv::before,.icon-swf::before{content:' '}.icon-xls{background-image:url(../images/restyle/icons/page_white_excel.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-xls.x-tree-node-el{background-position:5px 5px!important}.icon-xls::before{content:' '}.icon-cfm{background-image:url(../images/restyle/icons/page_white_coldfusion.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-cfm.x-tree-node-el{background-position:5px 5px!important}.icon-cfm::before{content:' '}.icon-pdf{background-image:url(../images/restyle/icons/page_white_acrobat.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-pdf.x-tree-node-el{background-position:5px 5px!important}.icon-pdf::before{content:' '}.icon-js{background-image:url(../images/restyle/icons/javascript.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-js.x-tree-node-el{background-position:5px 5px!important}.icon-js::before{content:' '}.icon-action{background-image:url(../images/restyle/icons/application_osx_terminal.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-action.x-tree-node-el{background-position:5px 5px!important}.icon-action::before{content:' '}.icon-namespace{background-image:url(../images/restyle/icons/computer.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-namespace.x-tree-node-el{background-position:5px 5px!important}.icon-namespace::before{content:' '}.icon-list-new{background-image:url(../images/restyle/icons/layout_add.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-list-new.x-tree-node-el{background-position:5px 5px!important}.icon-list-new::before{content:' '}.icon-mark-active{background-image:url(../images/restyle/icons/layout_edit.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-mark-active.x-tree-node-el{background-position:5px 5px!important}.icon-mark-active::before{content:' '}.icon-mark-complete{background-image:url(../images/restyle/icons/layout_header.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-mark-complete.x-tree-node-el{background-position:5px 5px!important}.icon-mark-complete::before{content:' '}.icon-package{background-image:url(../images/restyle/icons/package.png)!important;padding-right:5px!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-package.x-tree-node-el{background-position:5px 5px!important}.icon-package::before{content:' '}.icon-locked{background-image:url(../images/restyle/icons/lock_edit.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-locked.x-tree-node-el{background-position:5px 5px!important}.icon-locked::before{content:' '}.icon-lock{background-image:url(../images/restyle/icons/lock.png)!important;background-repeat:no-repeat!important;background-position:center!important;min-width:16px;min-height:16px;vertical-align:middle}.icon-lock.x-tree-node-el{background-position:5px 5px!important}.icon-lock::before{content:' '}#modx-resource-tree-panel .x-accordion-hd{background-position:0 0}#modx-element-tree-panel .x-accordion-hd{background-position:0 -32px}#modx-file-tree-panel .x-accordion-hd{background-position:0 -64px}#modx-static-page-settings .x-accordion-hd{background-position:0 -96px}.x-tree-node-el .x-tree-node-icon{display:inline-block}.x-tree-node-loading .x-tree-node-icon{background-image:url(../images/modx-theme/tree/loading.gif)!important}.x-tree-node-loading a span{color:#444;font-style:italic}.ext-ie .x-tree-node-el input{height:15px;width:15px}.x-tree-root-ct{border-radius:0;overflow:hidden;padding:0!important}.x-tree-root-node{margin:0}.x-tree-arrows .x-tree-elbow-end-minus,.x-tree-arrows .x-tree-elbow-end-plus,.x-tree-arrows .x-tree-elbow-minus,.x-tree-arrows .x-tree-elbow-plus{background:0 0}.x-tree-arrows .x-tree-elbow-end-minus:before,.x-tree-arrows .x-tree-elbow-end-plus:before,.x-tree-arrows .x-tree-elbow-minus:before,.x-tree-arrows .x-tree-elbow-plus:before{content:"\f0da";background:transparent 0 0;display:inline-block;width:10px;padding-left:6px;margin:0}.x-tree-arrows .x-tree-elbow-end-minus:before,.x-tree-arrows .x-tree-elbow-minus:before{content:"\f0d7";padding-left:4px;width:12px}.tree-context:before{content:"\f0ac"}.x-tree-node-expanded .tree-folder:before{content:"\f07c"}.tree-folder:before{content:"\f07b"}.tree-resource:before{content:"\f15b"}.tree-static-resource:before{content:"\f0f6"}.tree-weblink:before{content:"\f0c1"}.tree-symlink:before{content:"\f0c5"}.x-dd-drag-ghost a,.x-dd-drag-ghost a span,.x-tree-node,.x-tree-node a,.x-tree-node a span{color:#556c88}.x-tree-node .x-tree-node-disabled a span{color:#eaeef2}.x-tree-node div.x-tree-drag-insert-below{border-bottom-color:#686868}.x-tree-node div.x-tree-drag-insert-above{border-top-color:#686868}.x-tree-dd-underline .x-tree-node div.x-tree-drag-insert-below a{border-bottom-color:#686868}.x-tree-dd-underline .x-tree-node div.x-tree-drag-insert-above a{border-top-color:#686868}.x-tree-node .x-tree-drag-append a span{background-color:#ddd;border-color:#e4e4e4}.x-tree-node .x-tree-node-over,.x-tree-node .x-tree-selected{background-color:#e8f0f8}.x-tree-drop-ok-append .x-dd-drop-icon{background-image:url(../images/modx-theme/tree/drop-add.gif)}.x-tree-drop-ok-above .x-dd-drop-icon{background-image:url(../images/modx-theme/tree/drop-over.gif)}.x-tree-drop-ok-below .x-dd-drop-icon{background-image:url(../images/modx-theme/tree/drop-under.gif)}.x-tree-drop-ok-between .x-dd-drop-icon{background-image:url(../images/modx-theme/tree/drop-between.gif)}.nobg .x-panel-body{background:0 0;padding-right:1.5em}#managerbuttons{margin-bottom:1em;overflow:hidden;width:100%}#managerbuttons ul:after,#managerbuttons ul:before{content:" ";display:table}#managerbuttons ul:after{clear:both}#managerbuttons ul{*zoom:1;margin:0;width:100%}#managerbuttons ul li{display:table;float:left;margin:0;padding:0 1%;position:relative;width:25%;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}#managerbuttons ul li:first-child{padding-left:0}#managerbuttons ul li:last-child{padding-right:0}#managerbuttons ul li a{background-color:#fff;background-image:-webkit-linear-gradient(top,#fff,#f5f5f5);background-image:-webkit-gradient(linear,left top,left bottom,from(#fff),to(#f5f5f5));background-image:linear-gradient(to bottom,#fff,#f5f5f5);border-radius:3px;border:1px solid #e4e4e4;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.025);box-shadow:0 1px 0 rgba(0,0,0,.025);color:#53595f;display:table-cell;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700;padding:12px;position:relative;text-align:center;text-decoration:none;vertical-align:middle}#managerbuttons ul li a span{display:block;line-height:1.4}#managerbuttons ul li a span.headline{font-size:12px}#managerbuttons ul li a span.subline{font-weight:400}#managerbuttons ul li a span.icon{display:block;margin:0 auto;padding:0 0 10px;wdith:auto}#managerbuttons ul li a:hover span.icon{color:#3697cd}#contactus,#helpBanner{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;background:#fff;border:1px solid #e4e4e4;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.025);box-shadow:0 1px 0 rgba(0,0,0,.025);margin:.75em 0 1.75em;padding:18px;width:100%}#contactus h3,#helpBanner h3{margin:0 0 1em}#helpBanner{margin-top:1.5em;min-height:112px;background-repeat:no-repeat;background-position:right top;background-image:url(../images/modx-help-logo.png);background-image:-webkit-image-set(url(../images/modx-help-logo.png) 1x,url(../images/modx-help-logo@2x.png) 2x)}#helpBanner #helpLogo{float:right;height:76px;margin-right:1em;width:200px}#contactus{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;float:left;width:60%}#contactus form{display:inline}#contactus input[type=email]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;font-size:1.1em;margin-right:4px;padding:.4em;width:70%}#contactus input[type=submit]{border:0;cursor:pointer;font-size:1.1em;padding:6px 10px}#contactus p{color:#113445;margin:1em 0}#contactus form+p{margin:2em 0 0}#contactus a{color:#020608;text-decoration:none}#contactus a:hover{text-decoration:underline}#contactus a:hover i{text-decoration:none}#contactus a i{margin:0 8px -6px 0}#aboutMODX{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;background:#f8f8f8;float:left;margin:1em 0 0 2%;min-height:300px;padding:1em;width:38%}#aboutMODX p{line-height:1.6;margin:0 0 1em}#aboutMODX a{color:#3697cd;margin:-2px -4px;padding:2px 4px}#aboutMODX a:hover{background-color:#3697cd;color:#fff;text-decoration:none}body{color:#020608;font:400 13px/1.4 "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;-webkit-font-smoothing:antialiased}body a{color:#3697cd}body a:hover{color:#297aa7}h2,h3{color:#555;font:400 25px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;margin:0 0 8px 5px}h3{font:700 15px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}strong{font-weight:700}em{font-style:italic}hr{background-color:#a1b7c4;border:0;color:#a1b7c4;height:1px;margin:20px}.aleft{text-align:left}.aright{text-align:right}.right{float:right}.left{float:left}.clear{clear:left}.bold{font-weight:700}.not-installed{color:red}.red{color:red!important}.green{color:#81b548!important}.primary{color:#58a598!important}.error{color:red!important}.centered{text-align:center}.wait{background:transparent url(../images/style/wait.gif) no-repeat scroll center 55px;color:#53595f;font-size:15px;font-weight:700;padding:20px 10px 60px}.padding{background-color:#fff;padding:11px}.dashed{border-bottom:1px #90b1b9 dashed}.x-form-text,textarea.x-form-field{border-color:#e4e4e4}#modx-content,#modx-footer,#modx-leftbar{position:absolute}.modx-form p{padding-bottom:10px}.x-layout-mini{left:2px}#modx-resource-tabs{margin:20px 0 0}#modx-resource-tabs .x-tab-panel-header{width:auto!important}#modx-resource-tabs .x-tab-panel-header.vertical-tabs-header{width:150px!important}#modx-resource-tabs .x-tab-panel-header .x-tab-strip li{float:left;margin-left:0}#modx-resource-tabs #modx-tv-tabs{border-left:0;border-right:0}#modx-resource-tabs #modx-tv-tabs .x-tab-strip,#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip{margin-top:12px}#modx-resource-tabs #modx-tv-tabs .x-tab-strip li,#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip li{width:100%!important;margin-left:0;border-bottom:1px solid #e4e4e4}#modx-resource-tabs #modx-tv-tabs .x-tab-strip li:nth-last-child(3),#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip li:nth-last-child(3){border-color:transparent}#modx-resource-tabs #modx-tv-tabs .x-tab-strip li.x-tab-strip-active,#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip li.x-tab-strip-active{border-bottom:1px solid #e4e4e4}#modx-resource-content{background-color:transparent;-webkit-box-shadow:0 0 5px rgba(0,0,0,.1);box-shadow:0 0 5px rgba(0,0,0,.1)}#modx-resource-content .x-panel-header{margin:0;padding:15px}#modx-content-above .x-panel-bwrap,#modx-content-below .x-panel-bwrap,#modx-resource-content .x-panel-bwrap{border:none}.x-tab-panel-header,.x-tab-panel-header .x-tab-strip li{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.x-window-footer .x-toolbar-right-row td:last-of-type .x-btn{background-color:#79b7ad;background-image:-webkit-linear-gradient(#79b7ad,#58a598);background-image:-webkit-gradient(linear,left top,left bottom,from(#79b7ad),to(#58a598));background-image:linear-gradient(#79b7ad,#58a598);border-color:#4d9186}.x-window-footer .x-toolbar-right-row td:last-of-type .x-btn button{color:#fff}.x-window-footer .x-toolbar-right-row td:last-of-type .x-btn-over{border-color:#468479;background-color:#8dc2b9;background-image:-webkit-linear-gradient(#8dc2b9,#58a598);background-image:-webkit-gradient(linear,left top,left bottom,from(#8dc2b9),to(#58a598));background-image:linear-gradient(#8dc2b9,#58a598)}#modx-container{height:100%;width:100%;background:#f2f2f2}.x-panel-header{background:0 0;border:none;font-size:16px;margin:0 0 0 15px;padding:0 0 8px}.x-small-editor .x-form-field{font-size:12px!important}.grid-row-inactive{color:#999!important}a.x-grid-link{color:#020608;text-decoration:none}a.x-grid-link:focus,a.x-grid-link:hover{text-decoration:underline}#modx-resource-tabs .x-tool-toggle{margin-top:0;position:absolute;right:20px;top:65px;z-index:10}#modx-content form.x-panel-body,.modx-page-header,.modx-page-header div{background-color:transparent!important}#modx-mainpanel{height:100%;position:relative}.news_article{border-bottom:1px solid #ddd;padding:10px 0 33px}.news_article h2{font-size:17px}.news_article .content{color:#444}.news_article a{color:#535d6c;text-decoration:none}.news_article a:hover{color:#90b1b9}.news_article .date_stamp{color:#535d6c;float:right;font-size:11px;font-style:italic}.x-static-text-field{background:0 0;border:none;color:inherit;opacity:1}.modx-console .debug{color:gray}.modx-console .success{color:#81b548}.modx-console .warn{color:#00f}.modx-console .error{color:red}.modx-console-text{background-color:#fff;font:13px "Courier New",Courier,monospace!important;padding:8px;border:none}.x-form-text.modx-console-text{height:auto}.x-portal .x-panel-dd-spacer,.x-portlet{margin-bottom:10px}.x-portlet .x-panel-ml{padding-left:2px}.x-portlet .x-panel-mr{padding-right:2px}.x-portlet .x-panel-bl{padding-left:2px}.x-portlet .x-panel-br{padding-right:2px}.x-portlet .x-panel-body{background:#fff}.x-portlet .x-panel-mc{padding-top:2px}.x-portlet .x-panel-bc .x-panel-footer{padding-bottom:2px}.x-portlet .x-panel-nofooter .x-panel-bc{height:2px}.x-portal-space h2{border-bottom:1px solid #d4d4d4;margin:0 0 8px;padding:0 0 2px}.x-column-tree .x-panel-header{border-bottom-width:0;padding:3px 0 0}.x-column-tree .x-panel-header .x-panel-header-text{margin-left:3px}.x-column-tree .x-tree-node,.x-column-tree .x-tree-node-el{zoom:1}.x-column-tree .x-tree-selected{background:#d9e8fb}.x-column-tree .x-tree-node a{line-height:18px;vertical-align:middle}.x-column-tree .x-tree-node .x-tree-selected a span{background:0 0;color:#000}.x-tree-col{float:left;overflow:hidden;padding:0 1px;zoom:1}.x-tree-col-text,.x-tree-hd-text{color:#000;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;overflow:hidden;padding:3px 3px 3px 5px;text-overflow:ellipsis;white-space:nowrap}.x-tree-headers{cursor:default;margin-top:3px;zoom:1}.x-tree-hd{border-left:1px solid #eee;border-right:1px solid #d0d0d0;float:left;overflow:hidden}.ux-row-action-cell .x-grid3-cell-inner{padding:1px 0 0}.ext-ie .ux-row-action-item{width:16px}.ext-ie .ux-row-action-text{width:auto}.ux-row-action-item span{background:transparent url(../images/style/go-next.png) no-repeat scroll 1px 4px;display:inline!important;line-height:24px;margin:0 5px;padding:5px 5px 5px 22px;vertical-align:middle}.icon-uninstall span{background:url(../images/style/delete.png) no-repeat scroll 1px 4px transparent}.package-details span{background:url(../images/style/info.png) no-repeat scroll 1px 4px transparent}.package-download span{background:url(../images/style/download.png) no-repeat scroll 1px 4px transparent}.package-installed span{background:url(../images/style/accept.png) no-repeat scroll 1px 4px transparent}.ext-ie .ux-row-action-item span{width:auto}.x-grid-group-hd div{height:16px;position:relative}.ux-grow-action-item{background-position:0 50%!important;background-repeat:no-repeat;cursor:pointer;float:left;margin:0;min-width:16px;padding:0!important}.ext-ie .ux-grow-action-item{width:16px}.ux-action-right{float:right;margin:0 3px 0 2px;padding:0!important}.ux-grow-action-text{background:transparent none!important;float:left;margin:0!important;padding:0!important}.ux-row-action-item:hover{background:#dfdfdf;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fff),color-stop(100%,#dfdfdf));background:-webkit-linear-gradient(center bottom,#dfdfdf 0,#fff 100%);background:-webkit-gradient(linear,,from(#dfdfdf),to(#fff));background:linear-gradient(center bottom,#dfdfdf 0,#fff 100%);border:1px solid #9caf78;color:#636f4c!important;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#ffffff, endColorstr=#dfdfdf, GradientType=0)}.ux-row-action-item:active{background-color:#fff;background-image:none;border-color:#CFCFCF silver #AAA;-webkit-box-shadow:0 0 3px #aaa inset;box-shadow:0 0 3px #aaa inset;margin:2px 1px 0}.ux-row-action-item:active span{text-shadow:none}.ux-row-action-item{background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fcfcfc),color-stop(100%,#dcdcdc));background:-webkit-linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);background:-webkit-gradient(linear,,from(#dcdcdc),to(#fcfcfc));background:linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);background:url(/manager/templates/default/images/modx-theme/form/button-bg.png) repeat-x scroll 0 bottom #dcdcdc;border-collapse:separate;border-color:#CACACA silver #AAA;border-radius:3px;border-style:solid;border-width:1px;-webkit-box-shadow:rgba(0,0,0,.2)0 0 1px;box-shadow:rgba(0,0,0,.2)0 0 1px;color:#444;cursor:pointer;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc, endColorstr=#dcdcdc, GradientType=0);float:left;font-weight:700;margin:2px 1px 0;overflow:hidden;padding:3px;position:relative;text-shadow:0 1px 0 #FAFAFA}.x-tree-checkbox{background:url(../../../assets/ext3/resources/images/default/form/checkbox.gif) no-repeat 0 0;height:13px;margin:0 1px;vertical-align:middle;width:13px}.x-tree-checkbox-over .x-tree-checkbox{background-position:-13px 0}.x-tree-checkbox-down .x-tree-checkbox{background-position:-26px 0}.x-tree-node-disabled .x-tree-checkbox{background-position:-39px 0}.x-tree-node-checked{background-position:0 -13px}.x-tree-checkbox-over .x-tree-node-checked{background-position:-13px -13px}.x-tree-checkbox-down .x-tree-node-checked{background-position:-26px -13px}.x-tree-node-disabled .x-tree-node-checked{background-position:-39px -13px}.x-tree-node-grayed{background-position:0 -26px}.x-tree-checkbox-over .x-tree-node-grayed{background-position:-13px -26px}.x-tree-checkbox-down .x-tree-node-grayed{background-position:-26px -26px}.x-tree-node-disabled .x-tree-node-grayed{background-position:-39px -26px}.x-tree-branch-unchecked .x-tree-checkbox,.x-tree-branch-unchecked .x-tree-node-checked,.x-tree-branch-unchecked .x-tree-node-grayed{background-position:0 0}.x-tree-branch-unchecked .x-tree-checkbox-over .x-tree-checkbox,.x-tree-branch-unchecked .x-tree-checkbox-over .x-tree-node-checked,.x-tree-branch-unchecked .x-tree-checkbox-over .x-tree-node-grayed{background-position:-13px 0}.x-tree-branch-unchecked .x-tree-checkbox-down .x-tree-checkbox,.x-tree-branch-unchecked .x-tree-checkbox-down .x-tree-node-checked,.x-tree-branch-unchecked .x-tree-checkbox-down .x-tree-node-grayed{background-position:-26px 0}.x-tree-branch-unchecked .x-tree-node-disabled .x-tree-checkbox,.x-tree-branch-unchecked .x-tree-node-disabled .x-tree-node-checked,.x-tree-branch-unchecked .x-tree-node-disabled .x-tree-node-grayed{background-position:-39px 0}.x-tree-branch-checked .x-tree-checkbox,.x-tree-branch-checked .x-tree-node-checked,.x-tree-branch-checked .x-tree-node-grayed{background-position:0 -13px}.x-tree-branch-checked .x-tree-checkbox-over .x-tree-checkbox,.x-tree-branch-checked .x-tree-checkbox-over .x-tree-node-checked,.x-tree-branch-checked .x-tree-checkbox-over .x-tree-node-grayed{background-position:-13px -13px}.x-tree-branch-checked .x-tree-checkbox-down .x-tree-checkbox,.x-tree-branch-checked .x-tree-checkbox-down .x-tree-node-checked,.x-tree-branch-checked .x-tree-checkbox-down .x-tree-node-grayed{background-position:-26px -13px}.x-tree-branch-checked .x-tree-node-disabled .x-tree-checkbox,.x-tree-branch-checked .x-tree-node-disabled .x-tree-node-checked,.x-tree-branch-checked .x-tree-node-disabled .x-tree-node-grayed{background-position:-39px -13px}.x-rbtn button{-moz-outline:0 none;background-color:transparent;background-position:center;background-repeat:no-repeat;border:0 none;cursor:pointer;font-size:1px;height:16px;line-height:1px;margin:0;outline:0 none;padding:0;width:24px}.x-rbtn{table-layout:fixed}.x-rbtn td{background-image:url(../images/restyle/icons/rbtn.gif);background-repeat:no-repeat;border:0 none;height:21px;padding:0;vertical-align:middle;width:24px}.x-rbtn td.x-rbtn-first{background-position:0 0}.x-rbtn td.x-rbtn-item{background-position:0 -42px}.x-rbtn td.x-rbtn-last{background-position:right -21px}.x-rbtn td.x-rbtn-first-active{background-position:0 -63px}.x-rbtn td.x-rbtn-item-active{background-position:0 -105px}.x-rbtn td.x-rbtn-last-active{background-position:right -84px}.ux-up-item{background-color:#f0f0f0;background-image:url(../../../assets/modext/util/filetree/img/white_bg.png);background-repeat:no-repeat;cursor:default;height:17px;line-height:17px;margin-bottom:1px;position:relative}.ux-up-icon-file{float:left;height:16px;margin-right:4px;vertical-align:-3px;width:16px}.ux-up-indicator{background-color:#FF0;height:17px;opacity:.4;position:absolute;width:40px}.ux-up-icon-state{cursor:pointer;float:right;margin-right:2px;width:16px;z-index:-1}.ux-up-icon-queued{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/page_white_get.png)}.ux-up-icon-uploading{background-image:url(../../../../ext2/resources/images/default/grid/wait.gif)}.ux-up-icon-done{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/accept.png)}.ux-up-icon-failed{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/error.png)}.ux-up-icon-stopped{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/stop.png)}.ux-up-text{float:left}.ux-ftm-nodename{color:#000;cursor:default!important;font-weight:700}.ux-icon-combo-icon{background-position:0 50%;background-repeat:no-repeat;height:14px;width:18px}.ux-icon-combo-input{padding-left:25px}.x-form-field-wrap .ux-icon-combo-icon{left:5px;top:3px}.ux-icon-combo-item{background-position:3px 50%!important;background-repeat:no-repeat!important;padding-left:24px!important}.modx-status-msg{background:#f4f4f4;border-radius:4px;left:70%;margin:0;opacity:.8;padding:5px;position:fixed;top:10px;width:25%;z-index:20000}iframe[classname=x-hidden]{visibility:hidden}ul.modx-tag-list{list-style:none;margin:3px 0 0;overflow:auto;padding:0}ul.modx-tag-list li{cursor:pointer;float:left;list-style:none;margin:1px 5px 0;padding:1px 6px;text-decoration:underline}ul.modx-tag-list li.modx-tag-checked{background-color:#779937;border-radius:10px;color:#fff;text-decoration:none}.modx-tv-reload-btn{float:right;position:absolute;right:19px;z-index:10}.modx-tv-reload-btn div{z-index:10}.modx-tv-th label{cursor:pointer}.modx-tv-th .tv-description{color:#444;font-size:11px;font-weight:400}.ext-ux-uploaddialog-addbtn{background:url(../images/restyle/fileup/file-add.gif) no-repeat left center!important}.ext-ux-uploaddialog-removebtn{background:url(../images/restyle/fileup/file-remove.gif) no-repeat left center!important}.ext-ux-uploaddialog-resetbtn{background:url(../images/restyle/fileup/reset.gif) no-repeat left center!important}.ext-ux-uploaddialog-uploadstartbtn{background:url(../images/restyle/fileup/upload-start.gif) no-repeat left center!important}.ext-ux-uploaddialog-uploadstopbtn{background:url(../images/restyle/fileup/upload-stop.gif) no-repeat left center!important}.ext-ux-uploaddialog-indicator-stoped{background:url(../images/restyle/fileup/done.gif) no-repeat center center;height:16px;width:16px}.ext-ux-uploaddialog-indicator-processing{background:url(../images/restyle/fileup/loading.gif) no-repeat center center;height:16px;width:16px}.ext-ux-uploaddialog-state{background-position:center center;background-repeat:no-repeat;text-align:center}.ext-ux-uploaddialog-state-0{background-image:url(../images/restyle/fileup/uncheck.gif)}.ext-ux-uploaddialog-state-1{background-image:url(../images/restyle/fileup/check.gif)}.ext-ux-uploaddialog-state-2{background-image:url(../images/restyle/fileup/failed.gif)}.ext-ux-uploaddialog-state-3{background-image:url(../images/restyle/fileup/file-uploading.gif)}.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-bar .x-progress-text div{display:none}.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-text-back{left:0;position:absolute;right:0}.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-text-back div{white-space:nowrap;width:auto!important}.tq-treegrid .tq-treegrid-col{border:none}.tq-treegrid .tq-treegrid-icons{float:left}.tq-treegrid .x-tree-node-el{line-height:13px;padding:1px 3px 1px 5px}.tq-treegrid .tq-treegrid-static .x-tree-ec-icon{display:none}.tq-treegrid .tq-treegrid-static .x-tree-node-el{cursor:default}.x-superboxselect{display:block;height:auto!important;margin:0;outline:0!important;overflow:hidden;padding:2px;position:relative;width:auto!important}.x-superboxselect input[disabled]{background-color:transparent}.x-superboxselect ul{cursor:text;overflow:hidden}.x-superboxselect-display-btns{padding-right:33px!important}.x-superboxselect-btns{overflow:hidden;padding:2px;position:absolute;right:1px;top:0}.x-superboxselect-btns div{float:left;height:16px;margin-top:4px;width:16px}.x-superboxselect-btn-clear{background:url(../images/restyle/icons/sb_clear.png) no-repeat scroll left 0}.x-superboxselect-btn-expand{background:url(../images/restyle/icons/sb_expand.png) no-repeat scroll left 0}.x-superboxselect-btn-over{background-position:left -16px}.x-superboxselect-btn-hide{display:none}.x-superboxselect li{float:left;line-height:18px;margin:1px 1px 2px;padding:0}.x-superboxselect-stacked li{float:none!important}.x-superboxselect-input input{border:none;margin-bottom:4px;margin-top:4px;outline:0}body.ext-ie .x-superboxselect-input input{background:0 0;border:none;margin-top:3px}.x-superboxselect-item{background-color:#DEE7F8;border-radius:6px;border:1px solid #CAD8F3;padding:1px 15px 1px 5px!important;position:relative}body.ext-ie7 .x-superboxselect-item{line-height:1.2em;margin:2px 1px;padding:2px 17px 4px 5px!important}.x-superboxselect-item-hover{background:#BBCEF1;border:1px solid #6D95E0}.x-superboxselect-item-focus{background:#598BEC;border-color:#598BEC;color:#fff}.x-superboxselect-item-close{background:url(../images/restyle/icons/sb_close.png) no-repeat scroll left 0;border:none;cursor:pointer;display:block;font-size:1px;height:16px;padding:0;position:absolute;right:0;top:2px;width:13px}.x-superboxselect-list{font-size:14px!important}.x-superboxselect-item-close:active,.x-superboxselect-item-close:hover{background-position:left -12px}.x-superboxselect-item-focus .x-superboxselect-item-close{background-position:left -24px}.x-item-disabled .x-superboxselect-item-close{background-position:left -36px}.ext-strict .x-superboxselect-ct .x-form-field-trigger-wrap .x-form-text,.x-superboxselect-ct .x-form-field-wrap,.x-superboxselect-ct .x-superboxselect{height:auto!important}.modx-tree-load-msg{color:#020608;font-size:.9em;line-height:1;padding:3px;white-space:pre-line}.dashboard{overflow:visible}.dashboard-block{background-color:#fff;border-radius:2px;float:left;margin:6px 0}.dashboard-block h4{color:#535d6c;font-size:13px;padding-bottom:2px}.dashboard-block em{font-style:italic}.dashboard-block strong{font-weight:700}.dashboard-block li{padding-left:10px}.dashboard-block .body{color:#444;font-size:12px;height:auto;max-height:300px;overflow:auto;padding:10px}.dashboard-block .title{background:#d2dbe2;border-radius:2px 2px 0 0;color:#5E5E5E;font-size:12px;font-weight:700;margin:0;padding:15px;zoom:1}.dashboard-block-half{width:49%;margin-left:0;float:left;clear:left}.dashboard-block-half:nth-of-type(2n+0){margin-left:1%;float:right;clear:none}.dashboard-block-full{clear:both;height:auto;width:100%}.dashboard-block-double{clear:both;height:auto;min-height:400px;width:100%}.dashboard-block-variable .body{height:auto}.container{margin:20px 15px}.panel-desc{background-color:#f5f5f5;border:none;color:#5A5A5A;line-height:1.5;margin-top:5px;padding:15px!important}.panel-desc .x-panel-bwrap{background-color:transparent!important}.with-title .panel-desc{margin:0}.panel-desc p{padding:0}.win-desc{background:#DFDFDF;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#f4f4f4),color-stop(100%,#dfdfdf));background:-webkit-linear-gradient(center bottom,#dfdfdf 0,#f4f4f4 100%);background:-webkit-gradient(linear,,from(#dfdfdf),to(#f4f4f4));background:linear-gradient(center bottom,#dfdfdf 0,#f4f4f4 100%);border-bottom:1px solid #CCC!important;border:0 none;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#F4F4F4, endColorstr=#DFDFDF, GradientType=0);margin-top:0;padding:10px 0 0!important}.win-desc p{color:#555;font-size:13px;font-style:italic;line-height:1.4;padding:0 10px 10px;text-shadow:0 1px 0 #fff}.main-wrapper{padding:15px}.with-title .main-wrapper{padding:0 15px 10px}.left-col{padding-right:15px}.right-col{padding-left:15px}#modx-tv-tabs{width:100%}.modx-tv{border-bottom:1px solid #f4f4f4;margin:0;padding:15px 0!important;width:100%}#modx-tv-tabs .tv-first{padding-top:0!important}#modx-tv-tabs .tv-last{border-bottom:0!important;padding-bottom:0!important}.modx-tv-label{float:left;width:auto!important}.modx-tv-label:hover .modx-tv-reset{opacity:100}.modx-tv-label-title{float:left}.modx-tv-label-description{display:block;float:left;font-style:italic;font-weight:400;padding-left:5px}.modx-tv-reset{background:url(../images/restyle/icons/arrow_rotate_anticlockwise.png) top right no-repeat;cursor:pointer;float:left;height:16px;opacity:0;width:16px}.modx-tv-description{color:#666;font-size:10px;line-height:1.2;margin-top:2px!important}.modx-tv-inherited{color:#666;display:block;float:right;font-size:10px;font-style:italic;line-height:1.2;padding-top:4px}#modx-page-settings .modx-tv-label,#modx-resource-settings .modx-tv-label{width:216px}.modx-tv .x-form-check-wrap{line-height:14px!important}.modx-tv .x-form-cb-label{font-weight:400;top:0}.tvs-wrapper{padding:0}#modx-resource-tvs-div{border-top-width:0}#modx-resource-tvs-div.below-content{border-top-width:1px;margin-top:10px}.modx-permissions-list{color:#777;font-size:12px}.modx-permissions-list-textarea{background-color:transparent!important;border:0!important}.x-selectable,.x-selectable *{-khtml-user-select:all!important;-webkit-user-select:text!important;-moz-user-select:text!important;-ms-user-select:text!important;user-select:text!important}.crumb_wrapper{border-bottom:1px solid #CACACA;border-top:1px solid #D0D0D0;margin-top:5px}.crumbs{background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fcfcfc),color-stop(100%,#dcdcdc));background:-webkit-linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);background:-webkit-gradient(linear,,from(#dcdcdc),to(#fcfcfc));background:linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);border-bottom:1px solid #EFEFEF;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc, endColorstr=#dcdcdc, GradientType=0);height:34px}.crumbs li{background:url(../images/style/crumbs-bg.png) no-repeat scroll right center transparent;color:#53595f;float:left;font-size:12px;font-weight:400;line-height:35px;padding:0 20px 0 15px;text-shadow:0 1px 0 #FFF}.crumbs li button{background-color:transparent;border:0 none;color:#53595f;cursor:pointer;font:400 13px/1.4 "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-weight:700;padding:0;text-decoration:none}.crumbs li .root{background:url(../images/style/home.png) no-repeat scroll center top transparent;display:block;height:16px;margin:10px 0 9px;text-indent:-999em;width:16px}.crumbs li button.root{background-position:center -16px;text-indent:-999em;width:16px}.breadcrumbs .panel-desc{margin-top:1px}#ux-lightbox{left:0;line-height:0;position:absolute;text-align:center;width:100%;z-index:15000}#ux-lightbox img{height:auto;width:auto}#ux-lightbox a img{border:medium none}#ux-lightbox-outerImageContainer{background-color:#fff;height:250px;margin:0 auto;position:relative;width:250px}#ux-lightbox-imageContainer{padding:10px}#ux-lightbox-loading{background:url(../images/style/loading.gif) no-repeat scroll center 15% transparent;height:25%;left:0;line-height:0;position:absolute;text-align:center;top:40%;width:100%}#ux-lightbox-hoverNav{height:100%;left:0;position:absolute;top:0;width:100%;z-index:10}#ux-lightbox-hoverNav a{outline:medium none}#ux-lightbox-imageContainer>#ux-lightbox-hoverNav{left:0}#ux-lightbox-navNext,#ux-lightbox-navPrev{display:block;height:100%;width:49%}#ux-lightbox-navPrev{float:left;left:0}#ux-lightbox-navPrev:hover,#ux-lightbox-navPrev:visited:hover{background:transparent url(images/lb-prev.png) no-repeat scroll left 33%}#ux-lightbox-navNext{float:right;right:0}#ux-lightbox-navNext:hover,#ux-lightbox-navNext:visited:hover{background:transparent url(images/lb-next.png) no-repeat scroll right 33%}#ux-lightbox-outerDataContainer{margin:0 auto;width:100%}#ux-lightbox-dataContainer{background-color:#fff;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-size:10px;overflow:auto}#ux-lightbox-data{color:#666;padding:0 10px}#ux-lightbox-data #ux-lightbox-details{float:left;text-align:left;width:80%}#ux-lightbox-data #ux-lightbox-caption{font-weight:700}#ux-lightbox-data #ux-lightbox-imageNumber{clear:left;display:block;padding-bottom:1em}#ux-lightbox-data #ux-lightbox-navClose{background:transparent url(../images/style/close.png) no-repeat scroll 0 0;float:right;height:16px;outline:medium none;padding-bottom:.7em;width:16px}#ux-lightbox-overlay,#ux-lightbox-shim{background-color:#000;border:0 none;height:500px;left:0;margin:0;padding:0;position:absolute;top:0;width:100%;z-index:14999}#ux-lightbox-shim{background-color:transparent;z-index:89}.x-panel-body-noheader .x-grid3-row{position:relative}.x-grid3-col-main{padding:10px 5px 35px}.x-grid3-cell-inner.x-grid3-col-main h3{color:#555;font:400 13px/1.4 "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;font-size:20px;line-height:1;margin:0 0 2px}.x-grid3-cell-inner.x-grid3-col-main .not-installed{color:#999}.package-installed{color:gray;opacity:.5}#modx-grid-package .green{text-align:center}#modx-grid-package .green a{color:red!important}#modx-grid-package .red{color:#81b548!important;text-align:center}.grid-with-buttons .x-grid3-row-expanded .x-grid3-row-body{margin:-45px 2px 0 -20px;padding:18px 25px 40px}.home-panel ol{border-top:1px solid #CACACA}.home-panel ol li{border-bottom:1px solid #e0e0e0}.home-panel ol li:first-child{border-top-color:0 none}.home-panel ol li:last-child{border-bottom:0 none}.home-panel ol li button{background-color:transparent;border:0 none;color:#53595f;cursor:pointer;display:block;font-size:15px;font-weight:700;padding:12px 20px 12px 6px;position:relative;text-decoration:none}.home-panel ol li:hover button{background:transparent url(../images/style/search.png) no-repeat scroll right center;color:#3D4349}.home-panel ol li .highlighted{color:#909090;float:right;font-size:10px;padding:13px 10px 0}.home-panel ol li button .ct{color:#AAA;margin-right:10px}.home-panel .one_half{overflow:hidden}.home-panel .desc-wrapper{margin-top:38px}.home-panel .text-wrapper{font-style:normal;max-height:none}.home-panel .provider_name{background-color:#9bb3bf;line-height:1.8}.home-panel .pnl_instructions{margin:20px 0}.home-panel .stats{clear:both;display:inline-block;margin-top:15px}.home-panel .stats p{color:#777;font-size:12px;font-style:italic;line-height:1.5}.pbr-provider-box{float:left;margin-top:10px;width:250px}.pbr-provider-home,.pbr-repository-view,.pbr-tag-view{padding:10px}.pbr-details-right{float:right!important;text-align:right!important}.pbr-thumb-downloaded{opacity:.5}#package-browser-card-container{margin:0}.one_half{float:left;margin-right:3%;position:relative;width:48%}.last{clear:right;margin-right:0!important}.modx-pb-view-ct{background:#fff;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif}.modx-pb-thumb{border:1px solid #ddd;height:80px;line-height:80px;padding:5px;text-align:center;width:100px}.modx-pb-thumb img{vertical-align:middle}.modx-pb-thumb-wrap{border:1px solid transparent;float:left;margin:4px 0 4px 4px;overflow:hidden;padding:4px}.modx-pb-thumb-wrap span{display:block;overflow:hidden;text-align:center}.modx-pb-view-ct .x-view-over{border:1px solid #ddd;padding:4px}.modx-pb-view-ct .x-view-selected{background:#DFEDFF;border:1px solid #6593cf;padding:4px}.modx-pb-view-ct .x-view-selected .thumb{background:0 0}.modx-pb-view-ct .x-view-selected span{color:#1A4D8F}.modx-pb-view-ct .loading-indicator{background-position:left;background-repeat:no-repeat;font-size:11px;margin:10px;padding-left:20px}.modx-pb-detail-thumb{cursor:pointer;margin-top:5px;text-align:center}.modx-pb-details-info{border-top:1px solid #ccc;font:400 11px "Helvetica Neue",Helvetica,arial,tahoma,sans-serif;margin-top:5px;padding:5px;text-align:left}.modx-pb-details-info b{color:#555;display:block;margin-bottom:4px}.modx-pb-details-info span{display:block;margin-bottom:5px;margin-left:5px}.modx-pb-fullview{text-align:center}.package-readme{padding:8px 11px 0}#modx-package-browser-home{margin-top:5px;min-height:560px}.empty-text-wrapper{color:#888;font-weight:700;line-height:1.4}.modx-template-detail{background-color:transparent}.modx-template-detail .aside-details{background-color:#FDFDFD;border:1px solid #E0E0E0;margin-right:0}.modx-template-detail .selected h5{color:#53595f;font-size:14px;margin:10px 0}.modx-template-detail .selected img{border-radius:3px;border:1px solid #aaa;height:80px;width:90px}.modx-template-detail .item{margin-bottom:25px}.modx-template-detail .item li,.modx-template-detail .item p{color:#888;line-height:1.4}.modx-template-detail .item a{color:#53595f;font-style:italic}.modx-template-detail h4{color:#53595f;font-size:14px;margin:10px 0;text-shadow:0 1px 0 #fff;text-transform:uppercase}.modx-template-detail .aside-details h4{font-size:11px;margin-top:0}.modx-template-detail .selected{border-bottom:1px solid #E0E0E0;color:#5B7A98;padding:15px;text-align:center}.modx-template-detail .description{background-color:#F3F3F3;border-bottom:1px solid #E0E0E0;border-top:1px solid #FFF;color:#666;font-size:10px;line-height:1.2;margin-left:1px;padding:15px;text-shadow:0 1px 0 #FFF}.modx-template-detail .infos{border-top:1px solid #FFF;margin-left:1px;padding:15px}.modx-template-detail .infos ul li{font-size:10px}.modx-template-detail .infos ul li .infoname{color:#AAA;font-weight:700;width:50%}.modx-template-detail .infos ul li .infovalue{max-width:50%;padding:0 8px;word-wrap:break-word}.modx-template-detail .infos ul li span{display:inline-block;padding:0}.thumb-wrapper{background-color:#F5F5F5;border-radius:2px;border:1px solid #ccc;cursor:pointer;float:left;margin:0 15px 15px 0;overflow:hidden;padding:0 0 12px;position:relative;text-align:center;width:132px}.thumb-wrapper .thumb{background-color:#fff;border-bottom:1px solid #ccc;height:95px;margin:0 auto;width:132px}.thumb-wrapper .thumb img{height:95px;width:135px}.thumb-wrapper .thumb .no-preview{color:#888;display:inline-block;font-size:9px;font-weight:700;padding:31px 15px;text-align:center;text-transform:uppercase}.thumb-wrapper span{display:block;overflow:hidden;text-align:center;text-shadow:0 1px 0 #fff}.thumb-wrapper span.downloaded{background-color:#658F1A;color:#fff;font-weight:700;padding:5px 0;position:absolute;text-align:center;text-shadow:none;top:68px;width:100%}.thumb-wrapper .name{color:#53595f;font-size:12px;font-weight:700;margin-top:10px}.thumb-wrapper .downloads{color:#999;font-size:9px;text-transform:uppercase}.thumb-wrapper.selected{background-color:#fff;padding:0 0 12px}.thumb-wrapper.selected img{border:0 none}.pbr-thumb{background:#ddd;height:80px;padding:3px;width:100px}.pbr-thumb img{height:80px;width:100px}.x-grid3-hd-info-col,.x-grid3-hd-meta-col,.x-grid3-hd-text-col{text-align:center}.x-grid3-col-text-col{font-size:11px;text-align:center}.x-grid3-col-info-col,.x-grid3-col-meta-col{font-size:11px;font-weight:700;text-align:center}.x-grid3-col-meta-col{color:#53595f}.x-grid3-col-info-col{color:#92AF4C}.not-installed .x-grid3-col-info-col{color:red}.inline-button{-webkit-box-align:center;display:inline;margin:0 auto;padding:8px;text-align:center}.meta-wrapper{color:gray;max-height:400px;overflow:auto;padding:15px;white-space:pre}.window-no-padding .x-panel-mc,.window-no-padding .x-panel-ml,.window-no-padding .x-panel-mr{padding:0!important}.window-no-padding .x-tab-panel-noborder{margin:0!important}.upload-error{color:red}.upload-success{color:#090}.upload-status-text{white-space:normal}.upload-thumb{float:right}
+ */
+/* FONT PATH
+ * -------------------------- */
+@font-face {
+  font-family: 'FontAwesome';
+  src: url("../fonts/fontawesome-webfont.eot?v=4.1.0");
+  src: url("../fonts/fontawesome-webfont.eot?#iefix&v=4.1.0") format("embedded-opentype"), url("../fonts/fontawesome-webfont.woff?v=4.1.0") format("woff"), url("../fonts/fontawesome-webfont.ttf?v=4.1.0") format("truetype"), url("../fonts/fontawesome-webfont.svg?v=4.1.0#fontawesomeregular") format("svg");
+  font-weight: normal;
+  font-style: normal;
+}
+.icon {
+  display: inline-block;
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* makes the font 33% larger relative to the icon container */
+.icon-lg, .icon-large {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -15%;
+}
+
+.icon-2x {
+  font-size: 2em;
+}
+
+.icon-3x {
+  font-size: 3em;
+}
+
+.icon-4x {
+  font-size: 4em;
+}
+
+.icon-5x {
+  font-size: 5em;
+}
+
+.icon-fw {
+  width: 1.28571em;
+  text-align: center;
+}
+
+.icon-ul {
+  padding-left: 0;
+  margin-left: 2.14286em;
+  list-style-type: none;
+}
+.icon-ul > li {
+  position: relative;
+}
+
+.icon-li {
+  position: absolute;
+  left: -2.14286em;
+  width: 2.14286em;
+  top: 0.14286em;
+  text-align: center;
+}
+.icon-li.icon-lg, .icon-li.icon-large {
+  left: -1.85714em;
+}
+
+.icon-border {
+  padding: .2em .25em .15em;
+  border: solid 0.08em #eeeeee;
+  border-radius: .1em;
+}
+
+.pull-right {
+  float: right;
+}
+
+.pull-left {
+  float: left;
+}
+
+.icon.pull-left {
+  margin-right: .3em;
+}
+.icon.pull-right {
+  margin-left: .3em;
+}
+
+.icon-spin {
+  -webkit-animation: spin 2s infinite linear;
+  -moz-animation: spin 2s infinite linear;
+  -o-animation: spin 2s infinite linear;
+  animation: spin 2s infinite linear;
+}
+
+@-moz-keyframes spin {
+  0% {
+    -moz-transform: rotate(0deg);
+  }
+
+  100% {
+    -moz-transform: rotate(359deg);
+  }
+}
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(359deg);
+  }
+}
+@-o-keyframes spin {
+  0% {
+    -o-transform: rotate(0deg);
+  }
+
+  100% {
+    -o-transform: rotate(359deg);
+  }
+}
+@keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+.icon-rotate-90 {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=1);
+  -webkit-transform: rotate(90deg);
+  -moz-transform: rotate(90deg);
+  -ms-transform: rotate(90deg);
+  -o-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+
+.icon-rotate-180 {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+.icon-rotate-270 {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=3);
+  -webkit-transform: rotate(270deg);
+  -moz-transform: rotate(270deg);
+  -ms-transform: rotate(270deg);
+  -o-transform: rotate(270deg);
+  transform: rotate(270deg);
+}
+
+.icon-flip-horizontal {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=0);
+  -webkit-transform: scale(-1, 1);
+  -moz-transform: scale(-1, 1);
+  -ms-transform: scale(-1, 1);
+  -o-transform: scale(-1, 1);
+  transform: scale(-1, 1);
+}
+
+.icon-flip-vertical {
+  filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=2);
+  -webkit-transform: scale(1, -1);
+  -moz-transform: scale(1, -1);
+  -ms-transform: scale(1, -1);
+  -o-transform: scale(1, -1);
+  transform: scale(1, -1);
+}
+
+.icon-stack {
+  position: relative;
+  display: inline-block;
+  width: 2em;
+  height: 2em;
+  line-height: 2em;
+  vertical-align: middle;
+}
+
+.icon-stack-1x, .icon-stack-2x {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  text-align: center;
+}
+
+.icon-stack-1x {
+  line-height: inherit;
+}
+
+.icon-stack-2x {
+  font-size: 2em;
+}
+
+.icon-inverse {
+  color: white;
+}
+
+/* Font Awesome uses the Unicode Private Use Area (PUA) to ensure screen
+   readers do not read off random characters that represent icons */
+.icon-glass:before {
+  content: "\f000";
+}
+
+.icon-music:before {
+  content: "\f001";
+}
+
+.icon-search:before {
+  content: "\f002";
+}
+
+.icon-envelope-o:before {
+  content: "\f003";
+}
+
+.icon-heart:before {
+  content: "\f004";
+}
+
+.icon-star:before {
+  content: "\f005";
+}
+
+.icon-star-o:before {
+  content: "\f006";
+}
+
+.icon-user:before {
+  content: "\f007";
+}
+
+.icon-film:before {
+  content: "\f008";
+}
+
+.icon-th-large:before {
+  content: "\f009";
+}
+
+.icon-th:before {
+  content: "\f00a";
+}
+
+.icon-th-list:before {
+  content: "\f00b";
+}
+
+.icon-check:before {
+  content: "\f00c";
+}
+
+.icon-times:before {
+  content: "\f00d";
+}
+
+.icon-search-plus:before {
+  content: "\f00e";
+}
+
+.icon-search-minus:before {
+  content: "\f010";
+}
+
+.icon-power-off:before {
+  content: "\f011";
+}
+
+.icon-signal:before {
+  content: "\f012";
+}
+
+.icon-gear:before,
+.icon-cog:before {
+  content: "\f013";
+}
+
+.icon-trash-o:before {
+  content: "\f014";
+}
+
+.icon-home:before {
+  content: "\f015";
+}
+
+.icon-file-o:before {
+  content: "\f016";
+}
+
+.icon-clock-o:before {
+  content: "\f017";
+}
+
+.icon-road:before {
+  content: "\f018";
+}
+
+.icon-download:before {
+  content: "\f019";
+}
+
+.icon-arrow-circle-o-down:before {
+  content: "\f01a";
+}
+
+.icon-arrow-circle-o-up:before {
+  content: "\f01b";
+}
+
+.icon-inbox:before {
+  content: "\f01c";
+}
+
+.icon-play-circle-o:before {
+  content: "\f01d";
+}
+
+.icon-rotate-right:before,
+.icon-repeat:before {
+  content: "\f01e";
+}
+
+.icon-refresh:before {
+  content: "\f021";
+}
+
+.icon-list-alt:before {
+  content: "\f022";
+}
+
+.icon-lock:before {
+  content: "\f023";
+}
+
+.icon-flag:before {
+  content: "\f024";
+}
+
+.icon-headphones:before {
+  content: "\f025";
+}
+
+.icon-volume-off:before {
+  content: "\f026";
+}
+
+.icon-volume-down:before {
+  content: "\f027";
+}
+
+.icon-volume-up:before {
+  content: "\f028";
+}
+
+.icon-qrcode:before {
+  content: "\f029";
+}
+
+.icon-barcode:before {
+  content: "\f02a";
+}
+
+.icon-tag:before {
+  content: "\f02b";
+}
+
+.icon-tags:before {
+  content: "\f02c";
+}
+
+.icon-book:before {
+  content: "\f02d";
+}
+
+.icon-bookmark:before {
+  content: "\f02e";
+}
+
+.icon-print:before {
+  content: "\f02f";
+}
+
+.icon-camera:before {
+  content: "\f030";
+}
+
+.icon-font:before {
+  content: "\f031";
+}
+
+.icon-bold:before {
+  content: "\f032";
+}
+
+.icon-italic:before {
+  content: "\f033";
+}
+
+.icon-text-height:before {
+  content: "\f034";
+}
+
+.icon-text-width:before {
+  content: "\f035";
+}
+
+.icon-align-left:before {
+  content: "\f036";
+}
+
+.icon-align-center:before {
+  content: "\f037";
+}
+
+.icon-align-right:before {
+  content: "\f038";
+}
+
+.icon-align-justify:before {
+  content: "\f039";
+}
+
+.icon-list:before {
+  content: "\f03a";
+}
+
+.icon-dedent:before,
+.icon-outdent:before {
+  content: "\f03b";
+}
+
+.icon-indent:before {
+  content: "\f03c";
+}
+
+.icon-video-camera:before {
+  content: "\f03d";
+}
+
+.icon-photo:before,
+.icon-image:before,
+.icon-picture-o:before {
+  content: "\f03e";
+}
+
+.icon-pencil:before {
+  content: "\f040";
+}
+
+.icon-map-marker:before {
+  content: "\f041";
+}
+
+.icon-adjust:before {
+  content: "\f042";
+}
+
+.icon-tint:before {
+  content: "\f043";
+}
+
+.icon-edit:before,
+.icon-pencil-square-o:before {
+  content: "\f044";
+}
+
+.icon-share-square-o:before {
+  content: "\f045";
+}
+
+.icon-check-square-o:before {
+  content: "\f046";
+}
+
+.icon-arrows:before {
+  content: "\f047";
+}
+
+.icon-step-backward:before {
+  content: "\f048";
+}
+
+.icon-fast-backward:before {
+  content: "\f049";
+}
+
+.icon-backward:before {
+  content: "\f04a";
+}
+
+.icon-play:before {
+  content: "\f04b";
+}
+
+.icon-pause:before {
+  content: "\f04c";
+}
+
+.icon-stop:before {
+  content: "\f04d";
+}
+
+.icon-forward:before {
+  content: "\f04e";
+}
+
+.icon-fast-forward:before {
+  content: "\f050";
+}
+
+.icon-step-forward:before {
+  content: "\f051";
+}
+
+.icon-eject:before {
+  content: "\f052";
+}
+
+.icon-chevron-left:before {
+  content: "\f053";
+}
+
+.icon-chevron-right:before {
+  content: "\f054";
+}
+
+.icon-plus-circle:before {
+  content: "\f055";
+}
+
+.icon-minus-circle:before {
+  content: "\f056";
+}
+
+.icon-times-circle:before {
+  content: "\f057";
+}
+
+.icon-check-circle:before {
+  content: "\f058";
+}
+
+.icon-question-circle:before {
+  content: "\f059";
+}
+
+.icon-info-circle:before {
+  content: "\f05a";
+}
+
+.icon-crosshairs:before {
+  content: "\f05b";
+}
+
+.icon-times-circle-o:before {
+  content: "\f05c";
+}
+
+.icon-check-circle-o:before {
+  content: "\f05d";
+}
+
+.icon-ban:before {
+  content: "\f05e";
+}
+
+.icon-arrow-left:before {
+  content: "\f060";
+}
+
+.icon-arrow-right:before {
+  content: "\f061";
+}
+
+.icon-arrow-up:before {
+  content: "\f062";
+}
+
+.icon-arrow-down:before {
+  content: "\f063";
+}
+
+.icon-mail-forward:before,
+.icon-share:before {
+  content: "\f064";
+}
+
+.icon-expand:before {
+  content: "\f065";
+}
+
+.icon-compress:before {
+  content: "\f066";
+}
+
+.icon-plus:before {
+  content: "\f067";
+}
+
+.icon-minus:before {
+  content: "\f068";
+}
+
+.icon-asterisk:before {
+  content: "\f069";
+}
+
+.icon-exclamation-circle:before {
+  content: "\f06a";
+}
+
+.icon-gift:before {
+  content: "\f06b";
+}
+
+.icon-leaf:before {
+  content: "\f06c";
+}
+
+.icon-fire:before {
+  content: "\f06d";
+}
+
+.icon-eye:before {
+  content: "\f06e";
+}
+
+.icon-eye-slash:before {
+  content: "\f070";
+}
+
+.icon-warning:before,
+.icon-exclamation-triangle:before {
+  content: "\f071";
+}
+
+.icon-plane:before {
+  content: "\f072";
+}
+
+.icon-calendar:before {
+  content: "\f073";
+}
+
+.icon-random:before {
+  content: "\f074";
+}
+
+.icon-comment:before {
+  content: "\f075";
+}
+
+.icon-magnet:before {
+  content: "\f076";
+}
+
+.icon-chevron-up:before {
+  content: "\f077";
+}
+
+.icon-chevron-down:before {
+  content: "\f078";
+}
+
+.icon-retweet:before {
+  content: "\f079";
+}
+
+.icon-shopping-cart:before {
+  content: "\f07a";
+}
+
+.icon-folder:before {
+  content: "\f07b";
+}
+
+.icon-folder-open:before {
+  content: "\f07c";
+}
+
+.icon-arrows-v:before {
+  content: "\f07d";
+}
+
+.icon-arrows-h:before {
+  content: "\f07e";
+}
+
+.icon-bar-chart-o:before {
+  content: "\f080";
+}
+
+.icon-twitter-square:before {
+  content: "\f081";
+}
+
+.icon-facebook-square:before {
+  content: "\f082";
+}
+
+.icon-camera-retro:before {
+  content: "\f083";
+}
+
+.icon-key:before {
+  content: "\f084";
+}
+
+.icon-gears:before,
+.icon-cogs:before {
+  content: "\f085";
+}
+
+.icon-comments:before {
+  content: "\f086";
+}
+
+.icon-thumbs-o-up:before {
+  content: "\f087";
+}
+
+.icon-thumbs-o-down:before {
+  content: "\f088";
+}
+
+.icon-star-half:before {
+  content: "\f089";
+}
+
+.icon-heart-o:before {
+  content: "\f08a";
+}
+
+.icon-sign-out:before {
+  content: "\f08b";
+}
+
+.icon-linkedin-square:before {
+  content: "\f08c";
+}
+
+.icon-thumb-tack:before {
+  content: "\f08d";
+}
+
+.icon-external-link:before {
+  content: "\f08e";
+}
+
+.icon-sign-in:before {
+  content: "\f090";
+}
+
+.icon-trophy:before {
+  content: "\f091";
+}
+
+.icon-github-square:before {
+  content: "\f092";
+}
+
+.icon-upload:before {
+  content: "\f093";
+}
+
+.icon-lemon-o:before {
+  content: "\f094";
+}
+
+.icon-phone:before {
+  content: "\f095";
+}
+
+.icon-square-o:before {
+  content: "\f096";
+}
+
+.icon-bookmark-o:before {
+  content: "\f097";
+}
+
+.icon-phone-square:before {
+  content: "\f098";
+}
+
+.icon-twitter:before {
+  content: "\f099";
+}
+
+.icon-facebook:before {
+  content: "\f09a";
+}
+
+.icon-github:before {
+  content: "\f09b";
+}
+
+.icon-unlock:before {
+  content: "\f09c";
+}
+
+.icon-credit-card:before {
+  content: "\f09d";
+}
+
+.icon-rss:before {
+  content: "\f09e";
+}
+
+.icon-hdd-o:before {
+  content: "\f0a0";
+}
+
+.icon-bullhorn:before {
+  content: "\f0a1";
+}
+
+.icon-bell:before {
+  content: "\f0f3";
+}
+
+.icon-certificate:before {
+  content: "\f0a3";
+}
+
+.icon-hand-o-right:before {
+  content: "\f0a4";
+}
+
+.icon-hand-o-left:before {
+  content: "\f0a5";
+}
+
+.icon-hand-o-up:before {
+  content: "\f0a6";
+}
+
+.icon-hand-o-down:before {
+  content: "\f0a7";
+}
+
+.icon-arrow-circle-left:before {
+  content: "\f0a8";
+}
+
+.icon-arrow-circle-right:before {
+  content: "\f0a9";
+}
+
+.icon-arrow-circle-up:before {
+  content: "\f0aa";
+}
+
+.icon-arrow-circle-down:before {
+  content: "\f0ab";
+}
+
+.icon-globe:before {
+  content: "\f0ac";
+}
+
+.icon-wrench:before {
+  content: "\f0ad";
+}
+
+.icon-tasks:before {
+  content: "\f0ae";
+}
+
+.icon-filter:before {
+  content: "\f0b0";
+}
+
+.icon-briefcase:before {
+  content: "\f0b1";
+}
+
+.icon-arrows-alt:before {
+  content: "\f0b2";
+}
+
+.icon-group:before,
+.icon-users:before {
+  content: "\f0c0";
+}
+
+.icon-chain:before,
+.icon-link:before {
+  content: "\f0c1";
+}
+
+.icon-cloud:before {
+  content: "\f0c2";
+}
+
+.icon-flask:before {
+  content: "\f0c3";
+}
+
+.icon-cut:before,
+.icon-scissors:before {
+  content: "\f0c4";
+}
+
+.icon-copy:before,
+.icon-files-o:before {
+  content: "\f0c5";
+}
+
+.icon-paperclip:before {
+  content: "\f0c6";
+}
+
+.icon-save:before,
+.icon-floppy-o:before {
+  content: "\f0c7";
+}
+
+.icon-square:before {
+  content: "\f0c8";
+}
+
+.icon-navicon:before,
+.icon-reorder:before,
+.icon-bars:before {
+  content: "\f0c9";
+}
+
+.icon-list-ul:before {
+  content: "\f0ca";
+}
+
+.icon-list-ol:before {
+  content: "\f0cb";
+}
+
+.icon-strikethrough:before {
+  content: "\f0cc";
+}
+
+.icon-underline:before {
+  content: "\f0cd";
+}
+
+.icon-table:before {
+  content: "\f0ce";
+}
+
+.icon-magic:before {
+  content: "\f0d0";
+}
+
+.icon-truck:before {
+  content: "\f0d1";
+}
+
+.icon-pinterest:before {
+  content: "\f0d2";
+}
+
+.icon-pinterest-square:before {
+  content: "\f0d3";
+}
+
+.icon-google-plus-square:before {
+  content: "\f0d4";
+}
+
+.icon-google-plus:before {
+  content: "\f0d5";
+}
+
+.icon-money:before {
+  content: "\f0d6";
+}
+
+.icon-caret-down:before {
+  content: "\f0d7";
+}
+
+.icon-caret-up:before {
+  content: "\f0d8";
+}
+
+.icon-caret-left:before {
+  content: "\f0d9";
+}
+
+.icon-caret-right:before {
+  content: "\f0da";
+}
+
+.icon-columns:before {
+  content: "\f0db";
+}
+
+.icon-unsorted:before,
+.icon-sort:before {
+  content: "\f0dc";
+}
+
+.icon-sort-down:before,
+.icon-sort-desc:before {
+  content: "\f0dd";
+}
+
+.icon-sort-up:before,
+.icon-sort-asc:before {
+  content: "\f0de";
+}
+
+.icon-envelope:before {
+  content: "\f0e0";
+}
+
+.icon-linkedin:before {
+  content: "\f0e1";
+}
+
+.icon-rotate-left:before,
+.icon-undo:before {
+  content: "\f0e2";
+}
+
+.icon-legal:before,
+.icon-gavel:before {
+  content: "\f0e3";
+}
+
+.icon-dashboard:before,
+.icon-tachometer:before {
+  content: "\f0e4";
+}
+
+.icon-comment-o:before {
+  content: "\f0e5";
+}
+
+.icon-comments-o:before {
+  content: "\f0e6";
+}
+
+.icon-flash:before,
+.icon-bolt:before {
+  content: "\f0e7";
+}
+
+.icon-sitemap:before {
+  content: "\f0e8";
+}
+
+.icon-umbrella:before {
+  content: "\f0e9";
+}
+
+.icon-paste:before,
+.icon-clipboard:before {
+  content: "\f0ea";
+}
+
+.icon-lightbulb-o:before {
+  content: "\f0eb";
+}
+
+.icon-exchange:before {
+  content: "\f0ec";
+}
+
+.icon-cloud-download:before {
+  content: "\f0ed";
+}
+
+.icon-cloud-upload:before {
+  content: "\f0ee";
+}
+
+.icon-user-md:before {
+  content: "\f0f0";
+}
+
+.icon-stethoscope:before {
+  content: "\f0f1";
+}
+
+.icon-suitcase:before {
+  content: "\f0f2";
+}
+
+.icon-bell-o:before {
+  content: "\f0a2";
+}
+
+.icon-coffee:before {
+  content: "\f0f4";
+}
+
+.icon-cutlery:before {
+  content: "\f0f5";
+}
+
+.icon-file-text-o:before {
+  content: "\f0f6";
+}
+
+.icon-building-o:before {
+  content: "\f0f7";
+}
+
+.icon-hospital-o:before {
+  content: "\f0f8";
+}
+
+.icon-ambulance:before {
+  content: "\f0f9";
+}
+
+.icon-medkit:before {
+  content: "\f0fa";
+}
+
+.icon-fighter-jet:before {
+  content: "\f0fb";
+}
+
+.icon-beer:before {
+  content: "\f0fc";
+}
+
+.icon-h-square:before {
+  content: "\f0fd";
+}
+
+.icon-plus-square:before {
+  content: "\f0fe";
+}
+
+.icon-angle-double-left:before {
+  content: "\f100";
+}
+
+.icon-angle-double-right:before {
+  content: "\f101";
+}
+
+.icon-angle-double-up:before {
+  content: "\f102";
+}
+
+.icon-angle-double-down:before {
+  content: "\f103";
+}
+
+.icon-angle-left:before {
+  content: "\f104";
+}
+
+.icon-angle-right:before {
+  content: "\f105";
+}
+
+.icon-angle-up:before {
+  content: "\f106";
+}
+
+.icon-angle-down:before {
+  content: "\f107";
+}
+
+.icon-desktop:before {
+  content: "\f108";
+}
+
+.icon-laptop:before {
+  content: "\f109";
+}
+
+.icon-tablet:before {
+  content: "\f10a";
+}
+
+.icon-mobile-phone:before,
+.icon-mobile:before {
+  content: "\f10b";
+}
+
+.icon-circle-o:before {
+  content: "\f10c";
+}
+
+.icon-quote-left:before {
+  content: "\f10d";
+}
+
+.icon-quote-right:before {
+  content: "\f10e";
+}
+
+.icon-spinner:before {
+  content: "\f110";
+}
+
+.icon-circle:before {
+  content: "\f111";
+}
+
+.icon-mail-reply:before,
+.icon-reply:before {
+  content: "\f112";
+}
+
+.icon-github-alt:before {
+  content: "\f113";
+}
+
+.icon-folder-o:before {
+  content: "\f114";
+}
+
+.icon-folder-open-o:before {
+  content: "\f115";
+}
+
+.icon-smile-o:before {
+  content: "\f118";
+}
+
+.icon-frown-o:before {
+  content: "\f119";
+}
+
+.icon-meh-o:before {
+  content: "\f11a";
+}
+
+.icon-gamepad:before {
+  content: "\f11b";
+}
+
+.icon-keyboard-o:before {
+  content: "\f11c";
+}
+
+.icon-flag-o:before {
+  content: "\f11d";
+}
+
+.icon-flag-checkered:before {
+  content: "\f11e";
+}
+
+.icon-terminal:before {
+  content: "\f120";
+}
+
+.icon-code:before {
+  content: "\f121";
+}
+
+.icon-mail-reply-all:before,
+.icon-reply-all:before {
+  content: "\f122";
+}
+
+.icon-star-half-empty:before,
+.icon-star-half-full:before,
+.icon-star-half-o:before {
+  content: "\f123";
+}
+
+.icon-location-arrow:before {
+  content: "\f124";
+}
+
+.icon-crop:before {
+  content: "\f125";
+}
+
+.icon-code-fork:before {
+  content: "\f126";
+}
+
+.icon-unlink:before,
+.icon-chain-broken:before {
+  content: "\f127";
+}
+
+.icon-question:before {
+  content: "\f128";
+}
+
+.icon-info:before {
+  content: "\f129";
+}
+
+.icon-exclamation:before {
+  content: "\f12a";
+}
+
+.icon-superscript:before {
+  content: "\f12b";
+}
+
+.icon-subscript:before {
+  content: "\f12c";
+}
+
+.icon-eraser:before {
+  content: "\f12d";
+}
+
+.icon-puzzle-piece:before {
+  content: "\f12e";
+}
+
+.icon-microphone:before {
+  content: "\f130";
+}
+
+.icon-microphone-slash:before {
+  content: "\f131";
+}
+
+.icon-shield:before {
+  content: "\f132";
+}
+
+.icon-calendar-o:before {
+  content: "\f133";
+}
+
+.icon-fire-extinguisher:before {
+  content: "\f134";
+}
+
+.icon-rocket:before {
+  content: "\f135";
+}
+
+.icon-maxcdn:before {
+  content: "\f136";
+}
+
+.icon-chevron-circle-left:before {
+  content: "\f137";
+}
+
+.icon-chevron-circle-right:before {
+  content: "\f138";
+}
+
+.icon-chevron-circle-up:before {
+  content: "\f139";
+}
+
+.icon-chevron-circle-down:before {
+  content: "\f13a";
+}
+
+.icon-html5:before {
+  content: "\f13b";
+}
+
+.icon-css3:before {
+  content: "\f13c";
+}
+
+.icon-anchor:before {
+  content: "\f13d";
+}
+
+.icon-unlock-alt:before {
+  content: "\f13e";
+}
+
+.icon-bullseye:before {
+  content: "\f140";
+}
+
+.icon-ellipsis-h:before {
+  content: "\f141";
+}
+
+.icon-ellipsis-v:before {
+  content: "\f142";
+}
+
+.icon-rss-square:before {
+  content: "\f143";
+}
+
+.icon-play-circle:before {
+  content: "\f144";
+}
+
+.icon-ticket:before {
+  content: "\f145";
+}
+
+.icon-minus-square:before {
+  content: "\f146";
+}
+
+.icon-minus-square-o:before {
+  content: "\f147";
+}
+
+.icon-level-up:before {
+  content: "\f148";
+}
+
+.icon-level-down:before {
+  content: "\f149";
+}
+
+.icon-check-square:before {
+  content: "\f14a";
+}
+
+.icon-pencil-square:before {
+  content: "\f14b";
+}
+
+.icon-external-link-square:before {
+  content: "\f14c";
+}
+
+.icon-share-square:before {
+  content: "\f14d";
+}
+
+.icon-compass:before {
+  content: "\f14e";
+}
+
+.icon-toggle-down:before,
+.icon-caret-square-o-down:before {
+  content: "\f150";
+}
+
+.icon-toggle-up:before,
+.icon-caret-square-o-up:before {
+  content: "\f151";
+}
+
+.icon-toggle-right:before,
+.icon-caret-square-o-right:before {
+  content: "\f152";
+}
+
+.icon-euro:before,
+.icon-eur:before {
+  content: "\f153";
+}
+
+.icon-gbp:before {
+  content: "\f154";
+}
+
+.icon-dollar:before,
+.icon-usd:before {
+  content: "\f155";
+}
+
+.icon-rupee:before,
+.icon-inr:before {
+  content: "\f156";
+}
+
+.icon-cny:before,
+.icon-rmb:before,
+.icon-yen:before,
+.icon-jpy:before {
+  content: "\f157";
+}
+
+.icon-ruble:before,
+.icon-rouble:before,
+.icon-rub:before {
+  content: "\f158";
+}
+
+.icon-won:before,
+.icon-krw:before {
+  content: "\f159";
+}
+
+.icon-bitcoin:before,
+.icon-btc:before {
+  content: "\f15a";
+}
+
+.icon-file:before {
+  content: "\f15b";
+}
+
+.icon-file-text:before {
+  content: "\f15c";
+}
+
+.icon-sort-alpha-asc:before {
+  content: "\f15d";
+}
+
+.icon-sort-alpha-desc:before {
+  content: "\f15e";
+}
+
+.icon-sort-amount-asc:before {
+  content: "\f160";
+}
+
+.icon-sort-amount-desc:before {
+  content: "\f161";
+}
+
+.icon-sort-numeric-asc:before {
+  content: "\f162";
+}
+
+.icon-sort-numeric-desc:before {
+  content: "\f163";
+}
+
+.icon-thumbs-up:before {
+  content: "\f164";
+}
+
+.icon-thumbs-down:before {
+  content: "\f165";
+}
+
+.icon-youtube-square:before {
+  content: "\f166";
+}
+
+.icon-youtube:before {
+  content: "\f167";
+}
+
+.icon-xing:before {
+  content: "\f168";
+}
+
+.icon-xing-square:before {
+  content: "\f169";
+}
+
+.icon-youtube-play:before {
+  content: "\f16a";
+}
+
+.icon-dropbox:before {
+  content: "\f16b";
+}
+
+.icon-stack-overflow:before {
+  content: "\f16c";
+}
+
+.icon-instagram:before {
+  content: "\f16d";
+}
+
+.icon-flickr:before {
+  content: "\f16e";
+}
+
+.icon-adn:before {
+  content: "\f170";
+}
+
+.icon-bitbucket:before {
+  content: "\f171";
+}
+
+.icon-bitbucket-square:before {
+  content: "\f172";
+}
+
+.icon-tumblr:before {
+  content: "\f173";
+}
+
+.icon-tumblr-square:before {
+  content: "\f174";
+}
+
+.icon-long-arrow-down:before {
+  content: "\f175";
+}
+
+.icon-long-arrow-up:before {
+  content: "\f176";
+}
+
+.icon-long-arrow-left:before {
+  content: "\f177";
+}
+
+.icon-long-arrow-right:before {
+  content: "\f178";
+}
+
+.icon-apple:before {
+  content: "\f179";
+}
+
+.icon-windows:before {
+  content: "\f17a";
+}
+
+.icon-android:before {
+  content: "\f17b";
+}
+
+.icon-linux:before {
+  content: "\f17c";
+}
+
+.icon-dribbble:before {
+  content: "\f17d";
+}
+
+.icon-skype:before {
+  content: "\f17e";
+}
+
+.icon-foursquare:before {
+  content: "\f180";
+}
+
+.icon-trello:before {
+  content: "\f181";
+}
+
+.icon-female:before {
+  content: "\f182";
+}
+
+.icon-male:before {
+  content: "\f183";
+}
+
+.icon-gittip:before {
+  content: "\f184";
+}
+
+.icon-sun-o:before {
+  content: "\f185";
+}
+
+.icon-moon-o:before {
+  content: "\f186";
+}
+
+.icon-archive:before {
+  content: "\f187";
+}
+
+.icon-bug:before {
+  content: "\f188";
+}
+
+.icon-vk:before {
+  content: "\f189";
+}
+
+.icon-weibo:before {
+  content: "\f18a";
+}
+
+.icon-renren:before {
+  content: "\f18b";
+}
+
+.icon-pagelines:before {
+  content: "\f18c";
+}
+
+.icon-stack-exchange:before {
+  content: "\f18d";
+}
+
+.icon-arrow-circle-o-right:before {
+  content: "\f18e";
+}
+
+.icon-arrow-circle-o-left:before {
+  content: "\f190";
+}
+
+.icon-toggle-left:before,
+.icon-caret-square-o-left:before {
+  content: "\f191";
+}
+
+.icon-dot-circle-o:before {
+  content: "\f192";
+}
+
+.icon-wheelchair:before {
+  content: "\f193";
+}
+
+.icon-vimeo-square:before {
+  content: "\f194";
+}
+
+.icon-turkish-lira:before,
+.icon-try:before {
+  content: "\f195";
+}
+
+.icon-plus-square-o:before {
+  content: "\f196";
+}
+
+.icon-space-shuttle:before {
+  content: "\f197";
+}
+
+.icon-slack:before {
+  content: "\f198";
+}
+
+.icon-envelope-square:before {
+  content: "\f199";
+}
+
+.icon-wordpress:before {
+  content: "\f19a";
+}
+
+.icon-openid:before {
+  content: "\f19b";
+}
+
+.icon-institution:before,
+.icon-bank:before,
+.icon-university:before {
+  content: "\f19c";
+}
+
+.icon-mortar-board:before,
+.icon-graduation-cap:before {
+  content: "\f19d";
+}
+
+.icon-yahoo:before {
+  content: "\f19e";
+}
+
+.icon-google:before {
+  content: "\f1a0";
+}
+
+.icon-reddit:before {
+  content: "\f1a1";
+}
+
+.icon-reddit-square:before {
+  content: "\f1a2";
+}
+
+.icon-stumbleupon-circle:before {
+  content: "\f1a3";
+}
+
+.icon-stumbleupon:before {
+  content: "\f1a4";
+}
+
+.icon-delicious:before {
+  content: "\f1a5";
+}
+
+.icon-digg:before {
+  content: "\f1a6";
+}
+
+.icon-pied-piper-square:before,
+.icon-pied-piper:before {
+  content: "\f1a7";
+}
+
+.icon-pied-piper-alt:before {
+  content: "\f1a8";
+}
+
+.icon-drupal:before {
+  content: "\f1a9";
+}
+
+.icon-joomla:before {
+  content: "\f1aa";
+}
+
+.icon-language:before {
+  content: "\f1ab";
+}
+
+.icon-fax:before {
+  content: "\f1ac";
+}
+
+.icon-building:before {
+  content: "\f1ad";
+}
+
+.icon-child:before {
+  content: "\f1ae";
+}
+
+.icon-paw:before {
+  content: "\f1b0";
+}
+
+.icon-spoon:before {
+  content: "\f1b1";
+}
+
+.icon-cube:before {
+  content: "\f1b2";
+}
+
+.icon-cubes:before {
+  content: "\f1b3";
+}
+
+.icon-behance:before {
+  content: "\f1b4";
+}
+
+.icon-behance-square:before {
+  content: "\f1b5";
+}
+
+.icon-steam:before {
+  content: "\f1b6";
+}
+
+.icon-steam-square:before {
+  content: "\f1b7";
+}
+
+.icon-recycle:before {
+  content: "\f1b8";
+}
+
+.icon-automobile:before,
+.icon-car:before {
+  content: "\f1b9";
+}
+
+.icon-cab:before,
+.icon-taxi:before {
+  content: "\f1ba";
+}
+
+.icon-tree:before {
+  content: "\f1bb";
+}
+
+.icon-spotify:before {
+  content: "\f1bc";
+}
+
+.icon-deviantart:before {
+  content: "\f1bd";
+}
+
+.icon-soundcloud:before {
+  content: "\f1be";
+}
+
+.icon-database:before {
+  content: "\f1c0";
+}
+
+.icon-file-pdf-o:before {
+  content: "\f1c1";
+}
+
+.icon-file-word-o:before {
+  content: "\f1c2";
+}
+
+.icon-file-excel-o:before {
+  content: "\f1c3";
+}
+
+.icon-file-powerpoint-o:before {
+  content: "\f1c4";
+}
+
+.icon-file-photo-o:before,
+.icon-file-picture-o:before,
+.icon-file-image-o:before {
+  content: "\f1c5";
+}
+
+.icon-file-zip-o:before,
+.icon-file-archive-o:before {
+  content: "\f1c6";
+}
+
+.icon-file-sound-o:before,
+.icon-file-audio-o:before {
+  content: "\f1c7";
+}
+
+.icon-file-movie-o:before,
+.icon-file-video-o:before {
+  content: "\f1c8";
+}
+
+.icon-file-code-o:before {
+  content: "\f1c9";
+}
+
+.icon-vine:before {
+  content: "\f1ca";
+}
+
+.icon-codepen:before {
+  content: "\f1cb";
+}
+
+.icon-jsfiddle:before {
+  content: "\f1cc";
+}
+
+.icon-life-bouy:before,
+.icon-life-saver:before,
+.icon-support:before,
+.icon-life-ring:before {
+  content: "\f1cd";
+}
+
+.icon-circle-o-notch:before {
+  content: "\f1ce";
+}
+
+.icon-ra:before,
+.icon-rebel:before {
+  content: "\f1d0";
+}
+
+.icon-ge:before,
+.icon-empire:before {
+  content: "\f1d1";
+}
+
+.icon-git-square:before {
+  content: "\f1d2";
+}
+
+.icon-git:before {
+  content: "\f1d3";
+}
+
+.icon-hacker-news:before {
+  content: "\f1d4";
+}
+
+.icon-tencent-weibo:before {
+  content: "\f1d5";
+}
+
+.icon-qq:before {
+  content: "\f1d6";
+}
+
+.icon-wechat:before,
+.icon-weixin:before {
+  content: "\f1d7";
+}
+
+.icon-send:before,
+.icon-paper-plane:before {
+  content: "\f1d8";
+}
+
+.icon-send-o:before,
+.icon-paper-plane-o:before {
+  content: "\f1d9";
+}
+
+.icon-history:before {
+  content: "\f1da";
+}
+
+.icon-circle-thin:before {
+  content: "\f1db";
+}
+
+.icon-header:before {
+  content: "\f1dc";
+}
+
+.icon-paragraph:before {
+  content: "\f1dd";
+}
+
+.icon-sliders:before {
+  content: "\f1de";
+}
+
+.icon-share-alt:before {
+  content: "\f1e0";
+}
+
+.icon-share-alt-square:before {
+  content: "\f1e1";
+}
+
+.icon-bomb:before {
+  content: "\f1e2";
+}
+
+/* Brand colors */
+/* Core colors */
+/* main colors */
+/* Context menu */
+/* tree menus */
+/* Tree menus */
+/* top nav */
+/* Top navigation colors */
+/* borders */
+/* text colors and font stacks */
+.x-tbar-page-last:before, .x-tbar-page-next:before, .x-tbar-page-prev:before, .x-tbar-loading:before, .x-tbar-page-first:before, .x-btn-icon.arrow_up button:before, .x-btn-icon.arrow_down button:before, .x-btn-icon.refresh button:before, .x-form-invalid-msg:before, .x-btn em.x-btn-split:before, .tree-new-resource > em > button:before, .tree-new-weblink > em > button:before, .tree-new-symlink > em > button:before, .tree-new-static-resource > em > button:before, .tree-trash > em > button:before, .tree-new-template > em > button:before, .tree-new-tv > em > button:before, .tree-new-chunk > em > button:before, .tree-new-snippet > em > button:before, .tree-new-plugin > em > button:before, .tree-new-category > em > button:before, .x-tree-arrows .x-tree-elbow-minus:before,
+.x-tree-arrows .x-tree-elbow-end-minus:before, .tree-context:before, .x-tree-node-expanded .tree-folder:before, .x-tree-node-collapsed .tree-folder:before, .tree-resource:before, .tree-static-resource:before, .tree-weblink:before, .tree-symlink:before, .x-tree-arrows .x-tree-elbow-plus:before,
+.x-tree-arrows .x-tree-elbow-end-plus:before, .tree-folder:before {
+  display: inline-block;
+  font-family: FontAwesome;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.x-tbar-page-last:before, .x-tbar-page-next:before, .x-tbar-page-prev:before, .x-tbar-loading:before, .x-tbar-page-first:before, .x-btn-icon.arrow_up button:before, .x-btn-icon.arrow_down button:before, .x-btn-icon.refresh button:before {
+  position: absolute;
+  top: 0px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  line-height: 100%;
+  width: 100%;
+  height: 100%;
+  font-size: 14px;
+  color: inherit;
+  text-align: center;
+}
+
+#modx-tv-tabs .lt-ie8 {
+  *zoom: 1;
+}
+#modx-tv-tabs:before, #modx-tv-tabs:after {
+  content: " ";
+  /* 1 */
+  display: table;
+  /* 2 */
+}
+#modx-tv-tabs:after {
+  clear: both;
+}
+
+@-moz-document url-prefix() {
+}
+/* Instead of writing the same code for every nav bar */
+/**
+ * xtheme-modx
+ * Copyright (c) 2009-2014, MODX, LLC
+ *
+ * xtheme-modx is licensed under the terms of the GNU Open Source GPL 2.0
+ * or later license.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/gpl.html>.
+ */
+.ext-el-mask {
+  background-color: #C0C0C0;
+  z-index: 10;
+}
+
+.ext-el-mask-msg {
+  -moz-box-shadow: 0 1px 3px #575757;
+  -webkit-box-shadow: 0 1px 3px #575757;
+  box-shadow: 0 1px 3px #575757;
+  background-color: #FAFAFA;
+  background-image: none;
+  border-color: #A7A7A7;
+  border-radius: 5px;
+  padding: 5px;
+  z-index: 10;
+}
+
+.ext-el-mask-msg div {
+  background-color: transparent;
+  border: 0 none;
+  color: #444;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-mask-loading div {
+  background-color: #fbfbfb;
+  background-image: url("../images/modx-theme/grid/loading.gif");
+}
+
+.x-item-disabled {
+  color: gray;
+}
+
+.x-item-disabled * {
+  color: gray !important;
+}
+
+.x-splitbar-proxy {
+  background-color: #aaa;
+}
+
+.x-color-palette a {
+  border-color: #fff;
+}
+
+.x-color-palette a:hover, .x-color-palette a.x-color-palette-sel {
+  background-color: #ebebeb;
+  border-color: #b4b4b4;
+}
+
+.x-color-palette em {
+  border-color: #aca899;
+}
+
+.x-ie-shadow {
+  background-color: #777;
+}
+
+.x-shadow .xsmc {
+  background-image: none;
+}
+
+.x-shadow .xsml, .x-shadow .xsmr {
+  background-image: none;
+}
+
+.x-shadow .xstl, .x-shadow .xstc, .x-shadow .xstr, .x-shadow .xsbl, .x-shadow .xsbc, .x-shadow .xsbr {
+  background-image: none;
+}
+
+.loading-indicator {
+  background-image: url("../images/modx-theme/grid/loading.gif");
+  font-size: 11px;
+}
+
+.x-spotlight {
+  background-color: #ccc;
+}
+
+.x-panel-tbar-noheader .x-toolbar, .x-panel-mc .x-panel-tbar .x-toolbar {
+  border-bottom: 0 none;
+  border-top: none;
+}
+
+.x-panel-bbar .x-toolbar, .x-panel-tbar .x-toolbar {
+  border-width: 0;
+  overflow: hidden;
+}
+
+.x-panel-bbar {
+  padding-top: 10px;
+}
+
+.x-panel-tbar {
+  padding-bottom: 2px;
+}
+
+.ext-ie7 .x-plain-body {
+  position: relative;
+}
+
+.ext-ie7 .x-toolbar-ct {
+  width: auto;
+}
+
+.x-toolbar {
+  background-color: #F7F7F7;
+  background-image: none;
+  border-color: #DFDFDF;
+}
+
+.x-toolbar td, .x-toolbar span, .x-toolbar input,
+.x-toolbar div, .x-toolbar select, .x-toolbar label {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-toolbar .x-item-disabled {
+  color: gray;
+}
+
+.x-toolbar .x-item-disabled * {
+  color: gray;
+}
+
+.x-toolbar em.x-btn-split {
+  background-image: url("../images/modx-theme/button/s-arrow-noline.gif");
+}
+
+.x-toolbar .x-btn-over em.x-btn-split,
+.x-toolbar .x-btn-click em.x-btn-split,
+.x-toolbar .x-btn-menu-active em.x-btn-split,
+.x-toolbar .x-btn-pressed em.x-btn-split {
+  /* background-image: url($imgPath + 'modx-theme/button/s-arrow-o.gif');*/
+}
+
+.x-toolbar em.x-btn-split-bottom {
+  background-image: url("../images/modx-theme/button/s-arrow-b-noline.gif");
+}
+
+.x-toolbar .x-btn-over em.x-btn-split-bottom,
+.x-toolbar .x-btn-click em.x-btn-split-bottom,
+.x-toolbar .x-btn-menu-active em.x-btn-split-bottom,
+.x-toolbar .x-btn-pressed em.x-btn-split-bottom {
+  background-image: url("../images/modx-theme/button/s-arrow-bo.gif");
+}
+
+.ext-ie .x-toolbar-cell .x-form-field-wrap {
+  height: 30px;
+}
+
+.x-tbar-page-first {
+  background-image: url("../images/modx-theme/grid/page-first.png") !important;
+}
+
+.x-tbar-loading {
+  background-image: url("../images/modx-theme/grid/refresh.png") !important;
+}
+
+.x-tbar-page-last {
+  background: none !important;
+  position: relative;
+}
+.x-tbar-page-last:before {
+  content: "\f04e";
+  top: 1px;
+  left: 1px;
+  right: auto;
+}
+
+.x-tbar-page-next {
+  background: none !important;
+  position: relative;
+}
+.x-tbar-page-next:before {
+  content: "\f0da";
+  font-size: 18px;
+  line-height: 110%;
+  left: 1px;
+  right: auto;
+}
+
+.x-tbar-page-prev {
+  background: none !important;
+  position: relative;
+}
+.x-tbar-page-prev:before {
+  content: "\f0d9";
+  font-size: 18px;
+  line-height: 110%;
+  left: auto;
+  right: 1px;
+}
+
+.x-tbar-loading {
+  background: none !important;
+  position: relative;
+}
+.x-tbar-loading:before {
+  content: "\f01e";
+  top: 1px;
+  bottom: auto;
+}
+
+.x-tbar-page-first {
+  background: none !important;
+  position: relative;
+}
+.x-tbar-page-first:before {
+  content: "\f04a";
+  top: 1px;
+  left: auto;
+  right: 1px;
+}
+
+.x-paging-info {
+  color: #444;
+}
+
+.x-toolbar-more-icon {
+  background-image: url("../images/modx-theme/toolbar/more.gif") !important;
+}
+
+.x-statusbar .x-status-busy {
+  background-image: url("../images/modx-theme/grid/loading.gif");
+}
+
+.x-statusbar .x-status-text-panel {
+  border-color: #DFDFDF #fff #fff #DFDFDF;
+}
+
+.x-resizable-handle-southeast {
+  bottom: 1px;
+  right: 1px;
+}
+
+.x-resizable-over .x-resizable-handle-east, .x-resizable-pinned .x-resizable-handle-east,
+.x-resizable-over .x-resizable-handle-west, .x-resizable-pinned .x-resizable-handle-west {
+  background-image: url("../images/modx-theme/sizer/e-handle.gif");
+}
+
+.x-resizable-over .x-resizable-handle-south, .x-resizable-pinned .x-resizable-handle-south,
+.x-resizable-over .x-resizable-handle-north, .x-resizable-pinned .x-resizable-handle-north {
+  background-image: url("../images/modx-theme/sizer/s-handle.gif");
+}
+
+.x-resizable-over .x-resizable-handle-north, .x-resizable-pinned .x-resizable-handle-north {
+  background-image: url("../images/modx-theme/sizer/s-handle.gif");
+}
+
+.x-resizable-over .x-resizable-handle-southeast, .x-resizable-pinned .x-resizable-handle-southeast {
+  background-image: url("../images/modx-theme/sizer/se-handle.gif");
+}
+
+.x-resizable-over .x-resizable-handle-northwest, .x-resizable-pinned .x-resizable-handle-northwest {
+  background-image: url("../images/modx-theme/sizer/nw-handle.gif");
+}
+
+.x-resizable-over .x-resizable-handle-northeast, .x-resizable-pinned .x-resizable-handle-northeast {
+  background-image: url("../images/modx-theme/sizer/ne-handle.gif");
+}
+
+.x-resizable-over .x-resizable-handle-southwest, .x-resizable-pinned .x-resizable-handle-southwest {
+  background-image: url("../images/modx-theme/sizer/sw-handle.gif");
+}
+
+.x-resizable-proxy {
+  border-color: #575757;
+}
+
+.x-resizable-overlay {
+  background-color: #fff;
+}
+
+.x-grid3 {
+  background-color: transparent;
+  background-image: none;
+  border-radius: 3px;
+  overflow: hidden;
+  padding: 0;
+}
+
+.x-grid-panel .x-panel-mc .x-panel-body {
+  border: 0 none;
+}
+
+.x-grid3-hd-row td, .x-grid3-row td, .x-grid3-summary-row td {
+  font: normal 12px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-grid3-row td, .x-grid3-summary-row td {
+  padding-left: 0;
+}
+
+.x-grid3-hd-row td {
+  border-left: 1px solid #e4e9ee;
+  border-right: none;
+}
+
+.x-grid3-hd-row td.x-grid3-cell-first {
+  border-left: 0 none;
+}
+
+.x-grid3-hd-row td.x-grid3-cell-last {
+  border-right: 0 none;
+}
+
+.x-grid-row-loading {
+  background-color: #fff;
+  background-image: url("../images/modx-theme/shared/loading-balls.gif");
+}
+
+.x-grid3-row {
+  border-color: #FFFFFF #FFFFFF #EFEFEF;
+}
+
+.x-grid3-row-expanded .x-grid3-row-body {
+  color: #888888;
+  margin: 0 2px 0 -20px;
+  padding: 0 25px 15px;
+  word-wrap: break-word;
+}
+
+.x-grid3-row-expanded .x-grid3-row-body .desc {
+  word-wrap: break-word;
+}
+
+.x-grid3-row-alt {
+  background-color: #f5f6f9;
+}
+
+.x-panel-body-noheader .x-grid3-row {
+  border-color: transparent;
+}
+
+.x-panel-body-noheader .x-grid3-row-alt {
+  border-bottom: 1px solid #EAEAEA;
+  border-top: 1px solid #EAEAEA;
+}
+
+.x-panel-body-noheader .x-grid3-row-alt .x-grid3-row-table {
+  border-top: 1px solid transparent;
+}
+
+.x-grid3-row-over {
+  background-color: #E0E8EF;
+  background-image: 0 none;
+  /*border: 0 none;*/
+  border-bottom: 1px solid #D1D9DF;
+}
+
+.x-grid3-resize-proxy {
+  background-color: #777;
+}
+
+.x-grid3-resize-marker {
+  background-color: #777;
+}
+
+.x-grid3-header {
+  background: #c9d4e0;
+  border-bottom: 1px solid #444444;
+  padding: 0;
+}
+
+.x-panel-body-noheader .x-grid3-header {
+  border: none;
+}
+
+.x-grid3-header-offset {
+  padding-left: 0;
+}
+
+.x-grid3-header .x-grid3-hd-row td {
+  color: dimgray;
+  font-weight: bold;
+}
+
+.x-grid3-header-pop {
+  border-left-color: #DFDFDF;
+}
+
+.x-grid3-header-pop-inner {
+  background-image: url("../images/modx-theme/grid/hd-pop.gif");
+  border-left-color: #eee;
+}
+
+td.x-grid3-hd-over,
+td.sort-desc,
+td.sort-asc,
+td.x-grid3-hd-menu-open {
+  border-left-color: #e4e9ee;
+  background: #9fb4c8;
+}
+
+td.x-grid3-hd-over .x-grid3-hd-inner,
+td.sort-desc .x-grid3-hd-inner,
+td.sort-asc .x-grid3-hd-inner,
+td.x-grid3-hd-menu-open .x-grid3-hd-inner {
+  color: white;
+}
+
+.sort-asc .x-grid3-sort-icon {
+  background-image: url("../images/modx-theme/grid/sort_asc.gif");
+}
+
+.sort-desc .x-grid3-sort-icon {
+  background-image: url("../images/modx-theme/grid/sort_desc.gif");
+}
+
+.x-panel-body-noheader .x-grid3-body {
+  background-color: #ffffff;
+}
+
+.x-grid3-cell-text, .x-grid3-hd-text {
+  color: #000;
+}
+
+.x-grid3-split {
+  background-image: url("../images/modx-theme/grid/grid-split.gif");
+}
+
+.x-grid3-hd-text {
+  color: #464646;
+}
+
+.x-dd-drag-proxy .x-grid3-hd-inner {
+  background-color: #f2f2f2;
+  background-image: url("../images/modx-theme/grid/grid3-hrow-over.gif");
+  border-color: #c8c8c8;
+}
+
+.col-move-top {
+  background-image: url("../images/modx-theme/grid/col-move-top.gif");
+}
+
+.col-move-bottom {
+  background-image: url("../images/modx-theme/grid/col-move-bottom.gif");
+}
+
+.x-grid3-row-selected {
+  background-color: #f0f0f0;
+  background-image: none;
+  border-bottom: 1px solid #e4e4e4 !important;
+  border-top: 1px solid #e4e4e4 !important;
+  color: #565550;
+}
+
+.x-grid3-cell-selected {
+  background-color: #E0EAEF !important;
+  color: #000;
+}
+
+.x-grid3-cell-selected span {
+  color: #000 !important;
+}
+
+.x-grid3-cell-selected .x-grid3-cell-text {
+  color: #000;
+}
+
+.x-grid3-locked td.x-grid3-row-marker, .x-grid3-locked .x-grid3-row-selected td.x-grid3-row-marker {
+  background-color: #d7d9df !important;
+  background-image: url("../images/modx-theme/grid/grid-hrow.gif") !important;
+  border-right-color: #9c9c9c !important;
+  border-top-color: #fff;
+  color: #000;
+}
+
+.x-grid3-locked td.x-grid3-row-marker div, .x-grid3-locked .x-grid3-row-selected td.x-grid3-row-marker div {
+  color: #464646 !important;
+}
+
+.x-grid3-dirty-cell {
+  background-image: url("../images/modx-theme/grid/dirty.gif");
+}
+
+.x-grid3-topbar, .x-grid3-bottombar {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-grid3-bottombar .x-toolbar {
+  border-top-color: #bcbcbc;
+}
+
+.x-props-grid .x-grid3-td-name .x-grid3-cell-inner {
+  background-image: url("../images/modx-theme/grid/grid3-special-col-bg.gif") !important;
+  color: #000 !important;
+}
+
+.x-grid3-hd-inner {
+  font-weight: bold;
+  padding: 13px 18px 13px 5px;
+}
+
+.ext-ie .x-grid3-hd-inner {
+  width: auto;
+}
+
+.x-grid3-cell-inner, .x-grid3-hd-inner {
+  padding: 13px 18px 13px 5px;
+}
+
+.x-props-grid .x-grid3-body .x-grid3-td-name {
+  background-color: #fff !important;
+  border-right-color: #eee;
+}
+
+.xg-hmenu-sort-asc .x-menu-item-icon {
+  background-image: url("../images/modx-theme/grid/hmenu-asc.gif");
+}
+
+.xg-hmenu-sort-desc .x-menu-item-icon {
+  background-image: url("../images/modx-theme/grid/hmenu-desc.gif");
+}
+
+.xg-hmenu-lock .x-menu-item-icon {
+  background-image: url("../images/modx-theme/grid/hmenu-lock.gif");
+}
+
+.xg-hmenu-unlock .x-menu-item-icon {
+  background-image: url("../images/modx-theme/grid/hmenu-unlock.gif");
+}
+
+.x-grid3-hd-btn {
+  background-color: #d8d8d8;
+  background-image: url("../images/modx-theme/grid/grid3-hd-btn.gif");
+}
+
+.x-grid3-body .x-grid3-td-expander {
+  background-image: none;
+}
+
+.x-grid3-row-collapsed .x-grid3-row-expander {
+  background-position: 5px 10px;
+  height: 30px;
+  margin-top: 6px;
+}
+
+.x-grid3-row-expanded .x-grid3-row-expander {
+  background-position: -31px 10px;
+  height: 30px;
+  margin-top: 6px;
+}
+
+.x-grid3-row-expander {
+  background-image: url("../images/modx-theme/grid/row-expand-sprite.png");
+}
+
+.x-grid3-body .x-grid3-td-checker {
+  background-image: none;
+  padding: 10px 0 0;
+}
+
+.x-grid3-row-checker, .x-grid3-hd-checker {
+  background-image: url("../images/modx-theme/grid/row-check-sprite.gif");
+  cursor: pointer;
+}
+
+.x-grid3-body .x-grid3-td-numberer {
+  background-color: #E5E5E5;
+  border-bottom: 1px solid #DADADA;
+  border-right: 1px solid #DADADA !important;
+}
+
+.x-grid3-body .x-grid3-td-numberer .x-grid3-cell-inner {
+  color: #444;
+  padding-left: 10px;
+  padding-top: 10px !important;
+}
+
+.x-grid3-body .x-grid3-td-row-icon {
+  background-image: url("../images/modx-theme/grid/grid3-special-col-bg.gif");
+}
+
+.x-grid3-body .x-grid3-row-selected .x-grid3-td-numberer,
+.x-grid3-body .x-grid3-row-selected .x-grid3-td-checker,
+.x-grid3-body .x-grid3-row-selected .x-grid3-td-expander {
+  background-image: none;
+}
+
+.x-grid3-check-col {
+  background-image: url("../images/modx-theme/menu/unchecked.gif");
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+.x-grid3-check-col-on {
+  background-image: url("../images/modx-theme/menu/checked.gif");
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+.x-grid-group, .x-grid-group-body, .x-grid-group-hd {
+  zoom: 1;
+}
+
+.x-grid-group-hd {
+  border-bottom-color: #53595f;
+}
+
+.x-grid-group-hd div.x-grid-group-title {
+  background: transparent url("../images/modx-theme/grid/group-collapse.png") no-repeat scroll 3px 10px;
+  color: #53595f;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+  padding: 10px 4px 6px 24px;
+}
+
+.x-grid-group-collapsed .x-grid-group-hd div.x-grid-group-title {
+  background-image: url("../images/modx-theme/grid/group-expand.png");
+}
+
+.x-group-by-icon {
+  background-image: url("../images/modx-theme/grid/group-by.gif");
+}
+
+.x-cols-icon {
+  background-image: url("../images/modx-theme/grid/columns.gif");
+}
+
+.x-show-groups-icon {
+  background-image: url("../images/modx-theme/grid/group-by.gif");
+}
+
+.x-grid-empty {
+  color: gray;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  text-align: center;
+}
+
+.x-grid-with-col-lines .x-grid3-row td.x-grid3-cell {
+  border-right-color: #ededed;
+}
+
+.x-grid-with-col-lines .x-grid3-row {
+  border-left: 0 none;
+  border-top: 0 none;
+}
+
+.x-grid-with-col-lines .x-grid3-row-selected {
+  border-top-color: #e4e4e4;
+}
+
+.x-dd-drag-ghost {
+  background-color: #fff;
+  border-color: #ddd #bbb #bbb #ddd;
+  color: #000;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-dd-drop-nodrop .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/dd/drop-no.gif");
+}
+
+.x-dd-drop-ok .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/dd/drop-yes.gif");
+}
+
+.x-dd-drop-ok-add .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/dd/drop-add.gif");
+}
+
+.x-view-selector {
+  background-color: #d8d8d8;
+  border-color: #8d8d8d;
+}
+
+.x-date-picker {
+  background-color: #F5F5F5;
+  border-color: #E4E4E4;
+}
+
+.x-date-middle, .x-date-left, .x-date-right {
+  background-image: none;
+  color: #fff;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+}
+
+.x-date-middle .x-btn {
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  background-color: transparent;
+  background-image: none;
+  border: 0 none;
+  box-shadow: none;
+  color: #575757;
+}
+
+.x-date-middle .x-btn-over {
+  border: 0 none;
+}
+
+.x-date-middle .x-btn .x-btn-text {
+  color: #575757;
+  font-weight: bold;
+}
+
+.x-date-right a {
+  background-image: url("../images/modx-theme/shared/right-btn.gif");
+}
+
+.x-date-left a {
+  background-image: url("../images/modx-theme/shared/left-btn.gif");
+}
+
+.x-date-inner th {
+  background-color: #F5F5F5;
+  background-image: none;
+  border-bottom-color: #DFDFDF;
+  color: #676767;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+}
+
+.x-date-inner td {
+  background-color: #FAFAFA;
+  border: 0 none;
+  padding: 1px;
+}
+
+.x-date-inner a {
+  color: #878787;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+}
+
+.x-date-inner .x-date-active {
+  color: #000;
+}
+
+.x-date-inner .x-date-selected a {
+  background-color: #717F37;
+  background-image: none;
+  border-color: #ffffff;
+}
+
+.x-date-inner .x-date-today a {
+  border-color: #717F37;
+}
+
+.x-date-inner .x-date-active span, .x-date-inner .x-date-selected span {
+  font-weight: bold;
+}
+
+.x-date-inner .x-date-selected span {
+  color: #FAFAFA;
+}
+
+.x-date-inner .x-date-prevday a, .x-date-inner .x-date-nextday a {
+  color: #D0D0D0;
+}
+
+.x-date-bottom {
+  background-color: #f5f5f5;
+  background-image: none;
+  border-top-color: #DFDFDF;
+}
+
+.x-date-inner a:hover, .x-date-inner .x-date-disabled a:hover {
+  background-color: #DFDFDF;
+  color: #000;
+}
+
+.x-date-inner .x-date-disabled a {
+  background-color: #eee;
+  color: #bbb;
+}
+
+.x-date-mmenu {
+  background-color: #eee !important;
+}
+
+.x-date-mmenu .x-menu-item {
+  color: #000;
+  font-size: 11px;
+}
+
+.x-date-mp {
+  background-color: #fff;
+}
+
+.x-date-mp td {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-date-mp-btns button {
+  background-color: #373737;
+  border-color: #686868 #101010 #101010 #686868;
+  color: #fff;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-date-mp-btns {
+  background-color: #ebebeb;
+  background-image: url("../images/modx-theme/shared/glass-bg.gif");
+}
+
+.x-date-mp-btns td {
+  border-top-color: #DFDFDF;
+}
+
+td.x-date-mp-month a, td.x-date-mp-year a {
+  color: #464646;
+}
+
+td.x-date-mp-month a:hover, td.x-date-mp-year a:hover {
+  background-color: #DFDFDF;
+  color: #464646;
+}
+
+td.x-date-mp-sel a {
+  background-color: #ebebeb;
+  background-image: url("../images/modx-theme/shared/glass-bg.gif");
+  border-color: #afafaf;
+}
+
+.x-date-mp-ybtn a {
+  background-image: url("../images/modx-theme/panel/tool-sprites.gif");
+}
+
+td.x-date-mp-sep {
+  border-right-color: #DFDFDF;
+}
+
+.x-tip {
+  background: #575757;
+  border-radius: 3px;
+  padding: 5px;
+}
+
+.x-tip .x-tip-close {
+  background-image: url("../images/modx-theme/qtip/close.gif");
+}
+
+.x-tip .x-tip-tc, .x-tip .x-tip-tl, .x-tip .x-tip-tr, .x-tip .x-tip-bc, .x-tip .x-tip-bl, .x-tip .x-tip-br, .x-tip .x-tip-ml, .x-tip .x-tip-mr {
+  background-image: none;
+}
+
+.x-tip .x-tip-mc {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-tip .x-tip-ml {
+  background-color: transparent;
+}
+
+.x-tip .x-tip-header-text {
+  color: #f0f0f0;
+  font: normal 13px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-tip .x-tip-body {
+  color: #f0f0f0;
+  font: normal 12px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-tip img {
+  min-width: 240px;
+  max-width: 100%;
+  max-width: 66vw;
+}
+
+.x-form-invalid-tip .x-tip-tc, .x-form-invalid-tip .x-tip-tl, .x-form-invalid-tip .x-tip-tr, .x-form-invalid-tip .x-tip-bc,
+.x-form-invalid-tip .x-tip-bl, .x-form-invalid-tip .x-tip-br, .x-form-invalid-tip .x-tip-ml, .x-form-invalid-tip .x-tip-mr {
+  background-image: url("../images/modx-theme/form/error-tip-corners.gif");
+}
+
+.x-form-invalid-tip .x-tip-body {
+  background-image: url("../images/modx-theme/form/exclamation.gif");
+}
+
+.x-tip-anchor {
+  background-image: url("../images/modx-theme/qtip/tip-anchor-sprite.gif");
+}
+
+.x-menu {
+  background-color: white;
+  border: 1px solid #bbbbbb;
+  border-radius: 3px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.25);
+}
+
+.x-menu-list {
+  padding: 0;
+}
+.x-menu-list li {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+.x-menu-list li:first-child {
+  margin-top: 3px;
+}
+.x-menu-list li:last-child {
+  margin-bottom: 3px;
+}
+.x-menu-list li a.x-menu-item {
+  color: #555555;
+  font-size: 13px;
+  padding: 5px 20px 5px 15px;
+}
+.x-menu-list li.x-menu-item-active {
+  background-color: #30759c;
+}
+.x-menu-list li.x-menu-item-active a {
+  color: white;
+}
+
+.x-menu-floating {
+  border-color: #C7C7C7;
+}
+
+.x-menu-nosep {
+  background-image: none;
+}
+
+.x-menu-list-item {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-menu-item-arrow {
+  background-image: url("../images/modx-theme/menu/menu-parent.gif");
+}
+
+.x-menu-sep {
+  background-color: #cccccc;
+  border-bottom: none;
+  margin: 2px 0;
+}
+
+.x-menu-item-active a.x-menu-item {
+  border: 0 none;
+  margin: 0;
+}
+
+.x-menu-check-item .x-menu-item-icon {
+  background-image: url("../images/modx-theme/menu/unchecked.gif");
+}
+
+.x-menu-item-checked .x-menu-item-icon {
+  background-image: url("../images/modx-theme/menu/checked.gif");
+}
+
+.x-menu-item-checked .x-menu-group-item .x-menu-item-icon {
+  background-image: url("../images/modx-theme/menu/group-checked.gif");
+}
+
+.x-menu-group-item .x-menu-item-icon {
+  background-image: none;
+}
+
+.x-menu-plain {
+  background-color: #fff !important;
+}
+
+.x-menu .x-date-picker {
+  border-color: #DFDFDF;
+}
+
+.x-cycle-menu .x-menu-item-checked {
+  background-color: #DFDFDF;
+  border-color: #b9b9b9 !important;
+}
+
+.x-menu-scroller-top {
+  background-image: url("../images/modx-theme/layout/mini-top.gif");
+}
+
+.x-menu-scroller-bottom {
+  background-image: url("../images/modx-theme/layout/mini-bottom.gif");
+}
+
+.x-box-tl, .x-box-ml {
+  background-color: #fafafa;
+  background-image: none;
+  color: #393939;
+  font: normal 13px/1.4 "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+}
+
+.x-box-mc p {
+  font-weight: normal;
+  margin-bottom: 5px;
+}
+
+.x-box-tl {
+  background-color: rgba(250, 250, 250, 0.8);
+  border-left: 1px solid #DEDEDE;
+  border-right: 1px solid #DEDEDE;
+  border-top: 1px solid #DEDEDE;
+}
+
+.x-box-ml {
+  background-color: rgba(250, 250, 250, 0.8);
+  border-left: 1px solid #DEDEDE;
+  border-right: 1px solid #DEDEDE;
+}
+
+.x-box-bl {
+  background-color: #eee;
+  background-color: rgba(230, 230, 230, 0.8);
+  border-bottom: 1px solid #DEDEDE;
+  border-left: 1px solid #DEDEDE;
+  border-right: 1px solid #DEDEDE;
+}
+
+.x-box-mc h3 {
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.x-box-mr, .x-box-bl, .x-box-bc, .x-box-br, .x-box-blue .x-box-bl, .x-box-blue .x-box-br, .x-box-blue .x-box-tl, .x-box-blue .x-box-tr {
+  background-image: none;
+}
+
+.x-box-blue .x-box-bc, .x-box-blue .x-box-mc, .x-box-blue .x-box-tc {
+  background-image: url("../images/modx-theme/box/tb-gray.gif");
+}
+
+.x-box-blue .x-box-mc {
+  background-color: #d8d8d8;
+}
+
+.x-box-blue .x-box-mc h3 {
+  color: #363636;
+}
+
+.x-box-blue .x-box-ml {
+  background-image: url("../images/modx-theme/box/l-gray.gif");
+}
+
+.x-box-blue .x-box-mr {
+  background-image: url("../images/modx-theme/box/r-gray.gif");
+}
+
+#x-debug-browser .x-tree .x-tree-node a span {
+  color: #333333;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+}
+
+#x-debug-browser .x-tree a i {
+  color: #ff4545;
+  font-style: normal;
+}
+
+#x-debug-browser .x-tree a em {
+  color: #999;
+}
+
+#x-debug-browser .x-tree .x-tree-node .x-tree-selected a span {
+  background-color: #d8d8d8;
+}
+
+.x-combo-list {
+  background-color: white;
+  border-color: #e4e4e4;
+  border-radius: 0 0 5px 5px;
+}
+
+.x-combo-list-inner {
+  background-color: white;
+}
+
+.x-combo-list-hd {
+  background-image: url("../images/modx-theme/layout/panel-title-light-bg.gif");
+  border-bottom-color: #bcbcbc;
+  color: #464646;
+}
+
+.x-resizable-pinned .x-combo-list-inner {
+  border-bottom-color: transparent;
+}
+
+.x-combo-list-item {
+  border: none;
+  padding: 5px;
+  color: #444444;
+}
+
+.x-combo-list .x-combo-selected {
+  background-color: #e1ecf1;
+  border: 0 none !important;
+}
+
+.x-combo-list .x-toolbar {
+  border-top-color: #bcbcbc;
+}
+
+.x-combo-list-small {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+/*.x-panel {
+    border:0 none;
+}*/
+.x-panel-bwrap {
+  overflow: visible;
+}
+
+.x-panel-body {
+  background-color: #fff;
+  border: 0;
+  overflow: visible;
+}
+
+.x-panel-noborder {
+  border: none;
+}
+
+.x-panel-bbar .x-toolbar {
+  background-color: transparent;
+  border: 0 none;
+}
+
+.x-panel-tbar-noheader .x-toolbar, .x-panel-mc .x-panel-tbar .x-toolbar {
+  border: 0 none;
+}
+
+.x-panel-tbar .x-toolbar {
+  background-color: transparent;
+  border: 0 none;
+  padding: 5px 4px;
+}
+
+.x-panel-mc .x-panel-tbar .x-toolbar {
+  background-image: none;
+}
+
+.x-panel-tbar-noheader .x-toolbar {
+  background-color: transparent;
+  background-image: none;
+  border: 0 none;
+  padding: 5px 0;
+}
+
+.x-panel-mc .x-panel-tbar .x-toolbar {
+  background-color: #F5F5F5;
+  border-bottom: 0 none;
+  padding: 5px 0;
+}
+
+.x-grid-panel .x-panel-body {
+  background-color: #F5F5F5;
+  border-bottom: 1px solid #E4E4E4;
+  border-top: 1px solid #FAFAFA;
+  border: 0 none;
+}
+
+.x-grid-panel .x-panel-body-noheader {
+  background-color: transparent;
+  border: 0 none;
+  padding: 0 !important;
+}
+
+.x-panel-tl .x-panel-header {
+  color: #6A6A6A;
+  font: normal 12px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+  text-shadow: 0 1px 0 #FAFAFA;
+}
+
+.x-panel-tl .x-panel-icon, .x-window-tl .x-panel-icon {
+  background-position: 0 8px;
+}
+
+.x-panel-tc {
+  background-image: none;
+}
+
+.x-panel-tl, .x-panel-tr, .x-panel-bl, .x-panel-br {
+  background-image: none;
+  border-bottom-color: #DFDFDF;
+}
+
+.x-panel-bc {
+  background-image: none;
+}
+
+.x-panel-tc {
+  background-color: #F5F5F5;
+}
+
+.x-panel-tl {
+  border-color: #E3E3E3 #E3E3E3;
+  border-style: solid solid none;
+  border-width: 1px 1px 0;
+}
+
+.x-panel-tl .x-panel-header {
+  border-bottom: 1px solid #E4E4E4;
+  padding: 10px 0;
+}
+
+.x-panel-bc .x-panel-footer {
+  padding-bottom: 0;
+}
+
+.x-panel-btns {
+  background-color: transparent;
+  border-top: 1px solid #FAFAFA;
+}
+
+.x-panel-mc {
+  background-color: #F5F5F5;
+  border-bottom: 1px solid #DFDFDF;
+  border-top: 1px solid #FAFAFA;
+  padding: 10px 5px;
+}
+
+.x-panel-tl, .x-panel-ml, .x-panel-bl {
+  background-color: #F5F5F5;
+  padding-left: 8px;
+}
+
+.x-panel-ml, .x-panel-mr {
+  background-image: none;
+}
+
+.x-panel-bl {
+  border-color: #E3E3E3 #E3E3E3;
+  border-style: none solid solid;
+  border-width: 0 1px 1px;
+  padding-bottom: 8px;
+}
+
+.x-window-dlg .x-msg-box-wait {
+  background-image: url("../images/modx-theme/grid/loading.gif");
+}
+
+.x-window-dlg .ext-mb-info {
+  background-image: url("../images/modx-theme/window/icon-info.gif");
+}
+
+.x-window-dlg .ext-mb-warning {
+  background-image: url("../images/modx-theme/window/icon-warning.gif");
+}
+
+.x-window-dlg .ext-mb-question {
+  background-image: url("../images/modx-theme/window/icon-question.gif");
+}
+
+.x-window-dlg .ext-mb-error {
+  background-image: url("../images/modx-theme/window/icon-error.gif");
+}
+
+.x-panel-ml {
+  border-left: 1px solid #E3E3E3;
+  border-right: 1px solid #E3E3E3;
+}
+
+.x-panel-mr {
+  padding-right: 8px;
+}
+
+.x-panel-tr, .x-panel-mr, .x-panel-br {
+  background-color: #f7f7f7;
+}
+
+.x-tool {
+  background-image: url("../images/modx-theme/panel/tool-sprites.png");
+  height: 16px;
+  margin: 1px 2px 0 0;
+  width: 16px;
+}
+
+.x-tool-toggle, .x-accordion-hd .x-tool-toggle {
+  background-position: left -48px;
+}
+
+.x-tool-toggle-over, .x-accordion-hd .x-tool-toggle-over {
+  background-position: right -48px;
+}
+
+.x-panel-collapsed .x-tool-toggle {
+  background-position: left -96px;
+}
+
+.x-panel-collapsed .x-tool-toggle-over {
+  background-position: right -96px;
+}
+
+.x-tool-close {
+  background-position: left 0;
+}
+
+.x-tool-close-over {
+  background-position: right 0;
+}
+
+.x-tool-minimize {
+  background-position: left -16px;
+}
+
+.x-tool-minimize-over {
+  background-position: right -16px;
+}
+
+.x-tool-maximize {
+  background-position: left -32px;
+}
+
+.x-tool-maximize-over {
+  background-position: right -32px;
+}
+
+.x-tool-restore {
+  background-position: left -112px;
+}
+
+.x-tool-restore-over {
+  background-position: right -112px;
+}
+
+.x-tool-gear {
+  background-position: left -200px;
+}
+
+.x-tool-gear-over {
+  background-position: right -200px;
+}
+
+.x-tool-pin {
+  background-position: left -200px;
+}
+
+.x-tool-pin-over {
+  background-position: right -200px;
+}
+
+.x-tool-unpin {
+  background-position: left -200px;
+}
+
+.x-tool-unpin-over {
+  background-position: right -200px;
+}
+
+.x-tool-right, .x-tool-expand-west {
+  background-position: left -80px;
+}
+
+.x-tool-right-over, .x-tool-expand-west-over {
+  background-position: right -80px;
+}
+
+.x-tool-left, .x-tool-expand-east {
+  background-position: left -64px;
+}
+
+.x-tool-left-over, .x-tool-expand-east-over {
+  background-position: right -64px;
+}
+
+.x-tool-up {
+  background-position: left -48px;
+}
+
+.x-tool-up-over {
+  background-position: right -48px;
+}
+
+.x-tool-down {
+  background-position: left -96px;
+}
+
+.x-tool-down-over {
+  background-position: right -96px;
+}
+
+.x-tool-minus {
+  background-position: left -224px;
+}
+
+.x-tool-minus-over {
+  background-position: right -224px;
+}
+
+.x-tool-plus {
+  background-position: left -208px;
+}
+
+.x-tool-plus-over {
+  background-position: right -208px;
+}
+
+.x-panel-dd-spacer {
+  border-color: #DFDFDF;
+}
+
+.x-panel-fbar td, .x-panel-fbar span, .x-panel-fbar input, .x-panel-fbar div, .x-panel-fbar select, .x-panel-fbar label {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-window-proxy {
+  background-color: #dcdcdc;
+  border-color: #d0d0d0;
+}
+
+.x-window-tl .x-window-header, .x-panel-header {
+  color: #5E5E5E;
+  font: normal 13px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+}
+
+.x-panel-header {
+  border-radius: 2px 2px 0 0;
+  background: #dddddd;
+  background: -moz-linear-gradient(center bottom, #dddddd 0%, #eeeeee 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #dddddd 0%, #eeeeee 100%);
+  background: -o-linear-gradient(center bottom, #dddddd 0%, #eeeeee 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #eeeeee), color-stop(100%, #dddddd));
+  background: -webkit-linear-gradient(center bottom, #dddddd 0%, #eeeeee 100%);
+  background: linear-gradient(center bottom, #dddddd 0%, #eeeeee 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#eeeeee,endColorstr=#dddddd,GradientType=0);
+  border-bottom: 1px solid #dddddd;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  border: 1px solid #c0c0c0;
+  font-size: 14px;
+  font-weight: bold;
+  margin-top: 0;
+  padding: 10px 10px 8px;
+  text-shadow: 0 1px 1px #ffffff;
+}
+
+.x-portal-space {
+  border-bottom: 1px solid #afafaf;
+  padding: 0;
+}
+
+.x-column {
+  margin: 0 15px 0 0;
+  overflow: visible;
+}
+
+.x-column-inner {
+  overflow: visible;
+}
+
+.x-panel-nofooter .x-panel-bc {
+  background-image: none;
+  height: 0;
+}
+
+.x-panel-ghost .x-window-tl {
+  border-bottom-color: #d0d0d0;
+}
+
+.x-panel-ghost {
+  background-color: #dbdbdb;
+}
+
+.x-panel-ghost ul {
+  border-color: #d0d0d0;
+}
+
+.x-panel-dd-spacer {
+  border-color: #d0d0d0;
+}
+
+.x-dlg-mask {
+  background-color: #ccc;
+}
+
+body.x-body-masked .x-window-plain .x-window-mc {
+  background-color: #e2e2e2;
+}
+
+.x-html-editor-wrap {
+  background-color: #fff;
+  border-color: #bcbcbc;
+}
+
+.x-toolbar td, .x-toolbar span, .x-toolbar input, .x-toolbar div, .x-toolbar select, .x-toolbar label {
+  border-radius: 3px;
+}
+
+.x-html-editor-tb .x-btn-text {
+  background-image: url("../images/modx-theme/editor/tb-sprite.gif");
+}
+
+.x-panel-noborder .x-panel-header-noborder {
+  border-bottom-color: transparent;
+}
+
+.x-panel-noborder .x-panel-tbar-noborder .x-toolbar {
+  background-color: transparent;
+  border-bottom-color: transparent;
+}
+
+.x-panel-noborder .x-panel-bbar-noborder .x-toolbar {
+  border-top-color: transparent;
+}
+
+.x-border-layout-ct {
+  background-color: #FAFAFA;
+}
+
+.x-accordion-hd {
+  background-image: url("../images/modx-theme/panel/light-hd.gif");
+  color: #222;
+  font-weight: normal;
+}
+
+.x-layout-collapsed {
+  background-color: #E4E4E4;
+  border-color: #DFDFDF;
+  width: 7px !important;
+}
+
+.x-layout-collapsed-over {
+  background-color: #e6e6e6;
+}
+
+.x-layout-split-west .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-left.gif");
+}
+
+.x-layout-split-east .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-right.gif");
+}
+
+.x-layout-split-north .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-top.gif");
+}
+
+.x-layout-split-south .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-bottom.gif");
+}
+
+.x-layout-cmini-west .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-right.gif");
+}
+
+.x-layout-cmini-east .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-left.gif");
+}
+
+.x-layout-cmini-north .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-bottom.gif");
+}
+
+.x-layout-cmini-south .x-layout-mini {
+  background-image: url("../images/modx-theme/layout/mini-top.gif");
+}
+
+.x-progress-wrap {
+  border-color: #8f8f8f;
+}
+
+.x-progress-inner {
+  background-color: #e7e7e7;
+  background-image: url("../images/modx-theme/qtip/bg.gif");
+}
+
+.x-progress-bar {
+  background-color: #bcbcbc;
+  background-image: url("../images/modx-theme/progress/progress-bg.gif");
+  border-bottom-color: #a6a6a6;
+  border-right-color: #a6a6a6;
+  border-top-color: #e2e2e2;
+}
+
+.x-progress-text {
+  color: #fff;
+  font-size: 11px;
+  font-weight: bold;
+}
+
+.x-progress-text-back {
+  color: #396095;
+}
+
+.x-list-header {
+  background-color: #f9f9f9;
+  background-image: url("../images/modx-theme/grid/grid3-hrow.gif");
+}
+
+.x-list-header-inner div em {
+  border-left-color: #ddd;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-list-body dt em {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-list-over {
+  background-color: #eee;
+}
+
+.x-list-selected {
+  background-color: #e7e7e7;
+}
+
+.x-list-resizer {
+  border-left-color: #555;
+  border-right-color: #555;
+}
+
+.x-list-header-inner em.sort-asc, .x-list-header-inner em.sort-desc {
+  background-image: url("../images/modx-theme/grid/sort-hd.gif");
+  border-color: #DFDFDF;
+}
+
+.x-slider-horz, .x-slider-horz .x-slider-end, .x-slider-horz .x-slider-inner {
+  background-image: url("../images/modx-theme/slider/slider-bg.png");
+}
+
+.x-slider-horz .x-slider-thumb {
+  background-image: url("../images/modx-theme/slider/slider-thumb.png");
+}
+
+.x-slider-vert, .x-slider-vert .x-slider-end, .x-slider-vert .x-slider-inner {
+  background-image: url("../images/modx-theme/slider/slider-v-bg.png");
+}
+
+.x-slider-vert .x-slider-thumb {
+  background-image: url("../images/modx-theme/slider/slider-v-thumb.png");
+}
+
+/* portal */
+.x-portal .x-panel-tl .x-panel-header {
+  background: none;
+  font-size: 14px;
+  padding: 8px 0 8px 0;
+}
+
+.x-portal .x-tool {
+  margin-top: 0;
+}
+
+.x-portal .x-panel-body {
+  font-weight: normal;
+  margin-bottom: 5px;
+  padding: 0px;
+  text-transform: none;
+}
+
+.x-portal-space {
+  margin-bottom: 5px;
+}
+
+/* grid checker */
+.x-grid3-body .x-grid3-td-checker {
+  background-image: none !important;
+}
+
+/* combo tpl stuff */
+.modx-combo-desc {
+  color: gray;
+  font-size: .9em;
+  font-style: italic;
+}
+
+.modx-combo-title {
+  font-weight: bold;
+}
+
+/* draggable grids */
+.modx-grid-draggable .x-grid3-row {
+  cursor: move;
+}
+
+.x-window .desc-under .warning {
+  color: #df8d00;
+}
+
+.x-window h2 {
+  border-bottom: 1px solid #D6DFC3;
+  color: #5e5e5e;
+  font: bold 15px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-size: 18px;
+  margin: 0 0 11px;
+  padding: 8px 15px;
+  text-shadow: 0 1px 1px #FFFFFF;
+}
+
+.x-window .x-panel-tl,
+.x-window .x-panel-ml,
+.x-window .x-panel-bl,
+.x-window .x-panel-mc,
+.x-window .x-panel-tr,
+.x-window .x-panel-mr,
+.x-window .x-panel-br {
+  background-color: #f8f8f8;
+}
+
+.x-window .x-tab-panel-body-top {
+  background: white !important;
+}
+.x-window .modx-tabs {
+  background: #f0f0f0;
+}
+.x-window .modx-tabs .x-tab-strip-wrap {
+  border: 1px solid #e4e4e4;
+  border-bottom-width: 0;
+}
+
+.x-window .x-tab-strip {
+  margin-left: 0;
+}
+
+.x-window .x-form-item label.x-form-item-label {
+  padding: 0;
+}
+
+.x-window .x-form-label-top .x-form-element {
+  padding-top: 0;
+}
+
+.x-window .x-form-cb-label {
+  color: #707070;
+  font-weight: bold;
+}
+
+.x-window .x-panel-mc {
+  border: 0 none;
+}
+
+.x-window .x-panel-ml {
+  border: 0 none;
+}
+
+.x-window .x-panel-bl.x-panel-nofooter,
+.x-window .x-panel-tl {
+  background-color: transparent;
+  background-image: none;
+  border: 0 none;
+  padding: 0;
+}
+
+.x-window .x-window-plain .x-panel-btns {
+  border-top: 0 none;
+}
+
+.x-window .x-window-plain .x-window-mc {
+  background-color: #f5f5f5;
+  border-color: 0 none !important;
+}
+
+.x-window-plain .x-window-body {
+  border: 0 none;
+}
+
+.x-window-body {
+  background-color: white;
+  border-bottom: 1px solid #D0D0D0;
+  border-top: 1px solid #F7F7F7;
+}
+
+.x-window-dlg .x-window-body {
+  background: none repeat scroll 0 0 #F4F4F4 !important;
+  padding: 15px 15px 5px;
+}
+
+.x-window .x-window-bc .x-panel-btns {
+  background-color: #f7f8fa;
+  background: #dfdfdf;
+  background: -moz-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: -o-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #f4f4f4), color-stop(100%, #dfdfdf));
+  background: -webkit-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  border-bottom: 1px solid #dfdfdf;
+  border-top: 1px solid #ffffff;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#f4f4f4,endColorstr=#dfdfdf,GradientType=0);
+  padding: 8px;
+}
+
+.x-window-dlg .x-window-bc .x-panel-btns {
+  border-top: 0 none;
+}
+
+.x-window .x-window-bc .x-window-footer {
+  margin-bottom: 0;
+}
+
+.x-window .x-window-proxy {
+  background-color: #dcdcdc;
+  border-color: #dfdfdf;
+}
+
+.x-window .x-window-tl {
+  background-color: #ffffff;
+  background-image: none;
+  border-radius: 3px 3px 0 0;
+  overflow: hidden;
+  padding-left: 0;
+}
+
+.x-window .x-window-tl .x-window-header {
+  background: #d0d0d0;
+  background: -moz-linear-gradient(center bottom, #d0d0d0 0%, #eeeeee 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #d0d0d0 0%, #eeeeee 100%);
+  background: -o-linear-gradient(center bottom, #d0d0d0 0%, #eeeeee 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #eeeeee), color-stop(100%, #d0d0d0));
+  background: -webkit-linear-gradient(center bottom, #d0d0d0 0%, #eeeeee 100%);
+  background: linear-gradient(center bottom, #d0d0d0 0%, #eeeeee 100%);
+  border-bottom: 1px solid #ababab;
+  border-radius: 3px 3px 0 0;
+  color: #5e5e5e;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#eeeeee,endColorstr=#d0d0d0,GradientType=0);
+  margin-top: 0;
+  padding: 8px;
+  text-align: center;
+  text-shadow: 0 1px 0 #ffffff;
+}
+
+.x-window .x-window-bl {
+  background-color: #ffffff;
+  background-image: none;
+  border-radius: 0 0 3px 3px;
+  overflow: hidden;
+  padding-left: 0;
+}
+
+.x-window .x-panel-nofooter {
+  background-color: #f7f8fa;
+  background: #dfdfdf;
+  background: -moz-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: -o-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #f4f4f4), color-stop(100%, #dfdfdf));
+  background: -webkit-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  border-bottom: 1px solid #dfdfdf;
+  border-top: 1px solid #ffffff;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#f4f4f4,endColorstr=#dfdfdf,GradientType=0);
+}
+
+.x-window .x-window-header-text {
+  color: #666666;
+}
+
+.x-window .x-window-dlg .ext-mb-text {
+  font-size: 12px;
+}
+
+.x-window .x-window-dlg .x-window-header-text {
+  font-size: 14px;
+}
+
+.x-window .x-window-dlg .x-window-body {
+  padding: 15px;
+}
+
+.x-window .x-window-dlg .x-panel-btns {
+  border-top: 0 none;
+}
+
+.x-window .x-window-tc,
+.x-window .x-window-bc {
+  background-image: none;
+}
+
+.x-window .x-window-tr,
+.x-window .x-window-br,
+.x-window .x-window-mr {
+  background-image: none;
+  padding-right: 0;
+}
+
+.x-window .x-window-tl,
+.x-window .x-window-ml {
+  background-image: none;
+  padding-left: 0;
+}
+
+.x-window .x-window-mc {
+  background-color: #ffffff;
+  border-radius: 0 0  3px 3px;
+  border: 0 none;
+}
+
+.x-window .x-window-maximized .x-window-tc {
+  background-color: #ffffff;
+}
+
+.x-window .x-window-bbar .x-toolbar,
+.x-window .x-window-bbar-noborder .x-toolbar {
+  background-color: #f7f8fa;
+  background: #d5dade;
+  background: -moz-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
+  background: -o-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #eff0f4), color-stop(100%, #d5dade));
+  background: -webkit-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
+  background: linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#eff0f4,endColorstr=#d5dade,GradientType=0);
+  border-radius: 0 0 3px 3px;
+  border-bottom: 0 none;
+  border-top: 1px solid #d4d9df;
+  padding: 8px;
+}
+
+.x-window .x-dlg-mask {
+  background-color: #cccccc;
+}
+
+.x-window-maximized .x-window-tc {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.x-superboxselect,
+.x-superboxselect-btns {
+  overflow: visible;
+}
+
+.x-superboxselect-input input {
+  background: transparent;
+}
+
+.x-superboxselect-btn-expand {
+  margin-top: 9px !important;
+  margin-right: 6px;
+}
+
+.x-superboxselect-btn-clear {
+  background-color: #fbfbfb;
+  height: 17px !important;
+  top: -4px;
+  outline: 1px solid #e4e4e4;
+  border: 12px solid #fbfbfb;
+  position: absolute;
+  right: -42px;
+  display: block;
+}
+
+/* from index */
+textarea {
+  overflow: auto;
+}
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.modx-form .x-form-text,
+.modx-form .x-form-textarea {
+  font-size: 14px;
+}
+
+.modx-form .x-form-text {
+  height: 20px !important;
+  padding: 5px;
+}
+
+.modx-form .x-form-item label {
+  color: #505050;
+  font-size: 14px;
+}
+
+.x-form-check-wrap {
+  height: auto !important;
+}
+
+.x-form-check-wrap .x-form-cb-label {
+  color: #777;
+  font-weight: normal;
+}
+
+.inline-form {
+  border: 0 none;
+  padding: 15px 15px 0;
+}
+
+.inline-form label {
+  color: #777777;
+  display: block;
+  font-weight: bold;
+  margin-bottom: 2px;
+}
+
+.inline-form input[type=text], .inline-form textarea {
+  background-color: #fbfbfb;
+  background-image: none;
+  border-radius: 2px;
+  border: 1px solid #CCCCCC;
+  position: relative;
+  width: 97%;
+}
+
+.inline-form input[type=text] {
+  font-size: 13px;
+  height: 20px !important;
+  padding: 5px;
+}
+
+.x-form-field {
+  font: normal 13px/1.4 "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+textarea.x-form-field,
+.x-form-textarea {
+  font-family: "Courier New", Courier, monospace;
+}
+
+.x-form-text,
+textarea.x-form-field,
+.x-form-textarea {
+  background-color: #fbfbfb;
+  background-image: none;
+  border-radius: 3px;
+  border: 1px solid #e4e4e4;
+  position: relative;
+}
+
+.x-form-select-one {
+  background-color: #fff;
+  border-color: #c5c5c5;
+}
+
+.x-form-check-wrap,
+.x-form-check-wrap label,
+.x-form-checkbox {
+  cursor: pointer;
+}
+
+.x-form-checkbox {
+  margin: 0 2px;
+}
+
+.x-form-checkbox:focus {
+  outline-offset: 1px;
+  outline: 1px solid #648c32 !important;
+}
+
+.x-form-check-group-label {
+  border-bottom: 1px solid #d0d0d0;
+  color: #434343;
+}
+
+.x-form-radio {
+  margin-left: 1px;
+}
+
+.x-editor .x-form-check-wrap {
+  background-color: #fff;
+}
+
+.ext-strict .x-form-field-trigger-wrap .x-form-text,
+.ext-strict .x-small-editor .x-form-field-trigger-wrap .x-form-text {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  border-right: 0 none;
+  color: #606060;
+  font-weight: bold;
+  height: 20px;
+  padding: 6px;
+  text-shadow: 1px -1px 0 #fff;
+}
+
+.x-small-editor .x-form-field-wrap .x-form-trigger, .x-form-field-wrap .x-form-trigger {
+  background-image: url("../images/modx-theme/form/trigger.png");
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+  border: 1px solid #C5C5C5 !important;
+  border-left: 0 none;
+}
+
+/* fix combo on grid editor bug */
+.x-grid-editor .x-form-field-wrap {
+  background: #f6f2f7 url("../images/modx-theme/form/combo-bck.png") repeat-x scroll 0px 100%;
+}
+
+.x-grid-editor .x-form-field-wrap input {
+  background-color: transparent !important;
+}
+
+.x-grid-editor .x-form-field-wrap img {
+  background-color: white;
+  background-image: url("../images/modx-theme/form/trigger.png");
+}
+
+.x-form-field-trigger-wrap {
+  border-color: #D0D0D0 #CCCCCC #BEBEBE;
+  border-style: solid;
+  border-width: 1px;
+  height: 30px;
+  margin-right: 1px;
+}
+
+.x-form-field-trigger-wrap .x-form-text {
+  background-color: transparent;
+  border: 0 none;
+}
+
+.x-form-field-wrap {
+  background: #fbfbfb;
+  border-radius: 2px;
+}
+
+.x-form-field-wrap .x-form-trigger {
+  background-position: left center;
+  background-repeat: no-repeat;
+  border: 0 none !important;
+  height: 30px;
+  width: 32px;
+}
+
+.x-form-field-wrap .x-form-trigger-over {
+  background-position: right;
+}
+
+.x-form-field-wrap .x-form-arrow-trigger {
+  background: url("../images/modx-theme/form/trigger.png") no-repeat scroll left center transparent;
+}
+
+.x-form-field-wrap .x-form-trigger.x-form-trigger-over {
+  background-position: center center;
+}
+
+.x-form-field-wrap .x-form-trigger.x-form-trigger-click {
+  background-position: right center;
+}
+
+.x-small-editor .x-form-field-wrap {
+  background: #f0f0f0;
+  border-radius: 2px;
+}
+
+.x-small-editor .x-form-field-wrap .x-form-trigger {
+  border: 0 none !important;
+  height: 32px;
+  width: 32px;
+}
+
+.x-small-editor .x-form-field-wrap .x-form-trigger-over {
+  background-color: #f3f3f3;
+  background-position: right;
+}
+
+.x-small-editor .x-form-field-wrap .x-form-arrow-trigger {
+  background: url("../images/modx-theme/form/trigger.png") no-repeat scroll left center transparent;
+}
+
+.x-small-editor .x-form-field-wrap .x-form-trigger.x-form-trigger-over {
+  background-position: center center;
+}
+
+.x-small-editor .x-form-field-wrap .x-form-trigger.x-form-trigger-click {
+  background-position: right center;
+}
+
+.x-form-field-wrap .x-form-date-trigger, .x-small-editor .x-form-field-wrap .x-form-date-trigger {
+  background-image: url("../images/modx-theme/form/calendar.png");
+}
+
+.x-form-field-wrap .x-form-clear-trigger {
+  background-image: url("../images/modx-theme/form/clear-trigger.gif");
+}
+
+.x-form-field-wrap .x-form-search-trigger {
+  background-image: url("../images/modx-theme/form/search-trigger.gif");
+}
+
+.x-viewport .x-trigger-wrap-focus, .x-viewport input.x-form-focus, .x-viewport textarea.x-form-focus, .x-viewport .x-form-textarea.x-form-focus {
+  border-radius: 0;
+  outline-offset: 0;
+  outline: 1px solid #ddd !important;
+  /* #shame */
+}
+
+.x-viewport .x-trigger-wrap-focus .x-form-focus {
+  outline: none !important;
+}
+
+.x-datetime-wrap {
+  background: none;
+}
+
+.x-form-invalid, textarea.x-form-invalid {
+  border-color: red !important;
+}
+
+.ext-strict .x-small-editor .x-form-text {
+  border-radius: 2px;
+  height: 20px !important;
+}
+
+.ext-gecko .x-form-text, .ext-ie8 .x-form-text {
+  padding: 5px;
+}
+
+.ext-safari .x-form-invalid {
+  background-color: #fee;
+  border-color: #ff7870;
+}
+
+.x-form-inner-invalid, textarea.x-form-inner-invalid {
+  background-color: #fff;
+  background-image: url("../images/modx-theme/grid/invalid_line.gif");
+}
+
+.x-form-grow-sizer {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-form-invalid-msg {
+  /*background-image: url($imgPath + 'modx-theme/shared/warning.gif');*/
+  color: #c0272b;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  margin-top: 2px;
+  position: relative;
+}
+.x-form-invalid-msg:before {
+  content: "\f071";
+  /* : "\f071" */
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  color: inherit;
+}
+
+.x-form-empty-field {
+  color: gray;
+}
+
+.x-grid3 .x-small-editor .x-form-text, .x-grid3 .x-small-editor .x-form-field-wrap {
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  margin-top: 5px;
+}
+
+.x-grid3 .x-small-editor .x-form-field-wrap {
+  overflow: hidden;
+}
+
+.x-grid3 .x-small-editor .x-form-field-wrap .x-form-text {
+  margin-top: 0;
+}
+
+.ext-safari .x-small-editor .x-form-field {
+  font: normal 13px/1.4 "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.x-form-invalid-icon {
+  background-image: url("../images/modx-theme/form/exclamation.gif");
+}
+
+.x-fieldset {
+  border-color: #C5C5C5;
+}
+
+.x-fieldset legend {
+  color: #434343;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+}
+
+.ext-gecko .x-window-body .x-form-item {
+  overflow: hidden;
+}
+
+.x-form-item-label {
+  color: #777;
+  font-weight: bold;
+}
+
+.x-form fieldset {
+  border: 1px solid #dedede;
+}
+
+.x-form fieldset legend {
+  color: #606060;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+}
+
+.x-fieldset-body {
+  font-size: 12px;
+}
+
+/* issue #5505 */
+.x-form-text {
+  min-height: 20px;
+  padding: 5px;
+}
+
+.form-with-labels .x-form-label-top .x-form-element {
+  padding: 0;
+}
+
+.form-with-labels .x-form-label-top .x-form-item label.x-form-item-label {
+  color: #555;
+  font-size: 13px;
+  font-weight: bold;
+  margin-bottom: 0;
+  display: block;
+  padding: 7px 5px 4px 3px;
+}
+
+.form-with-labels .desc-under,
+.x-window .desc-under {
+  color: #aaaaaa;
+  display: block;
+  font-size: 11px;
+  font-style: italic;
+  margin: -8px 0 16px;
+}
+
+.form-with-labels .desc-under.desc-checkbox,
+.x-window .desc-under.desc-checkbox {
+  margin: -2px 0 4px;
+}
+
+.form-with-labels .desc-under .warning,
+.x-window {
+  -moz-box-shadow: 0 0 5px #A0A0A0;
+  -o-box-shadow: 0 0 5px #A0A0A0;
+  -webkit-box-shadow: 0 0 5px #A0A0A0;
+  border-radius: 3px;
+  border: 1px solid #C0C0C0;
+  box-shadow: 0 0 5px #A0A0A0;
+  overflow: hidden;
+  padding: 0;
+}
+
+/*
+having to do some real janky stuff to work with ExtJS markup
+*/
+#modx-resource-tabs #modx-tv-tabs .x-tab-panel-header {
+  border-width: 0 !important;
+  /* #shame */
+}
+#modx-resource-tabs .x-tab-panel-bwrap .x-tab-panel-bwrap {
+  border-width: 0 !important;
+}
+
+.primary-button, .x-btn.primary-button, #modx-action-buttons .x-btn#modx-abtn-save {
+  background-image: -webkit-linear-gradient(left top, #58a598, #3c8e8b);
+  background-image: linear-gradient(to right bottom , #58a598, #3c8e8b);
+  background-color: #58a598;
+  color: white;
+}
+.x-item-disabled.primary-button, #modx-action-buttons .x-item-disabled.x-btn#modx-abtn-save {
+  opacity: 1;
+  background: #b4b4b4;
+}
+.primary-button button, .x-btn.primary-button button, #modx-action-buttons .x-btn#modx-abtn-save button {
+  color: white;
+}
+.x-item-disabled.primary-button *, #modx-action-buttons .x-item-disabled.x-btn#modx-abtn-save * {
+  color: #455a6e !important;
+}
+.x-btn-over.primary-button, #modx-action-buttons .x-btn-over.x-btn#modx-abtn-save {
+  background: #7fbbb1;
+}
+
+/* action buttons bar */
+#modx-action-buttons {
+  position: fixed;
+  top: 55px;
+  right: 10px;
+  z-index: 9;
+  left: auto;
+  background: #f2f2f2;
+  padding: 10px 2px 7px 7px;
+  border: 0;
+  font-family: "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  border-radius: 0 0 0 5px;
+}
+#modx-action-buttons .x-toolbar-left {
+  width: auto !important;
+  zoom: 1;
+}
+
+/* btn style */
+.x-btn {
+  *display: inline;
+  background: linear-gradient(180deg, #e4e9ee 0%, #d2dbe2 100%) no-repeat;
+  border-radius: 4px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-block;
+  margin: 0 1px;
+  padding: 10px 15px;
+  position: relative;
+  text-decoration: none;
+  zoom: 1;
+  border: 1px solid #c8d2dc;
+}
+.x-btn button {
+  font-size: 13px;
+  color: #707070;
+  cursor: pointer;
+  height: 16px;
+  min-width: 100%;
+  vertical-align: middle;
+}
+#modx-leftbar .x-btn {
+  background: white;
+  border-radius: 3px;
+  padding: 13px 20px;
+  border: none;
+}
+#modx-leftbar .x-btn button {
+  color: #728da7;
+}
+#modx-action-buttons .x-btn {
+  background: white;
+  border-radius: 3px;
+  padding: 13px 20px;
+  border: none;
+  -webkit-box-shadow: 0 1px 0 0 #CCC;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.025), -1px 0 0 rgba(0, 0, 0, 0.025), 1px 0 0 rgba(0, 0, 0, 0.025);
+}
+#modx-action-buttons .x-btn button {
+  color: #728da7;
+}
+#modx-action-buttons .x-btn.x-btn-over {
+  border-color: #fbfbfb;
+  background-color: #fbfbfb;
+}
+
+.x-toolbar .x-form-field-trigger-wrap {
+  background: linear-gradient(180deg, #e4e9ee 0%, #d2dbe2 100%);
+  border-radius: 4px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-block;
+  margin: 0 1px;
+  position: relative;
+  text-decoration: none;
+  zoom: 1;
+  border: 1px solid #c8d2dc;
+  transition: background-color .2s;
+  padding: 3px 23px 3px 0;
+}
+.x-toolbar .x-form-field-trigger-wrap input.x-form-text {
+  font-weight: normal !important;
+  padding-left: 13px !important;
+}
+.x-toolbar .x-form-field-trigger-wrap .x-form-trigger {
+  padding-top: 2px;
+}
+.x-toolbar .x-form-field-trigger-wrap.x-trigger-wrap-focus {
+  outline: none !important;
+  border-color: #8a8a8a;
+}
+.x-toolbar .x-toolbar-cell input.x-form-text {
+  padding: 8px 13px;
+  border-radius: 4px;
+  font-size: 13px !important;
+}
+
+.x-btn-over {
+  border-color: #8a8a8a;
+  background-color: #f0f0f0;
+}
+
+.x-btn-icon button {
+  height: 16px;
+  width: 16px;
+}
+
+.x-btn-icon.arrow_up button {
+  background: none !important;
+  /* #shame */
+  position: relative;
+}
+.x-btn-icon.arrow_up button:before {
+  content: "\f148";
+  top: 1px;
+  bottom: auto;
+}
+.x-btn-icon.arrow_down button {
+  background: none !important;
+  /* #shame */
+  position: relative;
+}
+.x-btn-icon.arrow_down button:before {
+  content: "\f149";
+  top: 1px;
+  bottom: auto;
+}
+.x-btn-icon.refresh button {
+  background: none !important;
+  /* #shame */
+  position: relative;
+}
+.x-btn-icon.refresh button:before {
+  content: "\f021";
+  top: 1px;
+  bottom: auto;
+}
+
+.x-btn-text-icon button {
+  padding-left: 20px !important;
+}
+
+.x-html-editor-tb .x-btn {
+  -moz-box-shadow: none;
+  -o-box-shadow: none;
+  -webkit-box-shadow: none;
+  background-color: transparent;
+  background-image: none;
+  border: 0 none;
+  box-shadow: none;
+  margin: 0;
+}
+
+.x-html-editor-tb .x-btn-over {
+  border: 0 none;
+}
+
+.x-btn-click {
+  -moz-box-shadow: 0 0 3px #aaaaaa inset;
+  -o-box-shadow: 0 0 3px #aaaaaa inset;
+  -webkit-box-shadow: 0 0 3px #aaaaaa inset;
+  box-shadow: 0 0 3px #aaaaaa inset;
+  margin: 0 1px;
+}
+
+.x-btn-focus {
+  border: 1px solid #53595f;
+}
+
+.x-btn-group {
+  border-radius: 3px;
+  border: 1px solid #dbe0e4;
+  margin-right: 2px;
+  padding: 0;
+}
+
+.x-btn-group .x-btn {
+  -moz-box-shadow: transparent 0 0 1px;
+  -o-box-shadow: transparent 0 0 1px;
+  -webkit-box-shadow: transparent 0 0 1px;
+  background-color: transparent;
+  background-image: none;
+  border: 1px solid transparent;
+  box-shadow: transparent 0 0 1px;
+}
+
+.x-btn-group .x-btn button {
+  color: #868b8f;
+  height: auto !important;
+  /*text-shadow: 0 1px 0 #ffffff;*/
+}
+
+.x-btn-group .x-btn-over {
+  background: #dfdfdf;
+  background: #f0f0f0;
+  border: 1px solid #dbe0e4;
+}
+
+.x-btn-group .x-btn-over button {
+  color: #5b7a98;
+  /*text-shadow: 0 1px 0 #ffffff;*/
+}
+
+.x-btn-group .x-btn-click {
+  background-color: #ffffff;
+  background-image: none;
+  box-shadow: 0 0 3px #aaaaaa inset;
+  margin: 0 2px 0 0;
+}
+
+.x-btn-click .x-btn-text, .x-btn-menu-active .x-btn-text, .x-btn-pressed .x-btn-text {
+  color: #73797f;
+}
+
+.x-btn-disabled * {
+  color: gray !important;
+}
+
+.x-btn-group-bwrap {
+  padding: 1px 0 0;
+}
+
+.x-btn-group-header {
+  background-color: #dbe0e4;
+  color: #73797f;
+  text-shadow: 0 1px 0 #fafafa;
+}
+
+.x-btn-group-tl, .x-btn-group-tr {
+  background-image: none;
+  padding: 0;
+}
+
+.x-btn-group-tc, .x-btn-group-bc, .x-btn-group-bl, .x-btn-group-br {
+  background-image: none;
+}
+
+.x-btn-group-ml {
+  background-image: none;
+  padding-left: 1px;
+}
+
+.x-btn-group-mr {
+  background-image: none;
+  padding-right: 1px;
+}
+
+.x-btn em.x-btn-split {
+  /*background: transparent url($imgPath + 'modx-theme/button/s-arrow.gif') no-repeat right center;*/
+  display: block;
+  padding-right: 14px;
+  position: relative;
+}
+.x-btn em.x-btn-split:before {
+  content: "\f0d7";
+  position: absolute;
+  top: 4px;
+  right: 0;
+  color: inherit;
+}
+
+.x-btn em.x-btn-arrow {
+  background: transparent url("../images/modx-theme/button/arrow.gif") no-repeat right center;
+  display: block;
+  padding-right: 20px;
+}
+.x-btn em.x-btn-arrow button {
+  padding-right: 10px !important;
+  border-right: 1px solid #fff;
+}
+
+.x-btn-menu-active {
+  background: white;
+}
+.x-btn-menu-active button {
+  color: #444444;
+}
+
+/* //end button style */
+.x-btn-over em.x-btn-split, .x-btn-click em.x-btn-split, .x-btn-menu-active em.x-btn-split, .x-btn-pressed em.x-btn-split {
+  /*background-image: url($imgPath + 'modx-theme/button/s-arrow-o.gif');*/
+}
+
+.x-btn em.x-btn-arrow-bottom {
+  background-image: url("../images/modx-theme/button/s-arrow-b-noline.gif");
+}
+
+.x-btn em.x-btn-split-bottom {
+  background-image: url("../images/modx-theme/button/s-arrow-b.gif");
+}
+
+.x-btn-over em.x-btn-split-bottom, .x-btn-click em.x-btn-split-bottom, .x-btn-menu-active em.x-btn-split-bottom, .x-btn-pressed em.x-btn-split-bottom {
+  background-image: url("../images/modx-theme/button/s-arrow-bo.gif");
+}
+
+.x-btn-group-notitle .x-btn-group-tc {
+  background-image: url("../images/modx-theme/button/group-tb.gif");
+}
+
+/* Action buttons */
+.actions {
+  bottom: 8px;
+  margin: 0;
+  overflow: hidden;
+  position: absolute;
+}
+
+.actions li {
+  float: left;
+  line-height: 0.7;
+  margin-right: 2px;
+}
+
+.actions button,
+.inline-button {
+  background: #dcdcdc;
+  background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -o-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
+  background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  border-radius: 3px;
+  border: 1px solid #cccccc;
+  color: #888888;
+  cursor: pointer;
+  display: block;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#dcdcdc,GradientType=0);
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+  padding: 3px 5px;
+  text-decoration: none;
+  /*text-shadow: 0 1px 0 #ffffff;*/
+}
+
+.actions button:hover,
+.inline-button:hover {
+  background: #e0e0e0;
+  background: -moz-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
+  background: -o-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, #e0e0e0));
+  background: -webkit-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
+  background: linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
+  color: #565550;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#e0e0e0,GradientType=0);
+}
+
+.actions button:active,
+.inline-button:active {
+  background-color: #ffffff;
+  background-image: none;
+  box-shadow: 0 0 3px #aaaaaa inset;
+}
+
+.actions button.orange {
+  background: #febb4a;
+  background: -moz-linear-gradient(center bottom, #febb4a 0%, #feda71 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
+  background: -o-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #feda71), color-stop(100%, #febb4a));
+  background: -webkit-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
+  background: linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
+  border-color: #f5b74e #e7a93f #dfa138;
+  color: #996633;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#feda71,endColorstr=#febb4a,GradientType=0);
+  /*text-shadow: 0 1px 0 #fee1a0;*/
+}
+
+.actions button.orange:hover {
+  background: #fec95b;
+  background: -moz-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
+  background: -o-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fee1a0), color-stop(100%, #fec95b));
+  background: -webkit-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
+  background: linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fee1a0,endColorstr=#fec95b,GradientType=0);
+}
+
+.inline-button.green {
+  background: #9fcb57;
+  background: -moz-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
+  background: -o-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #d7e9a4), color-stop(100%, #9fcb57));
+  background: -webkit-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
+  background: linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
+  border: 1px solid #85a948;
+  color: #556f14 !important;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#d7e9a4,endColorstr=#9fcb57,GradientType=0);
+  /*text-shadow: 0 1px 0 #d7e9a4;*/
+}
+
+.inline-button.green:hover {
+  background: #9fcb57;
+  background: -moz-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
+  background: -o-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #e6efd1), color-stop(100%, #9fcb57));
+  background: -webkit-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
+  background: linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#e6efd1,endColorstr=#9fcb57,GradientType=0);
+}
+
+/* basic tree toolbar styles */
+#modx-leftbar .x-toolbar-ct .x-btn {
+  margin: 0 3px;
+  padding: 0;
+  width: 25px;
+  height: 30px;
+  border: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+  opacity: 1;
+  display: inline-block;
+  position: relative;
+}
+#modx-leftbar .x-toolbar-ct .x-btn > em > button {
+  font-size: 18px;
+  text-shadow: 0 !important;
+  overflow: visible;
+  position: absolute;
+  height: 24px;
+  top: 4px;
+  left: 2px;
+  color: #728da7;
+}
+#modx-leftbar .x-toolbar-ct .x-btn:hover, #modx-leftbar .x-toolbar-ct .x-btn button:hover {
+  color: #3697cd;
+}
+#modx-leftbar .x-toolbar-ct .x-btn span {
+  vertical-align: middle;
+}
+#modx-leftbar .x-toolbar-ct .x-toolbar-right .x-btn > em > button {
+  color: #96A9BB;
+}
+
+#modx-leftbar #emptifier.x-item-disabled {
+  opacity: .4 !important;
+}
+
+/* resource tree toolbar icons */
+.tree-new-resource > em > button:before {
+  content: "\f15b";
+}
+
+.tree-new-weblink > em > button:before {
+  content: "\f0c1";
+}
+
+.tree-new-symlink > em > button:before {
+  content: "\f0c5";
+}
+
+.tree-new-static-resource > em > button:before {
+  content: "\f0f6";
+}
+
+.tree-trash > em > button:before {
+  content: "\f014";
+}
+
+/* alignment overrides */
+#modx-leftbar .x-toolbar-ct .x-btn.tree-new-symlink > em > button {
+  top: 4px;
+  left: 2px;
+}
+
+#modx-leftbar .x-toolbar-ct .x-btn.tree-new-weblink > em > button {
+  left: 2px;
+}
+
+/* element tree toolbar */
+.tree-new-template > em > button:before {
+  content: "\f0db";
+}
+
+.tree-new-tv > em > button:before {
+  content: "\f022";
+}
+
+.tree-new-chunk > em > button:before {
+  content: "\f009";
+}
+
+.tree-new-snippet > em > button:before {
+  content: "\f121";
+}
+
+.tree-new-plugin > em > button:before {
+  content: "\f085";
+}
+
+.tree-new-category > em > button:before {
+  content: "\f07b";
+}
+
+/* top area around the tab strip */
+.x-tab-panel-noborder {
+  border: 1px solid #E2E3DE;
+  margin: 20px 0 10px;
+  overflow: visible;
+  /* background behind a button bar */
+}
+.x-tab-panel-noborder .x-tab-panel-body-noborder {
+  background-color: white;
+}
+#modx-leftbar .x-tab-panel-noborder .x-tab-panel-body-noborder {
+  background-color: white;
+}
+
+/* main tabs */
+.x-tab-panel-header,
+.x-tab-panel-footer {
+  border: 0;
+}
+
+.x-tab-panel-header ul.x-tab-strip-top {
+  border-bottom-color: white;
+  margin: 0;
+  /* was -1px */
+  width: auto;
+  background-color: transparent !important;
+  position: relative;
+  top: 1px;
+}
+
+.x-tab-panel-header-plain .x-tab-strip-spacer,
+.x-tab-panel-footer-plain .x-tab-strip-spacer {
+  background-color: #fff;
+  border: none;
+  height: 0;
+}
+
+.x-tab-panel-header,
+.x-tab-strip {
+  /*padding-left: 1px;*/
+  padding-left: 0;
+}
+
+.x-tab-panel-bwrap {
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+}
+
+.x-tab-strip li {
+  color: #3697cd;
+  cursor: pointer;
+  font: 14px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  line-height: 2.2;
+  margin: 1px 0 1px 2px;
+  padding: 0 12px;
+  position: relative;
+  z-index: 5;
+}
+.x-tab-strip li:hover {
+  color: #1f5c7e;
+}
+.x-tab-strip li.x-tab-strip-active {
+  color: #1a7fb8;
+  background-color: #fff;
+  box-shadow: 0 -3px 0 #3697cd, -1px 0 0 transparent;
+  cursor: default;
+  margin: 0 0 0 2px;
+  padding-bottom: 2px;
+}
+.vertical-tabs-header .x-tab-strip li.x-tab-strip-active {
+  border-radius: 0;
+}
+.x-tab-strip li.x-tab-strip-active:after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -3px;
+  right: 0;
+  bottom: 1px;
+  left: 0;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  z-index: -1;
+  border-radius: 3px;
+}
+.x-tab-strip li.x-tab-strip-active:before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 90%;
+  right: 0;
+  bottom: -4px;
+  left: 0;
+  background: white;
+}
+
+.x-tab-strip-wrap,
+.x-tab-panel-header,
+.x-tab-panel {
+  overflow: visible;
+  border: none;
+}
+
+.x-tab-strip-closable {
+  padding-right: 15px !important;
+}
+
+.x-tab-strip .x-tab-strip-closable a.x-tab-strip-close {
+  right: 8px;
+  top: 11px;
+  background-image: url("../images/modx-theme/tabs/tab-close.gif");
+}
+
+ul.x-tab-strip-top li:first-child {
+  /*margin-left: -1px*/
+  margin-left: 0;
+}
+
+ul.x-tab-strip-bottom {
+  background-color: #f4f4f4;
+  border-top-color: #dfdfdf;
+}
+ul.x-tab-strip-bottom .x-tab-right {
+  background-image: url("../images/modx-theme/tabs/tab-btm-inactive-right-bg.gif");
+}
+ul.x-tab-strip-bottom .x-tab-right .x-tab-right {
+  background-image: url("../images/modx-theme/tabs/tab-btm-right-bg.gif");
+}
+ul.x-tab-strip-bottom .x-tab-right .x-tab-left {
+  background-image: url("../images/modx-theme/tabs/tab-btm-left-bg.gif");
+}
+ul.x-tab-strip-bottom .x-tab-left {
+  background-image: url("../images/modx-theme/tabs/tab-btm-inactive-left-bg.gif");
+}
+
+.x-tab-panel-body {
+  background-color: white;
+  border: none;
+}
+
+.x-tab-panel-body-top {
+  border-top: 0 none;
+}
+
+.x-tab-panel-body-bottom {
+  border-bottom: 0 none;
+}
+
+.x-tab-scroller-left {
+  background-image: url("../images/modx-theme/tabs/scroll-left.gif");
+  border-bottom-color: #dfdfdf;
+}
+
+.x-tab-scroller-left-over {
+  background-position: 0 0;
+}
+
+.x-tab-scroller-left-disabled {
+  -khtml-opacity: 0.5;
+  -moz-opacity: 0.5;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+  background-position: -18px 0;
+  cursor: default;
+  filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50);
+  opacity: 0.5;
+}
+
+.x-tab-scroller-right {
+  background-image: url("../images/modx-theme/tabs/scroll-right.gif");
+  border-bottom-color: #dfdfdf;
+}
+
+.x-tab-panel-bbar .x-toolbar,
+.x-tab-panel-tbar .x-toolbar {
+  border-color: #dfdfdf;
+}
+
+.x-tab-panel-body-noborder .x-panel-body-noheader:first-child {
+  border-top: 0 none;
+}
+
+.x-tab-panel-bbar-noborder .x-toolbar {
+  border-top-color: transparent;
+}
+
+.x-tab-panel-tbar-noborder .x-toolbar {
+  border-bottom-color: transparent;
+}
+
+/* vertical tabs */
+.vertical-tabs-panel {
+  background: #f8f8f8;
+}
+.vertical-tabs-panel.wrapped {
+  border: 1px solid #e0e0e0;
+}
+
+.vertical-tabs-header {
+  background-color: #f8f8f8 !important;
+  float: left;
+  margin-left: 0;
+  padding: 13px 0 !important;
+  width: 150px !important;
+}
+.vertical-tabs-header ul {
+  border-top: 1px solid transparent;
+  width: auto;
+  border-bottom-color: transparent;
+}
+.vertical-tabs-header .vertical-tabs-header li {
+  background: none repeat scroll 0 0 transparent !important;
+  border-color: transparent transparent #E0E0E0 transparent !important;
+  border-radius: 0 !important;
+  border-style: none none solid none !important;
+  border-width: 1px 1px 1px 0 !important;
+  float: none !important;
+  margin: 0 !important;
+  overflow: hidden;
+  padding: 5px !important;
+  white-space: nowrap;
+  color: #555;
+  line-height: 1.3;
+  text-shadow: 0 1px 0 #fff;
+}
+.vertical-tabs-header .vertical-tabs-header li:first-child {
+  border-top: 0 none !important;
+}
+.vertical-tabs-header h4 {
+  margin-left: 15px;
+}
+.vertical-tabs-header ul.x-tab-strip-top {
+  border-bottom: none;
+  background: #f8f8f8 !important;
+}
+
+.window-vtabs .x-panel-mr {
+  padding-right: 0px;
+}
+.window-vtabs .vertical-tabs-panel {
+  width: 100% !important;
+  margin: 0px;
+}
+
+.vertical-tabs-header ul.x-tab-strip-top li {
+  width: 100%;
+}
+.vertical-tabs-header ul.x-tab-strip-top li .x-tab-strip-active {
+  background: white !important;
+  /*border-width: 0 0 1px;*/
+  color: #555;
+  /*padding-bottom: 5px !important;*/
+  text-shadow: none;
+}
+
+.vertical-tabs-header .x-tab-edge {
+  height: 0;
+}
+
+.vertical-tabs-header .x-tab-strip-spacer {
+  display: none;
+}
+
+.vertical-tabs-body {
+  padding: 20px 30px 20px 25px;
+}
+
+/* Main MODX Manager navbar */
+#modx-header {
+  background: #3f4850;
+  min-height: 55px;
+}
+
+#modx-navbar {
+  background-image: -webkit-linear-gradient( left , #3f4850 0%, #365462 46%, #3e5554 60%, #42554d 68%, #573d4e 100%);
+  background-image: linear-gradient(to right, #3f4850 0%, #365462 46%, #3e5554 60%, #42554d 68%, #573d4e 100%);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.025);
+  height: 100%;
+  position: relative;
+  z-index: 10;
+}
+
+#modx-user-menu {
+  float: right;
+  margin-right: 15px;
+}
+
+#modx-navbar {
+  font-weight: bold;
+  font: normal 13px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+#modx-topnav {
+  float: left;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+#modx-topnav li {
+  border-right: 1px solid #2f4150;
+}
+
+#modx-navbar li,
+#modx-navbar a {
+  background: transparent;
+  float: left;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+#modx-navbar li:hover {
+  z-index: 10000;
+}
+
+#modx-navbar a {
+  color: white;
+  cursor: pointer;
+  display: block;
+  line-height: 55px;
+  padding: 0 15px;
+  text-decoration: none;
+}
+
+@media screen and (max-width: 960px) {
+  #modx-topnav > li:not(#modx-home-dashboard) > a {
+    text-indent: -99999em;
+    display: block;
+    height: 100%;
+    position: relative;
+    width: 1em;
+  }
+  #modx-topnav > li:not(#modx-home-dashboard) > a:after {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: inline-block;
+    font-family: FontAwesome;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-indent: 0;
+    display: block;
+    text-align: center;
+    line-height: 55px;
+    font-size: 16px;
+  }
+}
+@media screen and (max-width: 960px) {
+  #modx-topnav #limenu-site > a:after {
+    content: "\f0f6";
+    /* "\f0f6" */
+  }
+  #modx-topnav #limenu-media > a:after {
+    content: "\f03e";
+    /* "\f03e" */
+  }
+  #modx-topnav #limenu-components > a:after {
+    content: "\f1b2";
+    /* "\f1b2" */
+  }
+  #modx-topnav #limenu-manage > a:after {
+    content: "\f1de";
+    /* "\f1de" */
+  }
+}
+
+@media screen and (max-width: 960px) {
+  #user-username {
+    display: none;
+  }
+}
+
+#modx-navbar .top {
+  padding-right: 15px;
+}
+#modx-navbar .top:after {
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid #60727c;
+  position: absolute;
+  content: ' ';
+  right: 12px;
+  top: 26px;
+}
+
+#modx-topnav li.top > a {
+  cursor: default;
+}
+
+#modx-topnav > li.top > a, #modx-user-menu > li.top > a {
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
+}
+
+#modx-topnav > li.top:hover > a, #modx-user-menu > li.top:hover > a {
+  padding-bottom: 1px;
+  z-index: 10001;
+}
+
+#modx-navbar li:hover a:hover.modx-help {
+  color: #3697cd;
+}
+
+#modx-navbar #limenu-admin ul.modx-subnav,
+#modx-navbar #limenu-user ul.modx-subnav {
+  left: auto;
+  right: 0;
+}
+
+#modx-navbar ul.modx-subnav {
+  float: left;
+  left: 0;
+  line-height: 1.1;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 54px;
+  z-index: 10000;
+  opacity: 0;
+  visibility: hidden;
+}
+
+#modx-navbar ul.modx-subnav, #modx-navbar ul.modx-subsubnav {
+  border-radius: 0 0 2px 2px;
+  border-top: none;
+  border: 1px solid #2f4150;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.025), -1px 0 0 rgba(0, 0, 0, 0.025), 1px 0 0 rgba(0, 0, 0, 0.025);
+}
+
+#modx-navbar #modx-home-dashboard {
+  background-image: url("../images/modx-logo@2x.png");
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: 45px 45px;
+  width: 50px;
+  border-right: none;
+  margin-left: 21px;
+}
+
+#user-avatar img {
+  border-radius: 20px;
+  margin: 8px 10px 0 0;
+  height: 40px;
+  width: 40px;
+  display: block;
+  float: left;
+}
+
+#modx-navbar #modx-home-dashboard a {
+  overflow: hidden;
+  padding: 0;
+  text-indent: -9999px;
+  width: 100%;
+}
+
+#modx-navbar #modx-home-dashboard:hover a {
+  background-color: transparent;
+}
+
+#modx-navbar #modx-home-dashboard:hover {
+  /*background-color: $navbarHover;*/
+}
+
+#modx-navbar li:hover ul.modx-subnav {
+  visibility: visible;
+  opacity: 1;
+  transition: all .15s ease;
+  transition-delay: .2s;
+}
+
+#modx-navbar ul.modx-subnav li {
+  background: #2b3948;
+  border-bottom: 1px solid #192b3e;
+  clear: both;
+  margin: 0;
+  padding: 0;
+}
+
+/*
+#modx-navbar ul.modx-subnav li:first-child a {
+  @include background(linear-gradient($navbarHover, $navbarDrop) top repeat);
+}
+*/
+#modx-navbar ul.modx-subnav li a {
+  background-color: #2b3948;
+  color: #c9d4e1;
+  float: left;
+  font-weight: bold;
+  line-height: 1.5;
+  margin: 0;
+  padding: 8px 15px;
+  text-shadow: none;
+  width: 240px;
+}
+
+/*
+#modx-navbar ul.modx-subnav li a {
+  border-top:1px solid $navbarDrop;
+  border-bottom:1px solid $navbarDrop;
+}
+*/
+#modx-navbar ul.modx-subnav li a:hover {
+  background: #182028;
+  border-top-color: #3f4850;
+  border-bottom-color: #3f4850;
+  color: white;
+}
+#modx-navbar ul.modx-subnav li a:hover .description {
+  color: #a0d9f0;
+}
+#modx-navbar ul.modx-subnav li:first-child a {
+  border-top-width: 0;
+}
+#modx-navbar ul.modx-subnav li:last-child a {
+  border-bottom-width: 0;
+}
+
+#modx-navbar ul.modx-subnav li a span {
+  color: #5abce5;
+  display: block;
+  float: none;
+  font-size: 12px;
+  font-weight: normal;
+  line-height: 1.3;
+  margin-top: 6px;
+  width: 100%;
+}
+
+#modx-navbar ul.modx-subnav ul {
+  display: none;
+  left: 270px;
+  list-style: none;
+  padding-left: 0;
+  position: absolute;
+  top: 2px;
+  z-index: 24;
+}
+
+#modx-navbar ul.modx-subnav ul li:first-child,
+#modx-navbar ul.modx-subnav ul li:first-child a {
+  border-radius: 0 2px 0 0;
+}
+
+#modx-navbar ul.modx-subnav ul li:last-child,
+#modx-navbar ul.modx-subnav ul li:last-child a {
+  border-radius: 0 0 2px 0;
+}
+
+#modx-navbar ul.modx-subnav ul ul li:last-child,
+#modx-navbar ul.modx-subnav ul ul li:last-child a {
+  border-radius: 0 0 2px 2px;
+}
+
+#modx-navbar ul.modx-subnav li:hover ul ul,
+#modx-navbar ul.modx-subnav ul li:hover ul ul,
+#modx-navbar ul.modx-subnav ul ul li:hover ul ul {
+  display: none;
+}
+
+#modx-navbar ul.modx-subnav li:hover ul,
+#modx-navbar ul.modx-subnav ul li:hover ul,
+#modx-navbar ul.modx-subnav ul ul li:hover ul,
+#modx-navbar ul.modx-subnav ul ul ul li:hover ul {
+  display: block;
+}
+
+.ext-ie7 #modx-header {
+  position: relative;
+  z-index: 10;
+}
+
+/* MODX MANAGER SEARCH */
+#modx-navbar #modx-manager-search {
+  /* #shame */
+  padding: 11px 8px 5px 10px;
+  height: 38px;
+  min-width: 120px;
+}
+@media screen and (min-width: 961px) {
+  #modx-navbar #modx-manager-search {
+    min-width: 194px;
+  }
+}
+@media screen and (max-width: 960px) {
+  #modx-navbar #modx-manager-search > .x-form-field-trigger-wrap {
+    max-width: 120px !important;
+  }
+}
+
+#modx-navbar #modx-manager-search:hover {
+  /* #shame */
+  background: none;
+}
+
+#modx-manager-search .x-form-trigger {
+  color: rgba(255, 255, 255, 0.25);
+  cursor: default;
+  height: 16px;
+  right: 0;
+  border-radius: 0;
+  border: none;
+  padding: 9px 5px;
+  width: 17px;
+  background-image: none;
+}
+
+#modx-manager-search .x-form-field-wrap {
+  background: rgba(0, 0, 0, 0.25);
+  border: 0;
+  border-radius: 4px;
+  overflow: hidden;
+  color: #565353;
+  font-size: 12px;
+  outline: none !important;
+  text-shadow: none;
+  box-shadow: rgba(0, 0, 0, 0.05) 0 0 3px 0 inset;
+}
+
+#modx-manager-search .x-form-field-trigger-wrap {
+  border-width: 0;
+  height: auto;
+  background-image: none;
+}
+#modx-manager-search .x-form-field-trigger-wrap .x-form-text {
+  text-shadow: none;
+  font-weight: normal;
+  color: #C9D3E0;
+  letter-spacing: 0;
+}
+#modx-manager-search .x-form-field-trigger-wrap .x-form-empty-field {
+  color: #5a6a79;
+}
+
+#modx-manager-search .x-form-field-wrap:hover,
+#modx-manager-search .x-trigger-wrap-focus {
+  /*@include transition(background-color, 360ms, ease-in);
+  @include transition-delay(0);
+  background: $gainsboro;*/
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+#modx-uberbar {
+  margin-right: 20px;
+}
+
+.modx-manager-search-results {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  background: transparent;
+  border-radius: 0 0 2px 2px;
+  border: #e4e4e4;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.025), -1px 0 0 rgba(0, 0, 0, 0.025), 1px 0 0 rgba(0, 0, 0, 0.025);
+  height: auto !important;
+  position: relative;
+  width: 450px !important;
+}
+
+.modx-manager-search-results:before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -7px;
+  left: 12px;
+  border: 8px solid transparent;
+  border-bottom: 8px solid #2a3949;
+}
+
+.modx-manager-search-results .x-combo-list-inner {
+  background: #2a3949;
+  width: 100% !important;
+  border-top: none;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  overflow: scroll;
+  margin-top: 9px;
+}
+
+.modx-manager-search-results .section {
+  border-left: 1px solid #1d2732;
+  font-size: 13px;
+  margin-left: 116px;
+  position: relative;
+}
+
+.modx-manager-search-results .x-combo-selected h3 {
+  left: 0;
+}
+
+.modx-manager-search-results h3,
+.modx-manager-search-results p {
+  line-height: 17px;
+  margin: 0;
+  padding: 4px 8px;
+}
+
+.modx-manager-search-results p {
+  color: #C9D3E0;
+}
+
+.modx-manager-search-results h3 {
+  color: #55bbe7;
+  font-size: 13px;
+  font-weight: normal;
+  left: -116px;
+  position: absolute;
+  text-align: right;
+  top: 0;
+  width: 95px;
+}
+
+.modx-manager-search-results a {
+  cursor: pointer;
+  display: inline-block;
+  padding-left: 18px;
+  position: relative;
+  color: inherit;
+  text-decoration: none;
+}
+
+.modx-manager-search-results i {
+  color: #3697cd;
+  left: 0;
+  position: absolute;
+  top: 2px;
+}
+
+.modx-manager-search-results em {
+  font-style: normal;
+  opacity: 0.5;
+}
+
+.modx-manager-search-results .x-combo-selected h3,
+.modx-manager-search-results .x-combo-selected p,
+.modx-manager-search-results .x-combo-selected i {
+  color: #fff;
+}
+
+.modx-manager-search-results .x-combo-selected p {
+  border-left-color: transparent;
+}
+
+.modx-manager-search-results .x-combo-selected {
+  border: none;
+  color: #fff !important;
+  background-color: #3e5268;
+  margin-left: 0;
+  z-index: 10;
+}
+
+.modx-manager-search-results .icon-user {
+  background-image: none !important;
+}
+
+#modx-leftbar {
+  /* the main container + bg behind the tabs */
+  /* the toolbars just below the tabs */
+  /* root box contaiing a context or category */
+  /* just the actual nodes */
+}
+#modx-leftbar .x-tab-panel-noborder {
+  margin: 25px 10px 25px 25px;
+}
+#modx-leftbar .x-toolbar {
+  padding: 6px 5px 0px;
+}
+#modx-leftbar .x-tree-root-ct {
+  padding: 6px;
+}
+#modx-leftbar .x-tree .x-panel-body {
+  backgroud: white;
+}
+#modx-leftbar .x-tab-panel-bwrap {
+  position: relative;
+  z-index: 1;
+}
+
+#modx-resource-tree-tbar .x-toolbar-left .x-btn.tree-new-resource,
+#modx-tree-element .x-toolbar-left .x-btn.tree-new-template {
+  margin-left: 16px;
+}
+
+/* tree menu splitter */
+.x-layout-split {
+  width: 8px;
+  z-index: 0;
+}
+.x-layout-split:hover {
+  background: gainsboro;
+}
+.x-layout-split .x-layout-mini {
+  left: -11px;
+  background-color: #fff;
+  width: 10px;
+  height: 50px;
+  background-image: none;
+  background-repeat: no-repeat;
+  background-position: center left;
+  border-radius: 0 4px 4px 0;
+  opacity: 1;
+}
+.x-layout-split .x-layout-mini:after {
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-right: 5px solid #3697cd;
+  position: absolute;
+  content: ' ';
+  right: 4px;
+  top: 21px;
+}
+
+.modx-tree {
+  padding: 0 0 5px;
+}
+#modx-file-tree .modx-tree:first-child {
+  padding-top: 5px;
+}
+#modx-file-tree .modx-tree .tree-pseudoroot-node {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* icons */
+.x-tree-arrows .x-tree-elbow-plus,
+.x-tree-arrows .x-tree-elbow-minus,
+.x-tree-arrows .x-tree-elbow-end-plus,
+.x-tree-arrows .x-tree-elbow-end-minus {
+  background: none;
+}
+
+.x-tree-arrows .x-tree-elbow-plus:before,
+.x-tree-arrows .x-tree-elbow-minus:before,
+.x-tree-arrows .x-tree-elbow-end-plus:before,
+.x-tree-arrows .x-tree-elbow-end-minus:before {
+  background: transparent 0 0;
+  display: inline-block;
+  width: 10px;
+  padding-left: 6px;
+  margin: 0 0 0 -16px;
+}
+
+.x-tree-arrows .x-tree-elbow-minus:before,
+.x-tree-arrows .x-tree-elbow-end-minus:before {
+  content: "\f0d7";
+  padding-left: 4px;
+  width: 12px;
+}
+
+/* icons for the various tree elements */
+.tree-context:before {
+  content: "\f0ac";
+}
+
+.x-tree-node-expanded .tree-folder:before {
+  content: "\f07c";
+}
+
+.x-tree-node-collapsed .tree-folder:before {
+  content: "\f07b";
+}
+
+.tree-resource:before {
+  content: "\f016";
+}
+
+.tree-static-resource:before {
+  content: "\f0f6";
+}
+
+.tree-weblink:before {
+  content: "\f0c1";
+}
+
+.tree-symlink:before {
+  content: "\f0c5";
+}
+
+/* tree states */
+.x-tree-node-el {
+  color: #556c88;
+  font: normal 13px/22px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  padding-left: 6px;
+  background-repeat: no-repeat;
+  background-position: 5px;
+}
+.x-tree-node-el .x-btn {
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.x-tree-node-el .icon {
+  display: inline-block;
+  width: 1em;
+  font-size: 1.15em;
+  line-height: 0.75em;
+  vertical-align: -15%;
+}
+
+.x-tree-node-el a span {
+  line-height: 1.7;
+  /* back to 18px */
+  padding-left: 7px;
+}
+.x-tree-node-el a span span {
+  padding-left: 0;
+}
+
+.unpublished,
+.unpublished a span {
+  color: #90a6bb !important;
+  font-style: italic;
+}
+.unpublished i.icon,
+.unpublished i.icon-large,
+.unpublished a span i.icon,
+.unpublished a span i.icon-large {
+  color: #90a6bb !important;
+  font-style: normal;
+}
+
+.hidemenu,
+.hidemenu a span {
+  color: #90a6bb !important;
+}
+.hidemenu i.icon,
+.hidemenu i.icon-large,
+.hidemenu a span i.icon,
+.hidemenu a span i.icon-large {
+  color: #90a6bb !important;
+  font-style: normal;
+}
+
+.deleted {
+  color: #b42260 !important;
+}
+.deleted i.icon,
+.deleted i.icon-large {
+  color: #b42260 !important;
+  font-style: normal;
+}
+
+.deleted a span {
+  color: #b42260 !important;
+  text-decoration: line-through;
+  font-style: normal;
+}
+
+.element-node-disabled a span {
+  color: #90a6bb !important;
+}
+
+.x-tree-node .x-tree-node-disabled a span {
+  color: #eaeef2;
+}
+
+.element-node-locked a span {
+  font-style: italic;
+}
+
+.x-tree-node {
+  position: relative;
+}
+
+.modx-tree-node-tool-ct {
+  position: absolute;
+  top: 0;
+  right: 6px;
+  bottom: 0;
+  line-height: 1.8;
+}
+
+.x-tree-root-ct {
+  border-radius: 0;
+  overflow: hidden;
+  padding: 0 !important;
+}
+
+.tree-pseudoroot-node.x-tree-node-el {
+  background-color: #f0f0f0;
+  font: normal 14px/35px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  position: relative;
+  padding: 0 0 0 4px;
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+.tree-pseudoroot-node.x-tree-node-el a span {
+  color: #447996;
+}
+.tree-pseudoroot-node.x-tree-node-el > .icon {
+  font-weight: normal;
+  color: #447996;
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -15%;
+}
+.tree-pseudoroot-node.x-tree-node-el .modx-tree-node-tool-ct {
+  line-height: 35px;
+  opacity: .5;
+}
+.tree-pseudoroot-node.x-tree-node-el .modx-tree-node-tool-ct .x-btn {
+  margin-left: 2px;
+}
+.tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded, .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded span, .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded > .icon {
+  color: #1a7fb8;
+  background-color: #e8f0f8;
+}
+.tree-pseudoroot-node.x-tree-node-el.x-tree-node-over {
+  background-color: #e8f0f8;
+  color: #1a7fb8;
+}
+.tree-pseudoroot-node.x-tree-node-el + .x-tree-node-ct {
+  margin-left: -16px;
+}
+.tree-pseudoroot-node.x-tree-node-el:hover .modx-tree-node-tool-ct {
+  opacity: 1;
+}
+
+.x-tree-elbow, .x-tree-elbow-end {
+  display: inline-block;
+}
+
+/* miscellaneous tree styles */
+.x-tree-node-el .x-tree-node-icon {
+  display: inline-block;
+}
+
+.x-tree-node-loading .x-tree-node-icon {
+  background-image: url("../images/modx-theme/tree/loading.gif") !important;
+}
+
+.x-tree-node-loading a span {
+  color: #444444;
+  font-style: italic;
+}
+
+.ext-ie .x-tree-node-el input {
+  height: 15px;
+  width: 15px;
+}
+
+/* accordion header row icons */
+#modx-leftbar .icon,
+.x-tree-node .icon {
+  background: none;
+  border: 0;
+  display: inline-block;
+  margin: 0;
+  padding: 3px;
+  text-align: center;
+  opacity: 0.8;
+}
+#modx-leftbar .icon i,
+.x-tree-node .icon i {
+  font-style: normal;
+}
+#modx-leftbar .icon button,
+.x-tree-node .icon button {
+  display: none;
+}
+
+.x-tree-node-ct .x-tree-node .icon {
+  position: relative;
+  top: -1px;
+  left: 1px;
+}
+
+/* drag and drop styles */
+.x-tree-node a,
+.x-dd-drag-ghost a,
+.x-tree-node a span,
+.x-dd-drag-ghost a span {
+  color: #556c88;
+}
+
+.x-tree-node div.x-tree-drag-insert-below {
+  border-bottom-color: #686868;
+}
+
+.x-tree-node div.x-tree-drag-insert-above {
+  border-top-color: #686868;
+}
+
+.x-tree-dd-underline .x-tree-node div.x-tree-drag-insert-below a {
+  border-bottom-color: #686868;
+}
+
+.x-tree-dd-underline .x-tree-node div.x-tree-drag-insert-above a {
+  border-top-color: #686868;
+}
+
+.x-tree-node .x-tree-drag-append a span {
+  background-color: #e8f0f8;
+  border-color: #e4e4e4;
+}
+
+.x-tree-node .x-tree-node-over {
+  background-color: #e8f0f8;
+}
+
+.x-tree-node .x-tree-expanded {
+  color: #3697cd;
+  background-color: #e8f0f8;
+}
+.x-tree-node .x-tree-expanded a {
+  color: #3697cd;
+}
+.x-tree-node .x-tree-expanded a span {
+  color: #3697cd;
+}
+
+.x-tree-drop-ok-append .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-add.gif");
+}
+
+.x-tree-drop-ok-above .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-over.gif");
+}
+
+.x-tree-drop-ok-below .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-under.gif");
+}
+
+.x-tree-drop-ok-between .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-between.gif");
+}
+
+/* legacy icons */
+.icon-rss {
+  background-image: url("../images/restyle/icons/feed.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-rss.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-rss::before {
+  content: ' ';
+}
+
+.icon-cal {
+  background-image: url("../images/restyle/icons/calendar.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-cal.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-cal::before {
+  content: ' ';
+}
+
+.icon-sql {
+  background-image: url("../images/restyle/icons/database_table.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-sql.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-sql::before {
+  content: ' ';
+}
+
+.icon-db {
+  background-image: url("../images/restyle/icons/database.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-db.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-db::before {
+  content: ' ';
+}
+
+.icon-java, .icon-jar {
+  background-image: url("../images/restyle/icons/cup.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-java.x-tree-node-el, .icon-jar.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-java::before, .icon-jar::before {
+  content: ' ';
+}
+
+.icon-css {
+  background-image: url("../images/restyle/icons/css.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-css.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-css::before {
+  content: ' ';
+}
+
+.icon-zip, .icon-tar, .icon-tgz, .icon-gz {
+  background-image: url("../images/restyle/icons/compress.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-zip.x-tree-node-el, .icon-tar.x-tree-node-el, .icon-tgz.x-tree-node-el, .icon-gz.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-zip::before, .icon-tar::before, .icon-tgz::before, .icon-gz::before {
+  content: ' ';
+}
+
+.icon-jpg, .icon-jpeg, .icon-gif, .icon-png, .icon-bmp, .icon-tiff {
+  background-image: url("../images/restyle/icons/picture.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-jpg.x-tree-node-el, .icon-jpeg.x-tree-node-el, .icon-gif.x-tree-node-el, .icon-png.x-tree-node-el, .icon-bmp.x-tree-node-el, .icon-tiff.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-jpg::before, .icon-jpeg::before, .icon-gif::before, .icon-png::before, .icon-bmp::before, .icon-tiff::before {
+  content: ' ';
+}
+
+.icon-bat, .icon-scr {
+  background-image: url("../images/restyle/icons/application_osx_terminal.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-bat.x-tree-node-el, .icon-scr.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-bat::before, .icon-scr::before {
+  content: ' ';
+}
+
+.icon-log {
+  background-image: url("../images/restyle/icons/computer.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-log.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-log::before {
+  content: ' ';
+}
+
+.icon-html, .icon-htm {
+  background-image: url("../images/restyle/icons/html_valid.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-html.x-tree-node-el, .icon-htm.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-html::before, .icon-htm::before {
+  content: ' ';
+}
+
+.icon-avi, .icon-mpg, .icon-mov {
+  background-image: url("../images/restyle/icons/film.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-avi.x-tree-node-el, .icon-mpg.x-tree-node-el, .icon-mov.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-avi::before, .icon-mpg::before, .icon-mov::before {
+  content: ' ';
+}
+
+.icon-rb {
+  background-image: url("../images/restyle/icons/ruby.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-rb.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-rb::before {
+  content: ' ';
+}
+
+.icon-doc {
+  background-image: url("../images/restyle/icons/page_white_word.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-doc.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-doc::before {
+  content: ' ';
+}
+
+.icon-ppt {
+  background-image: url("../images/restyle/icons/page_white_powerpoint.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-ppt.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-ppt::before {
+  content: ' ';
+}
+
+.icon-access, .icon-htaccess {
+  background-image: url("../images/restyle/icons/lock.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-access.x-tree-node-el, .icon-htaccess.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-access::before, .icon-htaccess::before {
+  content: ' ';
+}
+
+.icon-php {
+  background-image: url("../images/restyle/icons/page_white_php.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-php.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-php::before {
+  content: ' ';
+}
+
+.icon-flv, .icon-swf {
+  background-image: url("../images/restyle/icons/page_white_flash.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-flv.x-tree-node-el, .icon-swf.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-flv::before, .icon-swf::before {
+  content: ' ';
+}
+
+.icon-xls {
+  background-image: url("../images/restyle/icons/page_white_excel.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-xls.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-xls::before {
+  content: ' ';
+}
+
+.icon-cfm {
+  background-image: url("../images/restyle/icons/page_white_coldfusion.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-cfm.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-cfm::before {
+  content: ' ';
+}
+
+.icon-pdf {
+  background-image: url("../images/restyle/icons/page_white_acrobat.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-pdf.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-pdf::before {
+  content: ' ';
+}
+
+.icon-js {
+  background-image: url("../images/restyle/icons/javascript.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-js.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-js::before {
+  content: ' ';
+}
+
+.icon-action {
+  background-image: url("../images/restyle/icons/application_osx_terminal.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-action.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-action::before {
+  content: ' ';
+}
+
+.icon-namespace {
+  background-image: url("../images/restyle/icons/computer.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-namespace.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-namespace::before {
+  content: ' ';
+}
+
+/*.icon-propertyset {
+  background-image: url($imgPath + 'restyle/icons/property-set.png') !important;
+  @extend %hide-font-icon;
+}*/
+/*.icon-resourcegroup {
+  background: url($imgPath + 'restyle/icons/application_cascade.png') no-repeat left top !important;
+  @extend %hide-font-icon;
+}*/
+.icon-list-new {
+  background-image: url("../images/restyle/icons/layout_add.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-list-new.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-list-new::before {
+  content: ' ';
+}
+
+.icon-mark-active {
+  background-image: url("../images/restyle/icons/layout_edit.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-mark-active.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-mark-active::before {
+  content: ' ';
+}
+
+.icon-mark-complete {
+  background-image: url("../images/restyle/icons/layout_header.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-mark-complete.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-mark-complete::before {
+  content: ' ';
+}
+
+.icon-package {
+  background-image: url("../images/restyle/icons/package.png") !important;
+  padding-right: 5px !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-package.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-package::before {
+  content: ' ';
+}
+
+.icon-locked {
+  background-image: url("../images/restyle/icons/lock_edit.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-locked.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-locked::before {
+  content: ' ';
+}
+
+.icon-lock {
+  background-image: url("../images/restyle/icons/lock.png") !important;
+  background-repeat: no-repeat !important;
+  background-position: center !important;
+  min-width: 16px;
+  min-height: 16px;
+  vertical-align: middle;
+}
+.icon-lock.x-tree-node-el {
+  background-position: 5px 5px !important;
+}
+.icon-lock::before {
+  content: ' ';
+}
+
+#modx-resource-tree-panel .x-accordion-hd {
+  background-position: 0 0;
+}
+
+#modx-element-tree-panel .x-accordion-hd {
+  background-position: 0 -32px;
+}
+
+#modx-file-tree-panel .x-accordion-hd {
+  background-position: 0 -64px;
+}
+
+#modx-static-page-settings .x-accordion-hd {
+  background-position: 0 -96px;
+}
+
+/*
+.x-tree .x-panel-body {
+  background-color:#fff;
+  border:1px solid #E4E4E4;
+}*/
+.x-tree-node-el .x-tree-node-icon {
+  display: inline-block;
+}
+
+.x-tree-node-loading .x-tree-node-icon {
+  background-image: url("../images/modx-theme/tree/loading.gif") !important;
+}
+
+.x-tree-node-loading a span {
+  color: #444444;
+  font-style: italic;
+}
+
+.ext-ie .x-tree-node-el input {
+  height: 15px;
+  width: 15px;
+}
+
+.x-tree-root-ct {
+  border-radius: 0;
+  overflow: hidden;
+  padding: 0 !important;
+}
+
+.x-tree-root-node {
+  margin: 0;
+}
+
+.x-tree-arrows .x-tree-elbow-plus,
+.x-tree-arrows .x-tree-elbow-minus,
+.x-tree-arrows .x-tree-elbow-end-plus,
+.x-tree-arrows .x-tree-elbow-end-minus {
+  background: none;
+}
+
+.x-tree-arrows .x-tree-elbow-plus:before,
+.x-tree-arrows .x-tree-elbow-minus:before,
+.x-tree-arrows .x-tree-elbow-end-plus:before,
+.x-tree-arrows .x-tree-elbow-end-minus:before {
+  content: "\f0da";
+  background: transparent 0 0;
+  display: inline-block;
+  width: 10px;
+  padding-left: 6px;
+  margin: 0;
+}
+
+.x-tree-arrows .x-tree-elbow-minus:before,
+.x-tree-arrows .x-tree-elbow-end-minus:before {
+  content: "\f0d7";
+  padding-left: 4px;
+  width: 12px;
+}
+
+/* icons for the various tree elements */
+.tree-context:before {
+  content: "\f0ac";
+}
+
+.x-tree-node-expanded .tree-folder:before {
+  content: "\f07c";
+}
+
+.tree-folder:before {
+  content: "\f07b";
+}
+
+.tree-resource:before {
+  content: "\f15b";
+}
+
+.tree-static-resource:before {
+  content: "\f0f6";
+}
+
+.tree-weblink:before {
+  content: "\f0c1";
+}
+
+.tree-symlink:before {
+  content: "\f0c5";
+}
+
+.x-tree-node {
+  color: #556c88;
+}
+
+.x-tree-node a, .x-dd-drag-ghost a {
+  color: #556c88;
+}
+
+.x-tree-node a span, .x-dd-drag-ghost a span {
+  color: #556c88;
+}
+
+.x-tree-node .x-tree-node-disabled a span {
+  color: #eaeef2;
+}
+
+.x-tree-node div.x-tree-drag-insert-below {
+  border-bottom-color: #686868;
+}
+
+.x-tree-node div.x-tree-drag-insert-above {
+  border-top-color: #686868;
+}
+
+.x-tree-dd-underline .x-tree-node div.x-tree-drag-insert-below a {
+  border-bottom-color: #686868;
+}
+
+.x-tree-dd-underline .x-tree-node div.x-tree-drag-insert-above a {
+  border-top-color: #686868;
+}
+
+.x-tree-node .x-tree-drag-append a span {
+  background-color: #ddd;
+  border-color: #e4e4e4;
+}
+
+.x-tree-node .x-tree-node-over {
+  background-color: #e8f0f8;
+}
+
+.x-tree-node .x-tree-selected {
+  background-color: #e8f0f8;
+}
+
+.x-tree-drop-ok-append .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-add.gif");
+}
+
+.x-tree-drop-ok-above .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-over.gif");
+}
+
+.x-tree-drop-ok-below .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-under.gif");
+}
+
+.x-tree-drop-ok-between .x-dd-drop-icon {
+  background-image: url("../images/modx-theme/tree/drop-between.gif");
+}
+
+.nobg .x-panel-body {
+  background: transparent;
+  padding-right: 1.5em;
+}
+
+/* Thanks to Christian Seel for these! http://chsmedien.com/blog/2013/02/customize-your-modx-dashboard */
+#managerbuttons {
+  margin-bottom: 1em;
+  overflow: hidden;
+  width: 100%;
+}
+
+#managerbuttons ul:before,
+#managerbuttons ul:after {
+  content: " ";
+  display: table;
+}
+
+#managerbuttons ul:after {
+  clear: both;
+}
+
+#managerbuttons ul {
+  /* clearfix */
+  *zoom: 1;
+  margin: 0;
+  width: 100%;
+}
+
+#managerbuttons ul li {
+  display: table;
+  float: left;
+  margin: 0;
+  padding: 0 1%;
+  position: relative;
+  width: 25%;
+  box-sizing: border-box;
+}
+#managerbuttons ul li:first-child {
+  padding-left: 0%;
+}
+#managerbuttons ul li:last-child {
+  padding-right: 0%;
+}
+
+#managerbuttons ul li a {
+  background-color: white;
+  background-image: -webkit-linear-gradient(top, white, whitesmoke);
+  background-image: linear-gradient(to bottom,white, whitesmoke);
+  border-radius: 3px;
+  border: 1px solid #e4e4e4;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.025);
+  color: #53595f;
+  display: table-cell;
+  /* MODX 2.x.x Manager Button Styles */
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+  padding: 12px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+#managerbuttons ul li a span {
+  display: block;
+  line-height: 1.4;
+}
+
+#managerbuttons ul li a span.headline {
+  font-size: 12px;
+}
+
+#managerbuttons ul li a span.subline {
+  font-weight: normal;
+}
+
+#managerbuttons ul li a span.icon {
+  display: block;
+  margin: 0 auto;
+  padding: 0 0 10px;
+  wdith: auto;
+}
+
+#managerbuttons ul li a:hover span.icon {
+  color: #3697cd;
+}
+
+#helpBanner,
+#contactus {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  background: #fff;
+  border: 1px solid #e4e4e4;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.025);
+  margin: 0.75em 0 1.75em;
+  padding: 18px;
+  width: 100%;
+}
+#helpBanner h3,
+#contactus h3 {
+  margin: 0 0 1em;
+}
+
+#helpBanner {
+  margin-top: 1.5em;
+  min-height: 112px;
+  background-repeat: no-repeat;
+  background-position: right top;
+  background-image: url(../images/modx-help-logo.png);
+  background-image: -webkit-image-set(url(../images/modx-help-logo.png) 1x, url(../images/modx-help-logo@2x.png) 2x);
+}
+#helpBanner #helpLogo {
+  float: right;
+  height: 76px;
+  margin-right: 1em;
+  width: 200px;
+}
+
+#contactus {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  float: left;
+  width: 60%;
+}
+#contactus form {
+  display: inline;
+}
+#contactus input[type=email] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  font-size: 1.1em;
+  margin-right: 4px;
+  padding: 0.4em;
+  width: 70%;
+}
+#contactus input[type=submit] {
+  /*background: none;*/
+  border: 0;
+  cursor: pointer;
+  font-size: 1.1em;
+  padding: 6px 10px;
+}
+#contactus p {
+  color: #113445;
+  margin: 1em 0;
+}
+#contactus form + p {
+  margin: 2em 0 0;
+}
+
+#contactus a {
+  color: #020608;
+  text-decoration: none;
+}
+#contactus a:hover {
+  text-decoration: underline;
+}
+#contactus a:hover i {
+  text-decoration: none;
+}
+#contactus a i {
+  margin: 0 8px -6px 0;
+}
+
+#aboutMODX {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  background: #f8f8f8;
+  float: left;
+  margin: 1em 0 0 2%;
+  min-height: 300px;
+  padding: 1em;
+  width: 38%;
+}
+#aboutMODX p {
+  line-height: 1.6;
+  margin: 0 0 1em;
+}
+#aboutMODX a {
+  color: #3697cd;
+  margin: -2px -4px;
+  padding: 2px 4px;
+}
+#aboutMODX a:hover {
+  background-color: #3697cd;
+  color: #fff;
+  text-decoration: none;
+}
+
+body {
+  color: #020608;
+  font: normal 13px/1.4 "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+body a {
+  color: #3697cd;
+}
+body a:hover {
+  color: #297aa7;
+}
+
+/* TODO: conver font heirarchy into a vertical rhythm formula */
+h2, h3 {
+  color: #555555;
+  font: normal 25px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  margin: 0 0 8px 5px;
+}
+
+h3 {
+  font: bold 15px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+strong {
+  font-weight: bold;
+}
+
+em {
+  font-style: italic;
+}
+
+hr {
+  background-color: #a1b7c4;
+  border: 0;
+  color: #a1b7c4;
+  height: 1px;
+  margin: 20px;
+}
+
+.aleft {
+  text-align: left;
+}
+
+.aright {
+  text-align: right;
+}
+
+.right {
+  float: right;
+}
+
+.left {
+  float: left;
+}
+
+.clear {
+  clear: left;
+}
+
+.bold {
+  font-weight: bold;
+}
+
+.not-installed {
+  color: red;
+}
+
+.red {
+  color: red !important;
+}
+
+.green {
+  color: #81b548 !important;
+}
+
+.primary {
+  color: #58a598 !important;
+}
+
+.error {
+  color: red !important;
+}
+
+.centered {
+  text-align: center;
+}
+
+.wait {
+  background: transparent url("../images/style/wait.gif") no-repeat scroll center 55px;
+  color: #53595f;
+  font-size: 15px;
+  font-weight: bold;
+  padding: 20px 10px 60px;
+}
+
+.padding {
+  background-color: #fff;
+  padding: 11px;
+}
+
+.dashed {
+  border-bottom: 1px #90b1b9 dashed;
+}
+
+.x-form-text, textarea.x-form-field {
+  border-color: #e4e4e4;
+}
+
+/* panel setups */
+#modx-leftbar,
+#modx-content,
+#modx-footer {
+  position: absolute;
+}
+
+.modx-form p {
+  padding-bottom: 10px;
+}
+
+.x-layout-mini {
+  left: 2px;
+}
+
+#modx-resource-tabs {
+  margin: 20px 0 0;
+}
+#modx-resource-tabs .x-tab-panel-header {
+  width: auto !important;
+  /* #shame */
+}
+#modx-resource-tabs .x-tab-panel-header.vertical-tabs-header {
+  width: 150px !important;
+  /* #shame */
+}
+#modx-resource-tabs .x-tab-panel-header .x-tab-strip li {
+  float: left;
+  margin-left: 0;
+}
+#modx-resource-tabs #modx-tv-tabs {
+  border-left: 0;
+  border-right: 0;
+}
+
+#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip, #modx-resource-tabs #modx-tv-tabs .x-tab-strip {
+  margin-top: 12px;
+}
+#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip li, #modx-resource-tabs #modx-tv-tabs .x-tab-strip li {
+  width: 100% !important;
+  /* #shame */
+  margin-left: 0;
+  border-bottom: 1px solid #e4e4e4;
+}
+#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip li:nth-last-child(3), #modx-resource-tabs #modx-tv-tabs .x-tab-strip li:nth-last-child(3) {
+  border-color: transparent;
+}
+#modx-resource-tvs-div #modx-tv-tabs .x-tab-strip li.x-tab-strip-active, #modx-resource-tabs #modx-tv-tabs .x-tab-strip li.x-tab-strip-active {
+  border-bottom: 1px solid #e4e4e4;
+}
+
+#modx-resource-content {
+  background-color: transparent;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+}
+#modx-resource-content .x-panel-header {
+  margin: 0;
+  padding: 15px;
+}
+#modx-resource-content .x-panel-bwrap {
+  border: none;
+}
+
+#modx-content-above .x-panel-bwrap, #modx-content-below .x-panel-bwrap {
+  border: none;
+}
+
+.x-tab-panel-header {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.x-tab-panel-header .x-tab-strip li {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.x-window-footer .x-toolbar-right-row td:last-of-type .x-btn {
+  background-color: #79b7ad;
+  background-image: -webkit-linear-gradient(#79b7ad, #58a598);
+  background-image: linear-gradient(#79b7ad, #58a598);
+  border-color: #4d9186;
+}
+.x-window-footer .x-toolbar-right-row td:last-of-type .x-btn button {
+  color: white;
+}
+.x-window-footer .x-toolbar-right-row td:last-of-type .x-btn-over {
+  border-color: #468479;
+  background-color: #8dc2b9;
+  background-image: -webkit-linear-gradient(#8dc2b9, #58a598);
+  background-image: linear-gradient(#8dc2b9, #58a598);
+}
+
+#modx-container {
+  height: 100%;
+  width: 100%;
+  background: #f2f2f2;
+}
+
+.x-panel-header {
+  background: none;
+  border-bottom: 1px solid #ddd;
+  border: none;
+  font-size: 16px;
+  margin: 0 0 0 15px;
+  padding: 0 0 8px;
+}
+
+/* grids */
+.x-small-editor .x-form-field {
+  font-size: 12px !important;
+}
+
+.grid-row-inactive {
+  color: #999 !important;
+}
+
+a.x-grid-link {
+  color: #020608;
+  text-decoration: none;
+}
+
+a.x-grid-link:hover, a.x-grid-link:focus {
+  text-decoration: underline;
+}
+
+/* collapse for resource panel */
+#modx-resource-tabs .x-tool-toggle {
+  margin-top: 0;
+  position: absolute;
+  right: 20px;
+  top: 65px;
+  z-index: 10;
+}
+
+/* panel stylings */
+.modx-page-header, .modx-page-header div {
+  background-color: transparent !important;
+}
+
+#modx-content form.x-panel-body {
+  background-color: transparent !important;
+}
+
+/* TODO: remove it */
+#modx-mainpanel {
+  height: 100%;
+  position: relative;
+}
+
+/* news articles */
+.news_article {
+  border-bottom: 1px solid #ddd;
+  padding: 10px 0 33px;
+}
+
+.news_article h2 {
+  font-size: 17px;
+}
+
+.news_article .content {
+  color: #444;
+}
+
+.news_article a {
+  color: #535d6c;
+  text-decoration: none;
+}
+
+.news_article a:hover {
+  color: #90b1b9;
+}
+
+.news_article .date_stamp {
+  color: #535d6c;
+  float: right;
+  font-size: 11px;
+  font-style: italic;
+}
+
+/* ext extensions */
+.x-static-text-field {
+  background: transparent;
+  border: none;
+  color: inherit;
+  opacity: 1;
+  /*filter: alpha(opacity=100);*/
+}
+
+/* console */
+.modx-console .debug {
+  color: gray;
+}
+
+.modx-console .success {
+  color: #81b548;
+}
+
+.modx-console .warn {
+  color: blue;
+}
+
+.modx-console .error {
+  color: red;
+}
+
+.modx-console-text {
+  background-color: white;
+  font: 13px "Courier New", Courier, monospace !important;
+  padding: 8px;
+  border: none;
+}
+
+.x-form-text.modx-console-text {
+  height: auto;
+}
+
+/* portlets */
+.x-portal .x-panel-dd-spacer {
+  margin-bottom: 10px;
+}
+
+.x-portlet {
+  margin-bottom: 10px;
+}
+
+.x-portlet .x-panel-ml {
+  padding-left: 2px;
+}
+
+.x-portlet .x-panel-mr {
+  padding-right: 2px;
+}
+
+.x-portlet .x-panel-bl {
+  padding-left: 2px;
+}
+
+.x-portlet .x-panel-br {
+  padding-right: 2px;
+}
+
+.x-portlet .x-panel-body {
+  background: white;
+}
+
+.x-portlet .x-panel-mc {
+  padding-top: 2px;
+}
+
+.x-portlet .x-panel-bc .x-panel-footer {
+  padding-bottom: 2px;
+}
+
+.x-portlet .x-panel-nofooter .x-panel-bc {
+  height: 2px;
+}
+
+.x-portal-space h2 {
+  border-bottom: 1px solid #d4d4d4;
+  margin: 0 0 8px;
+  padding: 0 0 2px;
+}
+
+/* column tree */
+.x-column-tree .x-panel-header {
+  border-bottom-width: 0px;
+  padding: 3px 0px 0px 0px;
+}
+
+.x-column-tree .x-panel-header .x-panel-header-text {
+  margin-left: 3px;
+}
+
+.x-column-tree .x-tree-node {
+  zoom: 1;
+}
+
+.x-column-tree .x-tree-node-el {
+  zoom: 1;
+}
+
+.x-column-tree .x-tree-selected {
+  background: #d9e8fb;
+}
+
+.x-column-tree .x-tree-node a {
+  line-height: 18px;
+  vertical-align: middle;
+}
+
+.x-column-tree .x-tree-node .x-tree-selected a span {
+  background: transparent;
+  color: #000;
+}
+
+.x-tree-col {
+  float: left;
+  overflow: hidden;
+  padding: 0 1px;
+  zoom: 1;
+}
+
+.x-tree-col-text, .x-tree-hd-text {
+  color: #000;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  overflow: hidden;
+  padding: 3px 3px 3px 5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.x-tree-headers {
+  cursor: default;
+  margin-top: 3px;
+  zoom: 1;
+}
+
+.x-tree-hd {
+  border-left: 1px solid #eee;
+  border-right: 1px solid #d0d0d0;
+  float: left;
+  overflow: hidden;
+}
+
+/* rowactions */
+.ux-row-action-cell .x-grid3-cell-inner {
+  padding: 1px 0 0 0;
+}
+
+.ext-ie .ux-row-action-item {
+  width: 16px;
+}
+
+.ext-ie .ux-row-action-text {
+  width: auto;
+}
+
+.ux-row-action-item span {
+  background: transparent url("../images/style/go-next.png") no-repeat scroll 1px 4px;
+  display: inline !important;
+  line-height: 24px;
+  margin: 0 5px;
+  padding: 5px 5px 5px 22px;
+  vertical-align: middle;
+}
+
+.icon-uninstall span {
+  background: url("../images/style/delete.png") no-repeat scroll 1px 4px transparent;
+}
+
+.package-details span {
+  background: url("../images/style/info.png") no-repeat scroll 1px 4px transparent;
+}
+
+.package-download span {
+  background: url("../images/style/download.png") no-repeat scroll 1px 4px transparent;
+}
+
+.package-installed span {
+  background: url("../images/style/accept.png") no-repeat scroll 1px 4px transparent;
+}
+
+.ext-ie .ux-row-action-item span {
+  width: auto;
+}
+
+.x-grid-group-hd div {
+  height: 16px;
+  position: relative;
+}
+
+.ux-grow-action-item {
+  background-position: 0 50% !important;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  float: left;
+  margin: 0;
+  min-width: 16px;
+  padding: 0 !important;
+}
+
+.ext-ie .ux-grow-action-item {
+  width: 16px;
+}
+
+.ux-action-right {
+  float: right;
+  margin: 0 3px 0 2px;
+  padding: 0 !important;
+}
+
+.ux-grow-action-text {
+  background: transparent none !important;
+  float: left;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.ux-row-action-item:hover {
+  background: #dfdfdf;
+  background: -moz-linear-gradient(center bottom, #dfdfdf 0%, white 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  background: -o-linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #dfdfdf));
+  background: -webkit-linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  background: linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  border: 1px solid #9caf78;
+  color: #636f4c !important;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#ffffff,endColorstr=#dfdfdf,GradientType=0);
+}
+
+.ux-row-action-item:active {
+  background-color: #ffffff;
+  background-image: none;
+  border-color: #CFCFCF #C0C0C0 #AAAAAA;
+  box-shadow: 0 0 3px #aaaaaa inset;
+  margin: 2px 1px 0;
+}
+
+.ux-row-action-item:active span {
+  text-shadow: none;
+}
+
+.ux-row-action-item {
+  background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -o-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
+  background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: url("/manager/templates/default/images/modx-theme/form/button-bg.png") repeat-x scroll 0 bottom gainsboro;
+  border-collapse: separate;
+  border-color: #CACACA #C0C0C0 #AAA;
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
+  color: #444;
+  cursor: pointer;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#dcdcdc,GradientType=0);
+  float: left;
+  font-weight: bold;
+  margin: 2px 1px 0;
+  overflow: hidden;
+  padding: 3px;
+  position: relative;
+  text-shadow: 0 1px 0 #FAFAFA;
+}
+
+/* checkbox tree */
+.x-tree-checkbox {
+  background: url(../../../assets/ext3/resources/images/default/form/checkbox.gif) no-repeat 0 0;
+  height: 13px;
+  margin: 0 1px;
+  vertical-align: middle;
+  width: 13px;
+}
+
+.x-tree-checkbox-over .x-tree-checkbox {
+  background-position: -13px 0;
+}
+
+.x-tree-checkbox-down .x-tree-checkbox {
+  background-position: -26px 0;
+}
+
+.x-tree-node-disabled .x-tree-checkbox {
+  background-position: -39px 0;
+}
+
+.x-tree-node-checked {
+  background-position: 0 -13px;
+}
+
+.x-tree-checkbox-over .x-tree-node-checked {
+  background-position: -13px -13px;
+}
+
+.x-tree-checkbox-down .x-tree-node-checked {
+  background-position: -26px -13px;
+}
+
+.x-tree-node-disabled .x-tree-node-checked {
+  background-position: -39px -13px;
+}
+
+.x-tree-node-grayed {
+  background-position: 0 -26px;
+}
+
+.x-tree-checkbox-over .x-tree-node-grayed {
+  background-position: -13px -26px;
+}
+
+.x-tree-checkbox-down .x-tree-node-grayed {
+  background-position: -26px -26px;
+}
+
+.x-tree-node-disabled .x-tree-node-grayed {
+  background-position: -39px -26px;
+}
+
+.x-tree-branch-unchecked .x-tree-checkbox, .x-tree-branch-unchecked .x-tree-node-checked, .x-tree-branch-unchecked .x-tree-node-grayed {
+  background-position: 0 0;
+}
+
+.x-tree-branch-unchecked .x-tree-checkbox-over .x-tree-checkbox, .x-tree-branch-unchecked .x-tree-checkbox-over .x-tree-node-checked, .x-tree-branch-unchecked .x-tree-checkbox-over .x-tree-node-grayed {
+  background-position: -13px 0;
+}
+
+.x-tree-branch-unchecked .x-tree-checkbox-down .x-tree-checkbox, .x-tree-branch-unchecked .x-tree-checkbox-down .x-tree-node-checked, .x-tree-branch-unchecked .x-tree-checkbox-down .x-tree-node-grayed {
+  background-position: -26px 0;
+}
+
+.x-tree-branch-unchecked .x-tree-node-disabled .x-tree-checkbox, .x-tree-branch-unchecked .x-tree-node-disabled .x-tree-node-checked, .x-tree-branch-unchecked .x-tree-node-disabled .x-tree-node-grayed {
+  background-position: -39px 0;
+}
+
+.x-tree-branch-checked .x-tree-checkbox, .x-tree-branch-checked .x-tree-node-checked, .x-tree-branch-checked .x-tree-node-grayed {
+  background-position: 0 -13px;
+}
+
+.x-tree-branch-checked .x-tree-checkbox-over .x-tree-checkbox, .x-tree-branch-checked .x-tree-checkbox-over .x-tree-node-checked, .x-tree-branch-checked .x-tree-checkbox-over .x-tree-node-grayed {
+  background-position: -13px -13px;
+}
+
+.x-tree-branch-checked .x-tree-checkbox-down .x-tree-checkbox, .x-tree-branch-checked .x-tree-checkbox-down .x-tree-node-checked, .x-tree-branch-checked .x-tree-checkbox-down .x-tree-node-grayed {
+  background-position: -26px -13px;
+}
+
+.x-tree-branch-checked .x-tree-node-disabled .x-tree-checkbox, .x-tree-branch-checked .x-tree-node-disabled .x-tree-node-checked, .x-tree-branch-checked .x-tree-node-disabled .x-tree-node-grayed {
+  background-position: -39px -13px;
+}
+
+/* switchbutton */
+.x-rbtn button {
+  -moz-outline: 0 none;
+  background-color: transparent;
+  background-position: center;
+  background-repeat: no-repeat;
+  border: 0 none;
+  cursor: pointer;
+  font-size: 1px;
+  height: 16px;
+  line-height: 1px;
+  margin: 0;
+  outline: 0 none;
+  padding: 0;
+  width: 24px;
+}
+
+.x-rbtn {
+  table-layout: fixed;
+}
+
+.x-rbtn td {
+  background-image: url("../images/restyle/icons/rbtn.gif");
+  background-repeat: no-repeat;
+  border: 0 none;
+  height: 21px;
+  padding: 0;
+  vertical-align: middle;
+  width: 24px;
+}
+
+.x-rbtn td.x-rbtn-first {
+  background-position: 0 0;
+}
+
+.x-rbtn td.x-rbtn-item {
+  background-position: 0 -42px;
+}
+
+.x-rbtn td.x-rbtn-last {
+  background-position: right -21px;
+}
+
+.x-rbtn td.x-rbtn-first-active {
+  background-position: 0 -63px;
+}
+
+.x-rbtn td.x-rbtn-item-active {
+  background-position: 0 -105px;
+}
+
+.x-rbtn td.x-rbtn-last-active {
+  background-position: right -84px;
+}
+
+/* filetree */
+/*.icon-ob{background-image:url(../../../assets/modext/util/filetree/img/icons/ob_16.png)!important}.icon-graph{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/chart_curve.png)!important}.icon-chart{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/chart_bar.png)!important}.icon-prefs{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/application_form.png)!important}.icon-ok{background-image:url(../../../assets/modext/util/filetree/img/icons/ok16.png)!important}.icon-view-tile{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/application_view_tile.png)!important}.icon-check,.icon-check-off{background-image:url(../ext/resources/images/default/menu/unchecked.gif)!important}.icon-check-on{background-image:url(../ext/resources/images/default/menu/checked.gif)!important}.icon-stat-data{background-image:url(../../../assets/modext/util/filetree/img/icons/kate_16.png)!important}.icon-rename{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/textfield_rename.png)!important}.icon-add-col{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/page_white_add.png)!important}.icon-del-col{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/page_white_delete.png)!important}.icon-save-table{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/table_save.png)!important}.icon-add-tab{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/tab_add.png)!important}.icon-del-tab{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/tab_delete.png)!important}.icon-go-tab{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/tab_go.png)!important}.icon-add-table{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/table_add.png)!important}.icon-del-table{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/table_delete.png)!important}.icon-admin{background-image:url(../../../assets/modext/util/filetree/img/icons/adv_settings_16.png)!important}.icon-grid{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/grid.png)!important}.icon-key{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/key.png)!important}.icon-key2{background-image:url(../../../assets/modext/util/filetree/img/icons/key_16.png)!important}.icon-expand-all{background-image:url(../../../assets/modext/util/filetree/img/icons/expand-all.gif)!important}.icon-collapse-all{background-image:url(../../../assets/modext/util/filetree/img/icons/collapse-all.gif)!important}.icon-tree-orgboard{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/chart_organisation.png)!important}.icon-tree-area{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/post_title.png)!important}.icon-tree-post{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/page_white.png)!important}.icon-plus{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/add.png)!important}.icon-minus{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/delete.png)!important}.icon-house{background-image:url(../../../assets/modext/util/filetree/img/icons/house_16.png)!important}.icon-user{background-image:url(../../../assets/modext/util/filetree/img/icons/user2_16.png)!important}.icon-trash-empty{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/bin_empty.png)!important}.icon-trash-closed{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/bin_closed.png)!important}.icon-disk{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/disk.png)!important}.icon-disk-bullet{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/bullet_disk.png)!important}.icon-undo{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/arrow_undo.png)!important}.icon-loading{background-image:url(../ext/resources/images/default/grid/grid-loading.gif)!important}.icon-db-refresh{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/database_refresh.png)!important}.icon-magnifier{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/magnifier.png)!important}.icon-wrench{background-image:url(../../../assets/modext/util/filetree/img/icons/wrench_16.png)!important}.icon-wrench-orange{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/wrench_orange.png)!important}.icon-star{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/star.png)!important}.icon-lock-go{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/lock_go.png)!important}.icon-group-add{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/group_add.png)!important}.icon-group-del{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/group_delete.png)!important}.icon-stat-portal{background-image:url(../../../assets/modext/util/filetree/img/icons/stat_portal_16.png)!important}.icon-stat-list{background-image:url(../../../assets/modext/util/filetree/img/icons/stat_list_16.png)!important}.icon-cancel{background-image:url(../../../assets/modext/util/filetree/img/icons/cancel16.png)!important}.icon-cross{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/cross.png)!important}.icon-defaults{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/arrow_rotate_clockwise.png)!important}.icon-load{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/database_go.png)!important}.icon-working{background-image:url(../ext/resources/images/default/grid/wait.gif)!important}.icon-upload{background-image:url(../../../assets/modext/util/filetree/img/icons/up.png)!important}.icon-folder-add{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/folder_add.png)!important}.icon-open{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/application_go.png)!important}.icon-open-self{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/application.png)!important}.icon-open-popup{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/application_double.png)!important}.icon-open-blank{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/application_cascade.png)!important}.icon-open-download{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/application_put.png)!important}.icon-refresh{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/arrow_refresh.png)!important}.icon-pencil{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/pencil.png)!important}.icon-stop{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/control_stop.png)!important}.icon-email{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/email.png)!important}.icon-email-compose{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/email_edit.png)!important}.icon-coins{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/coins.png)!important}.icon-clock{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/clock.png)!important}.icon-zoom{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/zoom.png)!important}.icon-print{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/printer.png)!important}.icon-folder-component{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/folder_brick.png)!important}.icon-extension{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/brick.png)!important}.icon-function{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/flag_yellow.png)!important}.icon-bulb{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/lightbulb.png)!important}.icon-bulb-off{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/lightbulb_off.png)!important}.icon-copy{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/page_white_copy.png)!important}.icon-db-gear,.icon-reconfigure{background-image:url(../../../assets/modext/util/filetree/img/silk/icons/database_gear.png)!important}
+*/
+.ux-up-item {
+  background-color: #f0f0f0;
+  background-image: url(../../../assets/modext/util/filetree/img/white_bg.png);
+  background-repeat: no-repeat;
+  cursor: default;
+  height: 17px;
+  line-height: 17px;
+  margin-bottom: 1px;
+  position: relative;
+}
+
+.ux-up-icon-file {
+  float: left;
+  height: 16px;
+  margin-right: 4px;
+  vertical-align: -3px;
+  width: 16px;
+}
+
+.ux-up-indicator {
+  background-color: #FF0;
+  height: 17px;
+  opacity: 0.4;
+  position: absolute;
+  width: 40px;
+  /*filter: alpha(opacity=40);*/
+}
+
+.ux-up-icon-state {
+  cursor: pointer;
+  float: right;
+  margin-right: 2px;
+  width: 16px;
+  z-index: -1;
+}
+
+.ux-up-icon-queued {
+  background-image: url(../../../assets/modext/util/filetree/img/silk/icons/page_white_get.png);
+}
+
+.ux-up-icon-uploading {
+  background-image: url(../../../../ext2/resources/images/default/grid/wait.gif);
+}
+
+.ux-up-icon-done {
+  background-image: url(../../../assets/modext/util/filetree/img/silk/icons/accept.png);
+}
+
+.ux-up-icon-failed {
+  background-image: url(../../../assets/modext/util/filetree/img/silk/icons/error.png);
+}
+
+.ux-up-icon-stopped {
+  background-image: url(../../../assets/modext/util/filetree/img/silk/icons/stop.png);
+}
+
+.ux-up-text {
+  float: left;
+}
+
+.ux-ftm-nodename {
+  color: #000;
+  cursor: default !important;
+  font-weight: 700;
+}
+
+.ux-icon-combo-icon {
+  background-position: 0 50%;
+  background-repeat: no-repeat;
+  height: 14px;
+  width: 18px;
+}
+
+.ux-icon-combo-input {
+  padding-left: 25px;
+}
+
+.x-form-field-wrap .ux-icon-combo-icon {
+  left: 5px;
+  top: 3px;
+}
+
+.ux-icon-combo-item {
+  background-position: 3px 50% !important;
+  background-repeat: no-repeat !important;
+  padding-left: 24px !important;
+}
+
+/* status messages */
+.modx-status-msg {
+  background: #f4f4f4;
+  border-radius: 4px;
+  left: 70%;
+  /*filter: alpha(opacity=80);*/
+  margin: 0;
+  opacity: .8;
+  padding: 5px;
+  position: fixed;
+  top: 10px;
+  width: 25%;
+  z-index: 20000;
+}
+
+iframe[classname="x-hidden"] {
+  visibility: hidden;
+}
+
+/*.modx-property-description {
+    padding: 8px 11px 3px;
+}*/
+/* tag tv widget */
+ul.modx-tag-list {
+  list-style: none;
+  margin: 3px 0 0 0;
+  overflow: auto;
+  padding: 0;
+}
+
+ul.modx-tag-list li {
+  cursor: pointer;
+  float: left;
+  list-style: none;
+  margin: 1px 5px 0;
+  padding: 1px 6px;
+  text-decoration: underline;
+}
+
+ul.modx-tag-list li.modx-tag-checked {
+  background-color: #779937;
+  border-radius: 10px;
+  color: white;
+  text-decoration: none;
+}
+
+/* tv reload btn */
+/* TODO: is it used? */
+.modx-tv-reload-btn {
+  float: right;
+  position: absolute;
+  right: 19px;
+  z-index: 10;
+}
+
+.modx-tv-reload-btn div {
+  z-index: 10;
+}
+
+.modx-tv-th label {
+  cursor: pointer;
+}
+
+.modx-tv-th .tv-description {
+  color: #444;
+  font-size: 11px;
+  font-weight: normal;
+}
+
+/* file upload */
+.ext-ux-uploaddialog-addbtn {
+  background: url("../images/restyle/fileup/file-add.gif") no-repeat left center !important;
+}
+
+.ext-ux-uploaddialog-removebtn {
+  background: url("../images/restyle/fileup/file-remove.gif") no-repeat left center !important;
+}
+
+.ext-ux-uploaddialog-resetbtn {
+  background: url("../images/restyle/fileup/reset.gif") no-repeat left center !important;
+}
+
+.ext-ux-uploaddialog-uploadstartbtn {
+  background: url("../images/restyle/fileup/upload-start.gif") no-repeat left center !important;
+}
+
+.ext-ux-uploaddialog-uploadstopbtn {
+  background: url("../images/restyle/fileup/upload-stop.gif") no-repeat left center !important;
+}
+
+.ext-ux-uploaddialog-indicator-stoped {
+  background: url("../images/restyle/fileup/done.gif") no-repeat center center;
+  height: 16px;
+  width: 16px;
+}
+
+.ext-ux-uploaddialog-indicator-processing {
+  background: url("../images/restyle/fileup/loading.gif") no-repeat center center;
+  height: 16px;
+  width: 16px;
+}
+
+.ext-ux-uploaddialog-state {
+  background-position: center center;
+  background-repeat: no-repeat;
+  text-align: center;
+}
+
+.ext-ux-uploaddialog-state-0 {
+  background-image: url("../images/restyle/fileup/uncheck.gif");
+}
+
+.ext-ux-uploaddialog-state-1 {
+  background-image: url("../images/restyle/fileup/check.gif");
+}
+
+.ext-ux-uploaddialog-state-2 {
+  background-image: url("../images/restyle/fileup/failed.gif");
+}
+
+.ext-ux-uploaddialog-state-3 {
+  background-image: url("../images/restyle/fileup/file-uploading.gif");
+}
+
+.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-bar .x-progress-text div {
+  display: none;
+}
+
+.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-text-back {
+  left: 0px;
+  position: absolute;
+  right: 0px;
+}
+
+.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-text-back div {
+  white-space: nowrap;
+  width: auto !important;
+}
+
+/* tree grid */
+.tq-treegrid .tq-treegrid-col {
+  border: none;
+}
+
+.tq-treegrid .tq-treegrid-icons {
+  float: left;
+}
+
+.tq-treegrid .x-tree-node-el {
+  line-height: 13px;
+  padding: 1px 3px 1px 5px;
+}
+
+.tq-treegrid .tq-treegrid-static .x-tree-ec-icon {
+  display: none;
+}
+
+.tq-treegrid .tq-treegrid-static .x-tree-node-el {
+  cursor: default;
+}
+
+/* superbox */
+.x-superboxselect {
+  display: block;
+  height: auto !important;
+  margin: 0;
+  outline: none !important;
+  overflow: hidden;
+  padding: 2px;
+  position: relative;
+  width: auto !important;
+}
+
+.x-superboxselect input[disabled] {
+  background-color: transparent;
+}
+
+.x-superboxselect ul {
+  cursor: text;
+  overflow: hidden;
+}
+
+.x-superboxselect-display-btns {
+  padding-right: 33px !important;
+}
+
+.x-superboxselect-btns {
+  overflow: hidden;
+  padding: 2px;
+  position: absolute;
+  right: 1px;
+  top: 0;
+}
+
+.x-superboxselect-btns div {
+  float: left;
+  height: 16px;
+  margin-top: 4px;
+  width: 16px;
+}
+
+.x-superboxselect-btn-clear {
+  background: url("../images/restyle/icons/sb_clear.png") no-repeat scroll left 0;
+}
+
+.x-superboxselect-btn-expand {
+  background: url("../images/restyle/icons/sb_expand.png") no-repeat scroll left 0;
+}
+
+.x-superboxselect-btn-over {
+  background-position: left -16px;
+}
+
+.x-superboxselect-btn-hide {
+  display: none;
+}
+
+.x-superboxselect li {
+  float: left;
+  line-height: 18px;
+  margin: 1px 1px 2px;
+  padding: 0;
+}
+
+.x-superboxselect-stacked li {
+  float: none !important;
+}
+
+.x-superboxselect-input input {
+  border: none;
+  margin-bottom: 4px;
+  margin-top: 4px;
+  outline: none;
+}
+
+body.ext-ie .x-superboxselect-input input {
+  background: none;
+  border: none;
+  margin-top: 3px;
+}
+
+.x-superboxselect-item {
+  background-color: #DEE7F8;
+  border-radius: 6px;
+  border: 1px solid #CAD8F3;
+  padding: 1px 15px 1px 5px !important;
+  position: relative;
+}
+
+body.ext-ie7 .x-superboxselect-item {
+  line-height: 1.2em;
+  margin: 2px 1px;
+  padding: 2px 17px 4px 5px !important;
+}
+
+.x-superboxselect-item-hover {
+  background: #BBCEF1;
+  border: 1px solid #6D95E0;
+}
+
+.x-superboxselect-item-focus {
+  background: #598BEC;
+  border-color: #598BEC;
+  color: #fff;
+}
+
+.x-superboxselect-item-close {
+  background: url("../images/restyle/icons/sb_close.png") no-repeat scroll left 0;
+  border: none;
+  cursor: pointer;
+  display: block;
+  font-size: 1px;
+  height: 16px;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  top: 2px;
+  width: 13px;
+}
+
+.x-superboxselect-list {
+  font-size: 14px !important;
+}
+
+.x-superboxselect-item-close:hover, .x-superboxselect-item-close:active {
+  background-position: left -12px;
+}
+
+.x-superboxselect-item-focus .x-superboxselect-item-close {
+  background-position: left -24px;
+}
+
+.x-item-disabled .x-superboxselect-item-close {
+  background-position: left -36px;
+}
+
+.x-superboxselect-ct .x-form-field-wrap, .ext-strict .x-superboxselect-ct .x-form-field-trigger-wrap .x-form-text, .x-superboxselect-ct .x-superboxselect {
+  height: auto !important;
+}
+
+/* other */
+.modx-tree-load-msg {
+  color: #020608;
+  font-size: .9em;
+  line-height: 1;
+  padding: 3px;
+  white-space: pre-line;
+}
+
+/*.modx-policy-permissions-grid td {
+    cursor: pointer;
+}*/
+/* dashboard stuff */
+.dashboard {
+  overflow: visible;
+}
+
+.dashboard-block {
+  background-color: white;
+  border-radius: 2px;
+  float: left;
+  margin: 6px 0;
+}
+
+.dashboard-block h4 {
+  color: #535d6c;
+  font-size: 13px;
+  padding-bottom: 2px;
+}
+
+.dashboard-block em {
+  font-style: italic;
+}
+
+.dashboard-block strong {
+  font-weight: bold;
+}
+
+.dashboard-block li {
+  padding-left: 10px;
+}
+
+.dashboard-block .body {
+  color: #444;
+  font-size: 12px;
+  height: auto;
+  max-height: 300px;
+  overflow: auto;
+  padding: 10px;
+}
+
+.dashboard-block .title {
+  background: #d2dbe2;
+  border-radius: 2px 2px 0 0;
+  color: #5E5E5E;
+  font-size: 12px;
+  font-weight: bold;
+  margin: 0;
+  padding: 15px;
+  zoom: 1;
+}
+
+.dashboard-block-half {
+  width: 49%;
+  margin-left: 0;
+  float: left;
+  clear: left;
+}
+
+.dashboard-block-half:nth-of-type(2n+0) {
+  margin-left: 1%;
+  float: right;
+  clear: none;
+}
+
+.dashboard-block-full {
+  clear: both;
+  height: auto;
+  width: 100%;
+}
+
+.dashboard-block-double {
+  clear: both;
+  height: auto;
+  min-height: 400px;
+  width: 100%;
+}
+
+.dashboard-block-variable .body {
+  height: auto;
+}
+
+/* MODExt common classes */
+.container {
+  margin: 20px 15px 20px;
+}
+
+/* Wrap the main content */
+.structure-tabs {
+  /* margin-top: -1px; */
+}
+
+/* Realign modx-tabs for getPageStructure */
+/* Panel description text */
+.panel-desc {
+  background-color: #f5f5f5;
+  border: none;
+  color: #5A5A5A;
+  line-height: 1.5;
+  margin-top: 5px;
+  padding: 15px !important;
+}
+.panel-desc .x-panel-bwrap {
+  background-color: transparent !important;
+}
+
+.with-title .panel-desc {
+  margin: 0;
+}
+
+.panel-desc p {
+  padding: 0;
+}
+
+.win-desc {
+  background: #DFDFDF;
+  background: -moz-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: -o-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #f4f4f4), color-stop(100%, #dfdfdf));
+  background: -webkit-linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  background: linear-gradient(center bottom, #dfdfdf 0%, #f4f4f4 100%);
+  border-bottom: 1px solid #CCC !important;
+  border: 0 none;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#F4F4F4,endColorstr=#DFDFDF,GradientType=0);
+  margin-top: 0;
+  padding: 10px 0 0 !important;
+}
+
+.win-desc p {
+  color: #555;
+  font-size: 13px;
+  font-style: italic;
+  line-height: 1.4;
+  padding: 0 10px 10px;
+  text-shadow: 0 1px 0 #fff;
+}
+
+/* All the other wrapped element (forms need to be wrapped in a panel isolated from the other components) */
+.main-wrapper {
+  padding: 15px;
+}
+
+.with-title .main-wrapper {
+  padding: 0 15px 10px 15px;
+}
+
+.left-col {
+  padding-right: 15px;
+}
+
+.right-col {
+  padding-left: 15px;
+}
+
+/*span.required {
+    color: #777;
+}*/
+/* tv table */
+#modx-tv-tabs {
+  width: 100%;
+}
+
+.modx-tv {
+  border-bottom: 1px solid #f4f4f4;
+  margin: 0;
+  padding: 15px 0 !important;
+  width: 100%;
+}
+
+#modx-tv-tabs .tv-first {
+  padding-top: 0 !important;
+}
+
+#modx-tv-tabs .tv-last {
+  border-bottom: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.modx-tv-label {
+  float: left;
+  width: auto !important;
+}
+
+.modx-tv-label:hover .modx-tv-reset {
+  opacity: 100;
+}
+
+.modx-tv-label-title {
+  float: left;
+}
+
+.modx-tv-label-description {
+  display: block;
+  float: left;
+  font-style: italic;
+  font-weight: normal;
+  padding-left: 5px;
+}
+
+.modx-tv-reset {
+  background: url("../images/restyle/icons/arrow_rotate_anticlockwise.png") top right no-repeat;
+  cursor: pointer;
+  float: left;
+  height: 16px;
+  opacity: 0;
+  width: 16px;
+}
+
+.modx-tv-description {
+  color: #666;
+  font-size: 10px;
+  line-height: 1.2;
+  margin-top: 2px !important;
+}
+
+.modx-tv-inherited {
+  color: #666;
+  display: block;
+  float: right;
+  font-size: 10px;
+  font-style: italic;
+  line-height: 1.2;
+  padding-top: 4px;
+}
+
+#modx-resource-settings .modx-tv-label,
+#modx-page-settings .modx-tv-label {
+  width: 216px;
+}
+
+.modx-tv .x-form-check-wrap {
+  line-height: 14px !important;
+}
+
+.modx-tv .x-form-cb-label {
+  font-weight: normal;
+  top: 0;
+}
+
+.tvs-wrapper {
+  padding: 0;
+}
+
+#modx-resource-tvs-div {
+  border-top-width: 0;
+}
+
+#modx-resource-tvs-div.below-content {
+  border-top-width: 1px;
+  margin-top: 10px;
+}
+
+.modx-permissions-list {
+  color: #777;
+  font-size: 12px;
+}
+
+.modx-permissions-list-textarea {
+  background-color: transparent !important;
+  border: 0 !important;
+}
+
+/* for selectability in ext grids */
+.x-selectable, .x-selectable * {
+  -khtml-user-select: all !important;
+  user-select: text !important;
+}
+
+/* Breadcrumbs */
+.crumb_wrapper {
+  border-bottom: 1px solid #CACACA;
+  border-top: 1px solid #D0D0D0;
+  margin-top: 5px;
+}
+
+.crumbs {
+  background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -o-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
+  background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  border-bottom: 1px solid #EFEFEF;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#dcdcdc,GradientType=0);
+  height: 34px;
+}
+
+.crumbs li {
+  background: url("../images/style/crumbs-bg.png") no-repeat scroll right center transparent;
+  color: #53595f;
+  float: left;
+  font-size: 12px;
+  font-weight: normal;
+  line-height: 35px;
+  padding: 0 20px 0 15px;
+  text-shadow: 0 1px 0 #FFF;
+}
+
+.crumbs li button {
+  background-color: transparent;
+  border: 0 none;
+  color: #53595f;
+  cursor: pointer;
+  font: normal 13px/1.4 "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-weight: bold;
+  padding: 0;
+  text-decoration: none;
+}
+
+.crumbs li .root {
+  background: url("../images/style/home.png") no-repeat scroll center top transparent;
+  display: block;
+  height: 16px;
+  margin: 10px 0 9px;
+  text-indent: -999em;
+  width: 16px;
+}
+
+.crumbs li button.root {
+  background-position: center -16px;
+  text-indent: -999em;
+  width: 16px;
+}
+
+/*.breadcrumbs .highlight {
+	background-color: #FFF9DF;
+    border-color: #ECE3CB !important;
+    color: #5F5947;
+    font-weight: bold;
+}
+*/
+/* LIGHTBOX */
+.breadcrumbs .panel-desc {
+  margin-top: 1px;
+}
+
+#ux-lightbox {
+  left: 0;
+  line-height: 0;
+  position: absolute;
+  text-align: center;
+  width: 100%;
+  z-index: 15000;
+}
+
+#ux-lightbox img {
+  height: auto;
+  width: auto;
+}
+
+#ux-lightbox a img {
+  border: medium none;
+}
+
+#ux-lightbox-outerImageContainer {
+  background-color: white;
+  height: 250px;
+  margin: 0 auto;
+  position: relative;
+  width: 250px;
+}
+
+#ux-lightbox-imageContainer {
+  padding: 10px;
+}
+
+#ux-lightbox-loading {
+  background: url("../images/style/loading.gif") no-repeat scroll center 15% transparent;
+  height: 25%;
+  left: 0;
+  line-height: 0;
+  position: absolute;
+  text-align: center;
+  top: 40%;
+  width: 100%;
+}
+
+#ux-lightbox-hoverNav {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 10;
+}
+
+#ux-lightbox-hoverNav a {
+  outline: medium none;
+}
+
+#ux-lightbox-imageContainer > #ux-lightbox-hoverNav {
+  left: 0;
+}
+
+#ux-lightbox-navPrev,
+#ux-lightbox-navNext {
+  display: block;
+  height: 100%;
+  width: 49%;
+}
+
+#ux-lightbox-navPrev {
+  float: left;
+  left: 0;
+}
+
+#ux-lightbox-navPrev:hover,
+#ux-lightbox-navPrev:visited:hover {
+  background: transparent url("images/lb-prev.png") no-repeat scroll left 33%;
+}
+
+#ux-lightbox-navNext {
+  float: right;
+  right: 0;
+}
+
+#ux-lightbox-navNext:hover,
+#ux-lightbox-navNext:visited:hover {
+  background: transparent url("images/lb-next.png") no-repeat scroll right 33%;
+}
+
+#ux-lightbox-outerDataContainer {
+  margin: 0 auto;
+  width: 100%;
+}
+
+#ux-lightbox-dataContainer {
+  background-color: #ffffff;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-size: 10px;
+  overflow: auto;
+}
+
+#ux-lightbox-data {
+  color: #666;
+  padding: 0 10px;
+}
+
+#ux-lightbox-data #ux-lightbox-details {
+  float: left;
+  text-align: left;
+  width: 80%;
+}
+
+#ux-lightbox-data #ux-lightbox-caption {
+  font-weight: bold;
+}
+
+#ux-lightbox-data #ux-lightbox-imageNumber {
+  clear: left;
+  display: block;
+  padding-bottom: 1em;
+}
+
+#ux-lightbox-data #ux-lightbox-navClose {
+  background: transparent url("../images/style/close.png") no-repeat scroll 0 0;
+  float: right;
+  height: 16px;
+  outline: medium none;
+  padding-bottom: 0.7em;
+  width: 16px;
+}
+
+#ux-lightbox-overlay,
+#ux-lightbox-shim {
+  background-color: #000;
+  border: 0 none;
+  height: 500px;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 14999;
+}
+
+#ux-lightbox-shim {
+  background-color: transparent;
+  z-index: 89;
+}
+
+/* Package Manager */
+.x-panel-body-noheader .x-grid3-row {
+  position: relative;
+}
+
+.x-grid3-col-main {
+  padding: 10px 5px 35px;
+}
+
+.x-grid3-cell-inner.x-grid3-col-main h3 {
+  color: #555555;
+  font: normal 13px/1.4 "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  font-size: 20px;
+  line-height: 1;
+  margin: 0 0 2px;
+}
+
+.x-grid3-cell-inner.x-grid3-col-main .not-installed {
+  color: #999999;
+}
+
+.package-installed {
+  color: gray;
+  opacity: .5;
+}
+
+#modx-grid-package .green {
+  text-align: center;
+}
+
+#modx-grid-package .green a {
+  color: red !important;
+}
+
+#modx-grid-package .red {
+  color: #81b548 !important;
+  text-align: center;
+}
+
+.grid-with-buttons .x-grid3-row-expanded .x-grid3-row-body {
+  margin: -45px 2px 0 -20px;
+  padding: 18px 25px 40px;
+}
+
+/* Package browser */
+.home-panel ol {
+  border-top: 1px solid #CACACA;
+}
+
+.home-panel ol li {
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.home-panel ol li:first-child {
+  border-top-color: 0 none;
+}
+
+.home-panel ol li:last-child {
+  border-bottom: 0 none;
+}
+
+.home-panel ol li button {
+  background-color: transparent;
+  border: 0 none;
+  color: #53595f;
+  cursor: pointer;
+  display: block;
+  font-size: 15px;
+  font-weight: bold;
+  padding: 12px 20px 12px 6px;
+  position: relative;
+  text-decoration: none;
+}
+
+.home-panel ol li:hover button {
+  background: transparent url("../images/style/search.png") no-repeat scroll right center;
+  color: #3D4349;
+}
+
+.home-panel ol li .highlighted {
+  color: #909090;
+  float: right;
+  font-size: 10px;
+  padding: 13px 10px 0;
+}
+
+.home-panel ol li button .ct {
+  color: #AAA;
+  margin-right: 10px;
+}
+
+.home-panel .one_half {
+  overflow: hidden;
+}
+
+.home-panel .desc-wrapper {
+  margin-top: 38px;
+}
+
+.home-panel .text-wrapper {
+  font-style: normal;
+  max-height: none;
+}
+
+.home-panel .provider_name {
+  background-color: #9bb3bf;
+  line-height: 1.8;
+}
+
+.home-panel .pnl_instructions {
+  margin: 20px 0;
+}
+
+.home-panel .stats {
+  clear: both;
+  display: inline-block;
+  margin-top: 15px;
+}
+
+.home-panel .stats p {
+  color: #777777;
+  font-size: 12px;
+  font-style: italic;
+  line-height: 1.5;
+}
+
+.pbr-provider-box {
+  float: left;
+  margin-top: 10px;
+  width: 250px;
+}
+
+.pbr-provider-home {
+  padding: 10px;
+}
+
+.pbr-repository-view {
+  padding: 10px;
+}
+
+.pbr-tag-view {
+  padding: 10px;
+}
+
+.pbr-details-right {
+  float: right !important;
+  text-align: right !important;
+}
+
+.pbr-thumb-downloaded {
+  opacity: .5;
+  /*filter: alpha(opacity=50);*/
+}
+
+#package-browser-card-container {
+  margin: 0;
+}
+
+.one_half {
+  float: left;
+  margin-right: 3%;
+  position: relative;
+  width: 48%;
+}
+
+.last {
+  clear: right;
+  margin-right: 0 !important;
+}
+
+.modx-pb-view-ct {
+  background: white;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+}
+
+.modx-pb-thumb {
+  border: 1px solid #dddddd;
+  height: 80px;
+  line-height: 80px;
+  padding: 5px;
+  text-align: center;
+  width: 100px;
+}
+
+.modx-pb-thumb img {
+  vertical-align: middle;
+}
+
+.modx-pb-thumb-wrap {
+  border: 1px solid transparent;
+  float: left;
+  margin: 4px 0 4px 4px;
+  overflow: hidden;
+  padding: 4px;
+}
+
+.modx-pb-thumb-wrap span {
+  display: block;
+  overflow: hidden;
+  text-align: center;
+}
+
+.modx-pb-view-ct .x-view-over {
+  border: 1px solid #dddddd;
+  padding: 4px;
+}
+
+.modx-pb-view-ct .x-view-selected {
+  background: #DFEDFF;
+  border: 1px solid #6593cf;
+  padding: 4px;
+}
+
+.modx-pb-view-ct .x-view-selected .thumb {
+  background: transparent;
+}
+
+.modx-pb-view-ct .x-view-selected span {
+  color: #1A4D8F;
+}
+
+.modx-pb-view-ct .loading-indicator {
+  background-position: left;
+  background-repeat: no-repeat;
+  font-size: 11px;
+  margin: 10px;
+  padding-left: 20px;
+}
+
+.modx-pb-detail-thumb {
+  cursor: pointer;
+  margin-top: 5px;
+  text-align: center;
+}
+
+.modx-pb-details-info {
+  border-top: 1px solid #ccc;
+  font: normal 11px "Helvetica Neue", Helvetica, arial, tahoma, sans-serif;
+  margin-top: 5px;
+  padding: 5px;
+  text-align: left;
+}
+
+.modx-pb-details-info b {
+  color: #555;
+  display: block;
+  margin-bottom: 4px;
+}
+
+.modx-pb-details-info span {
+  display: block;
+  margin-bottom: 5px;
+  margin-left: 5px;
+}
+
+.modx-pb-fullview {
+  text-align: center;
+}
+
+.package-readme {
+  padding: 8px 11px 0px;
+}
+
+/* Template sidebar */
+#modx-package-browser-home {
+  margin-top: 5px;
+  min-height: 560px;
+}
+
+.empty-text-wrapper {
+  color: #888;
+  font-weight: bold;
+  line-height: 1.4;
+}
+
+.modx-template-detail {
+  background-color: transparent;
+}
+
+.modx-template-detail .aside-details {
+  background-color: #FDFDFD;
+  border: 1px solid #E0E0E0;
+  margin-right: 0;
+}
+
+.modx-template-detail .selected h5 {
+  color: #53595f;
+  font-size: 14px;
+  margin: 10px 0;
+}
+
+.modx-template-detail .selected img {
+  border-radius: 3px;
+  border: 1px solid #aaa;
+  height: 80px;
+  width: 90px;
+}
+
+.modx-template-detail .item {
+  margin-bottom: 25px;
+}
+
+.modx-template-detail .item p, .modx-template-detail .item li {
+  color: #888;
+  line-height: 1.4;
+}
+
+.modx-template-detail .item a {
+  color: #53595f;
+  font-style: italic;
+}
+
+.modx-template-detail h4 {
+  color: #53595f;
+  font-size: 14px;
+  margin: 10px 0;
+  text-shadow: 0 1px 0 white;
+  text-transform: uppercase;
+}
+
+.modx-template-detail .aside-details h4 {
+  font-size: 11px;
+  margin-top: 0;
+}
+
+.modx-template-detail .selected {
+  border-bottom: 1px solid #E0E0E0;
+  color: #5B7A98;
+  padding: 15px;
+  text-align: center;
+}
+
+.modx-template-detail .description {
+  background-color: #F3F3F3;
+  border-bottom: 1px solid #E0E0E0;
+  border-top: 1px solid #FFFFFF;
+  color: #666666;
+  font-size: 10px;
+  line-height: 1.2;
+  margin-left: 1px;
+  padding: 15px;
+  text-shadow: 0 1px 0 #FFFFFF;
+}
+
+.modx-template-detail .infos {
+  border-top: 1px solid #FFFFFF;
+  margin-left: 1px;
+  padding: 15px;
+}
+
+.modx-template-detail .infos ul li {
+  font-size: 10px;
+}
+
+.modx-template-detail .infos ul li .infoname {
+  color: #AAAAAA;
+  font-weight: bold;
+  width: 50%;
+}
+
+.modx-template-detail .infos ul li .infovalue {
+  max-width: 50%;
+  padding: 0 8px;
+  word-wrap: break-word;
+}
+
+.modx-template-detail .infos ul li span {
+  display: inline-block;
+  padding: 0;
+}
+
+.thumb-wrapper {
+  background-color: #F5F5F5;
+  border-radius: 2px;
+  border: 1px solid #ccc;
+  cursor: pointer;
+  float: left;
+  margin: 0 15px 15px 0;
+  overflow: hidden;
+  padding: 0 0 12px;
+  position: relative;
+  text-align: center;
+  width: 132px;
+}
+
+.thumb-wrapper .thumb {
+  background-color: #fff;
+  border-bottom: 1px solid #ccc;
+  height: 95px;
+  margin: 0 auto;
+  width: 132px;
+}
+
+.thumb-wrapper .thumb img {
+  height: 95px;
+  width: 135px;
+}
+
+.thumb-wrapper .thumb .no-preview {
+  color: #888;
+  display: inline-block;
+  font-size: 9px;
+  font-weight: bold;
+  padding: 31px 15px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.thumb-wrapper span {
+  display: block;
+  overflow: hidden;
+  text-align: center;
+  text-shadow: 0 1px 0 #fff;
+}
+
+.thumb-wrapper span.downloaded {
+  background-color: #658F1A;
+  color: #fff;
+  font-weight: bold;
+  padding: 5px 0;
+  position: absolute;
+  text-align: center;
+  text-shadow: none;
+  top: 68px;
+  width: 100%;
+}
+
+.thumb-wrapper .name {
+  color: #53595f;
+  font-size: 12px;
+  font-weight: bold;
+  margin-top: 10px;
+}
+
+.thumb-wrapper .downloads {
+  color: #999;
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.thumb-wrapper.selected {
+  background-color: #fff;
+  padding: 0 0 12px;
+}
+
+.thumb-wrapper.selected img {
+  border: 0 none;
+}
+
+.pbr-thumb {
+  background: #ddd;
+  height: 80px;
+  padding: 3px;
+  width: 100px;
+}
+
+.pbr-thumb img {
+  height: 80px;
+  width: 100px;
+}
+
+.x-grid3-hd-text-col, .x-grid3-hd-meta-col, .x-grid3-hd-info-col {
+  text-align: center;
+}
+
+.x-grid3-col-text-col {
+  font-size: 11px;
+  text-align: center;
+}
+
+.x-grid3-col-info-col, .x-grid3-col-meta-col {
+  font-size: 11px;
+  font-weight: bold;
+  text-align: center;
+}
+
+.x-grid3-col-meta-col {
+  color: #53595f;
+}
+
+.x-grid3-col-info-col {
+  color: #92AF4C;
+}
+
+.not-installed .x-grid3-col-info-col {
+  color: red;
+}
+
+.inline-button {
+  -webkit-box-align: center;
+  display: inline;
+  margin: 0 auto;
+  padding: 8px;
+  text-align: center;
+}
+
+.meta-wrapper {
+  color: #808080;
+  max-height: 400px;
+  overflow: auto;
+  padding: 15px;
+  white-space: pre;
+}
+
+.window-no-padding .x-panel-mc {
+  padding: 0 !important;
+}
+.window-no-padding .x-panel-ml {
+  padding: 0 !important;
+}
+.window-no-padding .x-panel-mr {
+  padding: 0 !important;
+}
+.window-no-padding .x-tab-panel-noborder {
+  margin: 0 !important;
+}
+
+.upload-error {
+  color: #f00;
+}
+
+.upload-success {
+  color: #090;
+}
+
+.upload-status-text {
+  white-space: normal;
+}
+
+.upload-thumb {
+  float: right;
+}
+
+/*# sourceMappingURL=index.css.map */

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -2035,6 +2035,8 @@
 /* main colors */
 /* Context menu */
 /* tree menus */
+/* $brandHover; */
+/* #1A7FB8; */
 /* Tree menus */
 /* top nav */
 /* Top navigation colors */
@@ -5961,12 +5963,12 @@ ul.x-tab-strip-bottom .x-tab-left {
   margin-left: 2px;
 }
 .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded, .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded span, .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded > .icon {
-  color: #1a7fb8;
-  background-color: #e8f0f8;
+  color: #447996;
+  background-color: #f0f0f0;
 }
 .tree-pseudoroot-node.x-tree-node-el.x-tree-node-over {
-  background-color: #e8f0f8;
-  color: #1a7fb8;
+  background-color: #f0f0f0;
+  color: #447996;
 }
 .tree-pseudoroot-node.x-tree-node-el + .x-tree-node-ct {
   margin-left: -16px;

--- a/manager/templates/default/css/login.css
+++ b/manager/templates/default/css/login.css
@@ -1,18 +1,268 @@
-/*!
-* 
-* Copyright (C) 2014 MODX LLC
-* 
-* This file is part of MODX Revolution and was compiled using Grunt.
-* 
-* MODX Revolution is free software: you can redistribute it and/or modify it under the terms of the
-* GNU General Public License as published by the Free Software Foundation, either version 2 of the
-* License, or (at your option) any later version.
-* 
-* MODX Revolution is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-* 
-* See the GNU General Public License for more details. You should have received a copy of the GNU
-* General Public License along with MODX Revolution. If not, see <http://www.gnu.org/licenses/>.
-* 
-*/
-html{color:#111;font-family:"Lucida Grande",Helvetica,Arial,sans-serif!important;font-family:Arial,Tahoma,Helvetica,sans-serif;font-size:100.01%;height:100%;line-height:1.5;width:100%}body{background:#eee url(../images/restyle/manager-loginscreen-bg.png) center -90px repeat-x;font-size:75%;height:100%;width:100%}.warning{color:#821517;font-weight:700}.success{color:#090;font-weight:700}#container{margin:70px auto 0;width:460px}#modx-login-logo{margin-bottom:3px}#modx-login-logo img{width:180px}#modx-panel-login-div{border:1px solid #e0e0e0}img.loginCaptcha{border:1px solid #039;height:60px;width:148px}.loginLicense{color:#555;font-size:90%;margin:0 auto;padding-left:20px;width:460px}#modx-login-form-panel{border:1px solid #ddd}.x-panel-tl,.x-panel-tl .x-panel-header{border:0;font-size:14px;padding:3px 5px}.x-panel-mc,.x-panel-ml,.x-panel-mr{background-color:transparent;border:0}.login-form-bwrap{-moz-border-radius:10px;-webkit-border-radius:10px;background-color:#fff;border-radius:10px;color:#eee;padding:5px}.login-form-bwrap-padding{-moz-border-radius:5px;-webkit-border-radius:5px;background:#000 url(../images/restyle/manager-loginscreen-form-bg.png) bottom left no-repeat;border-radius:5px;padding-bottom:10px}h2{color:#eee}.x-panel-ml{border-top:1px solid #e4e4e4;padding:10px 20px 22px}.x-btn button{font-size:12px;height:28px!important;padding:3px 10px 0!important}.x-btn:hover{background:#dfdfdf;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fff),color-stop(100%,#dfdfdf));background:-webkit-linear-gradient(center bottom,#dfdfdf 0,#fff 100%);background:-webkit-gradient(linear,,from(#dfdfdf),to(#fff));background:linear-gradient(center bottom,#dfdfdf 0,#fff 100%);border:1px solid #9caf78;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#ffffff, endColorstr=#dfdfdf, GradientType=0)}.x-btn:hover button{color:#636F4C;text-shadow:0 1px 0 #fff}.x-btn:active{-moz-box-shadow:0 0 3px #aaa inset;-o-box-shadow:0 0 3px #aaa inset;background-color:#fff;background-image:none;border-color:#CFCFCF silver #AAA;-webkit-box-shadow:0 0 3px #aaa inset;box-shadow:0 0 3px #aaa inset;margin:0 1px}.modx-forgot-login{float:left;padding-top:4px}a{color:#bbb;text-decoration:none}a :hover{text-decoration:underline}#modx-login-email{width:200px}#modx-panel-login-div{-moz-border-radius:3px;-webkit-border-radius:3px;background-color:#fff;border-radius:3px}label{cursor:pointer}.login-form-item{float:left;margin:0}.login-form-item-first{margin-right:8px}.login-form-element{padding:0}.login-form-element .x-form-text{padding:8px;width:181px;background:#fff}.login-cb-row{padding:9px 0 10px}.x-form-check-wrap .x-form-cb-label{color:#bbb}.login-cb-col{float:left;width:50%}.modx-login-fl-link{cursor:pointer;height:auto!important;line-height:18px;margin:2px 0 0 2px;white-space:nowrap}.login-form-btn{-moz-border-radius:3px;-moz-box-shadow:rgba(0,0,0,.2)0 0 1px;-o-box-shadow:rgba(0,0,0,.2)0 0 1px;-webkit-border-radius:3px;background:#eee;background:-webkit-gradient(linear,left top,left bottom,color-stop(0%,#fcfcfc),color-stop(100%,#dcdcdc));background:-webkit-linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);background:-webkit-gradient(linear,,from(#dcdcdc),to(#fcfcfc));background:linear-gradient(center bottom,#dcdcdc 0,#fcfcfc 100%);background:url(../images/modx-theme/form/button-bg.png) repeat-x scroll 0 bottom #dcdcdc;border-radius:3px;border:2px solid #ddd;-webkit-box-shadow:rgba(0,0,0,.2)0 0 1px;box-shadow:rgba(0,0,0,.2)0 0 1px;color:#555;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc, endColorstr=#dcdcdc, GradientType=0);font:700 13px arial,tahoma,helvetica,sans-serif;padding:8px 18px}#modx-login-btn{float:right}#modx-login-btn:hover{background:#ddd}#modx-fl-btn{margin-left:0}.x-panel-mr{padding-right:0}.x-panel-mc{padding:10px 0}#modx-login-language-select-div{bottom:0;color:#888;left:0;padding:4px;position:absolute}#modx-login-language-select{background:#eee;border:1px solid #aaa;position:relative}
+/* Brand colors */
+/* Core colors */
+/* main colors */
+/* Context menu */
+/* tree menus */
+/* Tree menus */
+/* top nav */
+/* Top navigation colors */
+/* borders */
+/* text colors and font stacks */
+html {
+  color: #111;
+  /* http://meyerweb.com/eric/thoughts/2006/02/08/unitless-line-heights/ */
+  font-family: "Lucida Grande", Helvetica, Arial, sans-serif !important;
+  /* IE ignores this and renders Arial better */
+  font-family: Arial, Tahoma, Helvetica, sans-serif;
+  font-size: 100.01%;
+  height: 100%;
+  /* avoids obscure font-size bug */
+  line-height: 1.5;
+  width: 100%;
+}
+
+body {
+  background: #eeeeee url("../images/restyle/manager-loginscreen-bg.png") center -90px repeat-x;
+  font-size: 75%;
+  /* 12px 62.5% for 10px*/
+  height: 100%;
+  width: 100%;
+}
+
+.warning {
+  color: #821517;
+  font-weight: bold;
+}
+
+.success {
+  color: #090;
+  font-weight: bold;
+}
+
+#container {
+  margin: 70px auto 0;
+  width: 460px;
+}
+
+#modx-login-logo {
+  margin-bottom: 3px;
+}
+#modx-login-logo img {
+  width: 180px;
+}
+
+#modx-panel-login-div {
+  border: 1px solid #e0e0e0;
+}
+
+img.loginCaptcha {
+  border: 1px solid #039;
+  height: 60px;
+  width: 148px;
+}
+
+.loginLicense {
+  color: #555;
+  font-size: 90%;
+  margin: 0 auto;
+  padding-left: 20px;
+  width: 460px;
+}
+
+#modx-login-form-panel {
+  border: 1px solid #ddd;
+}
+
+.x-panel-tl, .x-panel-tl .x-panel-header {
+  border: 0;
+  font-size: 14px;
+  padding: 3px 5px;
+}
+
+.x-panel-ml, .x-panel-mr, .x-panel-mc {
+  background-color: transparent;
+  border: 0;
+}
+
+.login-form-bwrap {
+  -moz-border-radius: 10px;
+  -webkit-border-radius: 10px;
+  background-color: white;
+  border-radius: 10px;
+  color: #eee;
+  padding: 5px;
+}
+
+.login-form-bwrap-padding {
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  background: black url("../images/restyle/manager-loginscreen-form-bg.png") bottom left no-repeat;
+  border-radius: 5px;
+  padding-bottom: 10px;
+}
+
+h2 {
+  color: #eee;
+}
+
+.x-panel-ml {
+  border-top: 1px solid #e4e4e4;
+  padding: 10px 20px 22px;
+}
+
+/* Fix styles because buttons are generated by extjs */
+.x-btn button {
+  font-size: 12px;
+  height: 28px !important;
+  padding: 3px 10px 0 !important;
+}
+.x-btn:hover {
+  background: #dfdfdf;
+  background: -moz-linear-gradient(center bottom, #dfdfdf 0%, white 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  background: -o-linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, white), color-stop(100%, #dfdfdf));
+  background: -webkit-linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  background: linear-gradient(center bottom, #dfdfdf 0%, white 100%);
+  border: 1px solid #9caf78;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#ffffff,endColorstr=#dfdfdf,GradientType=0);
+}
+.x-btn:hover button {
+  color: #636F4C;
+  text-shadow: 0 1px 0 #ffffff;
+}
+.x-btn:active {
+  -moz-box-shadow: 0 0 3px #aaaaaa inset;
+  -o-box-shadow: 0 0 3px #aaaaaa inset;
+  -webkit-box-shadow: 0 0 3px #aaaaaa inset;
+  background-color: #ffffff;
+  background-image: none;
+  border-color: #CFCFCF #C0C0C0 #AAAAAA;
+  box-shadow: 0 0 3px #aaaaaa inset;
+  margin: 0 1px;
+}
+
+.modx-forgot-login {
+  float: left;
+  padding-top: 4px;
+}
+
+a {
+  color: #bbb;
+  text-decoration: none;
+}
+a :hover {
+  text-decoration: underline;
+}
+
+#modx-login-email {
+  width: 200px;
+}
+
+#modx-panel-login-div {
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  background-color: white;
+  border-radius: 3px;
+}
+
+label {
+  cursor: pointer;
+}
+
+.login-form-item {
+  float: left;
+  margin: 0;
+}
+
+.login-form-item-first {
+  margin-right: 8px;
+}
+
+.login-form-element {
+  padding: 0;
+}
+.login-form-element .x-form-text {
+  padding: 8px;
+  width: 181px;
+  background: #fff;
+}
+
+.login-cb-row {
+  padding: 9px 0 10px 0;
+}
+
+.x-form-check-wrap .x-form-cb-label {
+  color: #bbb;
+}
+
+.login-cb-col {
+  float: left;
+  width: 50%;
+}
+
+.modx-login-fl-link {
+  cursor: pointer;
+  height: auto !important;
+  line-height: 18px;
+  margin: 2px 0 0 2px;
+  white-space: nowrap;
+}
+
+.login-form-btn {
+  -moz-border-radius: 3px;
+  -moz-box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
+  -o-box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
+  -webkit-border-radius: 3px;
+  -webkit-box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
+  background: #eee;
+  background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
+  background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -o-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
+  background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
+  background: url("../images/modx-theme/form/button-bg.png") repeat-x scroll 0 bottom gainsboro;
+  border-radius: 3px;
+  border: 2px solid #ddd;
+  box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
+  color: #555;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#dcdcdc,GradientType=0);
+  font: bold 13px arial, tahoma, helvetica, sans-serif;
+  padding: 8px 18px;
+}
+
+#modx-login-btn {
+  float: right;
+}
+#modx-login-btn:hover {
+  background: #ddd;
+}
+
+#modx-fl-btn {
+  margin-left: 0;
+}
+
+.x-panel-mr {
+  padding-right: 0;
+}
+
+.x-panel-mc {
+  padding: 10px 0;
+}
+
+#modx-login-language-select-div {
+  bottom: 0;
+  color: #888;
+  left: 0;
+  padding: 4px;
+  position: absolute;
+}
+
+#modx-login-language-select {
+  background: #eee;
+  border: 1px solid #aaa;
+  position: relative;
+}
+
+/*# sourceMappingURL=login.css.map */

--- a/manager/templates/default/css/login.css
+++ b/manager/templates/default/css/login.css
@@ -3,6 +3,8 @@
 /* main colors */
 /* Context menu */
 /* tree menus */
+/* $brandHover; */
+/* #1A7FB8; */
 /* Tree menus */
 /* top nav */
 /* Top navigation colors */


### PR DESCRIPTION
This PR includes the new tree design from issue #11540 (a merged version of @eladnova and my mockup) and various other smaller changes and improvements like:
- darker form labels for more contrast
- improved icon position in the tree
- other padding optimizations (mostly in the tree)
- font color changes for better contrast

BEFORE:
![voila_capture 2014-06-25_05-59-04_nachm](https://cloud.githubusercontent.com/assets/482184/3387915/951871ae-fc82-11e3-9943-0b09526611ee.png)

AFTER:
![voila_capture 2014-06-25_05-58-24_nachm](https://cloud.githubusercontent.com/assets/482184/3387920/9eed505a-fc82-11e3-86d3-f7a0d3572a92.png)
