### PR TITLE
Unset modx.user.userGroups in joinGroup()

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -692,7 +692,8 @@ class modUser extends modPrincipal {
             if (!$joined) {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'An unknown error occurred preventing adding the User to the User Group.');
             } else {
-                unset($_SESSION["modx.user.{$this->get('id')}.userGroupNames"]);
+                 unset($_SESSION["modx.user.{$this->get('id')}.userGroupNames"],
+                     $_SESSION["modx.user.{$this->get('id')}.userGroups"]);
             }
         } else {
             $joined = true;


### PR DESCRIPTION
The user's userGroups $_SESSION variable is used by other methods to get the user's groups. It needs to be cleared in addition to userGroupNames.
