### PR TITLE
Added ability to customize context icons (per context)

### DIFF
--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -447,6 +447,9 @@ $_lang['setting_manager_use_tabs_desc'] = 'If true, the manager will use tabs fo
 $_lang['setting_manager_week_start'] = 'Week start';
 $_lang['setting_manager_week_start_desc'] = 'Define the day starting the week. Use 0 (or leave empty) for sunday, 1 for monday and so on...';
 
+$_lang['setting_mgr_tree_icon_context'] = 'Context tree icon';
+$_lang['setting_mgr_tree_icon_context_desc'] = 'Define a CSS class here to be used to display the context icon in the tree. You can use this setting on each context to customize the icon per context.';
+
 $_lang['setting_modRequest.class'] = 'Request Handler Class';
 $_lang['setting_modRequest.class_desc'] = '';
 

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -344,7 +344,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             ),
             'leaf' => false,
             'cls' => implode(' ', $class),
-            'iconCls' => $this->modx->getOption('mgr_tree_icon_context', null, 'tree-context'),
+            'iconCls' => $context->getOption('mgr_tree_icon_context', 'tree-context'),
             'qtip' => $context->get('description') != '' ? strip_tags($context->get('description')) : '',
             'type' => 'modContext',
             'pseudoroot' => true,


### PR DESCRIPTION
### What does it do ?

Adds ability to define the contexts icon (resource tree) per context.
### Why is it needed ?

As of today, we can customize context icons using `mgr_tree_icon_context` system setting.
However, this setting applies to all contexts.
This PR should allow per context icon, creating `mgr_tree_icon_context` context setting.
### To do before merge
- [x] create appropriate lexicon strings to explain the system setting
