### PR TITLE
Update modX::toJSON to support not only arrays

### DIFF
--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -2357,22 +2357,20 @@ class xPDO {
     }
 
     /**
-     * Converts a PHP array into a JSON encoded string.
+     * Returns the JSON representation of a value.
      *
-     * @param array $array The PHP array to convert.
-     * @return string The JSON representation of the source array.
+     * @param mixed $value The value being encoded.
+     * @return string The JSON representation of the value.
      */
-    public function toJSON($array) {
+    public function toJSON($value) {
         $encoded= '';
-        if (is_array ($array)) {
-            if (!function_exists('json_encode')) {
-                if (@ include_once (XPDO_CORE_PATH . 'json/JSON.php')) {
-                    $json = new Services_JSON();
-                    $encoded= $json->encode($array);
-                }
-            } else {
-                $encoded= json_encode($array);
+        if (!function_exists('json_encode')) {
+            if (@ include_once (XPDO_CORE_PATH . 'json/JSON.php')) {
+                $json = new Services_JSON();
+                $encoded= $json->encode($value);
             }
+        } else {
+            $encoded= json_encode($value);
         }
         return $encoded;
     }
@@ -2391,13 +2389,9 @@ class xPDO {
         if ($src) {
             if (!function_exists('json_decode')) {
                 if (@ include_once (XPDO_CORE_PATH . 'json/JSON.php')) {
-                    if ($asArray) {
-                        $json = new Services_JSON(SERVICES_JSON_LOOSE_TYPE);
-                    } else {
-                    $json = new Services_JSON();
-                    }
+                    $json = new Services_JSON($asArray ? SERVICES_JSON_LOOSE_TYPE : 0);
                     $decoded= $json->decode($src);
-                    }
+                }
             } else {
                 $decoded= json_decode($src, $asArray);
             }


### PR DESCRIPTION
I think `modX::toJSON` should be not limited to the arrays only as the `Services_JSON::encode` and `json_encode` support not only arrays as input.
