### PR TITLE
Make handlers on menu actions be applied together with normal actions

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -403,6 +403,7 @@ $children[2]->fromArray(array (
   'description' => 'logout_desc',
   'parent' => 'user',
   'permissions' => 'logout',
+  'action' => 'security/logout',
   'handler' => 'MODx.logout(); return false;',
 ), '', true, true);
 

--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -650,7 +650,7 @@ abstract class modObjectCreateProcessor extends modObjectProcessor {
         }
 
         /* save element */
-        if ($this->object->save() == false) {
+        if ($this->saveObject() == false) {
             $this->modx->error->checkValidation($this->object);
             return $this->failure($this->modx->lexicon($this->objectType.'_err_save'));
         }
@@ -660,6 +660,15 @@ abstract class modObjectCreateProcessor extends modObjectProcessor {
         $this->fireAfterSaveEvent();
         $this->logManagerAction();
         return $this->cleanup();
+    }
+
+    /**
+     * Abstract the saving of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function saveObject() {
+        return $this->object->save();
     }
 
     /**
@@ -969,8 +978,8 @@ class modObjectDuplicateProcessor extends modObjectProcessor {
             return $this->failure($canSave);
         }
 
-        /* save new chunk */
-        if ($this->newObject->save() === false) {
+        /* save new object */
+        if ($this->saveObject() === false) {
             $this->modx->error->checkValidation($this->newObject);
             return $this->failure($this->modx->lexicon($this->objectType.'_err_duplicate'));
         }
@@ -978,6 +987,15 @@ class modObjectDuplicateProcessor extends modObjectProcessor {
         $this->afterSave();
         $this->logManagerAction();
         return $this->cleanup();
+    }
+
+    /**
+     * Abstract the saving of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function saveObject() {
+        return $this->newObject->save();
     }
 
     /**
@@ -1082,7 +1100,7 @@ abstract class modObjectRemoveProcessor extends modObjectProcessor {
             return $this->failure($preventRemoval);
         }
 
-        if ($this->object->remove() == false) {
+        if ($this->removeObject() == false) {
             return $this->failure($this->modx->lexicon($this->objectType.'_err_remove'));
         }
         $this->afterRemove();
@@ -1090,6 +1108,15 @@ abstract class modObjectRemoveProcessor extends modObjectProcessor {
         $this->logManagerAction();
         $this->cleanup();
         return $this->success('',array($this->primaryKeyField => $this->object->get($this->primaryKeyField)));
+    }
+
+    /**
+     * Abstract the removing of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function removeObject() {
+        return $this->object->save();
     }
 
     /**
@@ -1228,7 +1255,7 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor {
             $this->object->set($this->deletedByField, $this->modx->user->id);
         }
 
-        if ($this->object->save() == false) {
+        if ($this->saveObject() == false) {
             return $this->failure($this->modx->lexicon($this->objectType . '_err_soft_remove'));
         }
 
@@ -1238,6 +1265,15 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor {
         $this->cleanup();
 
         return $this->success('', array($this->primaryKeyField => $this->object->get($this->primaryKeyField)));
+    }
+
+    /**
+     * Abstract the saving of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function saveObject() {
+        return $this->object->save();
     }
 
     /**

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -151,9 +151,8 @@ class TopMenu
 
             $top = (!empty($menu['children'])) ? ' class="top"' : '';
             $menuTpl = '<li id="limenu-'.$menu['id'].'"'.$top.'>'."\n";
-            if (!empty($menu['handler'])) {
-                $menuTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'">'.$label.'</a>'."\n";
-            } elseif (!empty($menu['action'])) {
+
+            if (!empty($menu['action'])) {
                 if ($menu['namespace'] != 'core') {
                     // Handle the namespace
                     $menu['action'] .= '&namespace='.$menu['namespace'];
@@ -162,7 +161,10 @@ class TopMenu
                     // No icon, no title property
                     $title = '';
                 }
-                $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.( $top ? ' class="top-link"': '' ).$title.'>'.$label.$description.'</a>'."\n";
+                $onclick = (!empty($menu['handler'])) ? ' onclick="'.str_replace('"','\'',$menu['handler']).'"' : '';
+                $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.( $top ? ' class="top-link"': '' ).$onclick.$title.'>'.$label.$description.'</a>'."\n";
+            } elseif (!empty($menu['handler'])) {
+                $menuTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'">'.$label.'</a>'."\n";
             } else {
                 $menuTpl .= '<a href="javascript:;">'.$label.'</a>'."\n";
             }
@@ -293,19 +295,17 @@ class TopMenu
                 $description = '<span class="description">'.$menu['description'].'</span>'."\n";
             }
 
-            if (!empty($menu['handler'])) {
-                $smTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'">'.$menu['text'].$description.'</a>'."\n";
-            } else {
-                $url = '';
-                if (!empty($menu['action'])) {
-                    if ($menu['namespace'] != 'core') {
-                        $menu['action'] .= '&namespace='.$menu['namespace'];
-                    }
-                    $url = ' href="?a='.$menu['action'].$menu['params'].'"';
+            $attributes = '';
+            if (!empty($menu['action'])) {
+                if ($menu['namespace'] != 'core') {
+                    $menu['action'] .= '&namespace='.$menu['namespace'];
                 }
-                //$url = (!empty($menu['action']) ? '?a='.$menu['action'].$menu['params'] : '#');
-                $smTpl .= '<a'.$url.'>'.$menu['text'].$description.'</a>'."\n";
+                $attributes = ' href="?a='.$menu['action'].$menu['params'].'"';
             }
+            if (!empty($menu['handler'])) {
+                $attributes .= ' onclick="'.str_replace('"','\'',$menu['handler']).'"';
+            }
+            $smTpl .= '<a'.$attributes.'>'.$menu['text'].$description.'</a>'."\n";
 
             if (!empty($menu['children'])) {
                 $smTpl .= '<ul class="modx-subsubnav">'."\n";


### PR DESCRIPTION
### What does it do ?

Changed the logout menu item using the security/logout action. The handler is also be applied on menu items, together with the action. When the JS handler is returning false, it will not fire the action request URL at all.
### Why is it needed ?

When having JS issues, you cannot logout the manager anymore. Which is necessary in some cases. This will prevent (at least) the logout menu item to work.
### Related issue(s)/PR(s)

https://github.com/modx-ccc-2015/whishlist/issues/65
