### PR TITLE
$object in processors

### DIFF
--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -702,7 +702,7 @@ abstract class modObjectCreateProcessor extends modObjectProcessor {
                 'data' => $this->object->toArray(),
                 $this->primaryKeyField => 0,
                 $this->objectType => &$this->object,
-                'object' => &$this->object, // for backwards compatibility, do not use this key
+                'object' => &$this->object,
             ));
             if (is_array($OnBeforeFormSave)) {
                 $preventSave = false;
@@ -728,7 +728,7 @@ abstract class modObjectCreateProcessor extends modObjectProcessor {
                 'mode' => modSystemEvent::MODE_NEW,
                 $this->primaryKeyField => $this->object->get($this->primaryKeyField),
                 $this->objectType => &$this->object,
-                'object' => &$this->object, // for backwards compatibility, do not use this key
+                'object' => &$this->object,
             ));
         }
     }
@@ -869,6 +869,7 @@ abstract class modObjectUpdateProcessor extends modObjectProcessor {
                 'data' => $this->object->toArray(),
                 $this->primaryKeyField => $this->object->get($this->primaryKeyField),
                 $this->objectType => &$this->object,
+                'object' => &$this->object,
             ));
             if (is_array($OnBeforeFormSave)) {
                 $preventSave = false;
@@ -894,6 +895,7 @@ abstract class modObjectUpdateProcessor extends modObjectProcessor {
                 'mode' => modSystemEvent::MODE_UPD,
                 $this->primaryKeyField => $this->object->get($this->primaryKeyField),
                 $this->objectType => &$this->object,
+                'object' => &$this->object,
             ));
         }
     }
@@ -1127,6 +1129,7 @@ abstract class modObjectRemoveProcessor extends modObjectProcessor {
             $response = $this->modx->invokeEvent($this->beforeRemoveEvent,array(
                 $this->primaryKeyField => $this->object->get($this->primaryKeyField),
                 $this->objectType => &$this->object,
+                'object' => &$this->object,
             ));
             $preventRemove = $this->processEventResponse($response);
         }
@@ -1142,6 +1145,7 @@ abstract class modObjectRemoveProcessor extends modObjectProcessor {
             $this->modx->invokeEvent($this->afterRemoveEvent,array(
                 $this->primaryKeyField => $this->object->get($this->primaryKeyField),
                 $this->objectType => &$this->object,
+                'object' => &$this->object,
             ));
         }
     }
@@ -1281,6 +1285,7 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor {
             $response = $this->modx->invokeEvent($this->beforeRemoveEvent, array(
                 $this->primaryKeyField => $this->object->get($this->primaryKeyField),
                 $this->objectType => &$this->object,
+                'object' => &$this->object,
             ));
             $preventRemove = $this->processEventResponse($response);
         }
@@ -1297,6 +1302,7 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor {
             $this->modx->invokeEvent($this->afterRemoveEvent, array(
                 $this->primaryKeyField => $this->object->get($this->primaryKeyField),
                 $this->objectType => &$this->object,
+                'object' => &$this->object,
             ));
         }
     }


### PR DESCRIPTION
Usually plugins used $resource variable cause resource/update processor [have objectType = 'resource'](https://github.com/modxcms/revolution/blob/master/core/model/modx/processors/resource/update.class.php#L54). But some processors may use different variable, for example https://github.com/Fi1osof/shopModx/blob/master/core/components/shopmodx/processors/mgr/resourceproduct/update.class.php#L6 It`s need for [lexicon](https://github.com/modxcms/revolution/blob/master/core/model/modx/modprocessor.class.php#L964). 
For this reason some extras create fatal errors, for example:
https://github.com/Sterc/SEOPro/blob/master/core/components/seopro/elements/plugins/seopro.plugin.php#L13
https://github.com/Mark-H/VersionX/blob/develop/core/components/versionx/plugin.inc.php#L43
and have to do like this: https://github.com/Fi1osof/modRedirect/blob/master/core/components/modredirect/elements/plugins/modredirect.plugin.php#L49
