### PR TITLE
[2.3] Sort files and directories in a natural way in file trees

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -134,7 +134,6 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
             if (!$file->isReadable()) continue;
 
             $fileName = $file->getFilename();
-            $ucFileName = strtoupper($fileName);
             if (in_array(trim($fileName,'/'),$skipFiles)) continue;
             if (in_array($fullPath.$fileName,$skipFiles)) continue;
             $filePathName = $file->getPathname();
@@ -151,7 +150,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 if ($this->hasPermission('file_upload') && $canCreate) $cls[] = 'pupload';
                 if ($this->hasPermission('file_create') && $canCreate) $cls[] = 'pcreate';
 
-                $dirnames[] = $ucFileName;
+                $dirnames[] = strtoupper($fileName);
                 $directories[$fileName] = array(
                     'id' => $bases['urlRelative'].rtrim($fileName,'/').'/',
                     'text' => $fileName,
@@ -192,7 +191,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 $fromManagerUrl = $bases['url'].trim(str_replace('//','/',$path.$fileName),'/');
                 $fromManagerUrl = ($bases['urlIsRelative'] ? '../' : '').$fromManagerUrl;
 
-                $filenames[] = $ucFileName;
+                $filenames[] = strtoupper($fileName);
                 $files[$fileName] = array(
                     'id' => $bases['urlRelative'].$fileName,
                     'text' => $fileName,
@@ -218,12 +217,12 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $ls = array();
         /* now sort files/directories */
         array_multisort($dirnames, SORT_ASC, SORT_STRING, $directories);
-        uksort($directories, 'strnatcasecmp');
+        // uksort($directories, 'strnatcasecmp');
         foreach ($directories as $dir) {
             $ls[] = $dir;
         }
         array_multisort($filenames, SORT_ASC, SORT_STRING, $files);
-        uksort($files, 'strnatcasecmp');
+        // uksort($files, 'strnatcasecmp');
         foreach ($files as $file) {
             $ls[] = $file;
         }
@@ -871,6 +870,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
         /* iterate */
         $files = array();
+        $filenames = array();
+
         if (!is_dir($fullPath)) {
             $this->addError('dir',$this->xpdo->lexicon('file_folder_err_ns').$fullPath);
             return array();
@@ -945,6 +946,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 }
                 $octalPerms = substr(sprintf('%o', $file->getPerms()), -4);
 
+                $filenames[] = strtoupper($fileName);
                 $files[] = array(
                     'id' => $bases['urlAbsoluteWithPath'].$fileName,
                     'name' => $fileName,
@@ -972,6 +974,9 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 );
             }
         }
+
+        array_multisort($filenames, SORT_ASC, SORT_STRING, $files);
+
         return $files;
     }
     /**

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -121,7 +121,10 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $canCreate = $this->checkPolicy('create');
 
         $directories = array();
+        $dirnames = array();
         $files = array();
+        $filenames = array();
+
         if (!is_dir($fullPath)) return array();
 
         /* iterate through directories */
@@ -131,6 +134,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
             if (!$file->isReadable()) continue;
 
             $fileName = $file->getFilename();
+            $ucFileName = strtoupper($fileName);
             if (in_array(trim($fileName,'/'),$skipFiles)) continue;
             if (in_array($fullPath.$fileName,$skipFiles)) continue;
             $filePathName = $file->getPathname();
@@ -147,6 +151,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 if ($this->hasPermission('file_upload') && $canCreate) $cls[] = 'pupload';
                 if ($this->hasPermission('file_create') && $canCreate) $cls[] = 'pcreate';
 
+                $dirnames[] = $ucFileName;
                 $directories[$fileName] = array(
                     'id' => $bases['urlRelative'].rtrim($fileName,'/').'/',
                     'text' => $fileName,
@@ -186,6 +191,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 /* get relative url from manager/ */
                 $fromManagerUrl = $bases['url'].trim(str_replace('//','/',$path.$fileName),'/');
                 $fromManagerUrl = ($bases['urlIsRelative'] ? '../' : '').$fromManagerUrl;
+
+                $filenames[] = $ucFileName;
                 $files[$fileName] = array(
                     'id' => $bases['urlRelative'].$fileName,
                     'text' => $fileName,
@@ -210,10 +217,12 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
         $ls = array();
         /* now sort files/directories */
+        array_multisort($dirnames, SORT_ASC, SORT_STRING, $directories);
         uksort($directories, 'strnatcasecmp');
         foreach ($directories as $dir) {
             $ls[] = $dir;
         }
+        array_multisort($filenames, SORT_ASC, SORT_STRING, $files);
         uksort($files, 'strnatcasecmp');
         foreach ($files as $file) {
             $ls[] = $file;

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -210,11 +210,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
         $ls = array();
         /* now sort files/directories */
-        ksort($directories);
+        uksort($directories, 'strnatcasecmp');
         foreach ($directories as $dir) {
             $ls[] = $dir;
         }
-        ksort($files);
+        uksort($files, 'strnatcasecmp');
         foreach ($files as $file) {
             $ls[] = $file;
         }

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -153,7 +153,6 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         foreach ($list as $idx => $currentPath) {
             if ($currentPath == $path) continue;
             $fileName = basename($currentPath);
-            $ucFileName = strtoupper($fileName);
             $isDir = substr(strrev($currentPath),0,1) === '/';
 
             $extension = pathinfo($fileName,PATHINFO_EXTENSION);
@@ -165,7 +164,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 continue;
             }
             if ($isDir) {
-                $dirnames[] = $ucFileName;
+                $dirnames[] = strtoupper($fileName);
                 $directories[$currentPath] = array(
                     'id' => $currentPath,
                     'text' => $fileName,
@@ -191,7 +190,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 if ($this->hasPermission('file_remove')) $cls[] = 'premove';
                 if ($this->hasPermission('file_update')) $cls[] = 'pupdate';
 
-                $filenames[] = $ucFileName;
+                $filenames[] = strtoupper($fileName);
                 $files[$currentPath] = array(
                     'id' => $currentPath,
                     'text' => $fileName,
@@ -212,12 +211,12 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $ls = array();
         /* now sort files/directories */
         array_multisort($dirnames, SORT_ASC, SORT_STRING, $directories);
-        uksort($directories, 'strnatcasecmp');
+        // uksort($directories, 'strnatcasecmp');
         foreach ($directories as $dir) {
             $ls[] = $dir;
         }
         array_multisort($filenames, SORT_ASC, SORT_STRING, $files);
-        uksort($files, 'strnatcasecmp');
+        // uksort($files, 'strnatcasecmp');
         foreach ($files as $file) {
             $ls[] = $file;
         }
@@ -333,6 +332,8 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
         /* iterate */
         $files = array();
+        $filenames = array();
+
         foreach ($list as $object) {
             $objectUrl = $bucketUrl.trim($object,'/');
             $baseName = basename($object);
@@ -340,6 +341,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
             if (in_array($object,$skipFiles)) continue;
 
             if (!$isDir) {
+                $filenames[] = strtoupper($baseName);
                 $fileArray = array(
                     'id' => $object,
                     'name' => $baseName,
@@ -409,6 +411,9 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 $files[] = $fileArray;
             }
         }
+
+        array_multisort($filenames, SORT_ASC, SORT_STRING, $files);
+
         return $files;
     }
 

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -146,10 +146,14 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
 
         $directories = array();
+        $dirnames = array();
         $files = array();
+        $filenames = array();
+
         foreach ($list as $idx => $currentPath) {
             if ($currentPath == $path) continue;
             $fileName = basename($currentPath);
+            $ucFileName = strtoupper($fileName);
             $isDir = substr(strrev($currentPath),0,1) === '/';
 
             $extension = pathinfo($fileName,PATHINFO_EXTENSION);
@@ -161,6 +165,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 continue;
             }
             if ($isDir) {
+                $dirnames[] = $ucFileName;
                 $directories[$currentPath] = array(
                     'id' => $currentPath,
                     'text' => $fileName,
@@ -186,6 +191,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 if ($this->hasPermission('file_remove')) $cls[] = 'premove';
                 if ($this->hasPermission('file_update')) $cls[] = 'pupdate';
 
+                $filenames[] = $ucFileName;
                 $files[$currentPath] = array(
                     'id' => $currentPath,
                     'text' => $fileName,
@@ -205,10 +211,12 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
         $ls = array();
         /* now sort files/directories */
+        array_multisort($dirnames, SORT_ASC, SORT_STRING, $directories);
         uksort($directories, 'strnatcasecmp');
         foreach ($directories as $dir) {
             $ls[] = $dir;
         }
+        array_multisort($filenames, SORT_ASC, SORT_STRING, $files);
         uksort($files, 'strnatcasecmp');
         foreach ($files as $file) {
             $ls[] = $file;

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -205,11 +205,11 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
         $ls = array();
         /* now sort files/directories */
-        ksort($directories);
+        uksort($directories, 'strnatcasecmp');
         foreach ($directories as $dir) {
             $ls[] = $dir;
         }
-        ksort($files);
+        uksort($files, 'strnatcasecmp');
         foreach ($files as $file) {
             $ls[] = $file;
         }

--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -405,9 +405,10 @@ MODx.browser.View = function(config) {
         url: MODx.config.connector_url
         ,id: this.ident
         ,fields: [
-            'name','cls','url','relativeUrl','fullRelativeUrl','image','image_width','image_height','thumb','thumb_width','thumb_height','pathname','ext','disabled','preview'
-            ,{name:'size', type: 'float'}
-            ,{name:'lastmod', type:'date', dateFormat:'timestamp'}
+            {name: 'name', sortType: Ext.data.SortTypes.asUCString}
+            ,'cls','url','relativeUrl','fullRelativeUrl','image','image_width','image_height','thumb','thumb_width','thumb_height','pathname','ext','disabled','preview'
+            ,{name: 'size', type: 'float'}
+            ,{name: 'lastmod', type: 'date', dateFormat: 'timestamp'}
             ,'menu'
         ]
         ,baseParams: {


### PR DESCRIPTION
Should fix https://github.com/modxcms/revolution/issues/10286

thanks @rainbowtiger for the suggested fix, even he reports that it's not working on his side, in my environment it seems to work nicely...

before:
![bildschirmfoto 2014-07-21 um 19 44 04](https://cloud.githubusercontent.com/assets/445501/3647583/3e2739f6-1100-11e4-8766-2dd5209fce6f.png)

after:
![bildschirmfoto 2014-07-21 um 19 55 53](https://cloud.githubusercontent.com/assets/445501/3647587/4bfe857a-1100-11e4-859a-da45dc86feb4.png)

but don't ask me why the sort order is suddenly messed up slightly for the image_c.png (and variations) files...
