### PR TITLE
Fixed #12472 - The resource is always cached only in original context

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -499,7 +499,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     public function getCacheKey($context = '') {
         $id = $this->get('id') ? (string) $this->get('id') : '0';
         if (!is_string($context) || $context === '') {
-            $context = empty($this->_contextKey)
+            $context = !empty($this->_contextKey)
                 ? $this->_contextKey
                 : $this->get('context_key');
         }

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2563,6 +2563,7 @@ class modX extends xPDO {
     public function _postProcess() {
         if ($this->resourceGenerated && $this->getOption('cache_resource', null, true)) {
             if (is_object($this->resource) && $this->resource instanceof modResource && $this->resource->get('id') && $this->resource->get('cacheable')) {
+                $this->resource->_contextKey = $this->context->get('key');
                 $this->invokeEvent('OnBeforeSaveWebPageCache');
                 $this->cacheManager->generateResource($this->resource);
             }


### PR DESCRIPTION
Added set of context key before generation of resource cache and fixed type in modResource::getCacheKey method.

It fixes the #12472 issue.
