### PR TITLE
Set default background color for thumbs to WHITE instead of BLACK v1.1

### DIFF
--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -12,7 +12,8 @@ require_once MODX_CORE_PATH.'model/phpthumb/phpthumb.class.php';
  * @subpackage phpthumb
  */
 class modPhpThumb extends phpThumb {
-
+    var $bg   = "ffffff"; // Set BackGround color to white
+    
     function __construct(modX &$modx,array $config = array()) {
         $this->modx =& $modx;
         $this->config = array_merge(array(


### PR DESCRIPTION
The default background color for thumbs of "PNGs with transparency" used to be black, which does not play well together with the white background of the resource editing page. 
Black is NEVER the right choice for a thumb's background. ;-)

![cb9fc740-d26f-11e4-8f29-c4696b795b02](https://cloud.githubusercontent.com/assets/458619/7084207/018d098c-df6b-11e4-907d-c20f74d6dc72.png)

Another solution would have been to change the default filetype $f="png", but this would lead to bigger thumbnail files.
