### PR TITLE
Fix tree style bug #12644, enhance page title style

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -117,11 +117,14 @@ $treePseudoRootOverBg: $lightBg;
 $treePseudoRootOverColor: #447996;
 
 $iconColor: $treeText;
-$unpublished: lighten($treeText, 10%) !important;
+$unpublished: $treeText;
 $disabled: $unpublished;
-$hidden: $unpublished;
+
+$hidden: lighten($treeText, 10%) !important;
 $unpubText: italic;
-$lockedText: italic;
+/* locked is already signaled with lock-icon, no need to use other semantic style here
+   as italic is used for "unpublished" */
+$lockedText: inherit; //italic;
 
 $delTextColor: fade-out(darken(lighten(desaturate($red,50%), 33%), 25%), 0.5) !important;
 $delTextStyle: normal;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -226,7 +226,6 @@
 
   i.icon,
   i.icon-large {
-      color: $unpublished;
       font-style: normal;
   }
 }
@@ -246,19 +245,28 @@
       font-style: normal;
   }
 }
+:not(.hidemenu),
+:not(.hidemenu) a span {
+  &.unpublished,
+  &.unpublished a span {
+    //color: $unpublished;
+  }
+}
 .deleted {
   color: $delTextColor;
 
   i.icon,
   i.icon-large {
       color: $delTextColor;
-      font-style: normal;
+     // font-style: normal;
   }
 
   a span {
     color: $delTextColor;
     text-decoration: $delTextDeco;
-    font-style: $delTextStyle;
+    /* deleted files should inherit the text style from published/unpublished and
+       not overwrite it */
+    // font-style: $delTextStyle;
   }
 }
 

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -220,6 +220,10 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 /* panel stylings */
 .modx-page-header, .modx-page-header div {
   background-color: transparent !important;
+
+  h2.deleted {
+    text-decoration: line-through;
+  }
 }
 
 #modx-content form.x-panel-body {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -46,8 +46,13 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             } else if (pcmb) {
                 pcmb.setValue(this.config.record.parent_pagetitle+' ('+this.config.record.parent+')');
             }
+            var cssClasses = "";
+            if (this.config.record.deleted == 1) cssClasses +=" deleted";
+            if (this.config.record.published == 0) cssClasses +=" unpublished";
+            if (this.config.record.hidemenu == 1) cssClasses +=" hidemenu";
+
             if (!Ext.isEmpty(this.config.record.pagetitle)) {
-                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+Ext.util.Format.stripTags(this.config.record.pagetitle)+'</h2>');
+                Ext.getCmp('modx-resource-header').getEl().update('<h2 class="'+cssClasses+'">'+Ext.util.Format.stripTags(this.config.record.pagetitle)+'</h2>');
             }
             // initial check to enable realtime alias
             if (Ext.isEmpty(this.config.record.alias)) {
@@ -474,7 +479,13 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 'keyup': {fn: function(f,e) {
                     var titlePrefix = MODx.request.a == 'resource/create' ? _('new_document') : _('document');
                     var title = Ext.util.Format.stripTags(f.getValue());
-                    Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
+
+                    var cssClasses = "";
+                    if (this.config.record.deleted == 1) cssClasses +=" deleted";
+                    if (this.config.record.published == 0) cssClasses +=" unpublished";
+                    if (this.config.record.hidemenu == 1) cssClasses +=" hidemenu";
+
+                    Ext.getCmp('modx-resource-header').getEl().update('<h2 class="'+cssClasses+'">'+title+'</h2>');
 
                     // check some system settings before doing real time alias transliteration
                     if (parseInt(MODx.config.friendly_alias_realtime, 10) && parseInt(MODx.config.automatic_alias, 10)) {


### PR DESCRIPTION
### What does it do ?

This PR fixes bug #12644, additionally the same bug for deleted resources and also applies the styles to the resource header in order to visualize the resources state better:

![screenshot from 2015-09-11 13 42 42](https://cloud.githubusercontent.com/assets/2852461/9814124/d799c7ce-588b-11e5-98d5-7d5e09d01e3e.png)
### Why is it needed?

It was not possible to distinguish resources states at the resource tree because not all different combinations produced different styles. This is fixed now. 
When editing a resource, it was also not possible to see the resources' state at one glance (e.g. the tree is hidden, state is only visible over the checkboxes and the deleted checkbox is on another tab). Therefore it could happen that someone unintentionally edits a deleted resource. This is now fixed by applying the same styles to the header title as on the resource tree. 
### Related issue(s)/PR(s)
#12644
