### PR TITLE
Fixed group settings updatins

### DIFF
--- a/core/model/modx/processors/security/group/setting/update.class.php
+++ b/core/model/modx/processors/security/group/setting/update.class.php
@@ -39,7 +39,7 @@ class modUserGroupSettingUpdateProcessor extends modSystemSettingsUpdateProcesso
             return $this->modx->lexicon('access_denied');
         }
 
-        return parent::initialize();
+        return true;
     }
 }
 


### PR DESCRIPTION
### What does it do ?

FIX mistake in initialize() method
### Why is it needed ?

modUserGroupSetting have not primaryKeyField. Method initialize() have to return **true** - not parent::initialize()
### Related issue(s)/PR(s)
## 
