### PR TITLE
Add "Updatable" Column to packages grid

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -30,10 +30,11 @@ MODx.grid.Package = function(config) {
 
     var cols = [];
     cols.push(this.exp);
-    cols.push({ header: _('name') ,dataIndex: 'name', id:'main',renderer: { fn: this.mainColumnRenderer, scope: this } });
-    cols.push({ header: _('version') ,dataIndex: 'version', id: 'meta-col', fixed:true, width:120, renderer: function (v, md, record) { return v + '-' + record.data.release;} });
-    cols.push({ header: _('installed') ,dataIndex: 'installed', id: 'info-col', fixed:true, width: 160 ,renderer: this.dateColumnRenderer });
-    cols.push({ header: _('provider') ,dataIndex: 'provider_name', id: 'text-col', fixed:true, width:120 });
+    cols.push({ header: _('name')     ,dataIndex: 'name'         , id:'main'     , sortable: true,                        renderer: { fn: this.mainColumnRenderer, scope: this } });
+    cols.push({ header: _('version')  ,dataIndex: 'version'      , id:'meta-col' , sortable: true, fixed:true, width:120, renderer: function (v, md, record) { return v + '-' + record.data.release;} });
+    cols.push({ header: _('installed'),dataIndex: 'installed'    , id:'info-col' , sortable: true, fixed:true, width:160, renderer: this.dateColumnRenderer });
+    cols.push({ header: _('provider') ,dataIndex: 'provider_name', id:'text-col' , sortable: true, fixed:true, width:120});
+    cols.push({ header: _('update')   ,dataIndex: 'updateable'   , align:'center', sortable: true, fixed:true, width:120, renderer: function (v, md, record) { return (v ? _('yes') : _('no'));} });
 
     var dlbtn;
     if (MODx.curlEnabled) {
@@ -83,7 +84,7 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
-        ,pageSize: 10
+        ,pageSize: MODx.config.default_per_page > 30 ? MODx.config.default_per_page : 30
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true


### PR DESCRIPTION
### What does it do ?

This PR add an "Updatable" column to packages grid. This new column and the others are now sortable. Last the grid use the settings `default_per_page` in place of the previous fixed value (10).

<img width="512" alt="packages-grid" src="https://cloud.githubusercontent.com/assets/1462821/9546738/72c596f8-4d95-11e5-9446-641e2495868e.png">
### Why is it needed ?

This PR, help user with lot of packages to identify which ones are updatable.
### Related issue(s)/PR(s)
#12601 : Updatable Packages first in Package Manager
#12299 : 2.3.2-pl, Manager: In some grids the columns are not sortable
#12518 : Default Per Page number of packages listed not related to the Default Per Page System Setting
#8906 : Set amount of list grid-items in system settings
