### PR TITLE
Update resource getnodes processor to fix #11784

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -422,7 +422,9 @@ class modResourceGetNodesProcessor extends modProcessor {
             $classKey = substr($classKey, 3);
         }
         $classKeyIcon = $this->modx->getOption('mgr_tree_icon_' . $classKey, null, 'tree-resource');
-        $iconCls[] = $classKeyIcon;
+        if($tplIcon == '' && $classKeyIcon == 'tree-resource'){
+            $iconCls[] = $classKeyIcon;
+        }
 
         switch($classKey) {
             case 'weblink':


### PR DESCRIPTION
Add a conditional statement to prevent the default .tree-folder icon class from overriding template specific icon classes.
