### PR TITLE
Remove duplicate code by extend Resource pages

### DIFF
--- a/manager/assets/modext/sections/resource/create.js
+++ b/manager/assets/modext/sections/resource/create.js
@@ -20,7 +20,6 @@ MODx.page.CreateResource = function(config) {
             ,renderTo: config.panelRenderTo || 'modx-panel-resource-div'
             ,resource: 0
             ,record: config.record
-            ,access_permissions: config.access_permissions
             ,publish_document: config.publish_document
             ,show_tvs: config.show_tvs
             ,mode: config.mode

--- a/manager/assets/modext/sections/resource/static/create.js
+++ b/manager/assets/modext/sections/resource/static/create.js
@@ -9,53 +9,17 @@
 MODx.page.CreateStatic = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,formpanel: 'modx-panel-resource'
-        ,id: 'modx-page-update-resource'
-        ,which_editor: 'none'
-        ,action: 'resource/create'
-        ,buttons: this.getButtons(config)
-        ,components: [{
+        components: [{
             xtype: 'modx-panel-static'
             ,renderTo: 'modx-panel-static-div'
             ,resource: 0
             ,record: config.record || {}
             ,publish_document: config.publish_document
-            ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
             ,url: config.url
         }]
     });
     MODx.page.CreateStatic.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.page.CreateStatic,MODx.Component,{
-    getButtons: function(cfg) {
-        var btns = [];
-        if (cfg.canSave == 1) {
-            btns.push({
-                process: 'resource/create'
-                ,reload: true
-                ,text: _('save')
-                ,id: 'modx-abtn-save'
-                ,cls:'primary-button'
-                ,method: 'remote'
-                // ,checkDirty: true
-                ,keys: [{
-                    key: MODx.config.keymap_save || 's'
-                    ,ctrl: true
-                }]
-            });
-        }
-        btns.push({
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        });
-        btns.push({
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        });
-        return btns;
-    }
-});
+Ext.extend(MODx.page.CreateStatic,MODx.page.CreateResource);
 Ext.reg('modx-page-static-create',MODx.page.CreateStatic);

--- a/manager/assets/modext/sections/resource/static/update.js
+++ b/manager/assets/modext/sections/resource/static/update.js
@@ -7,25 +7,14 @@
  * @xtype modx-page-static-update
  */
 MODx.page.UpdateStatic = function(config) {
-    config = config || {record:{}};
-    config.record = config.record || {};
-    Ext.apply(config.record,{
-        'parent-cmb': config.record['parent']
-    });
-
+    config = config || {};
     Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,which_editor: 'none'
-        ,formpanel: 'modx-panel-resource'
-        ,id: 'modx-page-update-resource'
-        ,action: 'resource/update'
-        ,components: [{
+        components: [{
             xtype: 'modx-panel-static'
             ,renderTo: 'modx-panel-static-div'
             ,resource: config.resource
             ,record: config.record || {}
             ,publish_document: config.publish_document
-            ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
             ,url: config.url
         }]
@@ -33,116 +22,5 @@ MODx.page.UpdateStatic = function(config) {
     });
     MODx.page.UpdateStatic.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.page.UpdateStatic,MODx.Component,{
-    preview: function() {
-        window.open(this.config.preview_url);
-        return false;
-    }
-
-    ,duplicateResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_duplicate_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/duplicate'
-                ,id: this.config.resource
-            }
-            ,listeners: {
-                success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
-                },scope:this}
-            }
-        });
-    }
-
-    ,deleteResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_delete_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/delete'
-                ,id: this.config.resource
-            }
-            ,listeners: {
-                success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
-                },scope:this}
-            }
-        });
-    }
-
-    ,cancel: function(btn,e) {
-        var fp = Ext.getCmp(this.config.formpanel);
-        if (fp && fp.isDirty()) {
-            Ext.Msg.confirm(_('warning'),_('resource_cancel_dirty_confirm'),function(e) {
-                if (e == 'yes') {
-                    MODx.releaseLock(MODx.request.id);
-                    MODx.sleep(400);
-                    MODx.loadPage('?');
-                }
-            },this);
-        } else {
-            MODx.releaseLock(MODx.request.id);
-            MODx.loadPage('?');
-        }
-    }
-    ,getButtons: function(cfg) {
-        var btns = [];
-        if (cfg.canSave == 1) {
-            btns.push({
-                process: 'resource/update'
-                ,text: _('save')
-                ,id: 'modx-abtn-save'
-                ,cls:'primary-button'
-                ,method: 'remote'
-                // ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
-                ,keys: [{
-                    key: MODx.config.keymap_save || 's'
-                    ,ctrl: true
-                }]
-            });
-        } else {
-            btns.push({
-                text: cfg.lockedText || _('locked')
-                ,id: 'modx-abtn-locked'
-                ,handler: Ext.emptyFn
-                ,disabled: true
-            });
-        }
-        if (cfg.canCreate == 1) {
-            btns.push({
-                text: _('duplicate')
-                ,id: 'modx-abtn-duplicate'
-                ,handler: this.duplicateResource
-                ,scope:this
-            });
-        }
-        if (cfg.canDelete == 1 && !cfg.locked) {
-            btns.push({
-                text: _('delete')
-                ,id: 'modx-abtn-delete'
-                ,handler: this.deleteResource
-                ,scope:this
-            });
-        }
-        btns.push({
-            text: _('view')
-            ,id: 'modx-abtn-preview'
-            ,handler: this.preview
-            ,scope: this
-        });
-        btns.push({
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-            ,handler: this.cancel
-            ,scope: this
-        });
-        btns.push({
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        });
-        return btns;
-    }
-});
+Ext.extend(MODx.page.UpdateStatic,MODx.page.UpdateResource);
 Ext.reg('modx-page-static-update',MODx.page.UpdateStatic);

--- a/manager/assets/modext/sections/resource/symlink/create.js
+++ b/manager/assets/modext/sections/resource/symlink/create.js
@@ -9,53 +9,17 @@
 MODx.page.CreateSymLink = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,formpanel: 'modx-panel-resource'
-        ,id: 'modx-page-update-resource'
-        ,which_editor: 'none'
-        ,action: 'resource/create'
-        ,buttons: this.getButtons(config)
-        ,components: [{
+        components: [{
             xtype: 'modx-panel-symlink'
             ,renderTo: 'modx-panel-symlink-div'
             ,resource: 0
             ,record: config.record || {}
             ,publish_document: config.publish_document
-            ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
             ,url: config.url
         }]
     });
     MODx.page.CreateSymLink.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.page.CreateSymLink,MODx.Component,{
-    getButtons: function(cfg) {
-        var btns = [];
-        if (cfg.canSave == 1) {
-            btns.push({
-                process: 'resource/create'
-                ,reload: true
-                ,text: _('save')
-                ,id: 'modx-abtn-save'
-                ,cls:'primary-button'
-                ,method: 'remote'
-                // ,checkDirty: true
-                ,keys: [{
-                    key: MODx.config.keymap_save || 's'
-                    ,ctrl: true
-                }]
-            });
-        }
-        btns.push({
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        });
-        btns.push({
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        });
-        return btns;
-    }
-});
+Ext.extend(MODx.page.CreateSymLink,MODx.page.CreateResource);
 Ext.reg('modx-page-symlink-create',MODx.page.CreateSymLink);

--- a/manager/assets/modext/sections/resource/symlink/update.js
+++ b/manager/assets/modext/sections/resource/symlink/update.js
@@ -8,138 +8,18 @@
  */
 MODx.page.UpdateSymLink = function(config) {
     config = config || {};
-
     Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,which_editor: 'none'
-        ,formpanel: 'modx-panel-resource'
-        ,id: 'modx-page-update-resource'
-        ,action: 'resource/update'
-        ,components: [{
+        components: [{
             xtype: 'modx-panel-symlink'
             ,renderTo: 'modx-panel-symlink-div'
             ,resource: config.resource
             ,record: config.record || {}
             ,publish_document: config.publish_document
-            ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
             ,url: config.url
         }]
-        ,buttons: this.getButtons(config)
     });
     MODx.page.UpdateSymLink.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.page.UpdateSymLink,MODx.Component,{
-    preview: function() {
-        window.open(this.config.preview_url);
-        return false;
-    }
-
-    ,duplicateResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_duplicate_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/duplicate'
-                ,id: this.config.resource
-            }
-            ,listeners: {
-                success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
-                },scope:this}
-            }
-        });
-    }
-
-    ,deleteResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_delete_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/delete'
-                ,id: this.config.resource
-            }
-            ,listeners: {
-                success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
-                },scope:this}
-            }
-        });
-    }
-
-    ,cancel: function(btn,e) {
-        var fp = Ext.getCmp(this.config.formpanel);
-        if (fp && fp.isDirty()) {
-            Ext.Msg.confirm(_('warning'),_('resource_cancel_dirty_confirm'),function(e) {
-                if (e == 'yes') {
-                    MODx.releaseLock(MODx.request.id);
-                    MODx.sleep(400);
-                    MODx.loadPage('?');
-                }
-            },this);
-        } else {
-            MODx.releaseLock(MODx.request.id);
-            MODx.loadPage('?');
-        }
-    }
-
-    ,getButtons: function(cfg) {
-        var btns = [];
-        if (cfg.canSave == 1) {
-            btns.push({
-                process: 'resource/update'
-                ,text: _('save')
-                ,id: 'modx-abtn-save'
-                ,cls:'primary-button'
-                ,method: 'remote'
-                // ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
-                ,keys: [{
-                    key: MODx.config.keymap_save || 's'
-                    ,ctrl: true
-                }]
-            });
-        } else {
-            btns.push({
-                text: cfg.lockedText || _('locked')
-                ,id: 'modx-abtn-locked'
-                ,handler: Ext.emptyFn
-                ,disabled: true
-            });
-        }
-        if (cfg.canCreate == 1) {
-            btns.push({
-                text: _('duplicate')
-                ,id: 'modx-abtn-duplicate'
-                ,handler: this.duplicateResource
-                ,scope:this
-            });
-        }
-        if (cfg.canDelete == 1 && !cfg.locked) {
-            btns.push({
-                text: _('delete')
-                ,id: 'modx-abtn-delete'
-                ,handler: this.deleteResource
-                ,scope:this
-            });
-        }
-        btns.push({
-            text: _('view')
-            ,id: 'modx-abtn-preview'
-            ,handler: this.preview
-            ,scope: this
-        });
-        btns.push({
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-            ,handler: this.cancel
-            ,scope: this
-        });
-        btns.push({
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        });
-        return btns;
-    }
-});
+Ext.extend(MODx.page.UpdateSymLink,MODx.page.UpdateResource);
 Ext.reg('modx-page-symlink-update',MODx.page.UpdateSymLink);

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -24,7 +24,6 @@ MODx.page.UpdateResource = function(config) {
             ,resource: config.resource
             ,record: config.record || {}
             ,publish_document: config.publish_document
-            ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
             ,mode: config.mode
             ,url: config.url

--- a/manager/assets/modext/sections/resource/weblink/create.js
+++ b/manager/assets/modext/sections/resource/weblink/create.js
@@ -9,53 +9,17 @@
 MODx.page.CreateWebLink = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,formpanel: 'modx-panel-resource'
-        ,id: 'modx-page-update-resource'
-        ,which_editor: 'none'
-        ,action: 'resource/create'
-        ,buttons: this.getButtons(config)
-        ,components: [{
+        components: [{
             xtype: 'modx-panel-weblink'
             ,renderTo: 'modx-panel-weblink-div'
             ,resource: 0
             ,record: config.record || {}
             ,publish_document: config.publish_document
-            ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
             ,url: config.url
         }]
     });
     MODx.page.CreateWebLink.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.page.CreateWebLink,MODx.Component,{
-    getButtons: function(cfg) {
-        var btns = [];
-        if (cfg.canSave == 1) {
-            btns.push({
-                process: 'resource/create'
-                ,reload: true
-                ,text: _('save')
-                ,id: 'modx-abtn-save'
-                ,cls:'primary-button'
-                ,method: 'remote'
-                // ,checkDirty: true
-                ,keys: [{
-                    key: MODx.config.keymap_save || 's'
-                    ,ctrl: true
-                }]
-            });
-        }
-        btns.push({
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        });
-        btns.push({
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        });
-        return btns;
-    }
-});
+Ext.extend(MODx.page.CreateWebLink,MODx.page.CreateResource);
 Ext.reg('modx-page-weblink-create',MODx.page.CreateWebLink);

--- a/manager/assets/modext/sections/resource/weblink/update.js
+++ b/manager/assets/modext/sections/resource/weblink/update.js
@@ -9,136 +9,17 @@
 MODx.page.UpdateWebLink = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,which_editor: 'none'
-        ,formpanel: 'modx-panel-resource'
-        ,id: 'modx-page-update-resource'
-        ,action: 'resource/update'
-        ,components: [{
+        components: [{
             xtype: 'modx-panel-weblink'
             ,renderTo: 'modx-panel-weblink-div'
             ,resource: config.resource
             ,record: config.record || {}
             ,publish_document: config.publish_document
-            ,access_permissions: config.access_permissions
             ,show_tvs: config.show_tvs
             ,url: config.url
         }]
-        ,buttons: this.getButtons(config)
     });
     MODx.page.UpdateWebLink.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.page.UpdateWebLink,MODx.Component,{
-    preview: function() {
-        window.open(this.config.preview_url);
-        return false;
-    }
-
-    ,duplicateResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_duplicate_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/duplicate'
-                ,id: this.config.resource
-            }
-            ,listeners: {
-                success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
-                },scope:this}
-            }
-        });
-    }
-
-    ,deleteResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_delete_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/delete'
-                ,id: this.config.resource
-            }
-            ,listeners: {
-                success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
-                },scope:this}
-            }
-        });
-    }
-
-    ,cancel: function(btn,e) {
-        var fp = Ext.getCmp(this.config.formpanel);
-        if (fp && fp.isDirty()) {
-            Ext.Msg.confirm(_('warning'),_('resource_cancel_dirty_confirm'),function(e) {
-                if (e == 'yes') {
-                    MODx.releaseLock(MODx.request.id);
-                    MODx.sleep(400);
-                    MODx.loadPage('?');
-                }
-            },this);
-        } else {
-            MODx.releaseLock(MODx.request.id);
-            MODx.loadPage('?');
-        }
-    }
-
-    ,getButtons: function(cfg) {
-        var btns = [];
-        if (cfg.canSave == 1) {
-            btns.push({
-                process: 'resource/update'
-                ,text: _('save')
-                ,id: 'modx-abtn-save'
-                ,cls:'primary-button'
-                ,method: 'remote'
-                // ,checkDirty: cfg.richtext || MODx.request.reload ? false : true
-                ,keys: [{
-                    key: MODx.config.keymap_save || 's'
-                    ,ctrl: true
-                }]
-            });
-        } else {
-            btns.push({
-                text: cfg.lockedText || _('locked')
-                ,id: 'modx-abtn-locked'
-                ,handler: Ext.emptyFn
-                ,disabled: true
-            });
-        }
-        if (cfg.canCreate == 1) {
-            btns.push({
-                text: _('duplicate')
-                ,id: 'modx-abtn-duplicate'
-                ,handler: this.duplicateResource
-                ,scope:this
-            });
-        }
-        if (cfg.canDelete == 1 && !cfg.locked) {
-            btns.push({
-                text: _('delete')
-                ,id: 'modx-abtn-delete'
-                ,handler: this.deleteResource
-                ,scope:this
-            });
-        }
-        btns.push({
-            text: _('view')
-            ,id: 'modx-abtn-preview'
-            ,handler: this.preview
-            ,scope: this
-        });
-        btns.push({
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-            ,handler: this.cancel
-            ,scope: this
-        });
-        btns.push({
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        });
-        return btns;
-    }
-});
+Ext.extend(MODx.page.UpdateWebLink,MODx.page.UpdateResource);
 Ext.reg('modx-page-weblink-update',MODx.page.UpdateWebLink);

--- a/manager/controllers/default/resource/staticresource/create.class.php
+++ b/manager/controllers/default/resource/staticresource/create.class.php
@@ -15,6 +15,7 @@ class StaticResourceCreateManagerController extends ResourceCreateManagerControl
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.tv.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.static.js');
+        $this->addJavascript($mgrUrl.'assets/modext/sections/resource/create.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/static/create.js');
         $this->addHtml('<script type="text/javascript">
 // <![CDATA[

--- a/manager/controllers/default/resource/staticresource/update.class.php
+++ b/manager/controllers/default/resource/staticresource/update.class.php
@@ -15,6 +15,7 @@ class StaticResourceUpdateManagerController extends ResourceUpdateManagerControl
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.tv.js');
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.static.js');
+        $this->addJavascript($managerUrl.'assets/modext/sections/resource/update.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/static/update.js');
         $this->addHtml('<script type="text/javascript">
 // <![CDATA[

--- a/manager/controllers/default/resource/symlink/create.class.php
+++ b/manager/controllers/default/resource/symlink/create.class.php
@@ -15,6 +15,7 @@ class SymLinkCreateManagerController extends ResourceCreateManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.tv.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.symlink.js');
+        $this->addJavascript($mgrUrl.'assets/modext/sections/resource/create.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/symlink/create.js');
         $this->addHtml('<script type="text/javascript">
 // <![CDATA[

--- a/manager/controllers/default/resource/symlink/update.class.php
+++ b/manager/controllers/default/resource/symlink/update.class.php
@@ -15,6 +15,7 @@ class SymlinkUpdateManagerController extends ResourceUpdateManagerController {
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.tv.js');
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.symlink.js');
+        $this->addJavascript($managerUrl.'assets/modext/sections/resource/update.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/symlink/update.js');
         $this->addHtml('
         <script type="text/javascript">

--- a/manager/controllers/default/resource/weblink/create.class.php
+++ b/manager/controllers/default/resource/weblink/create.class.php
@@ -15,6 +15,7 @@ class WebLinkCreateManagerController extends ResourceCreateManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.tv.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.weblink.js');
+        $this->addJavascript($mgrUrl.'assets/modext/sections/resource/create.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/weblink/create.js');
         $this->addHtml('<script type="text/javascript">
 // <![CDATA[

--- a/manager/controllers/default/resource/weblink/update.class.php
+++ b/manager/controllers/default/resource/weblink/update.class.php
@@ -15,6 +15,7 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController {
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.tv.js');
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.weblink.js');
+        $this->addJavascript($managerUrl.'assets/modext/sections/resource/update.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/weblink/update.js');
         $this->addHtml('
         <script type="text/javascript">


### PR DESCRIPTION
Fix bug from #12186 by extending all types of resource pages from resource pages. Also removed access_permissions field since it is always undefined.
