### PR TITLE
Fix wrong error for namespace create

### DIFF
--- a/core/model/modx/processors/workspace/namespace/create.class.php
+++ b/core/model/modx/processors/workspace/namespace/create.class.php
@@ -10,7 +10,7 @@
  */
 class modNamespaceCreateProcessor extends modObjectCreateProcessor {
     public $classKey = 'modNamespace';
-    public $languageTopics = array('workspace','namespace','lexicon');
+    public $languageTopics = array('namespace');
     public $permission = 'namespaces';
     public $objectType = 'namespace';
     public $primaryKeyField = 'name';
@@ -18,13 +18,14 @@ class modNamespaceCreateProcessor extends modObjectCreateProcessor {
     public function beforeSave() {
         $name = $this->getProperty('name');
         if (empty($name)) {
-            $this->addFieldError('name',$this->modx->lexicon('namespace_err_ns_name'));
+            $this->addFieldError('name', $this->modx->lexicon($this->objectType.'_err_ns'));
         }
-        $this->object->set('name',$name);
+        $this->object->set('name', $name);
 
-        $this->object->set('path',trim($this->object->get('path')));
-        $this->object->set('assets_path',trim($this->object->get('assets_path')));
+        $this->object->set('path', trim($this->object->get('path')));
+        $this->object->set('assets_path', trim($this->object->get('assets_path')));
         return parent::beforeSave();
     }
 }
+
 return 'modNamespaceCreateProcessor';


### PR DESCRIPTION
Removed unnecessary lexicons, changed error (previous didn't exist)
