### PR TITLE
Delete redundant leading slash in modphpmailer.class.php (#12645)

### DIFF
--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -257,7 +257,7 @@ class modPHPMailer extends modMail {
      */
     public function embedImage($image, $cid, $name = '', $encoding = 'base64', $type = 'application/octet-stream') {
       parent :: embedImage($image,$cid);
-      $this->mailer->addEmbeddedImage('/'.$image,$cid,$name,$encoding,$type);
+      $this->mailer->addEmbeddedImage($image,$cid,$name,$encoding,$type);
     }
 
     /**


### PR DESCRIPTION
This PR removes redunant slash in the modphpmailer.class.php that prevents embedding images into email. Currently every path that we provide to modmailer becomes absolute because of leading slash. This is undocumented and doesn't mirror actual phpmailer function prototype.
### Related issue(s)/PR(s)
#12645
