### PR TITLE
Fixing tooltip full viewport width

### DIFF
--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -538,6 +538,8 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   border-radius: $borderRadius;
   padding: 5px;
   width: auto !important; /* override ExtJS inline width */
+  max-width: 400px;
+  min-width: 200px;
 }
 .x-tip .x-tip-close {
   background-image: url($imgPath + 'modx-theme/qtip/close.gif');


### PR DESCRIPTION
### What does it do ?

Two css rules are added. max-width: 400px; & min-width: 200px;
### Why is it needed ?

The Tooltip width i.e. in a MODX.window is set by .x-tip { width: auto !important; /\* override ExtJS inline width */  } to auto. Because of that a tooltip has full viewport width if there is enough text in it. This is a very bad UX.

As quick fix there should be a max-width (and a min-width) set.
