### PR TITLE
[2.3] [Re-build] Manager Theme: Revert normal font for textareas due to many incompatibilities

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -5,8 +5,18 @@ textarea {
 textarea.x-form-field,
 .x-form-textarea {
   display: block; /* make the field description (below) stick to the bottom correctly */
-  /*font-family: $codefonts;*/
+  font-family: $codefonts;
   padding: 5px; /* override standard extjs theme */
+}
+
+/* general class that can be applied to any form field that should display code font */
+.modx-code-content {
+  font-family: $codefonts;
+}
+
+textarea[name="description"],
+textarea[name="introtext"] {
+  font: $baseText;
 }
 
 .x-form-text, /* this screws up clear cache modal #shame */
@@ -930,17 +940,6 @@ input::-moz-focus-inner {
 /*.x-form-field {
   font: $baseText;
 }*/
-
-/* #ta, /* main resource content without RTE */
-/* #modx-chunk-snippet, /* chunk code */
-/* #modx-snippet-snippet, /* snippet code */
-/* #modx-plugin-plugincode, /* plugin code */
-/* #modx-template-content, /* template code */
-/* #modx-file-content, /* file code / content */
-/* #modx-error-log-content, /* error log content */
-.modx-code-content { /* general class that could be applied to any form field that should display code font */
-  font-family: $codefonts;
-}
 
 /*.x-form-select-one {
   background-color: #fff;

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -15,7 +15,8 @@ textarea.x-form-field,
 }
 
 textarea[name="description"],
-textarea[name="introtext"] {
+textarea[name="introtext"],
+.modx-text-content {
   font: $baseText;
 }
 

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -107,7 +107,6 @@ MODx.panel.CreateFile = function(config) {
                     ,fieldLabel: _('content')
                     ,name: 'content'
                     ,id: 'modx-file-content'
-                    ,cls: 'modx-code-content'
                     ,anchor: '100%'
                     ,grow: false
                     ,height: 400

--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -124,7 +124,6 @@ MODx.panel.EditFile = function(config) {
                     ,hideLabel: true
                     ,name: 'content'
                     ,id: 'modx-file-content'
-                    ,cls: 'modx-code-content'
                     ,anchor: '98%'
                     ,grow: false
                     ,height: 400

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -219,7 +219,6 @@ MODx.panel.Chunk = function(config) {
 					,fieldLabel: _('chunk_code')
 					,name: 'snippet'
 					,id: 'modx-chunk-snippet'
-                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.snippet || ''

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -230,7 +230,6 @@ MODx.panel.Plugin = function(config) {
 					,fieldLabel: _('plugin_code')
 					,name: 'plugincode'
 					,id: 'modx-plugin-plugincode'
-                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.plugincode || "<?php\n"

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -219,7 +219,6 @@ MODx.panel.Snippet = function(config) {
 					,fieldLabel: _('snippet_code')
 					,name: 'snippet'
 					,id: 'modx-snippet-snippet'
-                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.snippet || "<?php\n"

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -237,7 +237,6 @@ MODx.panel.Template = function(config) {
 					,fieldLabel: _('template_code')
 					,name: 'content'
 					,id: 'modx-template-content'
-                    ,cls: 'modx-code-content'
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.content || ''

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -794,7 +794,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             xtype: 'textarea'
             ,name: 'ta'
             ,id: 'ta'
-            ,cls: 'modx-code-content'
             ,hideLabel: true
             ,anchor: '100%'
             ,height: 400

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -34,7 +34,6 @@ MODx.panel.ErrorLog = function(config) {
                     ,name: 'log'
                     ,hideLabel: true
                     ,id: 'modx-error-log-content'
-                    ,cls: 'modx-code-content'
                     ,grow: true
                     ,growMax: 400
                     ,anchor: '100%'


### PR DESCRIPTION
This PR reverts the code introduced in https://github.com/modxcms/revolution/pull/11617 that makes the text inside textareas display in normal font. There are many textareas in extras now not displaying code correctly, so I changed the code to only affect (e.g. display normal font) in textareas with name attribute = "description" or "introtext" which still satisfies the initial issues behind this change. All other textareas display codefonts again.

In addition there is a new class .modx-text-content to apply for extra autors, if a textarea in their code needs to display normal text styles. The class of .modx-code-content is still available to force an input field to display the text in codefonts.
