### PR TITLE
Paging in modx-combo-category

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -382,6 +382,7 @@ MODx.combo.Category = function(config) {
         ,allowBlank: true
         ,editable: false
         ,enableKeyEvents: true
+        ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'element/category/getlist'


### PR DESCRIPTION
Also why all combos use hard-coded 20 per page instead of using MODx.config.default_per_page ?
