### PR TITLE
Pass signature via setup options

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -137,6 +137,7 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
 		if(this.win == undefined){
 			this.win = new MODx.window.SetupOptions({
 				id: 'modx-window-setupoptions'
+				,signature: btn.signature || ''
 			});
 		}
 		this.win.show(btn);

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -266,9 +266,11 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 		}
 		else if ( data.object['setup-options'] !== null ) {
 			/* No license/changelog, show setup-options */
+            Ext.getCmp('package-show-setupoptions-btn').signature = record.data.signature;
 			Ext.getCmp('modx-panel-packages').onSetupOptions();
 		} else {
 			/* No license/changelog, no setup-options, install directly */
+            Ext.getCmp('package-install-btn').signature = record.data.signature;
 			Ext.getCmp('modx-panel-packages').install();
 		}
 

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -159,7 +159,8 @@ Ext.extend(MODx.panel.PackageBeforeInstall, MODx.panel.PackageMetaPanel,{
 		}
 
 		if(meta['setup-options'] != null && meta['setup-options'] != ''){
-			Ext.getCmp('package-show-setupoptions-btn').show();
+            Ext.getCmp('package-show-setupoptions-btn').signature = record.data.signature;
+            Ext.getCmp('package-show-setupoptions-btn').show();
 			this.setupOptions = meta['setup-options'];
 		} else {
             Ext.getCmp('package-install-btn').signature = record.data.signature;

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -175,6 +175,7 @@ Ext.extend(MODx.window.SetupOptions,MODx.Window,{
 	,install: function(btn, ev){
 		this.hide();
 		var options = Ext.getCmp('modx-setupoptions-form').getForm().getValues();
+        options.signature = this.signature;
 		Ext.getCmp('modx-panel-packages').install( options );
 	}
 });


### PR DESCRIPTION
### What does it do ?

Passes signature via setup options window, when setup options are present.
### Why is it needed ?

Without this change, when installing dependency with setup options, it doesn't pass current signature and installer starts installing parent package, which fails, because of unresolved dependencies.
### Related issue(s)/PR(s)
- Package dependency not installing as expected #12541
