### PR TITLE
Fix javascript error while revert to default new property

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -393,17 +393,19 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
             if (e == 'yes') {
                 var ri = this.menu.recordIndex;
                 var d = this.defaultProperties[ri];
-                var rec = this.getStore().getAt(ri);
-                rec.set('name',d[0]);
-                rec.set('desc',d[1]);
-                rec.set('desc_trans',d[1]);
-                rec.set('xtype',d[2]);
-                rec.set('options',d[3]);
-                rec.set('value',d[4]);
-                rec.set('overridden',0);
-                rec.set('area',d[5]);
-                rec.set('area_trans',d[5]);
-                rec.commit();
+                if (d) {
+                    var rec = this.getStore().getAt(ri);
+                    rec.set('name',d[0]);
+                    rec.set('desc',d[1]);
+                    rec.set('desc_trans',d[1]);
+                    rec.set('xtype',d[2]);
+                    rec.set('options',d[3]);
+                    rec.set('value',d[4]);
+                    rec.set('overridden',0);
+                    rec.set('area',d[5]);
+                    rec.set('area_trans',d[5]);
+                    rec.commit();
+                }
             }
         },this);
     }

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.js
@@ -193,7 +193,7 @@ MODx.grid.PolicyPermissions = function(config) {
 Ext.extend(MODx.grid.PolicyPermissions,MODx.grid.LocalGrid,{
     onPermRowClick: function(g,ri,e) {
         var s = this.getStore();
-        if (!s) { return; }
+        if (!s || typeof ri == 'undefined') { return; }
 
         var r = s.getAt(ri);
         r.set('enabled',r.get('enabled') ? false : true);

--- a/manager/assets/modext/widgets/source/modx.grid.source.properties.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.properties.js
@@ -134,7 +134,8 @@ Ext.extend(MODx.grid.SourceProperties,MODx.grid.LocalProperty,{
                 'success': {fn:function(r) {
                     var s = this.getStore();
                     var ri = this.menu.recordIndex;
-                    var d = this.defaultProperties[ri][4];
+                    var d = this.defaultProperties[ri];
+                    d = (d && d[4]) ? d[4] : r.value;
                     var rec = s.getAt(this.menu.recordIndex);
                     rec.set('name',r.name);
                     rec.set('desc',r.desc);
@@ -156,14 +157,16 @@ Ext.extend(MODx.grid.SourceProperties,MODx.grid.LocalProperty,{
             if (e == 'yes') {
                 var ri = this.menu.recordIndex;
                 var d = this.defaultProperties[ri];
-                var rec = this.getStore().getAt(ri);
-                rec.set('name',d[0]);
-                rec.set('desc',d[1]);
-                rec.set('xtype',d[2]);
-                rec.set('options',d[3]);
-                rec.set('value',d[4]);
-                rec.set('overridden',0);
-                rec.commit();
+                if (d) {
+                    var rec = this.getStore().getAt(ri);
+                    rec.set('name',d[0]);
+                    rec.set('desc',d[1]);
+                    rec.set('xtype',d[2]);
+                    rec.set('options',d[3]);
+                    rec.set('value',d[4]);
+                    rec.set('overridden',0);
+                    rec.commit();
+                }
             }
         },this);
     }


### PR DESCRIPTION
### What does it do ?

Fix javascript error while revert new property to default (which doesn't exist)
### Why is it needed?

If you create property that has no default value the menu action "Revert Property to Default" yield javascript error in manager\assets\modext\widgets\element\modx.grid.element.properties.js:

```
TypeError: d is undefined
rec.set('name',d[0]);
```

Need a check for existance of variable or not to add this menu item at all.
That is only in element properties. In Property Sets menu there is no error if you choose element.

Same error if you create new mediaSource property and then try to revert back to default.

Also small fix in permission list. While in modx.grid.js 

```
onMouseDown:function(e,t){this.grid.fireEvent('rowclick')
```

onPermRowClick fires 2 times and first time has no needed parameters.
