### PR TITLE
[2.3] [Re-build] Manager Theme Windows Fixes

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -337,6 +337,7 @@ input::-moz-focus-inner {
   .x-fieldset-bwrap {
 
     .x-fieldset-body {
+      overflow-x: hidden !important; /* prevent unnecessary horizontal scrollbars */
       padding: 0 10px 10px 10px;
     }
   }

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -98,7 +98,8 @@
 
   .x-window-body {
     background-color: $winBodyBg !important; /* override extjs default theme transparent !important style from .x-window-plain */
-    overflow: visible; /* prevent box-shadow from tabs and panel being cut off */
+    /*overflow: visible; /* prevent box-shadow from tabs and panel being cut off */
+    overflow-y: auto;
     padding: 15px;
   }
 
@@ -106,7 +107,7 @@
     background: $winBodyBg;
     /*box-shadow: $boxShadow;*/
     /*border-radius: $borderRadius;*/
-    overflow-y: auto; /* make the content area of normal windows scrollable, fix always visible scrollbars with auto */
+    /*overflow-y: auto; /* make the content area of normal windows scrollable, fix always visible scrollbars with auto */
     /*padding: 10px;*/
     padding: 0;
 
@@ -124,6 +125,7 @@
 
     .x-window-body {
       background-color: $lightestGray !important; /* override !important rule from above */
+      overflow: visible; /* prevent box-shadow from tabs and panel being cut off */
     }
 
     .x-panel-bwrap {

--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -213,7 +213,7 @@ MODx.browser.Window = function(config) {
         ,minWidth: 500
         ,minHeight: 300
         ,width: '90%'
-        ,height: 500
+        ,height: Ext.getBody().getViewSize().height * 0.9
         ,modal: false
         ,closeAction: 'hide'
         ,border: false
@@ -245,14 +245,15 @@ MODx.browser.Window = function(config) {
             ,width: 250
         }]
         ,buttons: [{
-            id: this.ident+'-ok-btn'
-            ,text: _('ok')
-            ,handler: this.onSelect
-            ,scope: this
-        },{
             id: this.ident+'-cancel-btn'
             ,text: _('cancel')
             ,handler: this.close
+            ,scope: this
+        },{
+            id: this.ident+'-ok-btn'
+            ,text: _('ok')
+            ,cls: 'primary-button'
+            ,handler: this.onSelect
             ,scope: this
         }]
         ,keys: {

--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -289,7 +289,7 @@
         Ext.applyIf(config,{
             permitted_extensions: permittedFileTypes
             ,autoHeight: true
-            ,width: 550
+            ,width: 600
             ,closeAction: 'hide'
             ,layout: 'anchor'
             ,listeners: {

--- a/manager/assets/modext/util/uploaddialog.js
+++ b/manager/assets/modext/util/uploaddialog.js
@@ -425,9 +425,9 @@ Ext.ux.UploadDialog.FileRecord.STATE_PROCESSING = 3;
 Ext.ux.UploadDialog.Dialog = function(config) {
   var default_config = {
     border: false,
-    width: 450,
+    width: 600,
     height: 350,
-    minWidth: 450,
+    // minWidth: 450,
     minHeight: 350,
     plain: true,
     constrainHeader: true,

--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -12,7 +12,7 @@ MODx.Console = function(config) {
         ,maximizable: true
         ,autoScroll: true
         ,height: 400
-        ,width: 650
+        ,width: 600
         ,refreshRate: 2
         ,cls: 'modx-window modx-console'
         ,items: [{

--- a/manager/assets/modext/widgets/core/modx.orm.js
+++ b/manager/assets/modext/widgets/core/modx.orm.js
@@ -318,8 +318,8 @@ MODx.window.AddOrmAttribute = function(config) {
     Ext.applyIf(config,{
         title: _('orm_attribute_add')
         ,id: this.ident
-        ,height: 150
-        ,width: 350
+        // ,height: 150
+        // ,width: 350
         ,fields: [{
             xtype: 'hidden'
             ,name: 'parent'
@@ -371,8 +371,8 @@ MODx.window.AddOrmContainer = function(config) {
     Ext.applyIf(config,{
         title: _('orm_container_add')
         ,id: this.ident
-        ,height: 150
-        ,width: 350
+        // ,height: 150
+        // ,width: 350
         ,fields: [{
             xtype: 'hidden'
             ,name: 'parent'
@@ -417,8 +417,8 @@ MODx.window.RenameOrmContainer = function(config) {
     Ext.applyIf(config,{
         title: _('orm_container_rename')
         ,id: this.ident
-        ,height: 150
-        ,width: 350
+        // ,height: 150
+        // ,width: 350
         ,fields: [{
             xtype: 'hidden'
             ,name: 'parent'

--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -123,9 +123,11 @@ MODx.Window = function(config) {
         ,resizable: true
         ,collapsible: true
         ,maximizable: true
-        ,autoHeight: true
+        // ,autoHeight: true // this messes up many windows on smaller screens (e.g. too much height), ex. macbook air 11"
+        ,autoHeight: false
+        ,autoScroll: true
         ,allowDrop: true
-        ,width: 450
+        ,width: 400
         ,cls: 'modx-window'
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')

--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -16,12 +16,17 @@ Ext.override(Ext.Window, {
         // wait for onShow to finish and check if the window is already visible then, if not, try to do that
         setTimeout(function() {
             if (!win.el.hasClass('anim-ready')) {
-                win.addClass('anim-ready');
+                win.el.addClass('anim-ready');
                 setTimeout(function() {
                     if (win.mask !== undefined) {
-                        win.mask.addClass('fade-in');
+                        // respect that the mask is not always the same object
+                        if (win.mask instanceof Ext.Element) {
+                            win.mask.addClass('fade-in');
+                        } else {
+                            win.mask.el.addClass('fade-in');
+                        }
                     }
-                    win.addClass('zoom-in');
+                    win.el.addClass('zoom-in');
                 }, 250);
             }
         }, 300);
@@ -41,9 +46,14 @@ Ext.override(Ext.Window, {
             var win = this; // we need a reference to this for setTimeout
             setTimeout(function() {
                 if (win.mask !== undefined) {
-                    win.mask.addClass('fade-in');
+                    // respect that the mask is not always the same object
+                    if (win.mask instanceof Ext.Element) {
+                        win.mask.addClass('fade-in');
+                    } else {
+                        win.mask.el.addClass('fade-in');
+                    }
                 }
-                win.addClass('zoom-in');
+                win.el.addClass('zoom-in');
             }, 250);
         } else {
             // we need to handle MODx.msg windows (Ext.Msg singletons, e.g. always the same element, no multiple instances) differently
@@ -55,9 +65,14 @@ Ext.override(Ext.Window, {
         // for some unknown (to me) reason, onHide() get's called when a window is initialized, e.g. before onShow()
         // so we need to prevent the following routine be applied prematurely
         if (this.el.hasClass('zoom-in')) {
-            this.removeClass('zoom-in');
+            this.el.removeClass('zoom-in');
             if (this.mask !== undefined) {
-                this.mask.removeClass('fade-in');
+                // respect that the mask is not always the same object
+                if (this.mask instanceof Ext.Element) {
+                    this.mask.removeClass('fade-in');
+                } else {
+                    this.mask.el.removeClass('fade-in');
+                }
             }
             this.addClass('zoom-out');
             // let the CSS animation finish before hiding the window
@@ -69,8 +84,8 @@ Ext.override(Ext.Window, {
                 if (!win.isDestroyed) {
                     win.el.hide();
                     // and remove the CSS3 animation classes
-                    win.removeClass('zoom-out');
-                    win.removeClass('anim-ready');
+                    win.el.removeClass('zoom-out');
+                    win.el.removeClass('anim-ready');
                 }
             }, 250);
         } else if (this.el.hasClass('x-window-dlg')) {
@@ -78,7 +93,12 @@ Ext.override(Ext.Window, {
             this.el.applyStyles({'opacity': 0});
 
             if (this.mask !== undefined) {
-                this.mask.removeClass('fade-in');
+                // respect that the mask is not always the same object
+                if (this.mask instanceof Ext.Element) {
+                    this.mask.removeClass('fade-in');
+                } else {
+                    this.mask.el.removeClass('fade-in');
+                }
             }
         }
     }

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -577,6 +577,7 @@ MODx.grid.ElementPropertyOption = function(config) {
         }]
         ,tbar: [{
             text: _('property_option_create')
+            ,cls: 'primary-button'
             ,handler: this.create
             ,scope: this
         }]
@@ -624,8 +625,8 @@ MODx.window.CreateElementProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_create')
         ,id: 'modx-window-element-property-create'
-        ,height: 250
-        ,width: 650
+        // ,height: 250
+        ,width: 600
         ,saveBtnText: _('done')
         ,fields: [{
             layout: 'column'
@@ -776,8 +777,8 @@ MODx.window.UpdateElementProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_update')
         ,id: 'modx-window-element-property-update'
-        ,height: 250
-        ,width: 650
+        // ,height: 250
+        ,width: 600
         ,saveBtnText: _('done')
         ,forceLayout: true
         ,fields: [{
@@ -949,8 +950,8 @@ MODx.window.CreateElementPropertyOption = function(config) {
     Ext.applyIf(config,{
         title: _('property_option_create')
         ,id: 'modx-window-element-property-option-create'
-        ,height: 250
-        ,width: 450
+        // ,height: 250
+        // ,width: 450
         ,saveBtnText: _('done')
         ,fields: [{
             fieldLabel: _('name')

--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -141,7 +141,7 @@ MODx.window.UpdatePluginEvent = function(config) {
         ,id: 'modx-window-plugin-event-update'
         ,url: MODx.config.connector_url
         ,action: 'element/plugin/event/associate'
-        ,autoHeight: true
+        ,autoHeight: true // needed here or the window will always show a scrollbar
         ,width: 600
         ,fields: [{
             fieldLabel: _('name')
@@ -242,6 +242,7 @@ MODx.grid.PluginEventAssoc = function(config) {
         }]
         ,tbar: [{
             text: _('plugin_add')
+            ,cls: 'primary-button'
             ,handler: this.addPlugin
             ,scope: this
         }]
@@ -296,8 +297,8 @@ MODx.window.AddPluginToEvent = function(config) {
         ,id: this.ident
         ,url: MODx.config.connector_url
         ,action: 'element/plugin/event/addplugin'
-        ,height: 250
-        ,width: 600
+        // ,height: 250
+        // ,width: 600
         ,fields: [{
             xtype: 'modx-combo-plugin'
             ,fieldLabel: _('plugin')
@@ -311,6 +312,7 @@ MODx.window.AddPluginToEvent = function(config) {
             ,id: 'modx-'+this.ident+'-priority'
             ,value: 0
             ,allowBlank: false
+            ,anchor: '100%'
         }]
     });
     MODx.window.AddPluginToEvent.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -312,7 +312,7 @@ MODx.window.AddElementToPropertySet = function(config) {
         ,baseParams: {
             action: 'element/propertyset/addElement'
         }
-        ,width: 400
+        // ,width: 400
         ,fields: [{
             xtype: 'hidden'
             ,name: 'propertyset'
@@ -419,7 +419,7 @@ MODx.window.CreatePropertySet = function(config) {
         ,baseParams: {
             action: 'element/propertyset/create'
         }
-        ,width: 550
+        // ,width: 550
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -485,7 +485,7 @@ MODx.window.DuplicatePropertySet = function(config) {
         ,baseParams: {
             action: 'element/propertyset/duplicate'
         }
-        ,width: 550
+        // ,width: 550
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -499,7 +499,8 @@ MODx.window.DuplicatePropertySet = function(config) {
         },{
             xtype: 'xcheckbox'
             ,boxLabel: _('propertyset_duplicate_copyels')
-            ,labelSeparator: ''
+            // ,labelSeparator: ''
+            ,hideLabel: true
             ,name: 'copyels'
             ,id: 'modx-dpropset-copyels'
             ,checked: true

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -601,8 +601,8 @@ MODx.window.RenameCategory = function(config) {
     this.ident = config.ident || 'rencat-'+Ext.id();
     Ext.applyIf(config,{
         title: _('category_rename')
-        ,height: 150
-        ,width: 350
+        // ,height: 150
+        // ,width: 350
         ,url: MODx.config.connector_url
         ,action: 'element/category/update'
         ,fields: [{

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -559,16 +559,17 @@ MODx.window.DuplicateElement = function(config) {
         ,fieldLabel: _('element_name_new')
         ,name: config.record.type == 'template' ? 'templatename' : 'name'
         ,id: 'modx-'+this.ident+'-name'
-        ,anchor: '90%'
+        ,anchor: '100%'
     }];
     if (config.record.type == 'tv') {
         flds.push({
             xtype: 'xcheckbox'
-            ,fieldLabel: _('element_duplicate_values')
-            ,labelSeparator: ''
+            ,hideLabel: true
+            ,boxLabel: _('element_duplicate_values') // the text "Duplicate Resource Values?" does not really fit here
+            // ,labelSeparator: ''
             ,name: 'duplicateValues'
             ,id: 'modx-'+this.ident+'-duplicate-values'
-            ,anchor: '95%'
+            ,anchor: '100%'
             ,inputValue: 1
             ,checked: false
         });
@@ -616,7 +617,7 @@ MODx.window.RenameCategory = function(config) {
             ,id: 'modx-'+this.ident+'-category'
             ,width: 150
             ,value: config.record.category
-            ,anchor: '90%'
+            ,anchor: '100%'
         }]
     });
     MODx.window.RenameCategory.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -327,8 +327,8 @@ MODx.window.CreateFCProfile = function(config) {
         title: _('profile_create')
         ,url: MODx.config.connector_url
         ,action: 'security/forms/profile/create'
-        ,height: 150
-        ,width: 375
+        // ,height: 150
+        // ,width: 375
         ,fields: [{
             xtype: 'textfield'
             ,name: 'name'

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -349,8 +349,8 @@ MODx.window.CreateFCSet = function(config) {
         title: _('set_create')
         ,url: MODx.config.connector_url
         ,action: 'security/forms/set/create'
-        ,height: 150
-        ,width: 650
+        // ,height: 150
+        ,width: 600
         ,fields: [{
             xtype: 'hidden'
             ,name: 'profile'

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -198,8 +198,8 @@ MODx.window.AddGroupToProfile = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('usergroup_create')
-        ,height: 150
-        ,width: 375
+        // ,height: 150
+        // ,width: 375
         ,fields: [{
             fieldLabel: _('user_group')
             ,name: 'usergroup'

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -368,8 +368,8 @@ MODx.window.AddTabToSet = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('tab_create')
-        ,height: 150
-        ,width: 375
+        // ,height: 150
+        // ,width: 375
         ,fields: [{
             xtype: 'hidden'
             ,name: 'container'

--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -175,7 +175,7 @@ MODx.window.InsertElement = function(config) {
     Ext.applyIf(config,{
         title: _('select_el_opts')
         ,id: 'modx-window-insert-element'
-        ,width: 507 // match 300px fieldwidth plus the fieldset
+        ,width: 522 // match 300px fieldwidth plus the fieldset
         ,labelAlign: 'left'
         ,labelWidth: 160
         ,url: MODx.config.connector_url
@@ -228,14 +228,15 @@ MODx.window.InsertElement = function(config) {
         },{
             xtype: 'fieldset'
             ,title: _('properties')
-            ,autoHeight: true
+            // ,autoHeight: true
+            ,height: Ext.getBody().getViewSize().height * 0.6
             ,collapsible: true
             ,autoScroll: true
             ,items: [{
                 html: '<div id="modx-iprops-form"></div>'
                 ,id: 'modx-iprops-container'
-                ,height: 400
-                ,autoScroll: true
+                // ,height: 400
+                // ,autoScroll: true
             }]
         }]
     });

--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -175,7 +175,7 @@ MODx.window.InsertElement = function(config) {
     Ext.applyIf(config,{
         title: _('select_el_opts')
         ,id: 'modx-window-insert-element'
-        ,width: 600
+        ,width: 507 // match 300px fieldwidth plus the fieldset
         ,labelAlign: 'left'
         ,labelWidth: 160
         ,url: MODx.config.connector_url
@@ -200,6 +200,7 @@ MODx.window.InsertElement = function(config) {
             ,fieldLabel: _('property_set')
             ,name: 'propertyset'
             ,id: 'modx-dise-propset'
+            ,width: 300
             ,baseParams: {
                 action: 'element/propertyset/getList'
                 ,showAssociated: true

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -787,12 +787,12 @@ MODx.window.QuickCreateResource = function(config) {
         ,id: this.ident
         ,bwrapCssClass: 'x-window-with-tabs'
         ,width: 700
-        ,height: ['modSymLink', 'modWebLink', 'modStaticResource'].indexOf(config.record.class_key) == -1 ? 640 : 498
-        ,autoHeight: false
+        //,height: ['modSymLink', 'modWebLink', 'modStaticResource'].indexOf(config.record.class_key) == -1 ? 640 : 498
+        // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'resource/create'
-        ,shadow: false
+        // ,shadow: false
         ,fields: [{
             xtype: 'modx-tabs'
             ,bodyStyle: { background: 'transparent' }

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -805,7 +805,7 @@ MODx.window.QuickCreateResource = function(config) {
                 title: _('resource')
                 ,layout: 'form'
                 ,cls: 'modx-panel'
-                ,bodyStyle: { background: 'transparent', padding: '10px' }
+                // ,bodyStyle: { background: 'transparent', padding: '10px' } // we handle this in CSS
                 ,autoHeight: false
                 ,anchor: '100% 100%'
                 ,labelWidth: 100
@@ -925,7 +925,7 @@ MODx.window.QuickCreateResource = function(config) {
                     autoHeight: true
                     ,border: false
                 }
-                ,bodyStyle: { padding: '10px' }
+                // ,bodyStyle: { padding: '10px' } // we handle this in CSS
                 ,items: MODx.getQRSettings(this.ident,config.record)
             }]
         }]
@@ -1133,8 +1133,8 @@ MODx.getQRSettings = function(id,va) {
                 ,dateFormat: MODx.config.manager_date_format
                 ,timeFormat: MODx.config.manager_time_format
                 ,startDay: parseInt(MODx.config.manager_week_start)
-                ,dateWidth: 148
-                ,timeWidth: 148
+                ,dateWidth: 153
+                ,timeWidth: 153
                 ,offset_time: MODx.config.server_offset_time
                 ,value: va['publishedon']
             },{
@@ -1147,8 +1147,8 @@ MODx.getQRSettings = function(id,va) {
                 ,dateFormat: MODx.config.manager_date_format
                 ,timeFormat: MODx.config.manager_time_format
                 ,startDay: parseInt(MODx.config.manager_week_start)
-                ,dateWidth: 148
-                ,timeWidth: 148
+                ,dateWidth: 153
+                ,timeWidth: 153
                 ,offset_time: MODx.config.server_offset_time
                 ,value: va['pub_date']
             },{
@@ -1161,8 +1161,8 @@ MODx.getQRSettings = function(id,va) {
                 ,dateFormat: MODx.config.manager_date_format
                 ,timeFormat: MODx.config.manager_time_format
                 ,startDay: parseInt(MODx.config.manager_week_start)
-                ,dateWidth: 148
-                ,timeWidth: 148
+                ,dateWidth: 153
+                ,timeWidth: 153
                 ,offset_time: MODx.config.server_offset_time
                 ,value: va['unpub_date']
             },{

--- a/manager/assets/modext/widgets/security/modx.grid.access.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.context.js
@@ -139,8 +139,8 @@ MODx.window.CreateAccessContext = function(config) {
             action: 'security/access/addAcl'
             ,type: config.type || 'modAccessContext'
         }
-        ,height: 250
-        ,width: 350
+        // ,height: 250
+        // ,width: 350
         ,type: 'modAccessContext'
         ,acl: 0
         ,fields: [{
@@ -177,7 +177,8 @@ MODx.window.CreateAccessContext = function(config) {
             xtype: 'textfield'
             ,fieldLabel: _('authority')
             ,name: 'authority'
-            ,width: 75
+            // ,width: 75
+            ,anchor: '100%'
             ,value: r.authority || ''
         }]
     });

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -273,8 +273,8 @@ MODx.window.CreateAccessPolicy = function(config) {
     config = config || {};
     this.ident = config.ident || 'cacp'+Ext.id();
     Ext.applyIf(config,{
-        width: 500
-        ,title: _('policy_create')
+        // width: 500
+        title: _('policy_create')
         ,url: MODx.config.connector_url
         ,action: 'security/access/policy/create'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -277,8 +277,8 @@ MODx.window.CreateAccessPolicyTemplate = function(config) {
     config = config || {};
     this.ident = config.ident || 'cacpt'+Ext.id();
     Ext.applyIf(config,{
-        width: 500
-        ,title: _('policy_template_create')
+        // width: 500
+        title: _('policy_template_create')
         ,url: MODx.config.connector_url
         ,action: 'security/access/policy/template/create'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.grid.role.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.js
@@ -90,8 +90,8 @@ MODx.window.CreateRole = function(config) {
     this.ident = config.ident || 'crole'+Ext.id();
     Ext.applyIf(config,{
         title: _('role_create')
-        ,height: 150
-        ,width: 400
+        // ,height: 150
+        // ,width: 400
         ,url: MODx.config.connector_url
         ,action: 'security/role/create'
         ,fields: [{
@@ -114,7 +114,8 @@ MODx.window.CreateRole = function(config) {
             ,allowBlank: false
             ,allowNegative: false
             ,value: 0
-            ,width: 75
+            // ,width: 75
+            ,anchor: '100%'
         },{
             xtype: MODx.expandHelp ? 'label' : 'hidden'
             ,forId: 'modx-'+this.ident+'-authority'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
@@ -150,8 +150,8 @@ MODx.window.CreateUGCat = function(config) {
         title: _('category_add')
         ,url: MODx.config.connector_url
         ,action: 'security/access/usergroup/category/create'
-        ,height: 250
-        ,width: 500
+        // ,height: 250
+        // ,width: 500
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -175,7 +175,7 @@ MODx.window.CreateUGAccessContext = function(config) {
         title: _('ugc_mutate')
         ,url: MODx.config.connector_url
         ,action: 'security/access/usergroup/context/create'
-        ,width: 600
+        // ,width: 600
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -148,8 +148,8 @@ MODx.window.AddGroupToUser = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('user_group_user_add')
-        ,height: 150
-        ,width: 375
+        // ,height: 150
+        // ,width: 375
         ,url: MODx.config.connector_url
         ,action: 'security/group/user/create'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
@@ -150,8 +150,8 @@ MODx.window.CreateUGRG = function(config) {
         title: _('resource_group_add')
         ,url: MODx.config.connector_url
         ,action: 'security/access/usergroup/resourcegroup/create'
-        ,height: 250
-        ,width: 600
+        // ,height: 250
+        // ,width: 600
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
@@ -145,8 +145,8 @@ MODx.window.CreateUGSource = function(config) {
         title: _('source_add')
         ,url: MODx.config.connector_url
         ,action: 'security/access/usergroup/source/create'
-        ,height: 250
-        ,width: 500
+        // ,height: 250
+        // ,width: 500
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
@@ -241,8 +241,8 @@ MODx.window.NewTemplatePermission = function(config) {
     this.ident = config.ident || 'polpc'+Ext.id();
     Ext.applyIf(config,{
         title: _('permission_add_template')
-        ,height: 150
-        ,width: 475
+        // ,height: 150
+        // ,width: 475
         ,url: MODx.config.connector_url
         ,action: 'security/access/policy/addProperty'
         ,saveBtnText: _('add')

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -472,8 +472,8 @@ MODx.window.AddUserToUserGroup = function(config) {
     this.ident = config.ident || 'auug'+Ext.id();
     Ext.applyIf(config,{
         title: _('user_group_user_add')
-        ,height: 150
-        ,width: 500
+        // ,height: 150
+        // ,width: 500
         ,url: MODx.config.connector_url
         ,action: 'security/group/user/create'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.tree.resource.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.resource.group.js
@@ -220,8 +220,8 @@ MODx.window.CreateResourceGroup = function(config) {
     Ext.applyIf(config,{
         title: _('resource_group_create')
         ,id: this.ident
-        ,height: 150
-        ,width: 650
+        // ,height: 150
+        ,width: 600
         ,stateful: false
         ,url: MODx.config.connector_url
         ,action: 'security/resourcegroup/create'
@@ -337,8 +337,8 @@ MODx.window.UpdateResourceGroup = function(config) {
     Ext.applyIf(config,{
         title: _('resource_group_update')
         ,id: this.ident
-        ,height: 150
-        ,width: 350
+        // ,height: 150
+        // ,width: 350
         ,url: MODx.config.connector_url
         ,action: 'security/resourcegroup/update'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -190,8 +190,8 @@ MODx.window.CreateUserGroup = function(config) {
     Ext.applyIf(config,{
         title: _('create_user_group')
         ,id: this.ident
-        ,height: 150
-        ,width: 750
+        // ,height: 150
+        ,width: 700
         ,stateful: false
         ,url: MODx.config.connector_url
         ,action: 'security/group/create'
@@ -350,8 +350,8 @@ MODx.window.AddUserToUserGroup = function(config) {
     Ext.applyIf(config,{
         title: _('user_group_user_add')
         ,id: this.ident
-        ,height: 150
-        ,width: 375
+        // ,height: 150
+        // ,width: 375
         ,url: MODx.config.connector_url
         ,action: 'security/group/user/create'
         ,fields: [{

--- a/manager/assets/modext/widgets/source/modx.grid.source.access.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.access.js
@@ -131,8 +131,8 @@ MODx.window.CreateSourceAccess = function(config) {
 
     Ext.applyIf(config,{
         title: _('source_access_add')
-        ,height: 250
-        ,width: 350
+        // ,height: 250
+        // ,width: 350
         ,type: 'modAccessMediaSource'
         ,acl: 0
         ,fields: [{

--- a/manager/assets/modext/widgets/source/modx.grid.source.properties.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.properties.js
@@ -1,4 +1,3 @@
-
 MODx.grid.SourceProperties = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -332,8 +331,8 @@ MODx.window.CreateSourceProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_create')
         ,id: 'modx-window-source-property-create'
-        ,height: 250
-        ,width: 450
+        // ,height: 250
+        // ,width: 450
         ,saveBtnText: _('done')
         ,fields: [{
             fieldLabel: _('name')
@@ -428,8 +427,8 @@ MODx.window.UpdateSourceProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_update')
         ,id: 'modx-window-source-property-update'
-        ,height: 250
-        ,width: 450
+        // ,height: 250
+        // ,width: 450
         ,saveBtnText: _('done')
         ,forceLayout: true
         ,fields: [{
@@ -546,8 +545,8 @@ MODx.window.CreateSourcePropertyOption = function(config) {
     Ext.applyIf(config,{
         title: _('property_option_create')
         ,id: 'modx-window-source-property-option-create'
-        ,height: 250
-        ,width: 450
+        // ,height: 250
+        // ,width: 450
         ,saveBtnText: _('done')
         ,fields: [{
             fieldLabel: _('name')

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -245,7 +245,6 @@ MODx.window.CreateSource = function(config) {
         title: _('source_create')
         ,url: MODx.config.connector_url
         ,action: 'source/create'
-        ,cls:'primary-button'
         ,fields: [{
             xtype: 'textfield'
             ,fieldLabel: _('name')

--- a/manager/assets/modext/widgets/system/modx.grid.content.type.js
+++ b/manager/assets/modext/widgets/system/modx.grid.content.type.js
@@ -158,7 +158,7 @@ MODx.window.CreateContentType = function(config) {
     this.ident = config.ident || 'modx-cct'+Ext.id();
     Ext.applyIf(config,{
         title: _('content_type_new')
-        ,width: 550
+        ,width: 600
         ,url: MODx.config.connector_url
         ,action: 'system/contenttype/create'
         // ,cls: 'window-no-padding'

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -127,7 +127,6 @@ MODx.window.CreateContext = function(config) {
         title: _('context_create')
         ,url: MODx.config.connector_url
         ,action: 'context/create'
-        ,cls:'primary-button'
         ,fields: [{
             xtype: 'textfield'
             ,fieldLabel: _('context_key')

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -299,7 +299,7 @@ MODx.window.DashboardWidgetPlace = function(config) {
     this.ident = config.ident || 'dbugadd'+Ext.id();
     Ext.applyIf(config,{
         title: _('widget_place')
-        ,frame: true
+        // ,frame: true
         ,id: 'modx-window-dashboard-widget-place'
         ,fields: [{
             xtype: 'modx-combo-dashboard-widgets'

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -299,13 +299,13 @@ Ext.extend(MODx.grid.DashboardWidgetDashboards,MODx.grid.LocalGrid);
 Ext.reg('modx-grid-dashboard-widget-dashboards',MODx.grid.DashboardWidgetDashboards);
 
 
-
+/* seems unused */
 MODx.window.WidgetAddDashboard = function(config) {
     config = config || {};
     this.ident = config.ident || 'dbugadd'+Ext.id();
     Ext.applyIf(config,{
         title: _('widget_place')
-        ,frame: true
+        // ,frame: true
         ,id: 'modx-window-widget-add-dashboard'
         ,fields: [{
             xtype: 'modx-combo-dashboard'

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -650,9 +650,9 @@ Ext.reg('modx-tree-directory',MODx.tree.Directory);
 MODx.window.CreateDirectory = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        width: 430
-        ,height: 200
-        ,title: _('file_folder_create')
+        title: _('file_folder_create')
+        // width: 430
+        // ,height: 200
         ,url: MODx.config.connector_url
         ,action: 'browser/directory/create'
         ,fields: [{
@@ -692,8 +692,8 @@ MODx.window.ChmodDirectory = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('file_folder_chmod')
-        ,width: 430
-        ,height: 200
+        // ,width: 430
+        // ,height: 200
         ,url: MODx.config.connector_url
         ,action: 'browser/directory/chmod'
         ,fields: [{
@@ -734,8 +734,8 @@ MODx.window.RenameDirectory = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('rename')
-        ,width: 430
-        ,height: 200
+        // ,width: 430
+        // ,height: 200
         ,url: MODx.config.connector_url
         ,action: 'browser/directory/rename'
         ,fields: [{
@@ -781,8 +781,8 @@ MODx.window.RenameFile = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('rename')
-        ,width: 430
-        ,height: 200
+        // ,width: 430
+        // ,height: 200
         ,url: MODx.config.connector_url
         ,action: 'browser/file/rename'
         ,fields: [{
@@ -832,8 +832,8 @@ MODx.window.QuickUpdateFile = function(config) {
     Ext.applyIf(config,{
         title: _('file_quick_update')
         ,width: 600
-        ,height: 640
-        ,autoHeight: false
+        // ,height: 640
+        // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'browser/file/update'
@@ -861,7 +861,8 @@ MODx.window.QuickUpdateFile = function(config) {
             fieldLabel: _('content')
             ,xtype: 'textarea'
             ,name: 'content'
-            ,anchor: '100% -118'
+            ,anchor: '100%'
+            ,height: 200
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER
@@ -902,8 +903,8 @@ MODx.window.QuickCreateFile = function(config) {
     Ext.applyIf(config,{
         title: _('file_quick_create')
         ,width: 600
-        ,height: 640
-        ,autoHeight: false
+        // ,height: 640
+        // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'browser/file/create'
@@ -930,7 +931,8 @@ MODx.window.QuickCreateFile = function(config) {
             fieldLabel: _('content')
             ,xtype: 'textarea'
             ,name: 'content'
-            ,anchor: '100% -120'
+            ,anchor: '100%'
+            ,height: 200
         }]
        ,keys: [{
             key: Ext.EventObject.ENTER

--- a/manager/assets/modext/widgets/system/modx.tree.menu.js
+++ b/manager/assets/modext/widgets/system/modx.tree.menu.js
@@ -122,8 +122,8 @@ MODx.window.CreateMenu = function(config) {
     this.ident = config.ident || 'modx-cmenu-'+Ext.id();
     Ext.applyIf(config,{
         title: _('menu_create')
-        ,width: 650
-        ,height: 400
+        ,width: 600
+        // ,height: 400
         ,url: MODx.config.connector_url
         ,action: 'system/menu/create'
         ,fields: [{
@@ -135,6 +135,7 @@ MODx.window.CreateMenu = function(config) {
         },{
             layout: 'column'
             ,border: false
+            ,style: 'padding-top: 15px;'
             ,defaults: {
                 layout: 'form'
                 ,labelAlign: 'top'

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -12,7 +12,7 @@ MODx.window.DuplicateResource = function(config) {
     Ext.applyIf(config,{
         title: _('duplication_options')
         ,id: this.ident
-        ,width: 500
+        // ,width: 500
     });
     MODx.window.DuplicateResource.superclass.constructor.call(this,config);
 };
@@ -62,18 +62,22 @@ Ext.extend(MODx.window.DuplicateResource,MODx.Window,{
             ,title: _('publishing_options')
             ,items: [{
                 xtype: 'radiogroup'
+                ,hideLabel: true
                 ,columns: 1
                 ,value: pov
                 ,items: [{
                     boxLabel: _('po_make_all_unpub')
+                    ,hideLabel: true
                     ,name: 'published_mode'
                     ,inputValue: 'unpublish'
                 },{
                     boxLabel: _('po_make_all_pub')
+                    ,hideLabel: true
                     ,name: 'published_mode'
                     ,inputValue: 'publish'
                 },{
                     boxLabel: _('po_preserve')
+                    ,hideLabel: true
                     ,name: 'published_mode'
                     ,inputValue: 'preserve'
                 }]
@@ -104,8 +108,8 @@ MODx.window.CreateCategory = function(config) {
     Ext.applyIf(config,{
         title: _('new_category')
         ,id: this.ident
-        ,height: 150
-        ,width: 350
+        // ,height: 150
+        // ,width: 350
         ,url: MODx.config.connector_url
         ,action: 'element/category/create'
         ,fields: [{
@@ -194,7 +198,7 @@ MODx.window.QuickCreateChunk = function(config) {
         title: _('quick_create_chunk')
         ,width: 600
         //,height: 640
-        ,autoHeight: true
+        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'element/chunk/create'
@@ -277,7 +281,7 @@ MODx.window.QuickCreateTemplate = function(config) {
     Ext.applyIf(config,{
         title: _('quick_create_template')
         ,width: 600
-        ,autoHeight: true
+        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'element/template/create'
@@ -360,7 +364,7 @@ MODx.window.QuickCreateSnippet = function(config) {
     Ext.applyIf(config,{
         title: _('quick_create_snippet')
         ,width: 600
-        ,autoHeight: true
+        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'element/snippet/create'
@@ -444,7 +448,7 @@ MODx.window.QuickCreatePlugin = function(config) {
     Ext.applyIf(config,{
         title: _('quick_create_plugin')
         ,width: 600
-        ,autoHeight: true
+        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'element/plugin/create'
@@ -666,7 +670,7 @@ MODx.window.DuplicateContext = function(config) {
         ,id: this.ident
         ,url: MODx.config.connector_url
         ,action: 'context/duplicate'
-        ,width: 400
+        // ,width: 400
         ,fields: [{
             xtype: 'statictextfield'
             ,id: 'modx-'+this.ident+'-key'
@@ -682,16 +686,18 @@ MODx.window.DuplicateContext = function(config) {
             ,anchor: '100%'
             ,value: ''
         },{
-            xtype: 'checkbox',
-            id: 'modx-'+this.ident+'-preservealias'
-            ,fieldLabel: _('preserve_alias') // Todo: add translation
+            xtype: 'checkbox'
+            ,id: 'modx-'+this.ident+'-preservealias'
+            ,hideLabel: true
+            ,boxLabel: _('preserve_alias') // Todo: add translation
             ,name: 'preserve_alias'
             ,anchor: '100%'
             ,checked: true
         },{
-            xtype: 'checkbox',
-            id: 'modx-'+this.ident+'-preservemenuindex'
-            ,fieldLabel: _('preserve_menuindex') // Todo: add translation
+            xtype: 'checkbox'
+            ,id: 'modx-'+this.ident+'-preservemenuindex'
+            ,hideLabel: true
+            ,boxLabel: _('preserve_menuindex') // Todo: add translation
             ,name: 'preserve_menuindex'
             ,anchor: '100%'
             ,checked: true
@@ -711,7 +717,7 @@ MODx.window.Login = function(config) {
         ,id: this.ident
         ,url: MODx.config.connector_url
         ,action: 'security/login'
-        ,width: 400
+        // ,width: 400
         ,fields: [{
             html: '<p>'+_('session_logging_out')+'</p>'
             ,bodyCssClass: 'panel-desc'
@@ -739,6 +745,7 @@ MODx.window.Login = function(config) {
             ,handler: function() { location.href = '?logout=1' }
         },{
             text: _('login')
+            ,cls: 'primary-button'
             ,scope: this
             ,handler: this.submit
         }]

--- a/manager/assets/modext/workspace/lexicon/language.grid.js
+++ b/manager/assets/modext/workspace/lexicon/language.grid.js
@@ -90,7 +90,7 @@ MODx.window.CreateLanguage = function(config) {
             ,fieldLabel: _('name')
             ,name: 'name'
             ,itemId: 'name'
-            ,anchor: '95%'
+            ,anchor: '100%'
             ,maxLength: 100
             ,allowBlank: false
         }]

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -10,15 +10,16 @@ MODx.window.PackageUninstall = function(config) {
         title: _('package_uninstall')
         ,url: MODx.config.connector_url
         ,action: 'workspace/packages/uninstall'
-        ,height: 400
-        ,width: 500
+        // ,height: 400
+        // ,width: 400
         ,id: 'modx-window-package-uninstall'
         ,saveBtnText: _('uninstall')
         ,fields: [{
             html: _('preexisting_mode_select')
-            ,border: false
-            ,autoHeight: true
-        },MODx.PanelSpacer,{
+            ,cls: 'win-desc panel-desc'
+            // ,border: false
+            // ,autoHeight: true
+        },{
             xtype: 'radio'
             ,name: 'preexisting_mode'
             ,fieldLabel: _('preexisting_mode_preserve')
@@ -75,10 +76,11 @@ MODx.window.RemovePackage = function(config) {
         },MODx.PanelSpacer,{
             html: _('package_remove_force_desc')
             ,border: false
-        },MODx.PanelSpacer,{
+        },{
             xtype: 'xcheckbox'
             ,name: 'force'
             ,boxLabel: _('package_remove_force')
+            ,hideLabel: true
             ,id: 'modx-rpack-force'
             ,labelSeparator: ''
             ,inputValue: 'true'

--- a/manager/assets/modext/workspace/provider.grid.js
+++ b/manager/assets/modext/workspace/provider.grid.js
@@ -58,7 +58,7 @@ MODx.window.CreateProvider = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('provider_add')
-        ,width: 400
+        // ,width: 400
         ,url: MODx.config.connector_url
         ,action: 'workspace/providers/create'
         ,fields: [{


### PR DESCRIPTION
This PR fixes most importantly a bug that was introduced in #11689, which threw an error when trying to drop an element with properties into a resource content field (treedrop), the problem was, that this special window creates a loading mask, on which an unsupported method (addClass()) was called by the JS that handles the classes for the CSS3 transitions when the windows show.

Furthermore I normalized all windows to either 400px width, 600px width and for the resource quick update 700 (was already like that) and tested all of them again.

These changes also prevent windows from being oversized by autoHeight: true on smaller viewports (like my macbook air 11"), good example was the plugin quick update window.

Some small CSS adjustments for scrollbars were made too.
