### PR TITLE
Quick update title

### DIFF
--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -248,16 +248,20 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             }
             ,listeners: {
                 'success': {fn:function(r) {
+                    var nameField = (type == 'template') ? 'templatename' : 'name';
                     var w = MODx.load({
                         xtype: 'modx-window-quick-update-'+type
                         ,record: r.object
                         ,listeners: {
                             'success':{fn:function(r) {
                                 this.refreshNode(this.cm.activeNode.id);
+                                var newTitle = '<span dir="ltr">' + r.f.findField(nameField).getValue() + ' (' + w.record.id + ')</span>';
+                                w.setTitle(w.title.replace(/<span.*\/span>/, newTitle));
                             },scope:this}
                             ,'hide':{fn:function() {this.destroy();}}
                         }
                     });
+                    w.title += ' <span dir="ltr">' + w.record[nameField] + ' ('+ w.record.id + ')</span>';
                     w.setValues(r.object);
                     w.show(e.target);
                 },scope:this}
@@ -307,8 +311,8 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             /* do not allow anything to be dropped on an element */
             if(!(targetNode.parentNode &&
                 ((dropNode.attributes.cls == 'folder'
-                    && targetNode.attributes.cls == 'folder'
-                    && dropNode.parentNode.id == targetNode.parentNode.id
+                && targetNode.attributes.cls == 'folder'
+                && dropNode.parentNode.id == targetNode.parentNode.id
                 ) || targetNode.attributes.cls == 'file'))) {
                 r = true;
             }

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -464,12 +464,15 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                         xtype: 'modx-window-quick-update-modResource'
                         ,record: pr
                         ,listeners: {
-                            'success':{fn:function() {
+                            'success':{fn:function(r) {
                                 this.refreshNode(this.cm.activeNode.id);
+                                var newTitle = '<span dir="ltr">' + r.f.findField('pagetitle').getValue() + ' (' + w.record.id + ')</span>';
+                                w.setTitle(w.title.replace(/<span.*\/span>/, newTitle));
                             },scope:this}
                             ,'hide':{fn:function() {this.destroy();}}
                         }
                     });
+                    w.title += ' <span dir="ltr">' + w.record.pagetitle + ' ('+ w.record.id + ')</span>';
                     w.setValues(r.object);
                     w.show(e.target,function() {
                         Ext.isSafari ? w.setPosition(null,30) : w.center();


### PR DESCRIPTION
### Related to

Partly to #11096 and @frogabog in ambassadors channel
### What it does

It shows name of element and pagetitle of resource with ID in Quick Update window title.
### Why is it needed

Open two quick updates, anything. Then collapse them. They both say the same thing. Not the actual chunk name, etc. 
