### PR TITLE
Sort plugin events by enabled

### DIFF
--- a/core/model/modx/processors/element/plugin/event/getlist.class.php
+++ b/core/model/modx/processors/element/plugin/event/getlist.class.php
@@ -37,7 +37,11 @@ class modPluginEventGetListProcessor extends modObjectProcessor {
                     'handler' => 'this.updateEvent',
                 )
             );
-            $list[] = $eventArray;
+            if ($eventArray['enabled']) {
+                array_unshift($list, $eventArray);
+            } else {
+                array_push($list, $eventArray);
+            }
         }
         return $this->outputArray($list,$data['total']);
     }


### PR DESCRIPTION
### What does it do ?

Sort plugin events on plugin edit page by enabled first. 
### Why is it needed ?

To know what events are associated to plugin without sorting manually.
### Steps to reproduce
1. Open any Plugin from element tree.
2. Go to Systems Events tab
3. Now events are sorted without connect to plugin. So you need to click 2 times (!!!) on "Enabled" column header to see associated to this particular plugin events.
