### PR TITLE
Fixed a few issues in modX->_loadExtensionPackages preventing to load some services & handle table prefix

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -564,10 +564,10 @@ class modX extends xPDO {
         $cache = $this->call('modExtensionPackage','loadCache',array(&$this));
         if (!empty($cache)) {
             foreach ($cache as $package) {
-                $package['tablePrefix'] = !empty($package['tablePrefix']) ? $package['tablePrefix'] : null;
-                $this->addPackage($package['namespace'],$package['path'],$package['tablePrefix']);
-                if (!empty($package['serviceName']) && !empty($package['serviceClass'])) {
-                    $this->getService($package['serviceName'],$package['serviceClass'],$package['path']);
+                $package['table_prefix'] = !empty($package['table_prefix']) ? $package['table_prefix'] : null;
+                $this->addPackage($package['namespace'],$package['path'],$package['table_prefix']);
+                if (!empty($package['service_name']) && !empty($package['service_class'])) {
+                    $this->getService($package['service_name'],$package['service_class'],$package['path']);
                 }
             }
         }


### PR DESCRIPTION
### What does it do ?

Fixed a few issues in `modX->_loadExtensionPackages` preventing to load some services & handle table prefix
### Why is it needed ?

"Auto loading" services fail without this, as well as packages using table prefix.
### To do next

While digging on that issue, it also appeared there is some inconsistencies about path... (mostly about services).
If `modExtensionPackage.path` is empty, it will fallback to `modNamespace.path` (see https://github.com/modxcms/revolution/blob/master/core/model/modx/modcachemanager.class.php#L466).

Later, we add `model/` to the extension path (see https://github.com/modxcms/revolution/blob/master/core/model/modx/modcachemanager.class.php#L471), no matter if `model` is already present or not (ie. being set in `modExtensionPackage.path`).

Then, if a `modExtensionPackage.service_class` & `modExtensionPackage.service_name` is found, we try to load the appropriate service, using the package path... (ending with `model/`).
This will result in an error, since no service will be found : the path should have been `../model/$namespace`, unless the service_class is `Namespace.ServiceClass`.

Hope it makes sense.
### Related issue(s)/PR(s)

Closes #9573
