### PR TITLE
Fix URL Absolute Path (again)

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -200,7 +200,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'pathRelative' => $bases['pathRelative'].$fileName,
                     'directory' => $bases['path'],
                     'url' => $bases['url'].$url,
-                    'urlAbsolute' => $bases['urlAbsoluteWithPath'].ltrim($url,'/'),
+                    'urlAbsolute' => $bases['urlAbsolute'].ltrim($url,'/'),
+                    'urlAbsoluteWithPath' => $bases['urlAbsoluteWithPath'].ltrim($url,'/'),
                     'file' => $encFile,
                     'menu' => array(),
                 );


### PR DESCRIPTION
See modxcms/revolution#11291 :-1: 

This is a different approach to fix the same problem as
modxcms/revolution#11819 so only one should be considered to be merged

the disadvantage to this approach, is it re-introduces the same bug as
was present in 2.2.14 described in modxcms/revolution#11291 but the
advantage is this is less assumptive (doesn’t try to be smart and
adjust urlAbsolute) but rather adds another parameter,
urlAbsoluteWithPath that would allow developers to detect the
baseUrlRelative setting of a given media source, and use urlAbsolute or
urlAbsoluteWithPath respectively.
