### PR TITLE
Grid head/content column width fix

### DIFF
--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -145,6 +145,7 @@
 }
 
 .x-grid3-row td, .x-grid3-summary-row td {
+  border-left: 1px solid transparent;
   padding-left: 0;
 }
 
@@ -153,11 +154,11 @@
   border-right: none;
 }
 
-.x-grid3-hd-row td.x-grid3-cell-first {
+.x-grid3-hd-row td.x-grid3-cell-first, .x-grid3-row td.x-grid3-cell-first, .x-grid3-row td.x-grid3-summary-first {
   border-left: 0 none;
 }
 
-.x-grid3-hd-row td.x-grid3-cell-last {
+.x-grid3-hd-row td.x-grid3-cell-last, .x-grid3-row td.x-grid3-cell-last, .x-grid3-row td.x-grid3-summary-last {
   border-right: 0 none;
 }
 


### PR DESCRIPTION
The grid head and content have different widths because the head has a border left and the content has no border. This is only the scss fix.

Wrong:
![wrong](https://cloud.githubusercontent.com/assets/148371/5705772/06f1a330-9a7c-11e4-8663-c297ddf8467e.png)

Right:
![right](https://cloud.githubusercontent.com/assets/148371/5705783/11bff9f6-9a7c-11e4-8a7b-e1bf0abd66c1.png)
