### PR TITLE
Display a message when updating a user from grid with duplicate email address

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -134,16 +134,26 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,data: d
             }
             ,listeners: {
-                'success': {fn:function(r) {
-                    if (this.config.save_callback) {
-                        Ext.callback(this.config.save_callback,this.config.scope || this,[r]);
+                success: {
+                    fn: function(r) {
+                        if (this.config.save_callback) {
+                            Ext.callback(this.config.save_callback,this.config.scope || this,[r]);
+                        }
+                        e.record.commit();
+                        if (!this.config.preventSaveRefresh) {
+                            this.refresh();
+                        }
+                        this.fireEvent('afterAutoSave',r);
                     }
-                    e.record.commit();
-                    if (!this.config.preventSaveRefresh) {
-                        this.refresh();
+                    ,scope: this
+                }
+                ,failure: {
+                    fn: function(r) {
+                        e.record.reject();
+                        this.fireEvent('afterAutoSave', r);
                     }
-                    this.fireEvent('afterAutoSave',r);
-                },scope:this}
+                    ,scope: this
+                }
             }
         });
     }

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -155,6 +155,12 @@ MODx.grid.User = function(config) {
         }]
     });
     MODx.grid.User.superclass.constructor.call(this,config);
+    this.on('afterAutoSave', function(result) {
+        if (!result.success) {
+            var msg = result.data[0].msg || _('user_err_save');
+            MODx.msg.alert(_('error'), msg);
+        }
+    });
 };
 Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     getMenu: function() {


### PR DESCRIPTION
### What does it do ?
- reset the grid record on error (when trying to save/edit from a grid) and trigger the `afterAutoSave` event, even on failure
- add a notification of the error when editing a user in case of duplicated email.
### Why is it needed ?

When updating a record from a grid, there is no feedback when an error occurs (beside the record being marked as "dirty" (red triangle).

Since i did not check all processors to make sure they all return the error message the same, i only added a notification (`MODx.msg.alert`) for the users grid.
### Related issue(s)/PR(s)
- #11273
