### PR TITLE
Implement new use_frozen_parent_uris option to respect frozen parent URIs in generating child URIs

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -782,6 +782,15 @@ $settings['friendly_urls_strict']->fromArray(array (
   'area' => 'furls',
   'editedon' => null,
 ), '', true, true);
+$settings['use_frozen_parent_uris']= $xpdo->newObject('modSystemSetting');
+$settings['use_frozen_parent_uris']->fromArray(array (
+  'key' => 'use_frozen_parent_uris',
+  'value' => '0',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'furls',
+  'editedon' => null,
+), '', true, true);
 $settings['global_duplicate_uri_check']= $xpdo->newObject('modSystemSetting');
 $settings['global_duplicate_uri_check']->fromArray(array (
   'key' => 'global_duplicate_uri_check',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -750,6 +750,9 @@ $_lang['setting_use_editor'] = 'Enable Rich Text Editor';
 $_lang['setting_use_editor_desc'] = 'Do you want to enable the rich text editor? If you\'re more comfortable writing HTML, then you can turn the editor off using this setting. Note that this setting applies to all documents and all users!';
 $_lang['setting_use_editor_err'] = 'Please state whether or not you want to use an RTE editor.';
 
+$_lang['setting_use_frozen_parent_uris'] = 'Use Frozen Parent URIs';
+$_lang['setting_use_frozen_parent_uris_desc'] = 'When enabled, the URI for children resources will be relative to the frozen URI of one of its parents, ignoring the aliases of resources high in the tree.';
+
 $_lang['setting_use_multibyte'] = 'Use Multibyte Extension';
 $_lang['setting_use_multibyte_desc'] = 'Set to true if you want to use the mbstring extension for multibyte characters in your MODX installation. Only set to true if you have the mbstring PHP extension installed.';
 

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -633,7 +633,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         }
         $refreshChildURIs = false;
         if ($this->xpdo instanceof modX && $this->xpdo->getOption('friendly_urls')) {
-            $refreshChildURIs = ($this->get('refreshURIs') || $this->isDirty('alias') || $this->isDirty('parent') || $this->isDirty('context_key'));
+            $refreshChildURIs = ($this->get('refreshURIs') || $this->isDirty('uri') || $this->isDirty('alias') || $this->isDirty('parent') || $this->isDirty('context_key'));
             if ($this->get('uri') == '' || (!$this->get('uri_override') && ($this->isDirty('uri_override') || $this->isDirty('content_type') || $this->isDirty('isfolder') || $refreshChildURIs))) {
                 $this->set('uri', $this->getAliasPath($this->get('alias')));
             }
@@ -894,15 +894,25 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
             $aliasPath= '';
             /* if using full alias paths, calculate here */
             if ($workingContext->getOption('use_alias_path', false)) {
+                $useFrozenPathUris = $workingContext->getOption('use_frozen_parent_uris', false);
                 $pathParentId= $fields['parent'];
                 $parentResources= array ();
                 $query = $this->xpdo->newQuery('modResource');
-                $query->select($this->xpdo->getSelectColumns('modResource', '', '', array('parent', 'alias')));
+                $query->select($this->xpdo->getSelectColumns('modResource', '', '', array('parent', 'alias', 'uri', 'uri_override')));
                 $query->where("{$this->xpdo->escape('id')} = ?");
                 $query->prepare();
                 $query->stmt->execute(array($pathParentId));
                 $currResource= $query->stmt->fetch(PDO::FETCH_ASSOC);
+
                 while ($currResource) {
+                    // If the use_frozen_parent_uris setting is enabled, we will look at the parent frozen uri instead
+                    // of building the full uri from all parents. This makes sure children will have an uri relative
+                    // from the parent at all times.
+                    if ($useFrozenPathUris && $currResource['uri_override'] && !empty($currResource['uri'])) {
+                        $parentResources[] = rtrim($currResource['uri'], '/');
+                        break;
+                    }
+
                     $parentAlias= $currResource['alias'];
                     if (empty ($parentAlias)) {
                         $parentAlias= "{$pathParentId}";


### PR DESCRIPTION
### What does it do ?

Previously, generating the uri for a child resource would go through each of the parents, grab it alias, and stick that together to form the URI at which the child is accessible. 

With this patch, disabled by default through use_frozen_parent_uris setting, the uri generating for child resources will still go through each of the parents to build the uri. The difference is that it now checks if a parent has the uri_override flag. If it does, the uri is built from the frozen URI instead of whatever parents may be higher up in the tree.

To illustrate, imagine this tree from the modmore site:

```
- Home
- About
- Extras
--- ContentBlocks
----- Pricing
----- Documentation
--- Redactor 
```

Assuming no frozen URIs and each alias to be the lowercase of the title, the URI for the "Pricing" page would be `/extras/contentblocks/pricing.html`. 

Now imagine we set the ContentBlocks resource to have a frozen uri of `awesome-extra/`, so we have a nice short link to a page slightly deeper in the hierarchy. Prior to this patch (or if disabled), the Pricing page would still be located at `/extras/contentblocks/pricing.html`. When enabling this patch, it will instead follow the parent URI and end up at `/awesome-extra/pricing.html`. 
### Why is it needed ?

Covered above, but primarily it adds more flexibility in building URIs while keeping a semantic structure in the resource tree. 
