### PR TITLE
Prints out the name of failing plugin in error log

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1615,7 +1615,7 @@ class modX extends xPDO {
                     if ($msg && is_string($msg)) {
                         $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . ']' . $msg);
                     } elseif ($msg === false) {
-                        $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . '] Plugin failed!');
+                        $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . '] Plugin ' . $plugin->name . ' failed!');
                     }
                     $this->event->plugin = null;
                     $this->event->activePlugin= '';


### PR DESCRIPTION
### What does it do ?

Added a code to print out the plugin name.
### Why is it needed ?

Debugging the failing plugin was a guessing game, now it prints out the plugin name so it should help the developer.
**Before**
`[2015-08-21 21:46:46] (ERROR @ /connectors/index.php) [OnDocFormSave] Plugin failed!`

**After**
`[2015-08-21 21:46:46] (ERROR @ /connectors/index.php) [OnDocFormSave] Plugin some-plugin-name-here failed!`
### Related issue(s)/PR(s)

n/a

Thanks to @opengeek for the hint and the code.
