### PR TITLE
Fix CLI installation notices (#12564) due to undefined index type

### DIFF
--- a/core/model/modx/mysql/modtemplatevarresourcegroup.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevarresourcegroup.map.inc.php
@@ -37,6 +37,8 @@ $xpdo_meta_map['modTemplateVarResourceGroup']= array (
     'tmplvar_template' => 
     array (
       'alias' => 'tmplvar_template',
+      'primary' => false,
+      'unique' => false,
       'type' => 'BTREE',
       'columns' => 
       array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1217,7 +1217,7 @@
         <field key="tmplvarid" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         <field key="documentgroup" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
 
-        <index alias="tmplvar_template" name="tmplvar_template" type="BTREE">
+        <index alias="tmplvar_template" name="tmplvar_template" primary="false" unique="false" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />
             <column key="documentgroup" length="" collation="A" null="false" />
         </index>

--- a/core/xpdo/om/mysql/xpdomanager.class.php
+++ b/core/xpdo/om/mysql/xpdomanager.class.php
@@ -459,7 +459,10 @@ class xPDOManager_mysql extends xPDOManager {
         if (isset($meta['type']) && $meta['type'] == 'FULLTEXT') {
             $indexType = "FULLTEXT";
         } else {
-            $indexType = ($meta['primary'] ? 'PRIMARY KEY' : ($meta['unique'] ? 'UNIQUE KEY' : 'INDEX'));
+            if (!(isset($meta['primary']) && isset($meta['unique']))) {
+                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Undefined index type for '.$class.' / '.$name);
+            }
+            $indexType = ((isset($meta['primary']) && $meta['primary']) ? 'PRIMARY KEY' : ((isset($meta['unique']) && $meta['unique']) ? 'UNIQUE KEY' : 'INDEX'));
         }
         $index = $meta['columns'];
         if (is_array($index)) {


### PR DESCRIPTION
### What does it do ?

The index type for `modTemplateVarResourceGroup / tmplvar_template` is undefined since 5599467

Update MODX xPDO model to add index type definition (primary and unique). 

Also update `getIndexDef()` to replace these warnings by a log entry.
### Why is it needed ?

Fix CLI installation notices (#12564) due to undefined index type
### Related issue(s)/PR(s)
#12564 : CLI installation notices
