### PR TITLE
[2.3] Bump navbar username CSS media query from 960px to 1024px

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -86,7 +86,7 @@
 }
 
 #user-username {
-  @include media($desktop) {
+  @include media($tabletL) {
     display: none;
   }
 }


### PR DESCRIPTION
This PR addresses #11702

After testing quite a few different scenarios against `v2.3.1`, I've concluded the `max-width` breakpoint for hiding the username in the nav should be changed from:

``` css
$desktop /* 960px */
```

to:

``` css
$tabletL /* 1024px */
```

In my testing, a username of around 14 to 15 characters would trigger the layout issue pictured in #11702. This difference (`64px`) seems to better address the smaller space available on tablets (and some older desktops).
