### PR TITLE
Grid autosave error msg

### DIFF
--- a/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
+++ b/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
@@ -18,7 +18,7 @@
 class modContentTypeUpdateFromGridProcessor extends modProcessor {
     /** @var array $records */
     public $records;
-    
+
     public function checkPermissions() {
         return $this->modx->hasPermission('content_types');
     }
@@ -37,10 +37,14 @@ class modContentTypeUpdateFromGridProcessor extends modProcessor {
     public function process() {
         $refresh = array();
         $field = $this->record;
-        if (empty($field['id'])) continue;
+        if (empty($field['id'])) {
+            return $this->failure($this->modx->lexicon('content_type_err_ns'));
+        };
         /** @var modContentType $contentType */
         $contentType = $this->modx->getObject('modContentType',$field['id']);
-        if (empty($contentType)) continue;
+        if (!$contentType) {
+            return $this->failure($this->modx->lexicon('content_type_err_nfs', array('id', $field['id'])));
+        };
 
         /* save content type */
         $field['binary'] = !empty($field['binary']) ? true : false;
@@ -48,8 +52,8 @@ class modContentTypeUpdateFromGridProcessor extends modProcessor {
 
         $refresh[] = $contentType->isDirty('file_extensions') && $this->modx->getCount('modResource', array('content_type' => $contentType->get('id')));
         if ($contentType->save() == false) {
-            $this->modx->error->checkValidation($contentType);
-            return $this->failure($this->modx->lexicon('content_type_err_save'));
+            $msg = $this->modx->error->checkValidation($contentType);
+            return $this->failure(empty($mg) ? $this->modx->lexicon('content_type_err_save') : $msg);
         }
 
         /* log manager action */

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -95,12 +95,7 @@ MODx.grid.Grid = function(config) {
     this._loadMenu(config);
     this.addEvents('beforeRemoveRow','afterRemoveRow','afterAutoSave');
     if (this.autosave) {
-        this.on('afterAutoSave', function(response) {
-            if (!response.success) {
-                var msg = response.data[0].msg || this.autosaveErrorMsg || _('error');
-                MODx.msg.alert(_('error'), msg);
-            }
-        });
+        this.on('afterAutoSave', this.onAfterAutoSave, this);
     }
     if (!config.preventRender) { this.render(); }
 
@@ -171,6 +166,28 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 }
             }
         });
+    }
+
+    /**
+     * Method executed after a record has been edited/saved inline from within the grid
+     *
+     * @param {Object} response - The processor save response object. See modConnectorResponse::outputContent (PHP)
+     */
+    ,onAfterAutoSave: function(response) {
+        if (!response.success && response.message === '') {
+            var msg = '';
+            if (response.data.length) {
+                // We get some data for specific field(s) error but not regular error message
+                Ext.each(response.data, function(data, index, list) {
+                    msg += (msg != '' ? '<br/>' : '') + data.msg;
+                }, this);
+            }
+            if (Ext.isEmpty(msg)) {
+                // Still no valid message so far, let's use some fallback
+                msg = this.autosaveErrorMsg || _('error');
+            }
+            MODx.msg.alert(_('error'), msg);
+        }
     }
 
     ,onChangePerPage: function(tf,nv) {

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -34,7 +34,7 @@ MODx.grid.Grid = function(config) {
             ,emptyText: config.emptyText || _('ext_emptymsg')
         }
         ,groupingConfig: {
-	    enableGroupingMenu: true
+            enableGroupingMenu: true
         }
     });
     if (config.paging) {
@@ -94,6 +94,14 @@ MODx.grid.Grid = function(config) {
     MODx.grid.Grid.superclass.constructor.call(this,config);
     this._loadMenu(config);
     this.addEvents('beforeRemoveRow','afterRemoveRow','afterAutoSave');
+    if (this.autosave) {
+        this.on('afterAutoSave', function(response) {
+            if (!response.success) {
+                var msg = response.data[0].msg || this.autosaveErrorMsg || _('error');
+                MODx.msg.alert(_('error'), msg);
+            }
+        });
+    }
     if (!config.preventRender) { this.render(); }
 
     this.on('rowcontextmenu',this._showMenu,this);

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -153,14 +153,9 @@ MODx.grid.User = function(config) {
                 'click': {fn: this.clearFilter, scope: this}
             }
         }]
+        ,autosaveErrorMsg: 'Random demo'
     });
     MODx.grid.User.superclass.constructor.call(this,config);
-    this.on('afterAutoSave', function(result) {
-        if (!result.success) {
-            var msg = result.data[0].msg || _('user_err_save');
-            MODx.msg.alert(_('error'), msg);
-        }
-    });
 };
 Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     getMenu: function() {

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -42,6 +42,7 @@ MODx.grid.User = function(config) {
         ,paging: true
         ,autosave: true
         ,save_action: 'security/user/updatefromgrid'
+        ,autosaveErrorMsg: _('user_err_save')
         ,remoteSort: true
         ,viewConfig: {
             forceFit:true
@@ -153,7 +154,6 @@ MODx.grid.User = function(config) {
                 'click': {fn: this.clearFilter, scope: this}
             }
         }]
-        ,autosaveErrorMsg: 'Random demo'
     });
     MODx.grid.User.superclass.constructor.call(this,config);
 };


### PR DESCRIPTION
### What does it do ?

When a manager grid has the "autosave" attribute (meaning we could edit/save records editing the grid records), it adds a listener to display an error message when the save fails.
It also provides a new attribute, `autosaveErrorMsg`, which allow developers to define a generic error message in case the process just returns a "failure" without additional message.
Since the content type processor i used to test the feature had some errors, i tried to fix them up.
### Why is it needed ?

Just to give a better UX/visual feedback when error occurs (previously the UX could led the user think a record was properly saved, while it was not the case)
### Related issue(s)/PR(s)
- Fixes #11946
