### PR TITLE
Disable keyboard shortcut to focus the search bar, causing issue with some keyboard layouts

### DIFF
--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -103,7 +103,7 @@ MODx.SearchBar = function(config) {
         }
     });
     MODx.SearchBar.superclass.constructor.call(this, config);
-    this.setKeyMap();
+    //this.setKeyMap();
 };
 Ext.extend(MODx.SearchBar, Ext.form.ComboBox, {
     // Initialize the keyboard shortcuts to focus the bar (ctrl + alt + /)


### PR DESCRIPTION
### What does it do ?

Disable the keyboard shortcut to focus the manager search bar.
### Why is it needed ?

On some keyboard layouts, the defined shortcut is used to type some characters, thus this shortcut prevents writing those characters.
### Related issue(s)/PR(s)
- #11828 
- #11794
