### PR TITLE
Fix for imageTV access denied

### DIFF
--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -49,7 +49,7 @@ Ext.onReady(function() {
                     d.update('');
                 } else {
                     {/literal}
-                    d.update('<img src="'+MODx.config.connector_url+'?action=system/phpthumb&h=150&w=150&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
+                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?h=150&w=150&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
                     {literal}
                 }
             }}


### PR DESCRIPTION
When you select an imageTV the file is not loaded.
This happens only with MODX 2.3 (latest nightly).

When loading a resource in the manager the imageTV src is this (loaded correctly):
`http://site/system/phpthumb.php?h=150&w=150&src=image.jpg&source=1`

But when you create/change the imageTV you get an access denied:
`http://site/connectors/index.php?action=system/phpthumb&h=150&w=150&src=image.jpg&wctx=web&source=1`

_{"success":false,"message":"Access denied.","total":0,"data":[],"object":{"code":401}}_
