### PR TITLE
Fixed E_WARNING

### DIFF
--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -242,8 +242,10 @@ class modRestService {
      */
     public function iterateDirectories($pattern, $flags = 0) {
         $files = glob($pattern, $flags);
-        foreach (glob(dirname($pattern).'/*', GLOB_ONLYDIR|GLOB_NOSORT) as $dir) {
-            $files = array_merge($files, $this->iterateDirectories($dir.'/'.basename($pattern), $flags));
+        if ($dirs = glob(dirname($pattern).'/*', GLOB_ONLYDIR|GLOB_NOSORT)) {
+            foreach ($dirs as $dir) {
+                $files = array_merge($files, $this->iterateDirectories($dir.'/'.basename($pattern), $flags));
+            }
         }
         return $files;
     }


### PR DESCRIPTION
Current code can produce E_WARNING on some cases

```
 [2015-06-26 14:27:59] (ERROR @ /home/***/www/core/model/modx/rest/modrestservice.class.php : 245) PHP warning: Invalid argument supplied for foreach()
```
