### PR TITLE
Fix custom theme css

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -137,6 +137,7 @@ abstract class modManagerController {
         $this->checkFormCustomizationRules();
 
         $this->setPlaceholder('_config',$this->modx->config);
+        $this->setCssURLPlaceholders();
         /* help url */
         $helpUrl = $this->getHelpUrl();
         $this->addHtml('<script type="text/javascript">MODx.helpUrl = "'.($helpUrl).'"</script>');
@@ -900,6 +901,35 @@ abstract class modManagerController {
         $langTopics = implode(',',$langTopics);
         $this->setPlaceholder('_lang_topics',$langTopics);
         return $langTopics;
+    }
+
+    public function setCssURLPlaceholders()
+    {
+        $managerUrl = $this->modx->getOption('manager_url', null, MODX_MANAGER_URL);
+        $managerPath = $this->modx->getOption('manager_path',null,MODX_MANAGER_PATH);
+        
+        $index = false;
+        $login = false;
+        
+        if ($this->theme != 'default') {
+            if (file_exists($managerPath . 'templates/' . $this->theme . '/css/index.css')) {
+                $this->setPlaceholder('indexCss', $managerUrl . 'templates/' . $this->theme . '/css/index.css');
+                $index = true;
+            }
+
+            if (file_exists($managerPath . 'templates/' . $this->theme . '/css/login.css')) {
+                $this->setPlaceholder('loginCss', $managerUrl . 'templates/' . $this->theme . '/css/login.css');
+                $login = true;
+            }
+        }
+
+        if (!$index) {
+            $this->setPlaceholder('indexCss', $managerUrl . 'templates/default/css/index.css');
+        }
+        
+        if (!$login) {
+            $this->setPlaceholder('loginCss', $managerUrl . 'templates/default/css/login.css');
+        }
     }
 }
 

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -39,10 +39,6 @@
 {/foreach}
 
 {$rteincludes}
-<!--[if IE]>
-<style type="text/css">body { behavior: url("{$_config.manager_url}templates/{$_config.manager_theme}/css/csshover3.htc"); }</style>
-<link rel="stylesheet" type="text/css" href="templates/{$_config.manager_theme}/css/ie.css" />
-<![endif]-->
 </head>
 <body>
 

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -7,7 +7,7 @@
 {if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
 
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
-<link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/{$_config.manager_theme}/css/index.css" />
+<link rel="stylesheet" type="text/css" href="{$indexCss}" />
 
 {if $_config.ext_debug}
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -6,8 +6,8 @@
     {if $_config.manager_favicon_url}<link rel="shortcut icon" type="image/x-icon" href="{$_config.manager_favicon_url}" />{/if}
 
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
-    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/{$_config.manager_theme}/css/index.css" />
-    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/{$_config.manager_theme}/css/login.css" />
+    <link rel="stylesheet" type="text/css" href="{$indexCss}" />
+    <link rel="stylesheet" type="text/css" href="{$loginCss}" />
 
 {if $_config.ext_debug}
     <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>

--- a/manager/templates/default/security/logout.tpl
+++ b/manager/templates/default/security/logout.tpl
@@ -5,8 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all.css" />
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/xtheme-gray-extend.css" />
-    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/{$_config.manager_theme}/css/index.css" />
-    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/{$_config.manager_theme}/css/login.css" />
+    <link rel="stylesheet" type="text/css" href="{$indexCss}" />
+    <link rel="stylesheet" type="text/css" href="{$loginCss}" />
 
 
     {if $_config.ext_debug}


### PR DESCRIPTION
### What does it do ?

Creates new variables available in templates - `indexCss` and `loginCss` which contains URL to correct CSS file - template specific if exists, default otherwise.
### Why is it needed ?

Currently when someone wants to customise default template, he's forced to also duplicate CSS files, with this change there is no need for CSS duplication, because default CSS will be loaded if template specific doesn't exist.
### Related issue(s)/PR(s)

Resolves #12332
