### PR TITLE
Fix 12645

### DIFF
--- a/_build/build.sample.properties
+++ b/_build/build.sample.properties
@@ -11,7 +11,7 @@ git.command = git
 #project.name.fs = modx
 
 # Override to set the version and release strings
-#modx.core.version = 2.4.3
+#modx.core.version = 2.5.0
 #modx.core.release = dev
 
 # these properties require a local Git clone in order to produce distributions
@@ -25,7 +25,7 @@ git.command = git
 #build.nominify = true
 
 # Override to pull source from a specific ref in the git repository
-#build.src.tree = v2.4.3-pl
+#build.src.tree = v2.5.0-pl
 
 # Override to turn off the additional of timestamps to the distribution packages (used for nightlies)
 #build.timestamp = false

--- a/_build/build.xml
+++ b/_build/build.xml
@@ -19,7 +19,7 @@
     <property name="project.manager.dir" value="${project.root.dir}/manager" />
 
     <!-- Set the project version -->
-    <property name="modx.core.version" value="2.4.3" />
+    <property name="modx.core.version" value="2.5.0" />
     <property name="modx.core.release" value="dev" />
 
     <!-- Set some common build properties -->

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1576,6 +1576,15 @@ $settings['default_username']->fromArray(array (
   'area' => 'session',
   'editedon' => null,
 ), '', true, true);
+$settings['anonymous_sessions']= $xpdo->newObject('modSystemSetting');
+$settings['anonymous_sessions']->fromArray(array (
+  'key' => 'anonymous_sessions',
+  'value' => true,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'session',
+  'editedon' => null,
+), '', true, true);
 $settings['session_cookie_lifetime']= $xpdo->newObject('modSystemSetting');
 $settings['session_cookie_lifetime']->fromArray(array (
   'key' => 'session_cookie_lifetime',

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,9 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+MODX Revolution 2.5.0-dev
+====================================
+
 MODX Revolution 2.4.3-dev
 ====================================
 - Fix loading rich text editors on non-document resource types [#12632]

--- a/core/docs/version.inc.php
+++ b/core/docs/version.inc.php
@@ -1,8 +1,8 @@
 <?php
 $v= array ();
 $v['version']= '2'; // Current version.
-$v['major_version']= '4'; // Current major version.
-$v['minor_version']= '3'; // Current minor version.
+$v['major_version']= '5'; // Current major version.
+$v['minor_version']= '0'; // Current minor version.
 $v['patch_level']= 'dev'; // Current patch level.
 $v['code_name']= 'Revolution'; // Current codename.
 $v['distro']= '@git@';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -95,6 +95,9 @@ $_lang['setting_allow_manager_login_forgot_password_desc'] = 'Setting this to "N
 $_lang['setting_allow_tags_in_post'] = 'Allow Tags in POST';
 $_lang['setting_allow_tags_in_post_desc'] = 'If false, all POST variables will be stripped of HTML script tags, numeric entities, and MODX tags. MODX recommends to leave this set to false for Contexts other than mgr, where it is set to true by default.';
 
+$_lang['setting_anonymous_sessions'] = 'Anonymous Sessions';
+$_lang['setting_anonymous_sessions'] = 'If disabled, only authenticated users will have access to a PHP session. This can reduce overhead for anonymous users and the load they impose on a MODX site if they do not need access to a unique session. If session_enabled is false, this setting has no effect as sessions would never be available.';
+
 $_lang['setting_archive_with'] = 'Force PCLZip Archives';
 $_lang['setting_archive_with_desc'] = 'If true, will use PCLZip instead of ZipArchive as the zip extension. Turn this on if you are getting extractTo errors or are having problems with unzipping in Package Management.';
 

--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -257,7 +257,7 @@ class modPHPMailer extends modMail {
      */
     public function embedImage($image, $cid, $name = '', $encoding = 'base64', $type = 'application/octet-stream') {
       parent :: embedImage($image,$cid);
-      $this->mailer->addEmbeddedImage('/'.$image,$cid,$name,$encoding,$type);
+      $this->mailer->addEmbeddedImage($image,$cid,$name,$encoding,$type);
     }
 
     /**

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -341,6 +341,10 @@ class modUser extends modPrincipal {
      * @param string $context The context to add to the user session.
      */
     public function addSessionContext($context) {
+        if (!$this->xpdo->startSession()) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Attempt to start a session failed", '', __METHOD__, __FILE__, __LINE__);
+            return;
+        }
         if (!empty($context)) {
             $this->getSessionContexts();
             session_regenerate_id(true);
@@ -363,7 +367,7 @@ class modUser extends modPrincipal {
                 $_SESSION["modx.{$context}.user.token"]= $this->generateToken($context);
             }
         } else {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Attempt to login to a context with an empty key");
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Attempt to login to a context with an empty key", '', __METHOD__, __FILE__, __LINE__);
         }
     }
 

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2273,6 +2273,25 @@ class modX extends xPDO {
     }
 
     /**
+     * Start a PHP Session if one is not already available.
+     *
+     * @return bool Returns true if a session is successfully or already started, false otherwise.
+     */
+    public function startSession()
+    {
+        if ($this->_sessionState === modX::SESSION_STATE_UNINITIALIZED) {
+            if (!session_start()) {
+                $this->_sessionState = isset($_SESSION)
+                    ? modX::SESSION_STATE_EXTERNAL
+                    : modX::SESSION_STATE_UNAVAILABLE;
+            } elseif (isset($_SESSION)) {
+                $this->_sessionState = modX::SESSION_STATE_INITIALIZED;
+            }
+        }
+        return isset($_SESSION);
+    }
+
+    /**
      * Loads a specified Context.
      *
      * Merges any context settings with the modX::$config, and performs any
@@ -2438,18 +2457,26 @@ class modX extends xPDO {
                 $site_sessionname= $this->getOption('session_name', $options, '');
                 if (!empty($site_sessionname)) session_name($site_sessionname);
                 session_set_cookie_params($cookieLifetime, $cookiePath, $cookieDomain, $cookieSecure, $cookieHttpOnly);
-                session_start();
-                $this->_sessionState = modX::SESSION_STATE_INITIALIZED;
-                $this->getUser($contextKey);
-                $cookieExpiration= 0;
-                if (isset ($_SESSION['modx.' . $contextKey . '.session.cookie.lifetime'])) {
-                    $sessionCookieLifetime= (integer) $_SESSION['modx.' . $contextKey . '.session.cookie.lifetime'];
-                    if ($sessionCookieLifetime !== $cookieLifetime) {
-                        if ($sessionCookieLifetime) {
-                            $cookieExpiration= time() + $sessionCookieLifetime;
-                        }
-                        setcookie(session_name(), session_id(), $cookieExpiration, $cookiePath, $cookieDomain, $cookieSecure, $cookieHttpOnly);
+                if ($this->getOption('anonymous_sessions', $options, true) || isset($_COOKIE[session_name()])) {
+                    if (!$this->startSession()) {
+                        $this->log(modX::LOG_LEVEL_ERROR, 'Unable to initialize a session', '', __METHOD__, __FILE__, __LINE__);
+                        $this->getUser($contextKey);
+                        return;
                     }
+                    $this->getUser($contextKey);
+                    $cookieExpiration = 0;
+                    if (isset ($_SESSION['modx.' . $contextKey . '.session.cookie.lifetime'])) {
+                        $sessionCookieLifetime = (integer)$_SESSION['modx.' . $contextKey . '.session.cookie.lifetime'];
+                        if ($sessionCookieLifetime !== $cookieLifetime) {
+                            if ($sessionCookieLifetime) {
+                                $cookieExpiration = time() + $sessionCookieLifetime;
+                            }
+                            setcookie(session_name(), session_id(), $cookieExpiration, $cookiePath, $cookieDomain,
+                                $cookieSecure, $cookieHttpOnly);
+                        }
+                    }
+                } else {
+                    $this->getUser($contextKey);
                 }
             } else {
                 $this->getUser($contextKey);

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -277,7 +277,13 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     });
 
                     if (itm.redirect != false) {
-                        Ext.callback(this.redirect,this,[o,itm,r.result],1000);
+                        var redirect = this.redirect;
+
+                        if (typeof itm.redirect == 'function') {
+                            redirect = itm.redirect;
+                        }
+
+                        Ext.callback(redirect,this,[o,itm,r.result],1000);
                     }
 
                     this.resetDirtyButtons(r.result);

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -308,7 +308,8 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                     MODx.msg.status({
                         title: _('success')
                         ,message: _('empty_recycle_bin_emptied')
-                    })
+                    });
+                    this.fireEvent('emptyTrash');
                 },scope:this}
             }
         });


### PR DESCRIPTION
This PR removes redunant slash in the modphpmailer.class.php that prevents embedding images into email. Currently every path that we provide to modmailer becomes absolute because of leading slash. This is undocumented and doesn't mirror actual phpmailer function prototype.
### Related issue(s)/PR(s)
#12645
