### PR TITLE
[2.3] Manager Theme: Add body version class .modx23 for extra devs to target new theme

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -39,7 +39,7 @@
 </script>
 {/if}
 </head>
-<body id="modx-body-tag">
+<body id="modx-body-tag" class="modx23">
 
 <div id="modx-browser"></div>
 <div id="modx-container">


### PR DESCRIPTION
Very small change that allows extra devs to target the new 2.3 manager theme via a body class .modx23

I'm not sure if the naming is appropriate as it would indicate that with a 2.4 release another class .modx24 would have to be added (and the .modx23 one being kept to ensure BC) but I'm quite sure a class like this would make extra devs lifes easier when building versions of their extras for 2.2 and 2.3.
