### PR TITLE
Implements #12690, browser refresh for css/js after update

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -928,6 +928,9 @@ abstract class modManagerController {
             }
         }
 
+        $versionToken = hash('adler32', $this->modx->getOption('settings_version') . $this->modx->uuid );
+        $this->setPlaceholder('versionToken', $versionToken);
+
         if (!$index) {
             $this->setPlaceholder('indexCss', $managerUrl . 'templates/default/css/index.css');
         }

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -7,7 +7,7 @@
 {if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
 
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
-<link rel="stylesheet" type="text/css" href="{$indexCss}" />
+<link rel="stylesheet" type="text/css" href="{$indexCss}?v={$versionToken}" />
 
 {if $_config.ext_debug}
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
@@ -16,7 +16,7 @@
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
 <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
 {/if}
-<script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}" type="text/javascript"></script>
 <script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|htmlspecialchars}" type="text/javascript"></script>
 <script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
 


### PR DESCRIPTION
### What does it do ?

Adds a unique, short token to css/js links for manager resources. The token is computed by uuid of modx instance and the version. So after any update the version string changes therefore the token hash. Including the uuid acts like a salt to prevent recomputing and fingerprinting the version from the token. 
_Note: we could also use a random string here - but then we have to store it somewhere. I did not want to waste a system setting for a computable value, so I used the uuid+version token hash here._
### Why is it needed ?

This way you don't need to refresh your browsers cache after an upgrade (if the standard css and js have changed). Very useful because often clients forget that or don't know how to do that. 
#### Possible Enhancements

Can be used for all core js/css links in manager pages (currently not used for Extjs files for example).
Can maybe used also for package updates (if packages bring new versions of css and js with them).
### Related Issues
#12690
