### PR TITLE
processElementTags (speed) improvement

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -255,7 +255,7 @@ class modParser {
                 }
             }
             $this->mergeTagOutput($tagMap, $content);
-            if ($depth > 0) {
+            if ($processed > 0 && $depth > 0) {
                 $processed+= $this->processElementTags($parentTag, $content, $processUncacheable, $removeUnprocessed, $prefix, $suffix, $tokens, $depth);
             }
         }


### PR DESCRIPTION
Only recursively call itself when tags have been processed, there is no need to recursively call the function until depth is reached when no tags have been processed.

The depth parameter could / should be removed altogether, the recursiveness is automatically stopped when all tags are processed or none of the tags could be processed.

There is a noticeable speed gain on resources / templates / chunks with placeholders that cannot (immediately) be processed, FormIt placeholders for example.
