### PR TITLE
Enable path style on AWS driver if the bucket's name contains a dot

### DIFF
--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -95,6 +95,9 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
      */
     public function setBucket($bucket) {
         $this->bucket = $bucket;
+        if (strpos($bucket,'.') !== false) {
+            $this->driver->enable_path_style(true);
+        }
     }
 
     /**


### PR DESCRIPTION
The issue lies in how wildcard certificates work. If a bucket has dots in it, https://some.bucket.name.s3.amazonaws.com/ fails SSL verification, resulting in a cURL PHP error. So we need to tell the driver to use path style to access the bucket. This changes the url to https://s3.amazonaws.com/some.bucket.name/ which passes SSL verification.

Fixes #12017 
