### PR TITLE
Enhancement: Make it possible to not submit the emptyText of a form field

### DIFF
--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -225,7 +225,7 @@ Ext.extend(MODx.Window,Ext.Window,{
         if (f.isValid() && this.fireEvent('beforeSubmit',f.getValues())) {
             f.submit({
                 waitMsg: _('saving')
-                ,submitEmptyText: this.config.submitEmptyText === false ? false : true
+                ,submitEmptyText: this.config.submitEmptyText !== false
                 ,scope: this
                 ,failure: function(frm,a) {
                     if (this.fireEvent('failure',{f:frm,a:a})) {

--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -225,6 +225,7 @@ Ext.extend(MODx.Window,Ext.Window,{
         if (f.isValid() && this.fireEvent('beforeSubmit',f.getValues())) {
             f.submit({
                 waitMsg: _('saving')
+                ,submitEmptyText: this.config.submitEmptyText === false ? false : true
                 ,scope: this
                 ,failure: function(frm,a) {
                     if (this.fireEvent('failure',{f:frm,a:a})) {


### PR DESCRIPTION
### What does it do?

Makes it possible to specify (only in windows for now) a config property "submitEmtpyText" (takes a boolean) that is later passed to the Form action (e.g. submit) method and determines if form field values that were set by the config property "emptyText" (often used for listbox / superboxselect fields) should submitted as actual value or not. Default is true (as it was before), so it shouldn't break anything.
### Why is it needed?

Sometimes or most of the times we don't want a Text set with "emptyText" being submitted as a field value, as it's actually empty and should stay like this...there was no way to use/pass the Ext.form.Action config property submitEmptyText (as far as I can tell at least) before this change.
### Related issue(s)/PR(s)/Forum Post(s)

http://forums.modx.com/thread/76506/extjs-revo-2-3-0-dev-submitemptytext-false-not-working-within-modx-window
