### PR TITLE
improvement to news and security widget DNS check

### DIFF
--- a/manager/controllers/default/dashboard/widget.modx-news.php
+++ b/manager/controllers/default/dashboard/widget.modx-news.php
@@ -17,14 +17,15 @@ class modDashboardWidgetNewsFeed extends modDashboardWidgetInterface {
      * @return string
      */
     public function render() {
-        if (function_exists('checkdnsrr') && !checkdnsrr('google.com', 'ANY')) {
+        $url = $this->modx->getOption('feed_modx_news');
+        $feedHost = parse_url($url, PHP_URL_HOST);
+        if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
             return '';
         }
         $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
         $this->rss = new modRSSParser($this->modx);
 
         $o = array();
-        $url = $this->modx->getOption('feed_modx_news');
         $newsEnabled = $this->modx->getOption('feed_modx_news_enabled',null,true);
         if (!empty($url) && !empty($newsEnabled)) {
             $rss = $this->rss->parse($url);

--- a/manager/controllers/default/dashboard/widget.modx-security.php
+++ b/manager/controllers/default/dashboard/widget.modx-security.php
@@ -14,14 +14,15 @@ class modDashboardWidgetSecurityFeed extends modDashboardWidgetInterface {
     public $rss;
 
     public function render() {
-        if (function_exists('checkdnsrr') && !checkdnsrr('google.com', 'ANY')) {
+        $url = $this->modx->getOption('feed_modx_security');
+        $feedHost = parse_url($url, PHP_URL_HOST);
+        if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
             return '';
         }
         $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
         $this->rss = new modRSSParser($this->modx);
 
         $o = array();
-        $url = $this->modx->getOption('feed_modx_security');
         $newsEnabled = $this->modx->getOption('feed_modx_security_enabled',null,true);
         if (!empty($url) && !empty($newsEnabled)) {
             $rss = $this->rss->parse($url);


### PR DESCRIPTION
### What does it do ?
- bypasses what may be buggy, though uncommon, behavior in PHP's `checkdnsrr()` function
- changes the widgets' DNS check to use the hostname of the feed that will be read by the widget
### Why is it needed ?

See issue #12383 
### Related issue(s)/PR(s)

n/a
