### PR TITLE
Old Resources browser CSS loaded when compress_css is turned on

### DIFF
--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -7,7 +7,7 @@
 
 {if $_config.compress_css}
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
-<link rel="stylesheet" type="text/css" href="{$_config.manager_url}min/index.php?f={$_config.manager_url}templates/default/css/xtheme-modx.css,{$_config.manager_url}templates/default/css/index.css" />
+<link rel="stylesheet" type="text/css" href="{$_config.manager_url}min/index.php?f={$_config.manager_url}templates/default/css/index.css" />
 {else}
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
 <!--link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/xtheme-modx.css" /-->


### PR DESCRIPTION
When compress_css is turned on, the MODX resources browser is loading in an old CSS (looks like from 2.2). It will look like this:

![voila_capture 2015-08-16_12-46-47_pm](https://cloud.githubusercontent.com/assets/487567/9292961/702c0780-4415-11e5-96ad-6dbe59ff07f2.jpg)

This only happens with the browser which opens when using the insert image/file button in TinyMCE, not with the 'Media > MODX browser' function.

MODX 2.3.5

Related issue: https://github.com/modxcms/revolution/issues/12553
