### PR TITLE
Reset modError after process()

### DIFF
--- a/core/model/modx/error/moderror.class.php
+++ b/core/model/modx/error/moderror.class.php
@@ -165,7 +165,6 @@ class modError {
         if ($message != '') {
             $this->message = $message;
         }
-        $objarray = array ();
         if (is_array($object)) {
             $obj = reset($object);
             if (is_object($obj) && $obj instanceof xPDOObject) {
@@ -174,13 +173,18 @@ class modError {
             unset ($obj);
         }
         $objarray = $this->toArray($object);
-        return array (
+        $output =  array (
             'success' => $status,
             'message' => $this->message,
             'total' => isset ($this->total) && $this->total != 0 ? $this->total : count($this->errors),
             'errors' => $this->errors,
             'object' => $objarray,
         );
+
+        // Reset errors/message
+        $this->reset();
+
+        return $output;
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

Resets `modError` after calling `modError::process()`
### Why is it needed ?

First, some background (as i understand things to work)
- processors make extensive usage of modError to indicate if any error occurred
- `modProcessor` derivative classes stop execution if `modError` has some error OR if `modError->message` is not empty (which occurs if you pass any message, even a successful one)

This prevents multiple processors to run one after the other if either a message is sent to `modError` or if any error occurs.
Sample case : multiple TVs making use of processors. If a processor fails, all remaining TVs processors will never be executed since `modProcessor::initialize` check for any "error".

This PR aims to "reset" `modError` after every `modError::process()` call.

I'm not sure that's the expected behavior about `modError` (ie. should it keep all errors during modX instance ? If so, `modProcessor::initialize()` logic should be modified).

Hopefully this makes sense (if not, i'll gladly try to reformulate)
### Related issue(s)/PR(s)
- #11951
- #11498 (PR which introduced the current behavior)
