### PR TITLE
Fix checking if connectors are included by a defined constant instead of a get_included_files() check.

### DIFF
--- a/connectors/index.php
+++ b/connectors/index.php
@@ -23,8 +23,7 @@
  * @subpackage connectors
  */
 
-$included = get_included_files();
-$included = (reset($included) !== __FILE__);
+$included = defined('MODX_CONNECTOR_INCLUDED') || defined('MODX_CORE_PATH');
 
 if (!defined('MODX_CORE_PATH')) {
     if (file_exists(dirname(__FILE__) . '/config.core.php')) {

--- a/connectors/lang.js.php
+++ b/connectors/lang.js.php
@@ -6,6 +6,8 @@
  * @package modx
  * @subpackage lexicon
  */
+define('MODX_CONNECTOR_INCLUDED', 1);
+
 ob_start();
 require_once dirname(__FILE__).'/index.php';
 ob_clean();

--- a/connectors/modx.config.js.php
+++ b/connectors/modx.config.js.php
@@ -3,6 +3,7 @@
  * @package modx
  * @var modX $modx
  */
+define('MODX_CONNECTOR_INCLUDED', 1);
 define('MODX_REQP',false);
 require_once dirname(__FILE__).'/index.php';
 $_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));

--- a/connectors/system/phpthumb.php
+++ b/connectors/system/phpthumb.php
@@ -3,6 +3,7 @@
  * @var modX $modx
  * @package modx
  */
+define('MODX_CONNECTOR_INCLUDED', 1);
 require_once dirname(dirname(__FILE__)).'/index.php';
 $_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));
 $modx->request->handleRequest(array('location' => 'system','action' => 'phpthumb'));


### PR DESCRIPTION
This resolves an edge case scenario where a file that is automatically prepended (e.g. auto_prepend_file) causes the included check to fail as the connector.php is not the first file in get_included_files(). The entire manager becomes unusable in this case, as none of the AJAX requests work as expected.

The new check per this commit first checks the existence of a constant (which the other connectors define). As alternative, it also checks if the MODX_CORE_PATH is defined, which is a pretty good indicator that for example a third party connector loaded the main connector (as they can't find the connector location, without knowing the location of the core and loading the config file).

Should resolve modxcms/revolution#11738

(Now targeting master)
