### PR TITLE
[2.3] [Re-Build] Manager Theme: Checkbox/Radio accessibility when focus with keyboard

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -573,7 +573,8 @@ input::-moz-focus-inner {
       width: 18px; height: 18px;
     }
 
-    &:hover:before {
+    &:hover:before,
+    &:focus:before {
       color: $colorSplash;
     }
 
@@ -600,7 +601,9 @@ input::-moz-focus-inner {
     }
 
     &:hover + .x-form-cb-label:before,
-    &:hover + .x-fieldset-header-text:before {
+    &:hover + .x-fieldset-header-text:before,
+    &:focus + .x-form-cb-label:before,
+    &:focus + .x-fieldset-header-text:before {
       color: $colorSplash;
     }
 


### PR DESCRIPTION
Fixes #11772

Title says it all, now it's possible to tab to checkboxes and radios and light them up when focused! Thanks @pixelchutes for reporting!
