### PR TITLE
Not rendered output properties of custom TVs

### DIFF
--- a/core/model/modx/processors/element/tv/renders/getproperties.class.php
+++ b/core/model/modx/processors/element/tv/renders/getproperties.class.php
@@ -16,7 +16,7 @@ require_once dirname(__FILE__).'/getinputproperties.class.php';
 class modTvRendersGetOutputPropertiesProcessor extends modTvRendersGetPropertiesProcessor {
     public $propertiesKey = 'output_properties';
     public $renderDirectory = 'properties';
-    public $onPropertiesListEvent = 'OnTVOutputPropertiesList';
+    public $onPropertiesListEvent = 'OnTVOutputRenderPropertiesList';
 }
 
 return 'modTvRendersGetOutputPropertiesProcessor';


### PR DESCRIPTION
### What does it do ?

Fixing not rendered output properties of custom TVs.
### Why is it needed ?

Not rendered output properties of custom TVs.
### Related issue(s)/PR(s)

See: https://github.com/Jako/ImagePlus/issues/13
