### PR TITLE
Updated grunt-bower-task required version to 0.4.0

### DIFF
--- a/_build/templates/default/package.json
+++ b/_build/templates/default/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "grunt": "^0.4.3",
     "grunt-autoprefixer": "^0.7.2",
-    "grunt-bower-task": "^0.3.4",
+    "grunt-bower-task": "^0.4.0",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-csslint": "^0.1.2",


### PR DESCRIPTION
Setting up my machine to work with the new sass `grunt build` process, I kept receiving the following error:
`Fatal error: Arguments to path.join must be strings`

I had never run into this error before, but I was apparently running an older version of node...

This machine was using the latest stable node / npm:
`node -v` v0.10.29
`npm -v` 1.4.14

The final solution required bumping the `grunt-bower-task` version to 0.4.0

**NOTE:** I believe this change bumps the minimum required nodejs to `v0.10` and bower to `v1.3.0`. See: https://github.com/yatskevich/grunt-bower-task/pull/123/files ...I have not confirmed with this change on an _older_ version of node, I just know this was required to get working against the latest.
