### PR TITLE
Corrected dashboard's save button action

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -173,7 +173,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
             MODx.loadPage('system/dashboards/update', 'id='+o.result.object.id);
         } else {
-            Ext.getCmp('modx-btn-save').setDisabled(false);
+            Ext.getCmp('modx-abtn-save').setDisabled(false);
             var wg = Ext.getCmp('modx-grid-dashboard-widget-placements');
             if (wg) { wg.getStore().commitChanges(); }
 

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -264,7 +264,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
             MODx.loadPage('system/dashboards/widget/update', 'id='+o.result.object.id);
         } else {
-            Ext.getCmp('modx-btn-save').setDisabled(false);
+            Ext.getCmp('modx-abtn-save').setDisabled(false);
             var g = Ext.getCmp('modx-grid-dashboard-widget-dashboards');
             if (g) { g.getStore().commitChanges(); }
         }


### PR DESCRIPTION
### What does it do ?

Fix the save action for both dashboard panel and widget, and allow the post-save procedure to run correctly.
### Why is it needed ?

As it referenced a non-existing element, it produced JS error and blocked the rest of the function.
