### PR TITLE
clean "onAjaxException" to remove full HTML document tag to avoid breaking manager

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -113,9 +113,15 @@ Ext.extend(MODx,Ext.Component,{
         try {
             r = Ext.decode(r.responseText);
         } catch (e) {
+            var text, matched = r.responseText.match(/<body[^>]*>([\w|\W]*)<\/body>/im);
+            if (typeof(matched[1] !== 'undefined')) {
+                text = '<p>'+e.message+':</p>'+matched[1];
+            } else {
+                text = e.message+': '+ r.responseText;
+            }
             Ext.MessageBox.show({
                 title: _('error')
-                ,msg: e.message+': '+ r.responseText
+                ,msg: text
                 ,buttons: Ext.MessageBox.OK
                 ,cls: 'modx-js-parse-error'
                 ,minWidth: 600


### PR DESCRIPTION
**### What does it do ?**
Clean returning ajax message by removing full HTML contents from server.

``` html
<xml ...>
<!DOCTYPE html ...>
<html>
    <header>
         <!-- html headers -->
    </header>
    <body>
         <!-- error body -->
    </body>
</html>
```

**### Why is it needed ?**
Currently, if server returns FATAL ERROR on an AJAX request, the pop up error window also breaks Manager, because it resets HTML headers.
