### PR TITLE
Add support for MODX Tags in autotag parent(s) parameter

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/autotag.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/autotag.class.php
@@ -24,7 +24,12 @@ class modTemplateVarInputRenderAutoTag extends modTemplateVarInputRender {
         ));
         if (!empty($params['parent_resources'])) {
             $ids = array();
-            $parents = explode(',',$params['parent_resources']);
+
+            /** check if we have some TVs in place of id */
+            $chunk = $this->modx->newObject('modChunk', array('name' => uniqid()));
+            $chunk->setCacheable(false);
+            $parent_resources = $chunk->process(null, $params['parent_resources']);
+            $parents = explode(',', $parent_resources);
 
             $currCtx = 'web';
             $this->modx->switchContext('web');


### PR DESCRIPTION
### What does it do ?

With this PR the `parent` parameter can contain MODX tags (TV, Snippet), parsed before the tags list is created.

Parent: `1,[[*parent*]],10`
### Why is it needed ?

We often use autotag in Collections, but we don't want to share tags list between our Collections nor create as many TVs as Collections.
### Related issue(s)/PR(s)

n/a
