### PR TITLE
Fix policy template update

### DIFF
--- a/core/model/modx/processors/security/access/policy/template/update.class.php
+++ b/core/model/modx/processors/security/access/policy/template/update.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Updates a policy template
  *
@@ -10,18 +11,22 @@
  * @package modx
  * @subpackage processors.security.access.policy.template
  */
-class modAccessPolicyTemplateUpdateProcessor extends modObjectUpdateProcessor {
+class modAccessPolicyTemplateUpdateProcessor extends modObjectUpdateProcessor
+{
     public $classKey = 'modAccessPolicyTemplate';
     public $languageTopics = array('policy');
     public $permission = 'policy_template_save';
     public $objectType = 'policy';
 
-    public function afterSave() {
+    public function afterSave()
+    {
         /* now store the permissions into the modAccessPermission table */
         /* and cache the data into the policy table */
-        $permissions = $this->getProperty('permissions',null);
+        $permissions = $this->getProperty('permissions', null);
         if ($permissions !== null) {
-            $permissions = is_array($permissions) ? $permissions : $this->modx->fromJSON($permissions);
+            if (is_array($permissions)) {
+                $permissions = $this->modx->fromJSON($permissions);
+            }
 
             /* first erase all prior permissions */
             $oldPermissions = $this->object->getMany('Permissions');
@@ -32,17 +37,25 @@ class modAccessPolicyTemplateUpdateProcessor extends modObjectUpdateProcessor {
 
             $added = array();
             foreach ($permissions as $permissionArray) {
-                if (in_array($permissionArray['name'],$added)) continue;
+                if (in_array($permissionArray['name'], $added)) {
+                    continue;
+                }
+
                 $permission = $this->modx->newObject('modAccessPermission');
-                $permission->set('template',$this->object->get('id'));
-                $permission->set('name',$permissionArray['name']);
-                $permission->set('description',$permissionArray['description']);
-                $permission->set('value',true);
+
+                $permission->set('template', $this->object->get('id'));
+                $permission->set('name', $permissionArray['name']);
+                $permission->set('description', $permissionArray['description']);
+                $permission->set('value', true);
+
                 $permission->save();
+
                 $added[] = $permissionArray['name'];
             }
         }
+
         return parent::afterSave();
     }
 }
+
 return 'modAccessPolicyTemplateUpdateProcessor';


### PR DESCRIPTION
### What does it do ?

Added missing update of Policies which using updated Policy template if you remove some of permissions from Policy template.
### Why is it needed ?

If you remove "about" permission from AdministratorTemplate, Administrator policy will still have active "about" permission which is wrong.
### Related issue(s)/PR(s)

x
