### PR TITLE
Fix some typos in new system_events lexicon

### DIFF
--- a/core/lexicon/en/events.inc.php
+++ b/core/lexicon/en/events.inc.php
@@ -10,10 +10,10 @@
 $_lang['events'] = 'Events';
 $_lang['system_event'] = 'System Event';
 $_lang['system_events'] = 'System Events';
-$_lang['system_events.desc'] = 'System Events are the events in MODx that Plugins are registered to. They are "fired" throughout the MODx code, allowing Plugins to interact with MODx code and add custom functionality without hacking core code. You can create your own events for your custom project here too. You cannot remove core events, only your own.';
+$_lang['system_events.desc'] = 'System Events are the events in MODX that Plugins are registered to. They are "fired" throughout the MODX code, allowing Plugins to interact with MODX code and add custom functionality without hacking core code. You can create your own events for your custom project here too. You cannot remove core events, only your own.';
 $_lang['system_events.search_by_name'] = 'Search by event name';
 $_lang['system_events.create'] = 'Create New Event';
-$_lang['system_events.name_desc'] = 'The name of the event. Which you should use in a &dollar;modx->invoiceEvent(name, properties) call.';
+$_lang['system_events.name_desc'] = 'The name of the event. Which you should use in a &dollar;modx->invokeEvent(name, properties) call.';
 $_lang['system_events.groupname'] = 'Group';
 $_lang['system_events.groupname_desc'] = 'The name of the group where the new event belongs to. Select an existing one or type in a new group name.';
 


### PR DESCRIPTION
### What does it do ?

There were some typos in the new system events manager page. Made sure MODX is referred to in all caps, also fixes a wrong method name.
### Why is it needed ?

Brand consistency and making sure people don't lose their mind looking for an invoiceEvent method. :P
### Related issue(s)/PR(s)
#12316
