### PR TITLE
Fire js 'emptyTrash'  event when empting recycle bin

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -308,7 +308,8 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                     MODx.msg.status({
                         title: _('success')
                         ,message: _('empty_recycle_bin_emptied')
-                    })
+                    });
+                    this.fireEvent('emptyTrash');
                 },scope:this}
             }
         });


### PR DESCRIPTION
### What does it do ?

Fire js 'emptyTrash'  event on emptying recycle bin action like event 'OnEmptyTrash' for MODX plugins.
### Why is it needed ?

For interact with thirdparty Extras in manager.
