### PR TITLE
Make sure "locked" is sent before setting its "locked" value, when updating an element

### DIFF
--- a/core/model/modx/processors/element/update.class.php
+++ b/core/model/modx/processors/element/update.class.php
@@ -12,8 +12,10 @@ abstract class modElementUpdateProcessor extends modObjectUpdateProcessor {
     public $object;
 
     public function beforeSave() {
-        $locked = $this->getProperty('locked',false);
-        $this->object->set('locked',(boolean)$locked);
+        $locked = $this->getProperty('locked');
+        if (!is_null($locked)) {
+            $this->object->set('locked',(boolean)$locked);
+        }
 
         /* make sure a name was specified */
         $nameField = $this->classKey == 'modTemplate' ? 'templatename' : 'name';


### PR DESCRIPTION
### What does it do ?

Prevent setting `modElement.locked` if not sent.
### Why is it needed ?

When you "quick update" an element with the "locked" attribute, the element data sent does not include the 'locked' attribute, resulting in it being "reset" to `false`
### Related issue(s)/PR(s)
- Fixes #4298
