### PR TITLE
Small tree improvement

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -132,6 +132,10 @@
 .x-tree-arrows .x-tree-elbow-end-plus,
 .x-tree-arrows .x-tree-elbow-end-minus {
   background: none;
+  &:hover {
+    background: lighten($treeText, 25);
+    border-radius: 50%;
+  }
 }
 .x-tree-arrows .x-tree-elbow-plus:before,
 .x-tree-arrows .x-tree-elbow-minus:before,


### PR DESCRIPTION
This tiny commit adds hover effect to container nodes in the tree. It allows to easy expand/collapse nodes. In the current version it's not always clear what mouse click will do  - expand a node or open a resource.

![ezgif com-optimize](https://cloud.githubusercontent.com/assets/7704186/10025925/38a0e012-6178-11e5-9707-2ba46c593d95.gif)
