### PR TITLE
Ignore sass/font-awesome directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ node_modules
 .sass-cache
 _build/templates/default/sass/bourbon
 _build/templates/default/sass/neat
+_build/templates/default/sass/font-awesome
 *.css.map
 
 #ignore composer files


### PR DESCRIPTION
Sass source doesn’t need to be under version control

files in assets/ still are
