### PR TITLE
Add `createdon` date field to modUser (cf. #11472)

### DIFF
--- a/core/lexicon/en/user.inc.php
+++ b/core/lexicon/en/user.inc.php
@@ -200,3 +200,5 @@ $_lang['user_website'] = 'Website';
 $_lang['user_zip'] = 'Zip';
 $_lang['username'] = 'Username';
 $_lang['users'] = 'Users';
+$_lang['user_createdon'] = 'Created On';
+$_lang['user_createdon_desc'] = 'The date the user was created.';

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -15,6 +15,10 @@
  * @property json $remote_data Used for storing remote data for authentication for a User
  * @property string $hash_class The hashing class used to create this User's password
  * @property string $salt A salt that might have been used to create this User's password
+ * @property int $primary_group The user primary Group
+ * @property array $session_stale
+ * @property int $sudo If checked, this user will have full access to all the site and will bypass any Access Permissions checks
+ * @property int $createdon The user creation date
  *
  * @property modUserProfile $Profile
  * @property modUserGroup $PrimaryGroup
@@ -81,6 +85,7 @@ class modUser extends modPrincipal {
      */
     public function save($cacheFlag = false) {
         $isNew = $this->isNew();
+        if ($isNew) $this->set('createdon', time());
 
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('OnUserBeforeSave',array(

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -85,7 +85,7 @@ class modUser extends modPrincipal {
      */
     public function save($cacheFlag = false) {
         $isNew = $this->isNew();
-        if ($isNew) $this->set('createdon', time());
+        if ($isNew && ($this->get('createdon') < 1)) $this->set('createdon', time());
 
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('OnUserBeforeSave',array(

--- a/core/model/modx/mysql/moduser.map.inc.php
+++ b/core/model/modx/mysql/moduser.map.inc.php
@@ -22,6 +22,7 @@ $xpdo_meta_map['modUser']= array (
     'primary_group' => 0,
     'session_stale' => NULL,
     'sudo' => 0,
+    'createdon' => 0,
   ),
   'fieldMeta' => 
   array (
@@ -120,6 +121,14 @@ $xpdo_meta_map['modUser']= array (
       'precision' => '1',
       'phptype' => 'boolean',
       'attributes' => 'unsigned',
+      'null' => false,
+      'default' => 0,
+    ),
+    'createdon' =>
+    array (
+      'dbtype' => 'int',
+      'precision' => '20',
+      'phptype' => 'timestamp',
       'null' => false,
       'default' => 0,
     ),

--- a/core/model/modx/sqlsrv/moduser.map.inc.php
+++ b/core/model/modx/sqlsrv/moduser.map.inc.php
@@ -22,6 +22,7 @@ $xpdo_meta_map['modUser']= array (
     'primary_group' => 0,
     'session_stale' => NULL,
     'sudo' => 0,
+    'createdon' => 0,
   ),
   'fieldMeta' => 
   array (
@@ -116,6 +117,13 @@ $xpdo_meta_map['modUser']= array (
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+    'createdon' =>
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
       'null' => false,
       'default' => 0,
     ),

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1253,6 +1253,7 @@
         <field key="primary_group" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="index" />
         <field key="session_stale" dbtype="text" phptype="array" null="true" />
         <field key="sudo" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="false" default="0" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <index alias="username" name="username" primary="false" unique="true" type="BTREE">
             <column key="username" length="" collation="A" null="false" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -1192,6 +1192,7 @@
         <field key="primary_group" dbtype="int" phptype="integer" null="false" default="0" index="index" />
         <field key="session_stale" dbtype="nvarchar" precision="max" phptype="array" null="true" />
         <field key="sudo" dbtype="bit" phptype="boolean" null="false" default="0" />
+        <field key="createdon" dbtype="bigint" phptype="timestamp" null="false" default="0" />
 
         <index alias="username" name="username" primary="false" unique="true" type="BTREE">
             <column key="username" length="" collation="A" null="false" />

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -464,6 +464,12 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,description: _('user_failedlogincount_desc')
                     ,xtype: 'textfield'
                 },{
+                    id: 'modx-user-createdon'
+                    ,name: 'createdon'
+                    ,fieldLabel: _('user_createdon')
+                    ,description: _('user_createdon_desc')
+                    ,xtype: 'statictextfield'
+                },{
                     id: 'modx-user-class-key'
                     ,name: 'class_key'
                     ,fieldLabel: _('class_key')

--- a/setup/includes/upgrades/common/2.4.1-user-createdon.php
+++ b/setup/includes/upgrades/common/2.4.1-user-createdon.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Common upgrade script for 2.4 modUser
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+/* add modUser.createdon field */
+$class = 'modUser';
+$table = $modx->getTableName($class);
+
+$description = $this->install->lexicon('add_column',array('column' => 'createdon','table' => $table));
+$this->processResults($class, $description, array($modx->manager, 'addField'), array($class, 'createdon'));


### PR DESCRIPTION
### What does it do ?

Update MODX xPDO model, Lexicon, modUser class and the ExtJS panel to deal with this new column.
### Why is it needed ?

This PR is related to "#11472 - Add date joined to modUserProfile"
### Related issue(s)/PR(s)
- #8461 : User createdon 
- #12119 : User creation date 
- #4055 : RegisteredoOn date 
- #4591 : Add active and added user dates 
