### PR TITLE
[2.3] [Re-build] Manager Theme: Adjust appearance of saving window

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -252,6 +252,33 @@
   } /* .modx-console */
 } /* .x-window */
 
+/* the progress bar (ex. saving a resource), usually in a window too */
+.x-progress-wrap {
+  border: 1px solid $colorSplash;
+
+  .x-progress-inner {
+    background-color: $colorSplashLight;
+    /*background-image: url($imgPath + 'modx-theme/qtip/bg.gif');*/
+  }
+
+  .x-progress-bar {
+    background-color: $colorSplash;
+    /*background-image: url($imgPath + 'modx-theme/progress/progress-bg.gif');*/
+    border: 0;
+  }
+
+  .x-progress-text {
+    color: $colorSplashContrast;
+    font-size: 11px;
+    font-weight: bold;
+  }
+
+  .x-progress-text-back {
+    color: $darkGray;
+  }
+}
+
+/* the window modal mask, but also the mask that covers a grid when reloading for example */
 .ext-el-mask {
   background-color: $white;
   opacity: 0;
@@ -347,8 +374,9 @@
   color: $red;
 }
 
+/* the loading indicator when refreshing a grid or component */
 .x-mask-loading div {
-  background-color: $lightestGray;
+  /*background-color: $lightestGray;*/
   background-image: url($imgPath + 'modx-theme/grid/loading.gif');
 }
 

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -1176,28 +1176,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 .x-layout-cmini-south .x-layout-mini {
   background-image: url($imgPath + 'modx-theme/layout/mini-top.gif');
 }
-.x-progress-wrap {
-  border-color: #8f8f8f;
-}
-.x-progress-inner {
-  background-color: #e7e7e7;
-  background-image: url($imgPath + 'modx-theme/qtip/bg.gif');
-}
-.x-progress-bar {
-  background-color: #bcbcbc;
-  background-image: url($imgPath + 'modx-theme/progress/progress-bg.gif');
-  border-bottom-color: #a6a6a6;
-  border-right-color: #a6a6a6;
-  border-top-color: #e2e2e2;
-}
-.x-progress-text {
-  color: #fff;
-  font-size: 11px;
-  font-weight: bold;
-}
-.x-progress-text-back {
-  color: #396095;
-}
+
 .x-list-header {
   background-color: #f9f9f9;
   background-image: url($imgPath + 'modx-theme/grid/grid3-hrow.gif');

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -786,7 +786,8 @@ iframe[classname="x-hidden"] {
   background-image: url($imgPath + 'restyle/fileup/file-uploading.gif');
 }
 
-.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-bar .x-progress-text div {
+/* no more IE7 support */
+/*.ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-bar .x-progress-text div {
   display: none;
 }
 
@@ -799,7 +800,7 @@ iframe[classname="x-hidden"] {
 .ext-ie7 .ext-ux-uploaddialog-dialog .x-progress-text-back div {
   white-space: nowrap;
   width: auto !important;
-}
+}*/
 
 /* tree grid */
 .tq-treegrid .tq-treegrid-col {


### PR DESCRIPTION
This PR makes the saving progressbar fit better into the theme and stop using background images to save a few requests (not sure if the splash color is a good choice though, what is your opinion?)

before:
![bildschirmfoto 2014-07-21 um 15 17 56](https://cloud.githubusercontent.com/assets/445501/3644269/8ef9e152-10de-11e4-980c-40e81237854a.png)

after:
![bildschirmfoto 2014-07-21 um 15 50 52](https://cloud.githubusercontent.com/assets/445501/3644272/9366de84-10de-11e4-91dd-3d2ae05439db.png)
