### PR TITLE
[feature] Added a system event to allow developers to assign Smarty variables

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -868,6 +868,12 @@ $events['OnElementNotFound']->fromArray(array (
   'service' => 1,
   'groupname' => 'System',
 ), '', true, true);
+$events['OnBeforeMenuPlaceholders']= $xpdo->newObject('modEvent');
+$events['OnBeforeMenuPlaceholders']->fromArray(array (
+  'name' => 'OnBeforeMenuPlaceholders',
+  'service' => 1,
+  'groupname' => 'System',
+), '', true, true);
 
 /* Settings */
 $events['OnSiteSettingsRender']= $xpdo->newObject('modEvent');

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -82,6 +82,20 @@ class TopMenu
             'userImage' => $this->getUserImage(),
         );
 
+        $data = $this->modx->invokeEvent('OnBeforeMenuPlaceholders', array(
+            'controller' =>& $this->controller,
+            'placeholders' => $placeholders,
+        ));
+
+        if (!empty($data) && is_array($data)) {
+            foreach ($data as $phs) {
+                if (!is_array($phs) || empty($phs)) {
+                    continue;
+                }
+                $placeholders = array_merge($placeholders, $phs);
+            }
+        }
+
         $this->controller->setPlaceholders($placeholders);
     }
 

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -83,6 +83,7 @@ class TopMenu
         );
 
         $data = $this->modx->invokeEvent('OnBeforeMenuPlaceholders', array(
+            'topmenu' =>& $this,
             'controller' =>& $this->controller,
             'placeholders' => $placeholders,
         ));


### PR DESCRIPTION
### What does it do ?

Adds a system event to enable developers to assign Smarty variables to be used in user navigation.
### Why is it needed ?

Smarty variables could be used, ie., to display a notification count number on a menu entry.
### To do before merge
- [ ] triple check it is not possible to override critical variables (ie. `$_config`)
- [ ] make sure Smarty variables are usable/parsed in lexicon strings
