### PR TITLE
Pass modX object by reference as expected

### DIFF
--- a/core/model/modx/modmanagerresponse.class.php
+++ b/core/model/modx/modmanagerresponse.class.php
@@ -187,7 +187,7 @@ class modManagerResponse extends modResponse {
                 $getInstanceMethod = 'getInstance';
             }
             /* this line allows controller derivatives to decide what instance they want to return (say, for derivative class_key types) */
-            $this->modx->controller = call_user_func_array(array($c,$getInstanceMethod),array($this->modx,$className,$this->action));
+            $this->modx->controller = call_user_func_array(array($c,$getInstanceMethod),array(&$this->modx,$className,$this->action));
             $this->modx->controller->setProperties($c instanceof SecurityLoginManagerController ? $_POST : array_merge($_GET,$_POST));
             $this->modx->controller->initialize();
         } catch (Exception $e) {

--- a/core/model/modx/processors/element/tv/renders/getinputproperties.class.php
+++ b/core/model/modx/processors/element/tv/renders/getinputproperties.class.php
@@ -75,7 +75,7 @@ class modTvRendersGetPropertiesProcessor extends modProcessor {
      */
     public function renderController() {
         $c = new TvInputPropertiesManagerController($this->modx);
-        $this->modx->controller = call_user_func_array(array($c,'getInstance'),array($this->modx,'TvInputPropertiesManagerController'));
+        $this->modx->controller = call_user_func_array(array($c,'getInstance'),array(&$this->modx,'TvInputPropertiesManagerController'));
         return $this->modx->controller->render();
     }
 

--- a/core/model/modx/processors/element/tv/renders/getinputs.class.php
+++ b/core/model/modx/processors/element/tv/renders/getinputs.class.php
@@ -33,7 +33,7 @@ class modElementTvRendersGetInputsProcessor extends modProcessor {
 
         /* simulate controller with the faux class above */
         $c = new TvInputManagerController($this->modx);
-        $this->modx->controller = call_user_func_array(array($c,'getInstance'),array($this->modx,'TvInputManagerController'));
+        $this->modx->controller = call_user_func_array(array($c,'getInstance'),array(&$this->modx,'TvInputManagerController'));
         $this->modx->controller->render();
 
         $renderDirectories = array(


### PR DESCRIPTION
### What does it do ?

Pass `modX` as a reference as expected by some method signatures
### Why is it needed ?

Not doing so causes fatal errors in PHP7/HHVM
### Steps to reproduce issue

On a PHP7 powered installation, just launch any manager page and see a stack trace similar to the following one

```
WARNING: [pool dev.lab] child 7 said into stderr: "NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Call to a member function setProperties() on null in /app/vendor/modx/revolution/core/model/modx/modmanagerresponse.class.php:196"
WARNING: [pool dev.lab] child 7 said into stderr: "Stack trace:"
WARNING: [pool dev.lab] child 7 said into stderr: "#0 /app/vendor/modx/revolution/core/model/modx/modmanagerresponse.class.php(74): modManagerResponse->instantiateController('AppIndexManager...', 'getInstance')"
WARNING: [pool dev.lab] child 7 said into stderr: "#1 /app/vendor/modx/revolution/core/model/modx/modmanagerrequest.class.php(180): modManagerResponse->outputContent(Array)"
WARNING: [pool dev.lab] child 7 said into stderr: "#2 /app/vendor/modx/revolution/core/model/modx/modmanagerrequest.class.php(128): modManagerRequest->prepareResponse()"
WARNING: [pool dev.lab] child 7 said into stderr: "#3 /app/public/mgr/index.php(25): modManagerRequest->handleRequest()"
WARNING: [pool dev.lab] child 7 said into stderr: "#4 {main}"
WARNING: [pool dev.lab] child 7 said into stderr: "  thrown in /app/vendor/modx/revolution/core/model/modx/modmanagerresponse.class.php on line 196"
```
### Related issue(s)/PR(s)
- Similar to PR #12597
