### PR TITLE
Fix Incorrect urlAbsolute Path (again)

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -200,7 +200,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'pathRelative' => $bases['pathRelative'].$fileName,
                     'directory' => $bases['path'],
                     'url' => $bases['url'].$url,
-                    'urlAbsolute' => $bases['urlAbsoluteWithPath'].ltrim($url,'/'),
+                    'urlAbsolute' => ($bases['urlIsRelative']) ? $bases['urlAbsolute'].ltrim($url,'/') : $bases['urlAbsoluteWithPath'].ltrim($url,'/'),
                     'file' => $encFile,
                     'menu' => array(),
                 );


### PR DESCRIPTION
This commit adds a ternary to set `urlAbsolute` to `urlAbsoluteWithPath` if
`baseUrlRelative` is set to `No`
Closes modxcms/revolution#11291 ( again :( )

In 2.2.14 and prior, there was a bug where if you set the `baseUrlRelative` to No and `baseUrl` to `/` the `urlAbsolute` would be incorrect.

A patch that was merged in 2.2.15 fixed the above issue, but caused another. With default media system settings of `baseUrlRelative` set to `Yes` the `urlAbsolute` was doubling up ex:
`assets/uploads/assets/uploads/my.jpg`
