### PR TITLE
Fix #12549: Site name in header not accounting for quotes

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -64,7 +64,7 @@
 {$_lang.dashboard}">{$_lang.dashboard}</a>
                 </li>
                 <li id="modx-site-info">
-                    <div id="site_name" class="info-item site_name" title="{$_config.site_name|escape}">{$_config.site_name}</div>
+                    <div id="site_name" class="info-item site_name" title="{$_config.site_name|strip_tags|escape}">{$_config.site_name}</div>
                     {* TODO: Pull full_appname from docs/version.inc.php ? *}
                     <div class="info-item full_appname">MODX Revolution {$_config.settings_version}</div>
                 </li>

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -64,7 +64,7 @@
 {$_lang.dashboard}">{$_lang.dashboard}</a>
                 </li>
                 <li id="modx-site-info">
-                    <div id="site_name" class="info-item site_name" title="{$_config.site_name}">{$_config.site_name}</div>
+                    <div id="site_name" class="info-item site_name" title="{$_config.site_name|escape}">{$_config.site_name}</div>
                     {* TODO: Pull full_appname from docs/version.inc.php ? *}
                     <div class="info-item full_appname">MODX Revolution {$_config.settings_version}</div>
                 </li>


### PR DESCRIPTION
### Summary

Fixes issue #12549 where the tooltip for the site name does not account for quotes in the site name. The description visible in the tooltip is truncated at the first occurence of a quote.
### Step to reproduce

Give the site a name containing a quote.
### Observed behavior

Hover the site name in the top menu. The tooltip that should appear is truncated.
### Expected behavior

The tooltip should not be truncated.
### Environment

Running MODX Revolution 2.4.0-rc1, forked and synced with modxcms/revolution today (12.08.15). Nothing else is relevant
