### PR TITLE
Fixed instantiateController method for work with php 7

### DIFF
--- a/core/model/modx/modmanagerresponse.class.php
+++ b/core/model/modx/modmanagerresponse.class.php
@@ -187,7 +187,7 @@ class modManagerResponse extends modResponse {
                 $getInstanceMethod = 'getInstance';
             }
             /* this line allows controller derivatives to decide what instance they want to return (say, for derivative class_key types) */
-            $this->modx->controller = call_user_func_array(array($c,$getInstanceMethod),array($this->modx,$className,$this->action));
+            $this->modx->controller = $c->$getInstanceMethod($this->modx, $className, $this->action);
             $this->modx->controller->setProperties($c instanceof SecurityLoginManagerController ? $_POST : array_merge($_GET,$_POST));
             $this->modx->controller->initialize();
         } catch (Exception $e) {


### PR DESCRIPTION
### What does it do ?

Not fully clear why, but code with `call_user_func_array` not work in php7, so I changed this code to the same by action, but with another syntax.
### Why is it needed ?

It's fix fatal error 

```
Fatal error: Uncaught Error: Call to a member function setProperties() on null in /home/vagrant/Code/revo24/core/model/modx/modmanagerresponse.class.php:191 
Stack trace: 
#0 /home/vagrant/Code/revo24/core/model/modx/modmanagerresponse.class.php(73): modManagerResponse->instantiateController('WelcomeManagerC...', 'getInstance') 
#1 /home/vagrant/Code/revo24/core/model/modx/modmanagerrequest.class.php(180): modManagerResponse->outputContent(Array) 
#2 /home/vagrant/Code/revo24/core/model/modx/modmanagerrequest.class.php(128): modManagerRequest->prepareResponse() 
#3 /home/vagrant/Code/revo24/manager/index.php(75): modManagerRequest->handleRequest() 
#4 {main} thrown in /home/vagrant/Code/revo24/core/model/modx/modmanagerresponse.class.php on line 191
```

when running MODX on php 7
### Related issue(s)/PR(s)

No any relations.
