### PR TITLE
Enhancement: Make access policy template editable for access policies via grid editor

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -70,7 +70,20 @@ MODx.grid.AccessPolicy = function(config) {
             ,editor: { xtype: 'textfield' }
         },{
             header: _('policy_template')
-            ,dataIndex: 'template_name'
+            ,dataIndex: 'template'
+            ,editor: { 
+                xtype: 'modx-combo-access-policy-template'
+                ,allowBlank: false
+                ,listeners: { 
+                    select: function(e, rec) { 
+                        var sm = Ext.getCmp('modx-grid-access-policy').getSelectionModel().getSelected();
+                        sm.set('template_name',rec.data.name);
+                    }
+                } 
+            }
+            ,renderer: function(value, meta, record, rowIndex, columnIndex, view) {
+                return record.data.template_name;
+            }
             ,width: 375
         },{
             header: _('active_permissions')


### PR DESCRIPTION
This is a proposal to change an access policy's template via inline grid editor/combobox, it works so far, but an access policy with many permissions (e.g. based on AdministratorTemplate for example) will still have them after switching the template (for example if you switch the Content Editor Policy from AdministratorTemplate to ElementTemplate it will still have 24 permissions enabled instead of only the ones available in Element Template...)

I don't know yet how to solve this problem, but maybe somebody else has an idea or approach that could be tried out and added to this PR!

This PR is related to https://github.com/modxcms/revolution/issues/11937, #7383 and #3395
