### PR TITLE
Delete single property set record

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -509,7 +509,6 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
             ,handler: this.update
         });
 
-        console.log(r);
         if (r.overridden) {
             m.push({
                 text: _('property_revert')

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -502,13 +502,14 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
         var def = this.isDefaultPropSet();
 
         var r = this.menu.record;
-        var m = []
+        var m = [];
         m.push({
             text: _('property_update')
             ,scope: this
             ,handler: this.update
         });
 
+        console.log(r);
         if (r.overridden) {
             m.push({
                 text: _('property_revert')
@@ -516,7 +517,7 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
                 ,handler: this.revert
             });
         }
-        if (r.overridden == 2 && !def) {
+        if ((r.overridden == 2 && !def) || (r.overridden != 1 && def) || (!r.overridden && !def)) {
             m.push({
                 text: _('property_remove')
                 ,scope: this
@@ -527,16 +528,6 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
             });
         }
 
-        if (r.overridden != 1 && def) {
-            m.push({
-                text: _('property_remove')
-                ,scope: this
-                ,handler: this.remove.createDelegate(this,[{
-                    title: _('warning')
-                    ,text: _('property_remove_confirm')
-                }])
-            });
-        }
         return m;
     }
 


### PR DESCRIPTION
### What does it do ?

Make sure to offer the ability to remove a property set "property" if not overridden & not a default property.
### Why is it needed ?

When editing property sets, it was not possible to delete a single property.
### Related issue(s)/PR(s)
- Fixes #7918
