### PR TITLE
Get rid of useless "language string not found"

### DIFF
--- a/core/model/modx/modlexicon.class.php
+++ b/core/model/modx/modlexicon.class.php
@@ -389,7 +389,7 @@ class modLexicon {
         $language = !empty($language) ? $language : $this->modx->getOption('cultureKey',null,'en');
         /* make sure key exists */
         if (!is_string($key) || !isset($this->_lexicon[$language][$key])) {
-            $this->modx->log(xPDO::LOG_LEVEL_DEBUG,'Language string not found: "'.$key.'"');
+        //    $this->modx->log(xPDO::LOG_LEVEL_DEBUG,'Language string not found: "'.$key.'"');
             return $key;
         }
         /* if params are passed, allow for parsing of [[+key]] values to strings */


### PR DESCRIPTION
The debug message "Language string not found:" is quite useless here, because you don't see where it comes from. 
And, even worse these log lines poison your logfile making it hard to debug any other manager issues.
