### PR TITLE
Use window.location.search to populate MODx.request

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -97,7 +97,7 @@ Ext.extend(MODx,Ext.Component,{
 
     ,getURLParameters: function() {
         var arg = {};
-        var href = document.location.href;
+        var href = window.location.search;
 
         if (href.indexOf('?') !== -1) {
             var params = href.split('?')[1];


### PR DESCRIPTION
### What does it do ?

Makes use of `window.location.search` to populate `MODx.request`, instead of `document.location.href`
### Why is it needed ?

`location.href` contains the potential hash (ie. `uri?param=value#hash`).
Considering the previous example, with the current code, `MODx.request.param` value would be `value#hash` when it should be `value`.
This PR aims to allow hash usage without messing with "request parameters".
