### PR TITLE
Fix loading default manager controller without changing the manager them...

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -13,7 +13,7 @@
 interface modResourceInterface {
     /**
      * Determine the controller path for this Resource class. Return an absolute path.
-     * 
+     *
      * @static
      * @param xPDO $modx A reference to the modX object
      * @return string The absolute path to the controller for this Resource class
@@ -1123,10 +1123,10 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      * Determine the controller path for this Resource class
      * @static
      * @param xPDO $modx A reference to the modX object
+     * @param string $theme The manager theme to use for the controller
      * @return string The absolute path to the controller for this Resource class
      */
-    public static function getControllerPath(xPDO &$modx) {
-        $theme = $modx->getOption('manager_theme',null,'default');
+    public static function getControllerPath(xPDO &$modx, $theme = 'default') {
         $controllersPath = $modx->getOption('manager_path',null,MODX_MANAGER_PATH).'controllers/'.$theme.'/';
         return $controllersPath.'resource/';
     }

--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -213,10 +213,11 @@ class modStaticResource extends modResource implements modResourceInterface {
      * Sets the path to the Static Resource manager controller
      * @static
      * @param xPDO $modx A reference to the modX instance
+     * @param string $theme The manager theme to use for the controller
      * @return string
      */
-    public static function getControllerPath(xPDO &$modx) {
-        $path = modResource::getControllerPath($modx);
+    public static function getControllerPath(xPDO &$modx, $theme = 'default') {
+        $path = modResource::getControllerPath($modx, $theme);
         return $path.'staticresource/';
     }
 

--- a/core/model/modx/modweblink.class.php
+++ b/core/model/modx/modweblink.class.php
@@ -46,10 +46,11 @@ class modWebLink extends modResource implements modResourceInterface {
      * Get the full controller path for managing WebLinks in MODX
      * @static
      * @param xPDO $modx A reference to the modX instance
+     * @param string $theme The manager theme to use for the controller
      * @return string The absolute path to the controller for managing WebLinks
      */
-    public static function getControllerPath(xPDO &$modx) {
-        $path = modResource::getControllerPath($modx);
+    public static function getControllerPath(xPDO &$modx, $theme = 'default') {
+        $path = modResource::getControllerPath($modx, $theme);
         return $path.'weblink/';
     }
     /**

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -66,13 +66,13 @@ abstract class ResourceManagerController extends modManagerController {
                 $resourceClass = 'modDocument';
             }
 
-            $delegateView = $modx->call($resourceClass,'getControllerPath',array(&$modx));
+            $theme = $modx->getOption('manager_theme', $config, 'default');
+            $delegateView = $modx->call($resourceClass,'getControllerPath',array(&$modx, $theme));
             $action = strtolower(str_replace(array('Resource','ManagerController'),'',$className));
             $className = str_replace('mod','',$resourceClass).ucfirst($action).'ManagerController';
             $controllerFile = $delegateView.$action.'.class.php';
             if (!file_exists($controllerFile)) {
-                $modx->setOption('manager_theme','default');
-                $delegateView = $modx->call($resourceClass,'getControllerPath',array(&$modx));
+                $delegateView = $modx->call($resourceClass,'getControllerPath',array(&$modx, 'default'));
                 $controllerFile = $delegateView.$action.'.class.php';
             }
             require_once $controllerFile;


### PR DESCRIPTION
Fix loading default manager controller without changing the manager themee when the manager theme does not include  the requested controller

Requested by @rtripault :P 

Note that this may include an E_STRICT BC break with the new $theme argument that wont be present in derivatives. 
