### PR TITLE
[2.3] Manager Theme Fixes

### DIFF
--- a/_build/templates/default/sass/_breadcrumbs.scss
+++ b/_build/templates/default/sass/_breadcrumbs.scss
@@ -3,7 +3,7 @@
   margin-top: 0;
 }
 .crumb_wrapper {
-  background: #f9f9f9;
+  background: $lightestGray;
   border-bottom: 1px solid $borderColor;
   border-top: 1px solid $borderColor;
   margin-top: 15px;
@@ -19,33 +19,68 @@
       float: left;
       font-size: 12px;
       font-weight: normal;
-      line-height: 35px;
+      line-height: 12px;
       padding: 0 0 0 20px;
       position: relative;
+      z-index: 1;
 
-      &.first {
+      /*&.first {
         padding: 0;
 
         button {
           padding: 8px 16px 8px 20px;
         }
+      }*/
+
+      &.first {
+        padding: 0; /* neutralize the normal li padding and give it to the inner element */
+
+        /* the home breadcrumb with the house icon */
+        &:before {
+          @extend %pseudo-font-x-btn;
+
+          /*background-color: $lightestGray;*/
+          content: $fa-var-home;
+          display: inline-block;
+          font-size: 20px;
+          line-height: 34px;
+          position: absolute; top: 0; left: 6px;
+          text-align: center;
+          text-indent: 0;
+          z-index: 2; /* put the icon above the triangle :after element */
+        }
+
+        &:hover:before {
+          color: $colorSplashContrast;
+        }
+
+        &:hover {
+          background-color: $colorSplash;
+        }
+
+        .root {
+          background-color: transparent;
+          box-sizing: content-box; /* buttons have border-box and spans content-box, we normalize here */
+          display: inline-block;
+          line-height: 12px;
+          margin: 0; /* neutralize the normal li margin */
+          padding: 11px 13px 11px 20px;
+          text-indent: -999em;
+          width: 20px;
+          z-index: 3;
+
+          /* do not display the cover element here */
+          &:before {
+            display: none;
+          }
+
+          &:hover {
+            background-color: transparent;
+          }
+        }
       }
 
-      &:after {
-        content: " ";
-        display: block;
-        width: 0;
-        height: 0;
-        border-top: 50px solid transparent; /* Go big on the size, and let overflow hide */
-        border-bottom: 50px solid transparent;
-        border-left: 30px solid #f9f9f9;
-        position: absolute;
-        top: 50%;
-        margin-top: -50px;
-        left: 100%;
-        z-index: 2;
-      }
-      &:before {
+      /*&:before {
         content: '';
         display: block;
         width: 0;
@@ -55,65 +90,99 @@
         border-left: 30px solid $darkestGray;
         position: absolute;
         top: 50%;
-        margin-top: -50px;
+        margin-top: -50px;*/
         /*margin-left: 1px;*/ /* uncomment to make the line thicker */
-        left: 100%;
+        /*left: 100%;
         z-index: 1;
-      }
+      }*/
 
       &:hover {
-        background-color: $colorSplash;
+        /*background-color: $colorSplash;*/
 
         button,
-        span {
-          color: $white;
+        span,
+        span:after {
+          background-color: $colorSplash;
+          color: $colorSplashContrast;
+        }
+
+        span:after,
+        button:after {
+          border: 1px solid $lightestGray;
+          border-left-color: $colorSplash;
+          border-bottom-color: $colorSplash;
+        }
+
+        span:before,
+        button:before {
+          background-color: $colorSplash;
+        }
+
+        + li span:before,
+        + li button:before {
+          border-left-color: $colorSplash;
         }
       }
 
       &:hover:after {
-        border-left-color: $colorSplash;
+        /*border-left-color: $colorSplash;*/
       }
       &:hover:before {
-        border-left-color: $white;
+        /*border-left-color: $white;*/
       }
 
       button {
         background-color: transparent;
-        border: 0 none;
+        border: 0;
         color: $darkestGray;
         cursor: pointer;
-        font: $baseText;
+        font: $fontMedium;
         font-weight: bold;
-        margin: 0;
-        padding: 8px 0 8px 20px;
+        line-height: 1;
         text-decoration: none;
       }
 
       span {
-        padding-left: 20px;
+        background-color: $lightestGray;
       }
 
-      .root {
-        /*background: url($imgPath + 'style/home.png') no-repeat scroll center top transparent;*/
-        display: block;
-        height: 16px;
-        margin: 10px 0 10px 0;
-        text-indent: -999em;
-        width: 16px;
-      }
-      .root:before {
-        @extend %pseudo-font-x-btn;
+      button,
+      span {
+        display: inline-block;
+        margin: 0 0 0 1px;
+        padding: 11px 13px 11px 15px;
+        position: relative; /* to position the pseudo elements */
 
-        content: $fa-var-home;
-        display: block;
-        font-size: 20px;
-        line-height: 35px;
-        padding-left: 10px;
-        text-align: center;
-        text-indent: 0;
-      }
-      button.root {
-        /*background-position: center -16px;*/
+        /* the cover element, makes up the 2 triangle shapes at the left of each crumb */
+        &:before {
+          background-color: transparent;
+          content: '';
+          display: inline-block;
+          width: 0;
+          height: 0;
+          border-top: 50px solid rgba(0,0,0,0); /* no transparent, breaks anti-aliasing in FF */
+          border-bottom: 50px solid rgba(0,0,0,0);/* no transparent, breaks anti-aliasing in FF */
+          border-left: 30px solid $lightestGray;
+          padding-right: 3px;
+          position: absolute; top: 50%; left: -33px;
+          margin-top: -50px;
+          transform: scale(0.99999); /* fix blurry edges in FF */
+          z-index: -1;
+        }
+        /* the triangle shape and line to the right of each crumb */
+        &:after {
+          background-color: $lightestGray;
+          border: 1px solid $softGray;
+          border-left: 0;
+          border-bottom: 0;
+          border-radius: $borderRadius;
+          content: '';
+          display: inline-block;
+          width: 34px; height: 34px; /* + 2px border = 36px */
+          position: absolute; top: 0; right: -22px;
+          transform: scaleX(0.6) rotate(45deg);
+          z-index: -1;
+        }
       }
     }
   }

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -1,6 +1,19 @@
 @import "font-awesome/variables";
 @import "font-awesome/mixins";
 
+/* Fix oversize of buttons in FF */
+input[type="reset"]::-moz-focus-inner, 
+input[type="button"]::-moz-focus-inner, 
+input[type="submit"]::-moz-focus-inner,
+button::-moz-focus-inner {
+    padding: 0;
+    border: 0;
+}
+
+button {
+  margin: 2px; /* default in chrome, apply it to everybody */
+}
+
 /* btn style */
 .x-btn {
   @extend %secondary-button;
@@ -19,7 +32,8 @@
 .actions {
   bottom: 8px;
   margin: 0;
-  overflow: hidden;
+  /*overflow: hidden;*/ /* cuts off box-shadows in FF */
+  overflow: visible;
   position: absolute;
 
   li {

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -700,6 +700,7 @@ input::-moz-focus-inner {
           cursor: pointer;
           display: inline-block;
           /*font-size: 1px;*/
+          outline: 0; /* fix firefox dotted outlines */
           padding: 0;
           position: absolute; top: 0; right: 0;
           width: 16px; height: 100%;

--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -26,6 +26,7 @@
 .x-toolbar td,.x-toolbar span,.x-toolbar input,
 .x-toolbar div,.x-toolbar select,.x-toolbar label {
   font: $fontSmall;
+  line-height: 1;
 }
 
 .x-toolbar .x-btn-over em.x-btn-split,
@@ -162,13 +163,14 @@
 
 /* top toolbars */
 .x-panel-tbar {
+  overflow: visible; /* prevent cut off box-shadows in FF */
   padding-bottom: 2px;
 
   .x-toolbar {
-    background-color: #F5F5F5;
-    border: 0 none;
+    /*background-color: #F5F5F5;*/
+    border: 0;
     padding: 5px 0;
-    overflow: hidden;
+    overflow: visible; /* prevent cut off box-shadows in FF */
   }
 }
 

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -90,7 +90,7 @@
     /* Firefox & IE adjustments */
     .ext-gecko3 &,
     .ext-ie & {
-      height: 42px;
+      height: 40px;
       top: 69px;
     }
   }

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -272,7 +272,7 @@
   display: inline-block;
   float: left;
   position: relative;
-  width: 32px !important; /* override extjs default theme style */
+  width: 40px !important; /* override extjs default theme style */
 
   &:before {
     @extend %pseudo-font;
@@ -282,7 +282,7 @@
     font-size: 32px;
     margin-top: -14px; /* half of the height to center vertically with top 50% */
     position: absolute; top: 50%; right: 0;
-    text-align: center;
+    text-align: left;
     width: 100%;
   }
 
@@ -316,9 +316,10 @@
 }
 
 .ext-mb-content {
-  display: inline-block;
-  float: left;
+  display: block;
+  /*float: left;*/
   /*margin-left: 40px !important; /* override extjs default theme style */
+  margin-left: 0 !important;
 }
 
 /* don't know when these styles are used */

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -106,7 +106,7 @@
     background: $winBodyBg;
     /*box-shadow: $boxShadow;*/
     /*border-radius: $borderRadius;*/
-    overflow-y: scroll; /* make the content area of normal windows scrollable */
+    overflow-y: auto; /* make the content area of normal windows scrollable, fix always visible scrollbars with auto */
     /*padding: 10px;*/
     padding: 0;
 
@@ -164,7 +164,7 @@
   padding: 10px;
 
     .x-tab-panel-body {
-      overflow-y: scroll; /* tabs stay, content scrolls */
+      overflow-y: auto; /* tabs stay, content scrolls, but only show when necessary */
 
       .modx-panel {
         /*overflow-y: scroll; /* tabs stay, content scrolls */

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -340,6 +340,10 @@
   font: $fontSmall;
 }
 
+.ext-el-mask-msg.modx-lockmask div {
+  color: $red;
+}
+
 .x-mask-loading div {
   background-color: $lightestGray;
   background-image: url($imgPath + 'modx-theme/grid/loading.gif');

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -16,8 +16,10 @@
   zoom: 1;
 
   /* .x-btn buttons are wrapped in an em tag */
-  em {
-    font-size: 0; /* prevent strange excessive height */
+  .ext-webkit & {
+    em {
+      font-size: 0; /* prevent strange excessive height, creates too much height in firefox^^ */
+    }
   }
 
   button {


### PR DESCRIPTION
Fixes misaligned confirm icons/message, see https://github.com/modxcms/revolution/pull/11697 and https://github.com/modxcms/revolution/issues/11696  too (but my correction also takes windows with no icon into account)
- Fixes package manager breadcrumb looking crappy in FF
- Fixes buttons in Firefox (cut off, too big etc.)
- Fixes outline issue in Firefox on the multiselect options close button
- Fixes the red loading mask text everywhere, see #11695 too
- Fixes unnecessary scrollbars in windows (on Windows OS)
