### PR TITLE
[#11593] fix event output for expected string

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1608,12 +1608,12 @@ class modX extends xPDO {
                     $eventParams = array_merge($plugin->getProperties(),$params);
 
                     $msg= $plugin->process($eventParams);
-                    $results[]= $this->event->_output;
                     if ($msg && is_string($msg)) {
-                        $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . ']' . $msg);
+                        $this->event->_output = $msg;
                     } elseif ($msg === false) {
                         $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . '] Plugin failed!');
                     }
+                    $results[]= $this->event->_output;
                     $this->event->activePlugin= '';
                     $this->event->propertySet= '';
                     if (!$this->event->isPropagatable()) {


### PR DESCRIPTION
Some events expects string output to be rendered on smarty template.
