### PR TITLE
Update package.windows.js

### DIFF
--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -139,6 +139,8 @@ MODx.window.SetupOptions = function(config) {
     Ext.applyIf(config,{
         title: _('setup_options')
 		,layout: 'form'
+		,width: 650
+		,autoHeight: true
 		,items:[{
 			xtype: 'modx-template-panel'
 			,id: 'modx-setupoptions-panel'


### PR DESCRIPTION
Setup options window with a width and a auto-height to make setup-options view better.

A setup-option text-field input should be formatted like:

<pre>&#x3C;div class=&#x22;x-form-item &#x22; tabindex=&#x22;-1&#x22; id=&#x22;ext-gen-YOUR-UNIQUE-ID&#x22;&#x3E;
&#x9;&#x3C;label for=&#x22;ext-comp-YOUR-UNIQUE-ID&#x22; style=&#x22;width:auto;&#x22; class=&#x22;x-form-item-label&#x22; id=&#x22;ext-gen-YOUR-UNIQUE-ID&#x22;&#x3E;From amount:&#x3C;/label&#x3E;
&#x9;&#x3C;div class=&#x22;x-form-element&#x22; id=&#x22;x-form-el-ext-comp-sc-so-field1&#x22; style=&#x22;padding-left:0;&#x22;&#x3E;
&#x9;&#x9;&#x3C;input type=&#x22;text&#x22; autocomplete=&#x22;on&#x22; msgtarget=&#x22;under&#x22; id=&#x22;ext-comp-YOUR-UNIQUE-ID&#x22; name=&#x22;from_amount&#x22; class=&#x22;x-form-text x-form-field x-form-num-field&#x22; style=&#x22;width:98%;min-width:420px;&#x22;&#x3E;
&#x9;&#x3C;/div&#x3E;
&#x9;&#x3C;div class=&#x22;x-form-clear-left&#x22;&#x3E;&#x3C;/div&#x3E;
&#x3C;/div&#x3E;</pre>


Maybe even make setup options window handle an PHP array (JSON) to add fields dynamically? (in Extjs format?)
