### PR TITLE
Directory listing disabled by default .htaccess

### DIFF
--- a/ht.access
+++ b/ht.access
@@ -92,3 +92,6 @@ RewriteRule ^(.*)$ index.php?q=$1 [L,QSA]
 #BrowserMatch "Mozilla/4.[0-9]{2}" brokenvary=1
 #BrowserMatch "Opera" !brokenvary
 #SetEnvIf brokenvary 1 force-no-vary
+
+#Disable directory listing
+Options -Indexes


### PR DESCRIPTION
In my opinion directory listing should be disabled by default. Having this on may also be a security concern.

I'm no Apache expert, but this is how I use to do it.
