### PR TITLE
[2.3] [Re-build] Prevent combobox lists being taller than the screen, mainly from windows

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -1100,7 +1100,7 @@ input::-moz-focus-inner {
     border: 1px solid $colorSplash; /* apply the border here as we move this element 1px left to be in line with the combobox border */
     border-radius: 0 0 $borderRadius $borderRadius;
     margin-left: -1px; /* we cannot use this on the .x-combo-list element as it's used for position calculation */
-    width: 100% !important; height: 100% !important; /* override extjs calculated inline height and stretch to container */
+    width: 100% !important; /* override extjs calculated inline dimensions and stretch to container */
   }
 
   .x-combo-list-item {


### PR DESCRIPTION
Fixing bug introduced by me _shame_, the dropdown list of a combobox (when containing many items, 50 in the example) can overflow the screen and hide the pagination bar, see the following screencap:

![modx combobox-listheight](https://cloud.githubusercontent.com/assets/445501/4475038/e3bee450-4967-11e4-9081-3bd5a2837c00.gif)

the bug is coming from a forced height: 100% !important; in _forms.scss, this was somewhen done in the 2.3 UI re-styling process to override the calculated height from extjs, reverted this change and removed that rule...
