### PR TITLE
Fixed a few issues with packages installation/removal console

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -141,26 +141,23 @@ Ext.extend(MODx,Ext.Component,{
         if (!this.fireEvent('beforeClearCache')) { return false; }
 
         var topic = '/clearcache/';
-        if (this.console == null || this.console == undefined) {
-            this.console = MODx.load({
-               xtype: 'modx-console'
-               ,register: 'mgr'
-               ,topic: topic
-               ,clear: true
-               ,show_filename: 0
-               ,listeners: {
-                    'shutdown': {fn:function() {
-                        if (this.fireEvent('afterClearCache')) {
-                            if (MODx.config.clear_cache_refresh_trees == 1) {
-                                Ext.getCmp('modx-layout').refreshTrees();
-                            }
+        this.console = MODx.load({
+           xtype: 'modx-console'
+           ,register: 'mgr'
+           ,topic: topic
+           ,clear: true
+           ,show_filename: 0
+           ,listeners: {
+                'shutdown': {fn:function() {
+                    if (this.fireEvent('afterClearCache')) {
+                        if (MODx.config.clear_cache_refresh_trees == 1) {
+                            Ext.getCmp('modx-layout').refreshTrees();
                         }
-                    },scope:this}
-               }
-            });
-        } else {
-            this.console.setRegister('mgr',topic);
-        }
+                    }
+                },scope:this}
+           }
+        });
+
         this.console.show(Ext.getBody());
 
         MODx.Ajax.request({

--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -62,14 +62,15 @@ MODx.Console = function(config) {
             } catch (e) {}
         }
         this.fireEvent('shutdown');
-        this.getComponent('body').el.update('');
+        //this.getComponent('body').el.update('');
+        this.destroy();
     });
     this.on('complete',this.onComplete,this);
 };
 Ext.extend(MODx.Console,Ext.Window,{
     mgr: null
     ,running: false
-    
+
     ,init: function() {
         Ext.Msg.hide();
         this.fbar.setDisabled(true);
@@ -114,7 +115,7 @@ Ext.extend(MODx.Console,Ext.Window,{
         this.fbar.setDisabled(false);
         this.keyMap.setDisabled(false);
     }
-    
+
     ,download: function() {
         var c = this.getComponent('body').getEl().dom.innerHTML || '&nbsp;';
         MODx.Ajax.request({
@@ -127,15 +128,15 @@ Ext.extend(MODx.Console,Ext.Window,{
                 'success':{fn:function(r) {
                     location.href = MODx.config.connector_url+'?action=system/downloadOutput&HTTP_MODAUTH='+MODx.siteId+'&download='+r.message;
                 },scope:this}
-            }            
+            }
         });
     }
-        
+
     ,setRegister: function(register,topic) {
     	this.config.register = register;
         this.config.topic = topic;
     }
-    
+
     ,hideConsole: function() {
         this.hide();
     }

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -301,15 +301,11 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
     ,reloadFromBase: function() {
     	Ext.Ajax.timeout = 0;
     	var topic = '/workspace/lexicon/reload/';
-        if (this.console === null) {
-            this.console = MODx.load({
-               xtype: 'modx-console'
-               ,register: 'mgr'
-               ,topic: topic
-            });
-        } else {
-            this.console.setRegister('mgr',topic);
-        }
+        this.console = MODx.load({
+           xtype: 'modx-console'
+           ,register: 'mgr'
+           ,topic: topic
+        });
 
         this.console.on('complete',function(){
             this.refresh();
@@ -360,7 +356,7 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
     	r['namespace'] = tb.getComponent('namespace').getValue();
         r.language =  tb.getComponent('language').getValue();
         r.topic = tb.getComponent('topic').getValue();
-        
+
         if (!this.createEntryWindow) {
             this.createEntryWindow = MODx.load({
                 xtype: 'modx-window-lexicon-entry-create'

--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -64,25 +64,12 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
         Ext.each(this.buttons, function(btn){ Ext.getCmp(btn.id).hide(); });
     }
 
-	,loadConsole: function(btn,topic) {
-    	if (this.console === null || this.console == undefined) {
-            this.console = MODx.load({
-               xtype: 'modx-console'
-               ,register: 'mgr'
-               ,topic: topic
-            });
-        } else {
-            this.console.setRegister('mgr',topic);
-        }
-        this.console.show(btn);
-    }
-
 	,install: function(va){
-		var g = Ext.getCmp('modx-package-grid');
-		if (!g) return false;
-		var r = g.menu.record.data ? g.menu.record.data : g.menu.record;
-		var topic = '/workspace/package/install/'+r.signature+'/';
-        this.loadConsole(Ext.getBody(),topic);
+        var g = Ext.getCmp('modx-package-grid');
+        if (!g) return false;
+        var r = g.menu.record.data ? g.menu.record.data : g.menu.record;
+        var topic = '/workspace/package/install/'+r.signature+'/';
+        g.loadConsole(Ext.getBody(),topic);
 
 		va = va || {};
         Ext.apply(va,{
@@ -92,7 +79,6 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
             ,topic: topic
         });
 
-		var c = this.console;
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: va

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -387,7 +387,12 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
         this.loadWindow(btn,e,{
             xtype: 'modx-window-package-uninstall'
             ,listeners: {
-                'success': {fn: function(va) { this._uninstall(this.menu.record,va,btn); },scope:this}
+                success: {
+                    fn: function(va) {
+                        this._uninstall(this.menu.record,va,btn);
+                    }
+                    ,scope: this
+                }
             }
         });
     }
@@ -441,15 +446,11 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 
 	/* Load the console */
     ,loadConsole: function(btn,topic) {
-    	if (this.console === null) {
-            this.console = MODx.load({
-               xtype: 'modx-console'
-               ,register: 'mgr'
-               ,topic: topic
-            });
-        } else {
-            this.console.setRegister('mgr',topic);
-        }
+        this.console = MODx.load({
+           xtype: 'modx-console'
+           ,register: 'mgr'
+           ,topic: topic
+        });
         this.console.show(btn);
     }
 


### PR DESCRIPTION
### What does it do ?

Instantiate a new "console window" on every action (install/reinstall/remove) instead of trying to load previously loaded one (if any).
### Why is it needed ?

If you perform multiple actions (install/removal...) without reloading the package manager page, only logs from the first action (ie. install) would be displayed (so, uninstall logs would not, but any subsequent package installation will display logs. works the other way around).
