### PR TITLE
Fixed property set creation which allowed empty 'name'

### DIFF
--- a/core/model/modx/processors/element/propertyset/create.class.php
+++ b/core/model/modx/processors/element/propertyset/create.class.php
@@ -13,10 +13,13 @@ class modPropertySetCreateProcessor extends modObjectCreateProcessor {
 
     public function beforeSet() {
         $name = $this->getProperty('name');
+        if (empty($name)) {
+            $this->addFieldError('name', $this->modx->lexicon('propertyset_err_ns_name'));
+        }
         if ($this->doesAlreadyExist(array(
             'name' => $name,
         ))) {
-            $this->addFieldError('name',$this->modx->lexicon('propertyset_err_ns_name'));
+            $this->addFieldError('name', $this->modx->lexicon('propertyset_err_ae'));
         }
         return parent::beforeSet();
     }


### PR DESCRIPTION
### What does it do ?

Make sure a property set name is passed to `modPropertySetCreateProcessor` (and fixed a wrong lexicon used in case of property set already existing)
### Why is it needed ?

While the manager prevents submitting a form without `name`, running `runProcessor` could still allow the creation for a property set without name.
