### PR TITLE
Ability to use conditional output modifiers with custom output modifier

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -652,7 +652,8 @@ class modOutputFilter {
                                 'options' => $m_val,
                                 'token' => $element->_token, /* type of parent element */
                                 'name' => $element->get('name'), /* name of the parent element */
-                                'tag' => $element->getTag() /* complete parent tag */
+                                'tag' => $element->getTag(), /* complete parent tag */
+                                'condition' => $condition
                             );
                             $this->log('This modifier is custom running as snippet.');
                             $tmp = $this->modx->runSnippet($m_cmd, $params);

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -657,6 +657,7 @@ class modOutputFilter {
                             $this->log('This modifier is custom running as snippet.');
                             $tmp = $this->modx->runSnippet($m_cmd, $params);
                             if ($tmp!='') $output = $tmp;
+                            if ($tmp == '1' || $tmp == '0') $condition[] = intval($tmp);
                             break;
                     }
                 } catch (Exception $e) {


### PR DESCRIPTION
With this enhancement will be possible to create custom output modifier and chain it with existing conditional modifiers. For example:

```
[[++setting:customModifier=`5`:then=`something`:else=`something other`]]
```
