### PR TITLE
Make sure registered CSS/JS assets get loaded when using a "deprecated" manager controller

### DIFF
--- a/_build/test/Tests/Controllers/DeprecatedControllerTest.php
+++ b/_build/test/Tests/Controllers/DeprecatedControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Tests related to the modManagerControllerDeprecated controller class
+ */
+class DeprecatedControllerTest extends MODxTestCase {
+    /**
+     * @var modManagerControllerDeprecated
+     */
+    public $controller;
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->controller = new modManagerControllerDeprecated($this->modx);
+    }
+    public function tearDown() {
+        parent::tearDown();
+        $this->controller = null;
+    }
+
+    public function testCustomAssets() {
+        $data = <<<HTML
+<script>console.log('exists!');</script>
+HTML;
+
+        $this->controller->addHtml($data);
+        $output = $this->controller->render();
+
+        $this->assertContains($data, $output, 'Deprecated controller did not process additionally added assets/HTML');
+    }
+}

--- a/core/model/modx/modmanagercontrollerdeprecated.class.php
+++ b/core/model/modx/modmanagercontrollerdeprecated.class.php
@@ -4,7 +4,7 @@
  */
 /**
  * Handles backwards compatibility with pre-Revo 2.2 controllers
- * 
+ *
  * @package modx
  */
 class modManagerControllerDeprecated extends modManagerController {
@@ -91,7 +91,7 @@ class modManagerControllerDeprecated extends modManagerController {
     public function loadCustomCssJs() { return; }
     /**
      * Load the appropriate language topics for this page
-     * 
+     *
      * @return array
      */
     public function getLanguageTopics() { return array(); }
@@ -221,6 +221,12 @@ class modManagerControllerDeprecated extends modManagerController {
         }
         /* assign css/js to header */
         $this->setPlaceholder('cssjs',$this->modx->sjscripts);
+        if (!empty($this->head['js']) || !empty($this->head['lastjs']) || !empty($this->head['css']) ||
+            !empty($this->head['html'])
+        ) {
+            // Some plugin probably registered additional assets (ie. OnBeforeManagerPageInit), let's load them
+            parent::registerCssJs();
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

Execute parent method `modManagerController::registerCssJs` in `modManagerControllerDeprecated`.
### Why is it needed ?

At some point, some plugins could register additional CSS/JS/HTML using `$modx->controller->add{Javascript|Html|Css|LastJavascript}` methods.
Using those methods adds data into `modManagerController::$head`, which is never "processed" when the controller is an instance of `modManagerControllerDeprecated` and can result in "breaking" (or at least making it not consistent) a customized manager (additional JS/styling)

The controller can be an instance of `modManagerControllerDeprecated` when : 
1. using "pre 2.2 controller style" (not class based)
2. a controller is not found and the "Could not find action file at" error message is displayed
### Steps to reproduce issue
- create the following plugin

``` php
<?php
/**
 * @var modX $modx
 * @var array $scriptProperties
 *
 * @event OnBeforeManagerPageInit
 */

$modx->controller->addHtml(<<<HTML
<script>alert('Want some cake ?');</script>
HTML
);
```
- browse to any non existing controller/action, ie. `manager/?a=theCakeIsALie`
- notice you did not receive the alert message (apply this PR and see the alert message)
