### PR TITLE
"inherit_parent_template" Fix for #5980

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -185,7 +185,7 @@ class ResourceCreateManagerController extends ResourceManagerController {
      * @return int
      */
     public function getDefaultTemplate() {
-        $defaultTemplate = (isset($this->scriptProperties['template']) ? $this->scriptProperties['template'] : (!empty($this->parent->id) ? $this->parent->get('template') : $this->context->getOption('default_template', 0, $this->modx->_userConfig)));
+        $defaultTemplate = (isset($this->scriptProperties['template']) ? $this->scriptProperties['template'] : ((!empty($this->parent->id) && $this->context->getOption('inherit_parent_template', true, $this->modx->_userConfig)) ? $this->parent->get('template') : $this->context->getOption('default_template', 0, $this->modx->_userConfig)));
         $userGroups = $this->modx->user->getUserGroups();
         $c = $this->modx->newQuery('modActionDom');
         $c->innerJoin('modFormCustomizationSet','FCSet');


### PR DESCRIPTION
Add option to turn off inheriting parent templates by default, and add a system setting called "inherit_parent_template" to override it.
