### PR TITLE
Prevent save/remove on modAccessibleObject (and derivative classes) if appropriate policy is not met

### DIFF
--- a/core/model/modx/modaccessibleobject.class.php
+++ b/core/model/modx/modaccessibleobject.class.php
@@ -168,6 +168,7 @@ class modAccessibleObject extends xPDOObject {
         $saved = false;
         if (!$this->checkPolicy('save')) {
             $this->xpdo->error->failure($this->xpdo->lexicon('permission_denied'));
+            return $saved;
         }
         $saved = parent :: save($cacheFlag);
         return $saved;
@@ -182,6 +183,7 @@ class modAccessibleObject extends xPDOObject {
         $removed = false;
         if (!$this->checkPolicy('remove')) {
             $this->xpdo->error->failure($this->xpdo->lexicon('permission_denied'));
+            return $removed;
         }
         $removed = parent :: remove($ancestors);
         return $removed;


### PR DESCRIPTION
### What does it do ?

Prevent save/remove on modAccessibleObject (and derivative classes) if appropriate policy is not met
### Why is it needed ?

The current code does not "break" execution if appropriate policy is not met, resulting in object removal/save even if authenticated user does not have the right to.
### Related issue(s)/PR(s)

Closes #9757
