### PR TITLE
Remove C:\fakepath\ from filename when importing property sets

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -1178,6 +1178,16 @@ MODx.window.ImportProperties = function(config) {
         }]
     });
     MODx.window.ImportProperties.superclass.constructor.call(this,config);
+
+    // Trigger "fileselected" event
+    var fp = Ext.getCmp('modx-impp-file');
+    var onFileUploadFieldFileSelected = function(fp, fakeFilePath) {
+        var fileApi = fp.fileInput.dom.files;
+        var fileName = (typeof fileApi != 'undefined') ? fileApi[0].name : fakeFilePath.replace("C:\\fakepath\\", "");
+        fp.el.dom.value = fileName;
+    }
+    fp.on('fileselected', onFileUploadFieldFileSelected);
+
 };
 Ext.extend(MODx.window.ImportProperties,MODx.Window);
 Ext.reg('modx-window-properties-import',MODx.window.ImportProperties);


### PR DESCRIPTION
Fixes #12184
### Turns this:

![prop_set_import_before](https://cloud.githubusercontent.com/assets/352182/5212820/e558358c-75bd-11e4-806e-b0a07d154cfb.jpg)
### Into this:

![prop_set_after](https://cloud.githubusercontent.com/assets/352182/5212857/c62dee58-75be-11e4-9e88-77ad16d09ec0.jpg)
