### PR TITLE
Change loading / working indicator to dark gray

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -334,7 +334,7 @@
 .ext-el-mask-msg div {
   background-color: transparent;
   border: 0;
-  color: $red;
+  color: $darkGray;
   cursor: default; /* no need to show a wait cursor here */
   font: $fontSmall;
 }


### PR DESCRIPTION
A simple change to revert the red font color in the loading / warning indicator.
