### PR TITLE
TV option description for input type resource list

### DIFF
--- a/core/lexicon/en/tv_widget.inc.php
+++ b/core/lexicon/en/tv_widget.inc.php
@@ -110,7 +110,7 @@ $_lang['resourcelist_limit_desc'] = 'The number of Resources to limit to in the 
 $_lang['resourcelist_parents'] = 'Parents';
 $_lang['resourcelist_parents_desc'] = 'A list of IDs to grab children for the list.';
 $_lang['resourcelist_where'] = 'Where Conditions';
-$_lang['resourcelist_where_desc'] = 'A JSON object of where conditions to filter by in the query that grabs the list of Resources. (Does not support TV searching.)';
+$_lang['resourcelist_where_desc'] = 'A JSON object of where conditions to filter by in the query that grabs the list of Resources. (Does not support TV searching.)<br/>Examples: [{"template:=":"4"}], [{"pagetitle:!=":"Home"}], [{"parent:IN":[34,56]}]';
 $_lang['richtext'] = 'RichText';
 $_lang['sentence_case'] = 'Sentence Case';
 $_lang['shownone'] = 'Allow Empty Choice';


### PR DESCRIPTION
### What does it do ?

Adds examples to the option description "Where condition"
### Why is it needed ?

Was not exactly clear how to build the expression, therefore one has to google for examples. This is no more needed, examples are added to the description. 
