### PR TITLE
Fix potential E_RECOVERABLE (and other) errors in package download

### DIFF
--- a/core/model/modx/transport/modtransportprovider.class.php
+++ b/core/model/modx/transport/modtransportprovider.class.php
@@ -149,6 +149,7 @@ class modTransportProvider extends xPDOSimpleObject {
                 }
             }
         } else {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not load package info from name for ' . $identifier . ', not yet implemented.');
             /* TODO: implement package info by package name */
         }
         return $info;
@@ -229,7 +230,8 @@ class modTransportProvider extends xPDOSimpleObject {
             $package->parseSignature();
             $package->setPackageVersionData();
 
-            $url = $this->downloadUrl($signature, $this->arg('location', array_merge($metadata['file'], $args)), $args);
+            $locationArgs = (isset($metadata['file'])) ? array_merge($metadata['file'], $args) : $args;
+            $url = $this->downloadUrl($signature, $this->arg('location', $locationArgs), $args);
             if (!empty($url)) {
                 if (empty($target)) {
                     $target = $this->xpdo->getOption('core_path', $args, MODX_CORE_PATH) . 'packages/';


### PR DESCRIPTION
### What does it do ?

Added a check to make sure $metadata['file'] exists before passing it to the array_merge function. Also an extra log entry just in case a certain condition is hit to make sure that doesn't fail silently. 
### Why is it needed ?

When trying to test if the modmore extras work as expected in 2.4, I was unable of downloading any of the packages. By checking the MODX error log, the array_merge was quickly identified as suspect:

```
[2015-08-09 23:14:41] (ERROR @ core/model/modx/transport/modtransportprovider.class.php : 234) PHP warning: array_merge(): Argument #1 is not an array
[2015-08-09 23:14:41] (ERROR @ core/model/modx/transport/modtransportprovider.class.php : 359) Recoverable error: Argument 2 passed to modTransportProvider::arg() must be of the type array, null given, called in core/model/modx/transport/modtransportprovider.class.php on line 234 and defined
[2015-08-09 23:14:41] (ERROR @ core/model/modx/transport/modtransportprovider.class.php : 367) Recoverable error: Argument 1 passed to modTransportProvider::args() must be of the type array, null given, called in core/model/modx/transport/modtransportprovider.class.php on line 361 and defined
[2015-08-09 23:14:41] (ERROR @ core/model/modx/transport/modtransportprovider.class.php : 382) PHP warning: array_merge(): Argument #2 is not an array
[2015-08-09 23:14:41] (ERROR @ core/model/modx/transport/modtransportprovider.class.php : 361) PHP warning: array_key_exists() expects parameter 2 to be array, null given
```

All these errors come from the single array_merge, it just cascades into $this->arg, which calls $this->args which has another array_merge. 

This pull request checks if there is a $metadata['file'] element in the info it got from the provider prior to attempting the merge. This way the errors are prevented, and it also properly falls back to the BC way of downloading from the "location" element. 

With just this PR, I could also once again download packages from the modmore provider - even without adding the file element. This is because the array_merge was returning null instead of the $args array, which already contained the location as it got from an earlier request. Nevertheless, I did fix the modmore provider to also provide the <file> info, so that can't be used to validate the PR. If a reproduction case is needed I can temporarily revert that, just hit me up on slack.  
### Related issue(s)/PR(s)

None that I know off, though this might also affect other third party providers. 
