### PR TITLE
[2.3] Manager Theme: Fix excessive space in package update window

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -465,8 +465,8 @@ MODx.window.PackageUpdate = function(config) {
         title: _('package_update')
         ,url: MODx.config.connector_url
         ,action: 'workspace/packages/rest/download'
-        ,height: 400
-        ,width: 400
+        // ,height: 400
+        // ,width: 400
         ,id: 'modx-window-package-update'
         ,saveBtnText: _('update')
         ,fields: this.setupOptions(config.packages,config.record)
@@ -479,7 +479,7 @@ Ext.extend(MODx.window.PackageUpdate,MODx.Window,{
         var items = [{
             html: _('package_update_to_version')
             ,border: false
-        },MODx.PanelSpacer,{
+        },{
             xtype: 'hidden'
             ,name: 'provider'
             ,value: Ext.isDefined(rec.provider) ? rec.provider : MODx.provider
@@ -491,6 +491,7 @@ Ext.extend(MODx.window.PackageUpdate,MODx.Window,{
                 xtype: 'radio'
                 ,name: 'info'
                 ,boxLabel: pkg.signature
+                ,hideLabel: true
                 ,description: pkg.description
                 ,inputValue: pkg.info
                 ,labelSeparator: ''


### PR DESCRIPTION
Minor "fix" / adjustments to the package update window which had too much height and too much spacing/padding between description and the radio option.

before:
![bildschirmfoto 2014-07-21 um 14 51 46](https://cloud.githubusercontent.com/assets/445501/3643597/e2422cb0-10d5-11e4-9aef-8b7ae5ce694d.png)

after:
![bildschirmfoto 2014-07-21 um 14 52 16](https://cloud.githubusercontent.com/assets/445501/3643598/e5d6ea32-10d5-11e4-99ca-238e59c36e0a.png)
