### PR TITLE
Added multiple saveObjects and removeObjects to make the workflow the same

### DIFF
--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -650,7 +650,7 @@ abstract class modObjectCreateProcessor extends modObjectProcessor {
         }
 
         /* save element */
-        if ($this->object->save() == false) {
+        if ($this->saveObject() == false) {
             $this->modx->error->checkValidation($this->object);
             return $this->failure($this->modx->lexicon($this->objectType.'_err_save'));
         }
@@ -660,6 +660,15 @@ abstract class modObjectCreateProcessor extends modObjectProcessor {
         $this->fireAfterSaveEvent();
         $this->logManagerAction();
         return $this->cleanup();
+    }
+
+    /**
+     * Abstract the saving of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function saveObject() {
+        return $this->object->save();
     }
 
     /**
@@ -969,8 +978,8 @@ class modObjectDuplicateProcessor extends modObjectProcessor {
             return $this->failure($canSave);
         }
 
-        /* save new chunk */
-        if ($this->newObject->save() === false) {
+        /* save new object */
+        if ($this->saveObject() === false) {
             $this->modx->error->checkValidation($this->newObject);
             return $this->failure($this->modx->lexicon($this->objectType.'_err_duplicate'));
         }
@@ -978,6 +987,15 @@ class modObjectDuplicateProcessor extends modObjectProcessor {
         $this->afterSave();
         $this->logManagerAction();
         return $this->cleanup();
+    }
+
+    /**
+     * Abstract the saving of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function saveObject() {
+        return $this->newObject->save();
     }
 
     /**
@@ -1082,7 +1100,7 @@ abstract class modObjectRemoveProcessor extends modObjectProcessor {
             return $this->failure($preventRemoval);
         }
 
-        if ($this->object->remove() == false) {
+        if ($this->removeObject() == false) {
             return $this->failure($this->modx->lexicon($this->objectType.'_err_remove'));
         }
         $this->afterRemove();
@@ -1090,6 +1108,15 @@ abstract class modObjectRemoveProcessor extends modObjectProcessor {
         $this->logManagerAction();
         $this->cleanup();
         return $this->success('',array($this->primaryKeyField => $this->object->get($this->primaryKeyField)));
+    }
+
+    /**
+     * Abstract the removing of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function removeObject() {
+        return $this->object->save();
     }
 
     /**
@@ -1228,7 +1255,7 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor {
             $this->object->set($this->deletedByField, $this->modx->user->id);
         }
 
-        if ($this->object->save() == false) {
+        if ($this->saveObject() == false) {
             return $this->failure($this->modx->lexicon($this->objectType . '_err_soft_remove'));
         }
 
@@ -1238,6 +1265,15 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor {
         $this->cleanup();
 
         return $this->success('', array($this->primaryKeyField => $this->object->get($this->primaryKeyField)));
+    }
+
+    /**
+     * Abstract the saving of the object out to allow for transient and non-persistent object updating in derivative
+     * classes
+     * @return boolean
+     */
+    public function saveObject() {
+        return $this->object->save();
     }
 
     /**

--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -1116,7 +1116,7 @@ abstract class modObjectRemoveProcessor extends modObjectProcessor {
      * @return boolean
      */
     public function removeObject() {
-        return $this->object->save();
+        return $this->object->remove();
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

It updates a couple of modObject processors to use saveObject and removeObject etc. to make the flow the same as the modObjectCreateProcessor does.
### Why is it needed ?

Not really necessary, but it will keep things the same.
Also possible to use afterSave and that kind of methods, but now you can actually overwrite the savings itself.
### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/issues/12289
