### PR TITLE
[Re-Build] Enhancement: Prevent flash of unstyled TV form fields on resource panel load

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1356,6 +1356,7 @@ body.ext-ie7 .x-superboxselect-item {
 
 #modx-resource-tvs-div {
   border-top-width: 0;
+  visibility: hidden;
 }
 
 #modx-resource-tvs-div.below-content {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -343,7 +343,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,template: config.record.template
             ,anchor: '100%'
             ,border: true
-            ,bodyStyle: 'display: none'
+            ,style: 'visibility: visible'
         };
     }
 


### PR DESCRIPTION
This would resolve https://github.com/modxcms/revolution/issues/4763

When the resource edit screen is loaded, there is a short flash of the the unstyled TV form fields like that
![modx unstyledtvs old](https://cloud.githubusercontent.com/assets/445501/3428197/8ffedbe0-003d-11e4-8b17-e6776153051d.gif)

with these small changes, that flash is prevented. I replaced bodyStyle: 'display: none;' with style: 'visibility: visible;' and set the #modx-resource-tvs-div to 'visibility: hidden' initially in the css, I'm not entirely sure what the bodyStyle: 'display: none;' is supposed to do, it doesn't have an effect when I remove it...can also add it back when it has a purpose =)...

with the changes it load like this:
![modx unstyledtvs new](https://cloud.githubusercontent.com/assets/445501/3428223/e367d1c4-003d-11e4-8338-fed2789db93a.gif)
