### PR TITLE
Added some more flexibility is search results labels/icons (mostly in case of overrides)

### DIFF
--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -29,7 +29,7 @@ MODx.SearchBar = function(config) {
             '<div class="section">',
             // Display header only once
             '<tpl if="this.type != values.type">',
-            '<tpl exec="this.type = values.type; values.label = this.getLabel(values.type)"></tpl>',
+            '<tpl exec="this.type = values.type; values.label = this.getLabel(values)"></tpl>',
                 '<h3>{label}</h3>',
             '</tpl>',
                 // Real result, make it use the default styles for a combobox dropdown with x-combo-list-item
@@ -44,6 +44,9 @@ MODx.SearchBar = function(config) {
                  * @returns {string}
                  */
                 getClass: function(values) {
+                    if (values.icon) {
+                        return values.icon;
+                    }
                     switch (values.type) {
                         case 'resources':
                             return 'file';
@@ -66,11 +69,15 @@ MODx.SearchBar = function(config) {
                 /**
                  * Get the result type lexicon
                  *
-                 * @param {string} type
-                 * @returns {string}
+                 * @param {Array} values
+                 *
+                 * @returns {String}
                  */
-                ,getLabel: function(type) {
-                    return _('search_resulttype_' + type);
+                ,getLabel: function(values) {
+                    if (values.label) {
+                        return values.label;
+                    }
+                    return _('search_resulttype_' + values.type);
                 }
             }
         )
@@ -81,7 +88,7 @@ MODx.SearchBar = function(config) {
             }
             ,root: 'results'
             ,totalProperty: 'total'
-            ,fields: ['name', '_action', 'description', 'type']
+            ,fields: ['name', '_action', 'description', 'type', 'icon', 'label']
             ,listeners: {
                 beforeload: function(store, options) {
                     if (options.params._action) {


### PR DESCRIPTION
### What does it do ?

In short, it allows server side values (icon/label) computation for "uber bar" search results.
### Why is it needed ?

When you override the search bar (using a different processor) to allow search your own models, there is no way to return an icon nor a search type "label", due to those being "computed" client side (and overriding the Ext.Template seems complex... at least i did not find a convenient way to do so)
### Steps to reproduce issue

This' gonna be tricky to explain, but let's give it a try (untested pseudo code, you might need to adjust)
- create a plugin bound to `OnManagerPageInit` with the following content

```
<?php
/**
 * @var modX $modx
 * @var array $scriptProperties
 * 
 * @event
 */

$modx->controller->addHtml(<<<HTML
<script>
Ext.onReady(function() {
    // Create a new "searchbar" instance with overridden connector/processor
    var search = new MODx.SearchBar;
    search.store.baseParams.action = 'path/to/your/processor';
    search.store.url = 'http://domain.tld/your-connector.php';
    search.store.proxy.setUrl('http://domain.tld/your-connector.php', true);
});
</script>
HTML
);

return '';
```
- create your custom processor in 'path/to/your/processor.class.php'

```
<?php

/**
 * A custom search processor to add system settings search
 * (you might need to require_once the original search processor)
 */
class CustomSearch extends modSearchProcessor
{
    public function process()
    {
        // Override to allow searching system settings
        $this->query = $this->getProperty('query');
        if (!empty($this->query)) {
            if (strpos($this->query, ':') === 0) {
                // upcoming "launch actions"
                //$this->searchActions();
            } else {
                // Search elements & resources
                $this->searchResources();
                if ($this->modx->hasPermission('view_chunk')) {
                    $this->searchChunks();
                }
                if ($this->modx->hasPermission('view_template')) {
                    $this->searchTemplates();
                }
                if ($this->modx->hasPermission('view_tv')) {
                    $this->searchTVs();
                }
                if ($this->modx->hasPermission('view_snippet')) {
                    $this->searchSnippets();
                }
                if ($this->modx->hasPermission('view_plugin')) {
                    $this->searchPlugins();
                }
                if ($this->modx->hasPermission('view_user')) {
                    $this->searchUsers();
                }
                $this->searchSettings();
            }
        }

        return $this->outputArray($this->results);
    }

    protected function searchSettings()
    {
        $type = 'settings';

        $class = 'modSystemSetting';
        $c = $this->modx->newQuery($class);
        $c->where(array(
            'key:LIKE' => '%' . $this->query . '%',
        ));

        $c->limit($this->maxResults);

        $collection = $this->modx->getCollection($class, $c);
        /** @var modSystemSetting $record */
        foreach ($collection as $record) {
            $action = 'system/settings&ns=' . $record->get('namespace');
            $area = $record->get('area');
            if (!empty($area)) {
                $action .= "&area={$area}";
            }
            $this->results[] = [
                'name' => $record->get('key') .' - '. $record->get('value'),
                '_action' => $action,
                'description' => $record->get('description'),
                'type' => $type,
                'icon' => 'gears',
                'label' => 'System Settings',
            ];
        }
    }
}

return 'CustomSearch';
```
- search for system setting key you know, notice that without this patch, there are no label nor icon for the system setting results
- apply this PR, search a system setting, and see the label/icon in search results

Screenshot of the search results (on a highly customized manager, sorry)
![screenshot_2015-11-02_13-09-23](https://cloud.githubusercontent.com/assets/300920/10881503/85bd7710-8163-11e5-99d0-b2039cc1e1dc.png)
### Related issue(s)/PR(s)
- #12041
