### PR TITLE
[2.3] [Re-build] Fix superbox selects in toolbars

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -680,6 +680,10 @@ input::-moz-focus-inner {
   white-space: normal; /* make selected options wrap */
   width: auto !important; /* prevents the right border to be cut off */
 
+  .ext-strict .x-toolbar.x-small-editor & {
+    height: auto !important; /* override the extjs default theme style high specifiy + !important rule, wtf... */
+  }
+
   input[disabled] {
     /*background-color: transparent;*/
   }
@@ -689,7 +693,12 @@ input::-moz-focus-inner {
     min-height: 20px;
     overflow: visible; /* prevent item box-shadow from being cut off */
     padding-right: 61px; /* 2 * 30px for each .x-form-trigger + 1px border */
+    white-space: normal; /* make selected options wrap */
     width: auto !important; /* override extjs width calculation */
+
+    .x-toolbar & {
+      margin: -5px 0 0 -5px; /* fix for superbox selects in toolbars */
+    }
 
     li {
       /*color: $coreFieldLabelColor;*/
@@ -786,13 +795,6 @@ input::-moz-focus-inner {
     position: absolute; top: 0; right: 0;
     width: 61px; height: 100%; /* 61px account for the border of the clear button */
 
-    /*div {
-      float: left;
-      height: 16px;
-      margin-top: 4px;
-      width: 16px;
-    }*/
-
     .x-superboxselect-btn-expand {
       border-radius: 0;
       right: 31px; /* account for the border of the clear button */
@@ -816,15 +818,6 @@ input::-moz-focus-inner {
         border-left: 1px solid $borderColorActive;
       }
     }
-
-    /* unnecessary as the styles from secondary-button are inherited */
-    /*.x-superboxselect-btn-over {
-      background-position: left -16px;
-    }
-
-    .x-superboxselect-btn-hide {
-      display: none;
-    }*/
   }
 } /* .x-superboxselect */
 /*} /* .x-form-element */

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -1252,26 +1252,3 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 .modx-grid-draggable .x-grid3-row {
   cursor: move;
 }
-
-
-/* superselectbox xtype (ex. multiselect TV) */
-/*.x-superboxselect,
-.x-superboxselect-btns {
-  overflow: visible;
-}
-.x-superboxselect-input input {
-  background: transparent;
-}
-.x-superboxselect-btn-expand {
-  margin-top: 9px !important; margin-right: 6px;
-}
-.x-superboxselect-btn-clear {
-  background-color: #fbfbfb;
-  height: 17px !important;
-  top: -4px;
-  outline: 1px solid #e4e4e4;
-  border: 12px solid #fbfbfb;
-  position: absolute;
-  right: -42px;
-  display: block;
-}*/


### PR DESCRIPTION
There are major UI glitches with superboxselect inputs when they are used in toolbars, this PR fixes them

before
![bildschirmfoto 2014-10-01 um 16 29 35](https://cloud.githubusercontent.com/assets/445501/4476881/9b5b8008-4979-11e4-9b3e-9f1dfe45869f.png)

after
![bildschirmfoto 2014-10-01 um 16 29 17](https://cloud.githubusercontent.com/assets/445501/4476885/9f4226a4-4979-11e4-8e11-d440b2e43a04.png)
