### PR TITLE
Fix of default category name when creating a new element instead of showing zero

### DIFF
--- a/core/model/modx/processors/element/category/getlist.class.php
+++ b/core/model/modx/processors/element/category/getlist.class.php
@@ -28,7 +28,7 @@ class modElementCategoryGetListProcessor extends modObjectGetListProcessor {
     public function beforeIteration(array $list) {
         if ($this->getProperty('showNone',false)) {
             $list = array('0' => array(
-                'id' => '',
+                'id' => 0,
                 'category' => $this->modx->lexicon('none'),
                 'name' => $this->modx->lexicon('none'),
             ));


### PR DESCRIPTION
When you are creating a new element in default is selected category 0 but correct text should be None (for English).

**Example for Chunk**
Before:
![-screenshot-11 10 2014 22_39_24](https://cloud.githubusercontent.com/assets/378835/4604109/863fecd4-5187-11e4-8f44-3604c55e92dd.png)

After:
![-screenshot-11 10 2014 22_40_00](https://cloud.githubusercontent.com/assets/378835/4604110/8ab873f8-5187-11e4-91f8-3ebc508cf400.png)
