### PR TITLE
Preselect core namespace if it is available in namespace combo box

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -639,12 +639,19 @@ MODx.combo.Namespace = function(config) {
 Ext.extend(MODx.combo.Namespace,MODx.combo.ComboBox, {
     preselectFirstValue: function(r) {
         var item;
+        
         if (this.config.preselectValue == '') {
             item = r.getAt(0);
         } else {
-            item = {data: {name: this.config.preselectValue}};
+            var found = r.find('name', this.config.preselectValue);
+            
+            if (found != -1) {
+                item = r.getAt(found);
+            } else {
+                item = r.getAt(0);
+            }
         }
-
+        
         if (item) {
             this.setValue(item.data.name);
             this.fireEvent('select', this, item);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -23,7 +23,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,name: 'namespace'
         ,id: 'modx-filter-namespace'
         ,emptyText: _('namespace_filter')
-        ,preselectValue: MODx.request['ns'] ? MODx.request['ns'] : ''
+        ,preselectValue: MODx.request['ns'] ? MODx.request['ns'] : 'core'
         ,allowBlank: false
         ,editable: true
         ,typeAhead: true
@@ -138,7 +138,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'system/settings/getList'
-            ,namespace: MODx.request['ns'] ? MODx.request['ns'] : ''
+            ,namespace: MODx.request['ns'] ? MODx.request['ns'] : 'core'
             ,area: MODx.request['area']
         }
         ,clicksToEdit: 2


### PR DESCRIPTION
### What does it do ?

Preselect core namespace as default in namespace combo box, if core namespace is not available, first namespace is selected.
### Why is it needed ?

Currently is preselected first namespace every time.
