### PR TITLE
Unassign plugin from event

### DIFF
--- a/core/model/modx/processors/element/plugin/event/associate.php
+++ b/core/model/modx/processors/element/plugin/event/associate.php
@@ -16,14 +16,11 @@ $plugins = $modx->fromJSON($scriptProperties['plugins']);
 
 $eventName = $event->get('name');
 
+$modx->removeCollection('modPluginEvent', array(
+    'event' => $eventName,
+));
+
 foreach ($plugins as $pluginArray) {
-    $pluginEvent = $modx->getObject('modPluginEvent',array(
-        'event' => $eventName,
-        'pluginid' => $pluginArray['id'],
-    ));
-    if (!empty($pluginEvent)) {
-        $pluginEvent->remove();
-    }
     $pluginEvent = $modx->newObject('modPluginEvent');
     $pluginEvent->set('event',$eventName);
     $pluginEvent->set('pluginid',$pluginArray['id']);

--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -224,15 +224,16 @@ MODx.grid.PluginEventAssoc = function(config) {
             header: _('propertyset')
             ,dataIndex: 'propertyset'
             ,width: 150
-            ,editor: MODx.load({
+            ,editor: {
                 xtype: 'modx-combo-property-set'
+                ,renderer: true
                 ,baseParams: {
                     action: 'element/propertyset/getList'
                     ,showAssociated: true
                     ,elementId: config.plugin
                     ,elementType: 'modPlugin'
                 }
-            })
+            }
         },{
             header: _('priority')
             ,dataIndex: 'priority'


### PR DESCRIPTION
### What does it do ?

Fixes removing plugin from an event via the `Update plugin event` window.
### Why is it needed ?

Currently when you try to remove a plugin from an event by this window, it's not working. After save & refresh, the plugin is still assigned...
