### PR TITLE
Should take care of minor CSS issue for closable tabs

### DIFF
--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -159,8 +159,8 @@
 }
 
 .x-tab-strip .x-tab-strip-closable a.x-tab-strip-close {
-  right: 8px;
-  top: 11px;
+  right: 2px;
+  //top: 11px;
   background-image: url($imgPath + 'modx-theme/tabs/tab-close.gif');
 }
 


### PR DESCRIPTION
### What does it do ?

Tweaks some CSS
### Why is it needed ?

ExtJS supports closable tabs. After the new theme introduction, the cross allowing to close a tab was overlapping the tab label.
This PR should fix this
