### PR TITLE
Fix loading rich text editors on non-document resource types

### DIFF
--- a/manager/templates/default/resource/create.tpl
+++ b/manager/templates/default/resource/create.tpl
@@ -7,5 +7,5 @@
 
 {$onDocFormPrerender}
 {if $resource->richtext AND $_config.use_editor}
-{$onRichTextEditorInit}
+    {$onRichTextEditorInit}
 {/if}

--- a/manager/templates/default/resource/staticresource/create.tpl
+++ b/manager/templates/default/resource/staticresource/create.tpl
@@ -2,3 +2,6 @@
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput}</div>
 
 {$onDocFormPrerender}
+{if $resource->richtext AND $_config.use_editor}
+    {$onRichTextEditorInit}
+{/if}

--- a/manager/templates/default/resource/staticresource/update.tpl
+++ b/manager/templates/default/resource/staticresource/update.tpl
@@ -1,3 +1,7 @@
 <div id="modx-panel-static-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput}</div>
+
 {$onDocFormPrerender}
+{if $resource->richtext AND $_config.use_editor}
+    {$onRichTextEditorInit}
+{/if}

--- a/manager/templates/default/resource/symlink/create.tpl
+++ b/manager/templates/default/resource/symlink/create.tpl
@@ -2,3 +2,6 @@
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput}</div>
 
 {$onDocFormPrerender}
+{if $resource->richtext AND $_config.use_editor}
+    {$onRichTextEditorInit}
+{/if}

--- a/manager/templates/default/resource/symlink/update.tpl
+++ b/manager/templates/default/resource/symlink/update.tpl
@@ -2,3 +2,6 @@
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput}</div>
 
 {$onDocFormPrerender}
+{if $resource->richtext AND $_config.use_editor}
+    {$onRichTextEditorInit}
+{/if}

--- a/manager/templates/default/resource/update.tpl
+++ b/manager/templates/default/resource/update.tpl
@@ -7,5 +7,5 @@
 
 {$onDocFormPrerender}
 {if $resource->richtext AND $_config.use_editor}
-{$onRichTextEditorInit}
+    {$onRichTextEditorInit}
 {/if}

--- a/manager/templates/default/resource/weblink/create.tpl
+++ b/manager/templates/default/resource/weblink/create.tpl
@@ -2,3 +2,6 @@
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput}</div>
 
 {$onDocFormPrerender}
+{if $resource->richtext AND $_config.use_editor}
+    {$onRichTextEditorInit}
+{/if}

--- a/manager/templates/default/resource/weblink/update.tpl
+++ b/manager/templates/default/resource/weblink/update.tpl
@@ -2,3 +2,6 @@
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput}</div>
 
 {$onDocFormPrerender}
+{if $resource->richtext AND $_config.use_editor}
+    {$onRichTextEditorInit}
+{/if}


### PR DESCRIPTION
### What does it do ?

Rich text editors are loaded by firing the OnRichTextEditorInit plugin events, which then allows third party plugins to handle their instantiation and registering required assets.

Some of those editors, including modmore's Redactor, use the `$modx->event->output($html)` approach to feeding back the resulting markup that needs to be injected into the page. This markup is then successfully set into a placeholder that is loaded in the create.tpl or update.tpl template for the various resource types.

The problem is that prior to this patch, the placeholder value is only set into the page when it is a standard modDocument resource, and not when it is a weblink, symlink or static resource.
### Why is it needed ?

Redactor 2 introduces a new option to load a rich text editor for the introtext field, which people have also been doing using a plugin, for example this one: https://gist.github.com/christianseel/780b16f202c873b3b278

Without this patch, those features only work on modDocuments' as the markup that defines the MODx.loadRTE method is not inserted into the page. 
### Related issue(s)/PR(s)
#5691 is somewhat related, though not necessarily fixed by this PR.
