### PR TITLE
Children must be composites

### DIFF
--- a/core/model/modx/mysql/modusergroup.map.inc.php
+++ b/core/model/modx/mysql/modusergroup.map.inc.php
@@ -148,6 +148,14 @@ $xpdo_meta_map['modUserGroup']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
+    'Children' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'id',
+      'foreign' => 'parent',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
   ),
   'aggregates' => 
   array (
@@ -158,14 +166,6 @@ $xpdo_meta_map['modUserGroup']= array (
       'foreign' => 'id',
       'cardinality' => 'one',
       'owner' => 'foreign',
-    ),
-    'Children' => 
-    array (
-      'class' => 'modUserGroup',
-      'local' => 'id',
-      'foreign' => 'parent',
-      'cardinality' => 'many',
-      'owner' => 'local',
     ),
     'Dashboard' => 
     array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -948,7 +948,6 @@
         </index>
 
         <aggregate alias="Parent" class="modResource" local="parent" foreign="id" cardinality="one" owner="foreign" />
-        <aggregate alias="Children" class="modResource" local="id" foreign="parent" cardinality="many" owner="local" />
         <aggregate alias="CreatedBy" class="modUser" local="createdby" foreign="id" cardinality="one" owner="foreign" />
         <aggregate alias="EditedBy" class="modUser" local="editedby" foreign="id" cardinality="one" owner="foreign" />
         <aggregate alias="DeletedBy" class="modUser" local="deletedby" foreign="id" cardinality="one" owner="foreign" />
@@ -958,6 +957,7 @@
         <aggregate alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="template" foreign="templateid" cardinality="many" owner="local" />
         <aggregate alias="ContentType" class="modContentType" local="content_type" foreign="id" owner="foreign" cardinality="one" />
         <aggregate alias="Context" class="modContext" local="context_key" foreign="key" owner="foreign" cardinality="one" />
+        <composite alias="Children" class="modResource" local="id" foreign="parent" cardinality="many" owner="local" />
         <composite alias="TemplateVarResources" class="modTemplateVarResource" local="id" foreign="contentid" cardinality="many" owner="local" />
         <composite alias="ResourceGroupResources" class="modResourceGroupResource" local="id" foreign="document" cardinality="many" owner="local" />
         <composite alias="Acls" class="modAccessResource" local="id" foreign="target" owner="local" cardinality="many" />


### PR DESCRIPTION
I have changed only this (moved to aggregates):
'Children' =>
- array (
- 'class' => 'modUserGroup',
- 'local' => 'id',
- 'foreign' => 'parent',
- 'cardinality' => 'many',
- 'owner' => 'local',
- ),

Other - whitespaces.
