### PR TITLE
Update memberof output filter to return integer (0 or 1)

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -142,9 +142,9 @@ class modOutputFilter {
                             /** @var $user modUser */
                             $user = $this->modx->getObject('modUser',$output);
                             if ($user && is_object($user) && $user instanceof modUser) {
-                                $condition[]= $user->isMember($grps);
+                                $condition[]= (int) $user->isMember($grps);
                             } else {
-                                $condition[] = false;
+                                $condition[] = 0;
                             }
                             break;
                         case 'or':


### PR DESCRIPTION
This change mirrors the other conditional output filters that all return an integer `0` or `1` instead of a `boolean`

Also, this fixes #5612 related issue mentioned near the bottom.
