### PR TITLE
The DIV creates creates a duplicate ID and is not needed anayway

### DIFF
--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,4 +1,3 @@
-<div id="tvbrowser{$tv->id}"></div>
 <div id="tv-image-{$tv->id}"></div>
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
     {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&src={$tv->value}&source={$source}" alt="" />{/if}


### PR DESCRIPTION
The DIV has the same ID as the input element:
https://github.com/modxcms/revolution/blob/master/manager/assets/modext/widgets/element/modx.panel.tv.renders.js#L30

Deleting the DIV has no effect when editing the resource.
