### PR TITLE
[2.3] Fix minor window size issues

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -1083,6 +1083,7 @@ MODx.window.AddPropertySet = function(config) {
         ,id: 'modx-window-element-property-set-add'
         ,url: MODx.config.connector_url
         ,action: 'element/propertyset/associate'
+        ,autoHeight: true // makes window grow when the fieldset is toggled
         ,fields: [{
             xtype: 'hidden'
             ,name: 'elementId'
@@ -1123,9 +1124,11 @@ MODx.window.AddPropertySet = function(config) {
             ,listeners: {
                 'expand': {fn:function(p) {
                     Ext.getCmp('modx-aps-propertyset-new').setValue(true);
+                    this.center(); // re-centers window on screen after height changed
                 },scope:this}
                 ,'collapse': {fn:function(p) {
                     Ext.getCmp('modx-aps-propertyset-new').setValue(false);
+                    this.center(); // re-centers window on screen after height changed
                 },scope:this}
             }
             ,items: [{

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -188,7 +188,7 @@ MODx.window.ChangeProvider = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('provider_select')
-        ,width: 400
+        ,width: 600 // prevents primary button text from being cut off if it is a long string
 		,layout: 'form'
 		,items:[{
 			xtype: 'modx-template-panel'


### PR DESCRIPTION
### What does it do?

Fixes window width in package provider selection window. Set from 400 to 600px because the primary button text was cut when the string was long as for example in russian or german.

Makes the create property set window (in element properties grid) auto grow when the fieldset is toggled + centers the window after resizing again as it can be cut of on smaller screens if this is not done.
### Why is it needed?

For usability and visual sexyness =)
### Related issue(s)/PR(s)/Forum Post(s)

https://github.com/modxcms/revolution/issues/12025
https://github.com/modxcms/revolution/issues/12074
