### PR TITLE
Restore help "right"

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -531,7 +531,7 @@ $userNavMenus[2]->fromArray(array(
   'text' => 'about',
   'description' => '',
   'parent' => 'usernav',
-  'permissions' => '',
+  'permissions' => 'help',
   'action' => 'help',
   'icon' => '<i class="icon-question-circle icon icon-large"></i>',
 ), '', true, true);


### PR DESCRIPTION
### What does it do ?

Restores the help permission into the main menu.
### Why is it needed ?

When the `help` permission is disabled/removed, users are no able to access the help page.
Before this, the menu would still display the "help" link, leading the users to a beautiful "access denied" message.
### Steps to reproduce issue
- remove the "help" permission to any non 'sudo' user
- log in as that user, see the help menu (icon) is present and leads you to an "access denied" message
### Related issue(s)/PR(s)

This a just a small part of issues mentioned in #11622
