### PR TITLE
Make modTransportProvider.request available as public

### DIFF
--- a/core/model/modx/transport/modtransportprovider.class.php
+++ b/core/model/modx/transport/modtransportprovider.class.php
@@ -388,7 +388,7 @@ class modTransportProvider extends xPDOSimpleObject {
      * @param array $params An array of parameters to send to the REST request
      * @return modRestResponse|bool The response from the REST request, or false
      */
-    protected function request($path, $method = 'GET', $params = array()) {
+    public function request($path, $method = 'GET', $params = array()) {
         $response = false;
         $service = $this->getClient();
         if ($service) {


### PR DESCRIPTION
### Summary

Prior to 2.4, `modTransportProvider->request()` was available as public method. I've used this in a custom transport vehicle to communicate license information back and forth from a custom provider; tapping into the modTransportProvider object for making sure authentication and all other params are automatically passed along.

The rewritten `modTransportProvider->request()` being marked as protected broke that >:(
### Step to reproduce

Grab a provider object, and attempt to call ->request on it.
### Observed behavior

It throws a fatal php error due to the method access being set to protectd.
### Expected behavior

It should send a request to the provider, as it did in 2.3. 
### Environment

Any
