### PR TITLE
Auto suggest setting key in contexts and users settings

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -1020,3 +1020,27 @@ MODx.combo.ManagerTheme = function(config) {
 };
 Ext.extend(MODx.combo.ManagerTheme,MODx.combo.ComboBox);
 Ext.reg('modx-combo-manager-theme',MODx.combo.ManagerTheme);
+
+MODx.combo.SettingKey = function(config) {
+    config = config || {};
+    Ext.applyIf(config,{
+        name: 'key'
+        ,hiddenName: 'key'
+        ,displayField: 'key'
+        ,valueField: 'key'
+        ,fields: ['key']
+        ,url: MODx.config.connector_url
+        ,baseParams: {
+            action: 'system/settings/getlist'
+        }
+        ,typeAhead: false
+        ,triggerAction: 'all'
+        ,editable: true
+        ,forceSelection: false
+        ,queryParam: 'key'
+        ,pageSize: 20
+    });
+    MODx.combo.SettingKey.superclass.constructor.call(this,config);
+};
+Ext.extend(MODx.combo.SettingKey,MODx.combo.ComboBox);
+Ext.reg('modx-combo-setting-key',MODx.combo.SettingKey);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -360,6 +360,7 @@ Ext.reg('modx-combo-area',MODx.combo.Area);
 
 MODx.window.CreateSetting = function(config) {
     config = config || {};
+    config.keyField = config.keyField || {};
     Ext.applyIf(config,{
         title: _('setting_create')
         ,width: 600
@@ -381,14 +382,14 @@ MODx.window.CreateSetting = function(config) {
                     ,name: 'fk'
                     ,id: 'modx-cs-fk'
                     ,value: config.fk || 0
-                },{
+                },Ext.applyIf(config.keyField, {
                     xtype: 'textfield'
                     ,fieldLabel: _('key')
                     ,name: 'key'
                     ,id: 'modx-cs-key'
                     ,maxLength: 100
                     ,anchor: '100%'
-                },{
+                }),{
                     xtype: 'label'
                     ,forId: 'modx-cs-key'
                     ,html: _('key_desc')

--- a/manager/assets/modext/widgets/security/modx.grid.user.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.settings.js
@@ -31,6 +31,27 @@ MODx.grid.UserSettings = function(config) {
                 ,baseParams: {
                     action: 'security/user/setting/create'
                 }
+                ,keyField: {
+                    xtype: 'modx-combo-setting-key'
+                    ,fieldLabel: _('key')
+                    ,name: 'key'
+                    ,id: 'modx-cs-key'
+                    ,maxLength: 100
+                    ,anchor: '100%'
+                    ,listeners: {
+                        'render': {
+                            fn: function(key) {
+                                key.getStore().baseParams.namespace = Ext.getCmp('modx-cs-namespace').getValue();
+
+                                Ext.getCmp('modx-cs-namespace').on('select', function(combo, item) {
+                                    key.getStore().baseParams.namespace = item.data.name;
+                                    key.getStore().load();
+                                }, this);
+                            }
+                            ,scope: this
+                        }
+                    }
+                }
                 ,fk: config.user
             }
         }]

--- a/manager/assets/modext/widgets/system/modx.grid.context.settings.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.settings.js
@@ -31,6 +31,27 @@ MODx.grid.ContextSettings = function(config) {
                 ,baseParams: {
                     action: 'context/setting/create'
                 }
+                ,keyField: {
+                    xtype: 'modx-combo-setting-key'
+                    ,fieldLabel: _('key')
+                    ,name: 'key'
+                    ,id: 'modx-cs-key'
+                    ,maxLength: 100
+                    ,anchor: '100%'
+                    ,listeners: {
+                        'render': {
+                            fn: function(key) {
+                                key.getStore().baseParams.namespace = Ext.getCmp('modx-cs-namespace').getValue();
+
+                                Ext.getCmp('modx-cs-namespace').on('select', function(combo, item) {
+                                    key.getStore().baseParams.namespace = item.data.name;
+                                    key.getStore().load();
+                                }, this);
+                            }
+                            ,scope: this
+                        }
+                    }
+                }
                 ,fk: config.context_key
             }
         }]


### PR DESCRIPTION
### What does it do ?

Changes input type to select box with auto suggestion support based on selected namespace in user's and context's settings.
### Why is it needed ?

Prevent user error in copying system settings keys.
### Related issue(s)/PR(s)

Resolves #12325
