### PR TITLE
Fix problem with multiple placeholders in a system setting

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -232,15 +232,9 @@ class modCacheManager extends xPDOCacheManager {
                 $v= $setting->get('value');
                 $matches= array();
                 if (preg_match_all('~\{(.*?)\}~', $v, $matches, PREG_SET_ORDER)) {
-                    $matchValue= '';
                     foreach ($matches as $match) {
-                        if (isset ($this->modx->config["{$match[1]}"])) {
+                        if (array_key_exists("{$match[1]}", $this->modx->config)) {
                             $matchValue= $this->modx->config["{$match[1]}"];
-                        } else {
-                            /* this causes problems with JSON in settings, disabling for now */
-                            //$matchValue= '';
-                        }
-                        if (!empty($matchValue)) {
                             $v= str_replace($match[0], $matchValue, $v);
                         }
                     }


### PR DESCRIPTION
When using multiple placeholders ('{setting1}/{setting2}') in a single systemsetting and the first one is found and the second one isn't, then the second placeholder would be replace by '$matchValue' from the first placeholder.
