### PR TITLE
Added ability to generate custom manager "top menus"

### DIFF
--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -65,15 +65,20 @@ class TopMenu
         $this->setPlaceholders();
 
         // Then process menu "containers"
-        $this->buildMenu(
-            $this->modx->getOption('main_nav_parent', null, 'topnav', true),
-            'navb'
-        );
-        $this->buildMenu(
-            $this->modx->getOption('user_nav_parent', null, 'usernav', true),
-            'userNav'
-        );
-
+        $mainNav = $this->modx->smarty->getTemplateVars('navb');
+        if (empty($mainNav)) {
+            $this->buildMenu(
+                $this->modx->getOption('main_nav_parent', null, 'topnav', true),
+                'navb'
+            );
+        }
+        $userNav = $this->modx->smarty->getTemplateVars('userNav');
+        if (empty($userNav)) {
+            $this->buildMenu(
+                $this->modx->getOption('user_nav_parent', null, 'usernav', true),
+                'userNav'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

Build manager "top menus" only if some Smarty template variables (`$navb` & `$userNav`) are not already "defined".
### Why is it needed ?

Since 28517da9, we can generate custom manager top menu "navigation" making use of some `modMenu` records (with `main_nav_parent` & `user_nav_parent` settings).
However, one might want to build custom top menu without relying on some DB.

With this PR, we could achieve so with the following sample plugin : 

``` php
<?php
/**
 * @var modX $modx
 * @var array $scriptProperties
 *
 * @event OnBeforeManagerPageInit
 */

$html = <<<HTML
<li>
    <a href="?a=system/event">Error log</a>
</li>
<li class="top">
    <a>Container</a>
    <ul class="modx-subnav">
        <li>
            <a href="?a=system/event">
                Error log again
                <span class="description">This leads to the error log too</span>
            </a>
        </li>
    </ul>
</li>
HTML;

$modx->controller->setPlaceholder('navb', $html);
```
### To do next

For now `TopMenu::buildMenu` expects to process `modMenu` records to "format" the HTML output. It would be cool to provide public method(s) (or a dedicated service class) which would just process some array (using the same syntax `modMenu::rebuildCache` produces) so that developers would not have to "duplicate" that code chunk.
