### PR TITLE
Fix for #11789: User / User Group Settings update and delete fix

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
@@ -37,5 +37,51 @@ MODx.grid.GroupSettings = function(config) {
     });
     MODx.grid.GroupSettings.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.grid.GroupSettings,MODx.grid.SettingsGrid);
+Ext.extend(MODx.grid.GroupSettings,MODx.grid.SettingsGrid, {
+    _showMenu: function(g,ri,e) {
+        e.stopEvent();
+        e.preventDefault();
+        this.menu.record = this.getStore().getAt(ri).data;
+        if (!this.getSelectionModel().isSelected(ri)) {
+            this.getSelectionModel().selectRow(ri);
+        }
+        this.menu.removeAll();
+
+        var m = [];
+        if (this.menu.record.menu) {
+            m = this.menu.record.menu;
+        } else {
+            m.push({
+                text: _('setting_update')
+                ,handler: this.updateSetting
+            },'-',{
+                text: _('setting_remove')
+                ,handler: this.remove.createDelegate(this,['setting_remove_confirm', 'security/group/setting/remove'])
+            });
+        }
+        if (m.length > 0) {
+            this.addContextMenuItem(m);
+            this.menu.showAt(e.xy);
+        }
+    }
+
+    ,updateSetting: function(btn,e) {
+        var r = this.menu.record;
+        r.fk = Ext.isDefined(this.config.fk) ? this.config.fk : 0;
+        var uss = MODx.load({
+            xtype: 'modx-window-setting-update'
+            ,action: 'security/group/setting/update'
+            ,record: r
+            ,grid: this
+            ,listeners: {
+                'success': {fn:function(r) {
+                    this.refresh();
+                },scope:this}
+            }
+        });
+        uss.reset();
+        uss.setValues(r);
+        uss.show(e.target);
+    }
+});
 Ext.reg('modx-grid-group-settings',MODx.grid.GroupSettings);

--- a/manager/assets/modext/widgets/security/modx.grid.user.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.settings.js
@@ -37,5 +37,51 @@ MODx.grid.UserSettings = function(config) {
     });
     MODx.grid.UserSettings.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.grid.UserSettings,MODx.grid.SettingsGrid);
+Ext.extend(MODx.grid.UserSettings,MODx.grid.SettingsGrid {
+    _showMenu: function(g,ri,e) {
+        e.stopEvent();
+        e.preventDefault();
+        this.menu.record = this.getStore().getAt(ri).data;
+        if (!this.getSelectionModel().isSelected(ri)) {
+            this.getSelectionModel().selectRow(ri);
+        }
+        this.menu.removeAll();
+
+        var m = [];
+        if (this.menu.record.menu) {
+            m = this.menu.record.menu;
+        } else {
+            m.push({
+                text: _('setting_update')
+                ,handler: this.updateSetting
+            },'-',{
+                text: _('setting_remove')
+                ,handler: this.remove.createDelegate(this,['setting_remove_confirm', 'security/user/setting/remove'])
+            });
+        }
+        if (m.length > 0) {
+            this.addContextMenuItem(m);
+            this.menu.showAt(e.xy);
+        }
+    }
+
+    ,updateSetting: function(btn,e) {
+        var r = this.menu.record;
+        r.fk = Ext.isDefined(this.config.fk) ? this.config.fk : 0;
+        var uss = MODx.load({
+            xtype: 'modx-window-setting-update'
+            ,action: 'security/user/setting/update'
+            ,record: r
+            ,grid: this
+            ,listeners: {
+                'success': {fn:function(r) {
+                    this.refresh();
+                },scope:this}
+            }
+        });
+        uss.reset();
+        uss.setValues(r);
+        uss.show(e.target);
+    }
+});
 Ext.reg('modx-grid-user-settings',MODx.grid.UserSettings);

--- a/manager/assets/modext/widgets/security/modx.grid.user.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.settings.js
@@ -37,7 +37,7 @@ MODx.grid.UserSettings = function(config) {
     });
     MODx.grid.UserSettings.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.grid.UserSettings,MODx.grid.SettingsGrid {
+Ext.extend(MODx.grid.UserSettings,MODx.grid.SettingsGrid, {
     _showMenu: function(g,ri,e) {
         e.stopEvent();
         e.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/modxcms/revolution/issues/11789

See description in issue above, quite a severe bug if you ask me =)...basically updating a user or user group setting via context menu (directly in grid worked) is updating the system setting and not the user / user group setting, deleting it via context menu deletes a system setting with the same name instead of deleting the user / user group setting. I guess this bug was also present before 2.3, so maybe that should be added to 2.2.x patch releases too...

A question I couldn't answer is, **why it works for context settings**, when I search trough all extjs code, I cannot find one mention of "context/setting/remove" as an action, but deleting a context setting via contextmenu > delete triggers the right processor, can anybody explain why?

Not sure about the way I fixed it (basically overriding the methods from the MODx.grid.SettingsGrid class with the right actions), in the context settings grid it's solved differently (but I don't fully understand, see question above). **Question 2**: Would it be better to extend the setting update window (as it's done in the context settings grid) instead of overriding the methods of the parent class?
