### PR TITLE
Resolves #12578

### DIFF
--- a/core/model/modx/processors/system/log/getlist.class.php
+++ b/core/model/modx/processors/system/log/getlist.class.php
@@ -106,7 +106,7 @@ class modSystemLogGetListProcessor extends modProcessor {
             $logArray['name'] = $logArray['classKey'] . ' (' . $logArray['item'] . ')';
             /** @var xPDOObject $obj */
             $obj = $this->modx->getObject($logArray['classKey'], $logArray['item']);
-            if ($obj && ($obj->get($obj->getPK()) === $logArray['item'])) {
+            if ($obj && ($obj->get($obj->getPK()) == $logArray['item'])) {
                 $nameField = $this->getNameField($logArray['classKey']);
                 $k = $obj->getField($nameField, true);
                 if (!empty($k)) {


### PR DESCRIPTION
### What does it do ?

Add resource title in Manager Log, for edited resources.
### Why is it needed ?

The resource title was missing, and was only showing ID and the class_key
### Related issue(s)/PR(s)

Fixes #12578.

Special Thanks goes to @Mark-H :smile: 
