### PR TITLE
Fix of selection bug in MODx.grid.PluginEventAssoc

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -274,6 +274,9 @@ Ext.extend(MODx.grid.PluginEventAssoc,MODx.grid.LocalGrid,{
         var sm = this.getSelectionModel();
         e.stopEvent();
         e.preventDefault();
+        if (!this.getSelectionModel().isSelected(ri)) {
+            this.getSelectionModel().selectRow(ri);
+        }
         this.menu.removeAll();
         this.addContextMenuItem([{
             text: _('remove')


### PR DESCRIPTION
Find and fix bug when If you click on the grid by right mouse button it actually doesn't select row. So when you try to remove row from this grid it does nothing.
