### PR TITLE
Prevent JS error when Media Source is not in the first combo store page (Media Browser)

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -235,7 +235,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                         var id = combo.store.find('id', this.config.source);
                         var rec = combo.store.getAt(id);
                         var rn = this.getRootNode();
-                        if (rn) { rn.setText(rec.data.name); }
+                        if (rn && rec) { rn.setText(rec.data.name); }
                     }
                     ,scope: this
                 }


### PR DESCRIPTION
### What does it do ?

Make sure we find the record in the media source combo box store (Media Browser).
### Why is it needed ?

When you have a long list of media sources, it becomes paginated. If your default media source is not listed on the first page of the media source combo store, an error arises.
This just prevents the error, leaving the combo box and the tree "pseudo root node" displaying the media source ID instead of the name.
