### PR TITLE
Fix login after a session expired [#11763]

### DIFF
--- a/connectors/security/login.php
+++ b/connectors/security/login.php
@@ -1,0 +1,5 @@
+<?php
+define('MODX_CONNECTOR_INCLUDED', 1);
+define('MODX_REQP',false);
+require_once dirname(dirname(__FILE__)).'/index.php';
+$modx->request->handleRequest(array('location' => 'security','action' => 'login'));

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -715,8 +715,7 @@ MODx.window.Login = function(config) {
     Ext.applyIf(config,{
         title: _('login')
         ,id: this.ident
-        ,url: MODx.config.connector_url
-        ,action: 'security/login'
+        ,url: MODx.config.connectors_url + 'security/login.php'
         // ,width: 400
         ,fields: [{
             html: '<p>'+_('session_logging_out')+'</p>'


### PR DESCRIPTION
Resolves #11763 where a user could not log back in with the "your session expired" modal due to a 401 permission denied error. 

Also includes the constant that I've proposed in #11748 for the include check for connectors.
