### PR TITLE
Added rule for checking .htaccess in /core folder on Apache

### DIFF
--- a/core/lexicon/en/configcheck.inc.php
+++ b/core/lexicon/en/configcheck.inc.php
@@ -21,9 +21,16 @@ $_lang['configcheck_errorpage_unavailable_msg'] = 'This means that your Error pa
 $_lang['configcheck_errorpage_unpublished'] = 'Your site\'s Error page is not published or does not exist.';
 $_lang['configcheck_errorpage_unpublished_msg'] = 'This means that your Error page is inaccessible to the general public. Publish the page or make sure it is assigned to an existing document in your site tree in the System &gt; System Settings menu.';
 $_lang['configcheck_htaccess'] = 'Core folder is accessible by web';
-$_lang['configcheck_htaccess_msg'] = 'Your MODX installation is running on a <strong>Apache</strong> webserver and there is no <em>.htaccess</em> file in the <em>core directory</em>. To secure your site, you should at least properly set this file. This can be easily done by renaming the existing ht.access file to .htaccess at the location <em>[[+fileLocation]]</em>.
-After that, you should also change the file permissions at least to <strong>0400</strong> on this file. <br/>You can check your setup by browsing to the <a href="[[+checkUrl]]" target="new">Changelog</a> - if you get a permission denied you are fine. If you see the MODX changelog there, something is still wrong - follow the "Hardening MODX" guideline then or call an expert.';
-
+$_lang['configcheck_htaccess_msg'] = 'MODX detected that your core folder is (partially) accessible to the public.
+<strong>This is not recommended and a security risk.</strong>
+If your MODX installation is running on a Apache webserver
+you should at least set up the .htaccess file inside the core folder <em>[[+fileLocation]]</em>.
+This can be easily done by renaming the existing ht.access example file there to .htaccess.<br/>
+There are other methods and webservers you may use, please read the <a href="https://rtfm.modx.com/revolution/2.x/administering-your-site/security/hardening-modx-revolution">Hardening MODX Guide</a>
+for further information about securing your site.<br/>
+If you setup everything correctly, browsing e.g. to the <a href="[[+checkUrl]]" target="new">Changelog</a>
+should give you a 403 (permission denied) or better a 404 (not found). If you can see the changelog
+there in the browser, something is still wrong and you need to reconfigure or call an expert to solve this.';
 $_lang['configcheck_images'] = 'Images directory not writable';
 $_lang['configcheck_images_msg'] = 'The images directory isn\'t writable, or doesn\'t exist. This means the Image Manager functions in the editor will not work!';
 $_lang['configcheck_installer'] = 'Installer still present';

--- a/core/lexicon/en/configcheck.inc.php
+++ b/core/lexicon/en/configcheck.inc.php
@@ -20,6 +20,10 @@ $_lang['configcheck_errorpage_unavailable'] = 'Your site\'s Error page is not av
 $_lang['configcheck_errorpage_unavailable_msg'] = 'This means that your Error page is not accessible to normal web surfers or does not exist. This can lead to a recursive looping condition and many errors in your site logs. Make sure there are no webuser groups assigned to the page.';
 $_lang['configcheck_errorpage_unpublished'] = 'Your site\'s Error page is not published or does not exist.';
 $_lang['configcheck_errorpage_unpublished_msg'] = 'This means that your Error page is inaccessible to the general public. Publish the page or make sure it is assigned to an existing document in your site tree in the System &gt; System Settings menu.';
+$_lang['configcheck_htaccess'] = 'Core folder is accessible by web';
+$_lang['configcheck_htaccess_msg'] = 'Your MODX installation is running on a <strong>Apache</strong> webserver and there is no <em>.htaccess</em> file in the <em>core directory</em>. To secure your site, you should at least properly set this file. This can be easily done by renaming the existing ht.access file to .htaccess at the location <em>[[+fileLocation]]</em>.
+After that, you should also change the file permissions at least to <strong>0400</strong> on this file. <br/>You can check your setup by browsing to the <a href="[[+checkUrl]]" target="new">Changelog</a> - if you get a permission denied you are fine. If you see the MODX changelog there, something is still wrong - follow the "Hardening MODX" guideline then or call an expert.';
+
 $_lang['configcheck_images'] = 'Images directory not writable';
 $_lang['configcheck_images_msg'] = 'The images directory isn\'t writable, or doesn\'t exist. This means the Image Manager functions in the editor will not work!';
 $_lang['configcheck_installer'] = 'Installer still present';

--- a/core/model/modx/processors/system/config_check.inc.php
+++ b/core/model/modx/processors/system/config_check.inc.php
@@ -55,19 +55,63 @@ function getResourceBypass(modX &$modx,$criteria) {
     return $resource;
 }
 
-/* check if running on apache and .htaccess is not set */
-$searchFor = "Apache";
-$isApache = strpos( $_SERVER['SERVER_SOFTWARE'], $searchFor );
-if ($isApache!==false) {
-    /* apparently running on apache, check if core/.htaccess file is has been set */
+/* Check if the core folder (content) is accessible via web */
+if ( function_exists( 'curl_init' )) {
+    /* TODO: should we check both protocol variants here? */
+    $protocol = $modx->getOption('server_protocol');
 
-    $searchPath = strpos( MODX_CORE_PATH, MODX_BASE_PATH);
-    /* check if the core directory is still inside the base path */
-    if ($searchPath!==false && !strpos('..',MODX_CORE_PATH)) {
-        if (!file_exists(MODX_CORE_PATH . '.htaccess')) {
+    /* currently only checking one file. But it may be a good e.g. to also check more sensitive files */
+    $checkFiles = array( 'docs/changelog.txt', 'cache/logs/error.log' );
+
+    /* the Url construction does not work when the manager is hosted under a different
+       domain. We cannot determine the difference, it is configured outside of MODXs reach
+    */
+    $checkUrl = $protocol . "://" . $_SERVER['HTTP_HOST'] . MODX_BASE_URL .str_replace(  MODX_BASE_PATH, '', MODX_CORE_PATH . $checkFiles[0]);
+
+    /* try to call curl with minimal footprint - we don't want to wait everytime we access the dashboard */
+    $curl = curl_init(  );
+    curl_setopt($curl, CURLOPT_HEADER, false);
+    /* returntransfer must be true */
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    /* use small timeouts: we are on localhost somehow */
+    curl_setopt($curl,CURLOPT_TIMEOUT_MS, 500);
+    curl_setopt($curl, CURLOPT_CONNECTTIMEOUT_MS, 500);
+    /* do not verify ssl - we are not interested in this and
+        verifying would cause errors e.g. for self-signed certs
+    */
+    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+    curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
+    curl_setopt($curl, CURLOPT_FRESH_CONNECT,true);
+    curl_setopt($curl, CURLOPT_VERBOSE, false);
+    /* follow rewrites, e.g. http to https rewrites */
+    /* if a sites rewrites the checkurl to 200 page, this method fails */
+    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+    /* do not download anything */
+    curl_setopt($curl, CURLOPT_RANGE, '0-0');
+    curl_setopt( $curl, CURLOPT_URL, $checkUrl );
+
+    //$modx->log(MODX_LOG_LEVEL_DEBUG, "[configcheck] URL to test for core lockdown: ". $checkUrl);
+    $curl_result = curl_exec( $curl );
+
+    if (!curl_errno($curl)) {
+        $ch_info = curl_getinfo( $curl );
+        $http_code = $ch_info['http_code'];
+
+        //$modx->log(MODX_LOG_LEVEL_DEBUG, "[configcheck] http code for core lockdown: ". $ch_info['http_code']);
+
+        /* check the response code */
+        if (($http_code >= 200 && $http_code<=210)) {
             $warnings[] = array($modx->lexicon('configcheck_htaccess'));
+            $modx->log(MODX_LOG_LEVEL_INFO, "[configcheck] Core folder is accessible via web!");
         }
+    } else {
+        $modx->log(MODX_LOG_LEVEL_ERROR, "[configcheck] check core lockdown curl err: ". curl_errno($curl) );
     }
+    curl_close( $curl );
+} else {
+    /*
+        TODO: should we warn, if we cannot use curl and therefore fail to make this test?
+    */
 }
 
 /* check php version */

--- a/core/model/modx/processors/system/config_check.inc.php
+++ b/core/model/modx/processors/system/config_check.inc.php
@@ -55,6 +55,21 @@ function getResourceBypass(modX &$modx,$criteria) {
     return $resource;
 }
 
+/* check if running on apache and .htaccess is not set */
+$searchFor = "Apache";
+$isApache = strpos( $_SERVER['SERVER_SOFTWARE'], $searchFor );
+if ($isApache!==false) {
+    /* apparently running on apache, check if core/.htaccess file is has been set */
+
+    $searchPath = strpos( MODX_CORE_PATH, MODX_BASE_PATH);
+    /* check if the core directory is still inside the base path */
+    if ($searchPath!==false && !strpos('..',MODX_CORE_PATH)) {
+        if (!file_exists(MODX_CORE_PATH . '.htaccess')) {
+            $warnings[] = array($modx->lexicon('configcheck_htaccess'));
+        }
+    }
+}
+
 /* check php version */
 $phprequire = $modx->getOption('configcheck_min_phpversion', null, '5.3');
 $compare = version_compare( phpversion(), $phprequire );
@@ -171,6 +186,15 @@ if (!empty($warnings)) {
                 $warnings[$i][1] = $modx->lexicon( 'configcheck_phpversion_msg', array(
                     'phpversion' => phpversion(),
                     'phprequired' => $phprequire
+                ));
+                break;
+            case $modx->lexicon('configcheck_htaccess') :
+                /* need to construct the core URL here - this is kind of tricky and may fail */
+                /* we have to paths: BASE_PATH and CORE_PATH. We only want the remainder of core path */
+
+                $warnings[$i][1] = $modx->lexicon( 'configcheck_htaccess_msg', array(
+                    'checkUrl' => MODX_BASE_URL .str_replace(  MODX_BASE_PATH, '', MODX_CORE_PATH .'docs/changelog.txt'),
+                    'fileLocation' => MODX_CORE_PATH
                 ));
                 break;
             default :


### PR DESCRIPTION
### Summary

Show a warning at the configcheck-widget, if running on apache and there is no .htaccess file under /core. 

![screenshot from 2015-07-08 13 49 40](https://cloud.githubusercontent.com/assets/2852461/8569475/547a51e2-2578-11e5-92f2-6ed40c8bd728.png)

Related issues: #12490, #8854 
Pull Requests:  #12503
