### PR TITLE
Fixed rte popup not closing when clicking cancel

### DIFF
--- a/manager/assets/modext/widgets/core/modx.rte.browser.js
+++ b/manager/assets/modext/widgets/core/modx.rte.browser.js
@@ -86,7 +86,7 @@ MODx.browser.RTE = function(config) {
                 ,width: 200
             },{
                 text: _('cancel')
-                ,handler: this.hide
+                ,handler: this.closeWindow
                 ,scope: this
                 ,width: 200
             }]
@@ -226,6 +226,13 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
     
     ,onSelectHandler: function(data) {
         Ext.get(this.returnEl).dom.value = unescape(data.url);
+    }
+
+    ,closeWindow: function () {
+        var callback = this.config.onSelect || this.onSelectHandler;
+        var scope = this.config.scope;
+        Ext.callback(callback,scope || this,[null]);
+        this.fireEvent('select',null);
     }
 });
 Ext.reg('modx-browser-rte',MODx.browser.RTE);


### PR DESCRIPTION
This pull + modxcms/TinyMCE#15 should solve #8164.

These pulls are created this way to use the same methods as the "Ok" button uses, insead of solving it completely different.

The changes in the Modx Core (this pull) sends a callback to the handler and simply passes null as the data. The changes required by the TinyMCE is to check if the data is null and simply close if that is the case. 

In terms of BC this should not be any problems as far as I can see:
- If Modx Core is outdated, null will never be passed as the data and everything should behave like it does today
- If TinyMCE is outdated the check for null will fail and a script error will be thrown, however, this does not differ much from the current solution where the popup simply goes blank when clicking the button.

It is not a perfect solution, but it is the only way that honors the current implementation.
