### PR TITLE
ExtJS now takes care of friendly_alias_max_length setting

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -478,6 +478,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
 
     ,getMainRightFields: function(config) {
         config = config || {};
+
+        var aliasLength = ~~MODx.config['friendly_alias_max_length'] || 0;
+
         return [{
             xtype: 'modx-combo-template'
             ,fieldLabel: _('resource_template')
@@ -500,7 +503,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,description: '<b>[[*alias]]</b><br />'+_('resource_alias_help')
             ,name: 'alias'
             ,id: 'modx-resource-alias'
-            ,maxLength: 255
+            ,maxLength: (aliasLength > 255 || aliasLength === 0) ? 255 : aliasLength
             ,anchor: '100%'
             ,value: config.record.alias || ''
 


### PR DESCRIPTION
### What does it do ?

Limit the alias form field according to the `friendly_alias_max_length` setting
### Why is it needed ?

Better reflection of the alias length constraint in the UI
### Related issue(s)/PR(s)

Closes #12039
