### PR TITLE
Disable setup options button when dependencies are not met

### DIFF
--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -220,3 +220,5 @@ $_lang['workspace_scan_for_updates'] = 'Search for package updates';
 $_lang['view_details'] = 'View Details';
 $_lang['viewing_templates_available'] = 'Viewing Templates available in the selected Category.';
 $_lang['version'] = 'Version';
+$_lang['dependencies'] = 'Dependencies';
+$_lang['install_dependencies_first'] = 'Install all dependencies to continue';

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -39,7 +39,7 @@ Ext.extend(MODx.panel.PackageMetaPanel,MODx.VerticalTabs,{
 			this.addTab(_('changelog'), 'changelog', meta);
 		}
         if(meta.requires != undefined){
-            this.addDependenciesTab('Dependencies', 'dependencies', meta, record);
+            this.addDependenciesTab(_('dependencies'), 'dependencies', meta, record);
         }
 		if(meta.readme != undefined){
 			this.addTab(_('readme'), 'readme', meta);
@@ -283,7 +283,7 @@ MODx.panel.PackageDependencies = function(config) {
         ,cls: 'auto-width'
         ,bodyCssClass: 'vertical-tabs-body auto-width auto-height'
         ,items: [{
-            html: '<h2>'+ 'Dependencies' +'</h2>'
+            html: '<h2>'+ _('dependencies') +'</h2>'
             ,border: false
             ,cls: 'modx-page-header'
         },{
@@ -324,7 +324,10 @@ MODx.grid.PackageDependencies = function(config) {
 
     this.store.on('load', function () {
         if (!this.checkDependencies()) {
-            Ext.getCmp('package-install-btn').setText('Install all dependencies to continue');
+            Ext.getCmp('package-show-setupoptions-btn').setText(_('install_dependencies_first'));
+            Ext.getCmp('package-show-setupoptions-btn').disable();
+            
+            Ext.getCmp('package-install-btn').setText(_('install_dependencies_first'));
             Ext.getCmp('package-install-btn').disable();
         }
     }, this);

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -145,6 +145,9 @@ Ext.extend(MODx.panel.PackageBeforeInstall, MODx.panel.PackageMetaPanel,{
         if(meta.requires != undefined){
             this.addDependenciesTab('Dependencies', 'dependencies', meta, record);
         } else {
+            Ext.getCmp('package-show-setupoptions-btn').enable();
+            Ext.getCmp('package-show-setupoptions-btn').setText(_('setup_options'));
+            
             Ext.getCmp('package-install-btn').enable();
             Ext.getCmp('package-install-btn').setText(_('continue'));
         }


### PR DESCRIPTION
### What does it do ?

Disable setup options button when dependencies are not met. Also adds some missing translations.
### Why is it needed ?

Currently, if package with dependencies also has setup options, button for setup options is not disabled while dependencies are not installed, which can lead to errors during installing the main package.
