### PR TITLE
Updated generateContext to be quicker

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -85,8 +85,9 @@ class modCacheManager extends xPDOCacheManager {
 
                 /* generate the aliasMap and resourceMap */
                 $collResources = $obj->getResourceCacheMap();
-                $results['resourceMap']= array ();
-                if ($this->modx->getOption('friendly_urls', $contextConfig, false) && $this->getOption('cache_alias_map', $options, false)) {
+                $friendlyUrls = $this->getOption('friendly_urls', $contextConfig, false);
+                $cacheAliasMap = $this->getOption('cache_alias_map', $options, false);
+                if ($friendlyUrls && $cacheAliasMap) {
                     $results['aliasMap']= array ();
                 }
                 if ($collResources) {
@@ -96,7 +97,7 @@ class modCacheManager extends xPDOCacheManager {
                             $results['resourceMap'][(integer) $r->parent] = array();
                         }
                         $results['resourceMap'][(integer) $r->parent][] = (integer) $r->id;
-                        if ($this->modx->getOption('friendly_urls', $contextConfig, false) && $this->getOption('cache_alias_map', $options, false)) {
+                        if ($friendlyUrls && $cacheAliasMap) {
                             if (array_key_exists($r->uri, $results['aliasMap'])) {
                                 $this->modx->log(xPDO::LOG_LEVEL_ERROR, "Resource URI {$r->uri} already exists for resource id = {$results['aliasMap'][$r->uri]}; skipping duplicate resource URI for resource id = {$r->id}");
                                 continue;


### PR DESCRIPTION
Originally there was 2 getOption calls within the while loop. This doesn't display as a problem until a large amount of resources are pulled from the database.

By moving the getOption outside of the while loop and using the variable we see the generateContext() function speed up by about 100x.

With a resource tree of ~250,000 resources we saw about 1,600,000 calls to getOption, this new approach reduces that to 2.
