### PR TITLE
Remove limit from modx-combo-category combobox

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -386,6 +386,7 @@ MODx.combo.Category = function(config) {
         ,baseParams: {
             action: 'element/category/getlist'
             ,showNone: true
+            ,limit: 0
         }
     });
     MODx.combo.Category.superclass.constructor.call(this,config);


### PR DESCRIPTION
This fix ensures all available categories returned from the processor can be displayed in the combobox. This is especially important since category pagination was removed.

Fixes #12087
