### PR TITLE
[2.3] [Re-build] Manager Theme: Add new logo as inline SVG  + color adjustments to match logo colors

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -5,8 +5,8 @@ $colorSplashMedium: #1A7FB8;
 $colorSplashDark: darken($colorSplash, 20%);
 $colorSplashDesaturated: lighten(desaturate($colorSplash,100%), 20%); /* unused */
 $colorSplashContrast: #FFFFFF; /* needs much more adaption, should be used as text color for elements with $colorSplash background */
-$primary1: #32AB9A;
-$primary2: #00948E;
+$primary1: #44AC4A; /* was #32AB9A on 2.3 release */
+$primary2: #54B14C; /* was #00948E on 2.3 release */
 $lightestGray: #FBFBFB;
 $lighterGray: #F0F0F0;
 $lightGray: #E4E4E4;
@@ -17,14 +17,14 @@ $darkestGray: #53595F; /* a blueish dark gray */
 $white: #FFF;
 $black: darken($colorSplash, 42.5%); /* generate the black from the $colorSplash */
 $yellow: #FFEA80;
-$orange: #F49548;
-$red: #BE0000;
-$green: #6CB24A;
-$blue: #3697cd; /* default theme $colorSplash */
+$orange: #EB603C; /* was #F49548 on 2.3 release */
+$red: #BF2322; /* was #BE0000 on 2.3 release */
+$green: #44AC4A; /* was #6CB24A on 2.3 release, now $primary1 */
+$blue: #3697CD; /* default theme $colorSplash */
 
 /* Brand colors */
 $brandBg: #FFF;
-$brandHover: #e8f0f8;
+$brandHover: #E8F0F8;
 $brandSelectedBg: darken($brandHover, 3%);
 $brandSelectedColor: $colorSplash;
 
@@ -99,7 +99,7 @@ $menuSeparatorColor: $borderColor;
 
 /* ComboBox dropdown menus */
 $dropdownBg: $white;
-$dropdownSelectedBg: #e1ecf1;
+$dropdownSelectedBg: #E1ECF1;
 $dropdownTextColor: $darkGray;
 $dropdownBorder: $lightGray;
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -5,8 +5,8 @@ $colorSplashMedium: #1A7FB8;
 $colorSplashDark: darken($colorSplash, 20%);
 $colorSplashDesaturated: lighten(desaturate($colorSplash,100%), 20%); /* unused */
 $colorSplashContrast: #FFFFFF; /* needs much more adaption, should be used as text color for elements with $colorSplash background */
-$primary1: #44AC4A; /* was #32AB9A on 2.3 release */
-$primary2: #54B14C; /* was #00948E on 2.3 release */
+$primary1: #32AB9A; /* green 1 from the logo as an option #44AC4A */
+$primary2: #00948E; /* green 2 from the logo as an option #54B14C */
 $lightestGray: #FBFBFB;
 $lighterGray: #F0F0F0;
 $lightGray: #E4E4E4;
@@ -19,7 +19,7 @@ $black: darken($colorSplash, 42.5%); /* generate the black from the $colorSplash
 $yellow: #FFEA80;
 $orange: #EB603C; /* was #F49548 on 2.3 release */
 $red: #BF2322; /* was #BE0000 on 2.3 release */
-$green: #44AC4A; /* was #6CB24A on 2.3 release, now $primary1 */
+$green: #44AC4A; /* was #6CB24A on 2.3 release */
 $blue: #3697CD; /* default theme $colorSplash */
 
 /* Brand colors */

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -167,15 +167,39 @@
 }
 
 #modx-navbar #modx-home-dashboard {
-  background-image: url($imgPath + 'modx-icon-color.png');
+  /*background-image: url($imgPath + 'modx-icon-color.png');
   background-image: url($imgPath + 'modx-icon-color.svg'),none;
   background-position:center center;
   background-repeat:no-repeat;
-  background-size: 40px 40px;
-  width: 50px;
+  background-size: 40px 40px;*/
   border-right: none;
-  margin-left: 21px;
-  image-rendering: optimizequality;
+  margin-left: 20px;
+  width: 52px; height: 53px;
+  /*image-rendering: optimizequality;*/
+
+  a {
+    overflow: hidden;
+    padding: 0;
+    /*text-indent: -9999px;*/
+    width: 100%; height: 100%;
+
+    .ext-ie8 & {
+      /* SVG falls back to background image but only in IE8 */
+      background: url($imgPath + 'modx-logo-2014.png') no-repeat center center;
+    }
+  }
+
+  /* we live in lovely vector times, let's use an inline SVG for the logo, */
+  /* no more worries about high DPI devices, and no additional requests! */
+  svg {
+    padding: 8px;
+  }
+
+  span {
+    display: inline-block;
+    line-height: 0;
+    text-indent: -9999px;
+  }
 }
 #user-avatar img {
   border-radius: 20px;
@@ -187,21 +211,6 @@
 }
 /*#user-username {
 
-}*/
-
-#modx-navbar #modx-home-dashboard a {
-  overflow: hidden;
-  padding: 0;
-  text-indent: -9999px;
-  width: 100%;
-}
-
-#modx-navbar #modx-home-dashboard:hover a {
-  background-color: transparent;
-}
-
-/*#modx-navbar #modx-home-dashboard:hover {
-  background-color: $navbarHover;
 }*/
 
 #modx-navbar li:hover ul.modx-subnav {

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -52,7 +52,41 @@
 
             <ul id="modx-topnav">
                 <li id="modx-home-dashboard">
-                    <a href="?" title="{$_lang.dashboard}">{$_lang.dashboard}</a>
+                    <a href="?" title="{$_lang.dashboard}">
+                        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="36" height="37.388" viewBox="1.682 50.718 36 37.388">
+                            <g>
+                                <linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="877.3604" y1="620.4822" x2="859.7464" y2="609.0126" gradientTransform="matrix(0.7643 0 0 0.7643 -635.8752 -413.4337)">
+                                    <stop  offset="0" style="stop-color:#80C3E6"/>
+                                    <stop  offset="1" style="stop-color:#3380C2"/>
+                                </linearGradient>
+                                <polygon fill="url(#SVGID_1_)" points="30.205,66.181 37.682,54.026 19.652,54.026 17.119,58.083"/>
+                                <polygon opacity="0.15" points="17.119,58.316 18.446,56.265 30.205,66.336"/>
+                                
+                                <linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="880.0195" y1="647.1326" x2="867.0278" y2="638.5532" gradientTransform="matrix(0.7643 0 0 0.7643 -635.8752 -413.4337)">
+                                    <stop  offset="0" style="stop-color:#F38649"/>
+                                    <stop  offset="0.1849" style="stop-color:#F28147"/>
+                                    <stop  offset="0.4091" style="stop-color:#EF7242"/>
+                                    <stop  offset="0.6537" style="stop-color:#EA5A3A"/>
+                                    <stop  offset="0.911" style="stop-color:#E4382E"/>
+                                    <stop  offset="1" style="stop-color:#E12A29"/>
+                                </linearGradient>
+                                <polygon fill="url(#SVGID_2_)" points="33.853,88.105 33.853,70.075 30.13,67.602 21.861,80.567"/>
+                                <polygon opacity="0.15" points="22.064,80.567 24.114,81.834 30.265,67.602"/>
+                                
+                                <linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="837.6904" y1="628.6257" x2="862.6507" y2="613.0289" gradientTransform="matrix(0.7643 0 0 0.7643 -635.8752 -413.4337)">
+                                    <stop  offset="0" style="stop-color:#42AB4A"/>
+                                    <stop  offset="1" style="stop-color:#ADD155"/>
+                                </linearGradient>
+                                <polygon fill="url(#SVGID_3_)" points="5.448,50.718 5.448,68.748 9.475,71.22 30.497,66.336"/>
+                                
+                                <linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="842.7178" y1="656.1873" x2="863.0244" y2="623.6898" gradientTransform="matrix(0.7643 0 0 0.7643 -635.8752 -413.4337)">
+                                    <stop  offset="0" style="stop-color:#42AB4A"/>
+                                    <stop  offset="1" style="stop-color:#ADD155"/>
+                                </linearGradient>
+                                <polygon fill="url(#SVGID_4_)" points="9.159,72.429 1.682,84.009 19.712,84.009 30.265,67.333"/>
+                            </g>
+                        </svg>
+                    <span>{$_lang.dashboard}</span></a>
                 </li>
                 {if $_search}
                 <li id="modx-manager-search"></li>


### PR DESCRIPTION
As modx.com has a new logo it seems time to also replace it in the manager. I took the chance to re-use the SVG logo found on modx.com and save us one more manager request as the SVG is embedded inline. To help poor IE8 there is a PNG fallback that only shows up when IE8 is coming (e.g. no additional request for normal users). It scales beautifully BTW =)...(not the PNG though).

ups, @rtrash was faster =), but without the inline SVG change as I see...

Based on issue https://github.com/modxcms/revolution/issues/11776 I tried how it could look with the primary buttons in the new logo colors, happy to hear your comments (and will update PR if not better than before!). I also slightly adjusted the colors $orange, $red and $green to match the logo colors, almost no difference visible actually...

would look like that:
![bildschirmfoto 2014-07-22 um 22 52 04](https://cloud.githubusercontent.com/assets/445501/3665312/b6cad98c-11e4-11e4-9280-6b01328a6e95.png)

![modx managertheme newcolors](https://cloud.githubusercontent.com/assets/445501/3665340/e67675f6-11e4-11e4-83c7-80f845e4b844.gif)
don't worry, some of these colors are not normally used, they are just the classes for buttons .blue, .green, .orange, .red, .yellow

primary buttons
![bildschirmfoto 2014-07-22 um 22 54 00](https://cloud.githubusercontent.com/assets/445501/3665324/c0749dd8-11e4-11e4-9569-25f3e152d4b2.png)

![bildschirmfoto 2014-07-22 um 22 54 25](https://cloud.githubusercontent.com/assets/445501/3665326/c4f4da76-11e4-11e4-8632-f83b6ea5b1a7.png)

window
![bildschirmfoto 2014-07-22 um 22 54 53](https://cloud.githubusercontent.com/assets/445501/3665329/ca930dc2-11e4-11e4-9ddd-ecfbc2787bae.png)
