### PR TITLE
Add slackin badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MODX Revolution
 
-[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=develop)](https://travis-ci.org/modxcms/revolution) [![Slack Status](http://modx.org/badge.svg)](http://modx.org)
+[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=develop)](https://travis-ci.org/modxcms/revolution) [![Slack Status](https://modx.org/badge.svg)](https://modx.org)
 
 ## Content Management System and Application Framework
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MODX Revolution
 
-[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=develop)](https://travis-ci.org/modxcms/revolution)
+[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=develop)](https://travis-ci.org/modxcms/revolution) [![Slack Status](http://modx.org/badge.svg)](http://modx.org)
 
 ## Content Management System and Application Framework
 


### PR DESCRIPTION
Adds a slackin badge, as well as a link to the http://modx.org/ site for the MODX Community slack. Implements #12636. 
