### PR TITLE
Make use of the parser to process 'forgot_login_email' system setting value

### DIFF
--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -236,9 +236,13 @@ class SecurityLoginManagerController extends modManagerController {
             $placeholders['manager_url'] = $this->modx->getOption('manager_url');
             $placeholders['hash'] = $activationHash;
             $placeholders['password'] = $newPassword;
+            // Store previous placeholders
+            $ph = $this->modx->placeholders;
+            // now set those useful for modParser
             $this->modx->setPlaceholders($placeholders);
             $this->modx->getParser()->processElementTags('', $message, false, false);
-            $this->modx->unsetPlaceholders($placeholders);
+            // Then restore previous placeholders to prevent any breakage
+            $this->modx->placeholders = $ph;
 
             $this->modx->getService('mail', 'mail.modPHPMailer');
             $this->modx->mail->set(modMail::MAIL_BODY, $message);

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -236,11 +236,9 @@ class SecurityLoginManagerController extends modManagerController {
             $placeholders['manager_url'] = $this->modx->getOption('manager_url');
             $placeholders['hash'] = $activationHash;
             $placeholders['password'] = $newPassword;
-            foreach ($placeholders as $k => $v) {
-                if (is_string($v)) {
-                    $message = str_replace('[[+'.$k.']]',$v,$message);
-                }
-            }
+            $this->modx->setPlaceholders($placeholders);
+            $this->modx->getParser()->processElementTags('', $message, false, false);
+            $this->modx->unsetPlaceholders($placeholders);
 
             $this->modx->getService('mail', 'mail.modPHPMailer');
             $this->modx->mail->set(modMail::MAIL_BODY, $message);


### PR DESCRIPTION
### What does it do ?

Make use of the parser to process `forgot_login_email` system setting value.
### Why is it needed ?

To : 
1. ease the edition of the email (ie. chunks might be more convenient)
2. allow i18n
3. use additional tags (snippets/chunks/setting...)
### To do before merge
- [x] make sure `unsetPlaceholders` will not break anything
### Related issue(s)/PR(s)
- Fixes #3969
- Related to #6092
