### PR TITLE
[2.3] Fix last modified dates in settings and lexicon grids + lexicon grid / filter combos improvements

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -233,7 +233,6 @@ $_lang['key'] = 'Key';
 $_lang['keyword'] = 'Keyword';
 $_lang['keywords'] = 'Keywords';
 $_lang['last_modified'] = 'Last Modified';
-$_lang['not_modified'] = 'Not Modified';
 $_lang['launch_site'] = 'View Site';
 $_lang['language'] = 'Language';
 $_lang['lexicon'] = 'Lexicon';

--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -233,6 +233,7 @@ $_lang['key'] = 'Key';
 $_lang['keyword'] = 'Keyword';
 $_lang['keywords'] = 'Keywords';
 $_lang['last_modified'] = 'Last Modified';
+$_lang['not_modified'] = 'Not Modified';
 $_lang['launch_site'] = 'View Site';
 $_lang['language'] = 'Language';
 $_lang['lexicon'] = 'Lexicon';

--- a/core/model/modx/processors/context/setting/getlist.php
+++ b/core/model/modx/processors/context/setting/getlist.php
@@ -86,9 +86,13 @@ foreach ($settings as $setting) {
         $settingArray['name'] = $settingArray['name_trans'];
     }
 
-    $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-        ? ''
-        : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
+    // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
+    //     ? ''
+    //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
+
+    $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
+        ? date($modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
+        : $modx->lexicon('not_modified');
 
 
     $settingArray['menu'] = array(

--- a/core/model/modx/processors/context/setting/getlist.php
+++ b/core/model/modx/processors/context/setting/getlist.php
@@ -90,10 +90,7 @@ foreach ($settings as $setting) {
     //     ? ''
     //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
 
-    $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
-        ? date($modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
-        : $modx->lexicon('not_modified');
-
+    $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
 
     $settingArray['menu'] = array(
         array(

--- a/core/model/modx/processors/context/setting/getlist.php
+++ b/core/model/modx/processors/context/setting/getlist.php
@@ -86,10 +86,6 @@ foreach ($settings as $setting) {
         $settingArray['name'] = $settingArray['name_trans'];
     }
 
-    // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-    //     ? ''
-    //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
-
     $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
 
     $settingArray['menu'] = array(

--- a/core/model/modx/processors/security/group/setting/getlist.php
+++ b/core/model/modx/processors/security/group/setting/getlist.php
@@ -77,9 +77,7 @@ foreach ($settings as $setting) {
     //     ? ''
     //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
 
-    $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
-        ? date($modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
-        : $modx->lexicon('not_modified');
+    $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
 
     $list[] = $settingArray;
 }

--- a/core/model/modx/processors/security/group/setting/getlist.php
+++ b/core/model/modx/processors/security/group/setting/getlist.php
@@ -73,9 +73,6 @@ foreach ($settings as $setting) {
         $settingArray['name'] = $settingArray['name_trans'];
     }
     $settingArray['oldkey'] = $settingArray['key'];
-    // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-    //     ? ''
-    //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
 
     $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
 

--- a/core/model/modx/processors/security/group/setting/getlist.php
+++ b/core/model/modx/processors/security/group/setting/getlist.php
@@ -73,9 +73,13 @@ foreach ($settings as $setting) {
         $settingArray['name'] = $settingArray['name_trans'];
     }
     $settingArray['oldkey'] = $settingArray['key'];
-    $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-        ? ''
-        : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
+    // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
+    //     ? ''
+    //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
+
+    $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
+        ? date($modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
+        : $modx->lexicon('not_modified');
 
     $list[] = $settingArray;
 }

--- a/core/model/modx/processors/security/user/setting/getlist.php
+++ b/core/model/modx/processors/security/user/setting/getlist.php
@@ -77,9 +77,7 @@ foreach ($settings as $setting) {
     //     ? ''
     //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
 
-    $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
-        ? date($modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
-        : $modx->lexicon('not_modified');
+    $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
 
     $list[] = $settingArray;
 }

--- a/core/model/modx/processors/security/user/setting/getlist.php
+++ b/core/model/modx/processors/security/user/setting/getlist.php
@@ -73,9 +73,13 @@ foreach ($settings as $setting) {
         $settingArray['name'] = $settingArray['name_trans'];
     }
     $settingArray['oldkey'] = $settingArray['key'];    
-    $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-        ? ''
-        : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
+    // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
+    //     ? ''
+    //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
+
+    $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
+        ? date($modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
+        : $modx->lexicon('not_modified');
 
     $list[] = $settingArray;
 }

--- a/core/model/modx/processors/security/user/setting/getlist.php
+++ b/core/model/modx/processors/security/user/setting/getlist.php
@@ -72,10 +72,7 @@ foreach ($settings as $setting) {
     } else {
         $settingArray['name'] = $settingArray['name_trans'];
     }
-    $settingArray['oldkey'] = $settingArray['key'];    
-    // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-    //     ? ''
-    //     : strftime('%b %d, %Y %I:%M %p',strtotime($setting->get('editedon')));
+    $settingArray['oldkey'] = $settingArray['key'];
 
     $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
 

--- a/core/model/modx/processors/system/language/getlist.class.php
+++ b/core/model/modx/processors/system/language/getlist.class.php
@@ -19,7 +19,8 @@ class modSystemLanguageGetListProcessor extends modProcessor {
     public function initialize() {
         $this->setDefaultProperties(array(
             'start' => 0,
-            'limit' => 10,
+            // 'limit' => 10,
+            'limit' => 0,
             'namespace' => 'core',
         ));
         return true;
@@ -46,14 +47,19 @@ class modSystemLanguageGetListProcessor extends modProcessor {
     public function getData() {
         $data = array();
 
-        $limit = $this->getProperty('limit',10);
-        $isLimit = !empty($limit);
+        $limit = $this->getProperty('limit');
 
         $data['results'] = $this->modx->lexicon->getLanguageList($this->getProperty('namespace'));
         $data['total'] = count($data['results']);
 
-        if ($isLimit) {
+        if ($limit > 0) {
             $data['results'] = array_slice($data['results'],$this->getProperty('start'),$limit,true);
+        }
+        // this allows for typeahead filtering in the lexicon topics combobox
+        $query = $this->getProperty('query');
+        if (!empty($query)) {
+            $data['results'] = preg_grep('/' . $query . '/i', $data['results']);
+            $data['total'] = count($data['results']);
         }
         return $data;
     }

--- a/core/model/modx/processors/system/language/getlist.class.php
+++ b/core/model/modx/processors/system/language/getlist.class.php
@@ -19,7 +19,6 @@ class modSystemLanguageGetListProcessor extends modProcessor {
     public function initialize() {
         $this->setDefaultProperties(array(
             'start' => 0,
-            // 'limit' => 10,
             'limit' => 0,
             'namespace' => 'core',
         ));
@@ -52,15 +51,17 @@ class modSystemLanguageGetListProcessor extends modProcessor {
         $data['results'] = $this->modx->lexicon->getLanguageList($this->getProperty('namespace'));
         $data['total'] = count($data['results']);
 
-        if ($limit > 0) {
-            $data['results'] = array_slice($data['results'],$this->getProperty('start'),$limit,true);
-        }
         // this allows for typeahead filtering in the lexicon topics combobox
         $query = $this->getProperty('query');
         if (!empty($query)) {
             $data['results'] = preg_grep('/' . $query . '/i', $data['results']);
             $data['total'] = count($data['results']);
         }
+
+        if ($limit > 0) {
+            $data['results'] = array_slice($data['results'],$this->getProperty('start'),$limit,true);
+        }
+        
         return $data;
     }
 }

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -74,20 +74,20 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
     /**
      * Prepare a setting for output
      * 
-     * @param xPDOObject $setting
+     * @param xPDOObject $object
      * @return array
      */
-    public function prepareRow(xPDOObject $setting) {
-        $settingArray = $setting->toArray();
+    public function prepareRow(xPDOObject $object) {
+        $settingArray = $object->toArray();
         $k = 'setting_'.$settingArray['key'];
 
         /* if 3rd party setting, load proper text, fallback to english */
-        $this->modx->lexicon->load('en:'.$setting->get('namespace').':default','en:'.$setting->get('namespace').':setting');
-        $this->modx->lexicon->load($setting->get('namespace').':default',$setting->get('namespace').':setting');
+        $this->modx->lexicon->load('en:'.$object->get('namespace').':default','en:'.$object->get('namespace').':setting');
+        $this->modx->lexicon->load($object->get('namespace').':default',$object->get('namespace').':setting');
 
         /* get translated area text */
-        if ($this->modx->lexicon->exists('area_'.$setting->get('area'))) {
-            $settingArray['area_text'] = $this->modx->lexicon('area_'.$setting->get('area'));
+        if ($this->modx->lexicon->exists('area_'.$object->get('area'))) {
+            $settingArray['area_text'] = $this->modx->lexicon('area_'.$object->get('area'));
         } else {
             $settingArray['area_text'] = $settingArray['area'];
         }
@@ -116,11 +116,11 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
 
         $settingArray['oldkey'] = $settingArray['key'];
 
-        // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
+        // $settingArray['editedon'] = $object->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
         //     ? ''
-        //     : strftime($this->getProperty('dateFormat','%b %d, %Y %I:%M %p'),strtotime($setting->get('editedon')));
+        //     : strftime($this->getProperty('dateFormat','%b %d, %Y %I:%M %p'),strtotime($object->get('editedon')));
 
-        $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
+        $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($object->get('editedon')) ? strtotime($object->get('editedon')) : '');
 
         return $settingArray;
     }

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -74,20 +74,20 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
     /**
      * Prepare a setting for output
      * 
-     * @param xPDOObject $object
+     * @param xPDOObject $setting
      * @return array
      */
-    public function prepareRow(xPDOObject $object) {
-        $settingArray = $object->toArray();
+    public function prepareRow(xPDOObject $setting) {
+        $settingArray = $setting->toArray();
         $k = 'setting_'.$settingArray['key'];
 
         /* if 3rd party setting, load proper text, fallback to english */
-        $this->modx->lexicon->load('en:'.$object->get('namespace').':default','en:'.$object->get('namespace').':setting');
-        $this->modx->lexicon->load($object->get('namespace').':default',$object->get('namespace').':setting');
+        $this->modx->lexicon->load('en:'.$setting->get('namespace').':default','en:'.$setting->get('namespace').':setting');
+        $this->modx->lexicon->load($setting->get('namespace').':default',$setting->get('namespace').':setting');
 
         /* get translated area text */
-        if ($this->modx->lexicon->exists('area_'.$object->get('area'))) {
-            $settingArray['area_text'] = $this->modx->lexicon('area_'.$object->get('area'));
+        if ($this->modx->lexicon->exists('area_'.$setting->get('area'))) {
+            $settingArray['area_text'] = $this->modx->lexicon('area_'.$setting->get('area'));
         } else {
             $settingArray['area_text'] = $settingArray['area'];
         }
@@ -116,9 +116,13 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
 
         $settingArray['oldkey'] = $settingArray['key'];
 
-        $settingArray['editedon'] = $object->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-            ? ''
-            : strftime($this->getProperty('dateFormat','%b %d, %Y %I:%M %p'),strtotime($object->get('editedon')));
+        // $settingArray['editedon'] = $setting->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
+        //     ? ''
+        //     : strftime($this->getProperty('dateFormat','%b %d, %Y %I:%M %p'),strtotime($setting->get('editedon')));
+
+        $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
+            ? date($this->modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $this->modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
+            : $this->modx->lexicon('not_modified');
 
         return $settingArray;
     }

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -120,9 +120,7 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
         //     ? ''
         //     : strftime($this->getProperty('dateFormat','%b %d, %Y %I:%M %p'),strtotime($setting->get('editedon')));
 
-        $settingArray['editedon'] = strtotime($settingArray['editedon']) || strtotime($setting->get('editedon')) 
-            ? date($this->modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $this->modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($setting->get('editedon')))
-            : $this->modx->lexicon('not_modified');
+        $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($setting->get('editedon')) ? strtotime($setting->get('editedon')) : '');
 
         return $settingArray;
     }

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -24,7 +24,6 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
             'key' => false,
             'namespace' => false,
             'area' => false,
-            // 'dateFormat' => '%b %d, %Y %I:%M %p',
         ));
         return $initialized;
     }
@@ -115,10 +114,6 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
         }
 
         $settingArray['oldkey'] = $settingArray['key'];
-
-        // $settingArray['editedon'] = $object->get('editedon') == '-001-11-30 00:00:00' || $settingArray['editedon'] == '0000-00-00 00:00:00' || $settingArray['editedon'] == null
-        //     ? ''
-        //     : strftime($this->getProperty('dateFormat','%b %d, %Y %I:%M %p'),strtotime($object->get('editedon')));
 
         $settingArray['editedon'] = strtotime($settingArray['editedon']) ? strtotime($settingArray['editedon']) : (strtotime($object->get('editedon')) ? strtotime($object->get('editedon')) : '');
 

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -24,7 +24,7 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
             'key' => false,
             'namespace' => false,
             'area' => false,
-            'dateFormat' => '%b %d, %Y %I:%M %p',
+            // 'dateFormat' => '%b %d, %Y %I:%M %p',
         ));
         return $initialized;
     }

--- a/core/model/modx/processors/workspace/lexicon/getlist.class.php
+++ b/core/model/modx/processors/workspace/lexicon/getlist.class.php
@@ -110,12 +110,6 @@ class modLexiconGetListProcessor extends modProcessor {
             if (array_key_exists($name,$dbEntries)) {
                 $entryArray = array_merge($entryArray,$dbEntries[$name]);
 
-                // $entryArray['editedon'] = $entryArray['editedon'] == '0000-00-00 00:00:00'
-                //                        || $entryArray['editedon'] == '-001-11-30 00:00:00'
-                //                        || empty($entryArray['editedon'])
-                //     ? strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['createdon']))
-                //     : strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['editedon']));
-
                 $entryArray['editedon'] = strtotime($entryArray['editedon']) ? strtotime($entryArray['editedon']) : strtotime($entryArray['createdon']);
 
                 $entryArray['overridden'] = 1;

--- a/core/model/modx/processors/workspace/lexicon/getlist.class.php
+++ b/core/model/modx/processors/workspace/lexicon/getlist.class.php
@@ -103,17 +103,21 @@ class modLexiconGetListProcessor extends modProcessor {
                 'topic' => $this->getProperty('topic'),
                 'language' => $this->getProperty('language'),
                 'createdon' => null,
-                'editedon' => null,
+                'editedon' => $this->modx->lexicon('not_modified'),
                 'overridden' => 0,
             );
             /* if override in db, load */
             if (array_key_exists($name,$dbEntries)) {
                 $entryArray = array_merge($entryArray,$dbEntries[$name]);
-                $entryArray['editedon'] = $entryArray['editedon'] == '0000-00-00 00:00:00'
-                                       || $entryArray['editedon'] == '-001-11-30 00:00:00'
-                                       || empty($entryArray['editedon'])
-                    ? strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['createdon']))
-                    : strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['editedon']));
+                // $entryArray['editedon'] = $entryArray['editedon'] == '0000-00-00 00:00:00'
+                //                        || $entryArray['editedon'] == '-001-11-30 00:00:00'
+                //                        || empty($entryArray['editedon'])
+                //     ? strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['createdon']))
+                //     : strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['editedon']));
+                $entryArray['editedon'] = strtotime($entryArray['editedon']) ? $entryArray['editedon'] : $entryArray['createdon'];
+                $entryArray['editedon'] = strtotime($entryArray['editedon']) 
+                    ? date($this->modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $this->modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($entryArray['editedon']))
+                    : $this->modx->lexicon('not_modified'); // this will most likely never trigger as there's always a date set in createdon
                 $entryArray['overridden'] = 1;
             }
             $list[] = $entryArray;

--- a/core/model/modx/processors/workspace/lexicon/getlist.class.php
+++ b/core/model/modx/processors/workspace/lexicon/getlist.class.php
@@ -103,21 +103,21 @@ class modLexiconGetListProcessor extends modProcessor {
                 'topic' => $this->getProperty('topic'),
                 'language' => $this->getProperty('language'),
                 'createdon' => null,
-                'editedon' => $this->modx->lexicon('not_modified'),
+                'editedon' => null,
                 'overridden' => 0,
             );
             /* if override in db, load */
             if (array_key_exists($name,$dbEntries)) {
                 $entryArray = array_merge($entryArray,$dbEntries[$name]);
+
                 // $entryArray['editedon'] = $entryArray['editedon'] == '0000-00-00 00:00:00'
                 //                        || $entryArray['editedon'] == '-001-11-30 00:00:00'
                 //                        || empty($entryArray['editedon'])
                 //     ? strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['createdon']))
                 //     : strftime('%b %d, %Y %I:%M %p',strtotime($entryArray['editedon']));
-                $entryArray['editedon'] = strtotime($entryArray['editedon']) ? $entryArray['editedon'] : $entryArray['createdon'];
-                $entryArray['editedon'] = strtotime($entryArray['editedon']) 
-                    ? date($this->modx->getOption('manager_date_format', null, 'M d, Y', true) . ' ' . $this->modx->getOption('manager_time_format', null, 'g:i a', true), strtotime($entryArray['editedon']))
-                    : $this->modx->lexicon('not_modified'); // this will most likely never trigger as there's always a date set in createdon
+
+                $entryArray['editedon'] = strtotime($entryArray['editedon']) ? strtotime($entryArray['editedon']) : strtotime($entryArray['createdon']);
+
                 $entryArray['overridden'] = 1;
             }
             $list[] = $entryArray;

--- a/core/model/modx/processors/workspace/lexicon/topic/getlist.class.php
+++ b/core/model/modx/processors/workspace/lexicon/topic/getlist.class.php
@@ -22,7 +22,6 @@ class modLexiconTopicGetListProcessor extends modProcessor {
 
     public function initialize() {
         $this->setDefaultProperties(array(
-            // 'limit' => 10,
             'limit' => 0,
             'start' => 0,
             'namespace' => 'core',
@@ -48,15 +47,17 @@ class modLexiconTopicGetListProcessor extends modProcessor {
         $data['results'] = $this->modx->lexicon->getTopicList($this->getProperty('language'),$this->getProperty('namespace'));
         $data['total'] = count($data['results']);
 
-        $limit = $this->getProperty('limit');
-        if ($limit > 0) {
-            $data['results'] = array_slice($data['results'],$this->getProperty('start'),$limit,true);
-        }
         // this allows for typeahead filtering in the lexicon topics combobox
         $query = $this->getProperty('query');
         if (!empty($query)) {
             $data['results'] = preg_grep('/' . $query . '/i', $data['results']);
         }
+
+        $limit = $this->getProperty('limit');
+        if ($limit > 0) {
+            $data['results'] = array_slice($data['results'],$this->getProperty('start'),$limit,true);
+        }
+        
         return $data;
     }
 }

--- a/core/model/modx/processors/workspace/lexicon/topic/getlist.class.php
+++ b/core/model/modx/processors/workspace/lexicon/topic/getlist.class.php
@@ -22,7 +22,8 @@ class modLexiconTopicGetListProcessor extends modProcessor {
 
     public function initialize() {
         $this->setDefaultProperties(array(
-            'limit' => 10,
+            // 'limit' => 10,
+            'limit' => 0,
             'start' => 0,
             'namespace' => 'core',
             'language' => 'en',
@@ -50,6 +51,11 @@ class modLexiconTopicGetListProcessor extends modProcessor {
         $limit = $this->getProperty('limit');
         if ($limit > 0) {
             $data['results'] = array_slice($data['results'],$this->getProperty('start'),$limit,true);
+        }
+        // this allows for typeahead filtering in the lexicon topics combobox
+        $query = $this->getProperty('query');
+        if (!empty($query)) {
+            $data['results'] = preg_grep('/' . $query . '/i', $data['results']);
         }
         return $data;
     }

--- a/core/model/modx/processors/workspace/lexicon/updatefromgrid.class.php
+++ b/core/model/modx/processors/workspace/lexicon/updatefromgrid.class.php
@@ -57,7 +57,7 @@ class modLexiconEntryUpdateFromGridProcessor extends modProcessor {
                 $this->entry->set('language',$language);
                 $this->entry->set('topic',$topic);
             }
-            $this->entry->set('editedon',date('Y-m-d h:i:s'));
+            $this->entry->set('editedon',date('Y-m-d H:i:s'));
             $this->entry->set('value',$value);
 
             if (!$this->entry->save()) {

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -408,11 +408,11 @@ MODx.combo.Language = function(config) {
         ,displayField: 'name'
         ,valueField: 'name'
         ,fields: ['name']
-        ,forceSelection: true
-        ,typeAhead: false
-        ,editable: false
-        ,allowBlank: false
-        ,pageSize: 20
+        ,typeAhead: true
+        ,minChars: 1
+        ,editable: true
+        ,allowBlank: true
+        // ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'system/language/getlist'
@@ -607,12 +607,13 @@ MODx.combo.Namespace = function(config) {
     Ext.applyIf(config,{
         name: 'namespace'
         ,hiddenName: 'namespace'
-        ,forceSelection: true
-        ,typeAhead: false
-        ,editable: false
-        ,allowBlank: false
+        ,typeAhead: true
+        ,minChars: 1
+        ,queryParam: 'search'
+        ,editable: true
+        ,allowBlank: true
         // ,listWidth: 300
-        ,pageSize: 20
+        // ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'workspace/namespace/getlist'

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -102,7 +102,7 @@ MODx.grid.SettingsGrid = function(config) {
             ,dataIndex: 'editedon'
             ,sortable: true
             ,editable: false
-            ,renderer: this.renderLastModField.createDelegate(this,[this],true)
+            ,renderer: this.renderLastModDate.createDelegate(this,[this],true)
             ,width: 100
         },{
             header: _('area')
@@ -314,7 +314,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         return v;
     }
 
-    ,renderLastModField: function(value) {
+    ,renderLastModDate: function(value) {
         if (Ext.isEmpty(value)) {
             return _('not_modified');
         }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -316,7 +316,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
 
     ,renderLastModDate: function(value) {
         if (Ext.isEmpty(value)) {
-            return _('not_modified');
+            return '-';
         }
         // JavaScripts time is in milliseconds
         return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -102,6 +102,7 @@ MODx.grid.SettingsGrid = function(config) {
             ,dataIndex: 'editedon'
             ,sortable: true
             ,editable: false
+            ,renderer: this.renderLastModField.createDelegate(this,[this],true)
             ,width: 100
         },{
             header: _('area')
@@ -290,7 +291,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
             f = MODx.grid.Grid.prototype.rendYesNo;
             return f(v,md,rec,ri,ci,s,g);
         } else if (r.xtype === 'datefield') {
-            f = Ext.util.Format.dateRenderer('Y-m-d');
+            f = Ext.util.Format.dateRenderer(MODx.config.manager_date_format);
             return f(v,md,rec,ri,ci,s,g);
         } else if (r.xtype === 'text-password' || r.xtype == 'modx-text-password') {
             f = MODx.grid.Grid.prototype.rendPassword;
@@ -311,6 +312,14 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
             return f(v,md,rec,ri,ci,s,g);
         }
         return v;
+    }
+
+    ,renderLastModField: function(value) {
+        if (Ext.isEmpty(value)) {
+            return _('not_modified');
+        }
+        // JavaScripts time is in milliseconds
+        return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);
     }
 });
 Ext.reg('modx-grid-settings',MODx.grid.SettingsGrid);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -316,7 +316,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
 
     ,renderLastModDate: function(value) {
         if (Ext.isEmpty(value)) {
-            return '-';
+            return '—';
         }
         // JavaScripts time is in milliseconds
         return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);

--- a/manager/assets/modext/workspace/lexicon/combos.js
+++ b/manager/assets/modext/workspace/lexicon/combos.js
@@ -12,9 +12,10 @@ MODx.combo.LexiconTopic = function(config) {
         name: 'topic'
         ,hiddenName: 'topic'
         ,forceSelection: true
-        ,typeAhead: false
-        ,editable: false
-        ,allowBlank: false
+        ,typeAhead: true
+        ,minChars: 1
+        ,editable: true
+        ,allowBlank: true
         // ,listWidth: 300
         ,url: MODx.config.connector_url
         ,fields: ['name']
@@ -25,7 +26,7 @@ MODx.combo.LexiconTopic = function(config) {
             ,'namespace': 'core'
             ,'language': 'en'
         }
-        ,pageSize: 20
+        // ,pageSize: 20
     });
     MODx.combo.LexiconTopic.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -60,7 +60,6 @@ MODx.grid.Lexicon = function(config) {
             ,id: 'modx-lexicon-filter-topic'
             ,itemId: 'topic'
             ,value: 'default'
-            ,pageSize: 20
             ,width: 120
             ,baseParams: {
                 action: 'workspace/lexicon/topic/getList'

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -39,6 +39,7 @@ MODx.grid.Lexicon = function(config) {
             header: _('last_modified')
             ,dataIndex: 'editedon'
             ,width: 125
+            ,renderer: this._renderLastModDate
         }]
         ,tbar: [{
             xtype: 'tbtext'
@@ -193,6 +194,14 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
             default:
                 return '<span>'+v+'</span>';
         }
+    }
+
+    ,_renderLastModDate: function(value) {
+        if (Ext.isEmpty(value)) {
+            return _('not_modified');
+        }
+
+        return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);
     }
 
     ,filter: function(cb,r,i,name) {

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -198,7 +198,7 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
 
     ,_renderLastModDate: function(value) {
         if (Ext.isEmpty(value)) {
-            return '-';
+            return '—';
         }
 
         return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -198,7 +198,7 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
 
     ,_renderLastModDate: function(value) {
         if (Ext.isEmpty(value)) {
-            return _('not_modified');
+            return '-';
         }
 
         return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);


### PR DESCRIPTION
This PR would solve https://github.com/modxcms/revolution/issues/11762

~~It adds a new lexicon string not_modified (only for English, the translations go over crowdin now right?) which is displayed if there is no valid timestamp (or 0) from strtotime().~~

Additionally the last modified dates in settings grids are respecting the manager_date_format and manager_time_format... as these are specified to be compatible with php's date() function I had to switch strftime() with date() (to avoid another date format system setting), which causes the loss of localized dates (at least when using month names and other strings) which (as far as I know) only can be provided trough strftime().

**To solve this problem I'll look into transforming the pure timestamps with extjs when the grid loads.**

When working on this, I stumbled over the lexicons grid and removed the combobox paging for namespaces, topics and languages as discussed here https://github.com/modxcms/revolution/issues/11713 and made the comboboxes typeahead instead. I'm not sure if this is too radical or if for this particular grid this is acceptable. I cannot really imagine people having thousands of namespaces or topics which would justify paging inside the combobox? Does anybody know of such a project? For the languages combo it's not even worth the discussion as there is a quite limited number of languages I think...

Tested the following grids:
- System Settings
- User Group Settings
- User Settings
- Context Settings
- Lexicon Entries
