### PR TITLE
[rebuild] [2.3] Enable usernav menus for mobile devices

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -354,7 +354,7 @@ $userNavMenus[0]->fromArray(array(
   'description' => '',
   'parent' => 'usernav',
   'permissions' => 'menu_user',
-  'action' => 'security/profile',
+  'action' => '',
   'icon' => '<span id="user-avatar">{$userImage}</span> <span id="user-username">{$username}</span>',
 ), '', true, true);
 $children = array();
@@ -403,7 +403,7 @@ $userNavMenus[1]->fromArray(array(
   'description' => '',
   'parent' => 'usernav',
   'permissions' => 'settings',
-  'action' => 'system/settings',
+  'action' => '',
   'icon' => '<i class="icon-gear icon icon-large"></i>',
 ), '', true, true);
 $children = array();

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -105,8 +105,14 @@
   }
 }
 
+#modx-user-menu li.top > a,
 #modx-topnav li.top > a {
   cursor: default;
+}
+
+#modx-user-menu li.top > a.top-link,
+#modx-topnav li.top > a.top-link {
+  cursor: pointer;
 }
 
 #modx-topnav > li.top > a, #modx-user-menu > li.top > a {

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -177,9 +177,9 @@ class TopMenu
                     // No icon, no title property
                     $title = '';
                 }
-                $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.$title.'>'.$label.$description.'</a>'."\n";
+                $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.( $top ? ' class="top-link"': '' ).$title.'>'.$label.$description.'</a>'."\n";
             } else {
-                $menuTpl .= '<a href="javascript:;">'.$menu['text'].'</a>'."\n";
+                $menuTpl .= '<a href="javascript:;">'.$label.'</a>'."\n";
             }
 
             if (!empty($menu['children'])) {


### PR DESCRIPTION
_(Updated PR to target `master`)_

Should address #11600, #11704 and most of #11706 _(menus aren't easily closed on mobile per `:hover`)_

Now dropdown menus from usernav (right-hand side) are accessible from mobile devices. Also, mirrored topnav styles to usernav (cursor: default), but maintain cursor: pointer for top menus (containing children) with a defined action...e.g. for actual links.
