### PR TITLE
[WIP] Add destructors to JS objects (required by AjaxManager plugin)

### DIFF
--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -100,6 +100,10 @@ Ext.extend(MODx.TreeDrop,Ext.Component,{
         this.targetEl.addToGroup('modx-treedrop-elements-dd');
         this.targetEl.addToGroup('modx-treedrop-sources-dd');
     }
+    ,destroy: function(){
+        this.targetEl.destroy();
+        MODx.TreeDrop.superclass.destroy.call(this);
+    }
 });
 Ext.reg('modx-treedrop',MODx.TreeDrop);
 


### PR DESCRIPTION
Work in progress. There is a issue with TV fields - they and their TreeDrops (created by MODx.makeDroppable) should be destroyed properly. Otherwise Drag'n'Drop is broken (ExtJS while dragging tries to access removed DOM nodes).
