### PR TITLE
[2.3] - contextual menu media source root

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -140,6 +140,12 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         return menu;
     }
 
+    /**
+     * Override to handle root nodes contextual menus
+     *
+     * @param node
+     * @param e
+     */
     ,_showContextMenu: function(node,e) {
         this.cm.activeNode = node;
         this.cm.removeAll();

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -99,6 +99,67 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
     windows: {}
 
     /**
+     * Build the contextual menu for the root node
+     *
+     * @returns {Array}
+     */
+    ,getRootMenu: function() {
+        var menu = [];
+        if (MODx.perm.directory_create) {
+            menu.push({
+                text: _('file_folder_create')
+                ,handler: this.createDirectory
+                ,scope: this
+            });
+        }
+
+        if (MODx.perm.file_create) {
+            menu.push({
+                text: _('file_create')
+                ,handler: this.createFile
+                ,scope: this
+            });
+        }
+
+        if (MODx.perm.file_upload) {
+            menu.push({
+                text: _('upload_files')
+                ,handler: this.uploadFiles
+                ,scope: this
+            });
+        }
+
+//        if (MODx.perm.file_manager) {
+//            menu.push({
+//                text: _('modx_browser')
+//                ,handler: this.loadFileManager
+//                ,scope: this
+//            });
+//        }
+
+        return menu;
+    }
+
+    ,_showContextMenu: function(node,e) {
+        this.cm.activeNode = node;
+        this.cm.removeAll();
+        var m;
+
+        if (node.isRoot) {
+            m = this.getRootMenu();
+        } else if (node.attributes.menu && node.attributes.menu.items) {
+            m = node.attributes.menu.items;
+        }
+
+        if (m && m.length > 0) {
+            this.addContextMenuItem(m);
+            this.cm.showAt(e.xy);
+        }
+        e.preventDefault();
+        e.stopEvent();
+    }
+
+    /**
      * Create a refresh button on the root node
      *
      * @see MODx.Tree.Tree#_onAppend


### PR DESCRIPTION
Adds a contextual menu on media source root nodes (trees).

Should take care of #11614

This brings some "duplicate" features on the media browser (the top bar buttons)
