### PR TITLE
Added ability to edit a media source from the files tree

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -84,6 +84,7 @@ Ext.extend(MODx.panel.FileTree, Ext.Container, {
             ,itemId: this._treePrefix + source.id
             ,stateId: this._treePrefix + source.id
             ,id: this._treePrefix + source.id
+            ,cls: source.cls || ''
             ,rootName: source.name
             ,hideSourceCombo: true
             ,source: source.id

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -97,9 +97,11 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
     /**
      * Build the contextual menu for the root node
      *
+     * @param {Ext.data.Node} node
+     *
      * @returns {Array}
      */
-    ,getRootMenu: function() {
+    ,getRootMenu: function(node) {
         var menu = [];
         if (MODx.perm.directory_create) {
             menu.push({
@@ -125,6 +127,19 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             });
         }
 
+        if (node.ownerTree.el.hasClass('pupdate')) {
+            // User is allowed to edit media sources
+            menu.push([
+                '-'
+                ,{
+                    text: _('update')
+                    ,handler: function() {
+                        MODx.loadPage('source/update', 'id=' + node.ownerTree.source);
+                    }
+                }
+            ])
+        }
+
 //        if (MODx.perm.file_manager) {
 //            menu.push({
 //                text: _('modx_browser')
@@ -148,7 +163,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         var m;
 
         if (node.isRoot) {
-            m = this.getRootMenu();
+            m = this.getRootMenu(node);
         } else if (node.attributes.menu && node.attributes.menu.items) {
             m = node.attributes.menu.items;
         }


### PR DESCRIPTION
### What does it do ?

Allow users to edit a media source directly from the tree (`?a=source/update`)
Restores CSS classes in the tree giving hints on user permissions
### Why is it needed ?

Provide some consistency in the trees : most of listed data in trees could be editable directly from the tree (contexts, resources...) as well as save some clicks for lazy people :smile: 
