### PR TITLE
Do not overwrite `ext_debug` setting for git "distro"

### DIFF
--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -543,7 +543,7 @@ unset($setting);
 
 /* add ext_debug setting for sdk distro and turn it off if it exists outside sdk */
 $setting = $modx->getObject('modSystemSetting', array('key' => 'ext_debug'));
-if (!$setting && 'sdk' === trim($currentVersion['distro'], '@')) {
+if (!$setting && ('sdk' === trim($currentVersion['distro'], '@') || 'git' === trim($currentVersion['distro'], '@'))) {
     $setting = $modx->newObject('modSystemSetting');
     $setting->fromArray(
         array(
@@ -557,7 +557,7 @@ if (!$setting && 'sdk' === trim($currentVersion['distro'], '@')) {
         true
     );
     $setting->save();
-} elseif ($setting && 'sdk' !== trim($currentVersion['distro'], '@')) {
+} elseif ($setting &&  !in_array(trim($currentVersion['distro'], '@'), array('sdk', 'git'))) {
     $setting->set('value', false);
     $setting->save();
 }


### PR DESCRIPTION
### What does it do ?

Prevent `ext_debug` system setting overwrite when being on "git distro"
### Why is it needed ?

`ext_debug` system setting allows you to use the debug version of ExtJs (not minified), allowing easier debugging.
It is shipped with the "sdk" distro, as well when Revo is built from git.
If you use the "git" distro, each upgrade change the system setting to `false`. This PR aims aims to fix that.
