### PR TITLE
Prevent dashboard widgets with no output to be displayed

### DIFF
--- a/core/model/modx/moddashboard.class.php
+++ b/core/model/modx/moddashboard.class.php
@@ -67,17 +67,20 @@ class modDashboard extends xPDOSimpleObject {
         $c->where(array(
             'dashboard' => $this->get('id'),
         ));
-        $c->sortby('rank','ASC');
-        $placements = $this->getMany('Placements',$c);
+        $c->sortby('rank', 'ASC');
+        $placements = $this->getMany('Placements', $c);
         $output = array();
         /** @var modDashboardWidgetPlacement $placement */
         foreach ($placements as $placement) {
             /** @var modDashboardWidget $widget */
             $widget = $placement->getOne('Widget');
             if ($widget) {
-                $output[] = $widget->getContent($controller);
+                $content = $widget->getContent($controller);
+                if (!empty($content)) {
+                    $output[] = $content;
+                }
             }
         }
-        return implode("\n",$output);
+        return implode("\n", $output);
     }
 }


### PR DESCRIPTION
### What does it do ?

Prevents dashboard widgets with empty "output"/content to be displayed within the dashboard.
### Why is it needed ?

Before this patch, a widget with no output was still displayed (ad empty "frame") and somehow looked weird.
This allows some kind of "dynamic" widgets (ie. only displayed when there really is something to show).
