### PR TITLE
bugfix installed package list in its detail's page

### DIFF
--- a/core/model/modx/processors/workspace/packages/version/getlist.class.php
+++ b/core/model/modx/processors/workspace/packages/version/getlist.class.php
@@ -31,7 +31,7 @@ class modPackageVersionGetListProcessor extends modObjectGetListProcessor {
         /* get packages */
         $criteria = array(
             'workspace' => $this->getProperty('workspace',1),
-            'package_name' => $signatureArray[0],
+            'package_name' => urldecode($this->getProperty('package_name',$signatureArray[0])),
         );
         $limit = $this->getProperty('limit');
         $pkgList = $this->modx->call('transport.modTransportPackage', 'listPackageVersions', array(&$this->modx, $criteria, $limit > 0 ? $limit : 0, $this->getProperty('start')));
@@ -60,7 +60,7 @@ class modPackageVersionGetListProcessor extends modObjectGetListProcessor {
 
     public function parseVersion(modTransportPackage $package,array $packageArray) {
         $signatureArray = explode('-',$package->get('signature'));
-        $packageArray['name'] = $signatureArray[0];
+        $packageArray['name'] = !empty($packageArray['package_name']) ? $packageArray['package_name'] : $signatureArray[0];
         $packageArray['version'] = $signatureArray[1];
         if (isset($signatureArray[2])) {
             $packageArray['release'] = $signatureArray[2];

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -151,7 +151,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
+        this.refresh();
         return true;
     }
 
@@ -161,7 +161,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
     	};
         Ext.getCmp('modx-package-search').reset();
     	this.getBottomToolbar().changePage(1);
-        //this.refresh();
+        this.refresh();
     }
 
 
@@ -237,10 +237,10 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 	/* Install a package */
 	,install: function( record ){
 		Ext.Ajax.request({
-			url : MODx.config.connectors_url
+			url : MODx.config.connector_url
 			,params : {
 				action : 'workspace/packages/getAttribute'
-				,attributes: 'license,readme,changelog,setup-options,requires'
+				,attributes: 'license,readme,changelog,setup-options'
 				,signature: record.data.signature
 			}
 			,method: 'GET'
@@ -258,7 +258,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 	,processResult: function( response, record ){
 		var data = Ext.util.JSON.decode( response );
 
-		if ( data.object.license !== null && data.object.readme !== null && data.object.changelog !== null){
+		if ( data.object.license !== null && data.object.readme !== null && data.object.changelog !== null ){
 			/* Show license/changelog panel */
 			p = Ext.getCmp('modx-package-beforeinstall');
 			p.activate();
@@ -271,8 +271,6 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 			/* No license/changelog, no setup-options, install directly */
 			Ext.getCmp('modx-panel-packages').install();
 		}
-
-        Ext.getCmp('package-install-btn').setText(Ext.getCmp('package-install-btn').getText());
 	}
 
 	/* Launch Package Browser */
@@ -349,7 +347,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 
 	/* Go to package details @TODO : Stay on the same page */
     ,viewPackage: function(btn,e) {
-        MODx.loadPage('workspaces/package/view', 'signature='+this.menu.record.signature);
+        MODx.loadPage('workspaces/package/view', 'signature='+this.menu.record.signature+'&package_name='+this.menu.record.name);
     }
 
 	/* Search for a package update - only for installed package */

--- a/manager/assets/modext/workspace/package/index.js
+++ b/manager/assets/modext/workspace/package/index.js
@@ -5,6 +5,7 @@ MODx.page.Package = function(config) {
         ,components: [{
             xtype: 'modx-panel-package'
             ,signature: MODx.request.signature
+            ,package_name: MODx.request.package_name
         }]
         ,buttons: [{
             process: 'workspace/packages/update'

--- a/manager/assets/modext/workspace/package/package.panel.js
+++ b/manager/assets/modext/workspace/package/package.panel.js
@@ -85,6 +85,7 @@ MODx.panel.Package = function(config) {
                 xtype: 'modx-grid-package-versions'
 				,cls: 'main-wrapper'
                 ,signature: config.signature
+                ,package_name: config.package_name
                 ,preventRender: true
             }]
         }])]

--- a/manager/assets/modext/workspace/package/package.versions.grid.js
+++ b/manager/assets/modext/workspace/package/package.versions.grid.js
@@ -12,6 +12,7 @@ MODx.grid.PackageVersions = function(config) {
         ,baseParams: {
             action: 'workspace/packages/version/getList'
             ,signature: config.signature
+            ,package_name: config.package_name
         }
         ,fields: ['signature','name','version','release','created','updated','installed','state'
                  ,'workspace','provider','provider_name','disabled','source'


### PR DESCRIPTION
Re:  #11125
### Summary

bugfix installed package list in its detail's page when the package's name has spaces.
http://forums.modx.com/thread/88734/package-version-check#dis-post-489531
### Step to reproduce
1. Download lower version of any package that has spaces on its name, eg: [Grid Class Key](http://modx.com/extras/package/gridclasskey), [TinyMCE Rich Text Editor](http://modx.com/extras/package/tinymcerichtexteditor)
2. Search it locally.
3. Install it.
4. Open your DB admin, go to `modx_transport_packages` table, and edit its package name to the one like what you should get if it's downloaded from remote, eg: **Grid Class Key**, or **TinyMCE Rich Text Editor** (**...with spaces!**). (installing them from local searching also has another issue, it's not picking up the correct package name -- such if you download it from remote provider, but rather it's signature.).
5. Download again its higher version.
6. Upgrade it.
7. Edit its package name again.
8. Now, back to the Package list, click "view details". You won't find the lower version in the "Uploaded Versions" tab.
### Observed behavior

If you click "view details" of the package in Package Management/Installer, you can't find the lower version of those packages.
### Expected behavior

It should list the lower version of packages.
### Environment

MODX 2.3.5-pl sdk
