### PR TITLE
[2.3] Inherited TV value label fix

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1234,6 +1234,7 @@ body.ext-ie7 .x-superboxselect-item {
   margin: 0 0 4px 0;
   padding-bottom: 4px;
   width: 100%;
+  position: relative;
 }
 
 #modx-tv-tabs .tv-last {
@@ -1287,11 +1288,14 @@ body.ext-ie7 .x-superboxselect-item {
 .modx-tv-inherited {
   color: #666;
   display: block;
-  float: right;
   font-size: 10px;
   font-style: italic;
   line-height: 1.2;
-  padding-top: 4px;
+  padding-top: 10px;
+  position: absolute;
+  right: 0;
+  text-align: right;
+  top: 0;
 }
 
 #modx-resource-settings .modx-tv-label,


### PR DESCRIPTION
Addresses issue #11658.

**BEFORE (using an RTE):**
![ace_tv_editor](https://cloud.githubusercontent.com/assets/352182/3515348/fc2c406c-06d4-11e4-91a3-f95e824d0a04.jpg)

**AFTER (using an RTE, with long TV description):**
![inherit_tv_fix](https://cloud.githubusercontent.com/assets/352182/3574529/0ea6b4f8-0b7f-11e4-8a42-a74cc3654753.jpg)

**AFTER (using an RTE, NO TV description):**
![tv_after_rte_no_desc](https://cloud.githubusercontent.com/assets/352182/3574715/f3c21cf2-0b80-11e4-9208-9702d96dbb86.jpg)

**BEFORE (default textarea):**
![tv_before](https://cloud.githubusercontent.com/assets/352182/3574625/e34027a8-0b7f-11e4-89b7-112bb817fd28.jpg)

**AFTER (default textarea):**
![tv_after_default](https://cloud.githubusercontent.com/assets/352182/3574669/82fce2f4-0b80-11e4-9908-ac0d17045f3a.jpg)
