### PR TITLE
Fix MODx.Ajax.request ot handle multiple concurrent requests

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -426,43 +426,37 @@ Ext.reg('modx',MODx);
  */
 MODx.Ajax = function(config) {
     config = config || {};
-    MODx.Ajax.superclass.constructor.call(this,config);
-    this.addEvents({
-        'success': true
-        ,'failure': true
-    });
+    MODx.Ajax.superclass.constructor.call(this, config);
 };
 Ext.extend(MODx.Ajax,Ext.Component,{
     request: function(config) {
-        this.purgeListeners();
-        if (config.listeners) {
-            for (var i in config.listeners) {
-              if (config.listeners.hasOwnProperty(i)) {
-                var l = config.listeners[i];
-                this.on(i,l.fn,l.scope || this,l.options || {});
-              }
-            }
-        }
-
         Ext.apply(config,{
             success: function(r,o) {
                 r = Ext.decode(r.responseText);
-                if (!r) { return false; }
+                if (!r) {
+                    return false;
+                }
                 r.options = o;
                 if (r.success) {
-                    this.fireEvent('success',r);
-                } else if (this.fireEvent('failure',r)) {
+                    if (config.listeners.success && config.listeners.success.fn) {
+                        this._runCallback(config.listeners.success, [r]);
+                    }
+                } else if (config.listeners.failure && config.listeners.failure.fn) {
+                    this._runCallback(config.listeners.failure, [r]);
                     MODx.form.Handler.errorJSON(r);
                 }
                 return true;
             }
-            ,failure: function(r,o) {
-            	r = Ext.decode(r.responseText);
-                if (!r) { return false; }
-            	r.options = o;
-            	if (this.fireEvent('failure',r)) {
+            ,failure: function(r, o) {
+                r = Ext.decode(r.responseText);
+                if (!r) {
+                    return false;
+                }
+                r.options = o;
+                if (config.listeners.failure && config.listeners.failure.fn) {
+                    this._runCallback(config.listeners.failure, [r]);
                     MODx.form.Handler.errorJSON(r);
-            	}
+                }
                 return true;
             }
             ,scope: this
@@ -472,6 +466,21 @@ Ext.extend(MODx.Ajax,Ext.Component,{
             }
         });
         Ext.Ajax.request(config);
+    }
+    /**
+     * Execute the listener callback
+     *
+     * @param {Object} config - The listener configuration (ie.failure/success)
+     * @param {Array} args - An array of arguments to pass to the callback
+     */
+    ,_runCallback: function(config, args) {
+        var scope = window
+            ,fn = config.fn;
+
+        if (config.scope) {
+            scope = config.scope;
+        }
+        fn.apply(scope || window, args);
     }
 });
 Ext.reg('modx-ajax',MODx.Ajax);


### PR DESCRIPTION
### What does it do ?

Remove "listeners" in `MODx.Ajax` in favor of directly executing the callback, using the same "listener" syntax to be BC.
### Why is it needed ?

`MODx.Ajax` currently rely on listeners to perform callbacks on some events.
Each new `MODx.Ajax.request` resets previously set listeners, resulting in errors when doing concurrent requests (last added listeners being trigger for each request)
### To do before merge
- [ ] Check on as much browsers as possible (yeah, looking at you IE), since this has only been tested on Chrome/Linux
### Related issue(s)/PR(s)
- #2821
