### PR TITLE
Better modMenu management

### DIFF
--- a/core/model/modx/processors/system/menu/getlist.class.php
+++ b/core/model/modx/processors/system/menu/getlist.class.php
@@ -20,6 +20,26 @@ class modMenuGetListProcessor extends modObjectGetListProcessor {
     public $permission = 'menus';
     public $defaultSortField = 'menuindex';
 
+    public function initialize() {
+        $initialized = parent::initialize();
+        $this->setDefaultProperties(array(
+            'showNone' => false,
+        ));
+
+        return $initialized;
+    }
+
+    public function beforeIteration(array $list) {
+        if ($this->getProperty('showNone',false)) {
+            $list = array('0' => array(
+                'text' => '',
+                'text_lex' => "({$this->modx->lexicon('none')})",
+            ));
+        }
+
+        return $list;
+    }
+
     public function prepareRow(xPDOObject $object) {
         $objectArray = $object->toArray();
         $namespace = $object->get('namespace');

--- a/core/model/modx/processors/system/menu/getnodes.class.php
+++ b/core/model/modx/processors/system/menu/getnodes.class.php
@@ -67,9 +67,14 @@ class modMenuGetNodesProcessor extends modObjectGetListProcessor {
             'iconCls' => 'icon icon-' . ( $object->get('childrenCount') > 0 ? ( $object->get('parent') === '' ? 'navicon' : 'folder' ) : 'terminal' ),
             'type' => 'menu',
             'pk' => $object->get('text'),
-            'leaf' => $object->get('childrenCount') > 0 ? false : true,
+            // consider each node not being a "leaf" so we can drop records in it
+            'leaf' => false,
             'data' => $object->toArray(),
         );
+        if ($object->get('childrenCount') < 1) {
+            // Workaround for leaf record not to display "arrows"
+            $objectArray['loaded'] = true;
+        }
 
         return $objectArray;
     }

--- a/manager/assets/modext/widgets/system/modx.tree.menu.js
+++ b/manager/assets/modext/widgets/system/modx.tree.menu.js
@@ -34,7 +34,9 @@ Ext.extend(MODx.tree.Menu, MODx.tree.Tree, {
     windows: {}
 
     ,createMenu: function(n,e) {
-        var r = {};
+        var r = {
+            parent: ''
+        };
         if (this.cm && this.cm.activeNode && this.cm.activeNode.attributes && this.cm.activeNode.attributes.data) {
             r['parent'] = this.cm.activeNode.attributes.data.text;
         }
@@ -47,6 +49,7 @@ Ext.extend(MODx.tree.Menu, MODx.tree.Tree, {
                 }
             });
         }
+        this.windows.create_menu.reset();
         this.windows.create_menu.setValues(r);
         this.windows.create_menu.show(e.target);
     }
@@ -300,6 +303,8 @@ MODx.combo.Menu = function(config) {
         ,baseParams: {
             action: 'system/menu/getlist'
             ,combo: true
+            ,limit: 0
+            ,showNone: true
         }
         ,fields: ['text','text_lex']
         ,displayField: 'text_lex'


### PR DESCRIPTION
### What does it do ?

A bunch of fixes to handle `modMenu` more conveniently.
### Why is it needed ?
- allow dropping a record into a "leaf" (non "category"/"container" record)
- list all records in the "parent" combo box (not restricting to the first 20 records)
- added "none" as parent to allow creation (or update) of a record at the root level
- reset the "create record" window to prevent having previous record data when creating multiple records
### Related issue(s)/PR(s)
- Fixes #12330
- Fixes #12435
