### PR TITLE
Language string not found

### DIFF
--- a/core/lexicon/en/source.inc.php
+++ b/core/lexicon/en/source.inc.php
@@ -48,15 +48,25 @@ $_lang['sources.intro_msg'] = 'Manage all your Media Sources here.';
 $_lang['user_group'] = 'User Group';
 
 /* file source type */
+$_lang['allowedFileTypes'] = 'allowedFileTypes';
 $_lang['prop_file.allowedFileTypes_desc'] = 'If set, will restrict the files shown to only the specified extensions. Please specify in a comma-separated list, without the dots preceding the extensions.';
+$_lang['basePath'] = 'basePath';
 $_lang['prop_file.basePath_desc'] = 'The file path to point the Source to.';
+$_lang['basePathRelative'] = 'basePathRelative';
 $_lang['prop_file.basePathRelative_desc'] = 'If the Base Path setting above is not relative to the MODX install path, set this to No.';
+$_lang['baseUrl'] = 'baseUrl';
 $_lang['prop_file.baseUrl_desc'] = 'The URL that this source can be accessed from.';
+$_lang['baseUrlPrependCheckSlash'] = 'baseUrlPrependCheckSlash';
 $_lang['prop_file.baseUrlPrependCheckSlash_desc'] = 'If true, MODX only will prepend the baseUrl if no forward slash (/) is found at the beginning of the URL when rendering the TV. Useful for setting a TV value outside the baseUrl.';
+$_lang['baseUrlRelative'] = 'baseUrlRelative';
 $_lang['prop_file.baseUrlRelative_desc'] = 'If the Base URL setting above is not relative to the MODX install URL, set this to No.';
+$_lang['imageExtensions'] = 'imageExtensions';
 $_lang['prop_file.imageExtensions_desc'] = 'A comma-separated list of file extensions to use as images. MODX will attempt to make thumbnails of files with these extensions.';
+$_lang['skipFiles'] = 'skipFiles';
 $_lang['prop_file.skipFiles_desc'] = 'A comma-separated list. MODX will skip over and hide files and folders that match any of these.';
+$_lang['thumbnailQuality'] = 'thumbnailQuality';
 $_lang['prop_file.thumbnailQuality_desc'] = 'The quality of the rendered thumbnails, in a scale from 0-100.';
+$_lang['thumbnailType'] = 'thumbnailType';
 $_lang['prop_file.thumbnailType_desc'] = 'The image type to render thumbnails as.';
 
 /* s3 source type */

--- a/core/lexicon/en/source.inc.php
+++ b/core/lexicon/en/source.inc.php
@@ -80,3 +80,8 @@ $_lang['prop_s3.thumbnailQuality_desc'] = 'The quality of the rendered thumbnail
 $_lang['prop_s3.thumbnailType_desc'] = 'The image type to render thumbnails as.';
 $_lang['prop_s3.url_desc'] = 'The URL of the Amazon S3 instance.';
 $_lang['s3_no_move_folder'] = 'The S3 driver does not support moving of folders at this time.';
+
+/* file type */
+$_lang['PNG'] = 'PNG';
+$_lang['JPG'] = 'JPG';
+$_lang['GIF'] = 'GIF';

--- a/core/model/modx/processors/source/getlist.class.php
+++ b/core/model/modx/processors/source/getlist.class.php
@@ -13,7 +13,7 @@
  */
 class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'sources.modMediaSource';
-    public $languageTopics = array('sources');
+    public $languageTopics = array('source');
     public $permission = 'source_view';
 
     public function initialize() {

--- a/core/model/modx/processors/source/type/getlist.class.php
+++ b/core/model/modx/processors/source/type/getlist.class.php
@@ -14,7 +14,7 @@ class modMediaSourceTypeGetListProcessor extends modProcessor {
         return $this->modx->hasPermission('sources');
     }
     public function getLanguageTopics() {
-        return array('sources');
+        return array('source');
 
     }
     


### PR DESCRIPTION
### What does it do ?

The patches add some language keys and change the topic names of two processors.
### Why is it needed ?

Removing several debug messages in a default installation:
- Language string not found
- An error occurred while trying to cache lexicon/de/core/sources
### Related issue(s)/PR(s)

See #12291, #12466 
