### PR TITLE
Fix uploading packages on Windows

### DIFF
--- a/core/model/modx/processors/workspace/packages/upload.class.php
+++ b/core/model/modx/processors/workspace/packages/upload.class.php
@@ -46,7 +46,7 @@ class modBrowserPackageUploadProcessor extends modProcessor {
         $file =  array_shift($this->getProperty('files'));
 
         // Check MIME type of file
-        if (!in_array(strtolower($file['type']), array('application/zip', 'application/x-zip-compressed', 'application/x-zip'))) {
+        if (!in_array(strtolower($file['type']), array('application/zip', 'application/x-zip-compressed', 'application/x-zip', 'application/octet-stream'))) {
             return $this->failure("1 This file does not appear to be a transport package"); //@TODO Lexiconize
         }
 


### PR DESCRIPTION
### What does it do?

FIX uploading packages directly into package manager grid => Added MIME type
### Why is it needed?

It actually never worked on Windows ;)
