### PR TITLE
Deny any access to core folder from web

### DIFF
--- a/core/ht.access
+++ b/core/ht.access
@@ -1,5 +1,4 @@
 IndexIgnore */*
-<Files *.php>
-    Order Deny,Allow
-    Deny from all
-</Files>
+
+# deny access to _all_ files in the core, including changelog.txt and error.log
+Deny from all

--- a/core/ht.access
+++ b/core/ht.access
@@ -1,4 +1,16 @@
-IndexIgnore */*
-
 # deny access to _all_ files in the core, including changelog.txt and error.log
-Deny from all
+# original borrowed from owncloud
+
+# line below if for Apache 2.4
+<ifModule mod_authz_core.c>
+Require all denied
+</ifModule>
+
+# line below if for Apache 2.2
+<ifModule !mod_authz_core.c>
+deny from all
+Satisfy All
+</ifModule>
+
+# section for Apache 2.2 and 2.4
+IndexIgnore *

--- a/core/ht.access
+++ b/core/ht.access
@@ -1,4 +1,16 @@
-IndexIgnore */*
-
 # deny access to _all_ files in the core, including changelog.txt and error.log
-Deny from all
+# original borrowed from owncloud
+
+# line below if for Apache 2.4
+<ifModule mod_authz_core.c>
+    Require all denied
+</ifModule>
+
+# line below if for Apache 2.2
+<ifModule !mod_authz_core.c>
+    deny from all
+    Satisfy All
+</ifModule>
+
+# section for Apache 2.2 and 2.4
+IndexIgnore *


### PR DESCRIPTION
### What does it do?

Prevent sneaking around or fingerprinting, the whole core directory should be denied. 
### Why is it needed?

Otherwise it is possible to read the error log or check the changelog.txt from the web. As this is the example file, it should include the most secure set up. 
### Related issues

For example mentioned in #8854, #12490
### Enhancements

The file should give examples for other environments as well (or other example files). Set up for Nginx and IIS at least are a good advice for users. 
