### PR TITLE
[2.3] Enhancement: Real-Time resource alias field

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -674,6 +674,15 @@ $settings['friendly_alias_max_length']->fromArray(array (
   'area' => 'furls',
   'editedon' => null,
 ), '', true, true);
+$settings['friendly_alias_realtime']= $xpdo->newObject('modSystemSetting');
+$settings['friendly_alias_realtime']->fromArray(array (
+  'key' => 'friendly_alias_realtime',
+  'value' => '0',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'furls',
+  'editedon' => null,
+), '', true, true);
 $settings['friendly_alias_restrict_chars']= $xpdo->newObject('modSystemSetting');
 $settings['friendly_alias_restrict_chars']->fromArray(array (
   'key' => 'friendly_alias_restrict_chars',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * Setting English lexicon topic
@@ -304,6 +305,9 @@ $_lang['setting_friendly_alias_lowercase_only_desc'] = 'Determines whether to al
 
 $_lang['setting_friendly_alias_max_length'] = 'FURL Alias Maximum Length';
 $_lang['setting_friendly_alias_max_length_desc'] = 'If greater than zero, the maximum number of characters to allow in a Resource alias. Zero equals unlimited.';
+
+$_lang['setting_friendly_alias_realtime'] = 'FURL Alias Real-Time';
+$_lang['setting_friendly_alias_realtime_desc'] = 'Determines whether a resource alias should be created on the fly when typing the pagetitle or if this should happen when the resource is saved (automatic_alias needs to be enabled for this to have an effect).';
 
 $_lang['setting_friendly_alias_restrict_chars'] = 'FURL Alias Character Restriction Method';
 $_lang['setting_friendly_alias_restrict_chars_desc'] = 'The method used to restrict characters used in a Resource alias. "pattern" allows a RegEx pattern to be provided, "legal" allows any legal URL characters, "alpha" allows only letters of the alphabet, and "alphanumeric" allows only letters and numbers.';

--- a/core/model/modx/processors/resource/translit.class.php
+++ b/core/model/modx/processors/resource/translit.class.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Retrieves a string and returns it transliterated to use in various applications but mainly for real-time alias
+ *
+ * @param string $string The string to transliterate
+ * @return string
+ *
+ * @package modx
+ * @subpackage processors.resource
+ */
+class modTranslitProcessor extends modProcessor {
+
+	public function process() {
+		$string = $this->getProperty('string');
+		$transliteration = array(
+			'input' => $string,
+			'transliteration' => $this->modx->call('modResource', 'filterPathSegment', array(&$this->modx, $string)),
+		);
+
+		return $this->success('', $transliteration);
+	}
+}
+return 'modTranslitProcessor';

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -521,7 +521,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,maxLength: 255
             ,anchor: '100%'
             ,value: config.record.longtitle || ''
-
         },{
             xtype: 'textarea'
             ,fieldLabel: _('resource_description')
@@ -574,7 +573,14 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,maxLength: (aliasLength > 255 || aliasLength === 0) ? 255 : aliasLength
             ,anchor: '100%'
             ,value: config.record.alias || ''
-
+            ,listeners: {
+                'change': {fn: function(f,e) {
+                    // when the alias is manually cleared, enable real time alias
+                    if (Ext.isEmpty(f.getValue())) {
+                        this.config.aliaswasempty = true;
+                    }
+                }, scope: this}
+            }
         },{
             xtype: 'textfield'
             ,fieldLabel: _('resource_menutitle')
@@ -584,7 +590,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,maxLength: 255
             ,anchor: '100%'
             ,value: config.record.menutitle || ''
-
         },{
             xtype: 'textfield'
             ,fieldLabel: _('resource_link_attributes')
@@ -594,7 +599,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,maxLength: 255
             ,anchor: '100%'
             ,value: config.record.link_attributes || ''
-
         },{
             xtype: 'xcheckbox'
             ,boxLabel: _('resource_hide_from_menus')
@@ -604,7 +608,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,id: 'modx-resource-hidemenu'
             ,inputValue: 1
             ,checked: parseInt(config.record.hidemenu) || false
-
         },{
             xtype: 'xcheckbox'
             ,boxLabel: _('resource_published')

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -55,6 +55,8 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             } else {
                 this.config.aliaswasempty = false;
             }
+            this.config.translitloading = false; // the initial value for the realtime-alias throttling
+
             if (!Ext.isEmpty(this.config.record.resourceGroups)) {
                 var g = Ext.getCmp('modx-grid-resource-security');
                 if (g && Ext.isEmpty(g.config.url)) {
@@ -215,7 +217,28 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             uri.hide();
         }
     }
-
+    // used for realtime-alias transliteration
+    ,translitAlias: function(string) {
+        if (!this.config.translitloading) {
+            this.config.translitloading = true;
+            MODx.Ajax.request({
+                url: MODx.config.connector_url
+                ,params: {
+                    action: 'resource/translit'
+                    ,string: string
+                }
+                ,listeners: {
+                    'success': {fn:function(r) {
+                        var alias = Ext.getCmp('modx-resource-alias');
+                        if (!Ext.isEmpty(r.object.transliteration)) {
+                            alias.setValue(r.object.transliteration);
+                            this.config.translitloading = false;
+                        }
+                    },scope:this}
+                }
+            });
+        }
+    }
     ,templateWarning: function() {
         var t = Ext.getCmp('modx-resource-template');
         if (!t) { return false; }
@@ -448,67 +471,25 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     var title = Ext.util.Format.stripTags(f.getValue());
                     Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
 
-                    var alias = Ext.getCmp('modx-resource-alias');
-
-                    // the following code is a JavaScript replication of the method filterPathSegment() in modresource.class.php
-                    // there is no transliteration of special characters though
-                    if (this.config.aliaswasempty && title !== '') {
-                        
-                        var delimiter = MODx.config.friendly_alias_word_delimiter || '-';
-                        var delimiters = MODx.config.friendly_alias_word_delimiters || '-_';
-                        var maxlength = MODx.config.friendly_alias_max_length || 0;
-                        // what is \a in PHP regex? had to take it out as it stripped characters "a"
-                        var pattern = MODx.config.setting_friendly_alias_restrict_chars_pattern || /[\0\x0B\t\n\r\f&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/g;
-                        var restrict = MODx.config.friendly_alias_restrict_chars || 'pattern';
-                        //var trimchars = MODx.config.friendly_alias_trim_chars || '/.' + delimiters; // no easy way to implement this, no crossbrowser trim(regex) in JS
-
-                        // replace non-breaking space entities with delimiter
-                        title = title.replace('&nbsp;', delimiter);
-
-                        // JavaScript doesn't have anything to decode html entites, so the follwing is a bit hacky
-                        // takes also care of stripping tags, but no handling of MODX tags!
-                        var fakeel = document.createElement('div'); // create a fake element
-                        fakeel.innerHTML = title; // set the pagetitle as content to decode html entities
-                        title = fakeel.textContent || fakeel.innerText; // read the decoded text back into our title variable
-
-                        // replace any remaining ampersands with "and" from lexicons
-                        title = title.replace('&', _('and'));
-
-                        // console.log(restrict);
-                        switch (restrict) {
-                            case 'alphanumeric':
-                                title = title.replace(/[^\.%A-Za-z0-9 _-]/g, '');
-                                break;
-                            case 'alpha':
-                                title = title.replace(/[^\.%A-Za-z _-]/g, '');
-                                break;
-                            case 'legal':
-                                title = title.replace(/[\0\x0B\t\n\r\f&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/g, '');
-                                break;
-                            case 'pattern':
-                            default:
-                                title = title.replace(pattern, '');
-                                break;
+                    // check some system settings before doing real time alias transliteration
+                    if (parseInt(MODx.config.friendly_alias_realtime, 10) && parseInt(MODx.config.automatic_alias, 10)) {
+                        // handles the realtime-alias transliteration
+                        if (this.config.aliaswasempty && title !== '') {
+                            this.translitAlias(title);
                         }
+                    }
+                }, scope: this}
+                // also do realtime transliteration of alias on blur of pagetitle field
+                // as sometimes (when typing very fast) the last letter(s) are not catched
+                ,'blur': {fn: function(f,e) {
+                    var title = Ext.util.Format.stripTags(f.getValue());
 
-                        // replace spaces with the delimiter
-                        title = title.replace(/\s+/g, delimiter);
-
-                        // replace multiple occurences of word delimiters with one occurence
-                        var delimiterPattern = new RegExp('[' + delimiters.split('').join('|') + ']+', 'g');
-                        title = title.replace(delimiterPattern, delimiter);
-
-                        if (parseInt(MODx.config.friendly_alias_lowercase_only, 10)) {
-                            title = title.toLowerCase();
+                    // check some system settings before doing real time alias transliteration
+                    if (parseInt(MODx.config.friendly_alias_realtime, 10) && parseInt(MODx.config.automatic_alias, 10)) {
+                        // handles the realtime-alias transliteration
+                        if (this.config.aliaswasempty && title !== '') {
+                            this.translitAlias(title);
                         }
-
-                        // if maxlength is specified and exceeded, return substr with additional trim applied
-                        if (maxlength > 0 && title.length > maxlength) {
-                            title = title.substring(0, maxlength);
-                        }
-
-                        // finally push the new value to the alias field
-                        alias.setValue(title);
                     }
                 }, scope: this}
             }


### PR DESCRIPTION
This is a proposal to implement what was discussed here: https://github.com/modxcms/revolution/issues/11225

The alias field is a bit more complicated than the resource header (the big title), as it should reflect as good as possible what will actually be saved, which means I had to replicate the filterPathSegment() from the modresource.class.php method with all its regexes in JavaScript. Not all is possible (for example trim(regex) is a problem...thanks to IE8), but I'm quite ok with the results.

Tested:
- lowercase only yes / no
- maxlength
- restrict chars: alphanumeric, alpha, legal (=pattern), pattern
- multiple delimiters replaced by one

Caution:
- There is no transliteration available in Javascript, so characters like ä ö ü etc. get transformed on save!

Looks like that:
![modx realtime alias](https://cloud.githubusercontent.com/assets/445501/3682463/7f987e9e-12cd-11e4-9202-3bd2243b9219.gif)
