### PR TITLE
Removed some code that appeared not to be used in Resource Tree Panel

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -31,12 +31,6 @@ MODx.tree.Resource = function(config) {
         }
     });
     MODx.tree.Resource.superclass.constructor.call(this,config);
-    this.on('render',function() {
-        var el = Ext.get('modx-resource-tree');
-        el.createChild({tag: 'div', id: 'modx-resource-tree_tb'});
-        el.createChild({tag: 'div', id: 'modx-resource-tree_filter'});
-        //this.addSearchToolbar();
-    },this);
     this.addEvents('loadCreateMenus');
     this.on('afterSort',this._handleAfterDrop,this);
 };


### PR DESCRIPTION
### What does it do ?

Removed what appears to be unused code in the resource tree panel.
### Why is it needed ?

Cleanup.
Furthermore, code was relying on defined ID, which would prevent any developer to extend the `MODx.tree.Resource` class without JS issue/error.
