### PR TITLE
Fixes #12360 Add Namespace to checkForMenuPermissions()

### DIFF
--- a/core/model/modx/modmanagerresponse.class.php
+++ b/core/model/modx/modmanagerresponse.class.php
@@ -206,6 +206,7 @@ class modManagerResponse extends modResponse {
         /** @var modMenu $menu */
         $menu = $this->modx->getObject('modMenu',array(
             'action' => $action,
+            'namespace' => $this->namespace
         ));
         if ($menu) {
             $permissions = $menu->get('permissions');


### PR DESCRIPTION
### What does it do ?

Adds Namespace to checkForMenuPermissions() so Menu items that have the same Action can have separate permissions.
### Why is it needed ?

Fix the bug
### Related issue(s)/PR(s)

Did not see any
