### PR TITLE
Make sure modContext config is "prepared" before using makeUrl()

### DIFF
--- a/core/model/modx/modcontext.class.php
+++ b/core/model/modx/modcontext.class.php
@@ -9,7 +9,7 @@
  *
  * @property string $key The key of the context
  * @property string $description The description of the context
- * 
+ *
  * @package modx
  */
 class modContext extends modAccessibleObject {
@@ -221,6 +221,9 @@ class modContext extends modAccessibleObject {
         $url = '';
         $found = false;
         if ($id= intval($id)) {
+            if ($this->config === null) {
+                $this->prepare();
+            }
             if (is_object($this->xpdo->context) && $this->get('key') !== $this->xpdo->context->get('key')) {
                 $config = array_merge($this->xpdo->_systemConfig, $this->config, $this->xpdo->_userConfig, $options);
                 if ($scheme === -1 || $scheme === '' || strpos($scheme, 'abs') !== false) {


### PR DESCRIPTION
### What does it do ?

Calls `modContext->prepare()` before using `modContext->makeUrl()` if `modContext->config` is `null`
### Why is it needed ?

If you iterate modContext & try to use `makeUrl`, the generated URL is wrong since contexts aren't prepared (unless you manually call the method on each object).

This aims to ease the usage of `modContext->makeUrl`
