### PR TITLE
[2.3] [Re-build] Manager Theme: Fix labels / tvs in custom FC tabs

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -84,8 +84,8 @@ input::-moz-focus-inner {
       height: 16px;
       opacity: 0;
       filter: alpha(opacity=0); /* for IE <= 8 */
-      padding: 17px 5px 0 0;
-      position: absolute; top: 0; left: -21px;
+      padding: 17px 8px 0 0;
+      position: absolute; top: 0; left: -8px;
       transition: all 0.25s;
       width: 16px;
 
@@ -116,6 +116,10 @@ input::-moz-focus-inner {
       filter: alpha(opacity=100); /* for IE <= 8 */
     }
   } /* label.x-form-item-label */
+
+  &.modx-tv {
+    padding: 0 0 0 15px !important; /* account for the tv reset icon */
+  }
 
   /* is outside of the label */
   .modx-tv-inherited {
@@ -242,7 +246,7 @@ input::-moz-focus-inner {
         padding: 0 0 4px 0;
 
         .modx-tv-reset {
-          padding: 2px 5px 0 0;
+          padding: 2px 8px 0 0;
         }
       }
     }

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -376,9 +376,9 @@ ul.x-tab-strip-bottom {
       border: 0; /* do not add the top border for nested tabs panels */
       padding: 15px 20px 15px 15px; /* 20px account for too wide form fields (no border-box) */
 
-      .tvs-wrapper & {
-        padding: 15px 20px 15px 30px; /* 30px account for the tv reset icon */
-      }
+      /*.tvs-wrapper & {*/
+        /*padding: 15px 20px 15px 30px; /* 30px account for the tv reset icon */
+      /*}*/
     }
   }
 }

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -267,6 +267,7 @@ Ext.extend(MODx,Ext.Component,{
             Ext.applyIf(opt,{
                 id: 'modx-'+Ext.id()+'-tab'
                 ,layout: 'form'
+                ,labelAlign: 'top'
                 ,cls: 'modx-resource-tab'
                 ,bodyStyle: 'padding: 15px;'
                 ,autoHeight: true


### PR DESCRIPTION
This PR addresses https://github.com/modxcms/revolution/issues/11758 and creates a (consistent) form with labels on top for custom FC tabs, had to change the way the tv specific padding left is applied because of the tv reload button (was fixed for the standard tvs-wrapper, but not applied for custom tabs)

looks now like that:
![bildschirmfoto 2014-07-21 um 16 54 51](https://cloud.githubusercontent.com/assets/445501/3645080/02601230-10e7-11e4-9721-a596181ee511.png)
