### PR TITLE
Allowing empty resource pagetitle. Will be set automatically to "Untitled Resource {id}"

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2032,4 +2032,13 @@ $settings['auto_isfolder']->fromArray(array (
     'area' => 'site',
     'editedon' => null,
 ), '', true, true);
+$settings['resource_allow_empty_pagetitle']= $xpdo->newObject('modSystemSetting');
+$settings['resource_allow_empty_pagetitle']->fromArray(array (
+  'key' => 'resource_allow_empty_pagetitle',
+  'value' => false,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 return $settings;

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -617,6 +617,9 @@ $_lang['setting_resource_tree_node_name_fallback_desc'] = 'Specify the Resource 
 $_lang['setting_resource_tree_node_tooltip'] = 'Resource Tree Tooltip Field';
 $_lang['setting_resource_tree_node_tooltip_desc'] = 'Specify the Resource field to use when rendering the nodes in the Resource Tree. Any Resource field can be used, such as menutitle, alias, longtitle, etc. If blank, will be the longtitle with a description underneath.';
 
+$_lang['setting_resource_allow_empty_pagetitle'] = 'Allow Empty Resource Pagetitles';
+$_lang['setting_resource_allow_empty_pagetitle_desc'] = 'Whether or not the resource pagetitle may be left empty. When enabled, it will create "Untitled Resource" and use the new ID to the title, to make it unique.';
+
 $_lang['setting_richtext_default'] = 'Richtext Default';
 $_lang['setting_richtext_default_desc'] = 'Select \'Yes\' to make all new Resources use the Richtext Editor by default.';
 

--- a/core/model/modx/processors/resource/create.class.php
+++ b/core/model/modx/processors/resource/create.class.php
@@ -318,18 +318,21 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
      * @return string
      */
     public function preparePageTitle() {
+        $allowEmpty = $this->modx->getOption('resource_allow_empty_pagetitle', null, false);
         $pageTitle = $this->getProperty('pagetitle','');
-        if (!empty($pageTitle)) {
-            $pageTitle = trim($pageTitle);
-        }
-
-        /* default pagetitle if not reloading template */
-        if (!$this->getProperty('reloadOnly',false)) {
-            if ($pageTitle === '') {
-                $pageTitle = $this->modx->lexicon('resource_untitled');
+        if (!$allowEmpty) {
+            if (!empty($pageTitle)) {
+                $pageTitle = trim($pageTitle);
             }
+
+            /* default pagetitle if not reloading template */
+            if (!$this->getProperty('reloadOnly', false)) {
+                if ($pageTitle === '') {
+                    $pageTitle = $this->modx->lexicon('resource_untitled');
+                }
+            }
+            $this->setProperty('pagetitle', $pageTitle);
         }
-        $this->setProperty('pagetitle',$pageTitle);
         return $pageTitle;
     }
 
@@ -339,8 +342,9 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
      * @return string
      */
     public function setPageTitle() {
+        $allowEmpty = $this->modx->getOption('resource_allow_empty_pagetitle', null, false);
         $pageTitle = trim($this->object->get('pagetitle'));
-        if (empty($pageTitle)) {
+        if ($allowEmpty && empty($pageTitle)) {
             $pageTitle = $this->modx->lexicon('resource_untitled') . ' ' . $this->object->get('id');
             $this->object->set('pagetitle', $pageTitle);
             $this->object->set('alias', $pageTitle);

--- a/core/model/modx/processors/resource/create.class.php
+++ b/core/model/modx/processors/resource/create.class.php
@@ -173,6 +173,7 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
      */
     public function afterSave() {
         $this->object->addLock();
+        $this->setPageTitle();
         $this->setParentToContainer();
         $this->saveResourceGroups();
         $this->checkIfSiteStart();
@@ -329,6 +330,22 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
             }
         }
         $this->setProperty('pagetitle',$pageTitle);
+        return $pageTitle;
+    }
+
+    /**
+     * Checks the page it's title and will be set to "Untitled Resource {id}"
+     *
+     * @return string
+     */
+    public function setPageTitle() {
+        $pageTitle = trim($this->object->get('pagetitle'));
+        if (empty($pageTitle)) {
+            $pageTitle = $this->modx->lexicon('resource_untitled') . ' ' . $this->object->get('id');
+            $this->object->set('pagetitle', $pageTitle);
+            $this->object->set('alias', $pageTitle);
+            $this->object->save();
+        }
         return $pageTitle;
     }
 

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -126,6 +126,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         $this->workingContext = $this->modx->getContext($this->getProperty('context_key', $this->object->get('context_key') ? $this->object->get('context_key') : 'web'));
 
         $this->trimPageTitle();
+        $this->setPageTitle();
         $this->handleParent();
         $root = (int) $this->modx->getOption('tree_root_id');
         if ($this->object->parent != $root && $this->getProperty('parent') === $root && !$this->modx->hasPermission('new_document_in_root')) {
@@ -190,6 +191,20 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
             }
         }
         return $locked;
+    }
+
+    /**
+     * Checks the page it's title and will be set to "Untitled Resource {id}"
+     *
+     * @return string
+     */
+    public function setPageTitle() {
+        $pageTitle = trim($this->object->get('pagetitle'));
+        if (empty($pageTitle)) {
+            $pageTitle = $this->modx->lexicon('resource_untitled') . ' ' . $this->object->get('id');
+            $this->setProperty('pagetitle', $pageTitle);
+        }
+        return $pageTitle;
     }
 
     /**

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -199,8 +199,9 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
      * @return string
      */
     public function setPageTitle() {
-        $pageTitle = trim($this->object->get('pagetitle'));
-        if (empty($pageTitle)) {
+        $allowEmpty = $this->modx->getOption('resource_allow_empty_pagetitle', null, false);
+        $pageTitle = trim($this->getProperty('pagetitle'));
+        if ($allowEmpty && empty($pageTitle)) {
             $pageTitle = $this->modx->lexicon('resource_untitled') . ' ' . $this->object->get('id');
             $this->setProperty('pagetitle', $pageTitle);
         }

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -468,7 +468,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,id: 'modx-resource-pagetitle'
             ,maxLength: 255
             ,anchor: '100%'
-            ,allowBlank: true
+            ,allowBlank: !(MODx.config.resource_allow_empty_pagetitle == 0)
             ,enableKeyEvents: true
             ,listeners: {
                 'keyup': {fn: function(f,e) {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -468,7 +468,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,id: 'modx-resource-pagetitle'
             ,maxLength: 255
             ,anchor: '100%'
-            ,allowBlank: false
+            ,allowBlank: true
             ,enableKeyEvents: true
             ,listeners: {
                 'keyup': {fn: function(f,e) {

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -816,7 +816,7 @@ MODx.window.QuickCreateResource = function(config) {
                             ,fieldLabel: _('resource_pagetitle')+'<span class="required">*</span>'
                             ,description: '<b>[[*pagetitle]]</b><br />'+_('resource_pagetitle_help')
                             ,anchor: '100%'
-                            ,allowBlank: false
+                            ,allowBlank: true
                         },{
                             xtype: 'textfield'
                             ,name: 'longtitle'

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -816,7 +816,7 @@ MODx.window.QuickCreateResource = function(config) {
                             ,fieldLabel: _('resource_pagetitle')+'<span class="required">*</span>'
                             ,description: '<b>[[*pagetitle]]</b><br />'+_('resource_pagetitle_help')
                             ,anchor: '100%'
-                            ,allowBlank: true
+                            ,allowBlank: !(MODx.config.resource_allow_empty_pagetitle == 0)
                         },{
                             xtype: 'textfield'
                             ,name: 'longtitle'


### PR DESCRIPTION
### What does it do ?

It checks if you submit empty pagetitles and when you do, it uses Lexicon "resource_untitled" concatenated with the new ID of the resource and also updates the alias when you create a new resource.
At update, it is checking the pagetitle again to, also updating the title, not the alias.
Also added a system setting "resource_allow_empty_pagetitle" to enable/disable this feature.
### Why is it needed ?

It's not really necessary but it's a cool feature to allow empty pagetitles at creation and updating. Especially for those who sets the pagetitle hidden in FC
### Related issue(s)/PR(s)

Should resolve https://github.com/modxcms/revolution/issues/12239
