### PR TITLE
Fixes the getNodesFormatted method, when menu item has in a title "n_"

### DIFF
--- a/core/model/modx/processors/system/menu/sort.php
+++ b/core/model/modx/processors/system/menu/sort.php
@@ -45,7 +45,7 @@ return $modx->error->success();
 function getNodesFormatted(&$ar_nodes,$cur_level,$parent = '') {
 	$order = 0;
 	foreach ($cur_level as $id => $children) {
-		$id = str_replace('n_','',$id);
+		$id = preg_replace('/n_/', '', $id, 1);
 		$ar_nodes[] = array(
 			'text' => $id,
 			'parent' => $parent,


### PR DESCRIPTION
### What does it do ?

Fixes sort menu processor
### Why is it needed ?

When in the menu is an item with title that contains "n_", there is not possible to move the menu item by drag and drop.
