### PR TITLE
Update image.tpl

### DIFF
--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -48,7 +48,7 @@ Ext.onReady(function() {
                     d.update('');
                 } else {
                     {/literal}
-                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?h=150&w=150&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
+                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
                     {literal}
                 }
             }}


### PR DESCRIPTION
Making "first time" thumb and "every other time" thumb the same size.

When filling an imageTV with content, a thumbnail by the size of 150x150px was generated. Then, after the resources gets saved and is reopend, the thumb is displayed with a width of 400px.
Why not 400px width in the first place?
I changed that. ;-)
Now "both" thumbs have the same size. :-)
