### PR TITLE
Fix of load store if init combobox value is 0

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -26,7 +26,7 @@ Ext.override(Ext.form.ComboBox, {
     loaded: false
     ,setValue: Ext.form.ComboBox.prototype.setValue.createSequence(function(v) {
         var a = this.store.find(this.valueField, v);
-        if (v && v !== 0 && this.mode == 'remote' && a == -1 && !this.loaded) {
+        if (typeof v !== 'undefined' && v !== null && this.mode == 'remote' && a == -1 && !this.loaded) {
             var p = {};
             p[this.valueField] = v;
             this.loaded = true;


### PR DESCRIPTION
Long, long time ago... in 2009 has been made change for all Combo boxes in commit https://github.com/modxcms/revolution/commit/58a465aa3e906148741c879e199df10be2c4367a

This force Combobox with initial value 0 to not load store and through this prevent show correct value from DB. 

**E.g. default text if template hasn't been set in new resource and it's value remain 0.**

Before:
![-screenshot-11 10 2014 22_22_03](https://cloud.githubusercontent.com/assets/378835/4604031/903b6202-5184-11e4-918e-86c51daf9cf7.png)

After:
![-screenshot-11 10 2014 22_23_22](https://cloud.githubusercontent.com/assets/378835/4604032/956f6d90-5184-11e4-97ee-225880638387.png)
