### PR TITLE
Respect default setting for "syncsite" ("Empty cache" on resource save)

### DIFF
--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -177,7 +177,8 @@ class ResourceUpdateManagerController extends ResourceManagerController {
             $sync = intval($this->resourceArray['syncsite']) === 1;
         } else {
             // Default configuration (from context + user settings)
-            $sync = $this->resource->getOne('Context')->getOption('syncsite_default', true, $this->modx->_userConfig);
+            $sync = $this->modx->getContext($this->resource->context_key)
+                ->getOption('syncsite_default', true, $this->modx->_userConfig);
         }
 
         return $sync;

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -119,7 +119,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
         $this->resourceArray['cacheable'] = intval($this->resourceArray['cacheable']) == 1 ? true : false;
         $this->resourceArray['deleted'] = intval($this->resourceArray['deleted']) == 1 ? true : false;
         $this->resourceArray['uri_override'] = intval($this->resourceArray['uri_override']) == 1 ? true : false;
-        $this->resourceArray['syncsite'] = !isset($this->resourceArray['syncsite']) || intval($this->resourceArray['syncsite']) == 1 ? true : false;
+        $this->resourceArray['syncsite'] = $this->getSyncSite();
         if (!empty($this->resourceArray['parent'])) {
             if ($this->parent->get('id') == $this->resourceArray['parent']) {
                 $this->resourceArray['parent_pagetitle'] = $this->parent->get('pagetitle');
@@ -163,6 +163,24 @@ class ResourceUpdateManagerController extends ResourceManagerController {
 
         $this->setPlaceholder('resource',$this->resource);
         return $placeholders;
+    }
+
+    /**
+     * Check whether or not the "Empty cache" checkbox should be checked
+     *
+     * @return bool
+     */
+    protected function getSyncSite()
+    {
+        if (isset($this->resourceArray['syncsite'])) {
+            // Set via Form Customization
+            $sync = intval($this->resourceArray['syncsite']) === 1;
+        } else {
+            // Default configuration (from context + user settings)
+            $sync = $this->resource->getOne('Context')->getOption('syncsite_default', true, $this->modx->_userConfig);
+        }
+
+        return $sync;
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

Takes care of the `syncsite_default` setting when updating a resource.
### Why is it needed ?

`syncsite` is never stored, unless you define a Form Customization rule doing so.

Before this PR, the behavior was that the "Empty cache" checkbox was checked if no Form Customization rule dealing with "syncsite" was found, not matter what was defined as `syncsite_default` setting.
### Related issue(s)/PR(s)
- Should take care of #11980
