### PR TITLE
Added ability to update a namespace within a window

### DIFF
--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -151,7 +151,7 @@ MODx.window.CreateNamespace = function(config) {
             ,id: 'modx-'+this.ident+'-name'
             ,anchor: '100%'
             ,maxLength: 100
-
+            ,readOnly: config.isUpdate || false
         },{
             xtype: MODx.expandHelp ? 'label' : 'hidden'
             ,forId: 'modx-'+this.ident+'-name'
@@ -189,6 +189,19 @@ MODx.window.CreateNamespace = function(config) {
 };
 Ext.extend(MODx.window.CreateNamespace,MODx.Window);
 Ext.reg('modx-window-namespace-create',MODx.window.CreateNamespace);
+
+MODx.window.UpdateNamespace = function(config) {
+    config = config || {};
+
+    Ext.applyIf(config, {
+        title: _('namespace_update')
+        ,action: 'workspace/namespace/update'
+        ,isUpdate: true
+    });
+    MODx.window.UpdateNamespace.superclass.constructor.call(this, config);
+};
+Ext.extend(MODx.window.UpdateNamespace, MODx.window.CreateNamespace, {});
+Ext.reg('modx-window-namespace-update',MODx.window.UpdateNamespace);
 
 
 MODx.window.QuickCreateChunk = function(config) {

--- a/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
+++ b/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
@@ -1,6 +1,6 @@
 /**
  * Loads the panel for managing namespaces.
- * 
+ *
  * @class MODx.panel.Namespaces
  * @extends MODx.FormPanel
  * @param {Object} config An object of configuration properties
@@ -38,7 +38,7 @@ Ext.reg('modx-panel-namespaces',MODx.panel.Namespaces);
 
 /**
  * Loads a grid for managing namespaces.
- * 
+ *
  * @class MODx.grid.Namespace
  * @extends MODx.grid.Grid
  * @param {Object} config An object of configuration properties
@@ -123,14 +123,33 @@ Ext.extend(MODx.grid.Namespace,MODx.grid.Grid,{
                 ,scope: this
             });
         } else {
+            m.push({
+                text: _('namespace_update')
+                ,handler: this.updateNS
+            });
             if (p.indexOf('premove') != -1) {
-                m.push({
+                m.push('-',{
                     text: _('namespace_remove')
                     ,handler: this.remove.createDelegate(this,['namespace_remove_confirm','workspace/namespace/remove'])
                 });
             }
         }
         return m;
+    }
+
+    ,updateNS: function(elem, vent) {
+        var win = MODx.load({
+            xtype: 'modx-window-namespace-update'
+            ,record: this.menu.record
+            ,listeners: {
+                success: {
+                    fn: this.refresh
+                    ,scope: this
+                }
+            }
+        });
+        win.setValues(this.menu.record);
+        win.show(vent.target);
     }
 
     ,search: function(tf,newValue,oldValue) {


### PR DESCRIPTION
### What does it do ?

Adds the ability to update namespaces paths from a window.
### Why is it needed ?

This brings some UI consistency, as most of elements listed in a grid are created/updated that way.
### Related issue(s)/PR(s)
- #6628
- #11643
