### PR TITLE
Not rendered output properties of custom TVs

### DIFF
--- a/core/model/modx/processors/element/tv/renders/getinputproperties.class.php
+++ b/core/model/modx/processors/element/tv/renders/getinputproperties.class.php
@@ -16,7 +16,7 @@ class modTvRendersGetPropertiesProcessor extends modProcessor {
 
     public $propertiesKey = 'input_properties';
     public $renderDirectory = 'inputproperties';
-    public $onPropertiesListEvent= 'OnTVInputPropertiesList';
+    public $onPropertiesListEvent= 'OnTVOutputRenderPropertiesList';
 
     public function checkPermissions() {
         return $this->modx->hasPermission('view_tv');


### PR DESCRIPTION
### What does it do ?

Fixing not rendered output properties of custom TVs.
### Why is it needed ?

Not rendered output properties of custom TVs.
### Related issue(s)/PR(s)

See: https://github.com/Jako/ImagePlus/issues/13
