### PR TITLE
Bugfix for drag'n'drop

### DIFF
--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -248,6 +248,7 @@ MODx.window.InsertElement = function(config) {
                 // ,autoScroll: true
             }]
         }]
+        ,modps: []
     });
     MODx.window.InsertElement.superclass.constructor.call(this,config);
     this.on('show',function() {
@@ -342,7 +343,6 @@ Ext.extend(MODx.window.InsertElement,MODx.Window,{
         this.hide();
         return true;
     }
-    ,modps: []
     ,changeProp: function(k) {
         if (this.modps.indexOf(k) == -1) {
             this.modps.push(k);


### PR DESCRIPTION
### Bug description

If you drag'n'drop a snippet to the resource form and set a new value of some property you'll see something like this

```
[[snippet1? &propertyOfSnippet1=`new value for snippet1`]]
```

If you try to drag'n'drop another snippet (snippet2) without changing properties, you'll get this

```
[[snippet2? &propertyOfSnippet1=`new value for snippet1`]]
```

MODX remembered the property of snippet1 and set it to snippet2.
