### PR TITLE
Removed unnecessary element ID

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -10,7 +10,6 @@ MODx.panel.FileTree = function(config) {
     config = config || {};
     Ext.applyIf(config, {
         _treePrefix: 'source-tree-'
-        ,id: 'modx-leftbar-filetree'
         ,autoHeight: true
         ,defaults: {
             autoHeight: true


### PR DESCRIPTION
### What does it do ?

Removes a not used ID in file tree panel.
### Why is it needed ?

Allow developers to extend the panel without ID conflict
