### PR TITLE
Enhancement: Make modx-browser-combo look for the default media source system setting

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -633,7 +633,7 @@ MODx.combo.Browser = function(config) {
        width: 400
        ,triggerAction: 'all'
        ,triggerClass: 'x-form-file-trigger'
-       ,source: config.source || 1
+       ,source: config.source || MODx.config.default_media_source
     });
     MODx.combo.Browser.superclass.constructor.call(this,config);
     this.config = config;


### PR DESCRIPTION
### What does it do?

Make a modx-combo-browser field respect the default_media_source system setting instead of falling back to source with ID = 1 if no config.source is passed.
### Why is it needed?

Make static resources work with at least a bit media sources, as explained in https://github.com/modxcms/revolution/issues/12019 and there mentioned other issues it is not possible to configure the media source that should be used when choosing a static file for a static resource as it will always open the default Filesystem Media Source (ID = 1) because the panel of a static resource doesn't define a source to use, so the modx-combo-browser will fall back to the hardcoded default of source 1.

With this change the filebrowser will open the source specified in the setting default_media_source and whe additionally specifying the resource_static_path user / user group / context / system setting the path will be correct when choosing a file. This setting will be read by the existing code already if present, but it has to be configured manually...not sure if this makes sense, if not, please ask.
### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/issues/12019
#11385
#9153
#7693
