### PR TITLE
Fixed issue where TV output properties were not loaded due to bad column name

### DIFF
--- a/core/model/modx/processors/element/tv/renders/getproperties.class.php
+++ b/core/model/modx/processors/element/tv/renders/getproperties.class.php
@@ -14,7 +14,7 @@ require_once dirname(__FILE__).'/getinputproperties.class.php';
  */
 
 class modTvRendersGetOutputPropertiesProcessor extends modTvRendersGetPropertiesProcessor {
-    public $propertiesKey = 'properties';
+    public $propertiesKey = 'output_properties';
     public $renderDirectory = 'properties';
     public $onPropertiesListEvent = 'OnTVOutputPropertiesList';
 }


### PR DESCRIPTION
### What does it do ?

Fixed bad output properties `modTemplateVar` column name.
### Why is it needed ?

TVs output properties were not properly loaded from DB.
### Steps to reproduce issue
- create a TV with (for example) "delimiter" output, set the delimiter to `,` & save
- reload the TV form, and notice the delimiter field value is empty (albeit properly saved into the DB)
