### PR TITLE
Handle "site preview" when default_context is not "web" context or when manager is on its own (sub)domain

### DIFF
--- a/core/model/modx/processors/system/config.js.php
+++ b/core/model/modx/processors/system/config.js.php
@@ -60,6 +60,12 @@ $c = array(
     'resource_classes_drop' => $resourceClassesDrop,
 );
 
+// Handle default context
+$ctx = $modx->getContext($modx->getOption('default_context', null, 'web'));
+if ($ctx instanceof modContext && $ctx->prepare()) {
+    $c['default_site_url'] = $ctx->makeUrl($ctx->getOption('site_start'));
+}
+
 /* if custom context, load into MODx.config */
 if (isset($scriptProperties['action']) && $scriptProperties['action'] != '' && isset($modx->actionMap[$scriptProperties['action']])) {
 

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -380,7 +380,11 @@ Ext.extend(MODx,Ext.Component,{
         }
     }
     ,preview: function() {
-        window.open(MODx.config.site_url);
+        var url = MODx.config.site_url;
+        if (MODx.config.default_site_url) {
+            url = MODx.config.default_site_url;
+        }
+        window.open(url);
     }
     ,makeDroppable: function(fld,h,p) {
         if (!fld) return false;


### PR DESCRIPTION
### What does it do ?

Compute the `default_context` URL, make it available in `MODx.config.default_site_url` (manager) and use it in `MODx.preview()`
### Why is it needed ?

When the `default_context` system setting is set to something other than "web", hitting Content > Site preview opens the web context.
When the manager is on its own (sub)domain, hitting Content > Site preview opens a new manager.

With this PR, both of the above cases should be fixed, and Site preview should open the URL of `default_context` (falling back to web context)
