### PR TITLE
Added RTE to all resource types

### DIFF
--- a/manager/controllers/default/resource/staticresource/create.class.php
+++ b/manager/controllers/default/resource/staticresource/create.class.php
@@ -34,6 +34,8 @@ Ext.onReady(function() {
 });
 // ]]>
 </script>');
+        /* load RTE */
+        $this->loadRichTextEditor();
     }
     
     /**

--- a/manager/controllers/default/resource/staticresource/update.class.php
+++ b/manager/controllers/default/resource/staticresource/update.class.php
@@ -40,6 +40,8 @@ Ext.onReady(function() {
 });
 // ]]>
 </script>');
+        /* load RTE */
+        $this->loadRichTextEditor();
     }
 
 

--- a/manager/controllers/default/resource/symlink/create.class.php
+++ b/manager/controllers/default/resource/symlink/create.class.php
@@ -34,6 +34,8 @@ Ext.onReady(function() {
 });
 // ]]>
 </script>');
+        /* load RTE */
+        $this->loadRichTextEditor();
     }
     
     /**

--- a/manager/controllers/default/resource/weblink/create.class.php
+++ b/manager/controllers/default/resource/weblink/create.class.php
@@ -34,6 +34,8 @@ Ext.onReady(function() {
 });
 // ]]>
 </script>');
+        /* load RTE */
+        $this->loadRichTextEditor();
     }
     
     /**

--- a/manager/controllers/default/resource/weblink/update.class.php
+++ b/manager/controllers/default/resource/weblink/update.class.php
@@ -41,6 +41,8 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController {
         });
         // ]]>
         </script>');
+        /* load RTE */
+        $this->loadRichTextEditor();
     }
     
     /**


### PR DESCRIPTION
### What does it do ?

Fix the RichText TV type for weblink and symlink, by loading the same function as the modDocument resource
### Why is it needed ?

At the moment the RTE doesn't load for the RichText TV on these resource types.
### Related issue(s)/PR(s)
#11206 and #10296
