### PR TITLE
Prevent using Ext.getCmp() when not needed

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -534,7 +534,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,overviewResource: function() {this.loadAction('a=resource/data')}
 
     ,quickUpdateResource: function(itm,e) {
-        Ext.getCmp("modx-resource-tree").quickUpdate(itm,e,itm.classKey);
+        this.quickUpdate(itm,e,itm.classKey);
     }
 
     ,editResource: function() {this.loadAction('a=resource/update');}
@@ -633,7 +633,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,createResourceHere: function(itm) {
         var at = this.cm.activeNode.attributes;
         var p = itm.usePk ? itm.usePk : at.pk;
-        Ext.getCmp('modx-resource-tree').loadAction(
+        this.loadAction(
             'a=resource/create&class_key=' + itm.classKey + '&parent=' + p + (at.ctx ? '&context_key='+at.ctx : '')
         );
     }
@@ -641,7 +641,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,createResource: function(itm,e) {
         var at = this.cm.activeNode.attributes;
         var p = itm.usePk ? itm.usePk : at.pk;
-        Ext.getCmp('modx-resource-tree').quickCreate(itm,e,itm.classKey,at.ctx,p);
+        this.quickCreate(itm,e,itm.classKey,at.ctx,p);
     }
 
     ,_getCreateMenus: function(m,pk,ui) {


### PR DESCRIPTION
### What does it do ?

Prevents using `Ext.getCmp('modx-resource-tree')` in resources tree, which is a reference to `this`.
### Why is it needed ?

Using `Ext.getCmp('modx-resource-tree')` involves having the component `#modx-resource-tree` available, which might not be the case. When extending `MODx.tree.Resource` and `#modx-resource-tree` is not available, the modified methods break (before this patch).
