### PR TITLE
Fixing #12451 floatval input options are not possible

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -1129,8 +1129,10 @@ abstract class modTemplateVarRender {
                     $params[$k] = TRUE;
                 } elseif ($v === 'false') {
                     $params[$k] = FALSE;
-                } elseif (is_numeric($v)) {
+                } elseif (is_numeric($v) && ((int) $v == $v)) {
                     $params[$k] = intval($v);
+                } elseif (is_numeric($v)) {
+                    $params[$k] = (float)($v);
                 }
             }
         }


### PR DESCRIPTION
Floatval (input) options are not possible in a custom template variable
