### PR TITLE
Fixed issue with TVs inside modx-resource-content

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -166,6 +166,13 @@ hr {
   .x-panel-bwrap {
       border: 0;
   }
+  .modx-tv .modx-tv-label {
+      width: auto;
+      float: none;
+      clear: none;
+      padding: 15px 0 4px;
+      position: static;
+  }
 }
 
 #modx-content-above, #modx-content-below {


### PR DESCRIPTION
This fix refers to issue #11990. Tvs inside modx-resource-content now behave same as in Template variables tab.
