### PR TITLE
Prevent modContext.aliasMap usage when using modX::makeUrl from manager

### DIFF
--- a/core/model/modx/modcontext.class.php
+++ b/core/model/modx/modcontext.class.php
@@ -396,11 +396,14 @@ class modContext extends modAccessibleObject {
      * @return string|bool The URI of the Resource, or false if not found in this Context.
      */
     public function getResourceURI($id) {
-        $uri = false;
-        if (isset($this->aliasMap)) {
-            $uri= array_search($id, $this->aliasMap);
+        if ($this->getOption('cache_alias_map') && isset($this->aliasMap)) {
+            $uri = array_search($id, $this->aliasMap);
         } else {
-            $query = $this->xpdo->newQuery('modResource', array('id' => $id, 'deleted' => false, 'context_key' => $this->get('key')));
+            $query = $this->xpdo->newQuery('modResource', array(
+                'id' => $id,
+                'deleted' => false,
+                'context_key' => $this->get('key')
+            ));
             $query->select($this->xpdo->getSelectColumns('modResource', '', '', array('uri')));
             $uri = $this->xpdo->getValue($query->prepare());
         }

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -173,6 +173,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
      */
     public function getPreviewUrl() {
         if (!$this->resource->get('deleted')) {
+            $this->modx->setOption('cache_alias_map', false);
             $sessionEnabled = '';
             $ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $this->resource->get('context_key'), 'key' => 'session_enabled'));
 


### PR DESCRIPTION
### What does it do ?

Prevents using `modContext.aliasMap` (by setting `cache_alias_map` to `false`), when computing the "preview url" of a resource, from the manager.
### Why is it needed ?

When creating a new resource and having the "Empty cache" checkbox unchecked while `cache_alias_map` setting being active (`true`), the context cache is not cleared (as expected), resulting in having an empty "preview url" when being redirected to the update form.

On the update form, if you click the preview button, it will open a blank tab instead of the requested resource.
### Related issue(s)/PR(s)
- Possibly related to #12250
