### PR TITLE
Fix encoded htmlspecialchars in resource overview > cache output tab

### DIFF
--- a/core/model/modx/processors/resource/data.class.php
+++ b/core/model/modx/processors/resource/data.class.php
@@ -67,7 +67,7 @@ class modResourceDataProcessor extends modProcessor {
             xPDO::OPT_CACHE_FORMAT => (integer) $this->modx->getOption('cache_resource_format', null, $this->modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
         ));
         if ($buffer) {
-            $buffer = htmlspecialchars($buffer['resource']['_content']);
+            $buffer = $buffer['resource']['_content'];
         }
         return !empty($buffer) ? $buffer : $this->modx->lexicon('resource_notcached');
     }

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -13,6 +13,7 @@ MODx.page.ResourceData = function(config) {
         btns.push({
             text: _('edit')
             ,id: 'modx-abtn-edit'
+            ,cls: 'primary-button'
             ,hidden: config.canEdit == 1 ? false : true
             ,handler: this.editResource
             ,scope: this

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -150,6 +150,7 @@ MODx.panel.ResourceData = function(config) {
                 ,id: 'modx-rdata-buffer'
                 ,xtype: 'textarea'
                 ,hideLabel: true
+                ,readOnly: true
                 ,width: '90%'
                 ,grow: true
             }]
@@ -162,6 +163,13 @@ MODx.panel.ResourceData = function(config) {
         }
     });
     MODx.panel.ResourceData.superclass.constructor.call(this,config);
+
+    // prevent backspace key from going to the previous page in browser history
+    Ext.EventManager.on(window, 'keydown', function(e, t) {
+        if (e.getKey() == e.BACKSPACE && t.readOnly) {
+            e.stopEvent();
+        }
+    });
 };
 Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
     setup: function() {


### PR DESCRIPTION
This addresses https://github.com/modxcms/revolution/issues/11833

I'm not sure if removing htmlspecialchars() from core/model/modx/processors/resource/data.class.php is unsecure, but it solves the problem.

Additionally made the textarea readonly as there is no point in it being editable. Because of this an event-blocker for the backspace key has been added, as pressing the backspace key resulted in the browser going back to the previous page in browser history.

before
![bildschirmfoto 2014-08-04 um 13 39 11](https://cloud.githubusercontent.com/assets/445501/3796899/f6238a8e-1bd0-11e4-88cd-d7e9ad68875a.png)

after
![bildschirmfoto 2014-08-04 um 14 20 00](https://cloud.githubusercontent.com/assets/445501/3796959/cc7afa40-1bd1-11e4-8ca4-d9a556c878a5.png)
