### PR TITLE
Auto "add package" when listing manager actions, when appropriate

### DIFF
--- a/core/model/modx/processors/system/log/getlist.class.php
+++ b/core/model/modx/processors/system/log/getlist.class.php
@@ -102,7 +102,18 @@ class modSystemLogGetListProcessor extends modProcessor {
      */
     public function prepareLog(modManagerLog $log) {
         $logArray = $log->toArray();
-        if (!empty($logArray['classKey']) && !empty($logArray['item']) && $logArray['item'] !== 'unknown') {
+        if (strpos($logArray['action'], '.') !== false) {
+            // Action is prefixed with a namespace, assume we need to load a package
+            $exp = explode('.', $logArray['action']);
+            $ns = $exp[0];
+            $path = $this->modx->getOption(
+                "{$ns}.core_path",
+                null,
+                $this->modx->getOption('core_path') . "components/{$ns}/"
+            ) . 'model/';
+            $this->modx->addPackage($ns, $path);
+        }
+        if (!empty($logArray['classKey']) && !empty($logArray['item'])) {
             $logArray['name'] = $logArray['classKey'] . ' (' . $logArray['item'] . ')';
             /** @var xPDOObject $obj */
             $obj = $this->modx->getObject($logArray['classKey'], $logArray['item']);


### PR DESCRIPTION
### What does it do ?

Automatically calls `addPackage` when listing manager actions (`?a=system/logs`) if an action is prefixed with a namespace.
### Why is it needed ?

Unless the third party package registers itself (extension_packages), when listing manager actions dealing with third party tables, packages aren't loaded, thus we can't get appropriate objects (filling the logs with loads of `Could not load class: ClassName from mysql.classname. className::load() is not a valid static method.`).
### To do before merge
- [ ] make sure most (all ?) third party packages follow the file structure convention (`namespace/model/`)
### Related issue(s)/PR(s)

Closes #8747
