### PR TITLE
Take care of added records while counting the total number of widgets placed in a dashboard

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -236,9 +236,8 @@ Ext.extend(MODx.grid.DashboardWidgetPlacements,MODx.grid.LocalGrid,{
 
     ,onAfterRowMove: function(dt,sri,ri,sels) {
         var s = this.getStore();
-        var sourceRec = s.getAt(sri);
-        var belowRec = s.getAt(ri);
-        var total = s.getTotalCount();
+        var sourceRec = s.data.items[sri];
+        var total = s.data.length;
 
         sourceRec.set('rank',sri);
         sourceRec.commit();
@@ -246,7 +245,7 @@ Ext.extend(MODx.grid.DashboardWidgetPlacements,MODx.grid.LocalGrid,{
         /* get all rows below ri, and up their rank by 1 */
         var brec;
         for (var x=(ri-1);x<total;x++) {
-            brec = s.getAt(x);
+            brec = s.data.items[x];
             if (brec) {
                 brec.set('rank',x);
                 brec.commit();
@@ -324,7 +323,11 @@ Ext.extend(MODx.window.DashboardWidgetPlace,MODx.Window,{
             fld.markInvalid(_('dashboard_widget_err_placed'));
             return false;
         }
-        var rank = s.getAt(s.getTotalCount() - 1).get('rank') + 1;
+        var rank =  s.data.length > 0
+            // Get the rank of the last record
+            ? s.data.items[s.data.length - 1].get('rank') + 1
+            // Or set it to '0' if no record found
+            : 0;
 
         var fldStore = fld.getStore();
         var fldRi = fldStore.find('id',fld.getValue());

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -324,7 +324,7 @@ Ext.extend(MODx.window.DashboardWidgetPlace,MODx.Window,{
             fld.markInvalid(_('dashboard_widget_err_placed'));
             return false;
         }
-        var rank = s.data.length;
+        var rank = s.getAt(s.getTotalCount()).get('rank') + 1;
 
         var fldStore = fld.getStore();
         var fldRi = fldStore.find('id',fld.getValue());

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -324,7 +324,7 @@ Ext.extend(MODx.window.DashboardWidgetPlace,MODx.Window,{
             fld.markInvalid(_('dashboard_widget_err_placed'));
             return false;
         }
-        var rank = s.getTotalCount();
+        var rank = s.data.length;
 
         var fldStore = fld.getStore();
         var fldRi = fldStore.find('id',fld.getValue());

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -324,7 +324,7 @@ Ext.extend(MODx.window.DashboardWidgetPlace,MODx.Window,{
             fld.markInvalid(_('dashboard_widget_err_placed'));
             return false;
         }
-        var rank = s.getAt(s.getTotalCount()).get('rank') + 1;
+        var rank = s.getAt(s.getTotalCount() - 1).get('rank') + 1;
 
         var fldStore = fld.getStore();
         var fldRi = fldStore.find('id',fld.getValue());


### PR DESCRIPTION
### What does it do ?

Calculate the real total of dashboard widgets (to "mimic" a rank/placement), instead of the total returned by the server.
### Why is it needed ?

When editing/placing widgets into a dashboard, `Ext.data.Store#getTotalCount()` was used. This method only takes care of "cached" records (as in not counting newly added records -- see the note at the end of description http://docs.sencha.com/extjs/3.4.0/#!/api/Ext.data.Store-method-getTotalCount).

Basically, when editing a dashboard which only had 1 record, every records added/placed later (without save in between) would have a rank of `1`.

Making use of `store.data.length` appears to be more reliable.
