### PR TITLE
Fix typo forcing empty calls to modError::addError() for all sent emails

### DIFF
--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -179,7 +179,7 @@ class modPHPMailer extends modMail {
     public function send(array $attributes= array()) {
         $sent = parent :: send($attributes);
         $sent = $this->mailer->Send();
-        if ($send !== true) {
+        if ($sent !== true) {
             $this->modx->loadClass('error.modError');
             $this->error = new modError($this->modx);
             $this->error->addError($this->mailer->ErrorInfo);


### PR DESCRIPTION
Typo introduced in commit a1ae0917b08b64b8bf735146366d52fe0933dcf4
