### PR TITLE
Fix CURLOPT_FOLLOWLOCATION warning in logs

### DIFF
--- a/core/model/modx/processors/system/config_check.inc.php
+++ b/core/model/modx/processors/system/config_check.inc.php
@@ -91,7 +91,11 @@ if (substr( $real_core, 0,  strlen($real_base)) == $real_base) {
         curl_setopt($curl, CURLOPT_VERBOSE, false);
         /* follow rewrites, e.g. http to https rewrites */
         /* if a sites rewrites the checkurl to 200 page, this method fails */
-        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+        $safeMode = @ini_get('safe_mode');
+        $openBasedir = @ini_get('open_basedir');
+        if (empty($safeMode) && empty($openBasedir)) {
+            curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+        }
         /* do not download anything */
         curl_setopt($curl, CURLOPT_RANGE, '0-0');
         curl_setopt($curl, CURLOPT_URL, $checkUrl);


### PR DESCRIPTION
### What does it do ?

CURLOPT_FOLLOWLOCATION not works with `safe_mode` or `open_basedir` enabled. So config_check processor generates such entries in error log:

> [2015-10-31 09:00:50] (ERROR @ .../www/core/model/modx/processors/system/config_check.inc.php : 97) PHP warning: curl_setopt(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set
### Why is it needed ?

This will fix it.
