### PR TITLE
Fixed loading of modError class

### DIFF
--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -177,10 +177,10 @@ class modPHPMailer extends modMail {
      * @return boolean True if the email was successfully sent
      */
     public function send(array $attributes= array()) {
-        $sent = parent :: send($attributes);
+        parent :: send($attributes);
         $sent = $this->mailer->Send();
         if ($sent !== true) {
-            $this->modx->loadClass('error.modError');
+            $this->modx->loadClass('error.modError', '', false, true);
             $this->error = new modError($this->modx);
             $this->error->addError($this->mailer->ErrorInfo);
         }


### PR DESCRIPTION
`modError` is not a persistent table class, so the last argument should be `true`.
