### PR TITLE
Fix client part of bug #9983

### DIFF
--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -79,9 +79,14 @@ Ext.extend(MODx.TreeDrop,Ext.Component,{
                             MODx.insertAtCursor(ddTargetEl,data.node.attributes.pk,cfg.onInsert);
                         } else if (el.dom.id == 'modx-resource-parent') {
                             v = data.node.attributes.pk;
-                            Ext.getCmp('modx-resource-parent').setValue(v);
-                            Ext.getCmp('modx-resource-parent-hidden').setValue(v);
-                            var p = Ext.getCmp('modx-panel-resource');
+                            var pf = Ext.getCmp('modx-resource-parent');
+                            if (v == pf.currentid) {
+                                MODx.msg.alert('',_('resource_err_own_parent'));
+                                return false;
+                            }
+                            pf.setValue(v);
+                            Ext.getCmp(pf.parentcmp).setValue(v);
+                            var p = Ext.getCmp(pf.formpanel);
                             if (p) { p.markDirty(); }
                         } else {
                             MODx.insertAtCursor(ddTargetEl,v,cfg.onInsert);


### PR DESCRIPTION
It is a fix of client part of the issue #9983. It adds a check that resource id drag-and-dropped from tree to parent field is not equal to current id of a resource. Also it makes used config options parentcmp and formpanel of #modx-resource-parent instead of just strings.
