### PR TITLE
Revert handling output of OnBeforeWebLogin and OnBeforeManagerLogin

### DIFF
--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -61,9 +61,16 @@ class modSecurityLoginProcessor extends modProcessor {
         );
 
         $response = $this->modx->invokeEvent($this->isMgr ? "OnBeforeManagerLogin" : "OnBeforeWebLogin", $onBeforeLoginParams);
-        $preventLogin = $this->processEventResponse($response);
 
-        return $preventLogin;
+        if (is_array($response)) {
+            foreach ($response as $key => $value) {
+                if ($value !== true) {
+                    return $value;
+                }
+            }
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

Revert handling output of OnBeforeWebLogin and OnBeforeManagerLogin events
### Why is it needed ?

In 2.4.0 returning true results as an error because different method is used for handling the output which uses `empty` as a method for checking the plugin's output. This reverts back the checking for `$output !== true`
### Related issue(s)/PR(s)

Resolves #12595
