### PR TITLE
Custom Icons for Contexts

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -344,7 +344,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             ),
             'leaf' => false,
             'cls' => implode(' ', $class),
-            'iconCls' => $context->getOption('mgr_tree_icon_context', 'tree-context'),
+            'iconCls' => !empty($context->getOption('mgr_tree_icon')) ? $context->getOption('mgr_tree_icon') : $this->modx->getOption('mgr_tree_icon_context', null, 'tree-context'),
             'qtip' => $context->get('description') != '' ? strip_tags($context->get('description')) : '',
             'type' => 'modContext',
             'pseudoroot' => true,


### PR DESCRIPTION
![](http://j4p.us/image/3q3E0M2A0R3I/Screen%20Shot%202014-12-13%20at%203.13.33%20AM.png)

If this feature already exists please disregard.
Was under the impression it
already did but doesn’t appear to (i know it does for resource class_key)

the ternary may see overkill but this wasn’t working as expected:

``` php
'iconCls' => $context->getOption('mgr_tree_icon',null,$this->modx->getOption('mgr_tree_icon_context', null, 'tree-context')),
```

To use custom icons on context tree icons, create a `mgr_tree_icon` Context Setting with a value of a [Font Awesome Icon](http://fortawesome.github.io/Font-Awesome/icons/) within the given context.
