### PR TITLE
Create table for modAccessNamespace

### DIFF
--- a/setup/includes/tables_create.php
+++ b/setup/includes/tables_create.php
@@ -24,6 +24,7 @@ $classes= array (
     'modAccessResource',
     'modAccessResourceGroup',
     'modAccessTemplateVar',
+    'modAccessNamespace',
     'modAction',
     'modActionDom',
     'modActionField',

--- a/setup/includes/upgrades/common/2.4.1-namespace-access.php
+++ b/setup/includes/upgrades/common/2.4.1-namespace-access.php
@@ -1,0 +1,8 @@
+<?php
+$classes = array(
+    'modAccessNamespace',
+);
+
+if (!empty($classes)) {
+    $this->createTable($classes);
+}

--- a/setup/includes/upgrades/mysql/2.4.1-pl.php
+++ b/setup/includes/upgrades/mysql/2.4.1-pl.php
@@ -1,0 +1,11 @@
+<?php
+/*1
+ * Specific upgrades for Revolution 2.4.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(dirname(__FILE__)) . '/common/2.4.1-namespace-access.php';

--- a/setup/includes/upgrades/sqlsrv/2.4.1-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.4.1-pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Specific upgrades for Revolution 2.4.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(dirname(__FILE__)) . '/common/2.4.1-namespace-access.php';


### PR DESCRIPTION
### What does it do ?

Creates table for modAccessNamespace
### Why is it needed ?

Currently the table is created only when updating for older versions, not during new installs.
