### PR TITLE
Added ability send to provider information about language

### DIFF
--- a/core/model/modx/transport/modtransportprovider.class.php
+++ b/core/model/modx/transport/modtransportprovider.class.php
@@ -60,6 +60,7 @@ class modTransportProvider extends xPDOSimpleObject {
             'database' => $this->xpdo->config['dbtype'],
             'revolution_version' => $productVersion,
             'http_host' => $this->xpdo->getOption('http_host'),
+            'language' => $this->xpdo->getOption('manager_language'),
         ),$params);
         return $this->xpdo->rest->request($this->get('service_url'),$path,$method,$params);
     }


### PR DESCRIPTION
So, now we have official provider, modmore, extras.io and store of simpledream, maybe exists more.
General problem that provider don't know about current manager language. We can requested info from provider with preferred language and if provider can answer on our language, it will do it.
