### PR TITLE
Removed alias length limitation from ExtJS

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -500,7 +500,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,description: '<b>[[*alias]]</b><br />'+_('resource_alias_help')
             ,name: 'alias'
             ,id: 'modx-resource-alias'
-            ,maxLength: 100
+            ,maxLength: 255
             ,anchor: '100%'
             ,value: config.record.alias || ''
 


### PR DESCRIPTION
### What does it do ?

Remove resource alias limitation from ExtJS
### Why is it needed ?
1. DB is varchar 255
2. alias limitation could/should be handled server side
### Related issue(s)/PR(s)
- #11999
