### PR TITLE
[2.3] GRID - Fix sort menu padding

### DIFF
--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -683,7 +683,7 @@ td.x-date-mp-sep {
     a.x-menu-item {
       color: $menuTextColor;
       font-size: 13px;
-      padding: 5px 20px 5px 15px;
+      padding: 3px 21px 3px 27px;
     }
 
     &.x-menu-item-active {


### PR DESCRIPTION
Before:
![property sets modx revolution](https://cloud.githubusercontent.com/assets/825106/3551210/970c0a44-08e3-11e4-8c7e-f9023056b5c2.png)

After:
![property sets modx revolution_after](https://cloud.githubusercontent.com/assets/825106/3551215/a08d72c4-08e3-11e4-9036-9858ebf5f5e6.png)
