### PR TITLE
Set default background color for thumbs to WHITE instead of BLACK

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -39,7 +39,7 @@ class phpthumb {
 	var $sh   = null;     // Source crop Height
 	var $zc   = null;     // Zoom Crop
 	var $bc   = null;     // Border Color
-	var $bg   = null;     // BackGround color
+	var $bg   = "ffffff"; // BackGround color
 	var $fltr = array();  // FiLTeRs
 	var $goto = null;     // GO TO url after processing
 	var $err  = null;     // default ERRor image filename
@@ -1496,7 +1496,7 @@ class phpthumb {
 			// $UnAllowedParameters contains options that can only be processed in GD, not ImageMagick
 			// note: 'fltr' *may* need to be processed by GD, but we'll check that in more detail below
 			$UnAllowedParameters = array('xto', 'ar', 'bg', 'bc');
-			// 'ra' may be part of this list, if not a multiple of 90°
+			// 'ra' may be part of this list, if not a multiple of 90Â°
 			foreach ($UnAllowedParameters as $parameter) {
 				if (isset($this->$parameter)) {
 					$this->DebugMessage('$this->useRawIMoutput=false because "'.$parameter.'" is set', __FILE__, __LINE__);


### PR DESCRIPTION
The default background color for thumbs of "PNGs with transparency" used to be black, which does not play well together with the white background of the resource editing page. Black is NEVER the right choice.

![image](https://cloud.githubusercontent.com/assets/458619/6812521/cb9fc740-d26f-11e4-8f29-c4696b795b02.png)

Another solution would have been to change the default filetype $f="png", but this would lead to bigger thumbnail files.
