### PR TITLE
Fix lexicon service init order to extension packages services can use lexicons

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -530,10 +530,10 @@ class modX extends xPDO {
             $this->getCacheManager();
             $this->getConfig();
             $this->_initContext($contextKey, false, $options);
+            $this->_initCulture($options);
             $this->_loadExtensionPackages($options);
             $this->_initSession($options);
             $this->_initErrorHandler($options);
-            $this->_initCulture($options);
 
             $this->getService('registry', 'registry.modRegistry');
 


### PR DESCRIPTION
### What does it do ?

Fix bug which disallow to load default lexicons in component using autoloading of service by _extension_packages_ variable.
### Why is it needed ?

To allow component with automatic service initialization from _extension_packages_ to load lexicons in class constructor. Currently in 2.4.2 lexicon service is not initialized before load of Extension packages.

In main model class then you can use:

```
public function __construct(modX &$modx, array $options = array()) {
    $this->modx->lexicon->load('cmp:default');
}
```
