### PR TITLE
Take care of namespaces when checking manager controllers' permissions on modMenu records

### DIFF
--- a/core/model/modx/modmanagerresponse.class.php
+++ b/core/model/modx/modmanagerresponse.class.php
@@ -204,16 +204,17 @@ class modManagerResponse extends modResponse {
     public function checkForMenuPermissions($action) {
         $canAccess = true;
         /** @var modMenu $menu */
-        $menu = $this->modx->getObject('modMenu',array(
+        $menu = $this->modx->getObject('modMenu', array(
             'action' => $action,
+            'namespace' => $this->action['namespace'],
         ));
         if ($menu) {
             $permissions = $menu->get('permissions');
             if (!empty($permissions)) {
-                $permissions = explode(',',$permissions);
+                $permissions = explode(',', $permissions);
                 foreach ($permissions as $permission) {
                     if (!$this->modx->hasPermission($permission)) {
-                        $canAccess = false;
+                        return false;
                     }
                 }
             }


### PR DESCRIPTION
### What does it do ?

Takes care of manager controllers' namespace when checking for related `modMenu` permissions.
### Why is it needed ?

A really well detailed report as been done here https://github.com/modxcms/revolution/issues/7327#issuecomment-33815408

In addition, since 2.3, `modMenu.action` could be duplicate (they no more are integers). So we must handle namespaces.
### Related issue(s)/PR(s)
- Partially fixes #7327
