### PR TITLE
[feature] - user photo

### DIFF
--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -488,6 +488,9 @@ $_lang['setting_proxy_port_desc'] = 'The port for your proxy server.';
 $_lang['setting_proxy_username'] = 'Proxy Username';
 $_lang['setting_proxy_username_desc'] = 'The username to authenticate against with your proxy server.';
 
+$_lang['setting_photo_profile_source'] = 'User photo Media Source';
+$_lang['setting_photo_profile_source_desc'] = 'The Media Source used to store users profiles photos. Defaults to default Media Source.';
+
 $_lang['setting_phpthumb_allow_src_above_docroot'] = 'phpThumb Allow src Above Document Root';
 $_lang['setting_phpthumb_allow_src_above_docroot_desc'] = 'Indicates if the src path is allowed outside the document root. This is useful for multi-context deployments with multiple virtual hosts.';
 

--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -29,7 +29,7 @@ MODx.panel.Profile = function(config) {
         }
         ,layout: 'anchor'
         ,cls: 'container'
-        // ,bodyStyle: 'background: none;'
+        ,bodyStyle: 'background: none;'
         ,border: false
         ,items: [{
             html: '<h2>'+_('profile')+'</h2>'
@@ -92,7 +92,11 @@ MODx.panel.UpdateProfile = function(config) {
         ,buttonAlign: 'right'
         ,cls: 'container form-with-labels'
         ,labelAlign: 'top'
-        ,defaults: { border: false ,msgTarget: 'under' }
+        ,defaults: {
+            border: false
+            ,msgTarget: 'under'
+            ,anchor: '100%'
+        }
         ,labelWidth: 150
         ,items: [{
             xtype: 'textfield'
@@ -100,51 +104,50 @@ MODx.panel.UpdateProfile = function(config) {
             ,name: 'fullname'
             ,maxLength: 255
             ,allowBlank: false
-            ,anchor: '100%'
         },{
             xtype: 'textfield'
             ,fieldLabel: _('email')
             ,name: 'email'
             ,vtype: 'email'
-            ,anchor: '100%'
             ,allowBlank: false
+        },{
+            fieldLabel: _('user_photo')
+            ,name: 'photo'
+            ,xtype: 'modx-combo-browser'
+            ,hideFiles: true
+            ,source: MODx.config['photo_profile_source'] || MODx.config.default_media_source
+            ,hideSourceCombo: true
         },{
             xtype: 'textfield'
             ,fieldLabel: _('user_phone')
             ,name: 'phone'
-            // ,width: 200
             ,anchor: '50%'
         },{
             xtype: 'textfield'
             ,fieldLabel: _('user_mobile')
             ,name: 'mobilephone'
-            // ,width: 200
             ,anchor: '50%'
         },{
             xtype: 'textfield'
             ,fieldLabel: _('user_fax')
             ,name: 'fax'
-            // ,width: 200
             ,anchor: '50%'
         },{
             xtype: 'datefield'
             ,fieldLabel: _('user_dob')
             ,name: 'dob'
-            // ,width: 200
             ,anchor: '50%'
         },{
             xtype: 'textfield'
             ,fieldLabel: _('user_state')
             ,name: 'state'
             ,maxLength: 50
-            // ,width: 150
             ,anchor: '50%'
         },{
             xtype: 'textfield'
             ,fieldLabel: _('user_zip')
             ,name: 'zip'
             ,maxLength: 20
-            // ,width: 150
             ,anchor: '50%'
         }]
         // TODO: this button should be in a actionbar like any other panel

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -651,7 +651,7 @@ Ext.extend(MODx.combo.Browser,Ext.form.TriggerField,{
                 ,closeAction: 'close'
                 ,id: Ext.id()
                 ,multiple: true
-                ,source: this.config.source || 1
+                ,source: this.config.source || MODx.config.default_media_source
                 ,hideFiles: this.config.hideFiles || false
                 ,rootVisible: this.config.rootVisible || false
                 ,allowedFileTypes: this.config.allowedFileTypes || ''

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -357,6 +357,14 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,anchor: '100%'
                     ,maxLength: 255
                 },{
+                    fieldLabel: _('user_photo')
+                    ,name: 'photo'
+                    ,xtype: 'modx-combo-browser'
+                    ,hideFiles: true
+                    ,source: MODx.config['photo_profile_source'] || MODx.config.default_media_source
+                    ,hideSourceCombo: true
+                    ,anchor: '100%'
+                },{
                     id: 'modx-user-dob'
                     ,name: 'dob'
                     ,fieldLabel: _('user_dob')

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -92,31 +92,15 @@ class TopMenu
      */
     public function getUserImage()
     {
-        /** @var modUserProfile $userProfile */
-        $userProfile = $this->modx->user->getOne('Profile');
-
         // Default to FontAwesome
-        $userImage = '<i class="icon icon-user icon-large"></i>&nbsp;';
+        $output = '<i class="icon icon-user icon-large"></i>&nbsp;';
+        $img = $this->modx->user->getPhoto(128, 128);
 
-        if ($userProfile->photo) {
-            // First, handle user defined image
-            $src = $this->modx->getOption('connectors_url', MODX_CONNECTORS_URL)
-                .'system/phpthumb.php?zc=1&h=128&w=128&src='
-                .$userProfile->photo;
-            $userImage = '<img src="' . $src . '" />';
-        } elseif ($this->modx->getOption('enable_gravatar')) {
-            // Gravatar
-            $gravemail = md5(
-                strtolower(
-                    trim($userProfile->email)
-                )
-            );
-            $gravsrc = $this->modx->getOption('url_scheme', null, 'http://') . 'www.gravatar.com/avatar/'
-            .$gravemail . '?s=128&d=mm';
-            $userImage = '<img src="' . $gravsrc . '" />';
+        if (!empty($img)) {
+            $output = '<img src="' . $img . '" />';
         }
 
-        return $userImage;
+        return $output;
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

This is a WIP (mostly awaiting for feedback) to handle user profile photos.

It makes use of Media Sources (using the default one per default, but configurable using the `photo_profile_source` system setting -- expecting a media source ID).
### Why is it needed ?

There currently is no user interface to manage `modUserProfile.photo` (which is used in the manager -- user photo -- and could potentially be used anywhere else)
### To do before merge
- [x] create lexicon string for the system setting
- [x] replicate the UI on security/profile so users
- [x] put photo "retrieval" logic in `modUser` (since it might be useful for developers)
- [x] squash commits
### Related issue(s)

Closes #11824
