### PR TITLE
request_method_strict & friendly_urls_strict

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -89,7 +89,7 @@ class modRequest {
             $this->checkPublishStatus();
             $this->modx->resourceMethod = $this->getResourceMethod();
             $this->modx->resourceIdentifier = $this->getResourceIdentifier($this->modx->resourceMethod);
-            if ($this->modx->resourceMethod == 'id' && $this->modx->getOption('friendly_urls', null, false) && !$this->modx->getOption('request_method_strict', null, false)) {
+            if ($this->modx->resourceMethod == 'id' && $this->modx->getOption('friendly_urls', null, false) && $this->modx->getOption('request_method_strict', null, false)) {
                 $uri = $this->modx->context->getResourceURI($this->modx->resourceIdentifier);
                 if (!empty($uri)) {
                     if ((integer) $this->modx->resourceIdentifier === (integer) $this->modx->getOption('site_start', null, 1)) {


### PR DESCRIPTION
Strange behavior in system settings
"request_method_strict" and "friendly_urls_strict".
I want the page to be available at the "http://domain.com/friendurl" and the address "http://domain.com/index.php?id=5"
This is impossible, but if you make a change in commit, then SETUP 
"request_method_strict"=0
"friendly_urls_strict"=0
all works
