### PR TITLE
Restore backwards compatibility for addons interacting with modTransportProvider

### DIFF
--- a/core/model/modx/transport/modtransportprovider.class.php
+++ b/core/model/modx/transport/modtransportprovider.class.php
@@ -229,7 +229,7 @@ class modTransportProvider extends xPDOSimpleObject {
 
             $package->parseSignature();
             $package->setPackageVersionData();
-            
+
             $locationArgs = (isset($metadata['file'])) ? array_merge($metadata['file'], $args) : $args;
             $url = $this->downloadUrl($signature, $this->arg('location', $locationArgs), $args);
             if (!empty($url)) {
@@ -406,7 +406,7 @@ class modTransportProvider extends xPDOSimpleObject {
      *
      * @return modRestClient|bool A REST client instance, or FALSE.
      */
-    protected function getClient() {
+    public function getClient() {
         if (empty($this->xpdo->rest)) {
             $this->xpdo->getService('rest','rest.modRestClient');
             $loaded = $this->xpdo->rest->getConnection();


### PR DESCRIPTION
### What does it do?

The getClient method was previously public (see https://github.com/modxcms/revolution/blob/v2.3.6-pl/core/model/modx/transport/modtransportprovider.class.php#L73) and used by Gitify to provide a way of installing packages via the command line. When modTransportProvider was refactored, this method was marked protected, causing Gitify to break with the following error:

Fatal error: Call to protected method modTransportProvider::getClient() from context 'modmore\Gitify\Command\InstallPackageCommand' in Gitify/src/Command/InstallPackageCommand.php on line 168

Setting getClient back to public resolves that error. 
### Why is it needed?

2.4 was intended to be backwards compatible, however this change was overlooked. Restoring the public method will make it backwards compatible again in 2.4.1. 
### Related issue(s)/PR(s)

https://github.com/modmore/Gitify/issues/125
