### PR TITLE
[2.3] [Re-build] Fix long category name overflow in vertical tabs

### DIFF
--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -318,6 +318,7 @@ ul.x-tab-strip-bottom {
         width: auto;
 
         > li {
+          border-right: 1px solid $borderColor;
           border-bottom: 1px solid $borderColor;
           color: $coreFieldLabelColor;
           float: none;
@@ -326,18 +327,20 @@ ul.x-tab-strip-bottom {
           overflow: hidden;
           padding: 10px 15px 10px 15px;
           transition: background-color 0.25s, color 0.25s;
-          white-space: nowrap;
 
           &:hover {
             background: $white;
           }
+
           &.x-tab-strip-active {
             background: $white;
             border-color: $borderColorHover;
+            border-right-color: $white;
             box-shadow: none; /* removes the active tab strip on top */
             color: $tabActiveText;
-            width: 169px; /* make the active li 1px more wide to cover the containers right border */
+            width: 169px; /* make the active li 1px more wide to cover the containers right border, this makes the right border on inactive tabs necessary as the whole tab-strip wrap gets wider */
           }
+
           &.x-tab-edge {
             height: 0;
             visibility: hidden; /* display none makes the tab scroll buttons appear somehow */
@@ -345,6 +348,12 @@ ul.x-tab-strip-bottom {
             .x-tab-strip-text {
               display: none; /* prevent 4px high space at the end of the tab strip */
             }
+          }
+
+          .x-tab-strip-text {
+            line-height: 1.4;
+            padding: 2px 0 2px 0;
+            white-space: normal; /* prevent long category names from breaking out of the tab strip width */
           }
         }
       }


### PR DESCRIPTION
The bug was reported in https://github.com/modxcms/revolution/issues/11728, looked like that:

![bildschirmfoto 2014-07-20 um 17 43 41](https://cloud.githubusercontent.com/assets/445501/3637891/63d023e0-1027-11e4-8b3b-a64fbfe5260e.png)

with the proposed fix it look like that:

![bildschirmfoto 2014-07-20 um 17 59 42](https://cloud.githubusercontent.com/assets/445501/3637892/7ec9efa0-1027-11e4-8a31-865b9d139496.png)

@Mark-H: this could also solve the problem you had here: #11634 (still would love the vtabs in the user group edit panel)
