### PR TITLE
Fixes text / icon alignment in confirmation prompts

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -318,6 +318,7 @@
 .ext-mb-content {
   display: inline-block;
   float: left;
+  margin-top: -32px;
   /*margin-left: 40px !important; /* override extjs default theme style */
 }
 


### PR DESCRIPTION
Properly aligns text / icon in the confirmation prompts:

![image](https://cloud.githubusercontent.com/assets/352182/3591903/164815ee-0c6a-11e4-8504-86e47c56f954.png)

Fixes #11696
