### PR TITLE
Display context name in combo box

### DIFF
--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -56,6 +56,10 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
      */
     public function prepareRow(xPDOObject $object) {
         $contextArray = $object->toArray();
+        if (!empty($contextArray['name'])) {
+            $contextArray['name'] .= ' ';
+        }
+        $contextArray['name'] .= "({$contextArray['key']})";
         $contextArray['perm'] = array();
         if ($this->canEdit) {
             $contextArray['perm'][] = 'pedit';

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -309,9 +309,9 @@ MODx.combo.Context = function(config) {
     Ext.applyIf(config,{
         name: 'context'
         ,hiddenName: 'context'
-        ,displayField: 'key'
+        ,displayField: 'name'
         ,valueField: 'key'
-        ,fields: ['key']
+        ,fields: ['key', 'name']
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {


### PR DESCRIPTION
### What does it do ?

Adds the context name in the context/getlist processor (mostly only used in the context combo box)
### Why is it needed ?

Reflect the `modContext.name` addition
### Related issue(s)/PR(s)

Closes #11896
