### PR TITLE
Some TLC for the system information page

### DIFF
--- a/manager/assets/modext/sections/system/info.js
+++ b/manager/assets/modext/sections/system/info.js
@@ -27,109 +27,104 @@ var viewPHPInfo = function() {
 MODx.panel.SystemInfo = function(config) {
     config = config || {};
     var info = [{
-		xtype: 'statictextfield'
-		,fieldLabel: _('modx_version')
-		,name: 'modx_version'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('version_codename')
-		,name: 'code_name'
-	},{
-		html: '<a href="javascript:;" onclick="viewPHPInfo();return false;">'+_('view')+'</a>'
-		,fieldLabel: 'phpinfo()'
-		,name: 'phpinfo'
-		,value: ''
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('servertime')
-		,name: 'servertime'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('localtime')
-		,name: 'localtime'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('serveroffset')
-		,name: 'serveroffset'
-	},{
-		html: '<hr />'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('extjs_version')
-		,name: 'extjs_version'
-		,value: '3.4.1'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('smarty_version')
-		,name: 'smarty_version'
-		,value: '3.0.4'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('phpmailer_version')
-		,name: 'phpmailer_version'
-		,value: '5.2.8'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('magpie_version')
-		,name: 'magpie_version'
-		,value: '0.72'
-	},{
-		html: '<hr />'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('database_type')
-		,name: 'database_type'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('database_version')
-		,name: 'database_version'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('database_charset')
-		,name: 'database_charset'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('database_name')
-		,name: 'database_name'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('database_server')
-		,name: 'database_server'
-	},{
-		xtype: 'statictextfield'
-		,fieldLabel: _('table_prefix')
-		,name: 'table_prefix'
+        fieldLabel: _('modx_version')
+        ,name: 'modx_version'
+    },{
+        fieldLabel: _('version_codename')
+        ,name: 'code_name'
+    },{
+        html: '<a href="javascript:;" onclick="viewPHPInfo();return false;">'+_('view')+'</a>'
+        ,fieldLabel: 'phpinfo()'
+        ,name: 'phpinfo'
+        ,xtype: 'container'
+    },{
+        fieldLabel: _('servertime')
+        ,name: 'servertime'
+    },{
+        fieldLabel: _('localtime')
+        ,name: 'localtime'
+    },{
+        fieldLabel: _('serveroffset')
+        ,name: 'serveroffset'
+    },{
+        html: '<hr />'
+        ,xtype: 'container'
+    },{
+        fieldLabel: _('extjs_version')
+        ,name: 'extjs_version'
+        ,value: '3.4.1'
+    },{
+        fieldLabel: _('smarty_version')
+        ,name: 'smarty_version'
+        ,value: '3.0.4'
+    },{
+        fieldLabel: _('phpmailer_version')
+        ,name: 'phpmailer_version'
+        ,value: '5.2.8'
+    },{
+        fieldLabel: _('magpie_version')
+        ,name: 'magpie_version'
+        ,value: '0.72'
+    },{
+        html: '<hr />'
+        ,xtype: 'container'
+    },{
+        fieldLabel: _('database_type')
+        ,name: 'database_type'
+    },{
+        fieldLabel: _('database_version')
+        ,name: 'database_version'
+    },{
+        fieldLabel: _('database_charset')
+        ,name: 'database_charset'
+    },{
+        fieldLabel: _('database_name')
+        ,name: 'database_name'
+    },{
+        fieldLabel: _('database_server')
+        ,name: 'database_server'
+    },{
+        fieldLabel: _('table_prefix')
+        ,name: 'table_prefix'
     }];
     if (config.data) {
         for (var c in config.data) {
-            info.push({html: '<hr />'});
+            info.push({
+                html: '<hr />'
+                ,xtype: 'container'
+            });
             for (var d in config.data[c]) {
                 info.push({
-                    xtype: 'statictextfield'
-                    ,fieldLabel: d
+                    fieldLabel: d
                     ,name: d
                     ,value: config.data[c][d]
                 });
             }
         }
     }
-	var pnl = [{
+    var pnl = [{
         html: '<p>'+_('sysinfo_desc')+'</p>'
         ,id: 'modx-sysinfo-msg'
-		,bodyCssClass: 'panel-desc'
+        ,bodyCssClass: 'panel-desc'
     },{
-		xtype: 'panel'
-		,border: false
-		,cls:'main-wrapper'
-		,layout: 'form'
-		,defaults: { border: false, msgTarget: 'side', anchor: '100%' }
-		,items: [info]
-	}];
-    Ext.applyIf(config,{
+        xtype: 'panel'
+        ,border: false
+        ,cls:'main-wrapper'
+        ,layout: 'form'
+        ,defaults: {
+            border: false
+            ,msgTarget: 'side'
+            ,anchor: '100%'
+        }
+        ,defaultType: 'displayfield'
+        ,items: [info]
+    }];
+
+    Ext.applyIf(config, {
         id: 'modx-panel-system-info'
         ,url: MODx.config.connector_url
         ,layout: 'anchor'
-		,cls: 'container'
+        ,cls: 'container'
         ,items: [{
             html: '<h2>'+_('view_sysinfo')+'</h2>'
             ,id: 'modx-error-log-header'
@@ -146,28 +141,29 @@ MODx.panel.SystemInfo = function(config) {
         },{
             title: _('db_header')
             ,id: 'modx-sysinfo-dbtables'
-            ,layout: 'form'
+            ,layout: 'anchor'
             ,items: [{
                 html: '<p>'+_('db_info_' + MODx.config.dbtype)+'</p>'
                 ,id: 'modx-sysinfo-dbtables-msg'
-				,bodyCssClass: 'panel-desc'
+                ,bodyCssClass: 'panel-desc'
                 ,border: false
             },{
                 xtype: 'modx-grid-databasetables'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,preventRender: true
             }]
         },{
             title: _('recent_docs')
             ,id: 'modx-sysinfo-recent-docs'
+            ,layout: 'anchor'
             ,items: [{
                 html: '<p>'+_('sysinfo_activity_message')+'</p>'
                 ,id: 'modx-sysinfo-recent-docs-msg'
-				,bodyCssClass: 'panel-desc'
+                ,bodyCssClass: 'panel-desc'
                 ,border: false
             },{
                 xtype: 'modx-grid-resource-active'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,title: _('recent_docs')
                 ,preventRender: true
             }]
@@ -179,7 +175,7 @@ MODx.panel.SystemInfo = function(config) {
         }
     });
     MODx.panel.SystemInfo.superclass.constructor.call(this,config);
-}
+};
 Ext.extend(MODx.panel.SystemInfo,MODx.FormPanel,{
 
     initialized: false
@@ -194,10 +190,13 @@ Ext.extend(MODx.panel.SystemInfo,MODx.FormPanel,{
                 action: 'system/info'
             }
             ,listeners: {
-            	'success': {fn:function(r) {
-                    this.getForm().setValues(r.object);
-                    this.initialized = true;
-            	},scope:this}
+                'success': {
+                    fn: function(r) {
+                        this.getForm().setValues(r.object);
+                        this.initialized = true;
+                    }
+                    ,scope: this
+                }
             }
         });
     }


### PR DESCRIPTION
### What does it do ?
- make use of `defaultType` to define the default xtype of a panel's items (prevent "duplicate" xtype declarations)
- use `displayfield` xtype instead of `statictextfield`
### Why is it needed ?

Mostly to allow copy/paste of the data
### Related issue(s)/PR(s)
- Fixes #2516
