### PR TITLE
Fixed issue where batch removing access policies was only allowed for "core" policies (instead of preventing deletion for core policies)

### DIFF
--- a/core/model/modx/processors/security/access/policy/removemultiple.class.php
+++ b/core/model/modx/processors/security/access/policy/removemultiple.class.php
@@ -11,36 +11,41 @@ class modAccessPolicyRemoveMultipleProcessor extends modObjectProcessor {
     public $languageTopics = array('policy');
     public $permission = 'policy_delete';
     public $objectType = 'policy';
-    
+
     public function process() {
         $policies = $this->getProperty('policies');
         if (empty($policies)) {
             return $this->failure($this->modx->lexicon('policy_err_ns'));
         }
 
-        $policyIds = is_array($policies) ? $policies : explode(',',$policies);
+        $policyIds = is_array($policies) ? $policies : explode(',', $policies);
         $core = array('Resource','Object','Administrator','Element','Load Only','Load, List and View');
 
         foreach ($policyIds as $policyId) {
             /** @var modAccessPolicy $policy */
-            $policy = $this->modx->getObject('modAccessPolicy',$policyId);
-            if (empty($policy)) continue;
-
-            if (!in_array($policy->get('name'),$core)) {
+            $policy = $this->modx->getObject('modAccessPolicy', $policyId);
+            if (empty($policy)) {
                 continue;
             }
 
-            if ($policy->remove() == false) {
-                $this->modx->log(modX::LOG_LEVEL_ERROR,$this->modx->lexicon('policy_err_remove').print_r($policy->toArray(),true));
+            if (in_array($policy->get('name'), $core)) {
+                continue;
+            }
+
+            if (!$policy->remove()) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    $this->modx->lexicon('policy_err_remove') . print_r($policy->toArray(), true)
+                );
             }
             $this->logManagerAction($policy);
         }
 
         return $this->success();
     }
-    
+
     public function logManagerAction(modAccessPolicy $policy) {
-        $this->modx->logManagerAction('remove_policy','modAccessPolicy',$policy->get('id'));
+        $this->modx->logManagerAction('remove_policy', 'modAccessPolicy', $policy->get('id'));
     }
 }
 return 'modAccessPolicyRemoveMultipleProcessor';


### PR DESCRIPTION
### What does it do ?

Fixed bad "check" preventing to remove "core access policies" (`!in_array` instead of `in_array`) when "batch deleting" access policies +
Minor CS
### Why is it needed ?

Restore batch deletion function
### Related issue(s)/PR(s)
- #4442
