### PR TITLE
Fixing Language string not found: ""

### DIFF
--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -133,7 +133,7 @@ class modElement extends modAccessibleSimpleObject {
                 }
                 $property['desc_trans'] = $this->xpdo->lexicon($property['desc']);
                 $property['area'] = !empty($property['area']) ? $property['area'] : '';
-                $property['area_trans'] = $this->xpdo->lexicon($property['area']);
+                $property['area_trans'] = !empty($property['area']) ? $this->xpdo->lexicon($property['area']) : '';
 
                 if (!empty($property['options'])) {
                     foreach ($property['options'] as &$option) {


### PR DESCRIPTION
It makes no sense to search for an empty lexicon key and it creates debug warnings `Language string not found: ""`
