### PR TITLE
Make Gravatars always load over https

### DIFF
--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -111,7 +111,7 @@ class TopMenu
                     trim($userProfile->email)
                 )
             );
-            $gravsrc = $this->modx->getOption('url_scheme', null, 'http://') . 'www.gravatar.com/avatar/'
+            $gravsrc = 'https://www.gravatar.com/avatar/'
             .$gravemail . '?s=128&d=mm';
             $userImage = '<img src="' . $gravsrc . '" />';
         }


### PR DESCRIPTION
Omit the setting `url_scheme` since there is no default for it AFAIK.

This change would make every thing in the manager load over https, since this is the only thing not beeing https as fas as I have found. Also there is not really a point of not loading it over https anyway right?
