### PR TITLE
Update of Font Awesome to version 4.3.0

### DIFF
--- a/_build/templates/default/bower.json
+++ b/_build/templates/default/bower.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "bourbon": "^4.0.2",
     "neat":"~1.6.0",
-    "font-awesome": "~4.2.0"
+    "font-awesome": "~4.3.0"
   },
   "exportsOverride": {
     "bourbon": {


### PR DESCRIPTION
As a issue #12312 that is requesting Font Awesome to version 4.3.0 that adds new icons. I updated the bower file with the version and also checked if the icons are working in the manager.
