### PR TITLE
Added patch for ExtJS Drag & Drop issue #12576

### DIFF
--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -1,3 +1,26 @@
+Ext.dd.DragDropMgr.getZIndex = function(element) {
+    var body = document.body,
+        z,
+        zIndex = -1;
+    var overTargetEl = element;
+ 
+    element = Ext.getDom(element);
+    while (element !== body) {
+ 
+        // this fixes the problem
+        if(!element) {
+            this._remove(overTargetEl); // remove the drop target from the manager
+            break;
+        }
+        // fix end
+ 
+        if (!isNaN(z = Number(Ext.fly(element).getStyle('zIndex')))) {
+            zIndex = z;
+        }
+        element = element.parentNode;
+    }
+    return zIndex;
+};
 MODx.TreeDrop = function(config) {
     config = config || {};
     Ext.applyIf(config,{


### PR DESCRIPTION
Added code provided by berniesaurus to fix issue where you couldn't drag and drop into a window or closable tab panel after one had already been rendered. https://www.sencha.com/forum/showthread.php?264400-Ext-JS-3.4.4.1-Drag-amp-Drop-broken
