### PR TITLE
Add check for unpublish_document

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -420,6 +420,12 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
             $this->setProperty('pub_date',$this->object->get('pub_date'));
             $this->setProperty('unpub_date',$this->object->get('unpub_date'));
         }
+
+        $canUnpublish = $this->modx->hasPermission('unpublish_document');
+        if (!$canUnpublish && !$this->getProperty('published')) {
+            $this->setProperty('published', $this->object->get('published'));
+        }
+
         return $canPublish;
     }
 

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -71,7 +71,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
     public function prepareRow(modResource $object) {
         if (!$object->checkPolicy('view')) return array();
 
-        $resourceArray = $object->get(array('id','pagetitle','description','published','deleted'));
+        $resourceArray = $object->get(array('id','pagetitle','description','published','deleted','context_key'));
         $resourceArray['menu'] = array();
         $resourceArray['menu'][] = array(
             'text' => $this->modx->lexicon('resource_view'),

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -18,7 +18,7 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         ,autosave: true
         ,save_action: 'resource/updatefromgrid'
         ,pageSize: 10
-        ,fields: ['id','pagetitle','description','editedon','deleted','published','menu']
+        ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu']
         ,columns: [{
             header: _('id')
             ,dataIndex: 'id'


### PR DESCRIPTION
and fix error 500 in recently edited resources grid
### Related to #3164
### How to reproduce error 500
1. Go to user Profile (?a=security/profile) to Recently edited resources tab.
2. Try to change something.
3. Values in grid are changed but request returns error 500. After reload grid changes are dissapeared.
