### PR TITLE
The DIV creates creates a duplicate ID and is not needed anayway

### DIFF
--- a/manager/templates/default/element/tv/renders/input/file.tpl
+++ b/manager/templates/default/element/tv/renders/input/file.tpl
@@ -1,4 +1,3 @@
-<div id="tvbrowser{$tv->id}"></div>
 <div id="tvpanel{$tv->id}"></div>
 
 {if $disabled}


### PR DESCRIPTION
The DIV has the same ID as the input element:
https://github.com/modxcms/revolution/blob/master/manager/assets/modext/widgets/element/modx.panel.tv.renders.js#L30

Deleting the DIV has no effect when editing the resource.
