### PR TITLE
Fixes autoredirect after creating user

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -275,7 +275,10 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                         ,message: r.result.message || _('save_successful')
                         ,dontHide: r.result.message != '' ? true : false
                     });
-                    Ext.callback(this.redirect,this,[o,itm,r.result],1000);
+
+                    if (itm.redirect != false) {
+                        Ext.callback(this.redirect,this,[o,itm,r.result],1000);
+                    }
 
                     this.resetDirtyButtons(r.result);
                 },this);

--- a/manager/assets/modext/sections/security/user/create.js
+++ b/manager/assets/modext/sections/security/user/create.js
@@ -16,6 +16,7 @@ MODx.page.CreateUser = function(config) {
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
+            ,redirect: false
             ,method: 'remote'
             // ,checkDirty: true
             ,keys: [{


### PR DESCRIPTION
### What does it do ?

Fixes auto redirect that happens after creating a user that make impossible to get user's password from pop-up window.
### Why is it needed ?

Without this fix, after user is created, page is autoredirected to update panel. So the pop-up window with user password is visible for a second and admin is unable to read/copy user's password. With this fix, redirect happen after the pop-up window with password is clicked.
### Related issues

Fixes #11575
