### PR TITLE
The first few lines of ModX code updated to post 2004 standards

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,10 +20,7 @@
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *
  */
-$mtime= microtime();
-$mtime= explode(" ", $mtime);
-$mtime= $mtime[1] + $mtime[0];
-$tstart= $mtime;
+$tstart= microtime(true);
 
 /* define this as true in another entry file, then include this file to simply access the API
  * without executing the MODX request handler */


### PR DESCRIPTION
Who wrote this to begin with? I would expect a few issues with the code, but this is beyond bounds! Even pre PHP5, in PHP4 (which is nearly antique by now), one could do this:

``` php
$tstart = array_sum(explode(' ', microtime()));
```

But PHP5 shouldn't be an issue, as the ModX docs state that PHP 5.1.2 is required (oh, as long as you don't use 5.1.6...).

/rant
