### PR TITLE
(Enhancement + Code) Manager doesn't show users fullname in header #1…

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1969,4 +1969,13 @@ $settings['auto_isfolder']->fromArray(array (
     'area' => 'site',
     'editedon' => null,
 ), '', true, true);
+$settings['manager_use_fullname']= $xpdo->newObject('modSystemSetting');
+$settings['manager_use_fullname']->fromArray(array (
+    'key' => 'manager_use_fullname',
+    'value' => false,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'manager',
+    'editedon' => null,
+), '', true, true);
 return $settings;

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -767,3 +767,6 @@ $_lang['setting_default_context_desc'] = 'Select the default Context you wish to
 
 $_lang['setting_auto_isfolder'] = 'Set container automatically';
 $_lang['setting_auto_isfolder_desc'] = 'If set to yes, container property will be changed automatically.';
+
+$_lang['setting_manager_use_fullname'] = 'Show fullname in manager header ';
+$_lang['setting_manager_use_fullname_desc'] = 'If set to yes, the content of the "fullname" field will be shown in manager instead of "loginname"';

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -77,8 +77,17 @@ class TopMenu
      */
     public function setPlaceholders()
     {
+
+        if($this->modx->getOption('manager_use_fullname') == true) {
+            $userProfile = $this->modx->user->getOne('Profile');
+            $username = $userProfile->get('fullname');
+        } else {
+            $username = '';
+        }
+
+        if(empty($username)) $username = $this->modx->getLoginUserName();
         $placeholders = array(
-            'username' => $this->modx->getLoginUserName(),
+            'username' => $username,
             'userImage' => $this->getUserImage(),
         );
 


### PR DESCRIPTION
### What does it do ?

In #12457 @JensWolff provides a method for showing fullname instead of login name. I've added this method with system setting support.
### Why is it needed ?

Because some other people and i think  that it is a good idea :) and because modx posibilities and flexibility is awesome and should be developed further :) 
### Related issue(s)/PR(s)

fixes #12457
#12523

@Mark-H i hope thats better :) if I miss something please let me know.
