### PR TITLE
Check if host have an internet access before trying to retrieve RSS feeds for dashboard widgets

### DIFF
--- a/manager/controllers/default/dashboard/widget.modx-news.php
+++ b/manager/controllers/default/dashboard/widget.modx-news.php
@@ -17,6 +17,9 @@ class modDashboardWidgetNewsFeed extends modDashboardWidgetInterface {
      * @return string
      */
     public function render() {
+        if (!checkdnsrr('google.com', 'ANY')) {
+            return '';
+        }
         $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
         $this->rss = new modRSSParser($this->modx);
 

--- a/manager/controllers/default/dashboard/widget.modx-security.php
+++ b/manager/controllers/default/dashboard/widget.modx-security.php
@@ -12,8 +12,11 @@ class modDashboardWidgetSecurityFeed extends modDashboardWidgetInterface {
      * @var modRSSParser $rss
      */
     public $rss;
-    
+
     public function render() {
+        if (!checkdnsrr('google.com', 'ANY')) {
+            return '';
+        }
         $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
         $this->rss = new modRSSParser($this->modx);
 


### PR DESCRIPTION
**NOTES** : 
- not tested (no local installation available)
- method `checkdnsrr` is not available before PHP 5.3 for Windows **ONLY** (see http://php.net/manual/en/function.checkdnsrr.php). If that is a critical issue, we might consider making use of `gethostbyname()`
- source : http://stackoverflow.com/questions/1696202/check-if-host-computer-is-online-with-php
### What does it do ?

Check if we can find any DNS record for google.com, to assume "server" have an internet access, before trying to load RSS feeds.
### Why is it needed ?

When being "offline", feeds take a huge time trying to fetch RSS feeds, resulting in slow manager dashboard.
### Related issue(s)/PR(s)
- Should take care of #11531
