### PR TITLE
Show MODX version (and flavor) as a tooltip for the MODX logo

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -52,7 +52,8 @@
 
             <ul id="modx-topnav">
                 <li id="modx-home-dashboard">
-                    <a href="?" title="{$_lang.dashboard}">{$_lang.dashboard}</a>
+                    <a href="?" title="MODX {$_config.settings_version} ({$_config.settings_distro})
+{$_lang.dashboard}">{$_lang.dashboard}</a>
                 </li>
                 {if $_search}
                 <li id="modx-manager-search"></li>


### PR DESCRIPTION
### Summary

Show MODX version (and flavor) as a tooltip for the MODX logo. Ends the long journey to "Manage > Reports > System Info" to find out which version of MODX is used.
Note: The line break inside the "title" of the "a" tag is important to make the tooltip use 2 lines.
### Expected behavior

![image](https://cloud.githubusercontent.com/assets/458619/8431754/e575e8de-1f3b-11e5-8cc2-1193728b8a5d.png)
