### PR TITLE
Fixed adding new value from single select

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/listbox.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/listbox.class.php
@@ -11,15 +11,31 @@ class modTemplateVarInputRenderListbox extends modTemplateVarInputRender {
         $options = $this->getInputOptions();
         $items = array();
 
+        $found = false;
         foreach ($options as $option) {
             $opt = explode("==",$option);
             if (!isset($opt[1])) $opt[1] = $opt[0];
+
+            $selected = strcmp($opt[1], $value) == 0;
+            if ($selected == 1) {
+                $found = true;
+            }
+
             $items[] = array(
                 'text' => htmlspecialchars($opt[0],ENT_COMPAT,'UTF-8'),
                 'value' => htmlspecialchars($opt[1],ENT_COMPAT,'UTF-8'),
-                'selected' => strcmp($opt[1],$value) == 0,
+                'selected' => $selected,
             );
         }
+
+        if (!empty($value) && $found === false) {
+            $items[] = array(
+                'text' => htmlspecialchars($value,ENT_COMPAT,'UTF-8'),
+                'value' => htmlspecialchars($value,ENT_COMPAT,'UTF-8'),
+                'selected' => 1,
+            );
+        }
+
         $this->setPlaceholder('opts',$items);
     }
 }


### PR DESCRIPTION
### What does it do ?

Allows user to specify new value for single select list (when TV settings allows it).
### Why is it needed ?

Until now, when user filled new value (value not specified in Input Option Values, the value was saved to DB, but wasn't rendered and marked as selected in TV).
### Steps to reproduce
- Create a new TV of a type Listbox (single-select)
- Set some Input Option Values (for example `Hi==hi||Hello==hello`)
- Enable Type-ahead and Disable Force Selection
- Assign it to template
- Open resource and enter any value that is not in the list (for example `Aloha`)
- Save resource and refresh the page -> TV will be empty but it DB is the correct value
### Related Issues

Resolves #10072
