### PR TITLE
Fix RTE file browser file remove action for not default media source

### DIFF
--- a/manager/assets/modext/widgets/core/modx.rte.browser.js
+++ b/manager/assets/modext/widgets/core/modx.rte.browser.js
@@ -35,6 +35,19 @@ MODx.browser.RTE = function(config) {
         ,id: this.ident+'-tree'
         ,listeners: {
             'afterUpload': {fn:function() { this.view.run(); },scope:this}
+            ,'changeSource': {fn:function(s) {
+                this.config.source = s;
+                this.view.config.source = s;
+                this.view.baseParams.source = s;
+                this.view.dir = '/';
+                this.view.run();
+            },scope:this}
+            ,afterrender: {
+                fn: function(tree) {
+                    tree.root.expand();
+                }
+                ,scope: this
+            }
         }
     });
     this.tree.on('click',function(node,e) {


### PR DESCRIPTION
This functionality needs to be unified together with generic file browser.

There is almost same code (this.view, this.tree, ...) with lot of "bugs" in
a) manager/assets/modext/widgets/core/modx.rte.browser.js
b) manager/assets/modext/core/modx.view.js
c) manager/assets/modext/widgets/media/browser.js

Hopefully someone will have enough time make it soon :)
