### PR TITLE
Removed listeners/actions on Media browser data view double click

### DIFF
--- a/manager/assets/modext/widgets/media/browser.js
+++ b/manager/assets/modext/widgets/media/browser.js
@@ -14,10 +14,6 @@ MODx.Media = function(config) {
     // DataView
     this.view = MODx.load({
         xtype: 'modx-browser-view'
-        ,onSelect: {
-            fn: this.onSelect
-            ,scope: this
-        }
         ,source: config.source || MODx.config.default_media_source
         ,allowedFileTypes: config.allowedFileTypes || ''
         ,wctx: config.wctx || 'web'
@@ -257,28 +253,6 @@ Ext.extend(MODx.Media, Ext.Container, {
                 'select': {fn:this.changeViewmode, scope:this}
             }
         }];
-    }
-
-    ,onSelect: function(data) {
-        // @todo make sure this is never used
-        console.log('MODx.Media#onSelect', data);
-        var selNode = this.view.getSelectedNodes()[0];
-        var callback = this.config.onSelect || this.onSelectHandler;
-        var lookup = this.view.lookup;
-        var scope = this.config.scope;
-        this.hide(this.config.animEl || null,function(){
-            if (selNode && callback) {
-                var data = lookup[selNode.id];
-                Ext.callback(callback,scope || this,[data]);
-                this.fireEvent('select',data);
-            }
-        },scope);
-    }
-
-    ,onSelectHandler: function(data) {
-        // @todo make sure this is never used
-        console.log('MODx.Media#onSelectHandler', data);
-        Ext.get(this.returnEl).dom.value = unescape(data.url);
     }
 });
 Ext.reg('modx-media-view', MODx.Media);


### PR DESCRIPTION
### What does it do ?

Removes a function that was triggered when double clicking an item on the media browser data view (the data view extends `MODx.browser.View`, which sets a [listener](https://github.com/modxcms/revolution/blob/master/manager/assets/modext/core/modx.view.js#L428) on "double click")
### Why is it needed ?

I suppose either the original behavior was to be able to edit any text files (which was not implemented) or this is a leftover/copy paste legacy :)
### Related issue(s)/PR(s)

Closes #12032
