### PR TITLE
Target user menu wrapper to change "sub menu direction" instead of targeted IDs

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -131,8 +131,7 @@
   }
 }
 
-#modx-navbar #limenu-admin ul.modx-subnav,
-#modx-navbar #limenu-user ul.modx-subnav {
+#modx-navbar #modx-user-menu ul.modx-subnav {
   left: auto;
   right: 0;
 }


### PR DESCRIPTION
### What does it do ?

Target `#modx-user-menu` (the "user navigation wrapper") instead of specific IDs to change the sub menu dropdown "direction".
### Why is it needed ?

Since we can use custom parent/menus to populate the user navigation top bar, targeting `#limenu-admin` & `#limenu-user` does not make sense.
