### PR TITLE
[2.3] [Re-build] Manager Theme: Fix missing vertical spacing between tag TV tags

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -144,7 +144,7 @@ input::-moz-focus-inner {
   /* Tag TVs tag list below */
   .modx-tag-list {
     list-style: none;
-    margin: 4px 0 0 0;
+    margin: 0;
     overflow: auto;
     padding: 0;
 
@@ -155,7 +155,7 @@ input::-moz-focus-inner {
       display: inline-block;
       /*float: left;*/
       /*list-style: none;*/
-      margin: 0 5px 0 10px;
+      margin: 4px 5px 0 10px;
       padding: 1px 5px;
       position: relative;
       /*text-decoration: underline;*/


### PR DESCRIPTION
When implementing the new look for tags I forgot that there could be multiple lines of tags...so the tags didn't have vertical spacing which looked like that:

![bildschirmfoto 2014-07-24 um 03 18 15](https://cloud.githubusercontent.com/assets/445501/3682581/ddd405f2-12d0-11e4-8257-212f91042d87.png)

with the fix from this PR it looks like that:
![bildschirmfoto 2014-07-24 um 03 17 51](https://cloud.githubusercontent.com/assets/445501/3682584/e7bf6386-12d0-11e4-8f0f-bdf54b4c468a.png)
