### PR TITLE
A suggestion to add support for CONSTANT format for "debug" settings (#12579)

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -630,18 +630,31 @@ class modX extends xPDO {
      * @param boolean $stopOnNotice Indicates if processing should stop when
      * encountering PHP errors of type E_NOTICE.
      * @return boolean|int The previous value.
+     *
+     * @info PHP errors are handle by modErrorHandler with at most LOG_LEVEL_INFO
+     *       When called by modX $debug is a string (ie $this->getOption('debug'))
+     *
+     *          (bool)true , (string)true , (string)-1 -> LOG_LEVEL_DEBUG (MODX), E_ALL | E_STRICT (PHP)
+     *          (bool)false, (string)false, (string) 0 -> LOG_LEVEL_ERROR (MODX), 0                (PHP)
+     *          (int)nnn                               -> LOG_LEVEL_INFO  (MODX), nnn              (PHP)
+     *          (string)E_XXX                          -> LOG_LEVEL_INFO  (MODX), E_XXX            (PHP)
      */
     public function setDebug($debug= true) {
         $oldValue= $this->getDebug();
-        if ($debug === true) {
+        if (($debug === true) || ('true' === $debug) || ('-1' === $debug)) {
             error_reporting(-1);
             parent :: setDebug(true);
-        } elseif ($debug === false) {
-            error_reporting(0);
-            parent :: setDebug(false);
         } else {
-            error_reporting(intval($debug));
-            parent :: setDebug(intval($debug));
+            if (($debug === false) || ('false' === $debug) || ('0' === $debug)) {
+                error_reporting(0);
+                parent :: setDebug(false);
+            } else {
+                $debug = (is_int($debug) ? $debug : defined($debug) ? intval(constant($debug)) : 0);
+                if ($debug) {
+                    error_reporting($debug);
+                    parent :: setLogLevel(xPDO::LOG_LEVEL_INFO);
+                }
+            }
         }
         return $oldValue;
     }


### PR DESCRIPTION
### What does it do ?

Add supoort for PHP constants name `E_ALL`, `E_ERROR`..., some extra checks on values and replace XPDO `setDebug()` by a `setLogLevel()` in these cases.

At this point, combine form like `E_ALL & ~E_NOTICE` are not supported.  
### Why is it needed ?

Selecting PHP log level is more simple and the `error.log` really smallest
### Related issue(s)/PR(s)
#12579 : Problems with debug System Setting
