### PR TITLE
Update _buttons.scss

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -143,6 +143,10 @@ button {
 /* fix a weird issue in Safari, where the close button stretches above the whole item */
 .x-superboxselect-item .x-superboxselect-item-close {
   background: transparent;
+  top: -2px;
+}
+.x-superboxselect-item button {
+  min-width: auto !important;
 }
 
 /*.primary-button {

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -140,6 +140,11 @@ button {
   }
 }
 
+/* fix a weird issue in Safari, where the close button stretches above the whole item */
+.x-superboxselect-item .x-superboxselect-item-close {
+  background: transparent;
+}
+
 /*.primary-button {
   @extend %primary-button;
 }*/


### PR DESCRIPTION
Set background for x.superboxselect-item-close to transparent so that you can actually see the selected item in Safari
