### PR TITLE
Issues with Form customisation\Manager costumisation!

### DIFF
--- a/_build/build.sample.properties
+++ b/_build/build.sample.properties
@@ -11,7 +11,7 @@ git.command = git
 #project.name.fs = modx
 
 # Override to set the version and release strings
-#modx.core.version = 2.2.14
+#modx.core.version = 2.2.16
 #modx.core.release = dev
 
 # these properties require a local Git clone in order to produce distributions

--- a/_build/build.xml
+++ b/_build/build.xml
@@ -19,8 +19,8 @@
     <property name="project.manager.dir" value="${project.root.dir}/manager" />
 
     <!-- Set the project version -->
-    <property name="modx.core.version" value="2.2.15" />
-    <property name="modx.core.release" value="pl" />
+    <property name="modx.core.version" value="2.2.16" />
+    <property name="modx.core.release" value="dev" />
 
     <!-- Set some common build properties -->
     <property name="build.dir" value="${project.basedir}" />

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,8 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Consider dev version lower than alpha
+
 MODX Revolution 2.2.15-pl (July 15, 2014)
 ====================================
 - Prevent use of GET vars in login controller/processor

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,8 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Fix password reset feature [#11725]
+
 MODX Revolution 2.2.15-pl (July 15, 2014)
 ====================================
 - Prevent use of GET vars in login controller/processor

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Fix password reset feature [#11725]
 - Consider dev version lower than alpha
 
 MODX Revolution 2.2.15-pl (July 15, 2014)

--- a/core/docs/version.inc.php
+++ b/core/docs/version.inc.php
@@ -2,8 +2,8 @@
 $v= array ();
 $v['version']= '2'; // Current version.
 $v['major_version']= '2'; // Current major version.
-$v['minor_version']= '15'; // Current minor version.
-$v['patch_level']= 'pl'; // Current patch level.
+$v['minor_version']= '16'; // Current minor version.
+$v['patch_level']= 'dev'; // Current patch level.
 $v['code_name']= 'Revolution'; // Current codename.
 $v['distro']= '@git@';
 $v['full_version']= $v['version'] . ($v['major_version'] ? ".{$v['major_version']}" : ".0") . ($v['minor_version'] ? ".{$v['minor_version']}" : ".0") . ($v['patch_level'] ? "-{$v['patch_level']}" : "");

--- a/core/model/modx/transport/mysql/modtransportpackage.class.php
+++ b/core/model/modx/transport/mysql/modtransportpackage.class.php
@@ -22,11 +22,11 @@ class modTransportPackage_mysql extends modTransportPackage {
               FROM {$modx->getTableName('modTransportPackage')} AS `latestPackage`
               WHERE `latestPackage`.`package_name` = `modTransportPackage`.`package_name`
               ORDER BY
-                 `latestPackage`.`version_major` DESC,
-                 `latestPackage`.`version_minor` DESC,
-                 `latestPackage`.`version_patch` DESC,
-                 IF(`release` = '' OR `release` = 'ga' OR `release` = 'pl','z',`release`) DESC,
-                 `latestPackage`.`release_index` DESC
+                `latestPackage`.`version_major` DESC,
+                `latestPackage`.`version_minor` DESC,
+                `latestPackage`.`version_patch` DESC,
+                IF(`release` = '' OR `release` = 'ga' OR `release` = 'pl','z',IF(`release` = 'dev','a',`release`)) DESC,
+                `latestPackage`.`release_index` DESC
               LIMIT 1) = `modTransportPackage`.`signature`",
         ));
         if (!empty($search)) {
@@ -57,7 +57,7 @@ class modTransportPackage_mysql extends modTransportPackage {
         $c->sortby('modTransportPackage.version_major', 'DESC');
         $c->sortby('modTransportPackage.version_minor', 'DESC');
         $c->sortby('modTransportPackage.version_patch', 'DESC');
-        $c->sortby('IF(modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl","z",modTransportPackage.release) DESC','');
+        $c->sortby('IF(modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl","z",IF(modTransportPackage.release = "dev","a",modTransportPackage.release)) DESC','');
         $c->sortby('modTransportPackage.release_index', 'DESC');
         if((int)$limit > 0) {
             $c->limit((int)$limit, (int)$offset);

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -102,8 +102,8 @@ class SecurityLoginManagerController extends modManagerController {
      * @return void
      */
     public function handleForgotLoginHash() {
-        if (isset($this->scriptProperties['modahsh'])) {
-            $this->scriptProperties['modahsh'] = $this->modx->sanitizeString($this->scriptProperties['modahsh']);
+        if (isset($_GET['modahsh'])) {
+            $this->scriptProperties['modahsh'] = $this->modx->sanitizeString($_GET['modahsh']);
             $this->setPlaceholder('modahsh',$this->scriptProperties['modahsh']);
         }
     }


### PR DESCRIPTION
I shown this issue personally to theBoxer in Utreht. But several others were found while using form customisation in Revo 2.2.15 aswell in 2.3 version:
1. The constraint field and value doesen't have a not operator possibility, when I would like to make a rule for example 

modResource.parent = 1041 do some customisation rules but for everything that is  modResource.parent != 1041 I would like generic customisation.
1. To solve above issue I added 2 rules for resource\create and update

Examples:
1. Resource\Update Constraint field: Parent, Constrain value: 1040
   - I enable only 2 TV's
2. Resource\Update Constrain field: Parent Constraint value: 2
- I enable 3 TV's..

On both only 2 TV's are visible to the particular group that form customisation is applied to.. untill I enable the  the third TV to the 1st rule.. Seems something is buggy there.. Because I would like to achieve that I have 2 TV's enabled for 1 parent and 3 for another.. which I can't seem to achieve with form customisation alone.
