### PR TITLE
Fixed #12710 tree style for deactivated plugins.

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -118,7 +118,9 @@ $treePseudoRootOverColor: #447996;
 
 $iconColor: $treeText;
 $unpublished: $treeText;
-$disabled: $unpublished;
+
+$deactivatedTextColor: lighten($treeColor, 35%); // do not use 50% here - makes base color nearly invisible
+$disabledTextColor: $deactivatedTextColor;
 
 $hidden: lighten($treeText, 10%) !important;
 $unpubText: italic;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -275,10 +275,16 @@
 }
 
 .element-node-disabled a span {
-  color: $disabled;
+  color: $disabledTextColor;
 }
-.x-tree-node .x-tree-node-disabled a span {
-  color: lighten($treeColor, 50%);
+.x-tree-node {
+  .x-tree-node-disabled,
+  .element-node-disabled {
+    a span,
+    i.icon {
+      color: $disabledTextColor;
+    }
+  }
 }
 
 .element-node-locked a span {
@@ -799,3 +805,4 @@
 .x-tree-drop-ok-between .x-dd-drop-icon {
   background-image: url($imgPath + 'modx-theme/tree/drop-between.gif');
 }
+


### PR DESCRIPTION
### What does it do ?

Fixes #12710. Also changed the color of the corresponding plugin icon if deactivated.

![screenshot from 2015-10-12 10 09 58](https://cloud.githubusercontent.com/assets/2852461/10423705/6d3c29d4-70c9-11e5-99f9-6c81a8e02133.png)
### Why is it needed ?

Deactivated plugins were not marked visually after PR #12644 due to overuse of a color style for different purposes in the tree. 
