### PR TITLE
Add JSONP support to the modConnectorResponse

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -155,17 +155,22 @@ class modConnectorResponse extends modResponse {
         }
         if (is_array($this->body)) {
             @session_write_close();
-            die($this->modx->toJSON(array(
+            $json = $this->modx->toJSON(array(
                 'success' => isset($this->body['success']) ? $this->body['success'] : 0,
                 'message' => isset($this->body['message']) ? $this->body['message'] : $this->modx->lexicon('error'),
                 'total' => (isset($this->body['total']) && $this->body['total'] > 0)
-                        ? intval($this->body['total'])
-                        : (isset($this->body['errors'])
-                                ? count($this->body['errors'])
-                                : 1),
+                    ? intval($this->body['total'])
+                    : (isset($this->body['errors'])
+                        ? count($this->body['errors'])
+                        : 1),
                 'data' => isset($this->body['errors']) ? $this->body['errors'] : array(),
                 'object' => isset($this->body['object']) ? $this->body['object'] : array(),
-            )));
+            ));
+
+            if (!empty($_GET['callback'])) {
+                $json = $_GET['callback'] . '(' . $json . ')';
+            }
+            die($json);
         } else {
             @session_write_close();
             die($this->body);


### PR DESCRIPTION
When returning an array from a processor->process function, the modConnectorResponse can turn that into a nice JSON response. With this patch, it can also support JSONP by looking at a "callback" get parameter, and returning the json wrapped in that.

This makes it easier to use the connector/processor approach for cross-site stuff, while also allowing the $modx->runProcessor response (modProcessorResponse) to remain useful from within snippets or stuff like that. The approach to JSONP prior to this patch would be to prepare the specific JSONP format in the process() function of the processor, after which you'll need to strip it out again if you want to re-use the processor through $modx->runProcessor(), which sucks.  

I have some slight concerns if there may be security implications by adding this, discussed below, but all considered I think it is a safe addition. 
1. One aspect is using the `$_GET['callback']` without sanitisation - that could potentially be used to inject arbitrary javascript into the response, but given that javascript would be executed on the requester, any hypothetical attacker would already have access to run arbitrary code or XSS on that requester. Also, sanitisation could break a legitimate callback, so some comments you see online are that you should just make sure it is valid, and return a 400 Bad Request if it isn't. 
2. Given JSONP allows cross-origin requests where regular AJAX doesn't, it might be easier to execute CSRF attacks across hosts with this feature. That is what the HTTP_MODAUTH validation is for though, so with that in place I don't think that is an actual security issue either. 
