### PR TITLE
D&D resource sort in tree

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -95,8 +95,9 @@ MODx.tree.Tree = function(config) {
                 },
                 hide: function() {
                     var node = this.activeNode;
-                    if (node)
+                    if (node){
                         node.isSelected() || node.ui.removeClass('x-tree-selected');
+                    }
                 }
             }
         }


### PR DESCRIPTION
### What does it do ?

This PR tries to fix incorrect sorting resources in tree via d&d, when tree is in limited view (via resource groups). Instead of sending snapshot of visible elements in tree, it sends source node and target node, so even resources that user do not see are evaluated when sorting.
### Why is it needed ?

Currently, when resource tree shows only few resources (and others are hidden via resource groups), after user sort them via d&d, menu indexes for all resources are reevaluated and menu indexes for hidden resources are messed up (because current sort processor doesn't know about them).
### Related issue(s)/PR(s)
#9084
