### PR TITLE
Fix issue where a variable were not defined

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -930,6 +930,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                 } else {
                     $preview = 0;
+                    $size = null;
                     $thumb = $image = $this->ctx->getOption('manager_url', MODX_MANAGER_URL).'templates/default/images/restyle/nopreview.jpg';
                     $thumbWidth = $imageWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $thumbHeight = $imageHeight = $this->ctx->getOption('filemanager_thumb_height', 80);


### PR DESCRIPTION
### What does it do ?

Define a variable.
### Why is it needed ?

In some conditions, we try to use an undefined variable, causing PHP notices.
