### PR TITLE
[Bug] Fix error with $property['options'] not being an array

### DIFF
--- a/core/model/modx/processors/element/propertyset/get.php
+++ b/core/model/modx/processors/element/propertyset/get.php
@@ -86,9 +86,11 @@ foreach ($properties as $property) {
         $overridden = 2;
     }
 
-    foreach($property['options'] as &$option) {
-        if (empty($option['text']) && !empty($option['name'])) $option['text'] = $option['name'];
-        $option['text'] = !empty($property['lexicon']) ? $modx->lexicon($option['text']) : $option['text'];
+    if (is_array($property['options'])) {
+        foreach($property['options'] as &$option) {
+            if (empty($option['text']) && !empty($option['name'])) $option['text'] = $option['name'];
+            $option['text'] = !empty($property['lexicon']) ? $modx->lexicon($option['text']) : $option['text'];
+        }
     }
 
     $data[$property['name']] = array(


### PR DESCRIPTION
Reported in the forums: http://forums.modx.com/thread/92447/error-with-property-set#dis-post-505181
