### PR TITLE
Enhancement: Improve usability of tree by preventing accidental editing of containers

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -459,7 +459,9 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
         if (n.attributes.page && n.attributes.page !== '') {
             if (e.button == 1) return window.open(n.attributes.page,'_blank');
             else if (e.ctrlKey == 1 || e.metaKey == 1 || e.shiftKey == 1) return window.open(n.attributes.page);
-            MODx.loadPage(n.attributes.page);
+            else if (e.target.tagName == 'SPAN') MODx.loadPage(n.attributes.page); // only open the edit page when clicking on the text and nothing else (e.g. icon/empty space)
+            else if (n.isExpandable()) n.toggle(); // when clicking anything except the node-text, just open (if available) the node
+            else MODx.loadPage(n.attributes.page); // for non container nodes, they can be edited by clicking anywhere on the node
         } else if (n.isExpandable()) {
             n.toggle();
         }


### PR DESCRIPTION
### What does it do ?

This small change improves the usability of the resource tree by preventing accidental opening of the resource edit page when the intention was actually to open the container/"folder". It's a bit hacky (as it's relying on the tagName of the JS event.target)...but the problem here is, that the ExtJS node basically is the whole width of the tree and I couldn't find a better way to do this right now, suggestions of improving or making it less hacky are very welcome!

![modx-treeclickarea](https://cloud.githubusercontent.com/assets/445501/11318710/b859e7fe-905d-11e5-9c91-eb974670f67a.gif)
### Why is it needed ?

In the case of a container resource in the resource tree, the only way of opening the "folder"/container was to click that very tiny arrow icon to the left of the node, clicking anywhere else (even the folder icon) would open the resource edit page, which is an often heard complaint from clients and fellow MODXers.
### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/issues/12375, https://github.com/modxcms/revolution/issues/756, https://github.com/modxcms/revolution/issues/12698
