### PR TITLE
Added border for grids

### DIFF
--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -131,6 +131,7 @@
 .x-grid3 {
   background-color: transparent;
   background-image: none;
+  border: 1px solid $gridHeaderBgColor;
   border-radius: $borderRadius;
   overflow: hidden;
   padding: 0;
@@ -287,6 +288,11 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   border-top: 1px solid $borderColor !important;
   color: #565550;
 }
+
+.x-grid3-row-last, .x-grid3-row-last.x-grid3-row-selected {
+  border-bottom-color: transparent !important;
+}
+
 .x-grid3-row-expanded {}
 
 .x-grid3-row-selected .x-grid3-cell-inner, .x-grid3-hd-inner {}
@@ -471,7 +477,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   color: $darkestGray;
   font-size: 12px;
   font-weight: bold;
-  padding: 8px 4px 12px 0px;
+  padding: 8px 4px 12px 5px;
 }
 .x-grid-group-hd div.x-grid-group-title:before {
   font-family:fontawesome;


### PR DESCRIPTION
In MODX 2.2 grids has borders, but in version 2.3 they was disappeared.

I think we should return them back.

Current grid:
[![](https://file.modx.pro/files/6/a/1/6a1b9346db158cb2838f33e20b599f1bs.jpg)](https://file.modx.pro/files/6/a/1/6a1b9346db158cb2838f33e20b599f1b.png)

Improved grids:
[![](https://file.modx.pro/files/b/7/7/b77e304b8f082e1a130ad161a399f71fs.jpg)](https://file.modx.pro/files/b/7/7/b77e304b8f082e1a130ad161a399f71f.png) [![](https://file.modx.pro/files/0/d/2/0d2beb4d901222972f938deefa136cbas.jpg)](https://file.modx.pro/files/0/d/2/0d2beb4d901222972f938deefa136cba.png) [![](https://file.modx.pro/files/4/6/3/463d200bc98c19c21b59b776c21a62c4s.jpg)](https://file.modx.pro/files/4/6/3/463d200bc98c19c21b59b776c21a62c4.png)
