### PR TITLE
URL encode source attribute to prevent `getimagesize()` failing.

### DIFF
--- a/core/model/modx/processors/system/phpthumb.class.php
+++ b/core/model/modx/processors/system/phpthumb.class.php
@@ -33,7 +33,7 @@ class modSystemPhpThumbProcessor extends modProcessor {
      * @return mixed
      */
     public function process() {
-        $src = $this->getProperty('src');
+        $src = urlencode($this->getProperty('src'));
         if (empty($src)) return $this->failure();
 
         $this->unsetProperty('src');


### PR DESCRIPTION
When pulling resources from remote server, spaces and special chars in the filename can cause `@GetImageSize()` call in `phpthumb::ImageCreateFromFilename()` to fail. Adding a call to `urlencode()` on the source fixes this.

Verified that this change doesn't effect local FS.
