### PR TITLE
Added ability to use "non core" request handlers/classes

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1422,6 +1422,9 @@ class modX extends xPDO {
             $requestClass = $this->getOption('modRequest.class',$this->config,$class);
             if ($requestClass !== $class) {
                 $this->loadClass('modRequest', '', false, true);
+                if (!in_array($requestClass, array('modConnectorRequest', 'modManagerRequest')) && empty($path)) {
+                    $path = $this->getOption('modRequest.class_path', $this->config, '');
+                }
             }
             if ($className= $this->loadClass($requestClass, $path, !empty($path), true))
                 $this->request= new $className ($this);


### PR DESCRIPTION
### What does it do ?

Adds a system setting (`modRequest.class_path`) to set the ability to use a third party class to handle requests.
### Why is it needed ?

To extend the ability to use custom request handlers located elsewhere than `core/modx/` (and let the default core folders untouched)
