### PR TITLE
Option to allow define custom redirect method for each action button in action bar

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -277,7 +277,13 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     });
 
                     if (itm.redirect != false) {
-                        Ext.callback(this.redirect,this,[o,itm,r.result],1000);
+                        var redirect = this.redirect;
+
+                        if (typeof itm.redirect == 'function') {
+                            redirect = itm.redirect;
+                        }
+
+                        Ext.callback(redirect,this,[o,itm,r.result],1000);
                     }
 
                     this.resetDirtyButtons(r.result);


### PR DESCRIPTION
### What does it do ?

Add option to define custom redirect method within definition of component's action buttons  (Save, Cancel, ...) in Action bar.
### Why is it needed ?

If someone need to have a few of custom buttons in Action bar. For example those buttons should save FormPanel (as is default behavior in MODX) and then by type of button they should make a redirect to some other page (e.g. create form, different action page, ...).
### Related issue(s)/PR(s)
## 
