### PR TITLE
Add missing return statement 

### DIFF
--- a/core/model/modx/processors/workspace/packages/rest/download.class.php
+++ b/core/model/modx/processors/workspace/packages/rest/download.class.php
@@ -65,7 +65,7 @@ class modPackageDownloadProcessor extends modProcessor {
 
         $this->package = $this->provider->transfer($this->signature, null, array('location' => $this->location));
         if (!$this->package) {
-            $this->failure($this->modx->lexicon('package_download_err_create', array('signature' => $this->signature)));
+            return $this->failure($this->modx->lexicon('package_download_err_create', array('signature' => $this->signature)));
         }
 
         return $this->success('', $this->package);


### PR DESCRIPTION
### What does it do ?

The return statement in the package download processor was missing, and as a result the processor came back with "success: true", causing no error to be shown to the user.
### Why is it needed ?

When downloading of a package fails, the user wasn't getting an error message - it just refreshes like something was supposed to be happen.
### Related issue(s)/PR(s)

None that I know off. 
