### PR TITLE
Fix Profile  Password reset to have same field labels as User panel password reset

### DIFF
--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -226,14 +226,14 @@ MODx.panel.ChangeProfilePassword = function(config) {
             ,anchor: '100%'
         },{
             xtype: 'textfield'
-            ,fieldLabel: _('password')
+            ,fieldLabel: _('change_password_new')
             ,name: 'password_new'
             ,inputType: 'password'
             ,maxLength: 255
             ,anchor: '100%'
         },{
             xtype: 'textfield'
-            ,fieldLabel: _('password_confirm')
+            ,fieldLabel: _('change_password_confirm')
             ,name: 'password_confirm'
             ,id: 'modx-password-confirm'
             ,inputType: 'password'


### PR DESCRIPTION
### What does it do ?

User panel reset form use different field labels than Profile panel reset form. This is a bit "weird".
### Why is it needed ?

MODX users should have uniform look on the same fields (they should have same labels).
### Related issue(s)/PR(s)
## 
