### PR TITLE
Hide arrow next to Resource title in tree for empty folders

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -166,7 +166,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         );
         $this->itemClass= 'modResource';
         $c= $this->modx->newQuery($this->itemClass);
-        $c->leftJoin('modResource', 'Child', array('modResource.id = Child.parent'));
+        $c->leftJoin('modResource', 'Child', array('modResource.id = Child.parent AND Child.show_in_tree = true'));
         $c->select($this->modx->getSelectColumns('modResource', 'modResource', '', $resourceColumns));
         $c->select(array(
             'childrenCount' => 'COUNT(Child.id)',


### PR DESCRIPTION
### What does it do ?

Changes way how in getNode processor is calculated number of children for resources. Within this change it will not count Resource that has `show_in_tree` set to `false` as a children. Change is only in this processor where it affects only displaying expanding arrow in tree next to the resource and a folder icon.
### Why is it needed ?

Without this change expanding arrow appears in tree for all Resources that have any children (even if they are all hidden from tree), which leads to unnecessary request -> when you click on the arrow, it fires request, but no resources are returned and arrow disappear.
### Related issue(s)/PR(s)

Resolves modxcms/collections#13
