### PR TITLE
use system setting "modx_browser_default_sort" in media browser

### DIFF
--- a/manager/assets/modext/widgets/core/modx.rte.browser.js
+++ b/manager/assets/modext/widgets/core/modx.rte.browser.js
@@ -169,7 +169,7 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
             ,displayField: 'desc'
             ,valueField: 'name'
             ,lazyInit: false
-            ,value: 'name'
+            ,value: MODx.config.modx_browser_default_sort || 'name'
             ,store: new Ext.data.SimpleStore({
                 fields: ['name', 'desc'],
                 data : [['name',_('name')],['size',_('file_size')],['lastmod',_('last_modified')]]


### PR DESCRIPTION
"modx_browser_default_sort" system setting is used in media browser used to select image TVs, better is to use the same system setting in media browser used for example by TinyMCE editor or other.
