### PR TITLE
Allow "non core" session handler

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2400,7 +2400,12 @@ class modX extends xPDO {
             if (!in_array($this->getSessionState(), array(modX::SESSION_STATE_INITIALIZED, modX::SESSION_STATE_EXTERNAL, modX::SESSION_STATE_UNAVAILABLE), true)) {
                 $sh= false;
                 if ($sessionHandlerClass = $this->getOption('session_handler_class', $options)) {
-                    if ($shClass= $this->loadClass($sessionHandlerClass, '', false, true)) {
+                    if ($shClass= $this->loadClass(
+                        $sessionHandlerClass,
+                        $this->getOption('session_handler_class_path', $options, ''),
+                        false,
+                        true
+                    )) {
                         if ($sh= new $shClass($this)) {
                             session_set_save_handler(
                                 array (& $sh, 'open'),


### PR DESCRIPTION
### What does it do ?

Allows defining a path for a custom session handler.
### Why is it needed ?

We currently are able to define a custom class to act as session handler (cf. `session_handler_class` setting), but this class must be located within the `core_path`.

This PR allows defining a path (using `session_handler_class_path` setting) to load the custom session handler class.
