### PR TITLE
When using resource_tree_node_tooltip system setting, make sure the given field is not empty before displaying the quick tip

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -401,7 +401,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         }
 
         $qtip = '';
-        if (!empty($qtipField)) {
+        if (!empty($qtipField) && !empty($resource->$qtipField)) {
             $qtip = '<b>'.strip_tags($resource->$qtipField).'</b>';
         } else {
             if ($resource->longtitle != '') {


### PR DESCRIPTION
### What does it do ?

Make sure the field value used to display a (tree) quick tip is not empty.
### Why is it needed ?

Without this check, if the given field is empty, we have an empty tool tip
