### PR TITLE
Set the leaf property to true instead of 1

### DIFF
--- a/core/model/modx/processors/element/getnodes.class.php
+++ b/core/model/modx/processors/element/getnodes.class.php
@@ -392,7 +392,7 @@ class modElementGetNodesProcessor extends modProcessor {
                 'id' => 'n_'.$elementIdentifier.'_element_'.$element->get('id').'_'.$element->get('category'),
                 'pk' => $element->get('id'),
                 'category' => $categoryId,
-                'leaf' => 1,
+                'leaf' => true,
                 'name' => $name,
                 'cls' => implode(' ', $class),
                 'iconCls' => 'icon ' . ($element->get('icon') ? $element->get('icon') : ($element->get('static') ? 'icon-file-text-o' : 'icon-file-o')),

--- a/core/model/modx/processors/element/getnodes.class.php
+++ b/core/model/modx/processors/element/getnodes.class.php
@@ -208,7 +208,7 @@ class modElementGetNodesProcessor extends modProcessor {
             $nodes[] = array(
                 'text' => $this->modx->lexicon('categories'),
                 'id' => 'n_category',
-                'leaf' => 0,
+                'leaf' => false,
                 'cls' => $class,
                 'iconCls' => $this->getNodeIcon('category'),
                 'page' => '',

--- a/core/model/modx/processors/security/documentgroup/getnodes.php
+++ b/core/model/modx/processors/security/documentgroup/getnodes.php
@@ -47,7 +47,7 @@ if ($resourceGroup == null) {
 		$list[] = array(
 			'text' => $group->get('name'),
 			'id' => 'n_dg_'.$group->get('id'),
-			'leaf' => 0,
+			'leaf' => false,
 			'type' => 'modResourceGroup',
 			'cls' => 'icon-resourcegroup',
             'menu' => array('items' => $menu),
@@ -67,7 +67,7 @@ if ($resourceGroup == null) {
 		$list[] = array(
 			'text' => $resource->get('pagetitle'),
 			'id' => 'n_'.$resource->get('id'),
-			'leaf' => 1,
+			'leaf' => true,
 			'type' => 'modResource',
 			'cls' => 'icon-'.$resource->get('class_key'),
             'menu' => array('items' => $menu),

--- a/core/model/modx/processors/security/documentgroup/getpairingnodes.php
+++ b/core/model/modx/processors/security/documentgroup/getpairingnodes.php
@@ -22,7 +22,7 @@ if ($g == null) {
 		$da[] = array(
 			'text' => $group->get('name'),
 			'id' => 'n_rg_'.$group->get('id'),
-			'leaf' => 0,
+			'leaf' => false,
 			'type' => 'resourcegroup',
 			'cls' => 'folder',
 		);
@@ -33,7 +33,7 @@ if ($g == null) {
 		$da[] = array(
 			'text' => $ug->get('name'),
 			'id' => 'n_ug_'.$ug->get('id'),
-			'leaf' => 1,
+			'leaf' => true,
 			'type' => 'usergroup',
 			'cls' => '',
 		);


### PR DESCRIPTION
### Problem description

If the leaf property of elements is set to 1, function TreeNode.isLeaf () stops working correctly. 

```
//TreeNode.isLeaf function
isLeaf : function(){
    return this.leaf === true;
}
```
