### PR TITLE
Make sure FileCache uses correct permissions and optionally allow different permissions

### DIFF
--- a/core/model/modx/modscript.class.php
+++ b/core/model/modx/modscript.class.php
@@ -154,7 +154,12 @@ class modScript extends modElement {
                 $script= $this->xpdo->cacheManager->generateScript($this);
             }
             if (!empty($script)) {
-                $result = $this->xpdo->cacheManager->writeFile($includeFilename, "<?php\n" . $script);
+                $options = array();
+                $folderMode = $this->xpdo->getOption('new_cache_folder_permissions', null, false);
+                if ($folderMode) $options['new_folder_permissions'] = $folderMode;
+                $fileMode = $this->xpdo->getOption('new_cache_file_permissions', null, false);
+                if ($fileMode) $options['new_file_permissions'] = $fileMode;
+                $result = $this->xpdo->cacheManager->writeFile($includeFilename, "<?php\n" . $script, 'wb' , $options);
             }
         }
         if ($result !== false) {

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -253,10 +253,6 @@ class xPDOCacheManager {
                 }
             }
             @fclose($file);
-            if ($written !== false && $fileMode = $this->getOption('new_file_permissions', $options, false)) {
-                if (is_string($fileMode)) $fileMode = octdec($fileMode);
-                @ chmod($filename, $fileMode);
-            }
         }
         return ($written !== false);
     }
@@ -339,7 +335,7 @@ class xPDOCacheManager {
             } else {
                 $written= @ mkdir($dirname, $mode);
             }
-            if ($written) {
+            if ($written && !is_writable($dirname)) {
                 @ chmod($dirname, $mode);
             }
         }
@@ -991,11 +987,7 @@ class xPDOFileCache extends xPDOCache {
                     $content= '<?php ' . $expireContent . ' return ' . var_export($var, true) . ';';
                     break;
             }
-            $folderMode = $this->getOption('new_cache_folder_permissions', $options, false);
-            if ($folderMode) $options['new_folder_permissions'] = $folderMode;
-            $fileMode = $this->getOption('new_cache_file_permissions', $options, false);
-            if ($fileMode) $options['new_file_permissions'] = $fileMode;
-            $set= $this->xpdo->cacheManager->writeFile($fileName, $content, 'wb', $options);
+            $set= $this->xpdo->cacheManager->writeFile($fileName, $content);
         }
         return $set;
     }

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -996,7 +996,7 @@ class xPDOFileCache extends xPDOCache {
             if ($folderMode) $options['new_folder_permissions'] = $folderMode;
             $fileMode = $this->getOption('new_file_permissions_cache', $options, false);
             if ($fileMode) $options['new_file_permissions'] = $fileMode;
-            $set= $this->xpdo->cacheManager->writeFile($fileName, $content, null, $options);
+            $set= $this->xpdo->cacheManager->writeFile($fileName, $content, 'wb', $options);
         }
         return $set;
     }

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -991,7 +991,6 @@ class xPDOFileCache extends xPDOCache {
                     $content= '<?php ' . $expireContent . ' return ' . var_export($var, true) . ';';
                     break;
             }
-            $options = array();
             $folderMode = $this->getOption('new_cache_folder_permissions', $options, false);
             if ($folderMode) $options['new_folder_permissions'] = $folderMode;
             $fileMode = $this->getOption('new_cache_file_permissions', $options, false);

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -335,7 +335,7 @@ class xPDOCacheManager {
             } else {
                 $written= @ mkdir($dirname, $mode);
             }
-            if ($written && !is_writable($dirname)) {
+            if ($written) {
                 @ chmod($dirname, $mode);
             }
         }

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -253,6 +253,10 @@ class xPDOCacheManager {
                 }
             }
             @fclose($file);
+            if ($written !== false && $fileMode = $this->getOption('new_file_permissions', $options, false)) {
+                if (is_string($fileMode)) $fileMode = octdec($fileMode);
+                @ chmod($filename, $fileMode);
+            }
         }
         return ($written !== false);
     }

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -992,9 +992,9 @@ class xPDOFileCache extends xPDOCache {
                     break;
             }
             $options = array();
-            $folderMode = $this->getOption('new_folder_permissions_cache', $options, false);
+            $folderMode = $this->getOption('new_cache_folder_permissions', $options, false);
             if ($folderMode) $options['new_folder_permissions'] = $folderMode;
-            $fileMode = $this->getOption('new_file_permissions_cache', $options, false);
+            $fileMode = $this->getOption('new_cache_file_permissions', $options, false);
             if ($fileMode) $options['new_file_permissions'] = $fileMode;
             $set= $this->xpdo->cacheManager->writeFile($fileName, $content, 'wb', $options);
         }

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -991,7 +991,12 @@ class xPDOFileCache extends xPDOCache {
                     $content= '<?php ' . $expireContent . ' return ' . var_export($var, true) . ';';
                     break;
             }
-            $set= $this->xpdo->cacheManager->writeFile($fileName, $content);
+            $options = array();
+            $folderMode = $this->getOption('new_folder_permissions_cache', $options, false);
+            if ($folderMode) $options['new_folder_permissions'] = $folderMode;
+            $fileMode = $this->getOption('new_file_permissions_cache', $options, false);
+            if ($fileMode) $options['new_file_permissions'] = $fileMode;
+            $set= $this->xpdo->cacheManager->writeFile($fileName, $content, null, $options);
         }
         return $set;
     }


### PR DESCRIPTION
### What does it do ?

1) Update modScript to use and force the folder/file permissions set in the `new_folder_permissions` and `new_file_permissions` settings (if those are set).

2) Introduce 2 new optional settings `new_folder_permissions_cache` and `new_file_permissions_cache` that can be set to use different folder and file permissions for the cache when using `xPDOFileCache`.
### Why is it needed ?

The file cache wasn't respecting the settings if you e.g. need `0775` permissions on folders/files. I had this now in 2 projects that I needed different file permissions for the cache files, due to restrictions and/or security concerns from the infrastructure. (E.g. multiple servers sharing the file system, each with different default permissions)
### Related issue(s)/PR(s)

https://github.com/modxcms/xpdo/pull/89
