### PR TITLE
Create composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "modx/revolution",
+    "description": "Content Management System and Application Framework",
+    "keywords": [
+        "modx",
+        "cmf"
+    ],
+    "homepage": "http://www.modx.com/",
+    "type": "library",
+    "license": "GPLv2",
+    "require": {
+        "php": ">=5.3"
+    },
+    "config": {
+        "preferred-install": "dist"
+    }
+}


### PR DESCRIPTION
### What does it do ?

Turns modX into [Composer](http://getcomposer.org) library. No autoloading by namespaces, no core split into separate packages - just making modX available to be installed via Composer, nothing more and nothing less.
### Why is it needed ?

It gives modX an opportunity to be installed via the most popular dependency manager for PHP.
### Related issue(s)/PR(s)

This pull-request could be considered as a first step to https://github.com/modxcms/revolution/pull/12092 .
