### PR TITLE
[2.3] [Re-build] Manager-Theme: Buttons, Toolbars and TV-Panel reworked + various UI work

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -1,22 +1,22 @@
 @import "font-awesome/variables";
 @import "font-awesome/mixins";
 
-.primary-button {
+/*.primary-button {
   @extend %primary-button;
-}
+}*/
 
 /* action buttons bar */
 #modx-action-buttons {
   position: fixed;
   top: 55px;
-  right: 25px;
+  right: 30px;
   z-index: 9;
   left: auto;
-  background: $mainBg;
-  padding: 10px 2px 7px 7px;
+  background: rgba(230,230,230,0.7);
+  padding: 10px 5px 7px 7px;
   border: 0;
   font-family: $buttonfonts;
-  border-radius: 0 0 0 5px;
+  border-radius: 0 0 5px 5px;
 
   .x-toolbar-left {
     width: auto !important;
@@ -29,7 +29,14 @@
 .x-btn {
   @extend %secondary-button;
 
-  #modx-leftbar & {
+  #modx-action-buttons & {
+    margin: 0 0 0 5px;
+
+    &.primary-button {
+      margin: 0;
+    }
+  }
+  /*#modx-leftbar & {
     background: $buttonBackground;
     border-radius: $borderRadius;
     padding: 13px 20px;
@@ -47,12 +54,12 @@
     box-shadow: $shadowBorder;
     button {
       color: $buttonColor;
-    }
+    }*/
 
-    &#modx-abtn-save {
+/*    &#modx-abtn-save {
       @extend %primary-button;
-    }
-  }
+    }*/
+  /*}*/
 }
 // Toolbar combo/text styled just like the buttons
 .x-toolbar {

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -27,34 +27,11 @@
 
 /* btn style */
 .x-btn {
-  *display: inline;
-  background: linear-gradient(180deg, rgba(228, 233, 238, 1) 0%, rgba(210, 219, 226, 1) 100%) no-repeat;
-  border-radius: 4px;
-  box-shadow: $shadowBorder;
-  line-height: 1;
-  cursor: pointer;
-  display: inline-block;
-  margin: 0 1px;
-  padding: 10px 15px;
-  position: relative;
-  text-decoration: none;
-  zoom: 1;
-  /*border: 1px solid rgb(200, 210, 220);*/
-  button {
-    font-size: 13px;
-    color: $regularButtonColor;
-    cursor: pointer;
-    height: 16px;
-    min-width: 100%;
-    vertical-align: middle;
-  }
-  &.primary-button {
-	@extend %primary-button;
-  }
+  @extend %secondary-button;
 
   #modx-leftbar & {
     background: $buttonBackground;
-    border-radius: 3px;
+    border-radius: $borderRadius;
     padding: 13px 20px;
     border: none;
     button {
@@ -64,7 +41,7 @@
 
   #modx-action-buttons & {
     background: $buttonBackground;
-    border-radius: 3px;
+    border-radius: $borderRadius;
     padding: 10px 20px;
     border: none;
     box-shadow: $shadowBorder;
@@ -75,18 +52,13 @@
     &#modx-abtn-save {
       @extend %primary-button;
     }
-
-    &.x-btn-over {
-      /*border-color: $actionable;*/
-      background-color:$actionable;
-    }
   }
 }
 // Toolbar combo/text styled just like the buttons
 .x-toolbar {
   .x-form-field-trigger-wrap {
     background: linear-gradient(180deg, rgba(228, 233, 238, 1) 0%, rgba(210, 219, 226, 1) 100%);
-    border-radius: 4px;
+    border-radius: $borderRadius;
     line-height: 1;
     cursor: pointer;
     display: inline-block;
@@ -112,19 +84,52 @@
       border-color: darken($gainsboro,40%);
     }
   }
-  .x-toolbar-cell input.x-form-text {
+  .x-toolbar-right-row {
+    td {
+      .x-btn,
+      .x-form-text {
+        border-radius: 0;
+      }
+      &:first-of-type {
+        .x-btn,
+        .x-form-text {
+          border-radius: $borderRadius 0 0 $borderRadius;
+          z-index: 1;
+        }
+      }
+      &:last-of-type {
+        .x-btn,
+        .x-form-text {
+          border-radius: 0 $borderRadius $borderRadius 0;
+        }
+      }
+    }
+  }
+  .x-form-text {
     padding: 8px 13px;
-    border-radius: 4px;
+    border-radius: $borderRadius;
     font-size: 13px !important;
   }
+  &.x-small-editor .x-form-text {
+    padding-top: 8px; /* overrides ext standard theme rule which isn't overridden by padding rule above */
+  }
   .xtb-sep {
+      /* use margin on the elements itself as the separators are not inserted consistently by extjs */
       margin: 0;
+      width: 0;
   }
 }
 
-.x-btn-over {
-  border-color:darken($gainsboro,40%);
-  background-color:$gainsboro;
+.x-window-footer {
+  .x-toolbar-right-row {
+    td {
+      &:last-of-type {
+        .x-btn {
+          @extend %primary-button;
+        }
+      }
+    }
+  }
 }
 
 .x-btn-icon button {
@@ -190,20 +195,20 @@
   border: 0 none;
 }
 
-.x-btn-click {
+/*.x-btn-click {
   -moz-box-shadow: 0 0 3px #aaaaaa inset;
   -o-box-shadow: 0 0 3px #aaaaaa inset;
   -webkit-box-shadow: 0 0 3px #aaaaaa inset;
   box-shadow: 0 0 3px #aaaaaa inset;
   margin: 0 1px;
-}
+}*/
 
-.x-btn-focus {
+/*.x-btn-focus {
   border: 1px solid $darkNeutral;
-}
+}*/
 
 .x-btn-group {
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border: 1px solid #dbe0e4;
   margin-right: 2px;
   padding: 0;
@@ -359,7 +364,7 @@
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
   background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
   background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border: 1px solid #cccccc;
   color: #888888;
   cursor: pointer;

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -1,116 +1,72 @@
 @import "font-awesome/variables";
 @import "font-awesome/mixins";
 
-/*.primary-button {
-  @extend %primary-button;
-}*/
-
-/* action buttons bar */
-#modx-action-buttons {
-  position: fixed;
-  top: 55px;
-  right: 30px;
-  z-index: 9;
-  left: auto;
-  background: rgba(230,230,230,0.7);
-  padding: 10px 5px 7px 7px;
-  border: 0;
-  font-family: $buttonfonts;
-  border-radius: 0 0 5px 5px;
-
-  .x-toolbar-left {
-    width: auto !important;
-    zoom: 1;
-  }
-  .xtb-sep { width: 0; }
-}
-
 /* btn style */
 .x-btn {
   @extend %secondary-button;
 
   #modx-action-buttons & {
-    margin: 0 0 0 5px;
-
-    &.primary-button {
-      margin: 0;
-    }
+    display: block;
+    margin: 0 0 0 7px;
   }
-  /*#modx-leftbar & {
-    background: $buttonBackground;
-    border-radius: $borderRadius;
-    padding: 13px 20px;
-    border: none;
-    button {
-      color: $buttonColor;
-    }
-  }
-
-  #modx-action-buttons & {
-    background: $buttonBackground;
-    border-radius: $borderRadius;
-    padding: 10px 20px;
-    border: none;
-    box-shadow: $shadowBorder;
-    button {
-      color: $buttonColor;
-    }*/
-
-/*    &#modx-abtn-save {
-      @extend %primary-button;
-    }*/
-  /*}*/
 }
-// Toolbar combo/text styled just like the buttons
+/* Toolbar combo/text styled just like the buttons */
 .x-toolbar {
   .x-form-field-trigger-wrap {
-    background: linear-gradient(180deg, rgba(228, 233, 238, 1) 0%, rgba(210, 219, 226, 1) 100%);
+    background: $white;
+    border: 0;
     border-radius: $borderRadius;
-    line-height: 1;
+    box-shadow: $shadowBorder;
     cursor: pointer;
-    display: inline-block;
-    margin: 0 1px;
-    position: relative;
-    text-decoration: none;
-    zoom: 1;
-    border: 1px solid rgb(200, 210, 220);
-    transition: background-color .2s;
-    padding: 3px 23px 3px 0;
+    line-height: 1;
 
-    input.x-form-text {
-      font-weight: normal !important;
-      padding-left: 13px !important;
-      width: 30px !important;
+    .x-form-text {
+      background: $white;
+      border: 0;
+      margin: 0 !important;
     }
     .x-form-trigger {
-      padding-top: 2px;
+      margin-top: 1px;
     }
-
     &.x-trigger-wrap-focus {
-      outline: none !important;
-      border-color: darken($gainsboro,40%);
+      box-shadow: $shadowBorderHover;
     }
   }
-  .x-toolbar-right-row {
+
+  .x-toolbar-left-row {
     td {
+      .x-btn {
+        display: block;
+      }
       .x-btn,
-      .x-form-text {
-        border-radius: 0;
+      .x-form-text,
+      .x-form-field-trigger-wrap {
+        margin-right: 7px; /* 5px + 2px box-shadow = 5px visible spacing */
       }
       &:first-of-type {
         .x-btn,
-        .x-form-text {
-          border-radius: $borderRadius 0 0 $borderRadius;
-          z-index: 1;
-        }
-      }
-      &:last-of-type {
-        .x-btn,
-        .x-form-text {
-          border-radius: 0 $borderRadius $borderRadius 0;
+        .x-form-text,
+        .x-form-field-trigger-wrap {
+          margin-left: 1px; /* prevent first button to be cut off */
         }
       }
     }
+  }
+  .x-toolbar-right-row {
+      .x-btn,
+      .x-form-text,
+      .x-form-field-trigger-wrap {
+        margin-left: 7px; /* 5px + 2px box-shadow = 5px visible spacing */
+      }
+      
+      .x-form-filter {
+        border-radius: $borderRadius 0 0 $borderRadius;
+        z-index: 1; /* prevent clear filter button from overlapping the textfield */
+      }
+      .x-form-filter-clear {
+        border-radius: 0 $borderRadius $borderRadius 0;
+        margin-left: 0;
+      }
   }
   .x-form-text {
     padding: 8px 13px;
@@ -121,9 +77,49 @@
     padding-top: 8px; /* overrides ext standard theme rule which isn't overridden by padding rule above */
   }
   .xtb-sep {
-      /* use margin on the elements itself as the separators are not inserted consistently by extjs */
+      /* use margin on the elements itself as the separators are not inserted consistently */
+      /* separators are removed, but we leave this rule for safety */
       margin: 0;
       width: 0;
+  }
+  .x-tree & {
+    .x-btn {
+      padding: 7px;
+    }
+    .x-btn-icon {
+      box-shadow: none;
+      padding: 7px;
+
+      &.x-btn-over {
+        background: none;
+        box-shadow: none;
+        color: $colorSplash;
+      }
+      &.x-btn-click {
+        background: none;
+        box-shadow: none;
+        color: $borderColorActive;
+      }
+    }
+  }
+}
+
+/* action buttons bar, declare after general toolbar styles to make use of the cascade */
+#modx-action-buttons {
+  position: fixed;
+  top: 55px;
+  right: 30px;
+  z-index: 9;
+  left: auto;
+  background: rgba(230,230,230,0.7);
+  padding: 10px 5px 7px 0;
+  border: 0;
+  font-family: $buttonfonts;
+  border-radius: 0 0 5px 5px;
+
+  .x-toolbar-left {
+    width: auto !important;
+    zoom: 1;
   }
 }
 
@@ -202,18 +198,6 @@
   border: 0 none;
 }
 
-/*.x-btn-click {
-  -moz-box-shadow: 0 0 3px #aaaaaa inset;
-  -o-box-shadow: 0 0 3px #aaaaaa inset;
-  -webkit-box-shadow: 0 0 3px #aaaaaa inset;
-  box-shadow: 0 0 3px #aaaaaa inset;
-  margin: 0 1px;
-}*/
-
-/*.x-btn-focus {
-  border: 1px solid $darkNeutral;
-}*/
-
 .x-btn-group {
   border-radius: $borderRadius;
   border: 1px solid #dbe0e4;
@@ -234,7 +218,6 @@
 .x-btn-group .x-btn button {
   color: #868b8f;
   height: auto !important;
-  /*text-shadow: 0 1px 0 #ffffff;*/
 }
 
 .x-btn-group .x-btn-over {
@@ -245,7 +228,6 @@
 
 .x-btn-group .x-btn-over button {
   color: #5b7a98;
-  /*text-shadow: 0 1px 0 #ffffff;*/
 }
 
 .x-btn-group .x-btn-click {
@@ -292,24 +274,6 @@
   padding-right: 1px;
 }
 
-.x-btn em.x-btn-arrow {
-  background: transparent url($imgPath + 'modx-theme/button/arrow.gif') no-repeat right center;
-  display: block;
-  padding-right: 20px;
-
-  button {
-    padding-right: 10px !important;
-    border-right: 1px solid #fff;
-  }
-}
-.x-btn-menu-active {
-  background: $dropdownBg;
-
-  button {
-    color: $dropdownTextColor;
-  }
-}
-
 /* //end button style */
 
 .x-btn-over em.x-btn-split, .x-btn-click em.x-btn-split, .x-btn-menu-active em.x-btn-split, .x-btn-pressed em.x-btn-split {
@@ -349,35 +313,18 @@
 
 .actions button,
 .inline-button {
-  /*background: #dcdcdc;
-  background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  background: -o-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
-  background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  border-radius: $borderRadius;
-  border: 1px solid #cccccc;
-  color: #888888;
-  cursor: pointer;
-  display: block;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#dcdcdc,GradientType=0);
-  font: $fontSmall;
-  font-weight: bold;*/
   @extend %secondary-button;
 
   box-shadow: $shadowBorderDark;
   padding: 5px;
-  /*text-decoration: none;*/
-  /*text-shadow: 0 1px 0 #ffffff;*/
-  &:hover {
+  /*&:hover {
     background: $actionable;
   }
   &:active {
     background: $colorSplash;
     box-shadow: $shadowBorderActive;
     color: $white;
-  }
+  }*/
   &.orange {
     background: #F4B848;
     box-shadow: 0 0 0 1px #F4B848;
@@ -406,78 +353,8 @@
   }
 }
 
-.actions button:hover,
-.inline-button:hover {
-  /*background: #e0e0e0;
-  background: -moz-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
-  background: -o-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, #e0e0e0));
-  background: -webkit-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
-  background: linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
-  color: #565550;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#e0e0e0,GradientType=0);*/
-}
-
-.actions button:active,
-.inline-button:active {
-  /*background-color: #ffffff;
-  background-image: none;
-  box-shadow: 0 0 3px #aaaaaa inset;*/
-}
-
-.actions button.orange {
-  /*background: #febb4a;
-  background: -moz-linear-gradient(center bottom, #febb4a 0%, #feda71 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
-  background: -o-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #feda71), color-stop(100%, #febb4a));
-  background: -webkit-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
-  background: linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
-  border-color: #f5b74e #e7a93f #dfa138;
-  color: #996633;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#feda71,endColorstr=#febb4a,GradientType=0);*/
-  /*text-shadow: 0 1px 0 #fee1a0;*/
-}
-
-.actions button.orange:hover {
-  /*background: #fec95b;
-  background: -moz-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
-  background: -o-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fee1a0), color-stop(100%, #fec95b));
-  background: -webkit-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
-  background: linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fee1a0,endColorstr=#fec95b,GradientType=0);*/
-}
-
-.inline-button.green {
-  /*background: #9fcb57;
-  background: -moz-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
-  background: -o-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #d7e9a4), color-stop(100%, #9fcb57));
-  background: -webkit-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
-  background: linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
-  border: 1px solid #85a948;
-  color: #556f14 !important;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#d7e9a4,endColorstr=#9fcb57,GradientType=0);*/
-  /*text-shadow: 0 1px 0 #d7e9a4;*/
-}
-
-.inline-button.green:hover {
-  /*background: #9fcb57;
-  background: -moz-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
-  background: -o-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #e6efd1), color-stop(100%, #9fcb57));
-  background: -webkit-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
-  background: linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#e6efd1,endColorstr=#9fcb57,GradientType=0);*/
-}
-
 /* basic tree toolbar styles */
-#modx-leftbar{
+#modx-leftbar {
   .x-toolbar-ct {
     .x-btn {
       margin: 0 3px;

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -285,21 +285,6 @@
   padding-right: 1px;
 }
 
-.x-btn em.x-btn-split {
-  /*background: transparent url($imgPath + 'modx-theme/button/s-arrow.gif') no-repeat right center;*/
-  display: block;
-  padding-right: 14px;
-  position:relative;
-  &:before {
-    @extend %pseudo-font;
-    content:$fa-var-caret-down;
-    position:absolute;
-    top:4px;
-    right:0;
-    color:inherit;
-  }
-}
-
 .x-btn em.x-btn-arrow {
   background: transparent url($imgPath + 'modx-theme/button/arrow.gif') no-repeat right center;
   display: block;
@@ -357,7 +342,7 @@
 
 .actions button,
 .inline-button {
-  background: #dcdcdc;
+  /*background: #dcdcdc;
   background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
   background: -o-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
@@ -371,15 +356,52 @@
   display: block;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#dcdcdc,GradientType=0);
   font: $fontSmall;
-  font-weight: bold;
-  padding: 3px 5px;
-  text-decoration: none;
+  font-weight: bold;*/
+  @extend %secondary-button;
+
+  box-shadow: $shadowBorderDark;
+  padding: 5px;
+  /*text-decoration: none;*/
   /*text-shadow: 0 1px 0 #ffffff;*/
+  &:hover {
+    background: $actionable;
+  }
+  &:active {
+    background: $colorSplash;
+    box-shadow: $shadowBorderActive;
+    color: $white;
+  }
+  &.orange {
+    background: #F4B848;
+    box-shadow: 0 0 0 1px #F4B848;
+    color: $white;
+    &:hover {
+      background: #F4A448;
+      box-shadow: 0 0 0 1px #F4A448;
+    }
+    &:active {
+      background: #F49548;
+      box-shadow: 0 0 0 1px #F49548;
+    }
+  }
+  &.green {
+    background: #99c44f;
+    box-shadow: 0 0 0 1px #99c44f;
+    color: $white !important; /* override !important of .green class */
+    &:hover {
+      background: #6cb24a;
+      box-shadow: 0 0 0 1px #6cb24a;
+    }
+    &:active {
+      background: #4BA81E;
+      box-shadow: 0 0 0 1px #4BA81E;
+    }
+  }
 }
 
 .actions button:hover,
 .inline-button:hover {
-  background: #e0e0e0;
+  /*background: #e0e0e0;
   background: -moz-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
   background: -o-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
@@ -387,18 +409,18 @@
   background: -webkit-linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
   background: linear-gradient(center bottom, #e0e0e0 0%, #fcfcfc 100%);
   color: #565550;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#e0e0e0,GradientType=0);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#e0e0e0,GradientType=0);*/
 }
 
 .actions button:active,
 .inline-button:active {
-  background-color: #ffffff;
+  /*background-color: #ffffff;
   background-image: none;
-  box-shadow: 0 0 3px #aaaaaa inset;
+  box-shadow: 0 0 3px #aaaaaa inset;*/
 }
 
 .actions button.orange {
-  background: #febb4a;
+  /*background: #febb4a;
   background: -moz-linear-gradient(center bottom, #febb4a 0%, #feda71 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
   background: -o-linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
@@ -407,23 +429,23 @@
   background: linear-gradient(center bottom, #febb4a 0%, #feda71 100%);
   border-color: #f5b74e #e7a93f #dfa138;
   color: #996633;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#feda71,endColorstr=#febb4a,GradientType=0);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#feda71,endColorstr=#febb4a,GradientType=0);*/
   /*text-shadow: 0 1px 0 #fee1a0;*/
 }
 
 .actions button.orange:hover {
-  background: #fec95b;
+  /*background: #fec95b;
   background: -moz-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
   background: -o-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fee1a0), color-stop(100%, #fec95b));
   background: -webkit-linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
   background: linear-gradient(center bottom, #fec95b 0%, #fee1a0 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fee1a0,endColorstr=#fec95b,GradientType=0);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fee1a0,endColorstr=#fec95b,GradientType=0);*/
 }
 
 .inline-button.green {
-  background: #9fcb57;
+  /*background: #9fcb57;
   background: -moz-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
   background: -o-linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
@@ -432,19 +454,19 @@
   background: linear-gradient(center bottom, #9fcb57 0%, #d7e9a4 100%);
   border: 1px solid #85a948;
   color: #556f14 !important;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#d7e9a4,endColorstr=#9fcb57,GradientType=0);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#d7e9a4,endColorstr=#9fcb57,GradientType=0);*/
   /*text-shadow: 0 1px 0 #d7e9a4;*/
 }
 
 .inline-button.green:hover {
-  background: #9fcb57;
+  /*background: #9fcb57;
   background: -moz-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
   background: -o-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #e6efd1), color-stop(100%, #9fcb57));
   background: -webkit-linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
   background: linear-gradient(center bottom, #9fcb57 0%, #e6efd1 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#e6efd1,endColorstr=#9fcb57,GradientType=0);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#e6efd1,endColorstr=#9fcb57,GradientType=0);*/
 }
 
 /* basic tree toolbar styles */

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -101,6 +101,13 @@
         color: $borderColorActive;
       }
     }
+    .x-toolbar-left-row,
+    .x-toolbar-right-row {
+      .x-form-field-wrap {
+        margin-right: 6px;
+        margin-left: 6px !important; /* we need the selector to override the rules above */
+      }
+    }
   }
 }
 

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -244,14 +244,6 @@
   margin: 0 2px 0 0;
 }
 
-.x-btn-click .x-btn-text, .x-btn-menu-active .x-btn-text, .x-btn-pressed .x-btn-text {
-  color: #73797f;
-}
-
-.x-btn-disabled * {
-  color: gray !important;
-}
-
 .x-btn-group-bwrap {
   padding: 1px 0 0;
 }
@@ -387,8 +379,17 @@
       }
 
 
-      &:hover, button:hover {
+      &.x-btn-over,
+      &:hover,
+      &.x-btn-click,
+      &:active {
+        background: none;
+        box-shadow: none;
         color: $buttonHoverColor;
+
+        button {
+          color: inherit;
+        }
       }
 
       span {
@@ -396,16 +397,22 @@
       }
     }
     .x-toolbar-right .x-btn {
+      /* the resource trash button in the tree */
       & > em > button {
-        color: #96A9BB;
+        /*color: #96A9BB;*/ /* not sure why the trash needs a different color when active? */
+        font-size: 20px; /* trash icon is a bit smaller than the others at 18px */
+      }
+      &#emptifier.x-item-disabled {
+        color: $treeColorDesaturated !important; /* !important prevents hover / active styles */
+        opacity: 0.6;
+
+        button {
+          color: inherit;
+        }
       }
     }
   }
 }
-#modx-leftbar #emptifier.x-item-disabled  {
-  opacity: .4 !important;
-}
-
 
 /* resource tree toolbar icons */
 .tree-new-resource > em > button:before {

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -317,18 +317,12 @@
 
   box-shadow: $shadowBorderDark;
   padding: 5px;
-  /*&:hover {
-    background: $actionable;
-  }
-  &:active {
-    background: $colorSplash;
-    box-shadow: $shadowBorderActive;
-    color: $white;
-  }*/
+
   &.orange {
     background: #F4B848;
     box-shadow: 0 0 0 1px #F4B848;
     color: $white;
+
     &:hover {
       background: #F4A448;
       box-shadow: 0 0 0 1px #F4A448;
@@ -342,6 +336,7 @@
     background: #99c44f;
     box-shadow: 0 0 0 1px #99c44f;
     color: $white !important; /* override !important of .green class */
+
     &:hover {
       background: #6cb24a;
       box-shadow: 0 0 0 1px #6cb24a;

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -26,7 +26,7 @@
       margin: 0 !important;
     }
     .x-form-trigger {
-      margin-top: 1px;
+      margin-top: 2px;
     }
     &.x-trigger-wrap-focus {
       box-shadow: $shadowBorderHover;

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -105,7 +105,7 @@
     .x-toolbar-right-row {
       .x-form-field-wrap {
         margin-right: 6px;
-        margin-left: 6px !important; /* we need the selector to override the rules above */
+        margin-left: 6px !important; /* we need !important to override the rules above */
       }
     }
   }

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -123,6 +123,7 @@
   border: 0;
   font-family: $buttonfonts;
   border-radius: 0 0 5px 5px;
+  z-index: 11; /* prevent panel collaps arrows from overlapping */
 
   .x-toolbar-left {
     width: auto !important;

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -30,6 +30,7 @@
   *display: inline;
   background: linear-gradient(180deg, rgba(228, 233, 238, 1) 0%, rgba(210, 219, 226, 1) 100%) no-repeat;
   border-radius: 4px;
+  box-shadow: $shadowBorder;
   line-height: 1;
   cursor: pointer;
   display: inline-block;
@@ -38,7 +39,7 @@
   position: relative;
   text-decoration: none;
   zoom: 1;
-  border: 1px solid rgb(200, 210, 220);
+  /*border: 1px solid rgb(200, 210, 220);*/
   button {
     font-size: 13px;
     color: $regularButtonColor;
@@ -64,10 +65,9 @@
   #modx-action-buttons & {
     background: $buttonBackground;
     border-radius: 3px;
-    padding: 10px 16px;
-    border: 1px solid #E0E5E9;
-    -webkit-box-shadow: 0 1px 0 0 #CCC;
-    box-shadow: $shadower;
+    padding: 10px 20px;
+    border: none;
+    box-shadow: $shadowBorder;
     button {
       color: $buttonColor;
     }
@@ -77,6 +77,7 @@
     }
 
     &.x-btn-over {
+      /*border-color: $actionable;*/
       background-color:$actionable;
     }
   }
@@ -100,6 +101,7 @@
     input.x-form-text {
       font-weight: normal !important;
       padding-left: 13px !important;
+      width: 30px !important;
     }
     .x-form-trigger {
       padding-top: 2px;
@@ -114,6 +116,9 @@
     padding: 8px 13px;
     border-radius: 4px;
     font-size: 13px !important;
+  }
+  .xtb-sep {
+      margin: 0;
   }
 }
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -108,6 +108,7 @@ $primaryBorder:  #C0C0C0;
 
 $shadower: 0 1px 0 $borderColor, -1px 0 0 $borderColor, 1px 0 0 $borderColor;
 $shadowBorder: 0 0 0 1px $borderColor;
+$shadowBorderDark: 0 0 0 1px $primaryBorder;
 $shadowBorderFocus: 0 0 0 1px $borderColorFocus;
 $shadowBorderActive: 0 0 0 1px $borderColorActive;
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -100,10 +100,11 @@ $subnavDescriptionColor: #5ABCE5;
 
 /* borders */
 $borderColor: #E4E4E4;
-$borderShadow: rgba(0, 0, 0, 0.025);
+$borderShadow: #E4E4E4;
 $primaryBorder: #c0c0c0;
 
 $shadower: 0 1px 0 $borderShadow, -1px 0 0 $borderShadow, 1px 0 0 $borderShadow;
+$shadowBorder: 0 0 0 1px $borderShadow;
 
 
 
@@ -133,8 +134,7 @@ $buttonfonts: $bodyfonts;
 $treePseudoRootFont: normal 14px/35px $headfonts;
 $treeNodeFont: normal 13px/22px $bodyfonts;
 
-
-$buttonColor: #6B8BAC;
+$buttonColor: $treeColor;
 $buttonHoverColor: $brandSelectedColor;
 $regularButtonColor: #707070;
 $buttonBackground: $white;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -22,9 +22,9 @@ $searchresultshead: #55bbe7;
 
 $labelText: $darkNeutral;
 $primaryAction: #58a598;
-$success: #81B548;
-$green: $success;
-$red: #FF0000;
+$green: #6cb24a;
+$red: #BE0000;
+$success: $green;
 
 $colorSplash: #3697cd;
 $desaturatedSplash: lighten(desaturate($colorSplash,100%), 20%);
@@ -77,7 +77,7 @@ $unpubText: italic;
 $lockedText: italic;
 
 
-$deleted: #B42260 !important;
+$deleted: lighten(desaturate($red,25%), 25%) !important;
 $delTextStyle: normal;
 $delTextDeco: line-through;
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -1,5 +1,5 @@
 /* Brand colors */
-$brandBg: #ffffff;
+$brandBg: #FFF;
 $brandHover: #e8f0f8;
 $brandSelectedBg: darken($brandHover, 3%);
 $brandSelectedColor: #3697cd;
@@ -7,28 +7,10 @@ $brandText: #757575;
 
 /* Core colors */
 $coreFieldBg: #fbfbfb;
+$coreFieldLabelColor: #555;
 
 /* main colors */
-$aside: #f8f8f8;
-$gainsboro: #f0f0f0;
-$actionable: #fbfbfb;
-$dropdownBg: #ffffff;
-$dropdownSelectedBg: #e1ecf1;
-$dropdownTextColor: #444444;
-$dropdownBorder: #e4e4e4;
-
-/* Context menu */
-$menuBg: $brandBg;
-$menuBorder: 1px solid #bbb;
-$menuBorderRadius: 3px;
-$menuBoxShadow: 0 0 5px rgba(0, 0, 0, 0.25);
-$menuSelectedBg: #30759c;
-$menuSelectedColor: $brandBg;
-$menuTextColor: #555555;
-$menuSeparatorColor: #cccccc;
-
 $white: #ffffff;
-$mainBg: #F2F2F2;
 $softGrey: #dcdcdc;
 $darkNeutral:#53595F;
 $black: #020608;
@@ -37,11 +19,6 @@ $griddivider: #E4E9EE;
 $gridrowalt: #F5F6F9;
 $searchresults: #2a3949;
 $searchresultshead: #55bbe7;
-
-$lightBg: $gainsboro;
-$darkBg: $darkNeutral;
-$mediumBg: $aside;
-
 
 $labelText: $darkNeutral;
 $primaryAction: #58a598;
@@ -54,10 +31,32 @@ $desaturatedSplash: lighten(desaturate($colorSplash,100%), 20%);
 $desturatedSuccess: lighten(desaturate($success,100%), 10%);
 $lightSplash: lighten($colorSplash, 42.5%);
 
+$aside: #f8f8f8;
+$gainsboro: #f0f0f0;
+$actionable: #fbfbfb;
+$dropdownBg: #FFF;
+$dropdownSelectedBg: #e1ecf1;
+$dropdownTextColor: #444;
+$dropdownBorder: #e4e4e4;
+
+$mainBg: #F2F2F2;
+$lightBg: $gainsboro;
+$darkBg: $darkNeutral;
+$mediumBg: $aside;
+
+/* Context menu */
+$menuBg: $brandBg;
+$menuBorder: 1px solid #BBB;
+$menuBorderRadius: 3px;
+$menuBoxShadow: 0 0 5px rgba(0, 0, 0, 0.25);
+$menuSelectedBg: #30759c;
+$menuSelectedColor: $brandBg;
+$menuTextColor: #555;
+$menuSeparatorColor: #CCC;
+
 /* tree menus */
 $treeText: #718DA7;
 $tipText: $gainsboro;
-$lightSplash: lighten($colorSplash, 42.5%);
 $mainText: $black;
 $headerText: #555555;
 $treeColor: #556C88;
@@ -100,8 +99,9 @@ $subnavDescriptionColor: #5ABCE5;
 
 /* borders */
 $borderColor: #E4E4E4;
-$borderColorFocus: $colorSplash;
-$borderColorActive: $colorSplash;
+$borderColorHover: $colorSplash;
+$borderColorFocus: darken($colorSplash, 6%);
+$borderColorActive: darken($colorSplash, 6%);
 $borderRadius: 3px;
 $borderShadow: #E4E4E4;
 $primaryBorder:  #C0C0C0;
@@ -109,6 +109,7 @@ $primaryBorder:  #C0C0C0;
 $shadower: 0 1px 0 $borderColor, -1px 0 0 $borderColor, 1px 0 0 $borderColor;
 $shadowBorder: 0 0 0 1px $borderColor;
 $shadowBorderDark: 0 0 0 1px $primaryBorder;
+$shadowBorderHover: 0 0 0 1px $borderColorHover;
 $shadowBorderFocus: 0 0 0 1px $borderColorFocus;
 $shadowBorderActive: 0 0 0 1px $borderColorActive;
 
@@ -149,6 +150,10 @@ $buttonColorDisabled: darken($buttonColor, 20%);
 $buttonColorPrimary: $white;
 $buttonPrimaryBg1: #32AB9A;
 $buttonPrimaryBg2: #00948E;
+$buttonPrimaryBg1Hover: darken($buttonPrimaryBg1, 6%);
+$buttonPrimaryBg2Hover: darken($buttonPrimaryBg2, 6%);
+$buttonPrimaryBg1Active: darken($buttonPrimaryBg1, 12%);
+$buttonPrimaryBg2Active: darken($buttonPrimaryBg2, 12%);
 $baseText:   normal 13px/1.4 $bodyfonts;
 $fontSmall:  normal 11px $bodyfonts;
 $fontMedium: normal 12px $bodyfonts;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -28,7 +28,6 @@ $red: #FF0000;
 
 $colorSplash: #3697cd;
 $desaturatedSplash: lighten(desaturate($colorSplash,100%), 20%);
-$desturatedSuccess: lighten(desaturate($success,100%), 10%);
 $lightSplash: lighten($colorSplash, 42.5%);
 
 $aside: #f8f8f8;
@@ -60,6 +59,7 @@ $tipText: $gainsboro;
 $mainText: $black;
 $headerText: #555555;
 $treeColor: #556C88;
+$treeColorDesaturated: lighten(desaturate($treeColor,100%), 25%);
 $treeColor_2: #728DA7;
 $treePseudoRootBg: $lightBg;
 $treePseudoRootColor: #447996;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -77,7 +77,7 @@ $unpubText: italic;
 $lockedText: italic;
 
 
-$deleted: darken(lighten(desaturate($red,50%), 33%), 25%) !important;
+$deleted: fade-out(darken(lighten(desaturate($red,50%), 33%), 25%), 0.5) !important;
 $delTextStyle: normal;
 $delTextDeco: line-through;
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -43,11 +43,13 @@ $lightBg: $gainsboro;
 $darkBg: $darkNeutral;
 $mediumBg: $aside;
 
+$boxShadow: 0 0 5px 0 rgba(0, 0, 0, 0.1);
+
 /* Context menu */
 $menuBg: $brandBg;
 $menuBorder: 1px solid #BBB;
 $menuBorderRadius: 3px;
-$menuBoxShadow: 0 0 5px rgba(0, 0, 0, 0.25);
+$menuBoxShadow: $boxShadow;
 $menuSelectedBg: #30759c;
 $menuSelectedColor: $brandBg;
 $menuTextColor: #555;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -77,7 +77,7 @@ $unpubText: italic;
 $lockedText: italic;
 
 
-$deleted: lighten(desaturate($red,25%), 25%) !important;
+$deleted: darken(lighten(desaturate($red,50%), 33%), 25%) !important;
 $delTextStyle: normal;
 $delTextDeco: line-through;
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -100,11 +100,16 @@ $subnavDescriptionColor: #5ABCE5;
 
 /* borders */
 $borderColor: #E4E4E4;
+$borderColorFocus: $colorSplash;
+$borderColorActive: $colorSplash;
+$borderRadius: 3px;
 $borderShadow: #E4E4E4;
-$primaryBorder: #c0c0c0;
+$primaryBorder:  #C0C0C0;
 
-$shadower: 0 1px 0 $borderShadow, -1px 0 0 $borderShadow, 1px 0 0 $borderShadow;
-$shadowBorder: 0 0 0 1px $borderShadow;
+$shadower: 0 1px 0 $borderColor, -1px 0 0 $borderColor, 1px 0 0 $borderColor;
+$shadowBorder: 0 0 0 1px $borderColor;
+$shadowBorderFocus: 0 0 0 1px $borderColorFocus;
+$shadowBorderActive: 0 0 0 1px $borderColorActive;
 
 
 

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -69,6 +69,16 @@ textarea.x-form-field,
   padding: 5px; /* override standard extjs theme */
 }
 
+textarea[id="ta"], /* main resource content without RTE */
+textarea[id="modx-chunk-snippet"], /* chunk code */
+textarea[id="modx-snippet-snippet"], /* snippet code */
+textarea[id="modx-plugin-plugincode"], /* plugin code */
+textarea[id="modx-template-content"],
+textarea[id="modx-file-content"], /* file code / content */
+textarea[id="modx-error-log-content"] { /* error log content */
+  font-family: $codefonts;
+}
+
 .x-form-text, /* this screws up clear cache modal #shame */
 textarea.x-form-field,
 .x-form-textarea {
@@ -112,26 +122,6 @@ textarea.x-form-field,
   background-color: #fff;
 }
 
-.ext-strict .x-form-field-trigger-wrap .x-form-text,
-.ext-strict .x-small-editor .x-form-field-trigger-wrap .x-form-text {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
-  border-right: 0 none;
-  color: #606060;
-  font-weight: bold;
-  height: 20px;
-  padding: 6px;
-  text-shadow: 1px -1px 0 #fff;
-}
-
-.x-small-editor .x-form-field-wrap .x-form-trigger, .x-form-field-wrap .x-form-trigger {
-  background-image: url($imgPath + 'modx-theme/form/trigger.png');
-  border-bottom-right-radius: 3px;
-  border-top-right-radius: 3px;
-  border: 1px solid #C5C5C5 !important;
-  border-left: 0 none;
-}
-
 /* fix combo on grid editor bug */
 .x-grid-editor .x-form-field-wrap {
   background: #f6f2f7 url($imgPath + 'modx-theme/form/combo-bck.png') repeat-x scroll 0px 100%;
@@ -146,49 +136,33 @@ textarea.x-form-field,
   background-image: url($imgPath + 'modx-theme/form/trigger.png');
 }
 
-.x-form-field-trigger-wrap {
-  border-color: #D0D0D0 #CCCCCC #BEBEBE;
-  border-style: solid;
-  border-width: 1px;
-  height: 30px;
-  margin-right: 1px;
-}
-
-.x-form-field-trigger-wrap .x-form-text {
-  background-color: transparent;
-  border: 0 none;
-}
-
 .x-form-field-wrap {
   background: $coreFieldBg;
-  border-radius: 2px;
+  border: 1px solid $borderColor;
+  border-radius: $borderRadius;
+
+  .x-form-text {
+    border: 0;
+  }
+  .x-form-trigger {
+    background: url($imgPath + 'modx-theme/form/trigger.png') no-repeat left center;
+    border: 0;
+    height: 30px !important; /* override default extjs theme */
+    width: 32px;
+
+    &.x-form-trigger-over {
+
+    }
+    &.x-form-trigger-click {
+
+    }
+  }
+  &.x-datetime-wrap {
+    border: 0;
+  }
 }
 
-.x-form-field-wrap .x-form-trigger {
-  background-position: left center;
-  background-repeat: no-repeat;
-  border: 0 none !important;
-  height: 30px;
-  width: 32px;
-}
-
-.x-form-field-wrap .x-form-trigger-over {
-  background-position: right;
-}
-
-.x-form-field-wrap .x-form-arrow-trigger {
-  background: url($imgPath + 'modx-theme/form/trigger.png') no-repeat scroll left center transparent;
-}
-
-.x-form-field-wrap .x-form-trigger.x-form-trigger-over {
-  background-position: center center;
-}
-
-.x-form-field-wrap .x-form-trigger.x-form-trigger-click {
-  background-position: right center;
-}
-
-.x-small-editor .x-form-field-wrap {
+/*.x-small-editor .x-form-field-wrap {
   background: $gainsboro;
   border-radius: 2px;
 }
@@ -226,7 +200,7 @@ textarea.x-form-field,
 
 .x-form-field-wrap .x-form-search-trigger {
   background-image: url($imgPath + 'modx-theme/form/search-trigger.gif');
-}
+}*/
 
 .x-viewport .x-trigger-wrap-focus,
 .x-viewport input.x-form-focus,
@@ -373,6 +347,9 @@ textarea.x-form-field,
 .x-window .desc-under.desc-checkbox {
   margin: -2px 0 4px;
 }
+.form-with-labels label[for="modx-element-property-preprocess"].desc-under {
+  margin: -2px 0 0 0;
+}
 .form-with-labels .desc-under .warning,
 .x-window {
   -moz-box-shadow: 0 0 5px #A0A0A0;
@@ -383,5 +360,41 @@ textarea.x-form-field,
   box-shadow: 0 0 5px #A0A0A0;
   overflow: hidden;
   padding: 0;
+}
+.x-window .desc-under .warning {
+  color: #df8d00;
+}
+
+
+.x-combo-list {
+  background-color: $dropdownBg;
+  border-color: $dropdownBorder;
+  border-radius: 0 0 $borderRadius $borderRadius;
+}
+.x-combo-list-inner {
+  background-color: $dropdownBg;
+}
+.x-combo-list-hd {
+  background-image: url($imgPath + 'modx-theme/layout/panel-title-light-bg.gif');
+  border-bottom-color: #bcbcbc;
+  color: #464646;
+}
+.x-resizable-pinned .x-combo-list-inner {
+  border-bottom-color: transparent;
+}
+.x-combo-list-item {
+  border: none;
+  padding: 5px;
+  color: $dropdownTextColor;
+}
+.x-combo-list .x-combo-selected {
+  background-color: $dropdownSelectedBg;
+  border: 0 none !important;
+}
+.x-combo-list .x-toolbar {
+  border-top-color: #bcbcbc;
+}
+.x-combo-list-small {
+  font: $fontSmall;
 }
 

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -45,7 +45,7 @@ input::-moz-focus-inner {
   margin-bottom: 2px;
 }
 .inline-form input[type=text], .inline-form textarea {
-  background-color: #fbfbfb;
+  background-color: $coreFieldBg;
   background-image: none;
   border-radius: $borderRadius;
   border: 1px solid #CCCCCC;
@@ -64,15 +64,17 @@ input::-moz-focus-inner {
 
 textarea.x-form-field,
 .x-form-textarea {
-  font-family: $codefonts;
+  display: block; /* make the field description (below) stick to the bottom correctly */
+  /*font-family: $codefonts;*/
+  padding: 5px; /* override standard extjs theme */
 }
 
 .x-form-text, /* this screws up clear cache modal #shame */
 textarea.x-form-field,
 .x-form-textarea {
-  background-color: #fbfbfb;
+  background-color: $coreFieldBg;
   background-image: none;
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border: 1px solid $borderColor;
   position: relative;
 }
@@ -327,7 +329,7 @@ textarea.x-form-field,
   overflow: hidden;
 }
 .x-form-item-label {
-  color: #777;
+  color: $coreFieldLabelColor;
   font-weight: bold;
 }
 
@@ -352,16 +354,16 @@ textarea.x-form-field,
   padding: 0;
 }
 .form-with-labels .x-form-label-top .x-form-item label.x-form-item-label {
-  color: #555;
+  color: $coreFieldLabelColor;
   font-size: 13px;
   font-weight: bold;
   margin-bottom: 0;
   display: block;
-  padding: 7px 5px 4px 3px;
+  padding: 7px 5px 4px 0;
 }
 .form-with-labels .desc-under,
 .x-window .desc-under {
-  color: #aaaaaa;
+  color: $coreFieldLabelColor;
   display: block;
   font-size: 11px;
   font-style: italic;

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -69,13 +69,14 @@ textarea.x-form-field,
   padding: 5px; /* override standard extjs theme */
 }
 
-textarea[id="ta"], /* main resource content without RTE */
-textarea[id="modx-chunk-snippet"], /* chunk code */
-textarea[id="modx-snippet-snippet"], /* snippet code */
-textarea[id="modx-plugin-plugincode"], /* plugin code */
-textarea[id="modx-template-content"],
-textarea[id="modx-file-content"], /* file code / content */
-textarea[id="modx-error-log-content"] { /* error log content */
+#ta, /* main resource content without RTE */
+#modx-chunk-snippet, /* chunk code */
+#modx-snippet-snippet, /* snippet code */
+#modx-plugin-plugincode, /* plugin code */
+#modx-template-content, /* template code */
+#modx-file-content, /* file code / content */
+#modx-error-log-content, /* error log content */
+.modx-code-content { /* general class that could be applied to any form field that should display code font */
   font-family: $codefonts;
 }
 

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -69,13 +69,13 @@ textarea.x-form-field,
   padding: 5px; /* override standard extjs theme */
 }
 
-#ta, /* main resource content without RTE */
-#modx-chunk-snippet, /* chunk code */
-#modx-snippet-snippet, /* snippet code */
-#modx-plugin-plugincode, /* plugin code */
-#modx-template-content, /* template code */
-#modx-file-content, /* file code / content */
-#modx-error-log-content, /* error log content */
+/* #ta, /* main resource content without RTE */
+/* #modx-chunk-snippet, /* chunk code */
+/* #modx-snippet-snippet, /* snippet code */
+/* #modx-plugin-plugincode, /* plugin code */
+/* #modx-template-content, /* template code */
+/* #modx-file-content, /* file code / content */
+/* #modx-error-log-content, /* error log content */
 .modx-code-content { /* general class that could be applied to any form field that should display code font */
   font-family: $codefonts;
 }

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -47,7 +47,7 @@ input::-moz-focus-inner {
 .inline-form input[type=text], .inline-form textarea {
   background-color: #fbfbfb;
   background-image: none;
-  border-radius: 2px;
+  border-radius: $borderRadius;
   border: 1px solid #CCCCCC;
   position: relative;
   width: 97%;
@@ -226,15 +226,20 @@ textarea.x-form-field,
   background-image: url($imgPath + 'modx-theme/form/search-trigger.gif');
 }
 
-.x-viewport .x-trigger-wrap-focus, .x-viewport input.x-form-focus, .x-viewport textarea.x-form-focus, .x-viewport .x-form-textarea.x-form-focus {
-  border-radius: 0;
-  outline-offset: 0;
-  outline: 1px solid #ddd !important; /* #shame */
+.x-viewport .x-trigger-wrap-focus,
+.x-viewport input.x-form-focus,
+.x-viewport textarea.x-form-focus,
+.x-viewport .x-form-textarea.x-form-focus {
+  /*border-radius: 0;*/
+  /*outline-offset: 0;*/
+  /*outline: 1px solid #ddd !important; /* #shame */
+  /*box-shadow: $shadowBorderFocus;*/
+  border-color: $borderColorFocus;
 }
 
-.x-viewport .x-trigger-wrap-focus .x-form-focus {
+/*.x-viewport .x-trigger-wrap-focus .x-form-focus {
   outline: none !important;
-}
+}*/
 
 .x-datetime-wrap {
   background: none;
@@ -371,7 +376,7 @@ textarea.x-form-field,
   -moz-box-shadow: 0 0 5px #A0A0A0;
   -o-box-shadow: 0 0 5px #A0A0A0;
   -webkit-box-shadow: 0 0 5px #A0A0A0;
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border: 1px solid #C0C0C0;
   box-shadow: 0 0 5px #A0A0A0;
   overflow: hidden;

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -163,14 +163,15 @@ textarea.x-form-field,
   }
 }
 
-/*.x-small-editor .x-form-field-wrap {
+.x-small-editor .x-form-field-wrap {
   background: $gainsboro;
-  border-radius: 2px;
+  border-radius: $borderRadius;
 }
 
 .x-small-editor .x-form-field-wrap .x-form-trigger {
   border: 0 none !important;
-  height: 32px;
+  right: -3px;
+  height: 24px !important; /* override the overriding rule ^^*/
   width: 32px;
 }
 
@@ -201,7 +202,7 @@ textarea.x-form-field,
 
 .x-form-field-wrap .x-form-search-trigger {
   background-image: url($imgPath + 'modx-theme/form/search-trigger.gif');
-}*/
+}
 
 .x-viewport .x-trigger-wrap-focus,
 .x-viewport input.x-form-focus,
@@ -227,7 +228,7 @@ textarea.x-form-field,
 }
 
 .ext-strict .x-small-editor .x-form-text {
-  border-radius: 2px;
+  border-radius: $borderRadius;
   height: 20px !important;
 }
 
@@ -253,15 +254,15 @@ textarea.x-form-field,
   /*background-image: url($imgPath + 'modx-theme/shared/warning.gif');*/
   color: #c0272b;
   font: $fontSmall;
-  margin-top:2px;
-  position:relative;
+  margin-top: 2px;
+  position: relative;
 	&:before {
 		@extend %pseudo-font;
-		content:$fa-var-exclamation-triangle; /* : "\f071" */
+		content: $fa-var-exclamation-triangle; /* : "\f071" */
 		position: absolute;
-		top:3px;
-		left:3px;
-		color:inherit;
+		top: 3px;
+		left: 3px;
+		color: inherit;
 	}
 }
 
@@ -269,22 +270,46 @@ textarea.x-form-field,
   color: gray;
 }
 
-.x-grid3 .x-small-editor .x-form-text, .x-grid3 .x-small-editor .x-form-field-wrap {
+.x-grid3 {
+  .x-small-editor {
+    .x-form-text,
+    .x-form-field-wrap {
+      font: $fontSmall;
+      margin-top: 7px;
+      padding: 2px 5px 2px 5px;
+
+      .x-form-text {
+        margin: 0;
+        padding: 0;
+      }
+    }
+
+    .x-form-text {
+      /*margin-top: 7px;*/
+    }
+
+    .x-form-field-wrap {
+      overflow: hidden;
+    }
+  }
+}
+/*.x-grid3 .x-small-editor .x-form-text, .x-grid3 .x-small-editor .x-form-field-wrap {
   font: $fontSmall;
   margin-top: 5px;
+  padding: 2px 5px 2px 5px;
 }
 
 .x-grid3 .x-small-editor .x-form-field-wrap {
   overflow: hidden;
-}
+}*/
 
-.x-grid3 .x-small-editor .x-form-field-wrap .x-form-text {
-  margin-top: 0;
-}
+/*.x-grid3 .x-small-editor .x-form-field-wrap .x-form-text {
+  margin-top: 7px;
+}*/
 
-.ext-safari .x-small-editor .x-form-field {
+/*.ext-safari .x-small-editor .x-form-field {
   font: $baseText;
-}
+}*/
 
 .x-form-invalid-icon {
   background-image: url($imgPath + 'modx-theme/form/exclamation.gif');

--- a/_build/templates/default/sass/_help.scss
+++ b/_build/templates/default/sass/_help.scss
@@ -47,7 +47,7 @@
 
 #managerbuttons ul li a {
   @include linear-gradient(top, white, whitesmoke);
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border: 1px solid $borderColor;
   box-shadow: 0 1px 0 $borderShadow;
   color: $darkNeutral;

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -8,7 +8,7 @@
   box-shadow: 0 2px 0 $borderShadow;
   height: 100%;
   position: relative;
-  z-index: 10;
+  z-index: 20;
 }
 
 #modx-user-menu {

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -4,16 +4,10 @@
   margin: 20px 0 20px;
   overflow: visible;
 
-  #modx-leftbar & {
-  }
-
   /* background behind a button bar */
   .x-tab-panel-body-noborder {
     background-color: $white;
-
-    #modx-leftbar & {
-      background-color: $white;
-    }
+    border-radius: $borderRadius;
   }
 }
 
@@ -24,8 +18,9 @@
 }
 
 .x-tab-panel-header ul.x-tab-strip-top {
-  border-bottom-color: $white;
-  margin:0; /* was -1px */
+  /*border-bottom-color: $white;*/
+  border: 0; /* prevent overflowing border, add to .x-tab-strip-wrap if necessary */
+  margin: 0; /* was -1px */
   width: auto;
   background-color: $tabStripBg !important;
   position: relative;
@@ -49,6 +44,7 @@
 .x-tab-panel-bwrap {
   box-shadow: $boxShadow;
   border-radius: $borderRadius;
+  overflow: visible; /* prevent cutoff box-shadow */
 }
 
 .x-tab-strip li {
@@ -128,7 +124,7 @@
 
 ul.x-tab-strip-top li:first-child {
   /*margin-left: -1px*/;
-  margin-left:0;
+  margin-left: 0;
 }
 
 ul.x-tab-strip-bottom {

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -38,7 +38,7 @@
 .x-tab-panel-header,
 .x-tab-strip {
   /*padding-left: 1px;*/
-  padding-left:0;
+  padding-left: 0;
 }
 
 .x-tab-panel-bwrap {
@@ -73,7 +73,7 @@
       border-radius: 0;
     }
 
-    // For the box shadow around the tab
+    /* For the box shadow around the tab */
     &:after {
       content: "";
       display: block;
@@ -85,7 +85,7 @@
       box-shadow: 0 0 5px rgba(0,0,0,0.1);
       z-index: -1;
       border-radius: $borderRadius;
-	}
+    }
 
     &:before {
       content: "";
@@ -96,13 +96,12 @@
       bottom: -4px;
       left: 0;
       background: #fff
-	}
-  }
-  /*&:first-of-type {
-    &.x-tab-strip-active {
-      box-shadow: 0 -3px 0 $colorSplash, -1px 0 0 transparent, 1px 0 0 $borderColor;
     }
-  }*/
+  }
+  &.x-tab-edge {
+    height: 0;
+    visibility: hidden; /* display none makes the tab scroll buttons appear somehow */
+  }
 }
 
 .x-tab-strip-wrap,
@@ -202,8 +201,6 @@ ul.x-tab-strip-bottom {
   border-bottom-color: transparent;
 }
 
-
-
 /* vertical tabs */
 .vertical-tabs-panel {
   background: $white;
@@ -218,18 +215,13 @@ ul.x-tab-strip-bottom {
     background: $coreFieldBg !important; /* ovverride extjs default theme */
     border-right: 1px solid $borderColor !important; /* ovverride extjs default theme */
     float: left;
-    /*margin-top: -20px; /* pull the tab strip to the top  of the panel */
     margin-bottom: -10000px; /* dirty hack to make vertical tabs container stretch to bottom */
     padding-bottom: 10000px !important; /* dirty hack to make vertical tabs container stretch to bottom */
     width: 169px; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
 
     .x-tab-strip-wrap {
-      margin-bottom: -10px;
-      /*border-right: 1px solid $borderColor;*/
       display: inline-block;
       line-height: 0;
-      margin: 0 0 -10px 0; /* pull in the bottom */
-      /*padding-bottom: 100%;*/
       width: 100%;
 
       ul.x-tab-strip {
@@ -262,6 +254,11 @@ ul.x-tab-strip-bottom {
           }
           &.x-tab-edge {
             height: 0;
+            visibility: hidden; /* display none makes the tab scroll buttons appear somehow */
+
+            .x-tab-strip-text {
+              display: none; /* prevent 4px high space at the end of the tab strip */
+            }
           }
         }
       }
@@ -299,10 +296,6 @@ ul.x-tab-strip-bottom {
       border-radius: $borderRadius;
       box-shadow: $boxShadow;
     }
-
-    .vertical-tabs-header {
-      /*margin-top: 0;*/
-    }
   }
 }
 
@@ -316,61 +309,3 @@ ul.x-tab-strip-bottom {
     margin: 0px;
   }
 }
-
-/*.vertical-tabs-header ul.x-tab-strip-top li {*/
-    /*width: 100%;*/
-
-    /*& .x-tab-strip-active {
-        background: $white !important;
-        /*border-width: 0 0 1px;/
-        color: #555;
-        /*padding-bottom: 5px !important;/
-        text-shadow: none;
-    }*/
-/*}*/
-
-/*.vertical-tabs-header .x-tab-edge {
-  height: 0;
-}*/
-
-/*.vertical-tabs-header .x-tab-strip-spacer {
-  display: none;
-}*/
-
-/* refactor and delete, too much ids... use classes above */
-/*#modx-resource-tabs {
-  margin: 20px 0 0;
-
-  @extend %shaded-tab-box;
-  .x-tab-panel-header {
-    width:auto !important;
-    &.vertical-tabs-header {
-      width:150px !important;
-    }
-    .x-tab-strip {
-      li {
-        float:left;
-        /* width:auto; /
-        margin-left:0;
-      }
-    }
-  }
-  #modx-tv-tabs {
-      border-left:0;
-      border-right:0;
-  }
-}*/
-
-/*#modx-resource-tvs-div #modx-tv-tabs, #modx-resource-tabs #modx-tv-tabs {
-  .x-tab-strip {
-    margin-top:12px;
-    
-    li {
-      width:100% !important;
-      margin-left:0;
-      border-bottom:1px solid $borderColor;
-      &:nth-last-child(3) { border-color:transparent }
-      &.x-tab-strip-active { border-bottom:1px solid $borderColor; }
-    }
-  }
-}*/

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -1,7 +1,7 @@
 /* top area around the tab strip */
 .x-tab-panel-noborder {
   border: 1px solid #E2E3DE;
-  margin: 20px 0 10px;
+  margin: 20px 0 20px;
   overflow: visible;
 
   #modx-leftbar & {
@@ -37,7 +37,7 @@
   background-color: #fff;
   border: none;
   height: 0;
-  //margin: -2px 0 0 0; /* was -2px 0 0 -1px */
+  /*margin: -2px 0 0 0; /* was -2px 0 0 -1px */
 }
 
 .x-tab-panel-header,
@@ -47,7 +47,7 @@
 }
 
 .x-tab-panel-bwrap {
-  box-shadow: 0 0 5px rgba(0,0,0,0.1);
+  box-shadow: $boxShadow;
   border-radius: $borderRadius;
 }
 
@@ -102,11 +102,11 @@
       background: #fff
 	}
   }
-//  &:first-of-type {
-//    &.x-tab-strip-active {
-//      box-shadow: 0 -3px 0 $colorSplash, -1px 0 0 transparent, 1px 0 0 $borderColor;
-//    }
-//  }
+  /*&:first-of-type {
+    &.x-tab-strip-active {
+      box-shadow: 0 -3px 0 $colorSplash, -1px 0 0 transparent, 1px 0 0 $borderColor;
+    }
+  }*/
 }
 
 .x-tab-strip-wrap,
@@ -210,52 +210,107 @@ ul.x-tab-strip-bottom {
 
 /* vertical tabs */
 .vertical-tabs-panel {
-  background: #f8f8f8;
+  background: $white;
+  margin: 0; /* remove top and bottom margin */
+  overflow: hidden; /* dirty hack to make vertical tabs container stretch to bottom */
 
   &.wrapped {
-    border: 1px solid #e0e0e0;
-  }
-}
-
-.vertical-tabs-header {
-  background-color: #f8f8f8 !important;
-  float: left;
-  margin-left: 0;
-  padding: 13px 0 !important;
-  width: 150px !important;
-  & ul {
-    border-top: 1px solid transparent;
-    width: auto;
-    border-bottom-color:transparent;
+    border: 1px solid $borderColor;
   }
 
-  & .vertical-tabs-header li {
-    background: none repeat scroll 0 0 transparent !important;
-    border-color: transparent transparent #E0E0E0 transparent !important;
-    border-radius: 0 !important;
-    border-style: none none solid none !important;
-    border-width: 1px 1px 1px 0 !important;
-    float: none !important;
-    margin: 0 !important;
-    overflow: hidden;
-    padding: 5px !important;
-    white-space: nowrap;
-    color: #555;
-    line-height: 1.3;
-    text-shadow: 0 1px 0 #fff;
+  .vertical-tabs-header {
+    background: $coreFieldBg !important; /* ovverride extjs default theme */
+    border-right: 1px solid $borderColor !important; /* ovverride extjs default theme */
+    float: left;
+    /*margin-top: -20px; /* pull the tab strip to the top  of the panel */
+    margin-bottom: -10000px; /* dirty hack to make vertical tabs container stretch to bottom */
+    padding-bottom: 10000px !important; /* dirty hack to make vertical tabs container stretch to bottom */
+    width: 169px; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
 
-    &:first-child {
-      border-top: 0 none !important;
+    .x-tab-strip-wrap {
+      margin-bottom: -10px;
+      /*border-right: 1px solid $borderColor;*/
+      display: inline-block;
+      line-height: 0;
+      margin: 0 0 -10px 0; /* pull in the bottom */
+      /*padding-bottom: 100%;*/
+      width: 100%;
+
+      ul.x-tab-strip {
+        border: 0; /* overrides extjs default theme */
+        display: inline-block;
+        top: 0; /* overrides extjs default theme style of 1px */
+        width: 100%;
+
+        > li {
+          border-bottom: 1px solid $borderColor;
+          color: $coreFieldLabelColor;
+          float: none;
+          line-height: 1;
+          margin: 0; /* override default extjs theme value of 2px */
+          overflow: hidden;
+          padding: 10px 15px 10px 15px;
+          transition: all 0.3s;
+          white-space: nowrap;
+          width: 100%;
+
+          &:hover {
+            background: $white;
+          }
+          &.x-tab-strip-active {
+            background: $white;
+            border-color: $borderColorHover;
+            box-shadow: none; /* removes the active tab strip on top */
+            color: $tabActiveText;
+            width: 169px; /* make the active li 1px more wide to cover the containers right border */
+          }
+          &.x-tab-edge {
+            height: 0;
+          }
+        }
+      }
+    }
+    /* the "categories" text */
+    h4 {
+      background: $white;
+      /*border-right: 1px solid $borderColor;*/
+      border-bottom: 1px solid $borderColor;
+      color: $darkNeutral;
+      font-size: 16px;
+      padding: 15px 0 15px 15px;
+    }
+    .x-tab-strip-spacer {
+      display: none; /* added by extjs */
     }
   }
-  h4 {
-    margin-left:15px;
-  }
-  ul.x-tab-strip-top {
-    border-bottom: none;
-    background: #f8f8f8 !important;
+
+  /* this is the area where the TV form fields are displayed */
+  .x-tab-panel-bwrap {
+    box-shadow: none;
+
+    .vertical-tabs-body {
+      padding: 20px 30px 20px 25px;
+    }
   }
 }
+
+.tvs-wrapper {
+  &.below-content {
+    border-radius: $borderRadius;
+    margin-top: 20px;
+
+    .vertical-tabs-panel {
+      border-radius: $borderRadius;
+      box-shadow: $boxShadow;
+    }
+
+    .vertical-tabs-header {
+      /*margin-top: 0;*/
+    }
+  }
+}
+
+
 .window-vtabs {
   .x-panel-mr {
     padding-right: 0px;
@@ -266,26 +321,60 @@ ul.x-tab-strip-bottom {
   }
 }
 
-.vertical-tabs-header ul.x-tab-strip-top li {
-    width: 100%;
+/*.vertical-tabs-header ul.x-tab-strip-top li {*/
+    /*width: 100%;*/
 
-    & .x-tab-strip-active {
+    /*& .x-tab-strip-active {
         background: $white !important;
-        /*border-width: 0 0 1px;*/
+        /*border-width: 0 0 1px;/
         color: #555;
-        /*padding-bottom: 5px !important;*/
+        /*padding-bottom: 5px !important;/
         text-shadow: none;
-    }
-}
+    }*/
+/*}*/
 
-.vertical-tabs-header .x-tab-edge {
+/*.vertical-tabs-header .x-tab-edge {
   height: 0;
-}
+}*/
 
-.vertical-tabs-header .x-tab-strip-spacer {
+/*.vertical-tabs-header .x-tab-strip-spacer {
   display: none;
-}
+}*/
 
-.vertical-tabs-body {
-  padding: 20px 30px 20px 25px;
-}
+/* refactor and delete, too much ids... use classes above */
+/*#modx-resource-tabs {
+  margin: 20px 0 0;
+
+  @extend %shaded-tab-box;
+  .x-tab-panel-header {
+    width:auto !important;
+    &.vertical-tabs-header {
+      width:150px !important;
+    }
+    .x-tab-strip {
+      li {
+        float:left;
+        /* width:auto; /
+        margin-left:0;
+      }
+    }
+  }
+  #modx-tv-tabs {
+      border-left:0;
+      border-right:0;
+  }
+}*/
+
+/*#modx-resource-tvs-div #modx-tv-tabs, #modx-resource-tabs #modx-tv-tabs {
+  .x-tab-strip {
+    margin-top:12px;
+    
+    li {
+      width:100% !important;
+      margin-left:0;
+      border-bottom:1px solid $borderColor;
+      &:nth-last-child(3) { border-color:transparent }
+      &.x-tab-strip-active { border-bottom:1px solid $borderColor; }
+    }
+  }
+}*/

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -21,7 +21,7 @@
   /*border-bottom-color: $white;*/
   border: 0; /* prevent overflowing border, add to .x-tab-strip-wrap if necessary */
   margin: 0; /* was -1px */
-  width: auto;
+  width: auto; /* commented out bc it prevents tabs from triggering the scroll functionality */
   background-color: $tabStripBg !important;
   position: relative;
   top: 1px;

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -48,7 +48,7 @@
 
 .x-tab-panel-bwrap {
   box-shadow: 0 0 5px rgba(0,0,0,0.1);
-  border-radius: 3px;
+  border-radius: $borderRadius;
 }
 
 .x-tab-strip li {
@@ -88,7 +88,7 @@
       left: 0;
       box-shadow: 0 0 5px rgba(0,0,0,0.1);
       z-index: -1;
-      border-radius: 3px;
+      border-radius: $borderRadius;
 	}
 
     &:before {

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -10,7 +10,7 @@
   }
 
   .x-item-disabled {
-    opacity: 0.8;
+    opacity: 0.6;
   }
 
   td.x-toolbar-cell {

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -126,6 +126,7 @@
   background-image: url($imgPath + 'modx-theme/toolbar/more.gif') !important;
 }
 
+/* bottom toolbars like pagination */
 .x-panel-bbar {
   padding-top: 10px;
 
@@ -137,10 +138,11 @@
 
     .x-form-text {
       padding: 5px 10px;
-      width: 32px !important; /* overrides the 12px inline width I have no idea where it's coming from */
+      /* width set in widgets/core/modx.grid.js line 41 */
 
       &.x-tbar-page-number {
         margin-right: 3px;
+        width: 32px;
       }
     }
 
@@ -155,6 +157,7 @@
   }
 }
 
+/* top toolbars */
 .x-panel-tbar {
   padding-bottom: 2px;
 

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -17,9 +17,9 @@
   color: gray;
 }
 
-.x-toolbar em.x-btn-split {
+/*.x-toolbar em.x-btn-split {
   background-image: url($imgPath + 'modx-theme/button/s-arrow-noline.gif');
-}
+}*/
 
 .x-toolbar .x-btn-over em.x-btn-split,
 .x-toolbar .x-btn-click em.x-btn-split,

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -134,15 +134,17 @@
     background-color: transparent;
     border: 0 none;
     overflow: hidden;
-    padding: 2px 0; /* override extjs default style of 2px 2px */
+    padding: 2px 0; /* override extjs default theme style of 2px 2px */
 
     .x-form-text {
       padding: 5px 10px;
-      /* width set in widgets/core/modx.grid.js line 41 */
 
+      &.x-tbar-page-number,
+      &.x-tbar-page-size {
+        width: 32px;
+      }
       &.x-tbar-page-number {
         margin-right: 3px;
-        width: 32px;
       }
     }
 

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -3,7 +3,8 @@
   background-image: none;
   border-color: #DFDFDF;
 
-  .xtb-text {
+  .xtb-text,
+  .x-toolbar-cell label {
     margin: 0 5px 0 7px;
     padding: 0;
   }

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -1,0 +1,193 @@
+.x-toolbar {
+  background-color: #F7F7F7;
+  background-image: none;
+  border-color: #DFDFDF;
+}
+
+.x-toolbar td,.x-toolbar span,.x-toolbar input,
+.x-toolbar div,.x-toolbar select,.x-toolbar label {
+  font: $fontSmall;
+}
+
+.x-toolbar .x-item-disabled {
+  color: gray;
+}
+
+.x-toolbar .x-item-disabled * {
+  color: gray;
+}
+
+.x-toolbar em.x-btn-split {
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-noline.gif');
+}
+
+.x-toolbar .x-btn-over em.x-btn-split,
+.x-toolbar .x-btn-click em.x-btn-split,
+.x-toolbar .x-btn-menu-active em.x-btn-split,
+.x-toolbar .x-btn-pressed em.x-btn-split {
+ /* background-image: url($imgPath + 'modx-theme/button/s-arrow-o.gif');*/
+}
+
+.x-toolbar em.x-btn-split-bottom {
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-b-noline.gif');
+}
+
+.x-toolbar .x-btn-over em.x-btn-split-bottom,
+.x-toolbar .x-btn-click em.x-btn-split-bottom,
+.x-toolbar .x-btn-menu-active em.x-btn-split-bottom,
+.x-toolbar .x-btn-pressed em.x-btn-split-bottom {
+  background-image: url($imgPath + 'modx-theme/button/s-arrow-bo.gif');
+}
+
+.ext-ie .x-toolbar-cell .x-form-field-wrap {
+  height: 30px;
+}
+
+.x-tbar-page-first {
+  background-image: url($imgPath + 'modx-theme/grid/page-first.png') !important;
+}
+
+.x-tbar-loading {
+  background-image: url($imgPath + 'modx-theme/grid/refresh.png') !important;
+}
+
+.x-tbar-page-last {
+  background: none !important;
+  position:relative;
+  &:before {
+    @extend %pseudo-font-x-btn;
+    content:$fa-var-forward;
+    top:1px;
+    left:1px;
+    right:auto;
+  }
+}
+
+.x-tbar-page-next {
+  background: none !important;
+  position:relative;
+  &:before {
+    @extend %pseudo-font-x-btn;
+    content:$fa-var-caret-right;
+    font-size:18px;
+    line-height:110%;
+    left:1px;
+    right:auto;
+  }
+}
+
+.x-tbar-page-prev {
+  background: none !important;
+  position:relative;
+  &:before {
+    @extend %pseudo-font-x-btn;
+    content:$fa-var-caret-left;
+    font-size:18px;
+    line-height:110%;
+    left:auto;
+    right:1px;
+  }
+}
+
+.x-tbar-loading {
+  background: none !important;
+  position:relative;
+  &:before {
+    @extend %pseudo-font-x-btn;
+    content:$fa-var-repeat;
+    top:1px;
+    bottom:auto;
+  }
+}
+
+.x-tbar-page-first {
+  background: none !important;
+  position:relative;
+  &:before {
+    @extend %pseudo-font-x-btn;
+    content:$fa-var-backward;
+    top:1px;
+    left:auto;
+    right:1px;
+  }
+}
+
+.x-paging-info {
+  color: #444;
+}
+
+.x-toolbar-more-icon {
+  background-image: url($imgPath + 'modx-theme/toolbar/more.gif') !important;
+}
+
+.x-panel-bbar {
+  padding-top: 10px;
+
+  .x-toolbar {
+    background-color: transparent;
+    border: 0 none;
+    overflow: hidden;
+
+    .x-form-text {
+      padding: 5px 10px;
+      width: 32px !important; /* overrides the 12px inline width I have no idea where it's coming from */
+    }
+
+    .x-btn {
+      margin-right: 10px;
+      padding: 8px 13px;
+    }
+  }
+}
+
+.x-panel-tbar {
+  padding-bottom: 2px;
+
+  .x-toolbar {
+    background-color: #F5F5F5;
+    border: 0 none;
+    padding: 5px 0;
+    overflow: hidden;
+  }
+}
+
+.x-panel-mc .x-panel-tbar .x-toolbar {
+  background-image: none;
+}
+.x-panel-tbar-noheader .x-toolbar {
+  background-color: transparent;
+  background-image: none;
+  border: 0 none;
+  padding: 5px 0;
+}
+
+
+
+.x-toolbar td, .x-toolbar span, .x-toolbar input, .x-toolbar div, .x-toolbar select, .x-toolbar label {
+  border-radius: $borderRadius;
+}
+.x-html-editor-tb .x-btn-text {
+  background-image: url($imgPath + 'modx-theme/editor/tb-sprite.gif');
+}
+.x-panel-noborder .x-panel-tbar-noborder .x-toolbar {
+  background-color: transparent;
+  border-bottom-color: transparent;
+}
+.x-panel-noborder .x-panel-bbar-noborder .x-toolbar {
+  border-top-color: transparent;
+}
+
+.x-window .x-window-bbar .x-toolbar,
+.x-window .x-window-bbar-noborder .x-toolbar {
+  background: #d5dade;
+  background: linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#eff0f4,endColorstr=#d5dade,GradientType=0);
+  border-radius: 0 0 $borderRadius $borderRadius;
+  border-bottom: 0 none;
+  border-top: 1px solid #d4d9df;
+  padding: 8px;
+}
+
+.ext-ie7 .x-toolbar-ct {
+  width: auto;
+}

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -2,24 +2,29 @@
   background-color: #F7F7F7;
   background-image: none;
   border-color: #DFDFDF;
+
+  .xtb-text {
+    margin: 0 5px 0 7px;
+    padding: 0;
+  }
+
+  .x-item-disabled {
+    opacity: 0.8;
+  }
+
+  td.x-toolbar-cell {
+    &:first-of-type {
+      .xtb-text {
+        margin-left: 0;
+      }
+    }
+  }
 }
 
 .x-toolbar td,.x-toolbar span,.x-toolbar input,
 .x-toolbar div,.x-toolbar select,.x-toolbar label {
   font: $fontSmall;
 }
-
-.x-toolbar .x-item-disabled {
-  color: gray;
-}
-
-.x-toolbar .x-item-disabled * {
-  color: gray;
-}
-
-/*.x-toolbar em.x-btn-split {
-  background-image: url($imgPath + 'modx-theme/button/s-arrow-noline.gif');
-}*/
 
 .x-toolbar .x-btn-over em.x-btn-split,
 .x-toolbar .x-btn-click em.x-btn-split,
@@ -127,15 +132,24 @@
     background-color: transparent;
     border: 0 none;
     overflow: hidden;
+    padding: 2px 0; /* override extjs default style of 2px 2px */
 
     .x-form-text {
       padding: 5px 10px;
       width: 32px !important; /* overrides the 12px inline width I have no idea where it's coming from */
+
+      &.x-tbar-page-number {
+        margin-right: 3px;
+      }
     }
 
     .x-btn {
       margin-right: 10px;
       padding: 8px 13px;
+    }
+
+    .xtb-text {
+      margin: 0 3px 0 0;
     }
   }
 }

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -102,10 +102,10 @@
   padding: 0;
   #modx-file-tree & {
     &:first-child {
-      padding-top: 39px; /* ya, it's empty there, but looks also crappy with 5px */
+      padding-top: 3px;
     }
     .tree-pseudoroot-node {
-      /* why, this prevents the spacing between the nodes */
+      /* why was this here? this prevents the spacing between the nodes/sources in the filetree */
       /*margin-top: 0;
       margin-bottom: 0;*/
     }
@@ -215,6 +215,7 @@
 .hidemenu,
 .hidemenu a span {
   color: $hidden;
+  font-style: normal;
 
   i.icon,
   i.icon-large {
@@ -346,9 +347,11 @@
   padding: 3px;
   text-align: center;
   opacity: 0.8;
+
   i {
     font-style: normal;
   }
+
   button {
     display: none;
   }

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -102,7 +102,7 @@
   padding: 0;
   #modx-file-tree & {
     &:first-child {
-      padding-top: 3px;
+      padding-top: 4px;
     }
     .tree-pseudoroot-node {
       /* why was this here? this prevents the spacing between the nodes/sources in the filetree */

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -7,10 +7,13 @@
     margin: 25px 10px 25px 25px;
   }
   /* the toolbars just below the tabs */
+  & .x-panel-tbar {
+    padding: 0;
+  }
   & .x-toolbar {
     padding: 6px 5px 0px;
   }
-  /* root box contaiing a context or category */
+  /* root box containing a context or category */
   & .x-tree-root-ct {
     padding: 6px;
   }
@@ -20,8 +23,14 @@
   }
   
   .x-tab-panel-bwrap {
+    border-radius: $borderRadius 0 $borderRadius $borderRadius;
 	  position: relative;
 	  z-index: 1;
+
+    .x-tab-panel-body-noborder {
+      border-radius: $borderRadius 0 $borderRadius $borderRadius;
+      background-color: $white;
+    }
   }
 }
 
@@ -33,34 +42,58 @@
 #modx-leftbar-tabpanel {
 }
 
-/* tree menu splitter */
-.x-layout-split {
+/* tree menu splitter / tree expander */
+.x-layout-split,
+#modx-leftbar-tabs-xcollapsed {
+  overflow: visible;
   width: 8px;
-  z-index: 0;
+  z-index: 2; /* make it stay higher than the tree itself to cover the box shadow */
 
   &:hover {
     background: $navbarHover;
   }
 
   .x-layout-mini {
-    left: -11px;
     background-color: #fff;
-    width: 10px;
-    height: 50px;
+    box-shadow: $boxShadow;
     background-image: none;
     background-repeat: no-repeat;
     background-position: center left;
-    border-radius: 0 4px 4px 0;
+    border-radius: 0 $borderRadius $borderRadius 0;
+    left: -9px;
+    top: 65px;
+    width: 11px; /* to have left and right 3px equal space from the arrow which is 5px */
+    height: 41px;
     opacity: 1;
 
     &:after {
       border-top: 5px solid transparent;
       border-bottom: 5px solid transparent;
-      border-right: 5px solid $colorSplash;
+      border-right: 5px solid $treeColor;
       position: absolute;
       content: ' ';
       right: 4px;
-      top: 21px;
+      top: 16px;
+    }
+
+    &:hover:after {
+      border-right-color: $colorSplash;
+    }
+  }
+}
+
+/* style for the collapsed tree expander */
+#modx-leftbar-tabs-xcollapsed {
+  .x-layout-mini {
+    left: 0;
+
+    &:after {
+      border-right: 0;
+      border-left: 5px solid $treeColor;
+    }
+
+    &:hover:after {
+      border-left-color: $colorSplash;
     }
   }
 }
@@ -69,11 +102,12 @@
   padding: 0;
   #modx-file-tree & {
     &:first-child {
-      padding-top: 5px;
+      padding-top: 39px; /* ya, it's empty there, but looks also crappy with 5px */
     }
     .tree-pseudoroot-node {
-      margin-top: 0;
-      margin-bottom: 0;
+      /* why, this prevents the spacing between the nodes */
+      /*margin-top: 0;
+      margin-bottom: 0;*/
     }
   }
 }
@@ -153,7 +187,7 @@
     vertical-align: -15%;
   }
 
-  // For legacy icons
+  /* For legacy icons */
   background-repeat: no-repeat;
   background-position: 5px;
 }
@@ -196,12 +230,14 @@
       color: $deleted;
       font-style: normal;
   }
+
+  a span {
+    color: $deleted;
+    text-decoration: $delTextDeco;
+    font-style: $delTextStyle;
+  }
 }
-.deleted a span {
-  color: $deleted;
-  text-decoration: $delTextDeco;
-  font-style: $delTextStyle;
-}
+
 .element-node-disabled a span {
   color: $disabled;
 }
@@ -280,7 +316,7 @@
   display: inline-block;
 
   #modx-leftbar-tabpanel & {
-    //display: inline;
+    /*display: inline;*/
   }
 }
 

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -217,6 +217,11 @@
   color: $hidden;
   font-style: normal;
 
+  &.unpublished,
+  &.unpublished a span {
+    font-style: $unpubText;
+  }
+
   i.icon,
   i.icon-large {
       color: $hidden;

--- a/_build/templates/default/sass/_uberbar.scss
+++ b/_build/templates/default/sass/_uberbar.scss
@@ -13,6 +13,9 @@
           }
       }
   }
+  .x-form-text {
+    background: none; /* prevent white searchfield background */
+  }
 }
 
 #modx-navbar #modx-manager-search:hover { /* #shame */

--- a/_build/templates/default/sass/_uberbar.scss
+++ b/_build/templates/default/sass/_uberbar.scss
@@ -34,7 +34,7 @@
 #modx-manager-search .x-form-field-wrap {
   background: rgba(0,0,0,0.25);
   border:0;
-  border-radius:4px;
+  border-radius: $borderRadius;
   overflow:hidden;
   color: #565353;
   font-size: 12px;

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -46,13 +46,13 @@
   background-image: url($imgPath + 'modx-theme/grid/loading.gif');
 }
 
-.x-item-disabled {
+/*.x-item-disabled {
   color: gray;
 }
 
 .x-item-disabled * {
   color: gray !important;
-}
+}*/
 
 .x-splitbar-proxy {
   background-color: #aaa;

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -818,6 +818,7 @@ td.x-date-mp-sep {
 .x-panel-body {
   background-color: #fff;
   border: 0;
+  border-radius: $borderRadius;
   overflow: visible;
 }
 .x-panel-noborder {

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -821,6 +821,9 @@ td.x-date-mp-sep {
   border-radius: $borderRadius;
   overflow: visible;
 }
+#modx-panel-packages-browser .x-panel-body {
+  border-radius: 0; /* prevent rounded border on most pouplar / last updated panels */
+}
 .x-panel-noborder {
   border: none;
 }

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -809,38 +809,6 @@ td.x-date-mp-sep {
 #x-debug-browser .x-tree .x-tree-node .x-tree-selected a span {
   background-color: #d8d8d8;
 }
-
-.x-combo-list {
-  background-color: $dropdownBg;
-  border-color: $dropdownBorder;
-  border-radius: 0 0 5px 5px;
-}
-.x-combo-list-inner {
-  background-color: $dropdownBg;
-}
-.x-combo-list-hd {
-  background-image: url($imgPath + 'modx-theme/layout/panel-title-light-bg.gif');
-  border-bottom-color: #bcbcbc;
-  color: #464646;
-}
-.x-resizable-pinned .x-combo-list-inner {
-  border-bottom-color: transparent;
-}
-.x-combo-list-item {
-  border: none;
-  padding: 5px;
-  color: $dropdownTextColor;
-}
-.x-combo-list .x-combo-selected {
-  background-color: $dropdownSelectedBg;
-  border: 0 none !important;
-}
-.x-combo-list .x-toolbar {
-  border-top-color: #bcbcbc;
-}
-.x-combo-list-small {
-  font: $fontSmall;
-}
 /*.x-panel {
     border:0 none;
 }*/
@@ -1263,9 +1231,6 @@ body.x-body-masked .x-window-plain .x-window-mc {
 /* draggable grids */
 .modx-grid-draggable .x-grid3-row {
   cursor: move;
-}
-.x-window .desc-under .warning {
-  color: #df8d00;
 }
 .x-window h2 {
   border-bottom: 1px solid #D6DFC3;

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -96,151 +96,8 @@
   background-color: #ccc;
 }
 
-
-.x-panel-tbar-noheader .x-toolbar, .x-panel-mc .x-panel-tbar .x-toolbar {
-  border-bottom: 0 none;
-  border-top: none;
-}
-
-.x-panel-bbar .x-toolbar, .x-panel-tbar .x-toolbar {
-  border-width: 0;
-  overflow: hidden;
-}
-.x-panel-bbar {
-  padding-top: 10px;
-}
-.x-panel-tbar {
-  padding-bottom: 2px; 
-}
-
 .ext-ie7 .x-plain-body {
   position: relative;
-}
-
-.ext-ie7 .x-toolbar-ct {
-  width: auto;
-}
-
-.x-toolbar {
-  background-color: #F7F7F7;
-  background-image: none;
-  border-color: #DFDFDF;
-}
-
-.x-toolbar td,.x-toolbar span,.x-toolbar input,
-.x-toolbar div,.x-toolbar select,.x-toolbar label {
-  font: $fontSmall;
-}
-
-.x-toolbar .x-item-disabled {
-  color: gray;
-}
-
-.x-toolbar .x-item-disabled * {
-  color: gray;
-}
-
-.x-toolbar em.x-btn-split {
-  background-image: url($imgPath + 'modx-theme/button/s-arrow-noline.gif');
-}
-
-.x-toolbar .x-btn-over em.x-btn-split,
-.x-toolbar .x-btn-click em.x-btn-split,
-.x-toolbar .x-btn-menu-active em.x-btn-split,
-.x-toolbar .x-btn-pressed em.x-btn-split {
- /* background-image: url($imgPath + 'modx-theme/button/s-arrow-o.gif');*/
-}
-
-.x-toolbar em.x-btn-split-bottom {
-  background-image: url($imgPath + 'modx-theme/button/s-arrow-b-noline.gif');
-}
-
-.x-toolbar .x-btn-over em.x-btn-split-bottom,
-.x-toolbar .x-btn-click em.x-btn-split-bottom,
-.x-toolbar .x-btn-menu-active em.x-btn-split-bottom,
-.x-toolbar .x-btn-pressed em.x-btn-split-bottom {
-  background-image: url($imgPath + 'modx-theme/button/s-arrow-bo.gif');
-}
-
-.ext-ie .x-toolbar-cell .x-form-field-wrap {
-  height: 30px;
-}
-
-.x-tbar-page-first {
-  background-image: url($imgPath + 'modx-theme/grid/page-first.png') !important;
-}
-
-.x-tbar-loading {
-  background-image: url($imgPath + 'modx-theme/grid/refresh.png') !important;
-}
-
-.x-tbar-page-last {
-  background: none !important;
-  position:relative;
-  &:before {
-    @extend %pseudo-font-x-btn;
-    content:$fa-var-forward;
-    top:1px;
-    left:1px;
-    right:auto;
-  }
-}
-
-.x-tbar-page-next {
-  background: none !important;
-  position:relative;
-  &:before {
-    @extend %pseudo-font-x-btn;
-    content:$fa-var-caret-right;
-    font-size:18px;
-    line-height:110%;
-    left:1px;
-    right:auto;
-  }
-}
-
-.x-tbar-page-prev {
-  background: none !important;
-  position:relative;
-  &:before {
-    @extend %pseudo-font-x-btn;
-    content:$fa-var-caret-left;
-    font-size:18px;
-    line-height:110%;
-    left:auto;
-    right:1px;
-  }
-}
-
-.x-tbar-loading {
-  background: none !important;
-  position:relative;
-  &:before {
-    @extend %pseudo-font-x-btn;
-    content:$fa-var-repeat;
-    top:1px;
-    bottom:auto;
-  }
-}
-
-.x-tbar-page-first {
-  background: none !important;
-  position:relative;
-  &:before {
-    @extend %pseudo-font-x-btn;
-    content:$fa-var-backward;
-    top:1px;
-    left:auto;
-    right:1px;
-  }
-}
-
-.x-paging-info {
-  color: #444;
-}
-
-.x-toolbar-more-icon {
-  background-image: url($imgPath + 'modx-theme/toolbar/more.gif') !important;
 }
 
 .x-statusbar .x-status-busy {
@@ -301,7 +158,7 @@
 .x-grid3 {
   background-color: transparent;
   background-image: none;
-  border-radius: 3px;
+  border-radius: $borderRadius;
   overflow: hidden;
   padding: 0;
 }
@@ -765,7 +622,7 @@ td.x-date-mp-sep {
 }
 .x-tip {
   background: darken($tipText, 60%);
-  border-radius: 3px;
+  border-radius: $borderRadius;
   padding: 5px;
 }
 .x-tip .x-tip-close {
@@ -958,7 +815,7 @@ td.x-date-mp-sep {
   border-color: $dropdownBorder;
   border-radius: 0 0 5px 5px;
 }
-.x-combo-list-inner{
+.x-combo-list-inner {
   background-color: $dropdownBg;
 }
 .x-combo-list-hd {
@@ -1004,32 +861,7 @@ td.x-date-mp-sep {
 
 
 
-.x-panel-bbar .x-toolbar {
-  background-color: transparent;
-  border: 0 none;
-}
-.x-panel-tbar-noheader .x-toolbar, .x-panel-mc .x-panel-tbar .x-toolbar {
-  border: 0 none;
-}
-.x-panel-tbar .x-toolbar {
-  background-color: transparent;
-  border: 0 none;
-  padding: 5px 4px;
-}
-.x-panel-mc .x-panel-tbar .x-toolbar {
-  background-image: none;
-}
-.x-panel-tbar-noheader .x-toolbar {
-  background-color: transparent;
-  background-image: none;
-  border: 0 none;
-  padding: 5px 0;
-}
-.x-panel-mc .x-panel-tbar .x-toolbar {
-  background-color: #F5F5F5;
-  border-bottom: 0 none;
-  padding: 5px 0;
-}
+
 .x-grid-panel .x-panel-body {
   background-color: #F5F5F5;
   border-bottom: 1px solid #E4E4E4;
@@ -1079,7 +911,7 @@ td.x-date-mp-sep {
 }
 .x-panel-btns {
   background-color: transparent;
-  border-top: 1px solid #FAFAFA;
+  /*border-top: 1px solid #FAFAFA;*/
 }
 .x-panel-mc {
   background-color: #F5F5F5;
@@ -1239,7 +1071,7 @@ td.x-date-mp-sep {
   font-weight: bold;
 }
 .x-panel-header {
-  border-radius: 2px 2px 0 0;
+  border-radius: $borderRadius $borderRadius 0 0;
   background: #dddddd;
   background: -moz-linear-gradient(center bottom, #dddddd 0%, #eeeeee 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, #dddddd 0%, #eeeeee 100%);
@@ -1295,21 +1127,8 @@ body.x-body-masked .x-window-plain .x-window-mc {
   background-color: #fff;
   border-color: #bcbcbc;
 }
-.x-toolbar td, .x-toolbar span, .x-toolbar input, .x-toolbar div, .x-toolbar select, .x-toolbar label {
-  border-radius: 3px;
-}
-.x-html-editor-tb .x-btn-text {
-  background-image: url($imgPath + 'modx-theme/editor/tb-sprite.gif');
-}
 .x-panel-noborder .x-panel-header-noborder {
   border-bottom-color: transparent;
-}
-.x-panel-noborder .x-panel-tbar-noborder .x-toolbar {
-  background-color: transparent;
-  border-bottom-color: transparent;
-}
-.x-panel-noborder .x-panel-bbar-noborder .x-toolbar {
-  border-top-color: transparent;
 }
 .x-border-layout-ct {
   background-color: #FAFAFA;
@@ -1550,7 +1369,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
 .x-window .x-window-tl {
   background-color: #ffffff;
   background-image: none;
-  border-radius: 3px 3px 0 0;
+  border-radius: $borderRadius $borderRadius 0 0;
   overflow: hidden;
   padding-left: 0;
 }
@@ -1563,7 +1382,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
   background: -webkit-linear-gradient(center bottom, #d0d0d0 0%, #eeeeee 100%);
   background: linear-gradient(center bottom, #d0d0d0 0%, #eeeeee 100%);
   border-bottom: 1px solid #ababab;
-  border-radius: 3px 3px 0 0;
+  border-radius: $borderRadius $borderRadius 0 0;
   color: #5e5e5e;
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#eeeeee,endColorstr=#d0d0d0,GradientType=0);
   margin-top: 0;
@@ -1574,7 +1393,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
 .x-window .x-window-bl {
   background-color: #ffffff;
   background-image: none;
-  border-radius: 0 0 3px 3px;
+  border-radius: 0 0 $borderRadius $borderRadius;
   overflow: hidden;
   padding-left: 0;
 }
@@ -1623,27 +1442,11 @@ body.x-body-masked .x-window-plain .x-window-mc {
 }
 .x-window .x-window-mc {
   background-color: #ffffff;
-  border-radius: 0 0  3px 3px;
+  border-radius: 0 0 $borderRadius $borderRadius;
   border: 0 none;
 }
 .x-window .x-window-maximized .x-window-tc {
   background-color: #ffffff;
-}
-.x-window .x-window-bbar .x-toolbar,
-.x-window .x-window-bbar-noborder .x-toolbar {
-  background-color: #f7f8fa;
-  background: #d5dade;
-  background: -moz-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
-  background: -o-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #eff0f4), color-stop(100%, #d5dade));
-  background: -webkit-linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
-  background: linear-gradient(center bottom, #d5dade 0%, #eff0f4 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#eff0f4,endColorstr=#d5dade,GradientType=0);
-  border-radius: 0 0 3px 3px;
-  border-bottom: 0 none;
-  border-top: 1px solid #d4d9df;
-  padding: 8px;
 }
 .x-window .x-dlg-mask {
   background-color: #cccccc;

--- a/_build/templates/default/sass/components/_components.scss
+++ b/_build/templates/default/sass/components/_components.scss
@@ -1,2 +1,3 @@
 @import "shaded-box";
 @import "primary-button";
+@import "secondary-button";

--- a/_build/templates/default/sass/components/_primary-button.scss
+++ b/_build/templates/default/sass/components/_primary-button.scss
@@ -3,22 +3,32 @@
   background-color: $buttonPrimaryBg1;
   box-shadow: none;
   color: $buttonColorPrimary;
-  &.x-item-disabled {
-    opacity:1;
-    background: $desaturatedSplash;
-  }
+
   & button {
     color: $buttonColorPrimary;
   }
-  &.x-item-disabled * {
-    color: $buttonColorDisabled !important;
-  }
-  &.x-btn-over {
+
+  &.x-btn-over,
+  &:hover {
     @include background-image(linear-gradient(left top, $buttonPrimaryBg1Hover, $buttonPrimaryBg2Hover));
     box-shadow: none;
   }
-  &.x-btn-click {
+
+  &.x-btn-focus,
+  &.x-btn-click,
+  &:active {
     @include background-image(linear-gradient(left top, $buttonPrimaryBg1Active, $buttonPrimaryBg2Active));
     box-shadow: none;
+  }
+
+  &.x-item-disabled,
+  &.x-item-disabled:hover,
+  &.x-item-disabled:active {
+    /*background: $desaturatedSplash;*/
+    @include background-image(linear-gradient(left top, $buttonPrimaryBg1,$buttonPrimaryBg2));
+    background-color: $buttonPrimaryBg1;
+    box-shadow: none;
+    color: $buttonColorPrimary;
+    opacity: 0.6
   }
 }

--- a/_build/templates/default/sass/components/_primary-button.scss
+++ b/_build/templates/default/sass/components/_primary-button.scss
@@ -1,6 +1,7 @@
 %primary-button {
-  background: $buttonPrimaryBg1;
-  @include background-image(linear-gradient($buttonPrimaryBg1,$buttonPrimaryBg2));
+  @include background-image(linear-gradient(left top, $buttonPrimaryBg1,$buttonPrimaryBg2));
+  background-color: $buttonPrimaryBg1;
+  box-shadow: none;
   color: $buttonColorPrimary;
   &.x-item-disabled {
     opacity:1;
@@ -13,6 +14,6 @@
     color: $buttonColorDisabled !important;
   }
   &.x-btn-over {
-    @include background-image(linear-gradient(darken($buttonPrimaryBg1,2%),darken($buttonPrimaryBg2,2%)));
+    @include background-image(linear-gradient(left top, lighten($buttonPrimaryBg1,12%),ligthen($buttonPrimaryBg2,12%)));
   }
 }

--- a/_build/templates/default/sass/components/_primary-button.scss
+++ b/_build/templates/default/sass/components/_primary-button.scss
@@ -14,6 +14,11 @@
     color: $buttonColorDisabled !important;
   }
   &.x-btn-over {
-    @include background-image(linear-gradient(left top, lighten($buttonPrimaryBg1,12%),ligthen($buttonPrimaryBg2,12%)));
+    @include background-image(linear-gradient(left top, $buttonPrimaryBg1Hover, $buttonPrimaryBg2Hover));
+    box-shadow: none;
+  }
+  &.x-btn-click {
+    @include background-image(linear-gradient(left top, $buttonPrimaryBg1Active, $buttonPrimaryBg2Active));
+    box-shadow: none;
   }
 }

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -1,0 +1,47 @@
+%secondary-button {
+  /*background: linear-gradient(180deg, rgba(228, 233, 238, 1) 0%, rgba(210, 219, 226, 1) 100%) no-repeat;*/
+  background: white;
+  border-radius: $borderRadius;
+  box-shadow: $shadowBorder;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-block;
+  *display: inline;
+  /*margin: 0 1px;*/
+  padding: 10px 15px;
+  position: relative;
+  text-decoration: none;
+  zoom: 1;
+  /*border: 1px solid rgb(200, 210, 220);*/
+  & button {
+    font-size: 13px;
+    color: $regularButtonColor;
+    cursor: pointer;
+    height: 16px;
+    min-width: 100%;
+    vertical-align: middle;
+  }
+  &.x-btn-over {
+    /*border-color:darken($gainsboro,40%);*/
+    /*background-color:$gainsboro;*/
+    background-color:$actionable;
+  }
+  &.x-btn-focus {
+
+  }
+  &.x-btn-click {
+    background: $colorSplash;
+    box-shadow: $shadowBorderActive;
+    color: $white;
+
+    button {
+      color: $white;
+    }
+  }
+  &.x-item-disabled * {
+    opacity: 0.8;
+  }
+  &.primary-button {
+  @extend %primary-button;
+  }
+}

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -1,6 +1,7 @@
 %secondary-button {
   /*background: linear-gradient(180deg, rgba(228, 233, 238, 1) 0%, rgba(210, 219, 226, 1) 100%) no-repeat;*/
   background: white;
+  border: 0;
   border-radius: $borderRadius;
   box-shadow: $shadowBorder;
   line-height: 1;
@@ -21,10 +22,28 @@
     min-width: 100%;
     vertical-align: middle;
   }
+  .x-btn-split {
+    display: block;
+    padding-right: 20px;
+    position:relative;
+    &:before {
+      @extend %pseudo-font;
+      color: inherit;
+      content: $fa-var-caret-down;
+      font-size: 14px;
+      position: absolute;
+      top: 1px;
+      right: 0;
+    }
+    & button {
+      border-right: 1px solid rgba(255,255,255,0.4);
+      padding-right: 10px;
+    }
+  }
   &.x-btn-over {
     /*border-color:darken($gainsboro,40%);*/
     /*background-color:$gainsboro;*/
-    background-color:$actionable;
+    background-color: $actionable;
   }
   &.x-btn-focus {
 
@@ -35,7 +54,7 @@
     color: $white;
 
     button {
-      color: $white;
+      color: inherit;
     }
   }
   &.x-item-disabled * {

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -66,12 +66,15 @@
       content: $fa-var-caret-up;
     }
   }
-  &.x-item-disabled {
-    background: $white !important; /* prevent :hover and :active from overriding */
-    box-shadow: $shadowBorder !important; /* prevent :hover and :active from overriding */
-    opacity: 0.8;
+  &.x-item-disabled,
+  &.x-item-disabled:hover,
+  &.x-item-disabled:active {
+    background: $white;
+    box-shadow: $shadowBorder;
+    color: $regularButtonColor;
+    opacity: 0.6; /* extjs default theme is also 0.6 */
   }
   &.primary-button {
-  @extend %primary-button;
+    @extend %primary-button;
   }
 }

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -1,18 +1,16 @@
 %secondary-button {
-  /*background: linear-gradient(180deg, rgba(228, 233, 238, 1) 0%, rgba(210, 219, 226, 1) 100%) no-repeat;*/
-  background: white;
+  background: $white;
   border: 0;
   border-radius: $borderRadius;
   box-shadow: $shadowBorder;
-  line-height: 1;
   cursor: pointer;
-  display: block; /* make margins be exact */
-  /*margin: 0 1px;*/
+  display: inline-block;
+  *display: inline;
+  line-height: 1;
   padding: 10px 15px;
   position: relative;
   text-decoration: none;
   zoom: 1;
-  /*border: 1px solid rgb(200, 210, 220);*/
   & button {
     font-size: 13px;
     color: $regularButtonColor;
@@ -21,7 +19,8 @@
     min-width: 100%;
     vertical-align: middle;
   }
-  .x-btn-split {
+  .x-btn-split,
+  .x-btn-arrow {
     display: block;
     padding-right: 20px;
     position:relative;
@@ -35,13 +34,14 @@
       right: 0;
     }
     & button {
-      border-right: 1px solid rgba(255,255,255,0.4);
+      border-right-color: inherit;
+      border-right-style: solid;
+      border-right-width: 1px;
       padding-right: 10px;
     }
   }
-  &.x-btn-over {
-    /*border-color:darken($gainsboro,40%);*/
-    /*background-color:$gainsboro;*/
+  &.x-btn-over,
+  &:hover {
     background-color: $colorSplash;
     box-shadow: $shadowBorderHover;
     color: $white;
@@ -51,7 +51,8 @@
     }
   }
   &.x-btn-focus,
-  &.x-btn-click {
+  &.x-btn-click,
+  &:active {
     background: darken($colorSplash, 6%);
     box-shadow: $shadowBorderActive;
     color: $white;
@@ -65,7 +66,9 @@
       content: $fa-var-caret-up;
     }
   }
-  &.x-item-disabled * {
+  &.x-item-disabled {
+    background: $white !important; /* prevent :hover and :active from overriding */
+    box-shadow: $shadowBorder !important; /* prevent :hover and :active from overriding */
     opacity: 0.8;
   }
   &.primary-button {

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -6,8 +6,7 @@
   box-shadow: $shadowBorder;
   line-height: 1;
   cursor: pointer;
-  display: inline-block;
-  *display: inline;
+  display: block; /* make margins be exact */
   /*margin: 0 1px;*/
   padding: 10px 15px;
   position: relative;
@@ -43,18 +42,27 @@
   &.x-btn-over {
     /*border-color:darken($gainsboro,40%);*/
     /*background-color:$gainsboro;*/
-    background-color: $actionable;
-  }
-  &.x-btn-focus {
+    background-color: $colorSplash;
+    box-shadow: $shadowBorderHover;
+    color: $white;
 
+    button {
+      color: inherit;
+    }
   }
+  &.x-btn-focus,
   &.x-btn-click {
-    background: $colorSplash;
+    background: darken($colorSplash, 6%);
     box-shadow: $shadowBorderActive;
     color: $white;
 
     button {
       color: inherit;
+    }
+  }
+  &.x-btn-menu-active {
+    .x-btn-split:before {
+      content: $fa-var-caret-up;
     }
   }
   &.x-item-disabled * {

--- a/_build/templates/default/sass/components/_shaded-box.scss
+++ b/_build/templates/default/sass/components/_shaded-box.scss
@@ -16,7 +16,7 @@ having to do some real janky stuff to work with ExtJS markup
 	}
 	.x-tab-panel-bwrap {
 		.x-tab-panel-bwrap {
-			border-width:0 !important;
+			border-width:0 !important; /* #shame */
 		}
 	}
 }

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1220,15 +1220,16 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .modx-tv {
-  border-bottom: 1px solid #f4f4f4;
-  margin: 0;
-  padding: 15px 0 !important;
+  /*border-bottom: 1px solid #f4f4f4;*/
+  margin: 0 0 4px 0;
+  padding-bottom: 4px;
+  /*padding: 15px 0 !important;*/
   width: 100%;
 }
 
-#modx-tv-tabs .tv-first {
+/*#modx-tv-tabs .tv-first {
   padding-top: 0 !important;
-}
+}*/
 
 #modx-tv-tabs .tv-last {
   border-bottom: 0 !important;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -14,6 +14,7 @@ $fa-css-prefix:       icon;
 @import "tabs";
 @import "navbar";
 @import "uberbar";
+@import "toolbars";
 @import "tree";
 @import "help";
 
@@ -199,30 +200,6 @@ hr {
 	.x-tab-strip {
 		li {
 			@include box-sizing(border-box);
-		}
-	}
-}
-
-.x-window-footer {
-	.x-toolbar-right-row {
-		td {
-			&:last-of-type {
-        .x-btn {
-          @extend %primary-button;
-        }
-				/*.x-btn {
-					@include linear-gradient(lighten($primaryAction,10%), $primaryAction);
-					border-color:darken($primaryAction,6%);
-					button {
-						color:$white;
-					}
-				}
-				.x-btn-over {
-					border-color:darken($primaryAction,10%);
-					@include linear-gradient(lighten($primaryAction,16%), $primaryAction);
-				}*/
-
-			}
 		}
 	}
 }
@@ -563,7 +540,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
   background: url("/manager/templates/default/images/modx-theme/form/button-bg.png") repeat-x scroll 0 bottom gainsboro;
   border-collapse: separate;
   border-color: #CACACA #C0C0C0 #AAA;
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border-style: solid;
   border-width: 1px;
   box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
@@ -800,7 +777,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 /* status messages */
 .modx-status-msg {
   background: #f4f4f4;
-  border-radius: 4px;
+  border-radius: 5px;
   left: 70%;
   /*filter: alpha(opacity=80);*/
   margin: 0;
@@ -1119,7 +1096,7 @@ body.ext-ie7 .x-superboxselect-item {
 
 .dashboard-block {
   background-color: $white;
-  border-radius: 2px;
+  border-radius: $borderRadius;
   float: left;
   margin: 6px 0;
 }
@@ -1153,7 +1130,7 @@ body.ext-ie7 .x-superboxselect-item {
 
 .dashboard-block .title {
   background: #d2dbe2;
-  border-radius: 2px 2px 0 0;
+  border-radius: $borderRadius $borderRadius 0 0;
   color: #5E5E5E;
   font-size: 12px;
   font-weight: bold;
@@ -1817,7 +1794,7 @@ body.ext-ie7 .x-superboxselect-item {
   margin: 10px 0;
 }
 .modx-template-detail .selected img {
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border: 1px solid #aaa;
   height: 80px;
   width: 90px;
@@ -1885,7 +1862,7 @@ body.ext-ie7 .x-superboxselect-item {
 }
 .thumb-wrapper {
   background-color: #F5F5F5;
-  border-radius: 2px;
+  border-radius: $borderRadius;
   border: 1px solid #ccc;
   cursor: pointer;
   float: left;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -279,13 +279,10 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 
 .modx-console-text {
   background-color: white;
-  font: $bodyFontSize $codefonts !important;
-  padding: 8px;
   border: none;
-}
-
-.x-form-text.modx-console-text {
-  height: auto;
+  font: 12px $codefonts !important;
+  height: auto !important; /* override extjs default theme */
+  padding: 8px;
 }
 
 /* portlets */

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -141,45 +141,10 @@ hr {
   left: 2px;
 }
 
-#modx-resource-tabs {
-  margin: 20px 0 0;
-
-  @extend %shaded-tab-box;
-  .x-tab-panel-header {
-    width:auto !important; /* #shame */
-    &.vertical-tabs-header {
-      width:150px !important; /* #shame */
-    }
-    .x-tab-strip {
-      li {
-        float:left;
-        //width:auto;
-        margin-left:0;
-      }
-    }
-  }
-  #modx-tv-tabs {
-      border-left:0;
-      border-right:0;
-  }
-}
-
-#modx-resource-tvs-div #modx-tv-tabs, #modx-resource-tabs #modx-tv-tabs {
-	.x-tab-strip {
-		margin-top:12px;
-		li {
-			width:100% !important; /* #shame */
-			margin-left:0;
-			border-bottom:1px solid $borderColor;
-			&:nth-last-child(3) { border-color:transparent }
-			&.x-tab-strip-active { border-bottom:1px solid $borderColor; }
-		}
-	}
-}
-
 #modx-resource-content {
   background-color: $tabStripBg;
-  box-shadow: 0 0 5px rgba(0,0,0,0.1);
+  border-radius: $borderRadius;
+  box-shadow: $boxShadow;
   .x-panel-header {
       margin:0;
       padding: 15px;
@@ -1343,11 +1308,6 @@ body.ext-ie7 .x-superboxselect-item {
 
 #modx-resource-tvs-div {
   border-top-width: 0;
-}
-
-#modx-resource-tvs-div.below-content {
-  border-top-width: 1px;
-  margin-top: 10px;
 }
 
 .modx-permissions-list {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1271,8 +1271,10 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .modx-tv-label {
-  float: left;
-  width: auto !important;
+  display: inline-block;
+  /*float: left;*/
+  position: relative !important;
+  width: auto;
 }
 
 .modx-tv-label:hover .modx-tv-reset {
@@ -1280,23 +1282,27 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .modx-tv-label-title {
-  float: left;
+  /*float: left;*/
+  display: inline-block;
 }
 
 .modx-tv-label-description {
-  display: block;
-  float: left;
+  display: inline-block;
+  /*float: left;*/
   font-style: italic;
   font-weight: normal;
   padding-left: 5px;
 }
 
 .modx-tv-reset {
-  background: url($imgPath + 'restyle/icons/arrow_rotate_anticlockwise.png') top right no-repeat;
+  background: url($imgPath + 'restyle/icons/arrow_rotate_anticlockwise.png') bottom left no-repeat;
   cursor: pointer;
-  float: left;
+  display: inline-block;
+  /*float: left;*/
   height: 16px;
   opacity: 0;
+  padding: 38px 5px 0 0;
+  position: absolute; top: 0; left: -21px;
   width: 16px;
 }
 

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -207,7 +207,10 @@ hr {
 	.x-toolbar-right-row {
 		td {
 			&:last-of-type {
-				.x-btn {
+        .x-btn {
+          @extend %primary-button;
+        }
+				/*.x-btn {
 					@include linear-gradient(lighten($primaryAction,10%), $primaryAction);
 					border-color:darken($primaryAction,6%);
 					button {
@@ -217,7 +220,8 @@ hr {
 				.x-btn-over {
 					border-color:darken($primaryAction,10%);
 					@include linear-gradient(lighten($primaryAction,16%), $primaryAction);
-				}
+				}*/
+
 			}
 		}
 	}

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -36,7 +36,7 @@ body {
 h2, h3 {
   color:  $headerText;
   font:   $fontH2;
-  margin: 0 0 8px 5px;
+  margin: -3px 0 8px -1px; /* align main titles with treetabs and left panel edge */
 }
 h3 {
   font: $fontH3;
@@ -51,11 +51,11 @@ em {
 }
 
 hr {
-  background-color: #a1b7c4;
+  background-color: $borderColor;
   border: 0;
-  color: #a1b7c4;
+  color: $borderColor;
   height: 1px;
-  margin: 20px;
+  margin: 20px 0;
 }
 .aleft {
   text-align: left;
@@ -94,7 +94,7 @@ hr {
 }
 
 .primary {
-	color:$primaryAction !important;
+	color: $primaryAction !important;
 }
 
 .error {
@@ -1138,21 +1138,33 @@ body.ext-ie7 .x-superboxselect-item {
 .container {
   margin: 20px 15px 20px;
 }
-
-/* Wrap the main content */
-.structure-tabs {
-  /* margin-top: -1px; */
+/* prevent cut off box shadows */
+.container,
+.x-plain-bwrap,
+.x-plain-body {
+  overflow: visible;
 }
 
-/* Realign modx-tabs for getPageStructure */
+/* box-shadow for most panels + custom class to set explicitly */
+.shadowbox,
+.x-form-label-left {
+  border-radius: $borderRadius;
+  box-shadow: $boxShadow;
+
+  /* prevent box-shadow in nested panels */
+  .x-form-label-left {
+    border-radius: 0;
+    box-shadow: none;
+  }
+}
 
 /* Panel description text */
 .panel-desc {
-  background-color: #f5f5f5;
+  background-color: #f9f9f9;
   border: none;
-  color: #5A5A5A;
+  color: $darkNeutral;
   line-height: 1.5;
-  margin-top: 5px;
+  margin-top: 15px;
   padding: 15px !important;
 
   .x-panel-bwrap {
@@ -1323,78 +1335,127 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 /* Breadcrumbs */
-
-.crumb_wrapper {
-  border-bottom: 1px solid #CACACA;
-  border-top: 1px solid #D0D0D0;
-  margin-top: 5px;
-}
-
-.crumbs {
-  background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
-  background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  background: -o-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%, #fcfcfc), color-stop(100%, gainsboro));
-  background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
-  border-bottom: 1px solid #EFEFEF;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#fcfcfc,endColorstr=#dcdcdc,GradientType=0);
-  height: 34px;
-}
-
-.crumbs li {
-  background: url($imgPath + 'style/crumbs-bg.png') no-repeat scroll right center transparent;
-  color: $darkNeutral;
-  float: left;
-  font-size: 12px;
-  font-weight: normal;
-  line-height: 35px;
-  padding: 0 20px 0 15px;
-  text-shadow: 0 1px 0 #FFF;
-}
-
-.crumbs li button {
-  background-color: transparent;
-  border: 0 none;
-  color: $darkNeutral;
-  cursor: pointer;
-  font: $baseText;
-  font-weight: bold;
-  padding: 0;
-  text-decoration: none;
-}
-
-.crumbs li .root {
-  background: url($imgPath + 'style/home.png') no-repeat scroll center top transparent;
-  display: block;
-  height: 16px;
-  margin: 10px 0 9px;
-  text-indent: -999em;
-  width: 16px;
-}
-
-.crumbs li button:hover {}
-
-
-.crumbs li button.root {
-  background-position: center -16px;
-  text-indent: -999em;
-  width: 16px;
-}
-.crumbs li button.root:hover {}
-
-/*.breadcrumbs .highlight {
-	background-color: #FFF9DF;
-    border-color: #ECE3CB !important;
-    color: #5F5947;
-    font-weight: bold;
-}
-*/
-/* LIGHTBOX */
-
 .breadcrumbs .panel-desc {
-  margin-top: 1px;
+  margin-top: 0;
 }
+.crumb_wrapper {
+  background: #f9f9f9;
+  border-bottom: 1px solid $borderColor;
+  border-top: 1px solid $borderColor;
+  margin-top: 15px;
+
+  .crumbs {
+    /*border-bottom: 1px solid $borderColor;*/
+    height: 34px;
+    overflow: hidden; /* hide the overflow from the oversized arrows */
+
+    li {
+      /*background: url($imgPath + 'style/crumbs-bg.png') no-repeat scroll right center transparent;*/
+      color: $darkNeutral;
+      float: left;
+      font-size: 12px;
+      font-weight: normal;
+      line-height: 35px;
+      padding: 0 0 0 20px;
+      position: relative;
+
+      &.first {
+        padding: 0;
+
+        button {
+          padding: 8px 16px 8px 20px;
+        }
+      }
+
+      &:after {
+        content: " ";
+        display: block;
+        width: 0;
+        height: 0;
+        border-top: 50px solid transparent; /* Go big on the size, and let overflow hide */
+        border-bottom: 50px solid transparent;
+        border-left: 30px solid #f9f9f9;
+        position: absolute;
+        top: 50%;
+        margin-top: -50px;
+        left: 100%;
+        z-index: 2;
+      }
+      &:before {
+        content: " ";
+        display: block;
+        width: 0;
+        height: 0;
+        border-top: 50px solid transparent;      
+        border-bottom: 50px solid transparent;
+        border-left: 30px solid $darkNeutral;
+        position: absolute;
+        top: 50%;
+        margin-top: -50px;
+        /*margin-left: 1px;*/ /* uncomment to make the line thicker */
+        left: 100%;
+        z-index: 1;
+      }
+
+      &:hover {
+        background-color: $colorSplash;
+
+        button,
+        span {
+          color: $white;
+        }
+      }
+
+      &:hover:after {
+        border-left-color: $colorSplash;
+      }
+      &:hover:before {
+        border-left-color: $white;
+      }
+
+      button {
+        background-color: transparent;
+        border: 0 none;
+        color: $darkNeutral;
+        cursor: pointer;
+        font: $baseText;
+        font-weight: bold;
+        margin: 0;
+        padding: 8px 0 8px 20px;
+        text-decoration: none;
+      }
+
+      span {
+        padding-left: 20px;
+      }
+
+      .root {
+        /*background: url($imgPath + 'style/home.png') no-repeat scroll center top transparent;*/
+        display: block;
+        height: 16px;
+        margin: 10px 0 10px 0;
+        text-indent: -999em;
+        width: 16px;
+      }
+      .root:before {
+        @extend %pseudo-font-x-btn;
+
+        content: $fa-var-home;
+        display: block;
+        font-size: 20px;
+        line-height: 35px;
+        padding-left: 10px;
+        text-align: center;
+        text-indent: 0;
+      }
+      button.root {
+        /*background-position: center -16px;*/
+      }
+    }
+  }
+}
+
+/* Lightbox */
 #ux-lightbox {
   left: 0;
   line-height: 0;
@@ -1916,7 +1977,7 @@ body.ext-ie7 .x-superboxselect-item {
   color: $darkNeutral;
 }
 .x-grid3-col-info-col {
-  color: #92AF4C;
+  color: $green;
 }
 .not-installed .x-grid3-col-info-col {
   color: $red;
@@ -1934,6 +1995,7 @@ body.ext-ie7 .x-superboxselect-item {
   overflow: auto;
   padding: 15px;
   white-space: pre;
+  word-wrap: break-word;
 }
 .window-no-padding {
   .x-panel-mc {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1308,6 +1308,7 @@ body.ext-ie7 .x-superboxselect-item {
 
 #modx-resource-tvs-div {
   border-top-width: 0;
+  visibility: hidden; /* prevent flash of unstyled tv from elements on page load */
 }
 
 .modx-permissions-list {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1220,16 +1220,10 @@ body.ext-ie7 .x-superboxselect-item {
 }
 
 .modx-tv {
-  /*border-bottom: 1px solid #f4f4f4;*/
   margin: 0 0 4px 0;
   padding-bottom: 4px;
-  /*padding: 15px 0 !important;*/
   width: 100%;
 }
-
-/*#modx-tv-tabs .tv-first {
-  padding-top: 0 !important;
-}*/
 
 #modx-tv-tabs .tv-last {
   border-bottom: 0 !important;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1556,7 +1556,7 @@ body.ext-ie7 .x-superboxselect-item {
   background-color: transparent;
   z-index: 89;
 }
-/* Package Manager */
+/* Card Layout (ex. Package Manager) */
 .x-panel-body-noheader .x-grid3-row {
   position: relative;
 }
@@ -1568,7 +1568,7 @@ body.ext-ie7 .x-superboxselect-item {
   font: $baseText;
   font-size: 20px;
   line-height: 1;
-  margin: 0 0 2px;
+  margin: 0 0 5px 0;
 }
 .x-grid3-cell-inner.x-grid3-col-main  .not-installed {
   color: #999999;

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -78,8 +78,6 @@ img.loginCaptcha {
 }
 
 .login-form-bwrap {
-  -moz-border-radius: 10px;
-  -webkit-border-radius: 10px;
   background-color: white;
   border-radius: 10px;
   color: #eee;
@@ -87,8 +85,6 @@ img.loginCaptcha {
 }
 
 .login-form-bwrap-padding {
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
   background: black url($imgPath + 'restyle/manager-loginscreen-form-bg.png') bottom left no-repeat;
   border-radius: 5px;
   padding-bottom: 10px;
@@ -159,10 +155,8 @@ a {
 }
 
 #modx-panel-login-div {
-  -moz-border-radius: 3px;
-  -webkit-border-radius: 3px;
   background-color: white;
-  border-radius: 3px;
+  border-radius: $borderRadius;
 }
 
 label {
@@ -220,11 +214,6 @@ label {
 
 
 .login-form-btn {
-  -moz-border-radius: 3px;
-  -moz-box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
-  -o-box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
-  -webkit-border-radius: 3px;
-  -webkit-box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
   background: #eee;
   background: -moz-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%) repeat scroll 0 0 transparent;
   background: -ms-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
@@ -233,7 +222,7 @@ label {
   background: -webkit-linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
   background: linear-gradient(center bottom, gainsboro 0%, #fcfcfc 100%);
   background: url($imgPath + 'modx-theme/form/button-bg.png') repeat-x scroll 0 bottom gainsboro;
-  border-radius: 3px;
+  border-radius: $borderRadius;
   border: 2px solid #ddd;
   box-shadow: rgba(0, 0, 0, 0.2) 0 0 1px;
   color: #555;

--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -307,10 +307,10 @@ Ext.extend(MODx.browser.Window,Ext.Window,{
     }
 
     ,getToolbar: function() {
-        return ['-', {
+        return [{
             text: _('filter')+':'
             ,xtype: 'label'
-        }, '-', {
+        },{
             xtype: 'textfield'
             ,id: this.ident+'filter'
             ,selectOnFocus: true
@@ -322,10 +322,10 @@ Ext.extend(MODx.browser.Window,Ext.Window,{
                     }, this, {buffer:500});
                 }, scope:this}
             }
-        }, '-', {
+        },{
             text: _('sort_by')+':'
             ,xtype: 'label'
-        }, '-', {
+        },{
             id: this.ident+'sortSelect'
             ,xtype: 'combo'
             ,typeAhead: true

--- a/manager/assets/modext/sections/context/list.js
+++ b/manager/assets/modext/sections/context/list.js
@@ -14,6 +14,7 @@ MODx.page.Contexts = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 	});

--- a/manager/assets/modext/sections/context/update.js
+++ b/manager/assets/modext/sections/context/update.js
@@ -17,20 +17,24 @@ MODx.page.UpdateContext = function(config) {
         ,buttons: [{
             process: 'context/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls:'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || "s"
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             process: 'cancel'
             ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,params: {
                 a: 'context'
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/context/view.js
+++ b/manager/assets/modext/sections/context/view.js
@@ -24,39 +24,45 @@ Ext.extend(MODx.page.ViewContext,MODx.Component,{
 	    b.push({
 	        process: 'create'
 	        ,text: _('new')
+	        ,id: 'modx-abtn-new'
 	        ,params: {
 	            a: 'context/create'
 	        }
 	    },{
 	        process: 'edit'
 	        ,text: _('edit')
+	        ,id: 'modx-abtn-edit'
 	        ,params: {
 	            a: 'context/update'
 	            ,key: config.key
 	        }
-	    },'-',{
+	    },{
 	        process: 'duplicate'
 	        ,text: _('duplicate')
+	        ,id: 'modx-abtn-duplicate'
 	        ,method: 'remote'
 	        ,confirm: _('context_duplicate_confirm')
 	    });
 		if (config.key != 'web' && config.key != 'mgr') {
 			b.push({
-				process: 'delete',
-				text: _('delete'),
-				method: 'remote',
-				confirm: _('confirm_delete_context')
+				process: 'delete'
+				,text: _('delete')
+				,id: 'modx-abtn-delete'
+				,method: 'remote'
+				,confirm: _('confirm_delete_context')
 			});
 		}
-		b.push('-',{
+		b.push({
 	        process: 'cancel'
 	        ,text: _('cancel')
+	        ,id: 'modx-abtn-cancel'
 	        ,params: {
 	            a: 'context'
 	        }
 	    });
-        b.push('-',{
+        b.push({
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         });
 	    return b;

--- a/manager/assets/modext/sections/element/chunk/create.js
+++ b/manager/assets/modext/sections/element/chunk/create.js
@@ -12,18 +12,22 @@ MODx.page.CreateChunk = function(config) {
 		formpanel: 'modx-panel-chunk'
         ,buttons: [{
             process: 'element/chunk/create'
-            ,text: _('save')
-            ,method: 'remote'
-            ,checkDirty: true
             ,reload: true
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -13,20 +13,25 @@ MODx.page.UpdateChunk = function(config) {
         ,buttons: [{
             process: 'element/chunk/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('duplicate')
+            ,id: 'modx-abtn-duplicate'
             ,handler: this.duplicate
             ,scope: this
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/plugin/create.js
+++ b/manager/assets/modext/sections/element/plugin/create.js
@@ -12,18 +12,22 @@ MODx.page.CreatePlugin = function(config) {
         formpanel: 'modx-panel-plugin'
         ,buttons: [{
             process: 'element/plugin/create'
-            ,text: _('save')
-            ,method: 'remote'
-            ,checkDirty: true
             ,reload: true
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -13,20 +13,25 @@ MODx.page.UpdatePlugin = function(config) {
         ,buttons: [{
             process: 'element/plugin/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('duplicate')
+            ,id: 'modx-abtn-duplicate'
             ,handler: this.duplicate
             ,scope: this
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/propertyset/index.js
+++ b/manager/assets/modext/sections/element/propertyset/index.js
@@ -14,6 +14,7 @@ MODx.page.PropertySets = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
     });

--- a/manager/assets/modext/sections/element/snippet/create.js
+++ b/manager/assets/modext/sections/element/snippet/create.js
@@ -12,18 +12,22 @@ MODx.page.CreateSnippet = function(config) {
         formpanel: 'modx-panel-snippet'
         ,buttons: [{
             process: 'element/snippet/create'
-            ,text: _('save')
-            ,method: 'remote'
-            ,checkDirty: true
             ,reload: true
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || "s"
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -13,20 +13,25 @@ MODx.page.UpdateSnippet = function(config) {
         ,buttons: [{
             process: 'element/snippet/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('duplicate')
+            ,id: 'modx-abtn-duplicate'
             ,handler: this.duplicate
             ,scope: this
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/template/create.js
+++ b/manager/assets/modext/sections/element/template/create.js
@@ -12,18 +12,22 @@ MODx.page.CreateTemplate = function(config) {
         formpanel: 'modx-panel-template'
         ,buttons: [{
             process: 'element/template/create'
-            ,text: _('save')
-            ,method: 'remote'
-            ,checkDirty: true
             ,reload: true
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -14,20 +14,25 @@ MODx.page.UpdateTemplate = function(config) {
         ,buttons: [{
             process: 'element/template/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('duplicate')
+            ,id: 'modx-abtn-duplicate'
             ,handler: this.duplicate
             ,scope: this
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/tv/create.js
+++ b/manager/assets/modext/sections/element/tv/create.js
@@ -12,18 +12,22 @@ MODx.page.CreateTV = function(config) {
         formpanel: 'modx-panel-tv'
         ,buttons: [{
             process: 'element/tv/create'
-            ,text: _('save')
-            ,method: 'remote'
-            ,checkDirty: true
             ,reload: true
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -13,20 +13,25 @@ MODx.page.UpdateTV = function(config) {
         ,buttons: [{
             process: 'element/tv/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('duplicate')
+            ,id: 'modx-abtn-duplicate'
             ,handler: this.duplicate
             ,scope: this
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/fc/list.js
+++ b/manager/assets/modext/sections/fc/list.js
@@ -6,6 +6,7 @@ MODx.page.FormCustomization = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 	});

--- a/manager/assets/modext/sections/fc/profile/update.js
+++ b/manager/assets/modext/sections/fc/profile/update.js
@@ -18,19 +18,22 @@ MODx.page.UpdateFCProfile = function(config) {
         ,buttons: [{
             process: 'security/forms/profile/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
             ,cls:'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             process: 'cancel'
             ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,params: {a:'security/forms'}
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/fc/set/update.js
+++ b/manager/assets/modext/sections/fc/set/update.js
@@ -18,19 +18,22 @@ MODx.page.UpdateFCSet = function(config) {
         ,buttons: [{
             process: 'security/forms/set/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
             ,cls:'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             process: 'cancel'
             ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,params: {a:'security/forms/profile/update', id: config.record.profile}
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/resource/create.js
+++ b/manager/assets/modext/sections/resource/create.js
@@ -46,13 +46,12 @@ Ext.extend(MODx.page.CreateResource,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
+
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/create.js
+++ b/manager/assets/modext/sections/resource/create.js
@@ -36,9 +36,9 @@ Ext.extend(MODx.page.CreateResource,MODx.Component,{
             btns.push({
                 process: 'resource/create'
                 ,reload: true
+                ,text: _('save')
                 ,id: 'modx-abtn-save'
                 ,cls:'primary-button'
-                ,text: _('save')
                 ,method: 'remote'
                 //,checkDirty: true
                 ,keys: [{
@@ -46,17 +46,17 @@ Ext.extend(MODx.page.CreateResource,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
-            ,handler: MODx.loadHelpPane
             ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
         });
         return btns;
     }

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -11,21 +11,21 @@ MODx.page.ResourceData = function(config) {
     var btns = [];
     if (config.canEdit == 1) {
         btns.push({
-            id: 'modx-abtn-edit'
-            ,text: _('edit')
+            text: _('edit')
+            ,id: 'modx-abtn-edit'
             ,hidden: config.canEdit == 1 ? false : true
             ,handler: this.editResource
             ,scope: this
         });
-        btns.push('-');
+        // btns.push('-');
     }
     btns.push({
         text: _('view')
+        ,id: 'modx-abtn-preview'
         ,handler: this.preview
         ,scope: this
-        ,id: 'modx-abtn-preview'
     });
-    btns.push('-');
+    // btns.push('-');
     btns.push({
         text: _('cancel')
         ,id: 'modx-abtn-cancel'

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -17,7 +17,6 @@ MODx.page.ResourceData = function(config) {
             ,handler: this.editResource
             ,scope: this
         });
-        // btns.push('-');
     }
     btns.push({
         text: _('view')
@@ -25,7 +24,6 @@ MODx.page.ResourceData = function(config) {
         ,handler: this.preview
         ,scope: this
     });
-    // btns.push('-');
     btns.push({
         text: _('cancel')
         ,id: 'modx-abtn-cancel'

--- a/manager/assets/modext/sections/resource/static/create.js
+++ b/manager/assets/modext/sections/resource/static/create.js
@@ -35,27 +35,27 @@ Ext.extend(MODx.page.CreateStatic,MODx.Component,{
             btns.push({
                 process: 'resource/create'
                 ,reload: true
+                ,text: _('save')
                 ,id: 'modx-abtn-save'
                 ,cls:'primary-button'
-                ,text: _('save')
                 ,method: 'remote'
-                ,checkDirty: true
+                // ,checkDirty: true
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
-            ,handler: MODx.loadHelpPane
             ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
         });
         return btns;
     }

--- a/manager/assets/modext/sections/resource/static/create.js
+++ b/manager/assets/modext/sections/resource/static/create.js
@@ -45,13 +45,11 @@ Ext.extend(MODx.page.CreateStatic,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/static/update.js
+++ b/manager/assets/modext/sections/resource/static/update.js
@@ -91,62 +91,62 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
         if (cfg.canSave == 1) {
             btns.push({
                 process: 'resource/update'
+                ,text: _('save')
                 ,id: 'modx-abtn-save'
                 ,cls:'primary-button'
-                ,text: _('save')
                 ,method: 'remote'
-                ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
+                // ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         } else {
             btns.push({
                 text: cfg.lockedText || _('locked')
+                ,id: 'modx-abtn-locked'
                 ,handler: Ext.emptyFn
                 ,disabled: true
-                ,id: 'modx-abtn-locked'
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canCreate == 1) {
             btns.push({
                 text: _('duplicate')
+                ,id: 'modx-abtn-duplicate'
                 ,handler: this.duplicateResource
                 ,scope:this
-                ,id: 'modx-abtn-duplicate'
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
                 text: _('delete')
+                ,id: 'modx-abtn-delete'
                 ,handler: this.deleteResource
                 ,scope:this
-                ,id: 'modx-abtn-delete'
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
             text: _('view')
+            ,id: 'modx-abtn-preview'
             ,handler: this.preview
             ,scope: this
-            ,id: 'modx-abtn-preview'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
-            ,id: 'modx-abtn-cancel'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
-            ,handler: MODx.loadHelpPane
             ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
         });
         return btns;
     }

--- a/manager/assets/modext/sections/resource/static/update.js
+++ b/manager/assets/modext/sections/resource/static/update.js
@@ -101,7 +101,6 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
         } else {
             btns.push({
                 text: cfg.lockedText || _('locked')
@@ -109,7 +108,6 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
                 ,handler: Ext.emptyFn
                 ,disabled: true
             });
-            // btns.push('-');
         }
         if (cfg.canCreate == 1) {
             btns.push({
@@ -118,7 +116,6 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
                 ,handler: this.duplicateResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
@@ -127,7 +124,6 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
                 ,handler: this.deleteResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         btns.push({
             text: _('view')
@@ -135,14 +131,12 @@ Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
             ,handler: this.preview
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/symlink/create.js
+++ b/manager/assets/modext/sections/resource/symlink/create.js
@@ -45,13 +45,11 @@ Ext.extend(MODx.page.CreateSymLink,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/symlink/create.js
+++ b/manager/assets/modext/sections/resource/symlink/create.js
@@ -35,27 +35,27 @@ Ext.extend(MODx.page.CreateSymLink,MODx.Component,{
             btns.push({
                 process: 'resource/create'
                 ,reload: true
+                ,text: _('save')
                 ,id: 'modx-abtn-save'
                 ,cls:'primary-button'
-                ,text: _('save')
                 ,method: 'remote'
-                ,checkDirty: true
+                // ,checkDirty: true
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
-            ,handler: MODx.loadHelpPane
             ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
         });
         return btns;
     }

--- a/manager/assets/modext/sections/resource/symlink/update.js
+++ b/manager/assets/modext/sections/resource/symlink/update.js
@@ -89,53 +89,60 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
             btns.push({
                 process: 'resource/update'
                 ,text: _('save')
+                ,id: 'modx-abtn-save'
                 ,cls:'primary-button'
                 ,method: 'remote'
-                ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
+                // ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         } else {
             btns.push({
                 text: cfg.lockedText || _('locked')
+                ,id: 'modx-abtn-locked'
                 ,handler: Ext.emptyFn
                 ,disabled: true
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canCreate == 1) {
             btns.push({
                 text: _('duplicate')
+                ,id: 'modx-abtn-duplicate'
                 ,handler: this.duplicateResource
                 ,scope:this
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
                 text: _('delete')
+                ,id: 'modx-abtn-delete'
                 ,handler: this.deleteResource
                 ,scope:this
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
             text: _('view')
+            ,id: 'modx-abtn-preview'
             ,handler: this.preview
             ,scope: this
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         });
         return btns;

--- a/manager/assets/modext/sections/resource/symlink/update.js
+++ b/manager/assets/modext/sections/resource/symlink/update.js
@@ -98,7 +98,6 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
         } else {
             btns.push({
                 text: cfg.lockedText || _('locked')
@@ -106,7 +105,6 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
                 ,handler: Ext.emptyFn
                 ,disabled: true
             });
-            // btns.push('-');
         }
         if (cfg.canCreate == 1) {
             btns.push({
@@ -115,7 +113,6 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
                 ,handler: this.duplicateResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
@@ -124,7 +121,6 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
                 ,handler: this.deleteResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         btns.push({
             text: _('view')
@@ -132,14 +128,12 @@ Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
             ,handler: this.preview
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -117,7 +117,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
         } else if (cfg.locked) {
             btns.push({
                 text: cfg.lockedText || _('locked')
@@ -125,7 +124,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 ,handler: Ext.emptyFn
                 ,disabled: true
             });
-            // btns.push('-');
         }
         if (cfg.canDuplicate == 1 && (cfg.record.parent !== parseInt(MODx.config.tree_root_id) || cfg.canCreateRoot == 1)) {
             btns.push({
@@ -134,7 +132,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 ,handler: this.duplicateResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
@@ -143,7 +140,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 ,handler: this.deleteResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         btns.push({
             text: _('view')
@@ -151,14 +147,12 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             ,handler: this.preview
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -108,60 +108,61 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             btns.push({
                 process: 'resource/update'
                 ,text: _('save')
+                ,id: 'modx-abtn-save'
+                ,cls: 'primary-button'
                 ,method: 'remote'
                 //,checkDirty: MODx.request.reload ? false : true
-                ,id: 'modx-abtn-save'
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         } else if (cfg.locked) {
             btns.push({
                 text: cfg.lockedText || _('locked')
-                ,handler: Ext.emptyFn
                 ,id: 'modx-abtn-locked'
+                ,handler: Ext.emptyFn
                 ,disabled: true
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canDuplicate == 1 && (cfg.record.parent !== parseInt(MODx.config.tree_root_id) || cfg.canCreateRoot == 1)) {
             btns.push({
                 text: _('duplicate')
+                ,id: 'modx-abtn-duplicate'
                 ,handler: this.duplicateResource
                 ,scope:this
-                ,id: 'modx-abtn-duplicate'
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
                 text: _('delete')
+                ,id: 'modx-abtn-delete'
                 ,handler: this.deleteResource
                 ,scope:this
-                ,id: 'modx-abtn-delete'
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
             text: _('view')
+            ,id: 'modx-abtn-preview'
             ,handler: this.preview
             ,scope: this
-            ,id: 'modx-abtn-preview'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
-            ,id: 'modx-abtn-cancel'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
-            ,handler: MODx.loadHelpPane
             ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
         });
         return btns;
     }

--- a/manager/assets/modext/sections/resource/weblink/create.js
+++ b/manager/assets/modext/sections/resource/weblink/create.js
@@ -35,27 +35,27 @@ Ext.extend(MODx.page.CreateWebLink,MODx.Component,{
             btns.push({
                 process: 'resource/create'
                 ,reload: true
+                ,text: _('save')
                 ,id: 'modx-abtn-save'
                 ,cls:'primary-button'
-                ,text: _('save')
                 ,method: 'remote'
-                ,checkDirty: true
+                // ,checkDirty: true
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
-            ,handler: MODx.loadHelpPane
             ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
         });
         return btns;
     }

--- a/manager/assets/modext/sections/resource/weblink/create.js
+++ b/manager/assets/modext/sections/resource/weblink/create.js
@@ -45,13 +45,11 @@ Ext.extend(MODx.page.CreateWebLink,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
         }
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/weblink/update.js
+++ b/manager/assets/modext/sections/resource/weblink/update.js
@@ -87,62 +87,62 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
         if (cfg.canSave == 1) {
             btns.push({
                 process: 'resource/update'
+                ,text: _('save')
                 ,id: 'modx-abtn-save'
                 ,cls:'primary-button'
-                ,text: _('save')
                 ,method: 'remote'
-                ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
+                // ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-            btns.push('-');
+            // btns.push('-');
         } else {
             btns.push({
                 text: cfg.lockedText || _('locked')
+                ,id: 'modx-abtn-locked'
                 ,handler: Ext.emptyFn
                 ,disabled: true
-                ,id: 'modx-abtn-locked'
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canCreate == 1) {
             btns.push({
-                id: 'modx-abtn-duplicate'
-                ,text: _('duplicate')
+                text: _('duplicate')
+                ,id: 'modx-abtn-duplicate'
                 ,handler: this.duplicateResource
                 ,scope:this
             });
-            btns.push('-');
+            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
-                id: 'modx-abtn-delete'
-                ,text: _('delete')
+                text: _('delete')
+                ,id: 'modx-abtn-delete'
                 ,handler: this.deleteResource
                 ,scope:this
             });
-            btns.push('-');
+            // btns.push('-');
         }
         btns.push({
-            id: 'modx-abtn-preview'
-            ,text: _('view')
+            text: _('view')
+            ,id: 'modx-abtn-preview'
             ,handler: this.preview
             ,scope: this
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
-            id: 'modx-abtn-cancel'
-            ,text: _('cancel')
+            text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
         });
-        btns.push('-');
+        // btns.push('-');
         btns.push({
             text: _('help_ex')
-            ,handler: MODx.loadHelpPane
             ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
         });
         return btns;
     }

--- a/manager/assets/modext/sections/resource/weblink/update.js
+++ b/manager/assets/modext/sections/resource/weblink/update.js
@@ -97,7 +97,6 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
                     ,ctrl: true
                 }]
             });
-            // btns.push('-');
         } else {
             btns.push({
                 text: cfg.lockedText || _('locked')
@@ -105,7 +104,6 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
                 ,handler: Ext.emptyFn
                 ,disabled: true
             });
-            // btns.push('-');
         }
         if (cfg.canCreate == 1) {
             btns.push({
@@ -114,7 +112,6 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
                 ,handler: this.duplicateResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         if (cfg.canDelete == 1 && !cfg.locked) {
             btns.push({
@@ -123,7 +120,6 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
                 ,handler: this.deleteResource
                 ,scope:this
             });
-            // btns.push('-');
         }
         btns.push({
             text: _('view')
@@ -131,14 +127,12 @@ Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
             ,handler: this.preview
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('cancel')
             ,id: 'modx-abtn-cancel'
             ,handler: this.cancel
             ,scope: this
         });
-        // btns.push('-');
         btns.push({
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/security/access/policy/template/update.js
+++ b/manager/assets/modext/sections/security/access/policy/template/update.js
@@ -18,19 +18,22 @@ MODx.page.UpdateAccessPolicyTemplate = function(config) {
         ,buttons: [{
             process: 'security/access/policy/template/update'
             ,text: _('save')
-            ,cls:'primary-button'
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             process: 'cancel'
             ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,params: {a:'security/permission'}
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{ 

--- a/manager/assets/modext/sections/security/access/policy/update.js
+++ b/manager/assets/modext/sections/security/access/policy/update.js
@@ -18,19 +18,22 @@ MODx.page.UpdateAccessPolicy = function(config) {
         ,buttons: [{
             process: 'security/access/policy/update'
             ,text: _('save')
-            ,cls:'primary-button'
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             process: 'cancel'
             ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,params: {a:'security/permission'}
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{ 

--- a/manager/assets/modext/sections/security/permissions/list.js
+++ b/manager/assets/modext/sections/security/permissions/list.js
@@ -14,6 +14,7 @@ MODx.page.GroupsRoles = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 	});

--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -228,9 +228,10 @@ MODx.panel.ChangeProfilePassword = function(config) {
         }]
         ,buttons: [{
             text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,scope: this
             ,handler: this.submit
-            ,cls:'primary-button'
         }]
         ,listeners: {
             'success': {fn:this.success,scope:this}

--- a/manager/assets/modext/sections/security/resourcegroup/list.js
+++ b/manager/assets/modext/sections/security/resourcegroup/list.js
@@ -14,6 +14,7 @@ MODx.page.ResourceGroups = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
     });

--- a/manager/assets/modext/sections/security/role/create.js
+++ b/manager/assets/modext/sections/security/role/create.js
@@ -20,15 +20,23 @@ MODx.page.CreateRole = function(config) {
             ,cancel: 'security/role'
         }
         ,buttons: [{
-            process: 'create', text: _('save'), method: 'remote'
+            process: 'create'
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
-            process: 'cancel', text: _('cancel'), params:{a:'security/role'}
-        },'-',{
+        },{
+            process: 'cancel'
+            ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
+            ,params: {a:'security/role'}
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,tabs: [

--- a/manager/assets/modext/sections/security/role/list.js
+++ b/manager/assets/modext/sections/security/role/list.js
@@ -16,13 +16,17 @@ MODx.page.ListRoles = function(config) {
 		buttons: [{
             process: 'new'
             ,text: _('new')
+            ,id: 'modx-abtn-new'
+            ,cls: 'primary-button'
             ,params: {
                 a:'security/role/create'
             }
-        },'-',{
+        },{
             text: _('cancel')
-        },'-',{
+            ,id: 'modx-abtn-cancel'
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/security/user/create.js
+++ b/manager/assets/modext/sections/security/user/create.js
@@ -14,20 +14,23 @@ MODx.page.CreateUser = function(config) {
             process: 'security/user/create'
             ,reload: true
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,cls:'primary-button'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('security/user')
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/security/user/list.js
+++ b/manager/assets/modext/sections/security/user/list.js
@@ -14,6 +14,7 @@ MODx.page.Users = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 	});

--- a/manager/assets/modext/sections/security/user/update.js
+++ b/manager/assets/modext/sections/security/user/update.js
@@ -18,24 +18,28 @@ MODx.page.UpdateUser = function(config) {
         ,buttons: [{
             process: 'security/user/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,cls:'primary-button'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('security/user')
             }
-        },'-',{
+        },{
             text: _('delete')
+            ,id: 'modx-abtn-delete'
             ,handler: this.removeUser
             ,scope: this
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/security/usergroup/update.js
+++ b/manager/assets/modext/sections/security/usergroup/update.js
@@ -14,19 +14,23 @@ MODx.page.UpdateUserGroup = function(config) {
         ,buttons: [{
             process: 'security/group/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('security/permission')
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
         ,components: [{

--- a/manager/assets/modext/sections/source/index.js
+++ b/manager/assets/modext/sections/source/index.js
@@ -14,6 +14,7 @@ MODx.page.Sources = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 	});

--- a/manager/assets/modext/sections/source/update.js
+++ b/manager/assets/modext/sections/source/update.js
@@ -8,17 +8,24 @@ MODx.page.UpdateSource = function(config) {
             ,cancel: 'source'
        }
        ,buttons: [{
-            process: 'source/update', text: _('save'), method: 'remote'
-            ,checkDirty: false
-            ,id: 'modx-btn-save'
+            process: 'source/update'
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
-            process: 'cancel', text: _('cancel'), params: {a:'source'}
-        },'-',{
+        },{
+            process: 'cancel'
+            ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
+            ,params: {a:'source'}
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 		,components: [{

--- a/manager/assets/modext/sections/system/action.js
+++ b/manager/assets/modext/sections/system/action.js
@@ -14,6 +14,7 @@ MODx.page.Actions = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 	});

--- a/manager/assets/modext/sections/system/content.type.js
+++ b/manager/assets/modext/sections/system/content.type.js
@@ -12,10 +12,12 @@ MODx.page.ContentType = function(config) {
         formpanel: 'modx-panel-content-type'
         ,buttons: [{
             text: _('cancel')
-        },'-',{
-         text: _('help_ex')
-         ,handler: MODx.loadHelpPane
-         }]
+            ,id: 'modx-abtn-cancel'
+        },{
+            text: _('help_ex')
+            ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
+        }]
         ,components: [{
             xtype: 'modx-panel-content-type'
             ,title: ''

--- a/manager/assets/modext/sections/system/dashboards/create.js
+++ b/manager/assets/modext/sections/system/dashboards/create.js
@@ -11,20 +11,23 @@ MODx.page.CreateDashboard = function(config) {
             process: 'system/dashboard/create'
             ,reload: true
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
-            ,id: 'modx-btn-save'
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('system/dashboards');
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 		,components: [{

--- a/manager/assets/modext/sections/system/dashboards/list.js
+++ b/manager/assets/modext/sections/system/dashboards/list.js
@@ -14,6 +14,7 @@ MODx.page.Dashboards = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 	});

--- a/manager/assets/modext/sections/system/dashboards/update.js
+++ b/manager/assets/modext/sections/system/dashboards/update.js
@@ -10,20 +10,23 @@ MODx.page.UpdateDashboard = function(config) {
         ,buttons: [{
             process: 'system/dashboard/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
-            ,id: 'modx-btn-save'
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('system/dashboards');
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 		,components: [{

--- a/manager/assets/modext/sections/system/dashboards/widget/create.js
+++ b/manager/assets/modext/sections/system/dashboards/widget/create.js
@@ -11,20 +11,23 @@ MODx.page.CreateDashboardWidget = function(config) {
             process: 'system/dashboard/widget/create'
             ,reload: true
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
-            ,id: 'modx-btn-save'
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('system/dashboards');
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 		,components: [{

--- a/manager/assets/modext/sections/system/dashboards/widget/update.js
+++ b/manager/assets/modext/sections/system/dashboards/widget/update.js
@@ -10,20 +10,23 @@ MODx.page.UpdateDashboardWidget = function(config) {
         ,buttons: [{
             process: 'system/dashboard/widget/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: false
-            ,id: 'modx-btn-save'
+            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('system/dashboards');
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
 		,components: [{

--- a/manager/assets/modext/sections/system/error.log.js
+++ b/manager/assets/modext/sections/system/error.log.js
@@ -11,17 +11,21 @@ MODx.page.ErrorLog = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-error-log'
         ,buttons: [{
-            text: _('clear')
-            ,handler: this.clear
-            ,scope: this
-            ,hidden: MODx.hasEraseErrorLog ? false : true
-        },'-',{
             text: _('ext_refresh')
+            ,id: 'modx-abtn-refresh'
+            ,cls: 'primary-button'
             ,handler: this.refreshLog
             ,scope: this
             ,hidden: config.record.tooLarge
-        },'-',{
+        },{
+            text: _('clear')
+            ,id: 'modx-abtn-clear'
+            ,handler: this.clear
+            ,scope: this
+            ,hidden: MODx.hasEraseErrorLog ? false : true
+        },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
         }]
         ,components: [{
             xtype: 'modx-panel-error-log'

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -20,7 +20,6 @@ MODx.page.CreateFile = function(config) {
             ,ctrl: true
         }]
     });
-    // btns.push('-');
     btns.push({
         text: _('cancel')
         ,id: 'modx-abtn-cancel'

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -12,15 +12,18 @@ MODx.page.CreateFile = function(config) {
     btns.push({
         process: 'browser/file/create'
         ,text: _('save')
+        ,id: 'modx-abtn-save'
+        ,cls: 'primary-button'
         ,method: 'remote'
         ,keys: [{
             key: MODx.config.keymap_save || 's'
             ,ctrl: true
         }]
     });
-    btns.push('-');
+    // btns.push('-');
     btns.push({
         text: _('cancel')
+        ,id: 'modx-abtn-cancel'
     });
 
     Ext.applyIf(config,{

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -107,10 +107,10 @@ MODx.panel.CreateFile = function(config) {
                     ,fieldLabel: _('content')
                     ,name: 'content'
                     ,id: 'modx-file-content'
+                    ,cls: 'modx-code-content'
                     ,anchor: '100%'
                     ,grow: false
                     ,height: 400
-                    ,style: 'font-size: 11px;'
                 }]
             }]
         }])]

--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -21,7 +21,6 @@ MODx.page.EditFile = function(config) {
                 ,ctrl: true
             }]
         });
-        // btns.push('-');
     }
     btns.push({
         text: _('cancel')

--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -13,16 +13,19 @@ MODx.page.EditFile = function(config) {
         btns.push({
             process: 'browser/file/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
         });
-        btns.push('-');
+        // btns.push('-');
     }
     btns.push({
         text: _('cancel')
+        ,id: 'modx-abtn-cancel'
     });
 
     Ext.applyIf(config,{

--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -124,10 +124,10 @@ MODx.panel.EditFile = function(config) {
                     ,hideLabel: true
                     ,name: 'content'
                     ,id: 'modx-file-content'
+                    ,cls: 'modx-code-content'
                     ,anchor: '98%'
                     ,grow: false
                     ,height: 400
-                    ,style: 'font-size: 11px;'
                     ,value: config.record.content || ''
                 }]
             }]

--- a/manager/assets/modext/sections/system/import/html.js
+++ b/manager/assets/modext/sections/system/import/html.js
@@ -5,10 +5,12 @@ MODx.page.ImportHTML = function(config) {
         ,buttons: [{
             process: 'system/import/html'
             ,text: _('import_site')
-            ,method: 'remote'
+            ,id: 'modx-abtn-import'
             ,cls:'primary-button'
+            ,method: 'remote'
         },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
         }]
         ,components: [{
             xtype: 'modx-panel-import-html'

--- a/manager/assets/modext/sections/system/import/resource.js
+++ b/manager/assets/modext/sections/system/import/resource.js
@@ -5,9 +5,12 @@ MODx.page.ImportResource = function(config) {
         ,buttons: [{
             process: 'system/import/index'
             ,text: _('import_resources')
+            ,id: 'modx-abtn-import'
+            ,cls: 'primary-button'
             ,method: 'remote'
         },{
             text: _('cancel')
+            ,id: 'modx-abtn-cancel'
         }]
         ,components: [{
             xtype: 'modx-panel-import-resources'

--- a/manager/assets/modext/sections/system/settings.js
+++ b/manager/assets/modext/sections/system/settings.js
@@ -14,6 +14,7 @@ MODx.page.SystemSettings = function(config) {
         }]
         ,buttons: [{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
     });

--- a/manager/assets/modext/util/uploaddialog.js
+++ b/manager/assets/modext/util/uploaddialog.js
@@ -849,15 +849,13 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       handler: this.onAddButtonFileSelected,
       scope: this
     }));
-//    
     tb.x_buttons.remove = tb.addButton({
       text: this.i18n.remove_btn_text,
       tooltip: this.i18n.remove_btn_tip,
       iconCls: 'ext-ux-uploaddialog-removebtn',
       handler: this.onRemoveButtonClick,
       scope: this
-    });
-//    
+    }); 
     tb.x_buttons.reset = tb.addButton({
       text: this.i18n.reset_btn_text,
       tooltip: this.i18n.reset_btn_tip,
@@ -865,7 +863,6 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       handler: this.onResetButtonClick,
       scope: this
     });
-    tb.add('-');
     tb.x_buttons.upload = tb.addButton({
       text: this.i18n.upload_btn_start_text,
       tooltip: this.i18n.upload_btn_start_tip,
@@ -873,7 +870,6 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       handler: this.onUploadButtonClick,
       scope: this
     });
-    tb.add('-');
     tb.x_buttons.close = tb.addButton({
       text: this.i18n.close_btn_text,
       tooltip: this.i18n.close_btn_tip,

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -37,8 +37,8 @@ MODx.grid.Grid = function(config) {
     if (config.paging) {
         var pgItms = config.showPerPage ? [_('per_page')+':',{
             xtype: 'textfield'
+            ,cls: 'x-tbar-page-size'
             ,value: config.pageSize || (parseInt(MODx.config.default_per_page) || 20)
-            ,width: 54 /* 32px field width + 20px padding + 2px border = 54px */
             ,listeners: {
                 'change': {fn:this.onChangePerPage,scope:this}
                 ,'render': {fn: function(cmp) {

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -38,7 +38,7 @@ MODx.grid.Grid = function(config) {
         var pgItms = config.showPerPage ? [_('per_page')+':',{
             xtype: 'textfield'
             ,value: config.pageSize || (parseInt(MODx.config.default_per_page) || 20)
-            ,width: 40
+            ,width: 54 /* 32px field width + 20px padding + 2px border = 54px */
             ,listeners: {
                 'change': {fn:this.onChangePerPage,scope:this}
                 ,'render': {fn: function(cmp) {

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -35,7 +35,7 @@ MODx.grid.Grid = function(config) {
         }
     });
     if (config.paging) {
-        var pgItms = config.showPerPage ? ['-',_('per_page')+':',{
+        var pgItms = config.showPerPage ? [_('per_page')+':',{
             xtype: 'textfield'
             ,value: config.pageSize || (parseInt(MODx.config.default_per_page) || 20)
             ,width: 40

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -342,7 +342,6 @@ MODx.window.CreateSetting = function(config) {
         ,width: 600
         ,url: config.url
         ,action: 'system/settings/create'
-        ,cls:'primary-button'
         ,fields: [{
             layout: 'column'
             ,border: false

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -51,10 +51,11 @@ MODx.grid.SettingsGrid = function(config) {
         ,listeners: {
             'select': {fn: this.filterByArea, scope:this}
         }
-    },'-',{
+    },{
         xtype: 'textfield'
         ,name: 'filter_key'
         ,id: 'modx-filter-key'
+        ,cls: 'x-form-filter'
         ,emptyText: _('search_by_key')+'...'
         ,listeners: {
             'change': {fn: this.filterByKey, scope: this}
@@ -69,6 +70,7 @@ MODx.grid.SettingsGrid = function(config) {
     },{
         xtype: 'button'
         ,id: 'modx-filter-clear'
+        ,cls: 'x-form-filter-clear'
         ,text: _('filter_clear')
         ,listeners: {
             'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/core/modx.rte.browser.js
+++ b/manager/assets/modext/widgets/core/modx.rte.browser.js
@@ -149,7 +149,7 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
                     }, this, {buffer:500});
                 }, scope:this}
             }
-        }, ' ', '-', {
+        }, ' ', {
             text: _('sort_by')+':'
         }, {
             id: 'sortSelect'
@@ -170,7 +170,7 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
             ,listeners: {
                 'select': {fn:this.sortImages, scope:this}
             }
-        },'-',{
+        },{
             icon: MODx.config.template_url+'images/restyle/icons/refresh.png'
             ,cls: 'x-btn-icon'
             ,tooltip: {text: _('tree_refresh')}

--- a/manager/assets/modext/widgets/core/modx.tree.checkbox.js
+++ b/manager/assets/modext/widgets/core/modx.tree.checkbox.js
@@ -16,7 +16,6 @@ MODx.tree.CheckboxTree = function(config) {
     });
     var tb = this.getToolbar();
     if (config.tbar && config.useDefaultToolbar) {
-        tb.push('-');
         for (var i=0;i<config.tbar.length;i=i+1) {
             tb.push(config.tbar[i]);
         }
@@ -188,7 +187,7 @@ Ext.extend(MODx.tree.CheckboxTree,Ext.tree.TreePanel,{
             ,scope: this
             ,tooltip: {text: _('tree_collapse')}
             ,handler: this.collapse
-        },'-',{
+        },{
             icon: iu+'refresh.png'
             ,cls: 'x-btn-icon refresh'
             ,scope: this

--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -124,7 +124,6 @@ MODx.tree.Tree = function(config) {
     } else {
         var tb = this.getToolbar();
         if (config.tbar && config.useDefaultToolbar) {
-            tb.push('-');
             for (var i=0;i<config.tbar.length;i++) {
                 tb.push(config.tbar[i]);
             }
@@ -642,7 +641,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
             ,tooltip: {text: _('tree_collapse')}
             ,handler: this.collapseNodes
             ,scope: this
-        },'-',{
+        },{
             icon: iu+'refresh.png'
             ,cls: 'x-btn-icon refresh'
             ,tooltip: {text: _('tree_refresh')}

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -106,7 +106,7 @@ MODx.grid.ElementProperties = function(config) {
             ,handler: this.create
             ,scope: this
             ,disabled: true
-        },'-',{
+        },{
             text: _('properties_default_locked')
             ,id: 'modx-btn-propset-lock'
             ,handler: this.togglePropertiesLock
@@ -131,8 +131,9 @@ MODx.grid.ElementProperties = function(config) {
             text: _('propertyset_add')
             ,handler: this.addPropertySet
             ,scope: this
-        },'-',{
+        },{
             text: _('propertyset_save')
+            ,cls: 'primary-button'
             ,handler: this.save
             ,scope: this
             ,hidden: MODx.request.id ? false : true
@@ -143,11 +144,11 @@ MODx.grid.ElementProperties = function(config) {
             ,handler: this.revertAll
             ,scope:this
             ,disabled: true
-        },'-',{
+        },{
             text: _('properties_import')
             ,handler: this.importProperties
             ,scope: this
-        },'-',{
+        },{
             text: _('properties_export')
             ,handler: this.exportProperties
             ,scope: this

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -66,10 +66,11 @@ MODx.grid.TemplateTV = function(config) {
             ,listeners: {
                 'select': {fn: this.filterByCategory, scope:this}
             }
-        },'-',{
+        },{
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-temptv-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -84,6 +85,7 @@ MODx.grid.TemplateTV = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -218,6 +218,7 @@ MODx.panel.Chunk = function(config) {
 					,fieldLabel: _('chunk_code')
 					,name: 'snippet'
 					,id: 'modx-chunk-snippet'
+                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.snippet || ''

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -229,6 +229,7 @@ MODx.panel.Plugin = function(config) {
 					,fieldLabel: _('plugin_code')
 					,name: 'plugincode'
 					,id: 'modx-plugin-plugincode'
+                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.plugincode || "<?php\n"

--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -83,7 +83,7 @@ MODx.grid.PropertySetProperties = function(config) {
                 'select': {fn:function(cb) { Ext.getCmp('modx-grid-element-properties').changePropertySet(cb); },scope:this}
             }
             ,value: ''
-        },'-',{
+        },{
             text: _('property_create')
             ,handler: function(btn,e) {
                 if (Ext.getCmp('modx-combo-property-set').value != '') {
@@ -118,7 +118,7 @@ MODx.tree.PropertySets = function(config) {
         ,title: ''
         ,url: MODx.config.connector_url
         ,action: 'element/propertyset/getNodes'
-        ,tbar: [{
+        ,tbar: ['->', {
             text: _('propertyset_new')
             ,handler: this.createSet
             ,scope: this

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -218,6 +218,7 @@ MODx.panel.Snippet = function(config) {
 					,fieldLabel: _('snippet_code')
 					,name: 'snippet'
 					,id: 'modx-snippet-snippet'
+                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.snippet || "<?php\n"

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -236,6 +236,7 @@ MODx.panel.Template = function(config) {
 					,fieldLabel: _('template_code')
 					,name: 'content'
 					,id: 'modx-template-content'
+                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.content || ''

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -516,10 +516,6 @@ MODx.panel.TVInputProperties = function(config) {
                 ,html: _('tv_default_desc')
                 ,cls: 'desc-under'
             },{
-				html: '<hr />'
-				,anchor: '100%'
-				,border: false
-			},{
 				id: 'modx-input-props'
 				,autoHeight: true
 			}]

--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -84,7 +84,7 @@ MODx.grid.FCProfile = function(config) {
             ,scope: this
             ,handler: this.createProfile
             ,cls:'primary-button'
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('selected_activate')
@@ -94,7 +94,7 @@ MODx.grid.FCProfile = function(config) {
                 text: _('selected_deactivate')
                 ,handler: this.deactivateSelected
                 ,scope: this
-            },'-',{
+            },{
                 text: _('selected_remove')
                 ,handler: this.removeSelected
                 ,scope: this
@@ -103,6 +103,7 @@ MODx.grid.FCProfile = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-fcp-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('filter_by_search')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -120,6 +121,7 @@ MODx.grid.FCProfile = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -53,9 +53,10 @@ MODx.grid.FCSet = function(config) {
         }
         ,tbar: [{
             text: _('set_new')
+            ,cls: 'primary-button'
             ,scope: this
             ,handler: this.createSet
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('selected_activate')
@@ -65,12 +66,12 @@ MODx.grid.FCSet = function(config) {
                 text: _('selected_deactivate')
                 ,handler: this.deactivateSelected
                 ,scope: this
-            },'-',{
+            },{
                 text: _('selected_remove')
                 ,handler: this.removeSelected
                 ,scope: this
             }]
-        },'-',{
+        },{
             text: _('import_from_xml')
             ,handler: this.importSet
             ,scope: this
@@ -78,6 +79,7 @@ MODx.grid.FCSet = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-fcs-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('filter_by_search')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -92,6 +94,7 @@ MODx.grid.FCSet = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -75,7 +75,7 @@ MODx.panel.FCProfile = function(config) {
 					,anchor: '90%'
 					,allowBlank: true
 				}]
-            },{ html: '<hr />' },{
+            },{
                 xtype: 'modx-grid-fc-set'
 				,cls:'main-wrapper'
                 ,baseParams: {

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -151,6 +151,7 @@ MODx.grid.FCProfileUserGroups = function(config) {
         }]
         ,tbar: [{
             text: _('usergroup_create')
+            ,cls: 'primary-button'
             ,handler: this.addUserGroup
             ,scope: this
         }]

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -315,6 +315,7 @@ MODx.grid.FCSetTabs = function(config) {
         }
         ,tbar: [{
             text: _('tab_create')
+            ,cls: 'primary-button'
             ,handler: this.createTab
             ,scope: this
         }]

--- a/manager/assets/modext/widgets/media/browser.js
+++ b/manager/assets/modext/widgets/media/browser.js
@@ -92,14 +92,14 @@ MODx.Media = function(config) {
             ,width: 250
             ,items: this.tree
             ,id: this.ident+'-browser-tree'
-            ,cls: 'modx-pb-browser-tree'
+            ,cls: 'modx-pb-browser-tree shadowbox'
             ,autoScroll: true
             ,split: true
         },{
             region: 'center'
             ,layout: 'fit'
             ,items: this.view
-            ,id: this.ident+'-browser-view'
+            ,id: this.ident+'-browser-view shadowbox'
             ,cls: 'modx-pb-view-ct'
             ,autoScroll: true
             ,border: false
@@ -107,7 +107,7 @@ MODx.Media = function(config) {
         },{
             region: 'east'
             ,width: 250
-            ,id: this.ident+'-img-detail-panel'
+            ,id: this.ident+'-img-detail-panel shadowbox'
             ,cls: 'modx-pb-details-ct'
             ,split: true
             //,collapsed: true

--- a/manager/assets/modext/widgets/media/browser.js
+++ b/manager/assets/modext/widgets/media/browser.js
@@ -177,10 +177,10 @@ Ext.extend(MODx.Media, Ext.Container, {
      * @returns {Array}
      */
     ,getToolbar: function() {
-        return ['-', {
+        return [{
             text: _('filter')+':'
             ,xtype: 'label'
-        }, '-', {
+        },{
             xtype: 'textfield'
             ,id: this.ident+'filter'
             ,selectOnFocus: true
@@ -195,10 +195,10 @@ Ext.extend(MODx.Media, Ext.Container, {
                     ,scope: this
                 }
             }
-        }, '-', {
+        },{
             text: _('sort_by')+':'
             ,xtype: 'label'
-        }, '-', {
+        },{
             id: this.ident+'sortSelect'
             ,xtype: 'combo'
             ,typeAhead: true

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -343,7 +343,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,template: config.record.template
             ,anchor: '100%'
             ,border: true
-            ,bodyStyle: 'display: none'
+            ,style: 'visibility: visible'
         };
     }
 

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -794,6 +794,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             xtype: 'textarea'
             ,name: 'ta'
             ,id: 'ta'
+            ,cls: 'modx-code-content'
             ,hideLabel: true
             ,anchor: '100%'
             ,height: 400

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -83,11 +83,11 @@ MODx.grid.AccessPolicy = function(config) {
             ,cls:'primary-button'
             ,scope: this
             ,handler: this.createPolicy
-        },'-',{
+        },{
             text: _('import')
             ,scope: this
             ,handler: this.importPolicy
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('policy_remove_multiple')
@@ -98,6 +98,7 @@ MODx.grid.AccessPolicy = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-policy-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -115,6 +116,7 @@ MODx.grid.AccessPolicy = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-sacpol-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -86,11 +86,11 @@ MODx.grid.AccessPolicyTemplate = function(config) {
             ,cls:'primary-button'
             ,scope: this
             ,handler: this.createPolicyTemplate
-        },'-',{
+        },{
             text: _('import')
             ,scope: this
             ,handler: this.importPolicyTemplate
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('policy_remove_multiple')
@@ -101,6 +101,7 @@ MODx.grid.AccessPolicyTemplate = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-policy-template-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -118,6 +119,7 @@ MODx.grid.AccessPolicyTemplate = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-sacpoltemp-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/security/modx.grid.message.js
+++ b/manager/assets/modext/widgets/security/modx.grid.message.js
@@ -113,6 +113,7 @@ MODx.grid.Message = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-messages-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -127,6 +128,7 @@ MODx.grid.Message = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/security/modx.grid.role.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.user.js
@@ -115,9 +115,7 @@ Ext.extend(MODx.grid.RoleUser,MODx.grid.Grid,{
                         this.refresh();
                     },scope:this}
                 }
-            }
-			,'-'
-			,{
+            },{
 				xtype: 'button'
 				,text: _('clear_filter')
 				,scope: this

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -42,6 +42,7 @@ MODx.grid.UserGroupContext = function(config) {
         }]
         ,tbar: [{
             text: _('context_add')
+            ,cls:'primary-button'
             ,scope: this
             ,handler: this.createAcl
         },'->',{

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -42,6 +42,7 @@ MODx.grid.UserGroups = function(config) {
         })]
         ,tbar: [{
             text: _('user_group_user_add')
+            ,cls:'primary-button'
             ,handler: this.addGroup
         }]
     });

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
@@ -45,6 +45,7 @@ MODx.grid.UserGroupResourceGroup = function(config) {
         }]
         ,tbar: [{
             text: _('resource_group_add')
+            ,cls:'primary-button'
             ,scope: this
             ,handler: this.createAcl
         },'->',{

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
@@ -23,8 +23,8 @@ MODx.grid.GroupSettings = function(config) {
         ,fk: config.group
         ,tbar: [{
             text: _('create_new')
-            ,scope: this
             ,cls:'primary-button'
+            ,scope: this
             ,handler: {
                 xtype: 'modx-window-setting-create'
                 ,url: MODx.config.connector_url

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
@@ -40,6 +40,7 @@ MODx.grid.UserGroupSource = function(config) {
         }]
         ,tbar: [{
             text: _('source_add')
+            ,cls:'primary-button'
             ,scope: this
             ,handler: this.createAcl
         },'->',{

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -98,7 +98,7 @@ MODx.grid.User = function(config) {
             ,handler: this.createUser
             ,scope: this
             ,cls:'primary-button'
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('selected_activate')
@@ -108,7 +108,7 @@ MODx.grid.User = function(config) {
                 text: _('selected_deactivate')
                 ,handler: this.deactivateSelected
                 ,scope: this
-            },'-',{
+            },{
                 text: _('selected_remove')
                 ,handler: this.removeSelected
                 ,scope: this
@@ -128,10 +128,11 @@ MODx.grid.User = function(config) {
             ,listeners: {
                 'select': {fn:this.filterUsergroup,scope:this}
             }
-        },'-',{
+        },{
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-user-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -146,6 +147,7 @@ MODx.grid.User = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -334,6 +334,7 @@ MODx.grid.UserGroupUsers = function(config) {
         },'->',{
             xtype: 'textfield'
             ,id: 'modx-ugu-filter-username'
+            ,cls: 'x-form-filter'
             ,listeners: {
                 'change': {fn:this.searchUser,scope:this}
                 ,'render': {fn: function(cmp) {
@@ -352,6 +353,7 @@ MODx.grid.UserGroupUsers = function(config) {
         },{
             text: _('clear_filter')
             ,id: 'modx-ugu-clear-filter'
+            ,cls: 'x-form-filter-clear'
             ,handler: this.clearFilter
             ,scope: this
         }]

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -329,6 +329,7 @@ MODx.grid.UserGroupUsers = function(config) {
         }]
         ,tbar: [{
             text: _('user_group_user_add')
+            ,cls:'primary-button'
             ,handler: this.addMember
             ,hidden: MODx.perm.usergroup_user_edit == 0
         },'->',{

--- a/manager/assets/modext/widgets/security/modx.tree.resource.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.resource.group.js
@@ -21,8 +21,9 @@ MODx.tree.ResourceGroup = function(config) {
         ,baseParams: {
             limit: 0
         }
-        ,tbar: [{
+        ,tbar: ['->', {
             text: _('resource_group_create')
+            ,cls: 'primary-button'
             ,scope: this
             ,handler: this.createResourceGroup
         }]

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -23,9 +23,9 @@ MODx.tree.UserGroup = function(config) {
         ,useDefaultToolbar: true
         ,tbar: [{
             text: _('user_group_new')
+            ,cls: 'primary-button'
             ,scope: this
             ,handler: this.createUserGroup.createDelegate(this,[true],true)
-            ,cls:'primary-button'
         }]
     });
     MODx.tree.UserGroup.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/source/modx.grid.source.properties.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.properties.js
@@ -44,7 +44,7 @@ MODx.grid.SourceProperties = function(config) {
             ,id: 'modx-btn-property-create'
             ,handler: this.create
             ,scope: this
-        },'-',{
+        },{
             text: _('property_revert_all')
             ,id: 'modx-btn-property-revert-all'
             ,handler: this.revertAll

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -38,7 +38,7 @@ MODx.panel.Source = function(config) {
                 ,items: [{
 					xtype: 'panel'
 					,border: false
-					,cls:'main-wrapper'
+					,cls: 'main-wrapper'
 					,layout: 'form'
 					,labelAlign: 'top'
 					,items: [{
@@ -111,9 +111,6 @@ MODx.panel.Source = function(config) {
 
                         }]
                     }]
-                },{
-                    html: '<hr />'					
-                    ,border: false
                 },{
                     html: '<p>'+_('source_properties.intro_msg')+'</p>'
 					,bodyCssClass: 'panel-desc'

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -85,7 +85,7 @@ MODx.grid.Sources = function(config) {
             text: _('source_create')
             ,handler: { xtype: 'modx-window-source-create' ,blankValues: true }
             ,cls:'primary-button'
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('selected_remove')
@@ -96,6 +96,7 @@ MODx.grid.Sources = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-source-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -109,8 +110,9 @@ MODx.grid.Sources = function(config) {
             }
         },{
             xtype: 'button'
-            ,id: 'modx-filter-clear'
             ,text: _('filter_clear')
+            ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}
             }

--- a/manager/assets/modext/widgets/system/modx.grid.content.type.js
+++ b/manager/assets/modext/widgets/system/modx.grid.content.type.js
@@ -94,6 +94,7 @@ MODx.grid.ContentType = function(config) {
         },binaryColumn]
         ,tbar: [{
             text: _('content_type_new')
+            ,cls: 'primary-button'
             ,handler: this.newContentType
             ,scope: this
         }]

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -46,6 +46,7 @@ MODx.grid.Context = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-ctx-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -60,6 +61,7 @@ MODx.grid.Context = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -44,7 +44,7 @@ MODx.grid.DashboardWidgets = function(config) {
             text: _('widget_create')
             ,handler: this.createDashboard
             ,scope: this
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('selected_remove')
@@ -55,6 +55,7 @@ MODx.grid.DashboardWidgets = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-dashboard-widget-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -69,6 +70,7 @@ MODx.grid.DashboardWidgets = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-dashboard-widgets-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -42,6 +42,7 @@ MODx.grid.DashboardWidgets = function(config) {
         }]
         ,tbar: [{
             text: _('widget_create')
+            ,cls:'primary-button'
             ,handler: this.createDashboard
             ,scope: this
         },{
@@ -69,9 +70,9 @@ MODx.grid.DashboardWidgets = function(config) {
             }
         },{
             xtype: 'button'
+            ,text: _('filter_clear')
             ,id: 'modx-dashboard-widgets-filter-clear'
             ,cls: 'x-form-filter-clear'
-            ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}
             }

--- a/manager/assets/modext/widgets/system/modx.panel.actions.js
+++ b/manager/assets/modext/widgets/system/modx.panel.actions.js
@@ -20,6 +20,7 @@ MODx.panel.Actions = function(config) {
             ,itemId: 'header'
         },{
             itemId: 'form-menu'
+            ,bwrapCssClass: 'shadowbox'
             ,items: [{
                 html: '<p>'+_('topmenu_desc')+'</p>'
                 ,bodyCssClass: 'panel-desc'

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -28,6 +28,7 @@ MODx.panel.Dashboard = function(config) {
             ,getState:function() {
                 return {activeTab:this.items.indexOf(this.getActiveTab())};
             }
+            // todo: the layout is inconsistent with other panels, refactor the structure
             ,items: [{
                 title: _('general_information')
                 ,cls: 'main-wrapper form-with-labels'
@@ -104,10 +105,8 @@ MODx.panel.Dashboard = function(config) {
 
                     }]
                 },{
-                    html: '<hr />'
-                    ,border: false
-                },{
                     html: '<p>'+_('dashboard_widgets.intro_msg')+'</p>'
+                    ,bodyCssClass: 'panel-desc'
                     ,border: false
                 },{
                     xtype: 'modx-grid-dashboard-widget-placements'
@@ -217,6 +216,7 @@ MODx.grid.DashboardWidgetPlacements = function(config) {
         }]
         ,tbar: [{
             text: _('widget_place')
+            ,cls:'primary-button'
             ,handler: this.placeWidget
             ,scope: this
         }]

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -82,9 +82,9 @@ MODx.grid.Dashboards = function(config) {
         }]
         ,tbar: [{
             text: _('dashboard_create')
+            ,cls:'primary-button'
             ,handler: this.createDashboard
             ,scope: this
-            ,cls:'primary-button'
         },{
             text: _('bulk_actions')
             ,menu: [{
@@ -128,9 +128,9 @@ MODx.grid.Dashboards = function(config) {
             }
         },{
             xtype: 'button'
+            ,text: _('filter_clear')
             ,id: 'modx-filter-clear'
             ,cls: 'x-form-filter-clear'
-            ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}
             }

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -85,7 +85,7 @@ MODx.grid.Dashboards = function(config) {
             ,handler: this.createDashboard
             ,scope: this
             ,cls:'primary-button'
-        },'-',{
+        },{
             text: _('bulk_actions')
             ,menu: [{
                 text: _('selected_remove')
@@ -111,6 +111,7 @@ MODx.grid.Dashboards = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-dashboard-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -128,6 +129,7 @@ MODx.grid.Dashboards = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -33,6 +33,7 @@ MODx.panel.ErrorLog = function(config) {
                     xtype: 'textarea'
                     ,name: 'log'
                     ,id: 'modx-error-log-content'
+                    ,cls: 'modx-code-content'
                     ,grow: true
                     ,growMax: 400
                     ,anchor: '100%'

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -32,6 +32,7 @@ MODx.panel.ErrorLog = function(config) {
                 ,items: [{
                     xtype: 'textarea'
                     ,name: 'log'
+                    ,id: 'modx-error-log-content'
                     ,grow: true
                     ,growMax: 400
                     ,anchor: '100%'

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -7,7 +7,7 @@ MODx.panel.ErrorLog = function(config) {
         ,baseParams: {
             action: 'system/errorlog/clear'
         }
-        ,layout: 'form'
+        // ,layout: 'form' // unnecessary and creates a wrong box shadow
         ,items: [{
             html: '<h2>'+_('error_log')+'</h2>'
             ,id: 'modx-error-log-header'

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -52,7 +52,7 @@ MODx.grid.Lexicon = function(config) {
             ,listeners: {
                 'select': {fn: this.changeNamespace,scope:this}
             }
-        },'-',{
+        },{
             xtype: 'tbtext'
             ,text: _('topic')+':'
         },{
@@ -70,7 +70,7 @@ MODx.grid.Lexicon = function(config) {
             ,listeners: {
                 'select': {fn:this.changeTopic,scope:this}
             }
-        },'-',{
+        },{
             xtype: 'tbtext'
             ,text: _('language')+':'
         },{
@@ -95,10 +95,11 @@ MODx.grid.Lexicon = function(config) {
             ,cls:'primary-button'
             ,handler: this.createEntry
             ,scope: this
-        },'-',{
+        },{
             xtype: 'textfield'
             ,name: 'name'
             ,id: 'modx-lexicon-filter-search'
+            ,cls: 'x-form-filter'
             ,itemId: 'search'
             ,width: 120
             ,emptyText: _('search')+'...'
@@ -115,6 +116,7 @@ MODx.grid.Lexicon = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-lexicon-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,itemId: 'clear'
             ,text: _('filter_clear')
             ,listeners: {
@@ -127,7 +129,6 @@ MODx.grid.Lexicon = function(config) {
             ,scope: this
         }
         /*
-        ,'-'
         ,{
             xtype: 'button'
             ,id: 'modx-lexicon-import-btn'

--- a/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
+++ b/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
@@ -87,6 +87,7 @@ MODx.grid.Namespace = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-namespace-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -101,6 +102,7 @@ MODx.grid.Namespace = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/workspace/package.browser.panels.js
+++ b/manager/assets/modext/workspace/package.browser.panels.js
@@ -251,7 +251,7 @@ Ext.extend(MODx.grid.PackageBrowserGrid,MODx.grid.Grid,{
 		var h = [];
 		h.push({ className:'details', text: _('view_details') });
 		if(!record.data.downloaded){
-			h.push({ className:'download primary', text: _('download') });
+			h.push({ className:'download primary-button', text: _('download') });
 		}
 		values.actions = h;
 		return this.mainColumnTpl.apply(values);

--- a/manager/assets/modext/workspace/package.browser.tree.js
+++ b/manager/assets/modext/workspace/package.browser.tree.js
@@ -34,7 +34,7 @@ MODx.tree.PackageBrowserTree = function(config) {
 			,id: 'package-browser-search-fld'
 			,cls: 'icon-search'
 			,hideMode: 'offsets'
-			,width: 250
+			,width: 249
 			,listeners: {
 				change: this.search
 				,specialkey: function( form, e ) {

--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -42,12 +42,14 @@ MODx.panel.Packages = function(config) {
 		},{
 			text: _('continue')
 			,id:'package-install-btn'
+			,cls:'primary-button'
 			,hidden: true
 			,handler: this.install
 			,scope: this
 		},{
 			text: _('setup_options')
 			,id:'package-show-setupoptions-btn'
+			,cls:'primary-button'
 			,hidden: true
 			,handler: this.onSetupOptions
 			,scope: this

--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -15,6 +15,7 @@ MODx.panel.Packages = function(config) {
 		,layoutConfig:{ deferredRender:true }
 		,defaults:{
 			autoHeight: true
+			autoWidth: true
 			,border: false
 		}
 		,activeItem: 0

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -92,6 +92,7 @@ MODx.grid.Package = function(config) {
             xtype: 'textfield'
             ,name: 'search'
             ,id: 'modx-package-search'
+            ,cls: 'x-form-filter'
             ,emptyText: _('search_ellipsis')
             ,listeners: {
                 'change': {fn: this.search, scope: this}
@@ -106,6 +107,7 @@ MODx.grid.Package = function(config) {
         },{
             xtype: 'button'
             ,id: 'modx-package-filter-clear'
+            ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
                 'click': {fn: this.clearFilter, scope: this}

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -13,10 +13,12 @@ MODx.panel.PackageMetaPanel = function(config) {
 		cls: 'vertical-tabs-panel wrapped'
 		,headerCfg: { tag: 'div', cls: 'x-tab-panel-header vertical-tabs-header' }
 		,bwrapCfg: { tag: 'div', cls: 'x-tab-panel-bwrap vertical-tabs-bwrap' }
-        ,defaults: {
+		,defaults: {
 			bodyCssClass: 'vertical-tabs-body'
-            ,autoScroll: true
-        }
+			,autoScroll: true
+			,autoHeight: true
+			,autoWidth: true
+		}
 		,layoutOnTabChange: true
 		,listeners:{
 			tabchange: function(tb, pnl){
@@ -30,7 +32,7 @@ MODx.panel.PackageMetaPanel = function(config) {
 	});
 	MODx.panel.PackageMetaPanel.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.panel.PackageMetaPanel,MODx.Tabs,{
+Ext.extend(MODx.panel.PackageMetaPanel,MODx.VerticalTabs,{
 	updatePanel: function(meta){
 		if(meta.changelog != undefined){
 			this.addTab(_('changelog'), 'changelog', meta);

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -21,12 +21,12 @@ MODx.panel.PackageMetaPanel = function(config) {
 		}
 		,layoutOnTabChange: true
 		,listeners:{
-			tabchange: function(tb, pnl){
-				w = this.bwrap.getWidth();
-				this.body.setWidth(w);
-				this.doLayout();
-			}
-			,scope: this
+			// tabchange: function(tb, pnl){
+			// 	w = this.bwrap.getWidth();
+			// 	this.body.setWidth(w);
+			// 	this.doLayout();
+			// }
+			// ,scope: this
 		}
 		,items: []
 	});

--- a/manager/assets/modext/workspace/package/index.js
+++ b/manager/assets/modext/workspace/package/index.js
@@ -9,21 +9,25 @@ MODx.page.Package = function(config) {
         ,buttons: [{
             process: 'workspace/packages/update'
             ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
             ,method: 'remote'
-            ,checkDirty: true
+            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,alt: true
                 ,ctrl: true
             }]
-        },'-',{
+        },{
             process: 'cancel'
             ,text: _('cancel')
+            ,id: 'modx-abtn-cancel'
             ,handler: function() {
                 MODx.loadPage('workspaces');
             }
-        },'-',{
+        },{
             text: _('help_ex')
+            ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
     });

--- a/manager/assets/modext/workspace/provider.grid.js
+++ b/manager/assets/modext/workspace/provider.grid.js
@@ -36,6 +36,7 @@ MODx.grid.Provider = function(config) {
         }]
         ,tbar: [{
             text: _('provider_add')
+            ,cls: 'primary-button'
             ,handler: { xtype: 'modx-window-provider-create' ,blankValues: true }
         }]
     });

--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -9,18 +9,17 @@
     {foreach from=$category.tvs item=tv name='tv'}
 {if $tv->type NEQ "hidden"}
     <div class="x-form-item x-tab-item {cycle values=",alt"} modx-tv{if $smarty.foreach.tv.first} tv-first{/if}{if $smarty.foreach.tv.last} tv-last{/if}" id="tv{$tv->id}-tr">
-        <label for="tv{$tv->id}" class="x-form-item-label modx-tv-label" style="width: auto;">
+        <label for="tv{$tv->id}" class="x-form-item-label modx-tv-label">
             <div class="modx-tv-label-title">
                 {if $showCheckbox}<input type="checkbox" name="tv{$tv->id}-checkbox" class="modx-tv-checkbox" value="1" />{/if}
                 <span class="modx-tv-caption" id="tv{$tv->id}-caption">{if $tv->caption}{$tv->caption}{else}{$tv->name}{/if}</span>
             </div>
-            <a class="modx-tv-reset" id="modx-tv-reset-{$tv->id}" title="{$_lang.set_to_default}" style="float: left;"></a>
+            <a class="modx-tv-reset" id="modx-tv-reset-{$tv->id}" title="{$_lang.set_to_default}"></a>
             {if $tv->description}
             <span class="modx-tv-label-description">{$tv->description}</span>
             {/if}
         </label>
         {if $tv->inherited}<span class="modx-tv-inherited">{$_lang.tv_value_inherited}</span>{/if}
-        <div class="x-form-clear"></div>
         <div class="x-form-element modx-tv-form-element">
             <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
             {$tv->get('formElement')}


### PR DESCRIPTION
This is gonna be a long comment and a big PR, sorry in advance and thanks for your patience =)...

This PR is a proposal mainly for the manager theme buttons and toolbars but also includes various other things, that came along when working on it.

Related issues: https://github.com/modxcms/revolution/issues/11540,  https://github.com/modxcms/revolution/issues/11590, https://github.com/modxcms/revolution/issues/11577, https://github.com/modxcms/revolution/issues/11599, https://github.com/modxcms/revolution/issues/11604, https://github.com/modxcms/revolution/issues/11608, https://github.com/modxcms/revolution/pull/11616, https://github.com/modxcms/revolution/issues/11612, https://github.com/modxcms/revolution/pull/11605 and maybe more?

Long story short:
- Less padding for the buttons in general, now 10px 20px
- Implemented :hover and :active states
- Went trough all JS files generating toolbars and nuked all separators, saves a few dom nodes and they were just in the way IMO (and not used for styling purposes in the theme anyway)
- Added consistently ids to all action bar buttons throughout the JS files, I could avoid using the ids like #modx-abtn-save etc in the CSS. but I think if these ids are there they should be everywhere (on every page) the same and not sometimes omitted and sometimes just partly included etc., I would say either have them everywhere or remove them completely =)
- Added more consistent primary-buttons where applicable (in JS)
- Split buttons a bit more sexy but still room for improvement
- Special styling for the filter/clear filter parts of the UI, added according classes to all JS files that implement such functionality
- Pagination toolbar restyled, less padding, enough space for text etc.
- Commented out all checkDirty attributes of the save button (in JS), thought this is gone and the save button should always be active...or was this just for resources? (in that case please tell, I can activate them again)
- Re-styled TV labels that were too close to the field, refresh arrow now to the left of the TV field
- Completely re-styled TV panel
- Preventing flash of unstyled TV fields on manager page load
- Form field focus border-color now $colorSplash
- Form field labels nicely aligned
- Textareas have now the same font / style as single line fields, except for content fields and others that better show the code font, for this a new class .modx-code-content was introduced that could also be used for extra developers
- Made card layout "micro"-buttons (ex. package manager > package grid) follow the style of "normal" (secondary) buttons, just with less padding + special styles for .orange and .green
- Fixed overlapping label for the property preprocess checkbox in Elements > Properties
- Quite some SASS rewriting in the CSS + some reorganization

The more detailed version:

**The action bar**

before
![bildschirmfoto 2014-07-03 um 01 30 17](https://cloud.githubusercontent.com/assets/445501/3463832/f442e81c-0240-11e4-9513-d9de04d29cfd.png)

and after
![bildschirmfoto 2014-07-03 um 00 48 35](https://cloud.githubusercontent.com/assets/445501/3463833/01042d7c-0241-11e4-827c-223aa6b9b473.png)

and in motion
![modx mgrtheme actionbar](https://cloud.githubusercontent.com/assets/445501/3463849/4a9b7896-0241-11e4-8805-584e4526d416.gif)

in the full manager context before
![bildschirmfoto 2014-07-03 um 10 41 16](https://cloud.githubusercontent.com/assets/445501/3467220/e10371c0-028d-11e4-8bc2-77b870a75783.png)

in the full manager context after
![bildschirmfoto 2014-07-03 um 10 39 51](https://cloud.githubusercontent.com/assets/445501/3467211/bae4a75c-028d-11e4-8612-0f19d12d8804.png)

**The pagination toolbar for grids**

before
![bildschirmfoto 2014-07-03 um 01 35 33](https://cloud.githubusercontent.com/assets/445501/3463862/9d9bfe8a-0241-11e4-9144-0a3e8677573f.png)

after
![bildschirmfoto 2014-07-02 um 23 59 06](https://cloud.githubusercontent.com/assets/445501/3463864/aa83dc6c-0241-11e4-851c-2f82f2713c70.png)

in motion
![modx mgrtheme paginationbar](https://cloud.githubusercontent.com/assets/445501/3463872/dc88f45e-0241-11e4-9d59-033365d8006e.gif)

**The common "filter"/"Search"-Area top-right of many grids**

before
![bildschirmfoto 2014-07-03 um 10 34 06](https://cloud.githubusercontent.com/assets/445501/3467164/23135d74-028d-11e4-85d1-2137b1109129.png)

after
![bildschirmfoto 2014-07-03 um 10 34 41](https://cloud.githubusercontent.com/assets/445501/3467165/28da80de-028d-11e4-9976-705216fd4c71.png)

in motion
![modx mgrtheme filterarea](https://cloud.githubusercontent.com/assets/445501/3467166/30602e44-028d-11e4-89a4-a4928583ebbb.gif)

**The grid top toolbar, example 1**

before
![bildschirmfoto 2014-07-03 um 01 38 30](https://cloud.githubusercontent.com/assets/445501/3463878/0d7b657e-0242-11e4-8d08-e4afdeb1936a.png)

after
![bildschirmfoto 2014-07-02 um 23 59 19](https://cloud.githubusercontent.com/assets/445501/3463881/2245c74c-0242-11e4-8c58-27b7a9646c0d.png)

**Grid top toolbar, example 2 (property set tab in elements)**

before
![bildschirmfoto 2014-07-03 um 01 41 41](https://cloud.githubusercontent.com/assets/445501/3463895/73e08a74-0242-11e4-9472-b06a73ff1c37.png)

after
![bildschirmfoto 2014-07-03 um 01 40 55](https://cloud.githubusercontent.com/assets/445501/3463896/785502e2-0242-11e4-9aac-40f97341a9f3.png)

**Grid top toolbar, example 3**

before
![bildschirmfoto 2014-07-03 um 01 43 22](https://cloud.githubusercontent.com/assets/445501/3463911/cc8ba636-0242-11e4-8779-3321fe032562.png)

after
![bildschirmfoto 2014-07-03 um 01 44 49](https://cloud.githubusercontent.com/assets/445501/3463922/e45aa316-0242-11e4-8d42-9dcb9d6af4fb.png)

all in motion
![modx mgrtheme toolbarui](https://cloud.githubusercontent.com/assets/445501/3463951/64b039ae-0243-11e4-9264-3df0a2aa4fde.gif)

**Resource Groups panel (ex. for panels with trees)**

before
![bildschirmfoto 2014-07-03 um 02 29 35](https://cloud.githubusercontent.com/assets/445501/3464246/3a9be950-0249-11e4-98e1-ec7ded77fa59.png)

after
![bildschirmfoto 2014-07-03 um 02 28 59](https://cloud.githubusercontent.com/assets/445501/3464247/4017aeaa-0249-11e4-855c-c225135ea4a9.png)

**Property Sets page/panel (ex. for panel with grid and tree combined)**

before
![bildschirmfoto 2014-07-03 um 10 25 24](https://cloud.githubusercontent.com/assets/445501/3467092/ea2b5404-028b-11e4-91d9-0f64123c78b2.png)

after
![bildschirmfoto 2014-07-03 um 10 26 11](https://cloud.githubusercontent.com/assets/445501/3467095/f98dd0e8-028b-11e4-9e97-68d6cee54ee9.png)

**The card layout grid (ex. package manager)**

before
![bildschirmfoto 2014-07-03 um 01 52 39](https://cloud.githubusercontent.com/assets/445501/3463981/fe8e0c9a-0243-11e4-91f2-6ae236b564fc.png)

after
![bildschirmfoto 2014-07-03 um 01 51 54](https://cloud.githubusercontent.com/assets/445501/3463983/042229e8-0244-11e4-8c1b-8e3ec424d716.png)

in motion
![modx mgrtheme cardlayoutgrid](https://cloud.githubusercontent.com/assets/445501/3463990/30befbac-0244-11e4-8e53-1830cf671e90.gif)

**The media browser page**
more improvements are already proposed here: https://github.com/modxcms/revolution/pull/11587

before
![bildschirmfoto 2014-07-03 um 02 25 20](https://cloud.githubusercontent.com/assets/445501/3464214/9aa4112a-0248-11e4-8918-97ccdc259dfb.png)

after
![bildschirmfoto 2014-07-03 um 02 25 06](https://cloud.githubusercontent.com/assets/445501/3464216/9fc6d58e-0248-11e4-9455-717f374ad9f4.png)

**TVs panel**

before
![bildschirmfoto 2014-07-03 um 01 56 38](https://cloud.githubusercontent.com/assets/445501/3464011/9fb765d0-0244-11e4-9f1c-ce54c4f2532b.png)

after
![bildschirmfoto 2014-07-03 um 01 57 52](https://cloud.githubusercontent.com/assets/445501/3464017/b56aca2a-0244-11e4-9a82-3b7c589facca.png)

I tested all manager pages I could find for inconsitencies, but many eyes see more than two, so please let me know if you find something when playing around with this! Also this is not set in stone at all, suggestions, criticism, improvements are very welcome! If somebody likes demos for other areas, just write a comment. The discussion is open...
