### PR TITLE
Added ability to use qtip for tree root nodes & using it on media sources to display their description as quick tip

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -40,6 +40,7 @@ MODx.tree.Tree = function(config) {
         root = {
             nodeType: 'async'
             ,text: config.root_name || config.rootName || ''
+            ,qtip: config.root_qtip || config.rootQtip || ''
             ,draggable: false
             ,id: config.root_id || config.rootId || 'root'
             ,pseudoroot: true

--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -84,6 +84,7 @@ Ext.extend(MODx.panel.FileTree, Ext.Container, {
             ,stateId: this._treePrefix + source.id
             ,id: this._treePrefix + source.id
             ,rootName: source.name
+            ,rootQtip: source.description || ''
             ,hideSourceCombo: true
             ,source: source.id
             ,tbar: false


### PR DESCRIPTION
### What does it do ?

Adds the ability to define a quick tip for trees root nodes.
Displays the `modMediaSource.description` as tool tip in the files tree.
### Why is it needed ?

It could be a great addition to provide extra information on some root nodes (ie. media sources)
