### PR TITLE
Fiting portrait and landscape imageTV thumbs into a max. area of 400x400px

### DIFF
--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,6 +1,6 @@
 <div id="tv-image-{$tv->id}"></div>
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&src={$tv->value}&source={$source}" alt="" />{/if}
+    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&src={$tv->value}&source={$source}" alt="" />{/if}
 </div>
 {if $disabled}
 <script type="text/javascript">
@@ -48,7 +48,7 @@ Ext.onReady(function() {
                     d.update('');
                 } else {
                     {/literal}
-                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
+                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
                     {literal}
                 }
             }}


### PR DESCRIPTION
### Summary

This is an improvement for #12491 which only limited the width to 400px, the height remained unlimited.
Now the script also handles very tall images like skyscraper banners (120x600px) and fits them into a 400x400px area. This saves a lot of vertical space for portrait format images.
Smaller images remain unaltered.
### Step to reproduce

Just select an image for a TV. Here are examples for 120x120, 600x120, 120x600 and 600x600px:
##### 120x120

![image](https://cloud.githubusercontent.com/assets/458619/8437056/e7114a00-1f5c-11e5-8348-4b0e04484211.png)
##### 600x120

![image](https://cloud.githubusercontent.com/assets/458619/8437078/01610d14-1f5d-11e5-9b4c-b02839c5b60d.png)
##### 120x600

![image](https://cloud.githubusercontent.com/assets/458619/8437093/143d0438-1f5d-11e5-92c2-f377d5466024.png)
##### 600x600

![image](https://cloud.githubusercontent.com/assets/458619/8437103/223c3aea-1f5d-11e5-9725-961847f22f18.png)
### Observed behavior

The maximum thumbnail size is now fitted into 400x400px, no matter what kind or proportions the image has.
### Expected behavior

Just as observed. ;-)
