### PR TITLE
Update modx.grid.js

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -34,7 +34,7 @@ MODx.grid.Grid = function(config) {
             ,emptyText: config.emptyText || _('ext_emptymsg')
         }
         ,groupingConfig: {
-	    ,enableGroupingMenu: true
+	    enableGroupingMenu: true
         }
     });
     if (config.paging) {

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -33,6 +33,9 @@ MODx.grid.Grid = function(config) {
             ,scrollOffset: 0
             ,emptyText: config.emptyText || _('ext_emptymsg')
         }
+        ,groupingConfig: {
+	    ,enableGroupingMenu: true
+        }
     });
     if (config.paging) {
         var pgItms = config.showPerPage ? [_('per_page')+':',{
@@ -65,14 +68,19 @@ MODx.grid.Grid = function(config) {
         });
     }
     if (config.grouping) {
-        Ext.applyIf(config,{
-          view: new Ext.grid.GroupingView({
+        var groupingConfig = {
             forceFit: true
             ,scrollOffset: 0
             ,groupTextTpl: '{text} ({[values.rs.length]} {[values.rs.length > 1 ? "'
                 +(config.pluralText || _('records')) + '" : "'
                 +(config.singleText || _('record'))+'"]})'
-          })
+            };
+        if(config.groupingConfig){
+            Ext.applyIf(groupingConfig, config.groupingConfig);
+        }
+
+        Ext.applyIf(config,{
+          view: new Ext.grid.GroupingView(groupingConfig)
         });
     }
     if (config.tbar) {


### PR DESCRIPTION
When you enable grouping on a MODx.grid.Grid, it will apply a Ext.grid.GroupingView to the grid, which is great feature, but as I want to hide/disable the "group by this column" feature when you click on the little arrow near each column header, I need to pass "enableGroupingMenu: false" to the GroupingView. But I cannot do that (whithout touching the core files).

Maybe good to have a "groupingConfig: { }" which will be passed when you set this up in your grid. This is how it works for me.
