### PR TITLE
Fix Password tab visible to users without permission

### DIFF
--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -38,36 +38,47 @@ MODx.panel.Profile = function(config) {
             ,border: false
             ,autoHeight: true
             ,anchor: '100%'
-        },MODx.getPageStructure([{
+        },this.getTabs(config)]
+    });
+    MODx.panel.Profile.superclass.constructor.call(this,config);
+};
+Ext.extend(MODx.panel.Profile,MODx.Panel, {
+    getTabs: function(config) {
+        var items = [{
             xtype: 'modx-panel-profile-update'
             ,id: 'modx-panel-profile-update'
             ,user: config.user
             ,preventRender: true
-        },{
-            xtype: 'modx-panel-profile-password-change'
-            ,id: 'modx-panel-profile-password-change'
-            ,user: config.user
-            ,preventRender: true
-        },{
-            title: _('profile_recent_resources')
-            ,bodyStyle: 'padding: 15px;'
-            ,id: 'modx-profile-recent-docs'
-            ,autoHeight: true
-            ,layout: 'anchor'
-            ,items: [{
-                html: '<p>'+_('profile_recent_resources_desc')+'</p><br />'
-                ,id: 'modx-profile-recent-docs-msg'
-                ,border: false
-            },{
-                xtype: 'modx-grid-user-recent-resource'
+        }];
+        if (MODx.perm.change_password) {
+            items.push({
+                xtype: 'modx-panel-profile-password-change'
+                ,id: 'modx-panel-profile-password-change'
                 ,user: config.user
                 ,preventRender: true
-            }]
-        }])]
-    });
-    MODx.panel.Profile.superclass.constructor.call(this,config);
-};
-Ext.extend(MODx.panel.Profile,MODx.Panel);
+            });
+        }
+        if (MODx.perm.view_document) {
+            items.push({
+                title: _('profile_recent_resources')
+                ,bodyStyle: 'padding: 15px;'
+                ,id: 'modx-profile-recent-docs'
+                ,autoHeight: true
+                ,layout: 'anchor'
+                ,items: [{
+                    html: '<p>'+_('profile_recent_resources_desc')+'</p><br />'
+                    ,id: 'modx-profile-recent-docs-msg'
+                    ,border: false
+                },{
+                    xtype: 'modx-grid-user-recent-resource'
+                    ,user: config.user
+                    ,preventRender: true
+                }]
+            });
+        }
+        return MODx.getPageStructure(items);
+    }
+});
 Ext.reg('modx-panel-profile',MODx.panel.Profile);
 
 /**

--- a/manager/controllers/default/security/profile.class.php
+++ b/manager/controllers/default/security/profile.class.php
@@ -31,6 +31,8 @@ class SecurityProfileManagerController extends modManagerController {
                 ,user: "'.$this->modx->user->get('id').'"
             });
         });
+        MODx.perm.change_password = '.(int)$this->modx->hasPermission('change_password').';
+        MODx.perm.view_document = '.(int)$this->modx->hasPermission('view_document').';
         // ]]>
         </script>');
     }


### PR DESCRIPTION
Related to #11623 

Show tabs in profile after check of change_password for passwords and view_document for recently edited documents.
