### PR TITLE
Added ability to customize media source icons

### DIFF
--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -447,6 +447,9 @@ $_lang['setting_manager_use_tabs_desc'] = 'If true, the manager will use tabs fo
 $_lang['setting_manager_week_start'] = 'Week start';
 $_lang['setting_manager_week_start_desc'] = 'Define the day starting the week. Use 0 (or leave empty) for sunday, 1 for monday and so on...';
 
+$_lang['setting_mgr_source_icon'] = 'Media Source icon';
+$_lang['setting_mgr_source_icon_desc'] = 'Indicate a CSS class to be used to display the Media Sources icons in the files tree. Defaults to "icon-folder-open-o"';
+
 $_lang['setting_modRequest.class'] = 'Request Handler Class';
 $_lang['setting_modRequest.class_desc'] = '';
 

--- a/core/model/modx/processors/source/getlist.class.php
+++ b/core/model/modx/processors/source/getlist.class.php
@@ -67,10 +67,10 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         $canRemove = $this->modx->hasPermission('source_delete');
 
         $objectArray = $object->toArray();
-        $objectArray['iconCls'] = 'icon-folder-open-o';
+        $objectArray['iconCls'] = $this->modx->getOption('mgr_source_icon', null, 'icon-folder-open-o');
 
         $props = $object->getPropertyList();
-        if (isset($props['iconCls'])) {
+        if (isset($props['iconCls']) && !empty($props['iconCls'])) {
             $objectArray['iconCls'] = $props['iconCls'];
         }
 

--- a/core/model/modx/processors/source/getlist.class.php
+++ b/core/model/modx/processors/source/getlist.class.php
@@ -40,7 +40,7 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         }
         return $list;
     }
-    
+
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $query = $this->getProperty('query');
         if (!empty($query)) {
@@ -57,8 +57,8 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
 
     /**
      * Prepare the source for iteration and output
-     * 
-     * @param xPDOObject|modAccessibleObject $object
+     *
+     * @param xPDOObject|modAccessibleObject|modMediaSource $object
      * @return array
      */
     public function prepareRow(xPDOObject $object) {
@@ -67,12 +67,18 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         $canRemove = $this->modx->hasPermission('source_delete');
 
         $objectArray = $object->toArray();
+        $objectArray['iconCls'] = 'icon-folder-open-o';
+
+        $props = $object->getPropertyList();
+        if (isset($props['iconCls'])) {
+            $objectArray['iconCls'] = $props['iconCls'];
+        }
 
         $cls = array();
         if ($object->checkPolicy('save') && $canSave && $canEdit) $cls[] = 'pupdate';
         if ($object->checkPolicy('remove') && $canRemove) $cls[] = 'premove';
         if ($object->checkPolicy('copy') && $canSave) $cls[] = 'pduplicate';
-        
+
         $objectArray['cls'] = implode(' ',$cls);
         return $objectArray;
     }

--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -47,6 +47,7 @@ MODx.tree.Tree = function(config) {
                 pseudoroot: true
             }
             ,cls: 'tree-pseudoroot-node'
+            ,iconCls: config.root_iconCls || config.rootIconCls || ''
         };
     } else {
         tl = new Ext.tree.TreeLoader({

--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -87,6 +87,7 @@ Ext.extend(MODx.panel.FileTree, Ext.Container, {
             ,rootName: source.name
             ,hideSourceCombo: true
             ,source: source.id
+            ,rootIconCls: source.iconCls || ''
             ,tbar: false
             ,tbarCfg: {
                 hidden: true


### PR DESCRIPTION
### What does it do ?

Adds ability to customize media source icons (tree) using `iconCls` property.
### Why is it needed ?

Manager customization (Creative Freedom ? :smile:)
### To do before merge
- [x] create appropriate lexicon strings
- [x] create a system setting to allow users to define the default class ?
