### PR TITLE
Refresh/expand appropriate tree node when creating a resource using "quick create"

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -439,15 +439,11 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             xtype: 'modx-window-quick-create-modResource'
             ,record: r
             ,listeners: {
-                'success':{fn:function() {
-                    var node = this.getNodeById(this.cm.activeNode.id);
-                    if (node) {
-                        var n = node.parentNode ? node.parentNode : node;
-                        this.getLoader().load(n,function() {
-                            n.expand();
-                        },this);
+                'success':{
+                    fn: function() {
+                        this.refreshNode(this.cm.activeNode.id, true);
                     }
-                },scope:this}
+                    ,scope: this}
                 ,'hide':{fn:function() {this.destroy();}}
                 ,'show':{fn:function() {this.center();}}
             }


### PR DESCRIPTION
### What does it do ?

Refresh (& expand) the appropriate tree node when creating a resource using the "quick create" window.
Additionally, makes use of an existing function, removing some code duplication.
### Why is it needed ?

Previously, the parent node was refreshed and expanded, while it should have been the currently selected node (the one in which we want to create a new resource).
### Related issue(s)/PR(s)
- #6561
- #8328
- #11633
