### PR TITLE
Update PHPMailer to v5.2.13

### DIFF
--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -69,7 +69,7 @@ class modPHPMailer extends modMail {
                 $this->mailer->Hostname= $this->attributes[$key];
                 break;
             case modMail::MAIL_LANGUAGE :
-                $this->mailer->SetLanguage($this->attributes[$key]);
+                $this->mailer->setLanguage($this->attributes[$key]);
                 break;
             case modMail::MAIL_PRIORITY :
                 $this->mailer->Priority= $this->attributes[$key];
@@ -135,16 +135,16 @@ class modPHPMailer extends modMail {
                 $type= strtolower($type);
                 switch ($type) {
                     case 'to' :
-                        $this->mailer->AddAddress($email, $name);
+                        $this->mailer->addAddress($email, $name);
                         break;
                     case 'cc' :
-                        $this->mailer->AddCC($email, $name);
+                        $this->mailer->addCC($email, $name);
                         break;
                     case 'bcc' :
-                        $this->mailer->AddBCC($email, $name);
+                        $this->mailer->addBCC($email, $name);
                         break;
                     case 'reply-to' :
-                        $this->mailer->AddReplyTo($email, $name);
+                        $this->mailer->addReplyTo($email, $name);
                         break;
                 }
             }
@@ -165,7 +165,7 @@ class modPHPMailer extends modMail {
     public function header($header) {
         $set= parent :: header($header);
         if ($set) {
-            $this->mailer->AddCustomHeader($header);
+            $this->mailer->addCustomHeader($header);
         }
         return $set;
     }
@@ -179,7 +179,7 @@ class modPHPMailer extends modMail {
     public function send(array $attributes= array()) {
         parent :: send($attributes);
 
-        $sent = $this->mailer->Send();
+        $sent = $this->mailer->send();
         if ($sent !== true) {
             $this->error = $this->modx->getService('error.modError');
             $this->error->addError($this->mailer->ErrorInfo);
@@ -195,11 +195,11 @@ class modPHPMailer extends modMail {
      */
     public function reset(array $attributes= array()) {
         parent :: reset($attributes);
-        $this->mailer->ClearAllRecipients();
-        $this->mailer->ClearReplyTos();
-        $this->mailer->ClearAttachments();
-        $this->mailer->ClearCustomHeaders();
-        $this->mailer->IsHTML(false);
+        $this->mailer->clearAllRecipients();
+        $this->mailer->clearReplyTos();
+        $this->mailer->clearAttachments();
+        $this->mailer->clearCustomHeaders();
+        $this->mailer->isHTML(false);
     }
 
     /**
@@ -235,9 +235,9 @@ class modPHPMailer extends modMail {
      */
     public function attach($file,$name = '',$encoding = 'base64',$type = 'application/octet-stream') {
         parent :: attach($file);
-        $this->mailer->AddAttachment($file,$name,$encoding,$type);
+        $this->mailer->addAttachment($file,$name,$encoding,$type);
     }
-    
+
     /**
      * Embeds image inside message body.
      *
@@ -250,7 +250,7 @@ class modPHPMailer extends modMail {
      */
     public function embedImage($image, $cid, $name = '', $encoding = 'base64', $type = 'application/octet-stream') {
       parent :: embedImage($image,$cid);
-      $this->mailer->AddEmbeddedImage('/'.$image,$cid,$name,$encoding,$type);
+      $this->mailer->addEmbeddedImage('/'.$image,$cid,$name,$encoding,$type);
     }
 
     /**
@@ -258,7 +258,7 @@ class modPHPMailer extends modMail {
      */
     public function clearAttachments() {
         parent :: clearAttachments();
-        $this->mailer->ClearAttachments();
+        $this->mailer->clearAttachments();
     }
 
     /**
@@ -268,6 +268,6 @@ class modPHPMailer extends modMail {
      * @param boolean $toggle True to set to HTML.
      */
     public function setHTML($toggle) {
-        $this->mailer->IsHTML($toggle);
+        $this->mailer->isHTML($toggle);
     }
 }

--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -211,6 +211,13 @@ class modPHPMailer extends modMail {
         $success= false;
         if (!$this->mailer || !($this->mailer instanceof PHPMailer)) {
             if ($this->mailer= new PHPMailer()) {
+                // Make sure PHPMailer autoloader is loaded
+                if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
+                    $autoload = spl_autoload_functions();
+                    if ($autoload === false or !in_array('PHPMailerAutoload', $autoload)) {
+                        require 'phpmailer/PHPMailerAutoload.php';
+                    }
+                }
                 if (!empty($this->attributes)) {
                     foreach ($this->attributes as $attrKey => $attrVal) {
                         $this->set($attrKey, $attrVal);

--- a/core/model/modx/mail/phpmailer/class.phpmailer.php
+++ b/core/model/modx/mail/phpmailer/class.phpmailer.php
@@ -31,14 +31,15 @@ class PHPMailer
      * The PHPMailer Version number.
      * @type string
      */
-    public $Version = '5.2.8';
+    public $Version = '5.2.13';
 
     /**
      * Email priority.
-     * Options: 1 = High, 3 = Normal, 5 = low.
-     * @type int
+     * Options: null (default), 1 = High, 3 = Normal, 5 = low.
+     * When null, the header is not set at all.
+     * @type integer
      */
-    public $Priority = 3;
+    public $Priority = null;
 
     /**
      * The character set of the message.
@@ -149,7 +150,8 @@ class PHPMailer
 
     /**
      * Word-wrap the message body to this number of chars.
-     * @type int
+     * Set to 0 to not wrap. A useful value here is 78, for RFC2822 section 2.1.1 compliance.
+     * @type integer
      */
     public $WordWrap = 0;
 
@@ -169,7 +171,7 @@ class PHPMailer
     /**
      * Whether mail() uses a fully sendmail-compatible MTA.
      * One which supports sendmail's "-oi -f" options.
-     * @type bool
+     * @type boolean
      */
     public $UseSendmailOptions = true;
 
@@ -216,6 +218,8 @@ class PHPMailer
      * You can also specify a different port
      * for each host by using this format: [hostname:port]
      * (e.g. "smtp1.example.com:25;smtp2.example.com").
+     * You can also specify encryption type, for example:
+     * (e.g. "tls://smtp1.example.com:587;ssl://smtp2.example.com:465").
      * Hosts will be tried in order.
      * @type string
      */
@@ -223,8 +227,8 @@ class PHPMailer
 
     /**
      * The default SMTP server port.
-     * @type int
-     * @Todo Why is this needed when the SMTP class takes care of it?
+     * @type integer
+     * @TODO Why is this needed when the SMTP class takes care of it?
      */
     public $Port = 25;
 
@@ -237,20 +241,34 @@ class PHPMailer
     public $Helo = '';
 
     /**
-     * The secure connection prefix.
-     * Options: "", "ssl" or "tls"
+     * What kind of encryption to use on the SMTP connection.
+     * Options: '', 'ssl' or 'tls'
      * @type string
      */
     public $SMTPSecure = '';
 
     /**
+     * Whether to enable TLS encryption automatically if a server supports it,
+     * even if `SMTPSecure` is not set to 'tls'.
+     * Be aware that in PHP >= 5.6 this requires that the server's certificates are valid.
+     * @type boolean
+     */
+    public $SMTPAutoTLS = true;
+
+    /**
      * Whether to use SMTP authentication.
      * Uses the Username and Password properties.
-     * @type bool
+     * @type boolean
      * @see PHPMailer::$Username
      * @see PHPMailer::$Password
      */
     public $SMTPAuth = false;
+
+    /**
+     * Options array passed to stream_context_create when connecting via SMTP.
+     * @type array
+     */
+    public $SMTPOptions = array();
 
     /**
      * SMTP username.
@@ -287,19 +305,21 @@ class PHPMailer
 
     /**
      * The SMTP server timeout in seconds.
-     * @type int
+     * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
+     * @type integer
      */
-    public $Timeout = 10;
+    public $Timeout = 300;
 
     /**
      * SMTP class debug output mode.
+     * Debug output level.
      * Options:
-     *   0: no output
-     *   1: commands
-     *   2: data and commands
-     *   3: as 2 plus connection status
-     *   4: low level data output
-     * @type int
+     * * `0` No output
+     * * `1` Commands
+     * * `2` Data and commands
+     * * `3` As 2 plus connection status
+     * * `4` Low-level data output
+     * @type integer
      * @see SMTP::$do_debug
      */
     public $SMTPDebug = 0;
@@ -307,10 +327,15 @@ class PHPMailer
     /**
      * How to handle debug output.
      * Options:
-     *   'echo': Output plain-text as-is, appropriate for CLI
-     *   'html': Output escaped, line breaks converted to <br>, appropriate for browser output
-     *   'error_log': Output to error log as configured in php.ini
-     * @type string
+     * * `echo` Output plain-text as-is, appropriate for CLI
+     * * `html` Output escaped, line breaks converted to `<br>`, appropriate for browser output
+     * * `error_log` Output to error log as configured in php.ini
+     *
+     * Alternatively, you can provide a callable expecting two params: a message string and the debug level:
+     * <code>
+     * $mail->Debugoutput = function($str, $level) {echo "debug level $level; message: $str";};
+     * </code>
+     * @type string|callable
      * @see SMTP::$Debugoutput
      */
     public $Debugoutput = 'echo';
@@ -319,21 +344,21 @@ class PHPMailer
      * Whether to keep SMTP connection open after each message.
      * If this is set to true then to close the connection
      * requires an explicit call to smtpClose().
-     * @type bool
+     * @type boolean
      */
     public $SMTPKeepAlive = false;
 
     /**
      * Whether to split multiple to addresses into multiple messages
      * or send them all in one message.
-     * @type bool
+     * @type boolean
      */
     public $SingleTo = false;
 
     /**
      * Storage for addresses when SingleTo is enabled.
      * @type array
-     * @todo This should really not be public
+     * @TODO This should really not be public
      */
     public $SingleToArray = array();
 
@@ -342,13 +367,13 @@ class PHPMailer
      * Only applicable when sending via SMTP.
      * @link http://en.wikipedia.org/wiki/Variable_envelope_return_path
      * @link http://www.postfix.org/VERP_README.html Postfix VERP info
-     * @type bool
+     * @type boolean
      */
     public $do_verp = false;
 
     /**
      * Whether to allow sending messages with an empty body.
-     * @type bool
+     * @type boolean
      */
     public $AllowEmpty = false;
 
@@ -402,7 +427,7 @@ class PHPMailer
      * Value can be any php callable: http://www.php.net/is_callable
      *
      * Parameters:
-     *   bool    $result        result of the send action
+     *   boolean $result        result of the send action
      *   string  $to            email address of the recipient
      *   string  $cc            cc email addresses
      *   string  $bcc           bcc email addresses
@@ -414,12 +439,23 @@ class PHPMailer
     public $action_function = '';
 
     /**
-     * What to use in the X-Mailer header.
-     * Options: null for default, whitespace for none, or a string to use
+     * What to put in the X-Mailer header.
+     * Options: An empty string for PHPMailer default, whitespace for none, or a string to use
      * @type string
      */
     public $XMailer = '';
-
+    
+    /**
+     * Only For XOAUTH - Google
+     * Options: An empty string for PHPMailer default, Enter the email used to get access token
+     * @type string
+     */
+//    public $UserEmail = '';
+//    public $RefreshToken = '';
+//    public $ClientId = '';
+//    public $ClientSecret = '';
+    
+    
     /**
      * An instance of the SMTP sender class.
      * @type SMTP
@@ -457,7 +493,7 @@ class PHPMailer
 
     /**
      * An array of all kinds of addresses.
-     * Includes all of $to, $cc, $bcc, $replyto
+     * Includes all of $to, $cc, $bcc
      * @type array
      * @access protected
      */
@@ -527,6 +563,13 @@ class PHPMailer
     protected $sign_key_file = '';
 
     /**
+     * The optional S/MIME extra certificates ("CA Chain") file path.
+     * @type string
+     * @access protected
+     */
+    protected $sign_extracerts_file = '';
+
+    /**
      * The S/MIME password for the key.
      * Used only if the key is encrypted.
      * @type string
@@ -536,45 +579,51 @@ class PHPMailer
 
     /**
      * Whether to throw exceptions for errors.
-     * @type bool
+     * @type boolean
      * @access protected
      */
     protected $exceptions = false;
 
     /**
-     * Error severity: message only, continue processing
+     * Unique ID used for message ID and boundaries.
+     * @type string
+     * @access protected
+     */
+    protected $uniqueid = '';
+
+    /**
+     * Error severity: message only, continue processing.
      */
     const STOP_MESSAGE = 0;
 
     /**
-     * Error severity: message, likely ok to continue processing
+     * Error severity: message, likely ok to continue processing.
      */
     const STOP_CONTINUE = 1;
 
     /**
-     * Error severity: message, plus full stop, critical error reached
+     * Error severity: message, plus full stop, critical error reached.
      */
     const STOP_CRITICAL = 2;
 
     /**
-     * SMTP RFC standard line ending
+     * SMTP RFC standard line ending.
      */
     const CRLF = "\r\n";
 
     /**
-     * Constructor
-     * @param bool $exceptions Should we throw external exceptions?
+     * The maximum line length allowed by RFC 2822 section 2.1.1
+     * @type integer
+     */
+    const MAX_LINE_LENGTH = 998;
+
+    /**
+     * Constructor.
+     * @param boolean $exceptions Should we throw external exceptions?
      */
     public function __construct($exceptions = false)
     {
-        $this->exceptions = ($exceptions == true);
-        //Make sure our autoloader is loaded
-        if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
-            $autoload = spl_autoload_functions();
-            if ($autoload === false or !in_array('PHPMailerAutoload', $autoload)) {
-                require 'PHPMailerAutoload.php';
-            }
-        }
+        $this->exceptions = (boolean)$exceptions;
     }
 
     /**
@@ -582,7 +631,8 @@ class PHPMailer
      */
     public function __destruct()
     {
-        if ($this->Mailer == 'smtp') { //close any open SMTP connection nicely
+        //Close any open SMTP connection nicely
+        if ($this->Mailer == 'smtp') {
             $this->smtpClose();
         }
     }
@@ -598,7 +648,7 @@ class PHPMailer
      * @param string $header Additional Header(s)
      * @param string $params Params
      * @access private
-     * @return bool
+     * @return boolean
      */
     private function mailPassthru($to, $subject, $body, $header, $params)
     {
@@ -618,38 +668,55 @@ class PHPMailer
 
     /**
      * Output debugging info via user-defined method.
-     * Only if debug output is enabled.
+     * Only generates output if SMTP debug output is enabled (@see SMTP::$do_debug).
      * @see PHPMailer::$Debugoutput
      * @see PHPMailer::$SMTPDebug
      * @param string $str
      */
     protected function edebug($str)
     {
-        if (!$this->SMTPDebug) {
+        if ($this->SMTPDebug <= 0) {
+            return;
+        }
+        //Avoid clash with built-in function names
+        if (!in_array($this->Debugoutput, array('error_log', 'html', 'echo')) and is_callable($this->Debugoutput)) {
+            call_user_func($this->Debugoutput, $str, $this->SMTPDebug);
             return;
         }
         switch ($this->Debugoutput) {
             case 'error_log':
+                //Don't output, just log
                 error_log($str);
                 break;
             case 'html':
-                //Cleans up output a bit for a better looking display that's HTML-safe
-                echo htmlentities(preg_replace('/[\r\n]+/', '', $str), ENT_QUOTES, $this->CharSet) . "<br>\n";
+                //Cleans up output a bit for a better looking, HTML-safe output
+                echo htmlentities(
+                    preg_replace('/[\r\n]+/', '', $str),
+                    ENT_QUOTES,
+                    'UTF-8'
+                )
+                . "<br>\n";
                 break;
             case 'echo':
             default:
-                echo $str."\n";
+                //Normalize line breaks
+                $str = preg_replace('/(\r\n|\r|\n)/ms', "\n", $str);
+                echo gmdate('Y-m-d H:i:s') . "\t" . str_replace(
+                    "\n",
+                    "\n                   \t                  ",
+                    trim($str)
+                ) . "\n";
         }
     }
 
     /**
      * Sets message type to HTML or plain.
-     * @param bool $ishtml True for HTML mode.
+     * @param boolean $isHtml True for HTML mode.
      * @return void
      */
-    public function isHTML($ishtml = true)
+    public function isHTML($isHtml = true)
     {
-        if ($ishtml) {
+        if ($isHtml) {
             $this->ContentType = 'text/html';
         } else {
             $this->ContentType = 'text/plain';
@@ -681,7 +748,7 @@ class PHPMailer
     public function isSendmail()
     {
         $ini_sendmail_path = ini_get('sendmail_path');
-        
+
         if (!stristr($ini_sendmail_path, 'sendmail')) {
             $this->Sendmail = '/usr/sbin/sendmail';
         } else {
@@ -697,7 +764,7 @@ class PHPMailer
     public function isQmail()
     {
         $ini_sendmail_path = ini_get('sendmail_path');
-        
+
         if (!stristr($ini_sendmail_path, 'qmail')) {
             $this->Sendmail = '/var/qmail/bin/qmail-inject';
         } else {
@@ -710,7 +777,7 @@ class PHPMailer
      * Add a "To" address.
      * @param string $address
      * @param string $name
-     * @return bool true on success, false if address already used
+     * @return boolean true on success, false if address already used
      */
     public function addAddress($address, $name = '')
     {
@@ -722,7 +789,7 @@ class PHPMailer
      * @note: This function works with the SMTP mailer on win32, not with the "mail" mailer.
      * @param string $address
      * @param string $name
-     * @return bool true on success, false if address already used
+     * @return boolean true on success, false if address already used
      */
     public function addCC($address, $name = '')
     {
@@ -734,7 +801,7 @@ class PHPMailer
      * @note: This function works with the SMTP mailer on win32, not with the "mail" mailer.
      * @param string $address
      * @param string $name
-     * @return bool true on success, false if address already used
+     * @return boolean true on success, false if address already used
      */
     public function addBCC($address, $name = '')
     {
@@ -745,7 +812,7 @@ class PHPMailer
      * Add a "Reply-to" address.
      * @param string $address
      * @param string $name
-     * @return bool
+     * @return boolean
      */
     public function addReplyTo($address, $name = '')
     {
@@ -759,7 +826,7 @@ class PHPMailer
      * @param string $address The email address to send to
      * @param string $name
      * @throws phpmailerException
-     * @return bool true on success, false if address already used or invalid in some way
+     * @return boolean true on success, false if address already used or invalid in some way
      * @access protected
      */
     protected function addAnAddress($kind, $address, $name = '')
@@ -798,12 +865,67 @@ class PHPMailer
     }
 
     /**
+     * Parse and validate a string containing one or more RFC822-style comma-separated email addresses
+     * of the form "display name <address>" into an array of name/address pairs.
+     * Uses the imap_rfc822_parse_adrlist function if the IMAP extension is available.
+     * Note that quotes in the name part are removed.
+     * @param string $addrstr The address list string
+     * @param bool $useimap Whether to use the IMAP extension to parse the list
+     * @return array
+     * @link http://www.andrew.cmu.edu/user/agreen1/testing/mrbs/web/Mail/RFC822.php A more careful implementation
+     */
+    public function parseAddresses($addrstr, $useimap = true)
+    {
+        $addresses = array();
+        if ($useimap and function_exists('imap_rfc822_parse_adrlist')) {
+            //Use this built-in parser if it's available
+            $list = imap_rfc822_parse_adrlist($addrstr, '');
+            foreach ($list as $address) {
+                if ($address->host != '.SYNTAX-ERROR.') {
+                    if ($this->validateAddress($address->mailbox . '@' . $address->host)) {
+                        $addresses[] = array(
+                            'name' => (property_exists($address, 'personal') ? $address->personal : ''),
+                            'address' => $address->mailbox . '@' . $address->host
+                        );
+                    }
+                }
+            }
+        } else {
+            //Use this simpler parser
+            $list = explode(',', $addrstr);
+            foreach ($list as $address) {
+                $address = trim($address);
+                //Is there a separate name part?
+                if (strpos($address, '<') === false) {
+                    //No separate name, just use the whole thing
+                    if ($this->validateAddress($address)) {
+                        $addresses[] = array(
+                            'name' => '',
+                            'address' => $address
+                        );
+                    }
+                } else {
+                    list($name, $email) = explode('<', $address);
+                    $email = trim(str_replace('>', '', $email));
+                    if ($this->validateAddress($email)) {
+                        $addresses[] = array(
+                            'name' => trim(str_replace(array('"', "'"), '', $name)),
+                            'address' => $email
+                        );
+                    }
+                }
+            }
+        }
+        return $addresses;
+    }
+
+    /**
      * Set the From and FromName properties.
      * @param string $address
      * @param string $name
-     * @param bool $auto Whether to also set the Sender address, defaults to true
+     * @param boolean $auto Whether to also set the Sender address, defaults to true
      * @throws phpmailerException
-     * @return bool
+     * @return boolean
      */
     public function setFrom($address, $name = '', $auto = true)
     {
@@ -849,19 +971,25 @@ class PHPMailer
      * * `php` Use PHP built-in FILTER_VALIDATE_EMAIL; same as pcre8 but does not allow 'dotless' domains;
      * * `html5` Use the pattern given by the HTML5 spec for 'email' type form input elements.
      * * `noregex` Don't use a regex: super fast, really dumb.
-     * @return bool
+     * @return boolean
      * @static
      * @access public
      */
     public static function validateAddress($address, $patternselect = 'auto')
     {
         if (!$patternselect or $patternselect == 'auto') {
-            if (defined('PCRE_VERSION')) { //Check this constant so it works when extension_loaded() is disabled
-                if (version_compare(PCRE_VERSION, '8.0') >= 0) {
+            //Check this constant first so it works when extension_loaded() is disabled by safe mode
+            //Constant was added in PHP 5.2.4
+            if (defined('PCRE_VERSION')) {
+                //This pattern can get stuck in a recursive loop in PCRE <= 8.0.2
+                if (version_compare(PCRE_VERSION, '8.0.3') >= 0) {
                     $patternselect = 'pcre8';
                 } else {
                     $patternselect = 'pcre';
                 }
+            } elseif (function_exists('extension_loaded') and extension_loaded('pcre')) {
+                //Fall back to older PCRE
+                $patternselect = 'pcre';
             } else {
                 //Filter_var appeared in PHP 5.2.0 and does not require the PCRE extension
                 if (version_compare(PHP_VERSION, '5.2.0') >= 0) {
@@ -879,7 +1007,7 @@ class PHPMailer
                  * @copyright 2009-2010 Michael Rushton
                  * Feel free to use and redistribute this code. But please keep this copyright notice.
                  */
-                return (bool)preg_match(
+                return (boolean)preg_match(
                     '/^(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){255,})(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){65,}@)' .
                     '((?>(?>(?>((?>(?>(?>\x0D\x0A)?[\t ])+|(?>[\t ]*\x0D\x0A)?[\t ]+)?)(\((?>(?2)' .
                     '(?>[\x01-\x08\x0B\x0C\x0E-\'*-\[\]-\x7F]|\\\[\x00-\x7F]|(?3)))*(?2)\)))+(?2))|(?2))?)' .
@@ -891,10 +1019,9 @@ class PHPMailer
                     '|[1-9]?[0-9])(?>\.(?9)){3}))\])(?1)$/isD',
                     $address
                 );
-                break;
             case 'pcre':
                 //An older regex that doesn't need a recent PCRE
-                return (bool)preg_match(
+                return (boolean)preg_match(
                     '/^(?!(?>"?(?>\\\[ -~]|[^"])"?){255,})(?!(?>"?(?>\\\[ -~]|[^"])"?){65,}@)(?>' .
                     '[!#-\'*+\/-9=?^-~-]+|"(?>(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\xFF]))*")' .
                     '(?>\.(?>[!#-\'*+\/-9=?^-~-]+|"(?>(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\xFF]))*"))*' .
@@ -907,26 +1034,25 @@ class PHPMailer
                     '|[1-9]?[0-9])(?>\.(?>25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])){3}))\])$/isD',
                     $address
                 );
-                break;
             case 'html5':
                 /**
                  * This is the pattern used in the HTML5 spec for validation of 'email' type form input elements.
                  * @link http://www.whatwg.org/specs/web-apps/current-work/#e-mail-state-(type=email)
                  */
-                return (bool)preg_match('/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}' .
-                    '[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/sD', $address);
-                break;
-            case 'php':
-            default:
-                return (bool)filter_var($address, FILTER_VALIDATE_EMAIL);
-                break;
+                return (boolean)preg_match(
+                    '/^[a-zA-Z0-9.!#$%&\'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}' .
+                    '[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/sD',
+                    $address
+                );
             case 'noregex':
                 //No PCRE! Do something _very_ approximate!
                 //Check the address is 3 chars or longer and contains an @ that's not the first or last char
                 return (strlen($address) >= 3
                     and strpos($address, '@') >= 1
                     and strpos($address, '@') != strlen($address) - 1);
-                break;
+            case 'php':
+            default:
+                return (boolean)filter_var($address, FILTER_VALIDATE_EMAIL);
         }
     }
 
@@ -934,7 +1060,7 @@ class PHPMailer
      * Create a message and send it.
      * Uses the sending method specified by $Mailer.
      * @throws phpmailerException
-     * @return bool false on error - See the ErrorInfo property for details of the error.
+     * @return boolean false on error - See the ErrorInfo property for details of the error.
      */
     public function send()
     {
@@ -956,7 +1082,7 @@ class PHPMailer
     /**
      * Prepare a message for sending.
      * @throws phpmailerException
-     * @return bool
+     * @return boolean
      */
     public function preSend()
     {
@@ -971,15 +1097,20 @@ class PHPMailer
                 $this->ContentType = 'multipart/alternative';
             }
 
-            $this->error_count = 0; // reset errors
+            $this->error_count = 0; // Reset errors
             $this->setMessageType();
             // Refuse to send an empty message unless we are specifically allowing it
             if (!$this->AllowEmpty and empty($this->Body)) {
                 throw new phpmailerException($this->lang('empty_message'), self::STOP_CRITICAL);
             }
 
-            $this->MIMEHeader = $this->createHeader();
+            // Create body before headers in case body makes changes to headers (e.g. altering transfer encoding)
+            $this->MIMEHeader = '';
             $this->MIMEBody = $this->createBody();
+            // createBody may have added some headers, so retain them
+            $tempheaders = $this->MIMEHeader;
+            $this->MIMEHeader = $this->createHeader();
+            $this->MIMEHeader .= $tempheaders;
 
             // To capture the complete message when using mail(), create
             // an extra header list which createHeader() doesn't fold in
@@ -999,7 +1130,6 @@ class PHPMailer
             if (!empty($this->DKIM_domain)
                 && !empty($this->DKIM_private)
                 && !empty($this->DKIM_selector)
-                && !empty($this->DKIM_domain)
                 && file_exists($this->DKIM_private)) {
                 $header_dkim = $this->DKIM_Add(
                     $this->MIMEHeader . $this->mailHeader,
@@ -1010,7 +1140,6 @@ class PHPMailer
                     str_replace("\r\n", "\n", $header_dkim) . self::CRLF;
             }
             return true;
-
         } catch (phpmailerException $exc) {
             $this->setError($exc->getMessage());
             if ($this->exceptions) {
@@ -1024,7 +1153,7 @@ class PHPMailer
      * Actually send a message.
      * Send the email via the selected mechanism
      * @throws phpmailerException
-     * @return bool
+     * @return boolean
      */
     public function postSend()
     {
@@ -1043,7 +1172,7 @@ class PHPMailer
                     if (method_exists($this, $sendMethod)) {
                         return $this->$sendMethod($this->MIMEHeader, $this->MIMEBody);
                     }
-                    
+
                     return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
             }
         } catch (phpmailerException $exc) {
@@ -1063,7 +1192,7 @@ class PHPMailer
      * @see PHPMailer::$Sendmail
      * @throws phpmailerException
      * @access protected
-     * @return bool
+     * @return boolean
      */
     protected function sendmailSend($header, $body)
     {
@@ -1080,18 +1209,24 @@ class PHPMailer
                 $sendmail = sprintf('%s -oi -t', escapeshellcmd($this->Sendmail));
             }
         }
-        if ($this->SingleTo === true) {
-            foreach ($this->SingleToArray as $val) {
+        if ($this->SingleTo) {
+            foreach ($this->SingleToArray as $toAddr) {
                 if (!@$mail = popen($sendmail, 'w')) {
                     throw new phpmailerException($this->lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
                 }
-                fputs($mail, 'To: ' . $val . "\n");
+                fputs($mail, 'To: ' . $toAddr . "\n");
                 fputs($mail, $header);
                 fputs($mail, $body);
                 $result = pclose($mail);
-                // implement call back function if it exists
-                $isSent = ($result == 0) ? 1 : 0;
-                $this->doCallback($isSent, $val, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
+                $this->doCallback(
+                    ($result == 0),
+                    array($toAddr),
+                    $this->cc,
+                    $this->bcc,
+                    $this->Subject,
+                    $body,
+                    $this->From
+                );
                 if ($result != 0) {
                     throw new phpmailerException($this->lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
                 }
@@ -1103,9 +1238,7 @@ class PHPMailer
             fputs($mail, $header);
             fputs($mail, $body);
             $result = pclose($mail);
-            // implement call back function if it exists
-            $isSent = ($result == 0) ? 1 : 0;
-            $this->doCallback($isSent, $this->to, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
+            $this->doCallback(($result == 0), $this->to, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
             if ($result != 0) {
                 throw new phpmailerException($this->lang('execute') . $this->Sendmail, self::STOP_CRITICAL);
             }
@@ -1120,7 +1253,7 @@ class PHPMailer
      * @link http://www.php.net/manual/en/book.mail.php
      * @throws phpmailerException
      * @access protected
-     * @return bool
+     * @return boolean
      */
     protected function mailSend($header, $body)
     {
@@ -1140,18 +1273,14 @@ class PHPMailer
             ini_set('sendmail_from', $this->Sender);
         }
         $result = false;
-        if ($this->SingleTo === true && count($toArr) > 1) {
-            foreach ($toArr as $val) {
-                $result = $this->mailPassthru($val, $this->Subject, $body, $header, $params);
-                // implement call back function if it exists
-                $isSent = ($result == 1) ? 1 : 0;
-                $this->doCallback($isSent, $val, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
+        if ($this->SingleTo && count($toArr) > 1) {
+            foreach ($toArr as $toAddr) {
+                $result = $this->mailPassthru($toAddr, $this->Subject, $body, $header, $params);
+                $this->doCallback($result, array($toAddr), $this->cc, $this->bcc, $this->Subject, $body, $this->From);
             }
         } else {
             $result = $this->mailPassthru($to, $this->Subject, $body, $header, $params);
-            // implement call back function if it exists
-            $isSent = ($result == 1) ? 1 : 0;
-            $this->doCallback($isSent, $to, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
+            $this->doCallback($result, $this->to, $this->cc, $this->bcc, $this->Subject, $body, $this->From);
         }
         if (isset($old_from)) {
             ini_set('sendmail_from', $old_from);
@@ -1185,63 +1314,56 @@ class PHPMailer
      * @throws phpmailerException
      * @uses SMTP
      * @access protected
-     * @return bool
+     * @return boolean
      */
     protected function smtpSend($header, $body)
     {
         $bad_rcpt = array();
-
-        if (!$this->smtpConnect()) {
+        if (!$this->smtpConnect($this->SMTPOptions)) {
             throw new phpmailerException($this->lang('smtp_connect_failed'), self::STOP_CRITICAL);
         }
-        $smtp_from = ($this->Sender == '') ? $this->From : $this->Sender;
+        if ('' == $this->Sender) {
+            $smtp_from = $this->From;
+        } else {
+            $smtp_from = $this->Sender;
+        }
         if (!$this->smtp->mail($smtp_from)) {
             $this->setError($this->lang('from_failed') . $smtp_from . ' : ' . implode(',', $this->smtp->getError()));
             throw new phpmailerException($this->ErrorInfo, self::STOP_CRITICAL);
         }
 
         // Attempt to send to all recipients
-        foreach ($this->to as $to) {
-            if (!$this->smtp->recipient($to[0])) {
-                $bad_rcpt[] = $to[0];
-                $isSent = 0;
-            } else {
-                $isSent = 1;
+        foreach (array($this->to, $this->cc, $this->bcc) as $togroup) {
+            foreach ($togroup as $to) {
+                if (!$this->smtp->recipient($to[0])) {
+                    $error = $this->smtp->getError();
+                    $bad_rcpt[] = array('to' => $to[0], 'error' => $error['detail']);
+                    $isSent = false;
+                } else {
+                    $isSent = true;
+                }
+                $this->doCallback($isSent, array($to[0]), array(), array(), $this->Subject, $body, $this->From);
             }
-            $this->doCallback($isSent, $to[0], '', '', $this->Subject, $body, $this->From);
-        }
-        foreach ($this->cc as $cc) {
-            if (!$this->smtp->recipient($cc[0])) {
-                $bad_rcpt[] = $cc[0];
-                $isSent = 0;
-            } else {
-                $isSent = 1;
-            }
-            $this->doCallback($isSent, '', $cc[0], '', $this->Subject, $body, $this->From);
-        }
-        foreach ($this->bcc as $bcc) {
-            if (!$this->smtp->recipient($bcc[0])) {
-                $bad_rcpt[] = $bcc[0];
-                $isSent = 0;
-            } else {
-                $isSent = 1;
-            }
-            $this->doCallback($isSent, '', '', $bcc[0], $this->Subject, $body, $this->From);
         }
 
-        //Only send the DATA command if we have viable recipients
+        // Only send the DATA command if we have viable recipients
         if ((count($this->all_recipients) > count($bad_rcpt)) and !$this->smtp->data($header . $body)) {
             throw new phpmailerException($this->lang('data_not_accepted'), self::STOP_CRITICAL);
         }
-        if ($this->SMTPKeepAlive == true) {
+        if ($this->SMTPKeepAlive) {
             $this->smtp->reset();
         } else {
             $this->smtp->quit();
             $this->smtp->close();
         }
-        if (count($bad_rcpt) > 0) { //Create error message for any bad addresses
+        //Create error message for any bad addresses
+        if (count($bad_rcpt) > 0) {
+            $errstr = '';
+            foreach ($bad_rcpt as $bad) {
+                $errstr .= $bad['to'] . ': ' . $bad['error'];
+            }
             throw new phpmailerException(
-                $this->lang('recipients_failed') . implode(', ', $bad_rcpt),
+                $this->lang('recipients_failed') . $errstr,
                 self::STOP_CONTINUE
             );
         }
@@ -1255,15 +1377,15 @@ class PHPMailer
      * @uses SMTP
      * @access public
      * @throws phpmailerException
-     * @return bool
+     * @return boolean
      */
     public function smtpConnect($options = array())
     {
         if (is_null($this->smtp)) {
             $this->smtp = $this->getSMTPInstance();
         }
-
-        //Already connected?
+       
+        // Already connected?
         if ($this->smtp->connected()) {
             return true;
         }
@@ -1278,22 +1400,33 @@ class PHPMailer
         foreach ($hosts as $hostentry) {
             $hostinfo = array();
             if (!preg_match('/^((ssl|tls):\/\/)*([a-zA-Z0-9\.-]*):?([0-9]*)$/', trim($hostentry), $hostinfo)) {
-                //Not a valid host entry
+                // Not a valid host entry
                 continue;
             }
-            //$hostinfo[2]: optional ssl or tls prefix
-            //$hostinfo[3]: the hostname
-            //$hostinfo[4]: optional port number
-            //The host string prefix can temporarily override the current setting for SMTPSecure
-            //If it's not specified, the default value is used
+            // $hostinfo[2]: optional ssl or tls prefix
+            // $hostinfo[3]: the hostname
+            // $hostinfo[4]: optional port number
+            // The host string prefix can temporarily override the current setting for SMTPSecure
+            // If it's not specified, the default value is used
             $prefix = '';
+            $secure = $this->SMTPSecure;
             $tls = ($this->SMTPSecure == 'tls');
-            if ($hostinfo[2] == 'ssl' or ($hostinfo[2] == '' and $this->SMTPSecure == 'ssl')) {
+            if ('ssl' == $hostinfo[2] or ('' == $hostinfo[2] and 'ssl' == $this->SMTPSecure)) {
                 $prefix = 'ssl://';
-                $tls = false; //Can't have SSL and TLS at once
+                $tls = false; // Can't have SSL and TLS at the same time
+                $secure = 'ssl';
             } elseif ($hostinfo[2] == 'tls') {
                 $tls = true;
-                //tls doesn't use a prefix
+                // tls doesn't use a prefix
+                $secure = 'tls';
+            }
+            //Do we need the OpenSSL extension?
+            $sslext = defined('OPENSSL_ALGO_SHA1');
+            if ('tls' === $secure or 'ssl' === $secure) {
+                //Check for an OpenSSL constant rather than using extension_loaded, which is sometimes disabled
+                if (!$sslext) {
+                    throw new phpmailerException($this->lang('extension_missing').'openssl', self::STOP_CRITICAL);
+                }
             }
             $host = $hostinfo[3];
             $port = $this->Port;
@@ -1309,20 +1442,27 @@ class PHPMailer
                         $hello = $this->serverHostname();
                     }
                     $this->smtp->hello($hello);
-
+                    //Automatically enable TLS encryption if:
+                    // * it's not disabled
+                    // * we have openssl extension
+                    // * we are not already using SSL
+                    // * the server offers STARTTLS
+                    if ($this->SMTPAutoTLS and $sslext and $secure != 'ssl' and $this->smtp->getServerExt('STARTTLS')) {
+                        $tls = true;
+                    }
                     if ($tls) {
                         if (!$this->smtp->startTLS()) {
                             throw new phpmailerException($this->lang('connect_host'));
                         }
-                        //We must resend HELO after tls negotiation
+                        // We must resend HELO after tls negotiation
                         $this->smtp->hello($hello);
                     }
                     if ($this->SMTPAuth) {
                         if (!$this->smtp->authenticate(
-                            $this->Username,
-                            $this->Password,
-                            $this->AuthType,
-                            $this->Realm,
+                            $this->Username, 
+                            $this->Password, 
+                            $this->AuthType, 
+                            $this->Realm, 
                             $this->Workstation
                         )
                         ) {
@@ -1332,14 +1472,15 @@ class PHPMailer
                     return true;
                 } catch (phpmailerException $exc) {
                     $lastexception = $exc;
-                    //We must have connected, but then failed TLS or Auth, so close connection nicely
+                    $this->edebug($exc->getMessage());
+                    // We must have connected, but then failed TLS or Auth, so close connection nicely
                     $this->smtp->quit();
                 }
             }
         }
-        //If we get here, all connection attempts have failed, so close connection hard
+        // If we get here, all connection attempts have failed, so close connection hard
         $this->smtp->close();
-        //As we've caught all exceptions, just report whatever the last one was
+        // As we've caught all exceptions, just report whatever the last one was
         if ($this->exceptions and !is_null($lastexception)) {
             throw $lastexception;
         }
@@ -1366,12 +1507,12 @@ class PHPMailer
      * The default language is English.
      * @param string $langcode ISO 639-1 2-character language code (e.g. French is "fr")
      * @param string $lang_path Path to the language file directory, with trailing separator (slash)
-     * @return bool
+     * @return boolean
      * @access public
      */
     public function setLanguage($langcode = 'en', $lang_path = '')
     {
-        //Define full set of translatable strings in English
+        // Define full set of translatable strings in English
         $PHPMAILER_LANG = array(
             'authenticate' => 'SMTP Error: Could not authenticate.',
             'connect_host' => 'SMTP Error: Could not connect to SMTP host.',
@@ -1390,26 +1531,28 @@ class PHPMailer
             'signing' => 'Signing Error: ',
             'smtp_connect_failed' => 'SMTP connect() failed.',
             'smtp_error' => 'SMTP server error: ',
-            'variable_set' => 'Cannot set or reset variable: '
+            'variable_set' => 'Cannot set or reset variable: ',
+            'extension_missing' => 'Extension missing: '
         );
         if (empty($lang_path)) {
-            //Calculate an absolute path so it can work if CWD is not here
+            // Calculate an absolute path so it can work if CWD is not here
             $lang_path = dirname(__FILE__). DIRECTORY_SEPARATOR . 'language'. DIRECTORY_SEPARATOR;
         }
         $foundlang = true;
         $lang_file = $lang_path . 'phpmailer.lang-' . $langcode . '.php';
-        if ($langcode != 'en') { //There is no English translation file
-            //Make sure language file path is readable
+        // There is no English translation file
+        if ($langcode != 'en') {
+            // Make sure language file path is readable
             if (!is_readable($lang_file)) {
                 $foundlang = false;
             } else {
-                //Overwrite language-specific strings.
-                //This way we'll never have missing translations.
+                // Overwrite language-specific strings.
+                // This way we'll never have missing translation keys.
                 $foundlang = include $lang_file;
             }
         }
         $this->language = $PHPMAILER_LANG;
-        return ($foundlang == true); //Returns false if language not found
+        return (boolean)$foundlang; // Returns false if language not found
     }
 
     /**
@@ -1465,13 +1608,17 @@ class PHPMailer
      * Original written by philippe.
      * @param string $message The message to wrap
      * @param integer $length The line length to wrap to
-     * @param bool $qp_mode Whether to run in Quoted-Printable mode
+     * @param boolean $qp_mode Whether to run in Quoted-Printable mode
      * @access public
      * @return string
      */
     public function wrapText($message, $length, $qp_mode = false)
     {
-        $soft_break = ($qp_mode) ? sprintf(' =%s', $this->LE) : $this->LE;
+        if ($qp_mode) {
+            $soft_break = sprintf(' =%s', $this->LE);
+        } else {
+            $soft_break = $this->LE;
+        }
         // If utf-8 encoding is used, we will need to make sure we don't
         // split multibyte characters when we wrap
         $is_utf8 = (strtolower($this->CharSet) == 'utf-8');
@@ -1479,20 +1626,23 @@ class PHPMailer
         $crlflen = strlen(self::CRLF);
 
         $message = $this->fixEOL($message);
+        //Remove a trailing line break
         if (substr($message, -$lelen) == $this->LE) {
             $message = substr($message, 0, -$lelen);
         }
 
-        $line = explode($this->LE, $message); // Magic. We know fixEOL uses $LE
+        //Split message into lines
+        $lines = explode($this->LE, $message);
+        //Message will be rebuilt in here
         $message = '';
-        for ($i = 0; $i < count($line); $i++) {
-            $line_part = explode(' ', $line[$i]);
+        foreach ($lines as $line) {
+            $words = explode(' ', $line);
             $buf = '';
-            for ($e = 0; $e < count($line_part); $e++) {
-                $word = $line_part[$e];
+            $firstword = true;
+            foreach ($words as $word) {
                 if ($qp_mode and (strlen($word) > $length)) {
                     $space_left = $length - strlen($buf) - $crlflen;
-                    if ($e != 0) {
+                    if (!$firstword) {
                         if ($space_left > 20) {
                             $len = $space_left;
                             if ($is_utf8) {
@@ -1534,13 +1684,17 @@ class PHPMailer
                     }
                 } else {
                     $buf_o = $buf;
-                    $buf .= ($e == 0) ? $word : (' ' . $word);
+                    if (!$firstword) {
+                        $buf .= ' ';
+                    }
+                    $buf .= $word;
 
                     if (strlen($buf) > $length and $buf_o != '') {
                         $message .= $buf_o . $soft_break;
                         $buf = $word;
                     }
                 }
+                $firstword = false;
             }
             $message .= $buf . self::CRLF;
         }
@@ -1550,12 +1704,12 @@ class PHPMailer
 
     /**
      * Find the last character boundary prior to $maxLength in a utf-8
-     * quoted (printable) encoded string.
+     * quoted-printable encoded string.
      * Original written by Colin Brown.
      * @access public
      * @param string $encodedText utf-8 QP text
-     * @param int $maxLength   find last character boundary prior to this length
-     * @return int
+     * @param integer $maxLength Find the last character boundary prior to this length
+     * @return integer
      */
     public function utf8CharBoundary($encodedText, $maxLength)
     {
@@ -1564,22 +1718,26 @@ class PHPMailer
         while (!$foundSplitPos) {
             $lastChunk = substr($encodedText, $maxLength - $lookBack, $lookBack);
             $encodedCharPos = strpos($lastChunk, '=');
-            if ($encodedCharPos !== false) {
+            if (false !== $encodedCharPos) {
                 // Found start of encoded character byte within $lookBack block.
                 // Check the encoded byte value (the 2 chars after the '=')
                 $hex = substr($encodedText, $maxLength - $lookBack + $encodedCharPos + 1, 2);
                 $dec = hexdec($hex);
-                if ($dec < 128) { // Single byte character.
+                if ($dec < 128) {
+                    // Single byte character.
                     // If the encoded char was found at pos 0, it will fit
                     // otherwise reduce maxLength to start of the encoded char
-                    $maxLength = ($encodedCharPos == 0) ? $maxLength :
-                        $maxLength - ($lookBack - $encodedCharPos);
+                    if ($encodedCharPos > 0) {
+                        $maxLength = $maxLength - ($lookBack - $encodedCharPos);
+                    }
                     $foundSplitPos = true;
-                } elseif ($dec >= 192) { // First byte of a multi byte character
+                } elseif ($dec >= 192) {
+                    // First byte of a multi byte character
                     // Reduce maxLength to split at start of character
                     $maxLength = $maxLength - ($lookBack - $encodedCharPos);
                     $foundSplitPos = true;
-                } elseif ($dec < 192) { // Middle byte of a multi byte character, look further back
+                } elseif ($dec < 192) {
+                    // Middle byte of a multi byte character, look further back
                     $lookBack += 3;
                 }
             } else {
@@ -1591,7 +1749,10 @@ class PHPMailer
     }
 
     /**
-     * Set the body wrapping.
+     * Apply word wrapping to the message body.
+     * Wraps the message body to the number of chars set in the WordWrap property.
+     * You should only do this to plain-text bodies as wrapping HTML tags may break them.
+     * This is called automatically by createBody(), so you don't need to call it yourself.
      * @access public
      * @return void
      */
@@ -1623,12 +1784,6 @@ class PHPMailer
     {
         $result = '';
 
-        // Set the boundaries
-        $uniq_id = md5(uniqid(time()));
-        $this->boundary[1] = 'b1_' . $uniq_id;
-        $this->boundary[2] = 'b2_' . $uniq_id;
-        $this->boundary[3] = 'b3_' . $uniq_id;
-
         if ($this->MessageDate == '') {
             $this->MessageDate = self::rfcDate();
         }
@@ -1636,7 +1791,7 @@ class PHPMailer
 
 
         // To be created automatically by mail()
-        if ($this->SingleTo === true) {
+        if ($this->SingleTo) {
             if ($this->Mailer != 'mail') {
                 foreach ($this->to as $toaddr) {
                     $this->SingleToArray[] = $this->addrFormat($toaddr);
@@ -1680,10 +1835,12 @@ class PHPMailer
         if ($this->MessageID != '') {
             $this->lastMessageID = $this->MessageID;
         } else {
-            $this->lastMessageID = sprintf('<%s@%s>', $uniq_id, $this->ServerHostname());
+            $this->lastMessageID = sprintf('<%s@%s>', $this->uniqueid, $this->ServerHostname());
         }
-        $result .= $this->HeaderLine('Message-ID', $this->lastMessageID);
-        $result .= $this->headerLine('X-Priority', $this->Priority);
+        $result .= $this->headerLine('Message-ID', $this->lastMessageID);
+        if (!is_null($this->Priority)) {
+            $result .= $this->headerLine('X-Priority', $this->Priority);
+        }
         if ($this->XMailer == '') {
             $result .= $this->headerLine(
                 'X-Mailer',
@@ -1701,10 +1858,10 @@ class PHPMailer
         }
 
         // Add custom headers
-        for ($index = 0; $index < count($this->CustomHeader); $index++) {
+        foreach ($this->CustomHeader as $header) {
             $result .= $this->headerLine(
-                trim($this->CustomHeader[$index][0]),
-                $this->encodeHeader(trim($this->CustomHeader[$index][1]))
+                trim($header[0]),
+                $this->encodeHeader(trim($header[1]))
             );
         }
         if (!$this->sign_key_file) {
@@ -1747,14 +1904,14 @@ class PHPMailer
                 $ismultipart = false;
                 break;
         }
-        //RFC1341 part 5 says 7bit is assumed if not specified
+        // RFC1341 part 5 says 7bit is assumed if not specified
         if ($this->Encoding != '7bit') {
-            //RFC 2045 section 6.4 says multipart MIME parts may only use 7bit, 8bit or binary CTE
+            // RFC 2045 section 6.4 says multipart MIME parts may only use 7bit, 8bit or binary CTE
             if ($ismultipart) {
                 if ($this->Encoding == '8bit') {
                     $result .= $this->headerLine('Content-Transfer-Encoding', '8bit');
                 }
-                //The only remaining alternatives are quoted-printable and base64, which are both 7bit compatible
+                // The only remaining alternatives are quoted-printable and base64, which are both 7bit compatible
             } else {
                 $result .= $this->headerLine('Content-Transfer-Encoding', $this->Encoding);
             }
@@ -1780,7 +1937,6 @@ class PHPMailer
         return $this->MIMEHeader . $this->mailHeader . self::CRLF . $this->MIMEBody;
     }
 
-
     /**
      * Assemble the message body.
      * Returns an empty string on failure.
@@ -1791,6 +1947,11 @@ class PHPMailer
     public function createBody()
     {
         $body = '';
+        //Create unique IDs and preset boundaries
+        $this->uniqueid = md5(uniqid(time()));
+        $this->boundary[1] = 'b1_' . $this->uniqueid;
+        $this->boundary[2] = 'b2_' . $this->uniqueid;
+        $this->boundary[3] = 'b3_' . $this->uniqueid;
 
         if ($this->sign_key_file) {
             $body .= $this->getMailMIME() . $this->LE;
@@ -1800,30 +1961,48 @@ class PHPMailer
 
         $bodyEncoding = $this->Encoding;
         $bodyCharSet = $this->CharSet;
+        //Can we do a 7-bit downgrade?
         if ($bodyEncoding == '8bit' and !$this->has8bitChars($this->Body)) {
             $bodyEncoding = '7bit';
             $bodyCharSet = 'us-ascii';
         }
+        //If lines are too long, and we're not already using an encoding that will shorten them,
+        //change to quoted-printable transfer encoding
+        if ('base64' != $this->Encoding and self::hasLineLongerThanMax($this->Body)) {
+            $this->Encoding = 'quoted-printable';
+            $bodyEncoding = 'quoted-printable';
+        }
+
         $altBodyEncoding = $this->Encoding;
         $altBodyCharSet = $this->CharSet;
+        //Can we do a 7-bit downgrade?
         if ($altBodyEncoding == '8bit' and !$this->has8bitChars($this->AltBody)) {
             $altBodyEncoding = '7bit';
             $altBodyCharSet = 'us-ascii';
         }
+        //If lines are too long, change to quoted-printable transfer encoding
+        if (self::hasLineLongerThanMax($this->AltBody)) {
+            $altBodyEncoding = 'quoted-printable';
+        }
+        //Use this as a preamble in all multipart message types
+        $mimepre = "This is a multi-part message in MIME format." . $this->LE . $this->LE;
         switch ($this->message_type) {
             case 'inline':
+                $body .= $mimepre;
                 $body .= $this->getBoundary($this->boundary[1], $bodyCharSet, '', $bodyEncoding);
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= $this->LE . $this->LE;
                 $body .= $this->attachAll('inline', $this->boundary[1]);
                 break;
             case 'attach':
+                $body .= $mimepre;
                 $body .= $this->getBoundary($this->boundary[1], $bodyCharSet, '', $bodyEncoding);
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= $this->LE . $this->LE;
                 $body .= $this->attachAll('attachment', $this->boundary[1]);
                 break;
             case 'inline_attach':
+                $body .= $mimepre;
                 $body .= $this->textLine('--' . $this->boundary[1]);
                 $body .= $this->headerLine('Content-Type', 'multipart/related;');
                 $body .= $this->textLine("\tboundary=\"" . $this->boundary[2] . '"');
@@ -1836,6 +2015,7 @@ class PHPMailer
                 $body .= $this->attachAll('attachment', $this->boundary[1]);
                 break;
             case 'alt':
+                $body .= $mimepre;
                 $body .= $this->getBoundary($this->boundary[1], $altBodyCharSet, 'text/plain', $altBodyEncoding);
                 $body .= $this->encodeString($this->AltBody, $altBodyEncoding);
                 $body .= $this->LE . $this->LE;
@@ -1850,6 +2030,7 @@ class PHPMailer
                 $body .= $this->endBoundary($this->boundary[1]);
                 break;
             case 'alt_inline':
+                $body .= $mimepre;
                 $body .= $this->getBoundary($this->boundary[1], $altBodyCharSet, 'text/plain', $altBodyEncoding);
                 $body .= $this->encodeString($this->AltBody, $altBodyEncoding);
                 $body .= $this->LE . $this->LE;
@@ -1865,6 +2046,7 @@ class PHPMailer
                 $body .= $this->endBoundary($this->boundary[1]);
                 break;
             case 'alt_attach':
+                $body .= $mimepre;
                 $body .= $this->textLine('--' . $this->boundary[1]);
                 $body .= $this->headerLine('Content-Type', 'multipart/alternative;');
                 $body .= $this->textLine("\tboundary=\"" . $this->boundary[2] . '"');
@@ -1880,6 +2062,7 @@ class PHPMailer
                 $body .= $this->attachAll('attachment', $this->boundary[1]);
                 break;
             case 'alt_inline_attach':
+                $body .= $mimepre;
                 $body .= $this->textLine('--' . $this->boundary[1]);
                 $body .= $this->headerLine('Content-Type', 'multipart/alternative;');
                 $body .= $this->textLine("\tboundary=\"" . $this->boundary[2] . '"');
@@ -1911,23 +2094,42 @@ class PHPMailer
         } elseif ($this->sign_key_file) {
             try {
                 if (!defined('PKCS7_TEXT')) {
-                    throw new phpmailerException($this->lang('signing') . ' OpenSSL extension missing.');
+                    throw new phpmailerException($this->lang('extension_missing') . 'openssl');
                 }
-                //TODO would be nice to use php://temp streams here, but need to wrap for PHP < 5.1
+                // @TODO would be nice to use php://temp streams here, but need to wrap for PHP < 5.1
                 $file = tempnam(sys_get_temp_dir(), 'mail');
-                file_put_contents($file, $body); //TODO check this worked
+                if (false === file_put_contents($file, $body)) {
+                    throw new phpmailerException($this->lang('signing') . ' Could not write temp file');
+                }
                 $signed = tempnam(sys_get_temp_dir(), 'signed');
-                if (@openssl_pkcs7_sign(
-                    $file,
-                    $signed,
-                    'file://' . realpath($this->sign_cert_file),
-                    array('file://' . realpath($this->sign_key_file), $this->sign_key_pass),
-                    null
-                )
-                ) {
+                //Workaround for PHP bug https://bugs.php.net/bug.php?id=69197
+                if (empty($this->sign_extracerts_file)) {
+                    $sign = @openssl_pkcs7_sign(
+                        $file,
+                        $signed,
+                        'file://' . realpath($this->sign_cert_file),
+                        array('file://' . realpath($this->sign_key_file), $this->sign_key_pass),
+                        null
+                    );
+                } else {
+                    $sign = @openssl_pkcs7_sign(
+                        $file,
+                        $signed,
+                        'file://' . realpath($this->sign_cert_file),
+                        array('file://' . realpath($this->sign_key_file), $this->sign_key_pass),
+                        null,
+                        PKCS7_DETACHED,
+                        $this->sign_extracerts_file
+                    );
+                }
+                if ($sign) {
                     @unlink($file);
                     $body = file_get_contents($signed);
                     @unlink($signed);
+                    //The message returned by openssl contains both headers and body, so need to split them up
+                    $parts = explode("\n\n", $body, 2);
+                    $this->MIMEHeader .= $parts[0] . $this->LE . $this->LE;
+                    $body = $parts[1];
                 } else {
                     @unlink($file);
                     @unlink($signed);
@@ -1967,7 +2169,7 @@ class PHPMailer
         $result .= $this->textLine('--' . $boundary);
         $result .= sprintf('Content-Type: %s; charset=%s', $contentType, $charSet);
         $result .= $this->LE;
-        //RFC1341 part 5 says 7bit is assumed if not specified
+        // RFC1341 part 5 says 7bit is assumed if not specified
         if ($encoding != '7bit') {
             $result .= $this->headerLine('Content-Transfer-Encoding', $encoding);
         }
@@ -1996,17 +2198,17 @@ class PHPMailer
      */
     protected function setMessageType()
     {
-        $this->message_type = array();
+        $type = array();
         if ($this->alternativeExists()) {
-            $this->message_type[] = 'alt';
+            $type[] = 'alt';
         }
         if ($this->inlineImageExists()) {
-            $this->message_type[] = 'inline';
+            $type[] = 'inline';
         }
         if ($this->attachmentExists()) {
-            $this->message_type[] = 'attach';
+            $type[] = 'attach';
         }
-        $this->message_type = implode('_', $this->message_type);
+        $this->message_type = implode('_', $type);
         if ($this->message_type == '') {
             $this->message_type = 'plain';
         }
@@ -2044,7 +2246,7 @@ class PHPMailer
      * @param string $type File extension (MIME) type.
      * @param string $disposition Disposition to use
      * @throws phpmailerException
-     * @return bool
+     * @return boolean
      */
     public function addAttachment($path, $name = '', $encoding = 'base64', $type = '', $disposition = 'attachment')
     {
@@ -2053,7 +2255,7 @@ class PHPMailer
                 throw new phpmailerException($this->lang('file_access') . $path, self::STOP_CONTINUE);
             }
 
-            //If a MIME type is not specified, try to work it out from the file name
+            // If a MIME type is not specified, try to work it out from the file name
             if ($type == '') {
                 $type = self::filenameToType($path);
             }
@@ -2139,13 +2341,22 @@ class PHPMailer
                 $cidUniq[$cid] = true;
 
                 $mime[] = sprintf('--%s%s', $boundary, $this->LE);
-                $mime[] = sprintf(
-                    'Content-Type: %s; name="%s"%s',
-                    $type,
-                    $this->encodeHeader($this->secureHeader($name)),
-                    $this->LE
-                );
-                //RFC1341 part 5 says 7bit is assumed if not specified
+                //Only include a filename property if we have one
+                if (!empty($name)) {
+                    $mime[] = sprintf(
+                        'Content-Type: %s; name="%s"%s',
+                        $type,
+                        $this->encodeHeader($this->secureHeader($name)),
+                        $this->LE
+                    );
+                } else {
+                    $mime[] = sprintf(
+                        'Content-Type: %s%s',
+                        $type,
+                        $this->LE
+                    );
+                }
+                // RFC1341 part 5 says 7bit is assumed if not specified
                 if ($encoding != '7bit') {
                     $mime[] = sprintf('Content-Transfer-Encoding: %s%s', $encoding, $this->LE);
                 }
@@ -2159,20 +2370,29 @@ class PHPMailer
                 // Fixes a warning in IETF's msglint MIME checker
                 // Allow for bypassing the Content-Disposition header totally
                 if (!(empty($disposition))) {
-                    if (preg_match('/[ \(\)<>@,;:\\"\/\[\]\?=]/', $name)) {
+                    $encoded_name = $this->encodeHeader($this->secureHeader($name));
+                    if (preg_match('/[ \(\)<>@,;:\\"\/\[\]\?=]/', $encoded_name)) {
                         $mime[] = sprintf(
                             'Content-Disposition: %s; filename="%s"%s',
                             $disposition,
-                            $this->encodeHeader($this->secureHeader($name)),
+                            $encoded_name,
                             $this->LE . $this->LE
                         );
                     } else {
-                        $mime[] = sprintf(
-                            'Content-Disposition: %s; filename=%s%s',
-                            $disposition,
-                            $this->encodeHeader($this->secureHeader($name)),
-                            $this->LE . $this->LE
-                        );
+                        if (!empty($encoded_name)) {
+                            $mime[] = sprintf(
+                                'Content-Disposition: %s; filename=%s%s',
+                                $disposition,
+                                $encoded_name,
+                                $this->LE . $this->LE
+                            );
+                        } else {
+                            $mime[] = sprintf(
+                                'Content-Disposition: %s%s',
+                                $disposition,
+                                $this->LE . $this->LE
+                            );
+                        }
                     }
                 } else {
                     $mime[] = $this->LE;
@@ -2219,9 +2439,12 @@ class PHPMailer
             $magic_quotes = get_magic_quotes_runtime();
             if ($magic_quotes) {
                 if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-                    set_magic_quotes_runtime(0);
+                    set_magic_quotes_runtime(false);
                 } else {
-                    ini_set('magic_quotes_runtime', 0);
+                    //Doesn't exist in PHP 5.4, but we don't need to check because
+                    //get_magic_quotes_runtime always returns false in 5.4+
+                    //so it will never get here
+                    ini_set('magic_quotes_runtime', false);
                 }
             }
             $file_buffer = file_get_contents($path);
@@ -2258,7 +2481,7 @@ class PHPMailer
             case '7bit':
             case '8bit':
                 $encoded = $this->fixEOL($str);
-                //Make sure it ends with a line break
+                // Make sure it ends with a line break
                 if (substr($encoded, -(strlen($this->LE))) != $this->LE) {
                     $encoded .= $this->LE;
                 }
@@ -2310,14 +2533,15 @@ class PHPMailer
                 break;
         }
 
-        if ($matchcount == 0) { //There are no chars that need encoding
+        //There are no chars that need encoding
+        if ($matchcount == 0) {
             return ($str);
         }
 
         $maxlen = 75 - 7 - strlen($this->CharSet);
         // Try to select the encoding which should produce the shortest output
         if ($matchcount > strlen($str) / 3) {
-            //More than a third of the content will need encoding, so B encoding will be most efficient
+            // More than a third of the content will need encoding, so B encoding will be most efficient
             $encoding = 'B';
             if (function_exists('mb_strlen') && $this->hasMultiBytes($str)) {
                 // Use a custom function which correctly encodes and wraps long
@@ -2345,7 +2569,7 @@ class PHPMailer
      * Check if a string contains multi-byte characters.
      * @access public
      * @param string $str multi-byte text to wrap encode
-     * @return bool
+     * @return boolean
      */
     public function hasMultiBytes($str)
     {
@@ -2359,11 +2583,11 @@ class PHPMailer
     /**
      * Does a string contain any 8-bit chars (in any charset)?
      * @param string $text
-     * @return bool
+     * @return boolean
      */
     public function has8bitChars($text)
     {
-        return (bool)preg_match('/[\x80-\xFF]/', $text);
+        return (boolean)preg_match('/[\x80-\xFF]/', $text);
     }
 
     /**
@@ -2420,17 +2644,17 @@ class PHPMailer
      */
     public function encodeQP($string, $line_max = 76)
     {
-        if (function_exists('quoted_printable_encode')) { //Use native function if it's available (>= PHP5.3)
-            return $this->fixEOL(quoted_printable_encode($string));
+        // Use native function if it's available (>= PHP5.3)
+        if (function_exists('quoted_printable_encode')) {
+            return quoted_printable_encode($string);
         }
-        //Fall back to a pure PHP implementation
+        // Fall back to a pure PHP implementation
         $string = str_replace(
             array('%20', '%0D%0A.', '%0D%0A', '%'),
             array(' ', "\r\n=2E", "\r\n", '='),
             rawurlencode($string)
         );
-        $string = preg_replace('/[^\r\n]{' . ($line_max - 3) . '}[^=\r\n]{2}/', "$0=\r\n", $string);
-        return $this->fixEOL($string);
+        return preg_replace('/[^\r\n]{' . ($line_max - 3) . '}[^=\r\n]{2}/', "$0=\r\n", $string);
     }
 
     /**
@@ -2439,7 +2663,7 @@ class PHPMailer
      * @access public
      * @param string $string
      * @param integer $line_max
-     * @param bool $space_conv
+     * @param boolean $space_conv
      * @return string
      * @deprecated Use encodeQP instead.
      */
@@ -2461,33 +2685,33 @@ class PHPMailer
      */
     public function encodeQ($str, $position = 'text')
     {
-        //There should not be any EOL in the string
+        // There should not be any EOL in the string
         $pattern = '';
         $encoded = str_replace(array("\r", "\n"), '', $str);
         switch (strtolower($position)) {
             case 'phrase':
-                //RFC 2047 section 5.3
+                // RFC 2047 section 5.3
                 $pattern = '^A-Za-z0-9!*+\/ -';
                 break;
             /** @noinspection PhpMissingBreakStatementInspection */
             case 'comment':
-                //RFC 2047 section 5.2
+                // RFC 2047 section 5.2
                 $pattern = '\(\)"';
-                //intentional fall-through
-                //for this reason we build the $pattern without including delimiters and []
+                // intentional fall-through
+                // for this reason we build the $pattern without including delimiters and []
             case 'text':
             default:
-                //RFC 2047 section 5.1
-                //Replace every high ascii, control, =, ? and _ characters
+                // RFC 2047 section 5.1
+                // Replace every high ascii, control, =, ? and _ characters
                 $pattern = '\000-\011\013\014\016-\037\075\077\137\177-\377' . $pattern;
                 break;
         }
         $matches = array();
         if (preg_match_all("/[{$pattern}]/", $encoded, $matches)) {
-            //If the string contains an '=', make sure it's the first thing we replace
-            //so as to avoid double-encoding
+            // If the string contains an '=', make sure it's the first thing we replace
+            // so as to avoid double-encoding
             $eqkey = array_search('=', $matches[0]);
-            if ($eqkey !== false) {
+            if (false !== $eqkey) {
                 unset($matches[0][$eqkey]);
                 array_unshift($matches[0], '=');
             }
@@ -2495,7 +2719,7 @@ class PHPMailer
                 $encoded = str_replace($char, '=' . sprintf('%02X', ord($char)), $encoded);
             }
         }
-        //Replace every spaces to _ (more readable than =20)
+        // Replace every spaces to _ (more readable than =20)
         return str_replace(' ', '_', $encoded);
     }
 
@@ -2518,7 +2742,7 @@ class PHPMailer
         $type = '',
         $disposition = 'attachment'
     ) {
-        //If a MIME type is not specified, try to work it out from the file name
+        // If a MIME type is not specified, try to work it out from the file name
         if ($type == '') {
             $type = self::filenameToType($filename);
         }
@@ -2538,7 +2762,7 @@ class PHPMailer
     /**
      * Add an embedded (inline) attachment from a file.
      * This can include images, sounds, and just about any other document type.
-     * These differ from 'regular' attachmants in that they are intended to be
+     * These differ from 'regular' attachments in that they are intended to be
      * displayed inline with the message, not just attached for download.
      * This is used in HTML messages that embed the images
      * the HTML refers to using the $cid value.
@@ -2549,7 +2773,7 @@ class PHPMailer
      * @param string $encoding File encoding (see $Encoding).
      * @param string $type File MIME type.
      * @param string $disposition Disposition to use
-     * @return bool True on successfully adding an attachment
+     * @return boolean True on successfully adding an attachment
      */
     public function addEmbeddedImage($path, $cid, $name = '', $encoding = 'base64', $type = '', $disposition = 'inline')
     {
@@ -2558,7 +2782,7 @@ class PHPMailer
             return false;
         }
 
-        //If a MIME type is not specified, try to work it out from the file name
+        // If a MIME type is not specified, try to work it out from the file name
         if ($type == '') {
             $type = self::filenameToType($path);
         }
@@ -2594,7 +2818,7 @@ class PHPMailer
      * @param string $encoding File encoding (see $Encoding).
      * @param string $type MIME type.
      * @param string $disposition Disposition to use
-     * @return bool True on successfully adding an attachment
+     * @return boolean True on successfully adding an attachment
      */
     public function addStringEmbeddedImage(
         $string,
@@ -2604,8 +2828,8 @@ class PHPMailer
         $type = '',
         $disposition = 'inline'
     ) {
-        //If a MIME type is not specified, try to work it out from the name
-        if ($type == '') {
+        // If a MIME type is not specified, try to work it out from the name
+        if ($type == '' and !empty($name)) {
             $type = self::filenameToType($name);
         }
 
@@ -2626,7 +2850,7 @@ class PHPMailer
     /**
      * Check if an inline attachment is present.
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function inlineImageExists()
     {
@@ -2640,7 +2864,7 @@ class PHPMailer
 
     /**
      * Check if an attachment (non-inline) is present.
-     * @return bool
+     * @return boolean
      */
     public function attachmentExists()
     {
@@ -2654,7 +2878,7 @@ class PHPMailer
 
     /**
      * Check if this message has an alternative body set.
-     * @return bool
+     * @return boolean
      */
     public function alternativeExists()
     {
@@ -2747,8 +2971,17 @@ class PHPMailer
         $this->error_count++;
         if ($this->Mailer == 'smtp' and !is_null($this->smtp)) {
             $lasterror = $this->smtp->getError();
-            if (!empty($lasterror) and array_key_exists('smtp_msg', $lasterror)) {
-                $msg .= '<p>' . $this->lang('smtp_error') . $lasterror['smtp_msg'] . "</p>\n";
+            if (!empty($lasterror['error'])) {
+                $msg .= $this->lang('smtp_error') . $lasterror['error'];
+                if (!empty($lasterror['detail'])) {
+                    $msg .= ' Detail: '. $lasterror['detail'];
+                }
+                if (!empty($lasterror['smtp_code'])) {
+                    $msg .= ' SMTP code: ' . $lasterror['smtp_code'];
+                }
+                if (!empty($lasterror['smtp_code_ex'])) {
+                    $msg .= ' Additional SMTP info: ' . $lasterror['smtp_code_ex'];
+                }
             }
         }
         $this->ErrorInfo = $msg;
@@ -2762,8 +2995,8 @@ class PHPMailer
      */
     public static function rfcDate()
     {
-        //Set the time zone to whatever the default is to avoid 500 errors
-        //Will default to UTC if it's not set properly in php.ini
+        // Set the time zone to whatever the default is to avoid 500 errors
+        // Will default to UTC if it's not set properly in php.ini
         date_default_timezone_set(@date_default_timezone_get());
         return date('D, j M Y H:i:s O');
     }
@@ -2801,17 +3034,24 @@ class PHPMailer
             $this->setLanguage('en'); // set the default language
         }
 
-        if (isset($this->language[$key])) {
+        if (array_key_exists($key, $this->language)) {
+            if ($key == 'smtp_connect_failed') {
+                //Include a link to troubleshooting docs on SMTP connection failure
+                //this is by far the biggest cause of support questions
+                //but it's usually not PHPMailer's fault.
+                return $this->language[$key] . ' https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting';
+            }
             return $this->language[$key];
         } else {
-            return 'Language string failed to load: ' . $key;
+            //Return the key as a fallback
+            return $key;
         }
     }
 
     /**
      * Check if an error occurred.
      * @access public
-     * @return bool True if an error did occur.
+     * @return boolean True if an error did occur.
      */
     public function isError()
     {
@@ -2856,6 +3096,16 @@ class PHPMailer
     }
 
     /**
+     * Returns all custom headers
+     *
+     * @return array
+     */
+    public function getCustomHeaders()
+    {
+        return $this->CustomHeader;
+    }
+
+    /**
      * Create a message from an HTML string.
      * Automatically makes modifications for inline images and backgrounds
      * and creates a plain-text version by converting the HTML.
@@ -2863,7 +3113,8 @@ class PHPMailer
      * @access public
      * @param string $message HTML message string
      * @param string $basedir baseline directory for path
-     * @param bool $advanced Whether to use the advanced HTML to text converter
+     * @param boolean|callable $advanced Whether to use the internal HTML to text converter
+     *    or your own custom converter @see html2text()
      * @return string $message
      */
     public function msgHTML($message, $basedir = '', $advanced = false)
@@ -2871,14 +3122,31 @@ class PHPMailer
         preg_match_all('/(src|background)=["\'](.*)["\']/Ui', $message, $images);
         if (isset($images[2])) {
             foreach ($images[2] as $imgindex => $url) {
-                // do not change urls for absolute images (thanks to corvuscorax)
-                if (!preg_match('#^[A-z]+://#', $url)) {
+                // Convert data URIs into embedded images
+                if (preg_match('#^data:(image[^;,]*)(;base64)?,#', $url, $match)) {
+                    $data = substr($url, strpos($url, ','));
+                    if ($match[2]) {
+                        $data = base64_decode($data);
+                    } else {
+                        $data = rawurldecode($data);
+                    }
+                    $cid = md5($url) . '@phpmailer.0'; // RFC2392 S 2
+                    if ($this->addStringEmbeddedImage($data, $cid, 'embed' . $imgindex, 'base64', $match[1])) {
+                        $message = str_replace(
+                            $images[0][$imgindex],
+                            $images[1][$imgindex] . '="cid:' . $cid . '"',
+                            $message
+                        );
+                    }
+                } elseif (substr($url, 0, 4) !== 'cid:' && !preg_match('#^[A-z]+://#', $url)) {
+                    // Do not change urls for absolute images (thanks to corvuscorax)
+					// Do not change urls that are already inline images
                     $filename = basename($url);
                     $directory = dirname($url);
                     if ($directory == '.') {
                         $directory = '';
                     }
-                    $cid = md5($url) . '@phpmailer.0'; //RFC2392 S 2
+                    $cid = md5($url) . '@phpmailer.0'; // RFC2392 S 2
                     if (strlen($basedir) > 1 && substr($basedir, -1) != '/') {
                         $basedir .= '/';
                     }
@@ -2890,7 +3158,7 @@ class PHPMailer
                         $cid,
                         $filename,
                         'base64',
-                        self::_mime_types(self::mb_pathinfo($filename, PATHINFO_EXTENSION))
+                        self::_mime_types((string)self::mb_pathinfo($filename, PATHINFO_EXTENSION))
                     )
                     ) {
                         $message = preg_replace(
@@ -2903,7 +3171,7 @@ class PHPMailer
             }
         }
         $this->isHTML(true);
-        //Convert all message body line breaks to CRLF, makes quoted-printable encoding work much better
+        // Convert all message body line breaks to CRLF, makes quoted-printable encoding work much better
         $this->Body = $this->normalizeBreaks($message);
         $this->AltBody = $this->normalizeBreaks($this->html2text($message, $advanced));
         if (empty($this->AltBody)) {
@@ -2915,16 +3183,28 @@ class PHPMailer
 
     /**
      * Convert an HTML string into plain text.
+     * This is used by msgHTML().
+     * Note - older versions of this function used a bundled advanced converter
+     * which was been removed for license reasons in #232
+     * Example usage:
+     * <code>
+     * // Use default conversion
+     * $plain = $mail->html2text($html);
+     * // Use your own custom converter
+     * $plain = $mail->html2text($html, function($html) {
+     *     $converter = new MyHtml2text($html);
+     *     return $converter->get_text();
+     * });
+     * </code>
      * @param string $html The HTML text to convert
-     * @param bool $advanced Should this use the more complex html2text converter or just a simple one?
+     * @param boolean|callable $advanced Any boolean value to use the internal converter,
+     *   or provide your own callable for custom conversion.
      * @return string
      */
     public function html2text($html, $advanced = false)
     {
-        if ($advanced) {
-            require_once 'extras/class.html2text.php';
-            $htmlconverter = new html2text($html);
-            return $htmlconverter->get_text();
+        if (is_callable($advanced)) {
+            return call_user_func($advanced, $html);
         }
         return html_entity_decode(
             trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/si', '', $html))),
@@ -2943,96 +3223,109 @@ class PHPMailer
     public static function _mime_types($ext = '')
     {
         $mimes = array(
-            'xl' => 'application/excel',
-            'hqx' => 'application/mac-binhex40',
-            'cpt' => 'application/mac-compactpro',
-            'bin' => 'application/macbinary',
-            'doc' => 'application/msword',
-            'word' => 'application/msword',
+            'xl'    => 'application/excel',
+            'js'    => 'application/javascript',
+            'hqx'   => 'application/mac-binhex40',
+            'cpt'   => 'application/mac-compactpro',
+            'bin'   => 'application/macbinary',
+            'doc'   => 'application/msword',
+            'word'  => 'application/msword',
+            'xlsx'  => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'xltx'  => 'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
+            'potx'  => 'application/vnd.openxmlformats-officedocument.presentationml.template',
+            'ppsx'  => 'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
+            'pptx'  => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            'sldx'  => 'application/vnd.openxmlformats-officedocument.presentationml.slide',
+            'docx'  => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'dotx'  => 'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
+            'xlam'  => 'application/vnd.ms-excel.addin.macroEnabled.12',
+            'xlsb'  => 'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
             'class' => 'application/octet-stream',
-            'dll' => 'application/octet-stream',
-            'dms' => 'application/octet-stream',
-            'exe' => 'application/octet-stream',
-            'lha' => 'application/octet-stream',
-            'lzh' => 'application/octet-stream',
-            'psd' => 'application/octet-stream',
-            'sea' => 'application/octet-stream',
-            'so' => 'application/octet-stream',
-            'oda' => 'application/oda',
-            'pdf' => 'application/pdf',
-            'ai' => 'application/postscript',
-            'eps' => 'application/postscript',
-            'ps' => 'application/postscript',
-            'smi' => 'application/smil',
-            'smil' => 'application/smil',
-            'mif' => 'application/vnd.mif',
-            'xls' => 'application/vnd.ms-excel',
-            'ppt' => 'application/vnd.ms-powerpoint',
+            'dll'   => 'application/octet-stream',
+            'dms'   => 'application/octet-stream',
+            'exe'   => 'application/octet-stream',
+            'lha'   => 'application/octet-stream',
+            'lzh'   => 'application/octet-stream',
+            'psd'   => 'application/octet-stream',
+            'sea'   => 'application/octet-stream',
+            'so'    => 'application/octet-stream',
+            'oda'   => 'application/oda',
+            'pdf'   => 'application/pdf',
+            'ai'    => 'application/postscript',
+            'eps'   => 'application/postscript',
+            'ps'    => 'application/postscript',
+            'smi'   => 'application/smil',
+            'smil'  => 'application/smil',
+            'mif'   => 'application/vnd.mif',
+            'xls'   => 'application/vnd.ms-excel',
+            'ppt'   => 'application/vnd.ms-powerpoint',
             'wbxml' => 'application/vnd.wap.wbxml',
-            'wmlc' => 'application/vnd.wap.wmlc',
-            'dcr' => 'application/x-director',
-            'dir' => 'application/x-director',
-            'dxr' => 'application/x-director',
-            'dvi' => 'application/x-dvi',
-            'gtar' => 'application/x-gtar',
-            'php3' => 'application/x-httpd-php',
-            'php4' => 'application/x-httpd-php',
-            'php' => 'application/x-httpd-php',
+            'wmlc'  => 'application/vnd.wap.wmlc',
+            'dcr'   => 'application/x-director',
+            'dir'   => 'application/x-director',
+            'dxr'   => 'application/x-director',
+            'dvi'   => 'application/x-dvi',
+            'gtar'  => 'application/x-gtar',
+            'php3'  => 'application/x-httpd-php',
+            'php4'  => 'application/x-httpd-php',
+            'php'   => 'application/x-httpd-php',
             'phtml' => 'application/x-httpd-php',
-            'phps' => 'application/x-httpd-php-source',
-            'js' => 'application/x-javascript',
-            'swf' => 'application/x-shockwave-flash',
-            'sit' => 'application/x-stuffit',
-            'tar' => 'application/x-tar',
-            'tgz' => 'application/x-tar',
-            'xht' => 'application/xhtml+xml',
+            'phps'  => 'application/x-httpd-php-source',
+            'swf'   => 'application/x-shockwave-flash',
+            'sit'   => 'application/x-stuffit',
+            'tar'   => 'application/x-tar',
+            'tgz'   => 'application/x-tar',
+            'xht'   => 'application/xhtml+xml',
             'xhtml' => 'application/xhtml+xml',
-            'zip' => 'application/zip',
-            'mid' => 'audio/midi',
-            'midi' => 'audio/midi',
-            'mp2' => 'audio/mpeg',
-            'mp3' => 'audio/mpeg',
-            'mpga' => 'audio/mpeg',
-            'aif' => 'audio/x-aiff',
-            'aifc' => 'audio/x-aiff',
-            'aiff' => 'audio/x-aiff',
-            'ram' => 'audio/x-pn-realaudio',
-            'rm' => 'audio/x-pn-realaudio',
-            'rpm' => 'audio/x-pn-realaudio-plugin',
-            'ra' => 'audio/x-realaudio',
-            'wav' => 'audio/x-wav',
-            'bmp' => 'image/bmp',
-            'gif' => 'image/gif',
-            'jpeg' => 'image/jpeg',
-            'jpe' => 'image/jpeg',
-            'jpg' => 'image/jpeg',
-            'png' => 'image/png',
-            'tiff' => 'image/tiff',
-            'tif' => 'image/tiff',
-            'eml' => 'message/rfc822',
-            'css' => 'text/css',
-            'html' => 'text/html',
-            'htm' => 'text/html',
+            'zip'   => 'application/zip',
+            'mid'   => 'audio/midi',
+            'midi'  => 'audio/midi',
+            'mp2'   => 'audio/mpeg',
+            'mp3'   => 'audio/mpeg',
+            'mpga'  => 'audio/mpeg',
+            'aif'   => 'audio/x-aiff',
+            'aifc'  => 'audio/x-aiff',
+            'aiff'  => 'audio/x-aiff',
+            'ram'   => 'audio/x-pn-realaudio',
+            'rm'    => 'audio/x-pn-realaudio',
+            'rpm'   => 'audio/x-pn-realaudio-plugin',
+            'ra'    => 'audio/x-realaudio',
+            'wav'   => 'audio/x-wav',
+            'bmp'   => 'image/bmp',
+            'gif'   => 'image/gif',
+            'jpeg'  => 'image/jpeg',
+            'jpe'   => 'image/jpeg',
+            'jpg'   => 'image/jpeg',
+            'png'   => 'image/png',
+            'tiff'  => 'image/tiff',
+            'tif'   => 'image/tiff',
+            'eml'   => 'message/rfc822',
+            'css'   => 'text/css',
+            'html'  => 'text/html',
+            'htm'   => 'text/html',
             'shtml' => 'text/html',
-            'log' => 'text/plain',
-            'text' => 'text/plain',
-            'txt' => 'text/plain',
-            'rtx' => 'text/richtext',
-            'rtf' => 'text/rtf',
-            'vcf' => 'text/vcard',
+            'log'   => 'text/plain',
+            'text'  => 'text/plain',
+            'txt'   => 'text/plain',
+            'rtx'   => 'text/richtext',
+            'rtf'   => 'text/rtf',
+            'vcf'   => 'text/vcard',
             'vcard' => 'text/vcard',
-            'xml' => 'text/xml',
-            'xsl' => 'text/xml',
-            'mpeg' => 'video/mpeg',
-            'mpe' => 'video/mpeg',
-            'mpg' => 'video/mpeg',
-            'mov' => 'video/quicktime',
-            'qt' => 'video/quicktime',
-            'rv' => 'video/vnd.rn-realvideo',
-            'avi' => 'video/x-msvideo',
+            'xml'   => 'text/xml',
+            'xsl'   => 'text/xml',
+            'mpeg'  => 'video/mpeg',
+            'mpe'   => 'video/mpeg',
+            'mpg'   => 'video/mpeg',
+            'mov'   => 'video/quicktime',
+            'qt'    => 'video/quicktime',
+            'rv'    => 'video/vnd.rn-realvideo',
+            'avi'   => 'video/x-msvideo',
             'movie' => 'video/x-sgi-movie'
         );
-        return (array_key_exists(strtolower($ext), $mimes) ? $mimes[strtolower($ext)]: 'application/octet-stream');
+        if (array_key_exists(strtolower($ext), $mimes)) {
+            return $mimes[strtolower($ext)];
+        }
+        return 'application/octet-stream';
     }
 
     /**
@@ -3044,9 +3337,9 @@ class PHPMailer
      */
     public static function filenameToType($filename)
     {
-        //In case the path is a URL, strip any query string before getting extension
+        // In case the path is a URL, strip any query string before getting extension
         $qpos = strpos($filename, '?');
-        if ($qpos !== false) {
+        if (false !== $qpos) {
             $filename = substr($filename, 0, $qpos);
         }
         $pathinfo = self::mb_pathinfo($filename);
@@ -3068,36 +3361,33 @@ class PHPMailer
     {
         $ret = array('dirname' => '', 'basename' => '', 'extension' => '', 'filename' => '');
         $pathinfo = array();
-        preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im', $path, $pathinfo);
-        if (array_key_exists(1, $pathinfo)) {
-            $ret['dirname'] = $pathinfo[1];
-        }
-        if (array_key_exists(2, $pathinfo)) {
-            $ret['basename'] = $pathinfo[2];
-        }
-        if (array_key_exists(5, $pathinfo)) {
-            $ret['extension'] = $pathinfo[5];
-        }
-        if (array_key_exists(3, $pathinfo)) {
-            $ret['filename'] = $pathinfo[3];
+        if (preg_match('%^(.*?)[\\\\/]*(([^/\\\\]*?)(\.([^\.\\\\/]+?)|))[\\\\/\.]*$%im', $path, $pathinfo)) {
+            if (array_key_exists(1, $pathinfo)) {
+                $ret['dirname'] = $pathinfo[1];
+            }
+            if (array_key_exists(2, $pathinfo)) {
+                $ret['basename'] = $pathinfo[2];
+            }
+            if (array_key_exists(5, $pathinfo)) {
+                $ret['extension'] = $pathinfo[5];
+            }
+            if (array_key_exists(3, $pathinfo)) {
+                $ret['filename'] = $pathinfo[3];
+            }
         }
         switch ($options) {
             case PATHINFO_DIRNAME:
             case 'dirname':
                 return $ret['dirname'];
-                break;
             case PATHINFO_BASENAME:
             case 'basename':
                 return $ret['basename'];
-                break;
             case PATHINFO_EXTENSION:
             case 'extension':
                 return $ret['extension'];
-                break;
             case PATHINFO_FILENAME:
             case 'filename':
                 return $ret['filename'];
-                break;
             default:
                 return $ret;
         }
@@ -3105,33 +3395,27 @@ class PHPMailer
 
     /**
      * Set or reset instance properties.
-     *
+     * You should avoid this function - it's more verbose, less efficient, more error-prone and
+     * harder to debug than setting properties directly.
      * Usage Example:
-     * $page->set('X-Priority', '3');
-     *
+     * `$mail->set('SMTPSecure', 'tls');`
+     *   is the same as:
+     * `$mail->SMTPSecure = 'tls';`
      * @access public
-     * @param string $name
-     * @param mixed $value
-     * NOTE: will not work with arrays, there are no arrays to set/reset
-     * @throws phpmailerException
-     * @return bool
-     * @todo Should this not be using __set() magic function?
+     * @param string $name The property name to set
+     * @param mixed $value The value to set the property to
+     * @return boolean
+     * @TODO Should this not be using the __set() magic function?
      */
     public function set($name, $value = '')
     {
-        try {
-            if (isset($this->$name)) {
-                $this->$name = $value;
-            } else {
-                throw new phpmailerException($this->lang('variable_set') . $name, self::STOP_CRITICAL);
-            }
-        } catch (Exception $exc) {
-            $this->setError($exc->getMessage());
-            if ($exc->getCode() == self::STOP_CRITICAL) {
-                return false;
-            }
+        if (property_exists($this, $name)) {
+            $this->$name = $value;
+            return true;
+        } else {
+            $this->setError($this->lang('variable_set') . $name);
+            return false;
         }
-        return true;
     }
 
     /**
@@ -3167,12 +3451,14 @@ class PHPMailer
      * @param string $cert_filename
      * @param string $key_filename
      * @param string $key_pass Password for private key
+     * @param string $extracerts_filename Optional path to chain certificate
      */
-    public function sign($cert_filename, $key_filename, $key_pass)
+    public function sign($cert_filename, $key_filename, $key_pass, $extracerts_filename = '')
     {
         $this->sign_cert_file = $cert_filename;
         $this->sign_key_file = $key_filename;
         $this->sign_key_pass = $key_pass;
+        $this->sign_extracerts_file = $extracerts_filename;
     }
 
     /**
@@ -3198,15 +3484,15 @@ class PHPMailer
     /**
      * Generate a DKIM signature.
      * @access public
-     * @param string $signheader Header
+     * @param string $signHeader
      * @throws phpmailerException
      * @return string
      */
-    public function DKIM_Sign($signheader)
+    public function DKIM_Sign($signHeader)
     {
         if (!defined('PKCS7_TEXT')) {
             if ($this->exceptions) {
-                throw new phpmailerException($this->lang('signing') . ' OpenSSL extension missing.');
+                throw new phpmailerException($this->lang('extension_missing') . 'openssl');
             }
             return '';
         }
@@ -3216,7 +3502,7 @@ class PHPMailer
         } else {
             $privKey = $privKeyStr;
         }
-        if (openssl_sign($signheader, $signature, $privKey)) {
+        if (openssl_sign($signHeader, $signature, $privKey)) {
             return base64_encode($signature);
         }
         return '';
@@ -3225,21 +3511,21 @@ class PHPMailer
     /**
      * Generate a DKIM canonicalization header.
      * @access public
-     * @param string $signheader Header
+     * @param string $signHeader Header
      * @return string
      */
-    public function DKIM_HeaderC($signheader)
+    public function DKIM_HeaderC($signHeader)
     {
-        $signheader = preg_replace('/\r\n\s+/', ' ', $signheader);
-        $lines = explode("\r\n", $signheader);
+        $signHeader = preg_replace('/\r\n\s+/', ' ', $signHeader);
+        $lines = explode("\r\n", $signHeader);
         foreach ($lines as $key => $line) {
             list($heading, $value) = explode(':', $line, 2);
             $heading = strtolower($heading);
             $value = preg_replace('/\s+/', ' ', $value); // Compress useless spaces
             $lines[$key] = $heading . ':' . trim($value); // Don't forget to remove WSP around the value
         }
-        $signheader = implode("\r\n", $lines);
-        return $signheader;
+        $signHeader = implode("\r\n", $lines);
+        return $signHeader;
     }
 
     /**
@@ -3290,8 +3576,8 @@ class PHPMailer
                 $to_header = $header;
                 $current = 'to_header';
             } else {
-                if ($current && strpos($header, ' =?') === 0) {
-                    $current .= $header;
+                if (!empty($$current) && strpos($header, ' =?') === 0) {
+                    $$current .= $header;
                 } else {
                     $current = '';
                 }
@@ -3307,7 +3593,11 @@ class PHPMailer
         $body = $this->DKIM_BodyC($body);
         $DKIMlen = strlen($body); // Length of body
         $DKIMb64 = base64_encode(pack('H*', sha1($body))); // Base64 of packed binary SHA-1 hash of body
-        $ident = ($this->DKIM_identity == '') ? '' : ' i=' . $this->DKIM_identity . ';';
+        if ('' == $this->DKIM_identity) {
+            $ident = '';
+        } else {
+            $ident = ' i=' . $this->DKIM_identity . ';';
+        }
         $dkimhdrs = 'DKIM-Signature: v=1; a=' .
             $DKIMsignatureType . '; q=' .
             $DKIMquery . '; l=' .
@@ -3327,6 +3617,18 @@ class PHPMailer
         );
         $signed = $this->DKIM_Sign($toSign);
         return $dkimhdrs . $signed . "\r\n";
+    }
+
+    /**
+     * Detect if a string contains a line longer than the maximum line length allowed.
+     * @param string $str
+     * @return boolean
+     * @static
+     */
+    public static function hasLineLongerThanMax($str)
+    {
+        //+2 to include CRLF line break for a 1000 total
+        return (boolean)preg_match('/^(.{'.(self::MAX_LINE_LENGTH + 2).',})/m', $str);
     }
 
     /**
@@ -3381,15 +3683,15 @@ class PHPMailer
 
     /**
      * Perform a callback.
-     * @param bool $isSent
-     * @param string $to
-     * @param string $cc
-     * @param string $bcc
+     * @param boolean $isSent
+     * @param array $to
+     * @param array $cc
+     * @param array $bcc
      * @param string $subject
      * @param string $body
      * @param string $from
      */
-    protected function doCallback($isSent, $to, $cc, $bcc, $subject, $body, $from = null)
+    protected function doCallback($isSent, $to, $cc, $bcc, $subject, $body, $from)
     {
         if (!empty($this->action_function) && is_callable($this->action_function)) {
             $params = array($isSent, $to, $cc, $bcc, $subject, $body, $from);

--- a/core/model/modx/mail/phpmailer/class.pop3.php
+++ b/core/model/modx/mail/phpmailer/class.pop3.php
@@ -34,18 +34,18 @@ class POP3
      * @type string
      * @access public
      */
-    public $Version = '5.2.8';
+    public $Version = '5.2.13';
 
     /**
      * Default POP3 port number.
-     * @type int
+     * @type integer
      * @access public
      */
     public $POP3_PORT = 110;
 
     /**
      * Default timeout in seconds.
-     * @type int
+     * @type integer
      * @access public
      */
     public $POP3_TIMEOUT = 30;
@@ -61,7 +61,7 @@ class POP3
     /**
      * Debug display level.
      * Options: 0 = no, 1+ = yes
-     * @type int
+     * @type integer
      * @access public
      */
     public $do_debug = 0;
@@ -75,14 +75,14 @@ class POP3
 
     /**
      * POP3 port number.
-     * @type int
+     * @type integer
      * @access public
      */
     public $port;
 
     /**
      * POP3 Timeout Value in seconds.
-     * @type int
+     * @type integer
      * @access public
      */
     public $tval;
@@ -110,17 +110,17 @@ class POP3
 
     /**
      * Are we connected?
-     * @type bool
+     * @type boolean
      * @access private
      */
-    private $connected;
+    private $connected = false;
 
     /**
      * Error container.
      * @type array
      * @access private
      */
-    private $error;
+    private $errors = array();
 
     /**
      * Line break constant
@@ -128,36 +128,25 @@ class POP3
     const CRLF = "\r\n";
 
     /**
-     * Constructor.
-     * @access public
-     */
-    public function __construct()
-    {
-        $this->pop_conn = 0;
-        $this->connected = false;
-        $this->error = null;
-    }
-
-    /**
      * Simple static wrapper for all-in-one POP before SMTP
      * @param $host
-     * @param bool $port
-     * @param bool $tval
+     * @param integer|boolean $port The port number to connect to
+     * @param integer|boolean $timeout The timeout value
      * @param string $username
      * @param string $password
-     * @param int $debug_level
-     * @return bool
+     * @param integer $debug_level
+     * @return boolean
      */
     public static function popBeforeSmtp(
         $host,
         $port = false,
-        $tval = false,
+        $timeout = false,
         $username = '',
         $password = '',
         $debug_level = 0
     ) {
         $pop = new POP3;
-        return $pop->authorise($host, $port, $tval, $username, $password, $debug_level);
+        return $pop->authorise($host, $port, $timeout, $username, $password, $debug_level);
     }
 
     /**
@@ -165,34 +154,34 @@ class POP3
      * A connect, login, disconnect sequence
      * appropriate for POP-before SMTP authorisation.
      * @access public
-     * @param string $host
-     * @param bool|int $port
-     * @param bool|int $tval
+     * @param string $host The hostname to connect to
+     * @param integer|boolean $port The port number to connect to
+     * @param integer|boolean $timeout The timeout value
      * @param string $username
      * @param string $password
-     * @param int $debug_level
-     * @return bool
+     * @param integer $debug_level
+     * @return boolean
      */
-    public function authorise($host, $port = false, $tval = false, $username = '', $password = '', $debug_level = 0)
+    public function authorise($host, $port = false, $timeout = false, $username = '', $password = '', $debug_level = 0)
     {
         $this->host = $host;
         // If no port value provided, use default
-        if ($port === false) {
+        if (false === $port) {
             $this->port = $this->POP3_PORT;
         } else {
-            $this->port = $port;
+            $this->port = (integer)$port;
         }
         // If no timeout value provided, use default
-        if ($tval === false) {
+        if (false === $timeout) {
             $this->tval = $this->POP3_TIMEOUT;
         } else {
-            $this->tval = $tval;
+            $this->tval = (integer)$timeout;
         }
         $this->do_debug = $debug_level;
         $this->username = $username;
         $this->password = $password;
-        //  Refresh the error log
-        $this->error = null;
+        //  Reset the error log
+        $this->errors = array();
         //  connect
         $result = $this->connect($this->host, $this->port, $this->tval);
         if ($result) {
@@ -211,7 +200,7 @@ class POP3
      * Connect to a POP3 server.
      * @access public
      * @param string $host
-     * @param bool|int $port
+     * @param integer|boolean $port
      * @param integer $tval
      * @return boolean
      */
@@ -226,6 +215,10 @@ class POP3
         //Rather than suppress it with @fsockopen, capture it cleanly instead
         set_error_handler(array($this, 'catchWarning'));
 
+        if (false === $port) {
+            $port = $this->POP3_PORT;
+        }
+
         //  connect to the POP3 server
         $this->pop_conn = fsockopen(
             $host, //  POP3 Host
@@ -236,34 +229,20 @@ class POP3
         ); //  Timeout (seconds)
         //  Restore the error handler
         restore_error_handler();
-        //  Does the Error Log now contain anything?
-        if ($this->error && $this->do_debug >= 1) {
-            $this->displayErrors();
-        }
+
         //  Did we connect?
-        if ($this->pop_conn == false) {
+        if (false === $this->pop_conn) {
             //  It would appear not...
-            $this->error = array(
+            $this->setError(array(
                 'error' => "Failed to connect to server $host on port $port",
                 'errno' => $errno,
                 'errstr' => $errstr
-            );
-            if ($this->do_debug >= 1) {
-                $this->displayErrors();
-            }
+            ));
             return false;
         }
 
         //  Increase the stream time-out
-        //  Check for PHP 4.3.0 or later
-        if (version_compare(phpversion(), '5.0.0', 'ge')) {
-            stream_set_timeout($this->pop_conn, $tval, 0);
-        } else {
-            //  Does not work on Windows
-            if (substr(PHP_OS, 0, 3) !== 'WIN') {
-                socket_set_timeout($this->pop_conn, $tval, 0);
-            }
-        }
+        stream_set_timeout($this->pop_conn, $tval, 0);
 
         //  Get the POP3 server response
         $pop3_response = $this->getResponse();
@@ -286,12 +265,8 @@ class POP3
      */
     public function login($username = '', $password = '')
     {
-        if ($this->connected == false) {
-            $this->error = 'Not connected to POP3 server';
-
-            if ($this->do_debug >= 1) {
-                $this->displayErrors();
-            }
+        if (!$this->connected) {
+            $this->setError('Not connected to POP3 server');
         }
         if (empty($username)) {
             $username = $this->username;
@@ -323,7 +298,11 @@ class POP3
         $this->sendString('QUIT');
         //The QUIT command may cause the daemon to exit, which will kill our connection
         //So ignore errors here
-        @fclose($this->pop_conn);
+        try {
+            @fclose($this->pop_conn);
+        } catch (Exception $e) {
+            //Do nothing
+        };
     }
 
     /**
@@ -369,14 +348,11 @@ class POP3
     private function checkResponse($string)
     {
         if (substr($string, 0, 3) !== '+OK') {
-            $this->error = array(
+            $this->setError(array(
                 'error' => "Server reported an error: $string",
                 'errno' => 0,
                 'errstr' => ''
-            );
-            if ($this->do_debug >= 1) {
-                $this->displayErrors();
-            }
+            ));
             return false;
         } else {
             return true;
@@ -384,16 +360,20 @@ class POP3
     }
 
     /**
-     * Display errors if debug is enabled.
-     * @access private
+     * Add an error to the internal error store.
+     * Also display debug output if it's enabled.
+     * @param $error
      */
-    private function displayErrors()
+    private function setError($error)
     {
-        echo '<pre>';
-        foreach ($this->error as $single_error) {
-            print_r($single_error);
+        $this->errors[] = $error;
+        if ($this->do_debug >= 1) {
+            echo '<pre>';
+            foreach ($this->errors as $error) {
+                print_r($error);
+            }
+            echo '</pre>';
         }
-        echo '</pre>';
     }
 
     /**
@@ -406,12 +386,12 @@ class POP3
      */
     private function catchWarning($errno, $errstr, $errfile, $errline)
     {
-        $this->error[] = array(
+        $this->setError(array(
             'error' => "Connecting to the POP3 server raised a PHP warning: ",
             'errno' => $errno,
             'errstr' => $errstr,
             'errfile' => $errfile,
             'errline' => $errline
-        );
+        ));
     }
 }

--- a/core/model/modx/mail/phpmailer/class.smtp.php
+++ b/core/model/modx/mail/phpmailer/class.smtp.php
@@ -21,7 +21,7 @@
  * PHPMailer RFC821 SMTP email transport class.
  * Implements RFC 821 SMTP commands and provides some utility methods for sending mail to an SMTP server.
  * @package PHPMailer
- * @author Chris Ryan <unknown@example.com>
+ * @author Chris Ryan
  * @author Marcus Bointon <phpmailer@synchromedia.co.uk>
  */
 class SMTP
@@ -30,7 +30,7 @@ class SMTP
      * The PHPMailer SMTP version number.
      * @type string
      */
-    const VERSION = '5.2.8';
+    const VERSION = '5.2.13';
 
     /**
      * SMTP line break constant.
@@ -40,28 +40,53 @@ class SMTP
 
     /**
      * The SMTP port to use if one is not specified.
-     * @type int
+     * @type integer
      */
     const DEFAULT_SMTP_PORT = 25;
 
     /**
      * The maximum line length allowed by RFC 2822 section 2.1.1
-     * @type int
+     * @type integer
      */
     const MAX_LINE_LENGTH = 998;
 
     /**
+     * Debug level for no output
+     */
+    const DEBUG_OFF = 0;
+
+    /**
+     * Debug level to show client -> server messages
+     */
+    const DEBUG_CLIENT = 1;
+
+    /**
+     * Debug level to show client -> server and server -> client messages
+     */
+    const DEBUG_SERVER = 2;
+
+    /**
+     * Debug level to show connection status, client -> server and server -> client messages
+     */
+    const DEBUG_CONNECTION = 3;
+
+    /**
+     * Debug level to show all messages
+     */
+    const DEBUG_LOWLEVEL = 4;
+
+    /**
      * The PHPMailer SMTP Version number.
      * @type string
-     * @deprecated Use the constant instead
+     * @deprecated Use the `VERSION` constant instead
      * @see SMTP::VERSION
      */
-    public $Version = '5.2.8';
+    public $Version = '5.2.13';
 
     /**
      * SMTP server port number.
-     * @type int
-     * @deprecated This is only ever used as a default value, so use the constant instead
+     * @type integer
+     * @deprecated This is only ever used as a default value, so use the `DEFAULT_SMTP_PORT` constant instead
      * @see SMTP::DEFAULT_SMTP_PORT
      */
     public $SMTP_PORT = 25;
@@ -69,7 +94,7 @@ class SMTP
     /**
      * SMTP reply line ending.
      * @type string
-     * @deprecated Use the constant instead
+     * @deprecated Use the `CRLF` constant instead
      * @see SMTP::CRLF
      */
     public $CRLF = "\r\n";
@@ -77,22 +102,27 @@ class SMTP
     /**
      * Debug output level.
      * Options:
-     * * `0` No output
-     * * `1` Commands
-     * * `2` Data and commands
-     * * `3` As 2 plus connection status
-     * * `4` Low-level data output
-     * @type int
+     * * self::DEBUG_OFF (`0`) No debug output, default
+     * * self::DEBUG_CLIENT (`1`) Client commands
+     * * self::DEBUG_SERVER (`2`) Client commands and server responses
+     * * self::DEBUG_CONNECTION (`3`) As DEBUG_SERVER plus connection status
+     * * self::DEBUG_LOWLEVEL (`4`) Low-level data output, all messages
+     * @type integer
      */
-    public $do_debug = 0;
+    public $do_debug = self::DEBUG_OFF;
 
     /**
      * How to handle debug output.
      * Options:
      * * `echo` Output plain-text as-is, appropriate for CLI
-     * * `html` Output escaped, line breaks converted to <br>, appropriate for browser output
+     * * `html` Output escaped, line breaks converted to `<br>`, appropriate for browser output
      * * `error_log` Output to error log as configured in php.ini
-     * @type string
+     *
+     * Alternatively, you can provide a callable expecting two params: a message string and the debug level:
+     * <code>
+     * $smtp->Debugoutput = function($str, $level) {echo "debug level $level; message: $str";};
+     * </code>
+     * @type string|callable
      */
     public $Debugoutput = 'echo';
 
@@ -100,7 +130,7 @@ class SMTP
      * Whether to use VERP.
      * @link http://en.wikipedia.org/wiki/Variable_envelope_return_path
      * @link http://www.postfix.org/VERP_README.html Info on VERP
-     * @type bool
+     * @type boolean
      */
     public $do_verp = false;
 
@@ -109,15 +139,16 @@ class SMTP
      * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
      * This needs to be quite high to function correctly with hosts using greetdelay as an anti-spam measure.
      * @link http://tools.ietf.org/html/rfc2821#section-4.5.3.2
-     * @type int
+     * @type integer
      */
     public $Timeout = 300;
 
     /**
-     * The SMTP timelimit value for reads, in seconds.
-     * @type int
+     * How long to wait for commands to complete, in seconds.
+     * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
+     * @type integer
      */
-    public $Timelimit = 30;
+    public $Timelimit = 300;
 
     /**
      * The socket for the server connection.
@@ -126,16 +157,33 @@ class SMTP
     protected $smtp_conn;
 
     /**
-     * Error message, if any, for the last call.
-     * @type string
+     * Error information, if any, for the last SMTP command.
+     * @type array
      */
-    protected $error = '';
+    protected $error = array(
+        'error' => '',
+        'detail' => '',
+        'smtp_code' => '',
+        'smtp_code_ex' => ''
+    );
 
     /**
      * The reply the server sent to us for HELO.
-     * @type string
+     * If null, no HELO string has yet been received.
+     * @type string|null
      */
-    protected $helo_rply = '';
+    protected $helo_rply = null;
+
+    /**
+     * The set of SMTP extensions sent in reply to EHLO command.
+     * Indexes of the array are extension names.
+     * Value at index 'HELO' or 'EHLO' (according to command that was sent)
+     * represents the server name. In case of HELO it is the only element of the array.
+     * Other values can be boolean TRUE or an array containing extension options.
+     * If null, no HELO/EHLO string has yet been received.
+     * @type array|null
+     */
+    protected $server_caps = null;
 
     /**
      * The most recent reply received from the server.
@@ -144,24 +192,23 @@ class SMTP
     protected $last_reply = '';
 
     /**
-     * Constructor.
-     * @access public
-     */
-    public function __construct()
-    {
-        $this->smtp_conn = 0;
-        $this->error = null;
-        $this->helo_rply = null;
-        $this->do_debug = 0;
-    }
-
-    /**
      * Output debugging info via a user-selected method.
+     * @see SMTP::$Debugoutput
+     * @see SMTP::$do_debug
      * @param string $str Debug string to output
+     * @param integer $level The debug level of this message; see DEBUG_* constants
      * @return void
      */
-    protected function edebug($str)
+    protected function edebug($str, $level = 0)
     {
+        if ($level > $this->do_debug) {
+            return;
+        }
+        //Avoid clash with built-in function names
+        if (!in_array($this->Debugoutput, array('error_log', 'html', 'echo')) and is_callable($this->Debugoutput)) {
+            call_user_func($this->Debugoutput, $str, $this->do_debug);
+            return;
+        }
         switch ($this->Debugoutput) {
             case 'error_log':
                 //Don't output, just log
@@ -178,87 +225,111 @@ class SMTP
                 break;
             case 'echo':
             default:
-                echo gmdate('Y-m-d H:i:s')."\t".trim($str)."\n";
+                //Normalize line breaks
+                $str = preg_replace('/(\r\n|\r|\n)/ms', "\n", $str);
+                echo gmdate('Y-m-d H:i:s') . "\t" . str_replace(
+                    "\n",
+                    "\n                   \t                  ",
+                    trim($str)
+                )."\n";
         }
     }
 
     /**
      * Connect to an SMTP server.
      * @param string $host SMTP server IP or host name
-     * @param int $port The port number to connect to
-     * @param int $timeout How long to wait for the connection to open
+     * @param integer $port The port number to connect to
+     * @param integer $timeout How long to wait for the connection to open
      * @param array $options An array of options for stream_context_create()
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function connect($host, $port = null, $timeout = 30, $options = array())
     {
+        static $streamok;
+        //This is enabled by default since 5.0.0 but some providers disable it
+        //Check this once and cache the result
+        if (is_null($streamok)) {
+            $streamok = function_exists('stream_socket_client');
+        }
         // Clear errors to avoid confusion
-        $this->error = null;
+        $this->setError('');
         // Make sure we are __not__ connected
         if ($this->connected()) {
             // Already connected, generate error
-            $this->error = array('error' => 'Already connected to a server');
+            $this->setError('Already connected to a server');
             return false;
         }
         if (empty($port)) {
             $port = self::DEFAULT_SMTP_PORT;
         }
         // Connect to the SMTP server
-        if ($this->do_debug >= 3) {
-            $this->edebug('Connection: opening');
-        }
+        $this->edebug(
+            "Connection: opening to $host:$port, timeout=$timeout, options=".var_export($options, true),
+            self::DEBUG_CONNECTION
+        );
         $errno = 0;
         $errstr = '';
-        $socket_context = stream_context_create($options);
-        //Suppress errors; connection failures are handled at a higher level
-        $this->smtp_conn = @stream_socket_client(
-            $host . ":" . $port,
-            $errno,
-            $errstr,
-            $timeout,
-            STREAM_CLIENT_CONNECT,
-            $socket_context
-        );
-        // Verify we connected properly
-        if (empty($this->smtp_conn)) {
-            $this->error = array(
-                'error' => 'Failed to connect to server',
-                'errno' => $errno,
-                'errstr' => $errstr
+        if ($streamok) {
+            $socket_context = stream_context_create($options);
+            //Suppress errors; connection failures are handled at a higher level
+            $this->smtp_conn = @stream_socket_client(
+                $host . ":" . $port,
+                $errno,
+                $errstr,
+                $timeout,
+                STREAM_CLIENT_CONNECT,
+                $socket_context
             );
-            if ($this->do_debug >= 1) {
-                $this->edebug(
-                    'SMTP ERROR: ' . $this->error['error']
-                    . ": $errstr ($errno)"
-                );
-            }
+        } else {
+            //Fall back to fsockopen which should work in more places, but is missing some features
+            $this->edebug(
+                "Connection: stream_socket_client not available, falling back to fsockopen",
+                self::DEBUG_CONNECTION
+            );
+            $this->smtp_conn = fsockopen(
+                $host,
+                $port,
+                $errno,
+                $errstr,
+                $timeout
+            );
+        }
+        // Verify we connected properly
+        if (!is_resource($this->smtp_conn)) {
+            $this->setError(
+                'Failed to connect to server',
+                $errno,
+                $errstr
+            );
+            $this->edebug(
+                'SMTP ERROR: ' . $this->error['error']
+                . ": $errstr ($errno)",
+                self::DEBUG_CLIENT
+            );
             return false;
         }
-        if ($this->do_debug >= 3) {
-            $this->edebug('Connection: opened');
-        }
+        $this->edebug('Connection: opened', self::DEBUG_CONNECTION);
         // SMTP server can take longer to respond, give longer timeout for first read
         // Windows does not have support for this timeout function
         if (substr(PHP_OS, 0, 3) != 'WIN') {
             $max = ini_get('max_execution_time');
-            if ($max != 0 && $timeout > $max) { // Don't bother if unlimited
+            // Don't bother if unlimited
+            if ($max != 0 && $timeout > $max) {
                 @set_time_limit($timeout);
             }
             stream_set_timeout($this->smtp_conn, $timeout, 0);
         }
         // Get any announcement
         $announce = $this->get_lines();
-        if ($this->do_debug >= 2) {
-            $this->edebug('SERVER -> CLIENT: ' . $announce);
-        }
+        $this->edebug('SERVER -> CLIENT: ' . $announce, self::DEBUG_SERVER);
         return true;
     }
 
     /**
      * Initiate a TLS (encrypted) session.
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function startTLS()
     {
@@ -280,22 +351,62 @@ class SMTP
      * Perform SMTP authentication.
      * Must be run after hello().
      * @see hello()
-     * @param string $username    The user name
-     * @param string $password    The password
-     * @param string $authtype    The auth type (PLAIN, LOGIN, NTLM, CRAM-MD5)
-     * @param string $realm       The auth realm for NTLM
+     * @param string $username The user name
+     * @param string $password The password
+     * @param string $authtype The auth type (PLAIN, LOGIN, NTLM, CRAM-MD5, XOAUTH2)
+     * @param string $realm The auth realm for NTLM
      * @param string $workstation The auth workstation for NTLM
-     * @access public
-     * @return bool True if successfully authenticated.
+     * @param null|OAuth  $OAuth An optional OAuth instance (@see PHPMailerOAuth)
+     * @return bool True if successfully authenticated.* @access public
      */
     public function authenticate(
         $username,
         $password,
-        $authtype = 'LOGIN',
+        $authtype = null,
         $realm = '',
-        $workstation = ''
+        $workstation = '',
+        $OAuth = null
     ) {
-        if (empty($authtype)) {
+        if (!$this->server_caps) {
+            $this->setError('Authentication is not allowed before HELO/EHLO');
+            return false;
+        }
+
+        if (array_key_exists('EHLO', $this->server_caps)) {
+        // SMTP extensions are available. Let's try to find a proper authentication method
+
+            if (!array_key_exists('AUTH', $this->server_caps)) {
+                $this->setError('Authentication is not allowed at this stage');
+                // 'at this stage' means that auth may be allowed after the stage changes
+                // e.g. after STARTTLS
+                return false;
+            }
+
+            self::edebug('Auth method requested: ' . ($authtype ? $authtype : 'UNKNOWN'), self::DEBUG_LOWLEVEL);
+            self::edebug(
+                'Auth methods available on the server: ' . implode(',', $this->server_caps['AUTH']),
+                self::DEBUG_LOWLEVEL
+            );
+
+            if (empty($authtype)) {
+                foreach (array('LOGIN', 'CRAM-MD5', 'NTLM', 'PLAIN', 'XOAUTH2') as $method) {
+                    if (in_array($method, $this->server_caps['AUTH'])) {
+                        $authtype = $method;
+                        break;
+                    }
+                }
+                if (empty($authtype)) {
+                    $this->setError('No supported authentication methods found');
+                    return false;
+                }
+                self::edebug('Auth method selected: '.$authtype, self::DEBUG_LOWLEVEL);
+            }
+
+            if (!in_array($authtype, $this->server_caps['AUTH'])) {
+                $this->setError("The requested authentication method \"$authtype\" is not supported by the server");
+                return false;
+            }
+        } elseif (empty($authtype)) {
             $authtype = 'LOGIN';
         }
         switch ($authtype) {
@@ -326,6 +437,19 @@ class SMTP
                     return false;
                 }
                 break;
+            case 'XOAUTH2':
+                //If the OAuth Instance is not set. Can be a case when PHPMailer is used
+                //instead of PHPMailerOAuth
+                if (is_null($OAuth)) {
+                    return false;
+                }
+                $oauth = $OAuth->getOauth64();
+
+                // Start authentication
+                if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2 ' . $oauth, 235)) {
+                    return false;
+                }
+                break;
             case 'NTLM':
                 /*
                  * ntlm_sasl_client.php
@@ -336,17 +460,16 @@ class SMTP
                  * PROTOCOL Docs http://curl.haxx.se/rfc/ntlm.html#ntlmSmtpAuthentication
                  */
                 require_once 'extras/ntlm_sasl_client.php';
-                $temp = new stdClass();
+                $temp = new stdClass;
                 $ntlm_client = new ntlm_sasl_client_class;
                 //Check that functions are available
                 if (!$ntlm_client->Initialize($temp)) {
-                    $this->error = array('error' => $temp->error);
-                    if ($this->do_debug >= 1) {
-                        $this->edebug(
-                            'You need to enable some modules in your php.ini file: '
-                            . $this->error['error']
-                        );
-                    }
+                    $this->setError($temp->error);
+                    $this->edebug(
+                        'You need to enable some modules in your php.ini file: '
+                        . $this->error['error'],
+                        self::DEBUG_CLIENT
+                    );
                     return false;
                 }
                 //msg1
@@ -377,7 +500,6 @@ class SMTP
                 );
                 // send encoded username
                 return $this->sendCommand('Username', base64_encode($msg3), 235);
-                break;
             case 'CRAM-MD5':
                 // Start authentication
                 if (!$this->sendCommand('AUTH CRAM-MD5', 'AUTH CRAM-MD5', 334)) {
@@ -391,7 +513,9 @@ class SMTP
 
                 // send encoded credentials
                 return $this->sendCommand('Username', base64_encode($response), 235);
-                break;
+            default:
+                $this->setError("Authentication method \"$authtype\" is not supported");
+                return false;
         }
         return true;
     }
@@ -417,7 +541,7 @@ class SMTP
         // RFC 2104 HMAC implementation for php.
         // Creates an md5 HMAC.
         // Eliminates the need to install mhash to compute a HMAC
-        // Hacked by Lance Rushing
+        // by Lance Rushing
 
         $bytelen = 64; // byte length for md5
         if (strlen($key) > $bytelen) {
@@ -435,19 +559,18 @@ class SMTP
     /**
      * Check connection state.
      * @access public
-     * @return bool True if connected.
+     * @return boolean True if connected.
      */
     public function connected()
     {
-        if (!empty($this->smtp_conn)) {
+        if (is_resource($this->smtp_conn)) {
             $sock_status = stream_get_meta_data($this->smtp_conn);
             if ($sock_status['eof']) {
-                // the socket is valid but we are not connected
-                if ($this->do_debug >= 1) {
-                    $this->edebug(
-                        'SMTP NOTICE: EOF caught while checking if connected'
-                    );
-                }
+                // The socket is valid but we are not connected
+                $this->edebug(
+                    'SMTP NOTICE: EOF caught while checking if connected',
+                    self::DEBUG_CLIENT
+                );
                 $this->close();
                 return false;
             }
@@ -465,15 +588,14 @@ class SMTP
      */
     public function close()
     {
-        $this->error = null; // so there is no confusion
+        $this->setError('');
+        $this->server_caps = null;
         $this->helo_rply = null;
-        if (!empty($this->smtp_conn)) {
+        if (is_resource($this->smtp_conn)) {
             // close the connection and cleanup
             fclose($this->smtp_conn);
-            if ($this->do_debug >= 3) {
-                $this->edebug('Connection: closed');
-            }
-            $this->smtp_conn = 0;
+            $this->smtp_conn = null; //Makes for cleaner serialization
+            $this->edebug('Connection: closed', self::DEBUG_CONNECTION);
         }
     }
 
@@ -487,13 +609,15 @@ class SMTP
      * Implements rfc 821: DATA <CRLF>
      * @param string $msg_data Message data to send
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function data($msg_data)
     {
+        //This will use the standard timelimit
         if (!$this->sendCommand('DATA', 'DATA', 354)) {
             return false;
         }
+
         /* The server is ready to accept data!
          * According to rfc821 we should not send more than 1000 characters on a single line (including the CRLF)
          * so we will break the data up into lines by \r and/or \n then if needed we will break each of those into
@@ -521,13 +645,14 @@ class SMTP
             if ($in_headers and $line == '') {
                 $in_headers = false;
             }
-            // ok we need to break this line up into several smaller lines
-            //This is a small micro-optimisation: isset($str[$len]) is equivalent to (strlen($str) > $len)
+            //Break this line up into several smaller lines if it's too long
+            //Micro-optimisation: isset($str[$len]) is faster than (strlen($str) > $len),
             while (isset($line[self::MAX_LINE_LENGTH])) {
                 //Working backwards, try to find a space within the last MAX_LINE_LENGTH chars of the line to break on
                 //so as to avoid breaking in the middle of a word
                 $pos = strrpos(substr($line, 0, self::MAX_LINE_LENGTH), ' ');
-                if (!$pos) { //Deliberately matches both false and 0
+                //Deliberately matches both false and 0
+                if (!$pos) {
                     //No nice break found, add a hard break
                     $pos = self::MAX_LINE_LENGTH - 1;
                     $lines_out[] = substr($line, 0, $pos);
@@ -538,16 +663,14 @@ class SMTP
                     //Move along by the amount we dealt with
                     $line = substr($line, $pos + 1);
                 }
-                /* If processing headers add a LWSP-char to the front of new line
-                 * RFC822 section 3.1.1
-                 */
+                //If processing headers add a LWSP-char to the front of new line RFC822 section 3.1.1
                 if ($in_headers) {
                     $line = "\t" . $line;
                 }
             }
             $lines_out[] = $line;
 
-            // Send the lines to the server
+            //Send the lines to the server
             foreach ($lines_out as $line_out) {
                 //RFC2821 section 4.5.2
                 if (!empty($line_out) and $line_out[0] == '.') {
@@ -557,8 +680,14 @@ class SMTP
             }
         }
 
-        // Message data has been sent, complete the command
-        return $this->sendCommand('DATA END', '.', 250);
+        //Message data has been sent, complete the command
+        //Increase timelimit for end of DATA command
+        $savetimelimit = $this->Timelimit;
+        $this->Timelimit = $this->Timelimit * 2;
+        $result = $this->sendCommand('DATA END', '.', 250);
+        //Restore timelimit
+        $this->Timelimit = $savetimelimit;
+        return $result;
     }
 
     /**
@@ -569,12 +698,12 @@ class SMTP
      * and RFC 2821 EHLO.
      * @param string $host The host name or IP to connect to
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function hello($host = '')
     {
-        // Try extended hello first (RFC 2821)
-        return (bool)($this->sendHello('EHLO', $host) or $this->sendHello('HELO', $host));
+        //Try extended hello first (RFC 2821)
+        return (boolean)($this->sendHello('EHLO', $host) or $this->sendHello('HELO', $host));
     }
 
     /**
@@ -584,13 +713,60 @@ class SMTP
      * @param string $hello The HELO string
      * @param string $host The hostname to say we are
      * @access protected
-     * @return bool
+     * @return boolean
      */
     protected function sendHello($hello, $host)
     {
         $noerror = $this->sendCommand($hello, $hello . ' ' . $host, 250);
         $this->helo_rply = $this->last_reply;
+        if ($noerror) {
+            $this->parseHelloFields($hello);
+        } else {
+            $this->server_caps = null;
+        }
         return $noerror;
+    }
+
+    /**
+     * Parse a reply to HELO/EHLO command to discover server extensions.
+     * In case of HELO, the only parameter that can be discovered is a server name.
+     * @access protected
+     * @param string $type - 'HELO' or 'EHLO'
+     */
+    protected function parseHelloFields($type)
+    {
+        $this->server_caps = array();
+        $lines = explode("\n", $this->last_reply);
+
+        foreach ($lines as $n => $s) {
+            //First 4 chars contain response code followed by - or space
+            $s = trim(substr($s, 4));
+            if (empty($s)) {
+                continue;
+            }
+            $fields = explode(' ', $s);
+            if (!empty($fields)) {
+                if (!$n) {
+                    $name = $type;
+                    $fields = $fields[0];
+                } else {
+                    $name = array_shift($fields);
+                    switch ($name) {
+                        case 'SIZE':
+                            $fields = ($fields ? $fields[0] : 0);
+                            break;
+                        case 'AUTH':
+                            if (!is_array($fields)) {
+                                $fields = array();
+                            }
+                            break;
+                        default:
+                            $fields = true;
+                    }
+                }
+                $this->server_caps[$name] = $fields;
+            }
+        }
     }
 
     /**
@@ -602,7 +778,7 @@ class SMTP
      * Implements rfc 821: MAIL <SP> FROM:<reverse-path> <CRLF>
      * @param string $from Source address of this message
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function mail($from)
     {
@@ -618,9 +794,9 @@ class SMTP
      * Send an SMTP QUIT command.
      * Closes the socket if there is no error or the $close_on_error argument is true.
      * Implements from rfc 821: QUIT <CRLF>
-     * @param bool $close_on_error Should the connection close if an error occurs?
+     * @param boolean $close_on_error Should the connection close if an error occurs?
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function quit($close_on_error = true)
     {
@@ -640,7 +816,7 @@ class SMTP
      * Implements from rfc 821: RCPT <SP> TO:<forward-path> <CRLF>
      * @param string $toaddr The address the message is being sent to
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function recipient($toaddr)
     {
@@ -656,7 +832,7 @@ class SMTP
      * Abort any transaction that is currently in progress.
      * Implements rfc 821: RSET <CRLF>
      * @access public
-     * @return bool True on success.
+     * @return boolean True on success.
      */
     public function reset()
     {
@@ -667,44 +843,54 @@ class SMTP
      * Send a command to an SMTP server and check its return code.
      * @param string $command       The command name - not sent to the server
      * @param string $commandstring The actual command to send
-     * @param int|array $expect     One or more expected integer success codes
+     * @param integer|array $expect     One or more expected integer success codes
      * @access protected
-     * @return bool True on success.
+     * @return boolean True on success.
      */
     protected function sendCommand($command, $commandstring, $expect)
     {
         if (!$this->connected()) {
-            $this->error = array(
-                'error' => "Called $command without being connected"
-            );
+            $this->setError("Called $command without being connected");
             return false;
         }
         $this->client_send($commandstring . self::CRLF);
 
-        $reply = $this->get_lines();
-        $code = substr($reply, 0, 3);
-
-        if ($this->do_debug >= 2) {
-            $this->edebug('SERVER -> CLIENT: ' . $reply);
+        $this->last_reply = $this->get_lines();
+        // Fetch SMTP code and possible error code explanation
+        $matches = array();
+        if (preg_match("/^([0-9]{3})[ -](?:([0-9]\\.[0-9]\\.[0-9]) )?/", $this->last_reply, $matches)) {
+            $code = $matches[1];
+            $code_ex = (count($matches) > 2 ? $matches[2] : null);
+            // Cut off error code from each response line
+            $detail = preg_replace(
+                "/{$code}[ -]".($code_ex ? str_replace('.', '\\.', $code_ex).' ' : '')."/m",
+                '',
+                $this->last_reply
+            );
+        } else {
+            // Fall back to simple parsing if regex fails
+            $code = substr($this->last_reply, 0, 3);
+            $code_ex = null;
+            $detail = substr($this->last_reply, 4);
         }
 
+        $this->edebug('SERVER -> CLIENT: ' . $this->last_reply, self::DEBUG_SERVER);
+
         if (!in_array($code, (array)$expect)) {
-            $this->last_reply = null;
-            $this->error = array(
-                'error' => "$command command failed",
-                'smtp_code' => $code,
-                'detail' => substr($reply, 4)
+            $this->setError(
+                "$command command failed",
+                $detail,
+                $code,
+                $code_ex
             );
-            if ($this->do_debug >= 1) {
-                $this->edebug(
-                    'SMTP ERROR: ' . $this->error['error'] . ': ' . $reply
-                );
-            }
+            $this->edebug(
+                'SMTP ERROR: ' . $this->error['error'] . ': ' . $this->last_reply,
+                self::DEBUG_CLIENT
+            );
             return false;
         }
 
-        $this->last_reply = $reply;
-        $this->error = null;
+        $this->setError('');
         return true;
     }
 
@@ -719,7 +905,7 @@ class SMTP
      * Implements rfc 821: SAML <SP> FROM:<reverse-path> <CRLF>
      * @param string $from The address the message is from
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function sendAndMail($from)
     {
@@ -730,7 +916,7 @@ class SMTP
      * Send an SMTP VRFY command.
      * @param string $name The name to verify
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function verify($name)
     {
@@ -741,7 +927,7 @@ class SMTP
      * Send an SMTP NOOP command.
      * Used to keep keep-alives alive, doesn't actually do anything
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function noop()
     {
@@ -755,16 +941,12 @@ class SMTP
      * and _may_ be implemented in future
      * Implements from rfc 821: TURN <CRLF>
      * @access public
-     * @return bool
+     * @return boolean
      */
     public function turn()
     {
-        $this->error = array(
-            'error' => 'The SMTP TURN command is not implemented'
-        );
-        if ($this->do_debug >= 1) {
-            $this->edebug('SMTP NOTICE: ' . $this->error['error']);
-        }
+        $this->setError('The SMTP TURN command is not implemented');
+        $this->edebug('SMTP NOTICE: ' . $this->error['error'], self::DEBUG_CLIENT);
         return false;
     }
 
@@ -772,13 +954,11 @@ class SMTP
      * Send raw data to the server.
      * @param string $data The data to send
      * @access public
-     * @return int|bool The number of bytes sent to the server or false on error
+     * @return integer|boolean The number of bytes sent to the server or false on error
      */
     public function client_send($data)
     {
-        if ($this->do_debug >= 1) {
-            $this->edebug("CLIENT -> SERVER: $data");
-        }
+        $this->edebug("CLIENT -> SERVER: $data", self::DEBUG_CLIENT);
         return fwrite($this->smtp_conn, $data);
     }
 
@@ -790,6 +970,57 @@ class SMTP
     public function getError()
     {
         return $this->error;
+    }
+
+    /**
+     * Get SMTP extensions available on the server
+     * @access public
+     * @return array|null
+     */
+    public function getServerExtList()
+    {
+        return $this->server_caps;
+    }
+
+    /**
+     * A multipurpose method
+     * The method works in three ways, dependent on argument value and current state
+     *   1. HELO/EHLO was not sent - returns null and set up $this->error
+     *   2. HELO was sent
+     *     $name = 'HELO': returns server name
+     *     $name = 'EHLO': returns boolean false
+     *     $name = any string: returns null and set up $this->error
+     *   3. EHLO was sent
+     *     $name = 'HELO'|'EHLO': returns server name
+     *     $name = any string: if extension $name exists, returns boolean True
+     *       or its options. Otherwise returns boolean False
+     * In other words, one can use this method to detect 3 conditions:
+     *  - null returned: handshake was not or we don't know about ext (refer to $this->error)
+     *  - false returned: the requested feature exactly not exists
+     *  - positive value returned: the requested feature exists
+     * @param string $name Name of SMTP extension or 'HELO'|'EHLO'
+     * @return mixed
+     */
+    public function getServerExt($name)
+    {
+        if (!$this->server_caps) {
+            $this->setError('No HELO/EHLO was sent');
+            return null;
+        }
+
+        // the tight logic knot ;)
+        if (!array_key_exists($name, $this->server_caps)) {
+            if ($name == 'HELO') {
+                return $this->server_caps['EHLO'];
+            }
+            if ($name == 'EHLO' || array_key_exists('EHLO', $this->server_caps)) {
+                return false;
+            }
+            $this->setError('HELO handshake was used. Client knows nothing about server extensions');
+            return null;
+        }
+
+        return $this->server_caps[$name];
     }
 
     /**
@@ -825,14 +1056,9 @@ class SMTP
         }
         while (is_resource($this->smtp_conn) && !feof($this->smtp_conn)) {
             $str = @fgets($this->smtp_conn, 515);
-            if ($this->do_debug >= 4) {
-                $this->edebug("SMTP -> get_lines(): \$data was \"$data\"");
-                $this->edebug("SMTP -> get_lines(): \$str is \"$str\"");
-            }
+            $this->edebug("SMTP -> get_lines(): \$data is \"$data\"", self::DEBUG_LOWLEVEL);
+            $this->edebug("SMTP -> get_lines(): \$str is  \"$str\"", self::DEBUG_LOWLEVEL);
             $data .= $str;
-            if ($this->do_debug >= 4) {
-                $this->edebug("SMTP -> get_lines(): \$data is \"$data\"");
-            }
             // If 4th character is a space, we are done reading, break the loop, micro-optimisation over strlen
             if ((isset($str[3]) and $str[3] == ' ')) {
                 break;
@@ -840,21 +1066,19 @@ class SMTP
             // Timed-out? Log and break
             $info = stream_get_meta_data($this->smtp_conn);
             if ($info['timed_out']) {
-                if ($this->do_debug >= 4) {
-                    $this->edebug(
-                        'SMTP -> get_lines(): timed-out (' . $this->Timeout . ' sec)'
-                    );
-                }
+                $this->edebug(
+                    'SMTP -> get_lines(): timed-out (' . $this->Timeout . ' sec)',
+                    self::DEBUG_LOWLEVEL
+                );
                 break;
             }
             // Now check if reads took too long
             if ($endtime and time() > $endtime) {
-                if ($this->do_debug >= 4) {
-                    $this->edebug(
-                        'SMTP -> get_lines(): timelimit reached ('.
-                        $this->Timelimit . ' sec)'
-                    );
-                }
+                $this->edebug(
+                    'SMTP -> get_lines(): timelimit reached ('.
+                    $this->Timelimit . ' sec)',
+                    self::DEBUG_LOWLEVEL
+                );
                 break;
             }
         }
@@ -863,7 +1087,7 @@ class SMTP
 
     /**
      * Enable or disable VERP address generation.
-     * @param bool $enabled
+     * @param boolean $enabled
      */
     public function setVerp($enabled = false)
     {
@@ -872,7 +1096,7 @@ class SMTP
 
     /**
      * Get VERP address generation mode.
-     * @return bool
+     * @return boolean
      */
     public function getVerp()
     {
@@ -880,8 +1104,25 @@ class SMTP
     }
 
     /**
+     * Set error messages and codes.
+     * @param string $message The error message
+     * @param string $detail Further detail on the error
+     * @param string $smtp_code An associated SMTP error code
+     * @param string $smtp_code_ex Extended SMTP code
+     */
+    protected function setError($message, $detail = '', $smtp_code = '', $smtp_code_ex = '')
+    {
+        $this->error = array(
+            'error' => $message,
+            'detail' => $detail,
+            'smtp_code' => $smtp_code,
+            'smtp_code_ex' => $smtp_code_ex
+        );
+    }
+
+    /**
      * Set debug output method.
-     * @param string $method The function/method to use for debugging output.
+     * @param string|callable $method The name of the mechanism to use for debugging output, or a callable to handle it.
      */
     public function setDebugOutput($method = 'echo')
     {
@@ -899,7 +1140,7 @@ class SMTP
 
     /**
      * Set debug output level.
-     * @param int $level
+     * @param integer $level
      */
     public function setDebugLevel($level = 0)
     {
@@ -908,7 +1149,7 @@ class SMTP
 
     /**
      * Get debug output level.
-     * @return int
+     * @return integer
      */
     public function getDebugLevel()
     {
@@ -917,7 +1158,7 @@ class SMTP
 
     /**
      * Set SMTP timeout.
-     * @param int $timeout
+     * @param integer $timeout
      */
     public function setTimeout($timeout = 0)
     {
@@ -926,7 +1167,7 @@ class SMTP
 
     /**
      * Get SMTP timeout.
-     * @return int
+     * @return integer
      */
     public function getTimeout()
     {

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-am.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-am.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Armenian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Hrayr Grigoryan <hrayr@bits.am>
+ */
+ 
+$PHPMAILER_LANG['authenticate']         = 'SMTP -ի սխալ: չհաջողվեց ստուգել իսկությունը.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP -ի սխալ: չհաջողվեց կապ հաստատել SMTP սերվերի հետ.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP -ի սխալ: տվյալները ընդունված չեն.';
+$PHPMAILER_LANG['empty_message']        = 'Հաղորդագրությունը դատարկ է';
+$PHPMAILER_LANG['encoding']             = 'Կոդավորման անհայտ տեսակ: ';
+$PHPMAILER_LANG['execute']              = 'Չհաջողվեց իրականացնել հրամանը: ';
+$PHPMAILER_LANG['file_access']          = 'Ֆայլը հասանելի չէ: ';
+$PHPMAILER_LANG['file_open']            = 'Ֆայլի սխալ: ֆայլը չհաջողվեց բացել: ';
+$PHPMAILER_LANG['from_failed']          = 'Ուղարկողի հետևյալ հասցեն սխալ է: ';
+$PHPMAILER_LANG['instantiate']          = 'Հնարավոր չէ կանչել mail ֆունկցիան.';
+$PHPMAILER_LANG['invalid_address']      = 'Հասցեն սխալ է: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' փոստային սերվերի հետ չի աշխատում.';
+$PHPMAILER_LANG['provide_address']      = 'Անհրաժեշտ է տրամադրել գոնե մեկ ստացողի e-mail հասցե.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP -ի սխալ: չի հաջողվել ուղարկել հետևյալ ստացողների հասցեներին: ';
+$PHPMAILER_LANG['signing']              = 'Ստորագրման սխալ: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP -ի connect() ֆունկցիան չի հաջողվել';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP սերվերի սխալ: ';
+$PHPMAILER_LANG['variable_set']         = 'Չի հաջողվում ստեղծել կամ վերափոխել փոփոխականը: ';
+$PHPMAILER_LANG['extension_missing']    = 'Հավելվածը բացակայում է: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ar.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ar.php
@@ -1,26 +1,27 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Arabic Version, UTF-8
-* by : bahjat al mostafa <bahjat983@hotmail.com>
-*/
+ * Arabic PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author bahjat al mostafa <bahjat983@hotmail.com>
+ */
 
-$PHPMAILER_LANG['authenticate']         = 'SMTP Error: لم نستطع تأكيد الهوية.';
-$PHPMAILER_LANG['connect_host']         = 'SMTP Error: لم نستطع الاتصال بمخدم SMTP.';
-$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Error: لم يتم قبول المعلومات .';
-//$PHPMAILER_LANG['empty_message']        = 'Message body empty';
+$PHPMAILER_LANG['authenticate']         = 'خطأ SMTP : لا يمكن تأكيد الهوية.';
+$PHPMAILER_LANG['connect_host']         = 'خطأ SMTP: لا يمكن الاتصال بالخادم SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'خطأ SMTP: لم يتم قبول المعلومات .';
+$PHPMAILER_LANG['empty_message']        = 'نص الرسالة فارغ';
 $PHPMAILER_LANG['encoding']             = 'ترميز غير معروف: ';
-$PHPMAILER_LANG['execute']              = 'لم أستطع تنفيذ : ';
-$PHPMAILER_LANG['file_access']          = 'لم نستطع الوصول للملف: ';
-$PHPMAILER_LANG['file_open']            = 'File Error: لم نستطع فتح الملف: ';
-$PHPMAILER_LANG['from_failed']          = 'البريد التالي لم نستطع ارسال البريد له : ';
-$PHPMAILER_LANG['instantiate']          = 'لم نستطع توفير خدمة البريد.';
-//$PHPMAILER_LANG['invalid_address']        = 'Not sending, email address is invalid: ';
-$PHPMAILER_LANG['mailer_not_supported'] = ' mailer غير مدعوم.';
-//$PHPMAILER_LANG['provide_address']      = 'You must provide at least one recipient email address.';
-$PHPMAILER_LANG['recipients_failed']    = 'SMTP Error: الأخطاء التالية ' .
+$PHPMAILER_LANG['execute']              = 'لا يمكن تنفيذ : ';
+$PHPMAILER_LANG['file_access']          = 'لا يمكن الوصول للملف: ';
+$PHPMAILER_LANG['file_open']            = 'خطأ في الملف: لا يمكن فتحه: ';
+$PHPMAILER_LANG['from_failed']          = 'خطأ على مستوى عنوان المرسل : ';
+$PHPMAILER_LANG['instantiate']          = 'لا يمكن توفير خدمة البريد.';
+$PHPMAILER_LANG['invalid_address']      = 'الإرسال غير ممكن لأن عنوان البريد الإلكتروني غير صالح.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' برنامج الإرسال غير مدعوم.';
+$PHPMAILER_LANG['provide_address']      = 'يجب توفير عنوان البريد الإلكتروني لمستلم واحد على الأقل.';
+$PHPMAILER_LANG['recipients_failed']    = 'خطأ SMTP: الأخطاء التالية ' .
                                           'فشل في الارسال لكل من : ';
 $PHPMAILER_LANG['signing']              = 'خطأ في التوقيع: ';
-//$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
-//$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
-//$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() غير ممكن.';
+$PHPMAILER_LANG['smtp_error']           = 'خطأ على مستوى الخادم SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'لا يمكن تعيين أو إعادة تعيين متغير: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-az.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-az.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Azerbaijani PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author @mirjalal
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP xətası: Giriş uğursuz oldu.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP xətası: SMTP serverinə qoşulma uğursuz oldu.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP xətası: Verilənlər qəbul edilməyib.';
+$PHPMAILER_LANG['empty_message']        = 'Boş mesaj göndərilə bilməz.';
+$PHPMAILER_LANG['encoding']             = 'Qeyri-müəyyən kodlaşdırma: ';
+$PHPMAILER_LANG['execute']              = 'Əmr yerinə yetirilmədi: ';
+$PHPMAILER_LANG['file_access']          = 'Fayla giriş yoxdur: ';
+$PHPMAILER_LANG['file_open']            = 'Fayl xətası: Fayl açıla bilmədi: ';
+$PHPMAILER_LANG['from_failed']          = 'Göstərilən poçtlara göndərmə uğursuz oldu: ';
+$PHPMAILER_LANG['instantiate']          = 'Mail funksiyası işə salına bilmədi.';
+$PHPMAILER_LANG['invalid_address']      = 'Düzgün olmayan e-mail adresi: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - e-mail kitabxanası dəstəklənmir.';
+$PHPMAILER_LANG['provide_address']      = 'Ən azı bir e-mail adresi daxil edilməlidir.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP xətası: Aşağıdakı ünvanlar üzrə alıcılara göndərmə uğursuzdur: ';
+$PHPMAILER_LANG['signing']              = 'İmzalama xətası: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP serverinə qoşulma uğursuz oldu.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP serveri xətası: ';
+$PHPMAILER_LANG['variable_set']         = 'Dəyişənin quraşdırılması uğursuz oldu: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-be.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-be.php
@@ -1,8 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Belarusian Version by Aleksander Maksymiuk <info@setpro.pl>
-*/
+ * Belarusian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Aleksander Maksymiuk <info@setpro.pl>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Памылка SMTP: памылка ідэнтыфікацыі.';
 $PHPMAILER_LANG['connect_host']         = 'Памылка SMTP: нельга ўстанавіць сувязь з SMTP-серверам.';
@@ -22,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Памылка подпісу пав�
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Памылка сувязі з SMTP-серверам.';
 $PHPMAILER_LANG['smtp_error']           = 'Памылка SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Нельга ўстанавіць або перамяніць значэнне пераменнай: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-bg.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-bg.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Bulgarian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Mikhail Kyosev <mialygk@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP грешка: Не може да се удостовери пред сървъра.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP грешка: Не може да се свърже с SMTP хоста.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP грешка: данните не са приети.';
+$PHPMAILER_LANG['empty_message']        = 'Съдържанието на съобщението е празно';
+$PHPMAILER_LANG['encoding']             = 'Неизвестно кодиране: ';
+$PHPMAILER_LANG['execute']              = 'Не може да се изпълни: ';
+$PHPMAILER_LANG['file_access']          = 'Няма достъп до файл: ';
+$PHPMAILER_LANG['file_open']            = 'Файлова грешка: Не може да се отвори файл: ';
+$PHPMAILER_LANG['from_failed']          = 'Следните адреси за подател са невалидни: ';
+$PHPMAILER_LANG['instantiate']          = 'Не може да се инстанцира функцията mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Невалиден адрес';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - пощенски сървър не се поддържа.';
+$PHPMAILER_LANG['provide_address']      = 'Трябва да предоставите поне един email адрес за получател.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP грешка: Следните адреси за Получател са невалидни: ';
+$PHPMAILER_LANG['signing']              = 'Грешка при подписване: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP провален connect().';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP сървърна грешка: ';
+$PHPMAILER_LANG['variable_set']         = 'Не може да се установи или възстанови променлива: ';
+$PHPMAILER_LANG['extension_missing']    = 'Липсва разширение: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-br.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-br.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Brazilian Portuguese Version
-* By Paulo Henrique Garcia - paulo@controllerweb.com.br
-* Edited by Lucas Guimarães - lucas@lucasguimaraes.com
-*/
+ * Brazilian Portuguese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Paulo Henrique Garcia <paulo@controllerweb.com.br>
+ * @author Lucas Guimarães <lucas@lucasguimaraes.com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Erro de SMTP: Não foi possível autenticar.';
 $PHPMAILER_LANG['connect_host']         = 'Erro de SMTP: Não foi possível conectar com o servidor SMTP.';
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['signing']              = 'Erro ao assinar: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falhou.';
 $PHPMAILER_LANG['smtp_error']           = 'Erro de servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Não foi possível definir ou resetar a variável: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ca.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ca.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Catalan Version
-* By Ivan: web AT microstudi DOT com
-*/
+ * Catalan PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ivan <web AT microstudi DOT com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Error SMTP: No s’ha pogut autenticar.';
 $PHPMAILER_LANG['connect_host']         = 'Error SMTP: No es pot connectar al servidor SMTP.';
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Error al signar: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Ha fallat el SMTP Connect().';
 $PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'No s’ha pogut establir o restablir la variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ch.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ch.php
@@ -1,25 +1,26 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Chinese Version
-* By LiuXin: www.80x86.cn/blog/
-*/
+ * Chinese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author LiuXin <http://www.80x86.cn/blog/>
+ */
 
-$PHPMAILER_LANG['authenticate'] = 'SMTP 错误：身份验证失败。';
-$PHPMAILER_LANG['connect_host'] = 'SMTP 错误: 不能连接SMTP主机。';
-$PHPMAILER_LANG['data_not_accepted'] = 'SMTP 错误: 数据不可接受。';
+$PHPMAILER_LANG['authenticate']         = 'SMTP 错误：身份验证失败。';
+$PHPMAILER_LANG['connect_host']         = 'SMTP 错误: 不能连接SMTP主机。';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP 错误: 数据不可接受。';
 //$PHPMAILER_LANG['empty_message']        = 'Message body empty';
-$PHPMAILER_LANG['encoding'] = '未知编码：';
-$PHPMAILER_LANG['execute'] = '不能执行: ';
-$PHPMAILER_LANG['file_access'] = '不能访问文件：';
-$PHPMAILER_LANG['file_open'] = '文件错误：不能打开文件：';
-$PHPMAILER_LANG['from_failed'] = '下面的发送地址邮件发送失败了： ';
-$PHPMAILER_LANG['instantiate'] = '不能实现mail方法。';
-//$PHPMAILER_LANG['invalid_address']        = 'Not sending, email address is invalid: ';
+$PHPMAILER_LANG['encoding']             = '未知编码：';
+$PHPMAILER_LANG['execute']              = '不能执行: ';
+$PHPMAILER_LANG['file_access']          = '不能访问文件：';
+$PHPMAILER_LANG['file_open']            = '文件错误：不能打开文件：';
+$PHPMAILER_LANG['from_failed']          = '下面的发送地址邮件发送失败了： ';
+$PHPMAILER_LANG['instantiate']          = '不能实现mail方法。';
+//$PHPMAILER_LANG['invalid_address']      = 'Not sending, email address is invalid: ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' 您所选择的发送邮件的方法并不支持。';
-$PHPMAILER_LANG['provide_address'] = '您必须提供至少一个 收信人的email地址。';
-$PHPMAILER_LANG['recipients_failed'] = 'SMTP 错误： 下面的 收件人失败了： ';
+$PHPMAILER_LANG['provide_address']      = '您必须提供至少一个 收信人的email地址。';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 错误： 下面的 收件人失败了： ';
 //$PHPMAILER_LANG['signing']              = 'Signing Error: ';
 //$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-cz.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-cz.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Czech Version
-*/
+ * Czech PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Chyba SMTP: Autentizace selhala.';
 $PHPMAILER_LANG['connect_host']         = 'Chyba SMTP: Nelze navázat spojení se SMTP serverem.';
@@ -22,3 +22,4 @@ $PHPMAILER_LANG['signing']              = 'Chyba přihlašování: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() selhal.';
 $PHPMAILER_LANG['smtp_error']           = 'Chyba SMTP serveru: ';
 $PHPMAILER_LANG['variable_set']         = 'Nelze nastavit nebo změnit proměnnou: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-de.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-de.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* German Version
-*/
+ * German PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP Fehler: Authentifizierung fehlgeschlagen.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP Fehler: Konnte keine Verbindung zum SMTP-Host herstellen.';
@@ -14,7 +14,7 @@ $PHPMAILER_LANG['file_access']          = 'Zugriff auf folgende Datei fehlgeschl
 $PHPMAILER_LANG['file_open']            = 'Datei Fehler: konnte folgende Datei nicht öffnen: ';
 $PHPMAILER_LANG['from_failed']          = 'Die folgende Absenderadresse ist nicht korrekt: ';
 $PHPMAILER_LANG['instantiate']          = 'Mail Funktion konnte nicht initialisiert werden.';
-$PHPMAILER_LANG['invalid_address']        = 'E-Mail wird nicht gesendet, die Adresse ist ungültig.';
+$PHPMAILER_LANG['invalid_address']      = 'E-Mail wird nicht gesendet, die Adresse ist ungültig.';
 $PHPMAILER_LANG['mailer_not_supported'] = ' mailer wird nicht unterstützt.';
 $PHPMAILER_LANG['provide_address']      = 'Bitte geben Sie mindestens eine Empfänger E-Mailadresse an.';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP Fehler: Die folgenden Empfänger sind nicht korrekt: ';
@@ -22,3 +22,4 @@ $PHPMAILER_LANG['signing']              = 'Fehler beim Signieren: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Verbindung zu SMTP Server fehlgeschlagen.';
 $PHPMAILER_LANG['smtp_error']           = 'Fehler vom SMTP Server: ';
 $PHPMAILER_LANG['variable_set']         = 'Kann Variable nicht setzen oder zurücksetzen: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-dk.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-dk.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Danish Version
-* Author: Mikael Stokkebro <info@stokkebro.dk>
-*/
+ * Danish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Mikael Stokkebro <info@stokkebro.dk>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP fejl: Kunne ikke logge på.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP fejl: Kunne ikke tilslutte SMTP serveren.';
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTP fejl: Følgende modtagere er for
 //$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-el.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-el.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Greek Version
-*/
+ * Greek PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP Σφάλμα: Αδυναμία πιστοποίησης (authentication).';
 $PHPMAILER_LANG['connect_host']         = 'SMTP Σφάλμα: Αδυναμία σύνδεσης στον SMTP-Host.';
@@ -11,14 +11,15 @@ $PHPMAILER_LANG['empty_message']        = 'Το E-Mail δεν έχει περι�
 $PHPMAILER_LANG['encoding']             = 'Αγνωστο Encoding-Format: ';
 $PHPMAILER_LANG['execute']              = 'Αδυναμία εκτέλεσης ακόλουθης εντολής: ';
 $PHPMAILER_LANG['file_access']          = 'Αδυναμία προσπέλασης του αρχείου: ';
-$PHPMAILER_LANG['file_open']            = 'Σφάλμα Αρχείου: Δεν είναί δυνατό το άνοιγμα του ακόλουθου αρχείου: ';
+$PHPMAILER_LANG['file_open']            = 'Σφάλμα Αρχείου: Δεν είναι δυνατό το άνοιγμα του ακόλουθου αρχείου: ';
 $PHPMAILER_LANG['from_failed']          = 'Η παρακάτω διεύθυνση αποστολέα δεν είναι σωστή: ';
 $PHPMAILER_LANG['instantiate']          = 'Αδυναμία εκκίνησης Mail function.';
-$PHPMAILER_LANG['invalid_address']        = 'Το μήνυμα δεν αποστέλθηκε, η διεύθυνση δεν είναι έγκυρη.';
+$PHPMAILER_LANG['invalid_address']      = 'Το μήνυμα δεν εστάλη, η διεύθυνση δεν είναι έγκυρη.';
 $PHPMAILER_LANG['mailer_not_supported'] = ' mailer δεν υποστηρίζεται.';
 $PHPMAILER_LANG['provide_address']      = 'Παρακαλούμε δώστε τουλάχιστον μια e-mail διεύθυνση παραλήπτη.';
-$PHPMAILER_LANG['recipients_failed']    = 'SMTP Σφάλμα: Οι παρακάτων διευθύνσεις παραλήπτη δεν είναι έγκυρες: ';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP Σφάλμα: Οι παρακάτω διευθύνσεις παραλήπτη δεν είναι έγκυρες: ';
 $PHPMAILER_LANG['signing']              = 'Σφάλμα υπογραφής: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Αποτυχία σύνδεσης στον SMTP Server.';
 $PHPMAILER_LANG['smtp_error']           = 'Σφάλμα από τον SMTP Server: ';
 $PHPMAILER_LANG['variable_set']         = 'Αδυναμία ορισμού ή αρχικοποίησης μεταβλητής: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-eo.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-eo.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Esperanto version
-*/
+ * Esperanto PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Eraro de servilo SMTP : aŭtentigo malsukcesis.';
 $PHPMAILER_LANG['connect_host']         = 'Eraro de servilo SMTP : konektado al servilo malsukcesis.';
@@ -22,3 +22,4 @@ $PHPMAILER_LANG['signing']              = 'Eraro de subskribo: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP konektado malsukcesis.';
 $PHPMAILER_LANG['smtp_error']           = 'Eraro de servilo SMTP : ';
 $PHPMAILER_LANG['variable_set']         = 'Variablo ne pravalorizeblas aŭ ne repravalorizeblas: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-es.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-es.php
@@ -1,26 +1,26 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Spanish version
-* Versión en español
-* Edited by Matt Sturdy - matt.sturdy@gmail.com
-*/
+ * Spanish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Matt Sturdy <matt.sturdy@gmail.com>
+ */
 
-$PHPMAILER_LANG['authenticate']         = 'Error SMTP: No se pudo autentificar.';
-$PHPMAILER_LANG['connect_host']         = 'Error SMTP: No se pudo conectar al servidor SMTP.';
+$PHPMAILER_LANG['authenticate']         = 'Error SMTP: Imposible autentificar.';
+$PHPMAILER_LANG['connect_host']         = 'Error SMTP: Imposible conectar al servidor SMTP.';
 $PHPMAILER_LANG['data_not_accepted']    = 'Error SMTP: Datos no aceptados.';
-$PHPMAILER_LANG['empty_message']        = 'Cuerpo del mensaje vacío';
+$PHPMAILER_LANG['empty_message']        = 'El cuerpo del mensaje está vacío';
 $PHPMAILER_LANG['encoding']             = 'Codificación desconocida: ';
-$PHPMAILER_LANG['execute']              = 'No se pudo ejecutar: ';
-$PHPMAILER_LANG['file_access']          = 'No se pudo acceder al archivo: ';
-$PHPMAILER_LANG['file_open']            = 'Error de Archivo: No se pudo abrir el archivo: ';
+$PHPMAILER_LANG['execute']              = 'Imposible ejecutar: ';
+$PHPMAILER_LANG['file_access']          = 'Imposible acceder al archivo: ';
+$PHPMAILER_LANG['file_open']            = 'Error de Archivo: Imposible abrir el archivo: ';
 $PHPMAILER_LANG['from_failed']          = 'La(s) siguiente(s) direcciones de remitente fallaron: ';
-$PHPMAILER_LANG['instantiate']          = 'No se pudo crear una instancia de la función Mail.';
-$PHPMAILER_LANG['invalid_address']      = 'No se pudo enviar: dirección de email inválido: ';
+$PHPMAILER_LANG['instantiate']          = 'Imposible crear una instancia de la función Mail.';
+$PHPMAILER_LANG['invalid_address']      = 'Imposible enviar: dirección de email inválido: ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' mailer no está soportado.';
-$PHPMAILER_LANG['provide_address']      = 'Debe proveer al menos una dirección de email como destino.';
+$PHPMAILER_LANG['provide_address']      = 'Debe proporcionar al menos una dirección de email de destino.';
 $PHPMAILER_LANG['recipients_failed']    = 'Error SMTP: Los siguientes destinos fallaron: ';
 $PHPMAILER_LANG['signing']              = 'Error al firmar: ';
-$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() se falló.';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falló.';
 $PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
-$PHPMAILER_LANG['variable_set']         = 'No se pudo ajustar o reajustar la variable: ';
+$PHPMAILER_LANG['variable_set']         = 'No se pudo configurar la variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-et.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-et.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Estonian Version
-* By Indrek Päri
-* Revised By Elan Ruusamäe <glen@delfi.ee>
-*/
+ * Estonian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Indrek Päri
+ * @author Elan Ruusamäe <glen@delfi.ee>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP Viga: Autoriseerimise viga.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP Viga: Ei õnnestunud luua ühendust SMTP serveriga.';
@@ -16,7 +16,7 @@ $PHPMAILER_LANG['file_access']          = 'Pole piisavalt õiguseid järgneva fa
 $PHPMAILER_LANG['file_open']            = 'Faili Viga: Faili avamine ebaõnnestus: ';
 $PHPMAILER_LANG['from_failed']          = 'Järgnev saatja e-posti aadress on vigane: ';
 $PHPMAILER_LANG['instantiate']          = 'mail funktiooni käivitamine ebaõnnestus.';
-$PHPMAILER_LANG['invalid_address']        = 'Saatmine peatatud, e-posti address vigane: ';
+$PHPMAILER_LANG['invalid_address']      = 'Saatmine peatatud, e-posti address vigane: ';
 $PHPMAILER_LANG['provide_address']      = 'Te peate määrama vähemalt ühe saaja e-posti aadressi.';
 $PHPMAILER_LANG['mailer_not_supported'] = ' maileri tugi puudub.';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP Viga: Järgnevate saajate e-posti aadressid on vigased: ';
@@ -24,3 +24,4 @@ $PHPMAILER_LANG["signing"]              = 'Viga allkirjastamisel: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() ebaõnnestus.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP serveri viga: ';
 $PHPMAILER_LANG['variable_set']         = 'Ei õnnestunud määrata või lähtestada muutujat: ';
+$PHPMAILER_LANG['extension_missing']    = 'Nõutud laiendus on puudu: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-fa.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-fa.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Persian/Farsi Version, UTF-8
-* By: Ali Jazayeri <jaza.ali@gmail.com>
-* Edit: Mohammad Hossein Mojtahedi <mhm5000@gmail.com>
-*/
+ * Persian/Farsi PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ali Jazayeri <jaza.ali@gmail.com>
+ * @author Mohammad Hossein Mojtahedi <mhm5000@gmail.com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'خطای SMTP: احراز هویت با شکست مواجه شد.';
 $PHPMAILER_LANG['connect_host']         = 'خطای SMTP: اتصال به سرور SMTP برقرار نشد.';
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['signing']              = 'خطا در امضا: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'خطا در اتصال به SMTP.';
 $PHPMAILER_LANG['smtp_error']           = 'خطا در SMTP Server: ';
 $PHPMAILER_LANG['variable_set']         = 'امکان ارسال یا ارسال مجدد متغیر‌ها وجود ندارد: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-fi.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-fi.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Finnish Version
-* By Jyry Kuukanen
-*/
+ * Finnish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Jyry Kuukanen
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP-virhe: käyttäjätunnistus epäonnistui.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP-virhe: yhteys palvelimeen ei onnistu.';
@@ -15,7 +15,7 @@ $PHPMAILER_LANG['file_access']          = 'Seuraavaan tiedostoon ei ole oikeuksi
 $PHPMAILER_LANG['file_open']            = 'Tiedostovirhe: Ei voida avata tiedostoa: ';
 $PHPMAILER_LANG['from_failed']          = 'Seuraava lähettäjän osoite on virheellinen: ';
 $PHPMAILER_LANG['instantiate']          = 'mail-funktion luonti epäonnistui.';
-//$PHPMAILER_LANG['invalid_address']        = 'Not sending, email address is invalid: ';
+//$PHPMAILER_LANG['invalid_address']      = 'Not sending, email address is invalid: ';
 $PHPMAILER_LANG['mailer_not_supported'] = 'postivälitintyyppiä ei tueta.';
 $PHPMAILER_LANG['provide_address']      = 'Aseta vähintään yksi vastaanottajan sähk&ouml;postiosoite.';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP-virhe: seuraava vastaanottaja osoite on virheellinen.';
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['encoding']             = 'Tuntematon koodaustyyppi: ';
 //$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-fo.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-fo.php
@@ -1,10 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Faroese Version [language of the Faroe Islands, a Danish dominion]
-* This file created: 11-06-2004
-* Supplied by Dávur Sørensen [www.profo-webdesign.dk]
-*/
+ * Faroese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Dávur Sørensen <http://www.profo-webdesign.dk>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP feilur: Kundi ikki góðkenna.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP feilur: Kundi ikki knýta samband við SMTP vert.';
@@ -16,7 +15,7 @@ $PHPMAILER_LANG['file_access']          = 'Kundi ikki tilganga fílu: ';
 $PHPMAILER_LANG['file_open']            = 'Fílu feilur: Kundi ikki opna fílu: ';
 $PHPMAILER_LANG['from_failed']          = 'fylgjandi Frá/From adressa miseydnaðist: ';
 $PHPMAILER_LANG['instantiate']          = 'Kuni ikki instantiera mail funktión.';
-//$PHPMAILER_LANG['invalid_address']        = 'Not sending, email address is invalid: ';
+//$PHPMAILER_LANG['invalid_address']      = 'Not sending, email address is invalid: ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' er ikki supporterað.';
 $PHPMAILER_LANG['provide_address']      = 'Tú skal uppgeva minst móttakara-emailadressu(r).';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP Feilur: Fylgjandi móttakarar miseydnaðust: ';
@@ -24,3 +23,4 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTP Feilur: Fylgjandi móttakarar mi
 //$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-fr.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-fr.php
@@ -1,12 +1,11 @@
 <?php
 /**
- * PHPMailer language file: refer to English translation for definitive list
- * French Version
+ * French PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
  * Some French punctuation requires a thin non-breaking space (U+202F) character before it,
  * for example before a colon or exclamation mark.
  * There is one of these characters between these quotes: " "
  * @link http://unicode.org/udhr/n/notes_fra.html
- *
  */
 
 $PHPMAILER_LANG['authenticate']         = 'Erreur SMTP : échec de l\'authentification.';
@@ -27,3 +26,4 @@ $PHPMAILER_LANG['signing']              = 'Erreur de signature : ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Échec de la connexion SMTP.';
 $PHPMAILER_LANG['smtp_error']           = 'Erreur du serveur SMTP : ';
 $PHPMAILER_LANG['variable_set']         = 'Impossible d\'initialiser ou de réinitialiser une variable : ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-gl.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-gl.php
@@ -1,10 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Galician version
-* Versión en galego
-* Edited by Donato Rouco - donatorouco@gmail.com
-*/
+ * Galician PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author by Donato Rouco <donatorouco@gmail.com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Erro SMTP: Non puido ser autentificado.';
 $PHPMAILER_LANG['connect_host']         = 'Erro SMTP: Non puido conectar co servidor SMTP.';
@@ -24,3 +23,5 @@ $PHPMAILER_LANG['signing']              = 'Erro ó firmar: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() fallou.';
 $PHPMAILER_LANG['smtp_error']           = 'Erro do servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Non puidemos axustar ou reaxustar a variábel: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-he.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-he.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Hebrew Version, UTF-8
-* by : Ronny Sherer <ronny@hoojima.com>
-*/
+ * Hebrew PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ronny Sherer <ronny@hoojima.com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'שגיאת SMTP: פעולת האימות נכשלה.';
 $PHPMAILER_LANG['connect_host']         = 'שגיאת SMTP: לא הצלחתי להתחבר לשרת SMTP.';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-hr.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-hr.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * PHPMailer language file: refer to English translation for definitive list
- * Croatian Version
- * By Hrvoj3e <hrvoj3e@gmail.com>
+ * Croatian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Hrvoj3e <hrvoj3e@gmail.com>
  */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP Greška: Neuspjela autentikacija.';
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Greška prilikom prijave: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Spajanje na SMTP poslužitelj nije uspjelo.';
 $PHPMAILER_LANG['smtp_error']           = 'Greška SMTP poslužitelja: ';
 $PHPMAILER_LANG['variable_set']         = 'Ne mogu postaviti varijablu niti ju vratiti nazad: ';
+$PHPMAILER_LANG['extension_missing']    = 'Nedostaje proširenje: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-hu.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-hu.php
@@ -1,8 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Hungarian Version by @dominicus-75
-*/
+ * Hungarian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author @dominicus-75
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP hiba: az azonosítás sikertelen.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP hiba: nem lehet kapcsolódni az SMTP-szerverhez.';
@@ -22,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Hibás aláírás: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Hiba az SMTP-kapcsolatban.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP-szerver hiba: ';
 $PHPMAILER_LANG['variable_set']         = 'A következő változók beállítása nem sikerült: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-id.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-id.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Indonesian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Cecep Prawiro <cecep.prawiro@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Kesalahan SMTP: Tidak dapat mengautentikasi.';
+$PHPMAILER_LANG['connect_host']         = 'Kesalahan SMTP: Tidak dapat terhubung ke host SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Kesalahan SMTP: Data tidak diterima peladen.';
+$PHPMAILER_LANG['empty_message']        = 'Isi pesan kosong';
+$PHPMAILER_LANG['encoding']             = 'Pengkodean karakter tidak dikenali: ';
+$PHPMAILER_LANG['execute']              = 'Tidak dapat menjalankan proses : ';
+$PHPMAILER_LANG['file_access']          = 'Tidak dapat mengakses berkas : ';
+$PHPMAILER_LANG['file_open']            = 'Kesalahan File: Berkas tidak bisa dibuka : ';
+$PHPMAILER_LANG['from_failed']          = 'Alamat pengirim berikut mengakibatkan error : ';
+$PHPMAILER_LANG['instantiate']          = 'Tidak dapat menginisialisasi fungsi email';
+$PHPMAILER_LANG['invalid_address']      = 'Gagal terkirim, alamat email tidak valid : ';
+$PHPMAILER_LANG['provide_address']      = 'Harus disediakan minimal satu alamat tujuan';
+$PHPMAILER_LANG['mailer_not_supported'] = 'Mailer tidak didukung';
+$PHPMAILER_LANG['recipients_failed']    = 'Kesalahan SMTP: Alamat tujuan berikut menghasilkan error : ';
+$PHPMAILER_LANG['signing']              = 'Kesalahan dalam tanda tangan : ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() gagal.';
+$PHPMAILER_LANG['smtp_error']           = 'Kesalahan peladen SMTP : ';
+$PHPMAILER_LANG['variable_set']         = 'Tidak berhasil mengatur atau mengatur ulang variable : ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-it.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-it.php
@@ -1,10 +1,10 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Italian version
-* @package PHPMailer
-* @author Ilias Bartolini <brain79@inwind.it>, Stefano Sabatini <sabas88@gmail.com>
-*/
+ * Italian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Ilias Bartolini <brain79@inwind.it>
+ * @author Stefano Sabatini <sabas88@gmail.com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP Error: Impossibile autenticarsi.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP Error: Impossibile connettersi all\'host SMTP.';
@@ -16,7 +16,7 @@ $PHPMAILER_LANG['file_access']          = 'Impossibile accedere al file: ';
 $PHPMAILER_LANG['file_open']            = 'File Error: Impossibile aprire il file: ';
 $PHPMAILER_LANG['from_failed']          = 'I seguenti indirizzi mittenti hanno generato errore: ';
 $PHPMAILER_LANG['instantiate']          = 'Impossibile istanziare la funzione mail';
-$PHPMAILER_LANG['invalid_address']        = 'Impossibile inviare, l\'indirizzo email non è valido: ';
+$PHPMAILER_LANG['invalid_address']      = 'Impossibile inviare, l\'indirizzo email non è valido: ';
 $PHPMAILER_LANG['provide_address']      = 'Deve essere fornito almeno un indirizzo ricevente';
 $PHPMAILER_LANG['mailer_not_supported'] = 'Mailer non supportato';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP Error: I seguenti indirizzi destinatari hanno generato un errore: ';
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['signing']              = 'Errore nella firma: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() fallita.';
 $PHPMAILER_LANG['smtp_error']           = 'Errore del server SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Impossibile impostare o resettare la variabile: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ja.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ja.php
@@ -1,26 +1,27 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Japanese Version
-* By Mitsuhiro Yoshida - http://mitstek.com/
-* Modified by Yoshi Sakai - http://bluemooninc.jp/
-*/
+ * Japanese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Mitsuhiro Yoshida <http://mitstek.com/>
+ * @author Yoshi Sakai <http://bluemooninc.jp/>
+ */
 
-$PHPMAILER_LANG['authenticate'] = 'SMTPエラー: 認証できませんでした。';
-$PHPMAILER_LANG['connect_host'] = 'SMTPエラー: SMTPホストに接続できませんでした。';
-$PHPMAILER_LANG['data_not_accepted'] = 'SMTPエラー: データが受け付けられませんでした。';
+$PHPMAILER_LANG['authenticate']         = 'SMTPエラー: 認証できませんでした。';
+$PHPMAILER_LANG['connect_host']         = 'SMTPエラー: SMTPホストに接続できませんでした。';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTPエラー: データが受け付けられませんでした。';
 //$PHPMAILER_LANG['empty_message']        = 'Message body empty';
-$PHPMAILER_LANG['encoding'] = '不明なエンコーディング: ';
-$PHPMAILER_LANG['execute'] = '実行できませんでした: ';
-$PHPMAILER_LANG['file_access'] = 'ファイルにアクセスできません: ';
-$PHPMAILER_LANG['file_open'] = 'ファイルエラー: ファイルを開けません: ';
-$PHPMAILER_LANG['from_failed'] = 'Fromアドレスを登録する際にエラーが発生しました: ';
-$PHPMAILER_LANG['instantiate'] = 'メール関数が正常に動作しませんでした。';
-//$PHPMAILER_LANG['invalid_address']        = 'Not sending, email address is invalid: ';
-$PHPMAILER_LANG['provide_address'] = '少なくとも1つメールアドレスを 指定する必要があります。';
+$PHPMAILER_LANG['encoding']             = '不明なエンコーディング: ';
+$PHPMAILER_LANG['execute']              = '実行できませんでした: ';
+$PHPMAILER_LANG['file_access']          = 'ファイルにアクセスできません: ';
+$PHPMAILER_LANG['file_open']            = 'ファイルエラー: ファイルを開けません: ';
+$PHPMAILER_LANG['from_failed']          = 'Fromアドレスを登録する際にエラーが発生しました: ';
+$PHPMAILER_LANG['instantiate']          = 'メール関数が正常に動作しませんでした。';
+//$PHPMAILER_LANG['invalid_address']      = 'Not sending, email address is invalid: ';
+$PHPMAILER_LANG['provide_address']      = '少なくとも1つメールアドレスを 指定する必要があります。';
 $PHPMAILER_LANG['mailer_not_supported'] = ' メーラーがサポートされていません。';
-$PHPMAILER_LANG['recipients_failed'] = 'SMTPエラー: 次の受信者アドレスに 間違いがあります: ';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTPエラー: 次の受信者アドレスに 間違いがあります: ';
 //$PHPMAILER_LANG['signing']              = 'Signing Error: ';
 //$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ka.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ka.php
@@ -1,24 +1,26 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Georgian Version by Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
-*/
+ * Georgian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Avtandil Kikabidze aka LONGMAN <akalongman@gmail.com>
+ */
 
-$PHPMAILER_LANG['authenticate'] 			= 'SMTP შეცდომა: ავტორიზაცია შეუძლებელია.';
-$PHPMAILER_LANG['connect_host']  			= 'SMTP შეცდომა: SMTP სერვერთან დაკავშირება შეუძლებელია.';
-$PHPMAILER_LANG['data_not_accepted'] 		= 'SMTP შეცდომა: მონაცემები არ იქნა მიღებული.';
-$PHPMAILER_LANG['encoding'] 				= 'კოდირების უცნობი ტიპი: ';
-$PHPMAILER_LANG['execute'] 					= 'შეუძლებელია შემდეგი ბრძანების შესრულება: ';
-$PHPMAILER_LANG['file_access'] 				= 'შეუძლებელია წვდომა ფაილთან: ';
-$PHPMAILER_LANG['file_open'] 				= 'ფაილური სისტემის შეცდომა: არ იხსნება ფაილი: ';
-$PHPMAILER_LANG['from_failed'] 				= 'გამგზავნის არასწორი მისამართი: ';
-$PHPMAILER_LANG['instantiate'] 				= 'mail ფუნქციის გაშვება ვერ ხერხდება.';
-$PHPMAILER_LANG['provide_address'] 		= 'გთხოვთ მიუთითოთ ერთი ადრესატის e-mail მისამართი მაინც.';
-$PHPMAILER_LANG['mailer_not_supported'] 	= ' - საფოსტო სერვერის მხარდაჭერა არ არის.';
-$PHPMAILER_LANG['recipients_failed'] 		= 'SMTP შეცდომა: შემდეგ მისამართებზე გაგზავნა ვერ მოხერხდა: ';
-$PHPMAILER_LANG['empty_message'] 		= 'შეტყობინება ცარიელია';
-$PHPMAILER_LANG['invalid_address'] 			= 'არ გაიგზავნა, e-mail მისამართის არასწორი ფორმატი: ';
-$PHPMAILER_LANG['signing'] 					= 'ხელმოწერის შეცდომა: ';
-$PHPMAILER_LANG['smtp_connect_failed'] 	= 'შეცდომა SMTP სერვერთან დაკავშირებისას';
-$PHPMAILER_LANG['smtp_error'] 				= 'SMTP სერვერის შეცდომა: ';
-$PHPMAILER_LANG['variable_set'] 				= 'შეუძლებელია შემდეგი ცვლადის შექმნა ან შეცვლა: ';
+$PHPMAILER_LANG['authenticate']         = 'SMTP შეცდომა: ავტორიზაცია შეუძლებელია.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP შეცდომა: SMTP სერვერთან დაკავშირება შეუძლებელია.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP შეცდომა: მონაცემები არ იქნა მიღებული.';
+$PHPMAILER_LANG['encoding']             = 'კოდირების უცნობი ტიპი: ';
+$PHPMAILER_LANG['execute']              = 'შეუძლებელია შემდეგი ბრძანების შესრულება: ';
+$PHPMAILER_LANG['file_access']          = 'შეუძლებელია წვდომა ფაილთან: ';
+$PHPMAILER_LANG['file_open']            = 'ფაილური სისტემის შეცდომა: არ იხსნება ფაილი: ';
+$PHPMAILER_LANG['from_failed']          = 'გამგზავნის არასწორი მისამართი: ';
+$PHPMAILER_LANG['instantiate']          = 'mail ფუნქციის გაშვება ვერ ხერხდება.';
+$PHPMAILER_LANG['provide_address']      = 'გთხოვთ მიუთითოთ ერთი ადრესატის e-mail მისამართი მაინც.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' - საფოსტო სერვერის მხარდაჭერა არ არის.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP შეცდომა: შემდეგ მისამართებზე გაგზავნა ვერ მოხერხდა: ';
+$PHPMAILER_LANG['empty_message']        = 'შეტყობინება ცარიელია';
+$PHPMAILER_LANG['invalid_address']      = 'არ გაიგზავნა, e-mail მისამართის არასწორი ფორმატი: ';
+$PHPMAILER_LANG['signing']              = 'ხელმოწერის შეცდომა: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'შეცდომა SMTP სერვერთან დაკავშირებისას';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP სერვერის შეცდომა: ';
+$PHPMAILER_LANG['variable_set']         = 'შეუძლებელია შემდეგი ცვლადის შექმნა ან შეცვლა: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ko.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ko.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Korean PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author ChalkPE <amato0617@gmail.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP 오류: 인증할 수 없습니다.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP 오류: SMTP 호스트에 접속할 수 없습니다.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP 오류: 데이터가 받아들여지지 않았습니다.';
+$PHPMAILER_LANG['empty_message']        = '메세지 내용이 없습니다';
+$PHPMAILER_LANG['encoding']             = '알 수 없는 인코딩: ';
+$PHPMAILER_LANG['execute']              = '실행 불가: ';
+$PHPMAILER_LANG['file_access']          = '파일 접근 불가: ';
+$PHPMAILER_LANG['file_open']            = '파일 오류: 파일을 열 수 없습니다: ';
+$PHPMAILER_LANG['from_failed']          = '다음 From 주소에서 오류가 발생했습니다: ';
+$PHPMAILER_LANG['instantiate']          = 'mail 함수를 인스턴스화할 수 없습니다';
+$PHPMAILER_LANG['invalid_address']      = '잘못된 주소';
+$PHPMAILER_LANG['mailer_not_supported'] = ' 메일러는 지원되지 않습니다.';
+$PHPMAILER_LANG['provide_address']      = '적어도 한 개 이상의 수신자 메일 주소를 제공해야 합니다.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 오류: 다음 수신자에서 오류가 발생했습니다: ';
+$PHPMAILER_LANG['signing']              = '서명 오류: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP 연결을 실패하였습니다.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP 서버 오류: ';
+$PHPMAILER_LANG['variable_set']         = '변수 설정 및 초기화 불가: ';
+$PHPMAILER_LANG['extension_missing']    = '확장자 없음: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-lt.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-lt.php
@@ -1,8 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Lithuanian version by Dainius Kaupaitis <dk@sum.lt>
-*/
+ * Lithuanian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Dainius Kaupaitis <dk@sum.lt>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP klaida: autentifikacija nepavyko.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP klaida: nepavyksta prisijungti prie SMTP stoties.';
@@ -22,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Prisijungimo klaida: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP susijungimo klaida';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP stoties klaida: ';
 $PHPMAILER_LANG['variable_set']         = 'Nepavyko priskirti reikšmės kintamajam: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-lv.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-lv.php
@@ -1,8 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Latvian version by Eduards M. <e@npd.lv>
-*/
+ * Latvian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Eduards M. <e@npd.lv>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP kļūda: Autorizācija neizdevās.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP Kļūda: Nevar izveidot savienojumu ar SMTP serveri.';
@@ -22,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Autorizācijas kļūda: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP savienojuma kļūda';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP servera kļūda: ';
 $PHPMAILER_LANG['variable_set']         = 'Nevar piešķirt mainīgā vērtību: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ms.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ms.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Malaysian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Nawawi Jamili <nawawi@rutweb.com>
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'Ralat SMTP: Tidak dapat pengesahan.';
+$PHPMAILER_LANG['connect_host']         = 'Ralat SMTP: Tidak dapat menghubungi hos pelayan SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Ralat SMTP: Data tidak diterima oleh pelayan.';
+$PHPMAILER_LANG['empty_message']        = 'Tiada isi untuk mesej';
+$PHPMAILER_LANG['encoding']             = 'Pengekodan tidak diketahui: ';
+$PHPMAILER_LANG['execute']              = 'Tidak dapat melaksanakan: ';
+$PHPMAILER_LANG['file_access']          = 'Tidak dapat mengakses fail: ';
+$PHPMAILER_LANG['file_open']            = 'Ralat Fail: Tidak dapat membuka fail: ';
+$PHPMAILER_LANG['from_failed']          = 'Berikut merupakan ralat dari alamat e-mel: ';
+$PHPMAILER_LANG['instantiate']          = 'Tidak dapat memberi contoh fungsi e-mel.';
+$PHPMAILER_LANG['invalid_address']      = 'Alamat emel tidak sah';
+$PHPMAILER_LANG['mailer_not_supported'] = ' jenis penghantar emel tidak disokong.';
+$PHPMAILER_LANG['provide_address']      = 'Anda perlu menyediakan sekurang-kurangnya satu alamat e-mel penerima.';
+$PHPMAILER_LANG['recipients_failed']    = 'Ralat SMTP: Penerima e-mel berikut telah gagal: ';
+$PHPMAILER_LANG['signing']              = 'Ralat pada tanda tangan: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() telah gagal.';
+$PHPMAILER_LANG['smtp_error']           = 'Ralat pada pelayan SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'Tidak boleh menetapkan atau menetapkan semula pembolehubah: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-nl.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-nl.php
@@ -1,8 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to class.phpmailer.php for definitive list.
-* Dutch Version by Tuxion <team@tuxion.nl>
-*/
+ * Dutch PHPMailer language file: refer to class.phpmailer.php for definitive list.
+ * @package PHPMailer
+ * @author Tuxion <team@tuxion.nl>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP-fout: authenticatie mislukt.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP-fout: kon niet verbinden met SMTP-host.';
@@ -21,4 +22,5 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTP-fout: de volgende ontvangers zij
 $PHPMAILER_LANG['signing']              = 'Signeerfout: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Verbinding mislukt.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP-serverfout: ';
-$PHPMAILER_LANG['variable_set']         = 'Kan de volgende variablen niet instellen of resetten: ';
+$PHPMAILER_LANG['variable_set']         = 'Kan de volgende variabele niet instellen of resetten: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-no.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-no.php
@@ -1,11 +1,11 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Norwegian Version
-*/
+ * Norwegian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
 
-$PHPMAILER_LANG['authenticate']         = 'SMTP Feil: Kunne ikke authentisere.';
-$PHPMAILER_LANG['connect_host']         = 'SMTP Feil: Kunne ikke koble til SMTP host.';
+$PHPMAILER_LANG['authenticate']         = 'SMTP Feil: Kunne ikke autentisere.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP Feil: Kunne ikke koble til SMTP tjener.';
 $PHPMAILER_LANG['data_not_accepted']    = 'SMTP Feil: Data ble ikke akseptert.';
 $PHPMAILER_LANG['empty_message']        = 'Meldingsinnholdet er tomt';
 $PHPMAILER_LANG['encoding']             = 'Ukjent tegnkoding: ';
@@ -22,3 +22,4 @@ $PHPMAILER_LANG['signing']              = 'Signeringsfeil: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() feilet.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP-serverfeil: ';
 $PHPMAILER_LANG['variable_set']         = 'Kan ikke sette eller resette variabelen: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-pl.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-pl.php
@@ -1,8 +1,8 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Polish Version
-*/
+ * Polish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Błąd SMTP: Nie można przeprowadzić uwierzytelnienia.';
 $PHPMAILER_LANG['connect_host']         = 'Błąd SMTP: Nie można połączyć się z wybranym hostem.';
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Błąd podpisywania wiadomości: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() zakończone niepowodzeniem.';
 $PHPMAILER_LANG['smtp_error']           = 'Błąd SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Nie można ustawić lub zmodyfikować zmiennej: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-pt.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-pt.php
@@ -1,10 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* pt-PT
-* Portuguese (European) Version 1.0
-* By Jonadabe - jonadabe@hotmail.com
-*/
+ * Portuguese (European) PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Jonadabe <jonadabe@hotmail.com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Erro do SMTP: Não foi possível realizar a autenticação.';
 $PHPMAILER_LANG['connect_host']         = 'Erro do SMTP: Não foi possível realizar ligação com o servidor SMTP.';
@@ -24,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Erro ao assinar: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falhou.';
 $PHPMAILER_LANG['smtp_error']           = 'Erro de servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Não foi possível definir ou redefinir a variável: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ro.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ro.php
@@ -1,10 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Romanian Version
-* @package PHPMailer
-* @author Catalin Constantin <catalin@dazoot.ro>
-*/
+ * Romanian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Catalin Constantin <catalin@dazoot.ro>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Eroare SMTP: Nu a functionat autentificarea.';
 $PHPMAILER_LANG['connect_host']         = 'Eroare SMTP: Nu m-am putut conecta la adresa SMTP.';
@@ -24,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'A aparut o problema la semnarea email
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Conectarea la serverul SMTP a esuat.';
 $PHPMAILER_LANG['smtp_error']           = 'A aparut o eroare la serverul SMTP. ';
 $PHPMAILER_LANG['variable_set']         = 'Nu se poate seta/reseta variabila. ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-ru.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-ru.php
@@ -1,8 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Russian Version by Alexey Chumakov <alex@chumakov.ru>
-*/
+ * Russian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Alexey Chumakov <alex@chumakov.ru>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Ошибка SMTP: ошибка авторизации.';
 $PHPMAILER_LANG['connect_host']         = 'Ошибка SMTP: не удается подключиться к серверу SMTP.';
@@ -17,8 +18,9 @@ $PHPMAILER_LANG['provide_address']      = 'Пожалуйста, введите 
 $PHPMAILER_LANG['mailer_not_supported'] = ' - почтовый сервер не поддерживается.';
 $PHPMAILER_LANG['recipients_failed']    = 'Ошибка SMTP: отправка по следующим адресам получателей не удалась: ';
 $PHPMAILER_LANG['empty_message']        = 'Пустое тело сообщения';
-$PHPMAILER_LANG['invalid_address']        = 'Не отослано, неправильный формат email адреса: ';
+$PHPMAILER_LANG['invalid_address']      = 'Не отослано, неправильный формат email адреса: ';
 $PHPMAILER_LANG['signing']              = 'Ошибка подписывания: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Ошибка соединения с SMTP-сервером';
 $PHPMAILER_LANG['smtp_error']           = 'Ошибка SMTP-сервера: ';
 $PHPMAILER_LANG['variable_set']         = 'Невозможно установить или переустановить переменную: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-se.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-se.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Swedish Version
-* Author: Johan Linnér <johan@linner.biz>
-*/
+ * Swedish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Johan Linnér <johan@linner.biz>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP fel: Kunde inte autentisera.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP fel: Kunde inte ansluta till SMTP-server.';
@@ -15,7 +15,7 @@ $PHPMAILER_LANG['file_access']          = 'Ingen åtkomst till fil: ';
 $PHPMAILER_LANG['file_open']            = 'Fil fel: Kunde inte öppna fil: ';
 $PHPMAILER_LANG['from_failed']          = 'Följande avsändaradress är felaktig: ';
 $PHPMAILER_LANG['instantiate']          = 'Kunde inte initiera e-postfunktion.';
-//$PHPMAILER_LANG['invalid_address']        = 'Not sending, email address is invalid: ';
+//$PHPMAILER_LANG['invalid_address']      = 'Not sending, email address is invalid: ';
 $PHPMAILER_LANG['provide_address']      = 'Du måste ange minst en mottagares e-postadress.';
 $PHPMAILER_LANG['mailer_not_supported'] = ' mailer stöds inte.';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP fel: Följande mottagare är felaktig: ';
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTP fel: Följande mottagare är fel
 //$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-sk.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-sk.php
@@ -1,9 +1,9 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Slovak Version
-* Author: Michal Tinka <michaltinka@gmail.com>
-*/
+ * Slovak PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Michal Tinka <michaltinka@gmail.com>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP Error: Chyba autentifikácie.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP Error: Nebolo možné nadviazať spojenie so SMTP serverom.';
@@ -15,7 +15,7 @@ $PHPMAILER_LANG['file_access']          = 'Súbor nebol nájdený: ';
 $PHPMAILER_LANG['file_open']            = 'File Error: Súbor sa otvoriť pre čítanie: ';
 $PHPMAILER_LANG['from_failed']          = 'Následujúca adresa From je nesprávna: ';
 $PHPMAILER_LANG['instantiate']          = 'Nedá sa vytvoriť inštancia emailovej funkcie.';
-$PHPMAILER_LANG['invalid_address']        = 'Neodoslané, emailová adresa je nesprávna: ';
+$PHPMAILER_LANG['invalid_address']      = 'Neodoslané, emailová adresa je nesprávna: ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' emailový klient nieje podporovaný.';
 $PHPMAILER_LANG['provide_address']      = 'Musíte zadať aspoň jednu emailovú adresu príjemcu.';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP Error: Adresy príjemcov niesu správne ';
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Chyba prihlasovania: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() zlyhalo.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP chyba serveru: ';
 $PHPMAILER_LANG['variable_set']         = 'Nemožno nastaviť alebo resetovať premennú: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-sl.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-sl.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Slovene PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Klemen Tušar <techouse@gmail.com>
+ */
+ 
+$PHPMAILER_LANG['authenticate']         = 'SMTP napaka: Avtentikacija ni uspela.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP napaka: Ne morem vzpostaviti povezave s SMTP gostiteljem.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP napaka: Strežnik zavrača podatke.';
+$PHPMAILER_LANG['empty_message']        = 'E-poštno sporočilo nima vsebine.';
+$PHPMAILER_LANG['encoding']             = 'Nepoznan tip kodiranja: ';
+$PHPMAILER_LANG['execute']              = 'Operacija ni uspela: ';
+$PHPMAILER_LANG['file_access']          = 'Nimam dostopa do datoteke: ';
+$PHPMAILER_LANG['file_open']            = 'Ne morem odpreti datoteke: ';
+$PHPMAILER_LANG['from_failed']          = 'Neveljaven e-naslov pošiljatelja: ';
+$PHPMAILER_LANG['instantiate']          = 'Ne morem inicializirati mail funkcije.';
+$PHPMAILER_LANG['invalid_address']      = 'E-poštno sporočilo ni bilo poslano. E-naslov je neveljaven.';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer ni podprt.';
+$PHPMAILER_LANG['provide_address']      = 'Prosim vnesite vsaj enega naslovnika.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP napaka: Sledeči naslovniki so neveljavni: ';
+$PHPMAILER_LANG['signing']              = 'Napaka pri podpisovanju: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Ne morem vzpostaviti povezave s SMTP strežnikom.';
+$PHPMAILER_LANG['smtp_error']           = 'Napaka SMTP strežnika: ';
+$PHPMAILER_LANG['variable_set']         = 'Ne morem nastaviti oz. ponastaviti spremenljivke: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-sr.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-sr.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * PHPMailer language file: refer to English translation for definitive list
- * Serbian Version
- * Александар Јевремовић <ajevremovic@gmail.com>
+ * Serbian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Александар Јевремовић <ajevremovic@gmail.com>
  */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP грешка: аутентификација није успела.';
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['signing']              = 'Грешка приликом при�
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Повезивање са SMTP сервером није успело.';
 $PHPMAILER_LANG['smtp_error']           = 'Грешка SMTP сервера: ';
 $PHPMAILER_LANG['variable_set']         = 'Није могуће задати променљиву, нити је вратити уназад: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-tr.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-tr.php
@@ -1,11 +1,12 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Turkish version
-* Türkçe Versiyonu
-* Elçin Özel - Can Yılmaz - Mehmet Benlioğlu
-* Updated by: github.com/yasinaydin
-*/
+ * Turkish PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Elçin Özel
+ * @author Can Yılmaz
+ * @author Mehmet Benlioğlu
+ * @author @yasinaydin
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP Hatası: Oturum açılamadı.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP Hatası: SMTP sunucusuna bağlanılamadı.';
@@ -25,3 +26,4 @@ $PHPMAILER_LANG['signing']              = 'İmzalama hatası: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP connect() fonksiyonu başarısız.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP sunucu hatası: ';
 $PHPMAILER_LANG['variable_set']         = 'Değişken ayarlanamadı ya da sıfırlanamadı: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-uk.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-uk.php
@@ -1,11 +1,13 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Ukrainian Version by Yuriy Rudyy <yrudyy@prs.net.ua>
-*/
+ * Ukrainian PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author Yuriy Rudyy <yrudyy@prs.net.ua>
+ * @fixed by Boris Yurchenko <boris@yurchenko.pp.ua>
+ */
 
 $PHPMAILER_LANG['authenticate']         = 'Помилка SMTP: помилка авторизації.';
-$PHPMAILER_LANG['connect_host']         = 'Помилка SMTP: не вдається підєднатися до серверу SMTP.';
+$PHPMAILER_LANG['connect_host']         = 'Помилка SMTP: не вдається під\'єднатися до серверу SMTP.';
 $PHPMAILER_LANG['data_not_accepted']    = 'Помилка SMTP: дані не прийняті.';
 $PHPMAILER_LANG['encoding']             = 'Невідомий тип кодування: ';
 $PHPMAILER_LANG['execute']              = 'Неможливо виконати команду: ';
@@ -15,10 +17,11 @@ $PHPMAILER_LANG['from_failed']          = 'Невірна адреса відп�
 $PHPMAILER_LANG['instantiate']          = 'Неможливо запустити функцію mail.';
 $PHPMAILER_LANG['provide_address']      = 'Будь-ласка, введіть хоча б одну адресу e-mail отримувача.';
 $PHPMAILER_LANG['mailer_not_supported'] = ' - поштовий сервер не підтримується.';
-$PHPMAILER_LANG['recipients_failed']    = 'Помилка SMTP: відправти наступним отрмувачам не вдалася: ';
+$PHPMAILER_LANG['recipients_failed']    = 'Помилка SMTP: відправлення наступним отримувачам не вдалося: ';
 $PHPMAILER_LANG['empty_message']        = 'Пусте тіло повідомлення';
-$PHPMAILER_LANG['invalid_address']      = 'Не відправлено, невірний формат email адреси: ';
+$PHPMAILER_LANG['invalid_address']      = 'Не відправлено, невірний формат адреси e-mail: ';
 $PHPMAILER_LANG['signing']              = 'Помилка підпису: ';
-$PHPMAILER_LANG['smtp_connect_failed']  = 'Помилка зєднання із SMTP-сервером';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Помилка з\'єднання із SMTP-сервером';
 $PHPMAILER_LANG['smtp_error']           = 'Помилка SMTP-сервера: ';
 $PHPMAILER_LANG['variable_set']         = 'Неможливо встановити або перевстановити змінну: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-vi.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-vi.php
@@ -1,25 +1,26 @@
 <?php
 /**
- * PHPMailer language file: refer to English translation for definitive list.
- * Vietnamese (Tiếng Việt) Version
+ * Vietnamese (Tiếng Việt) PHPMailer language file: refer to English translation for definitive list.
+ * @package PHPMailer
  * @author VINADES.,JSC <contact@vinades.vn>
- * @license GNU/GPL version 2 or GNU/LGPL version 2.1 or any later version
  */
-$PHPMAILER_LANG['authenticate'] = 'Lỗi SMTP: Không thể xác thực.';
-$PHPMAILER_LANG['connect_host'] = 'Lỗi SMTP: Không thể kết nối máy chủ SMTP.';
-$PHPMAILER_LANG['data_not_accepted'] = 'Lỗi SMTP: Dữ liệu không được chấp nhận.';
-$PHPMAILER_LANG['empty_message'] = 'Không có nội dung';
-$PHPMAILER_LANG['encoding'] = 'Mã hóa không xác định: ';
-$PHPMAILER_LANG['execute'] = 'Không thực hiện được: ';
-$PHPMAILER_LANG['file_access'] = 'Không thể truy cập tệp tin ';
-$PHPMAILER_LANG['file_open'] = 'Lỗi Tập tin: Không thể mở tệp tin: ';
-$PHPMAILER_LANG['from_failed'] = 'Lỗi địa chỉ gửi đi: ';
-$PHPMAILER_LANG['instantiate'] = 'Không dùng được các hàm gửi thư.';
-$PHPMAILER_LANG['invalid_address'] = 'Đại chỉ emai không đúng';
+
+$PHPMAILER_LANG['authenticate']         = 'Lỗi SMTP: Không thể xác thực.';
+$PHPMAILER_LANG['connect_host']         = 'Lỗi SMTP: Không thể kết nối máy chủ SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Lỗi SMTP: Dữ liệu không được chấp nhận.';
+$PHPMAILER_LANG['empty_message']        = 'Không có nội dung';
+$PHPMAILER_LANG['encoding']             = 'Mã hóa không xác định: ';
+$PHPMAILER_LANG['execute']              = 'Không thực hiện được: ';
+$PHPMAILER_LANG['file_access']          = 'Không thể truy cập tệp tin ';
+$PHPMAILER_LANG['file_open']            = 'Lỗi Tập tin: Không thể mở tệp tin: ';
+$PHPMAILER_LANG['from_failed']          = 'Lỗi địa chỉ gửi đi: ';
+$PHPMAILER_LANG['instantiate']          = 'Không dùng được các hàm gửi thư.';
+$PHPMAILER_LANG['invalid_address']      = 'Đại chỉ emai không đúng';
 $PHPMAILER_LANG['mailer_not_supported'] = ' trình gửi thư không được hỗ trợ.';
-$PHPMAILER_LANG['provide_address'] = 'Bạn phải cung cấp ít nhất một địa chỉ người nhận.';
-$PHPMAILER_LANG['recipients_failed'] = 'Lỗi SMTP: lỗi địa chỉ người nhận: ';
-$PHPMAILER_LANG['signing'] = 'Lỗi đăng nhập: ';
-$PHPMAILER_LANG['smtp_connect_failed'] = 'Lỗi kết nối với SMTP';
-$PHPMAILER_LANG['smtp_error'] = 'Lỗi máy chủ smtp ';
-$PHPMAILER_LANG['variable_set'] = 'Không thể thiết lập hoặc thiết lập lại biến: ';
+$PHPMAILER_LANG['provide_address']      = 'Bạn phải cung cấp ít nhất một địa chỉ người nhận.';
+$PHPMAILER_LANG['recipients_failed']    = 'Lỗi SMTP: lỗi địa chỉ người nhận: ';
+$PHPMAILER_LANG['signing']              = 'Lỗi đăng nhập: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Lỗi kết nối với SMTP';
+$PHPMAILER_LANG['smtp_error']           = 'Lỗi máy chủ smtp ';
+$PHPMAILER_LANG['variable_set']         = 'Không thể thiết lập hoặc thiết lập lại biến: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-zh.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-zh.php
@@ -1,26 +1,28 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Traditional Chinese Version
-* @author liqwei <liqwei@liqwei.com>
-* @author Peter Dave Hello <https://github.com/PeterDaveHello/>
-*/
+ * Traditional Chinese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author liqwei <liqwei@liqwei.com>
+ * @author Peter Dave Hello <@PeterDaveHello/>
+ * @author Jason Chiang <xcojad@gmail.com>
+ */
 
-$PHPMAILER_LANG['authenticate'] = 'SMTP 錯誤：登入失敗。';
-$PHPMAILER_LANG['connect_host'] = 'SMTP 錯誤：無法連線到 SMTP 主機。';
-$PHPMAILER_LANG['data_not_accepted'] = 'SMTP 錯誤：無法接受的資料。';
-$PHPMAILER_LANG['empty_message'] = '郵件內容為空';
-$PHPMAILER_LANG['encoding'] = '未知編碼: ';
-$PHPMAILER_LANG['file_access'] = '無法存取檔案：';
-$PHPMAILER_LANG['file_open'] = '檔案錯誤：無法開啟檔案：';
-$PHPMAILER_LANG['from_failed'] = '發送地址錯誤：';
-$PHPMAILER_LANG['execute'] = '無法執行：';
-$PHPMAILER_LANG['instantiate'] = '未知函數呼叫。';
-$PHPMAILER_LANG['invalid_address'] = '因為電子郵件地址無效，無法傳送: ';
-$PHPMAILER_LANG['provide_address'] = '必須提供至少一個收件人地址。';
+$PHPMAILER_LANG['authenticate']         = 'SMTP 錯誤：登入失敗。';
+$PHPMAILER_LANG['connect_host']         = 'SMTP 錯誤：無法連線到 SMTP 主機。';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP 錯誤：無法接受的資料。';
+$PHPMAILER_LANG['empty_message']        = '郵件內容為空';
+$PHPMAILER_LANG['encoding']             = '未知編碼: ';
+$PHPMAILER_LANG['execute']              = '無法執行：';
+$PHPMAILER_LANG['file_access']          = '無法存取檔案：';
+$PHPMAILER_LANG['file_open']            = '檔案錯誤：無法開啟檔案：';
+$PHPMAILER_LANG['from_failed']          = '發送地址錯誤：';
+$PHPMAILER_LANG['instantiate']          = '未知函數呼叫。';
+$PHPMAILER_LANG['invalid_address']      = '因為電子郵件地址無效，無法傳送: ';
 $PHPMAILER_LANG['mailer_not_supported'] = '不支援的發信客戶端。';
-$PHPMAILER_LANG['recipients_failed'] = 'SMTP 錯誤：收件人地址錯誤：';
-$PHPMAILER_LANG['signing']              = '登入失敗: ';
-$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP連線失敗';
-$PHPMAILER_LANG['smtp_error']           = 'SMTP伺服器錯誤: ';
+$PHPMAILER_LANG['provide_address']      = '必須提供至少一個收件人地址。';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 錯誤：以下收件人地址錯誤：';
+$PHPMAILER_LANG['signing']              = '電子簽章錯誤: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP 連線失敗';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP 伺服器錯誤: ';
 $PHPMAILER_LANG['variable_set']         = '無法設定或重設變數: ';
+$PHPMAILER_LANG['extension_missing']    = '遺失模組 Extension: ';

--- a/core/model/modx/mail/phpmailer/language/phpmailer.lang-zh_cn.php
+++ b/core/model/modx/mail/phpmailer/language/phpmailer.lang-zh_cn.php
@@ -1,26 +1,27 @@
 <?php
 /**
-* PHPMailer language file: refer to English translation for definitive list
-* Simplified Chinese Version
-* @author liqwei <liqwei@liqwei.com>
-* @author young  <masxy@foxmail.com> blog：binaryoung.com
-*/
+ * Simplified Chinese PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ * @author liqwei <liqwei@liqwei.com>
+ * @author young <masxy@foxmail.com>
+ */
 
-$PHPMAILER_LANG['authenticate'] = 'SMTP 错误：登录失败。';
-$PHPMAILER_LANG['connect_host'] = 'SMTP 错误：无法连接到 SMTP 主机。';
-$PHPMAILER_LANG['data_not_accepted'] = 'SMTP 错误：数据不被接受。';
+$PHPMAILER_LANG['authenticate']         = 'SMTP 错误：登录失败。';
+$PHPMAILER_LANG['connect_host']         = 'SMTP 错误：无法连接到 SMTP 主机。';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP 错误：数据不被接受。';
 $PHPMAILER_LANG['empty_message']        = '邮件正文为空。';
-$PHPMAILER_LANG['encoding'] = '未知编码: ';
-$PHPMAILER_LANG['execute'] = '无法执行：';
-$PHPMAILER_LANG['file_access'] = '无法访问文件：';
-$PHPMAILER_LANG['file_open'] = '文件错误：无法打开文件：';
-$PHPMAILER_LANG['from_failed'] = '发送地址错误：';
-$PHPMAILER_LANG['instantiate'] = '未知函数调用。';
-$PHPMAILER_LANG['invalid_address']        = '发送失败，电子邮箱地址是无效的。';
+$PHPMAILER_LANG['encoding']             = '未知编码: ';
+$PHPMAILER_LANG['execute']              = '无法执行：';
+$PHPMAILER_LANG['file_access']          = '无法访问文件：';
+$PHPMAILER_LANG['file_open']            = '文件错误：无法打开文件：';
+$PHPMAILER_LANG['from_failed']          = '发送地址错误：';
+$PHPMAILER_LANG['instantiate']          = '未知函数调用。';
+$PHPMAILER_LANG['invalid_address']      = '发送失败，电子邮箱地址是无效的。';
 $PHPMAILER_LANG['mailer_not_supported'] = '发信客户端不被支持。';
-$PHPMAILER_LANG['provide_address'] = '必须提供至少一个收件人地址。';
-$PHPMAILER_LANG['recipients_failed'] = 'SMTP 错误：收件人地址错误：';
+$PHPMAILER_LANG['provide_address']      = '必须提供至少一个收件人地址。';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 错误：收件人地址错误：';
 $PHPMAILER_LANG['signing']              = '登录失败：';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP服务器连接失败。';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP服务器出错: ';
 $PHPMAILER_LANG['variable_set']         = '无法设置或重置变量：';
+//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';

--- a/manager/assets/modext/sections/system/info.js
+++ b/manager/assets/modext/sections/system/info.js
@@ -60,7 +60,7 @@ MODx.panel.SystemInfo = function(config) {
     },{
         fieldLabel: _('phpmailer_version')
         ,name: 'phpmailer_version'
-        ,value: '5.2.8'
+        ,value: '5.2.13'
     },{
         fieldLabel: _('magpie_version')
         ,name: 'magpie_version'


### PR DESCRIPTION
### What does it do ?

Updates PHPMailer from v5.2.8 to v5.2.13
### Why is it needed ?

Intended to address SMTP server connectivity issues on PHP 5.6+ _(improving MODX `2.4.x` compatibility on PHP 5.6)_.

From [PHPMailer](https://github.com/PHPMailer/PHPMailer/blob/v5.2.13/class.phpmailer.php#L250-L256):

>    /**
>     \* Whether to enable TLS encryption automatically if a server supports it,
>     \* even if `SMTPSecure` is not set to 'tls'.
>     \* Be aware that in PHP >= 5.6 this requires that the server's [certificates are valid](https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#php-56-certificate-verification-failure).
>     \* @type boolean
>     */
### Related issue(s)/PR(s)

Should resolve #12650. Please confirm!
