### PR TITLE
Updating and Relaxing bower packages

### DIFF
--- a/_build/templates/default/bower.json
+++ b/_build/templates/default/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "modx-revolution-theme",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "author": {
     "name": "JP DeVries",
     "url": "http://devries.jp/"
@@ -14,9 +14,9 @@
     "url": "http://bugs.modx.com/projects/revo"
   },
   "devDependencies": {
-    "bourbon": "^4.0.2",
-    "neat":"~1.6.0",
-    "font-awesome": "~4.3.0"
+    "bourbon": "^4.2.3",
+    "neat":"^1.7.2",
+    "font-awesome": "^4.3.0"
   },
   "exportsOverride": {
     "bourbon": {


### PR DESCRIPTION
to fetch any update of the same major version

> In the simplest terms, the tilde matches the most recent minor version (the middle number). ~1.2.3 will match all 1.2.x versions but will miss 1.3.0.
> The caret, on the other hand, is more relaxed. It will update you to the most recent major version (the first number). ^1.2.3 will match any 1.x.x release including 1.3.0, but will hold off on 2.0.0.  

&emsp;&mdash;&emsp;http://fredkschott.com/post/2014/02/npm-no-longer-defaults-to-tildes/

it is expected that after pulling this PR in running

``` bash
grunt build
```

may show changes to the CSS files but they aren't significant
