### PR TITLE
Reverted change that broke ability to customize Media Source tree icon (manager)

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -195,9 +195,6 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         el.className = 'modx-tree-node-tool-ct';
         node.ui.elNode.appendChild(el);
 
-        // add an icon for the source / root node (not possible via processor as for the other trees)
-        node.ui.iconNode.className = 'icon ' + (MODx.config.mgr_tree_icon_source || 'icon-hdd-o');
-
         MODx.load({
             xtype: 'modx-button'
             ,text: ''


### PR DESCRIPTION
### What does it do ?

Revert "forcing" Media Source root node tree icon.
### Why is it needed ?

https://github.com/modxcms/revolution/pull/11881 introduced the ability to customize Media Source tree icons. This line was breaking it.
