### PR TITLE
Typecast user group (proper way)

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -179,10 +179,12 @@ MODx.window.AddGroupToUser = function(config) {
 Ext.extend(MODx.window.AddGroupToUser,MODx.Window,{
     submit: function() {
         var r = this.fp.getForm().getValues();
+        // Typecast user group ID (for strict match search)
+        r.usergroup = ~~r.usergroup;
 
         var g = Ext.getCmp('modx-grid-user-groups');
         var s = g.getStore();
-        var ae = s.findExact('usergroup', ~~r.usergroup);
+        var ae = s.findExact('usergroup', r.usergroup);
         if (ae != -1) {
             MODx.msg.alert(_('error'), _('user_err_ae_group'));
             return false;


### PR DESCRIPTION
### What does it do ?

Typecast user group ID earlier (before adding value to store) to make sure "strict search" works correctly (follow up of PR #11975)
### Why is it needed ?

After PR #11975, if you add a new user group to the user, the user group ID is added as a string in the grid store.
If you try to add the same user group (without saving), the group is added twice, since we are trying to search an integer ID (while the store got a string).
### Related issue(s)/PR(s)
- #11975
