### PR TITLE
Nullify some methods in ResourceDataManagerController which could potentially cause issues

### DIFF
--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -135,4 +135,15 @@ class ResourceDataManagerController extends ResourceManagerController {
     public function getHelpUrl() {
         return 'Resources';
     }
+    public function firePreRenderEvents() {
+        return;
+    }
+    public function fireOnRenderEvent() {
+        return;
+    }
+    public function fireOnTVFormRender() {
+        return;
+    }
+    public function loadRichTextEditor() {
+    }
 }


### PR DESCRIPTION
### What does it do ?

Nullify some methods in `ResourceDataManagerController`
### Why is it needed ?

The controller fires some events (`On*Doc*`) which is not appropriate since most of those events are used on resource (creation/edition) form.
