### PR TITLE
Updating font-awesome to ^4.5.0

### DIFF
--- a/_build/templates/default/bower.json
+++ b/_build/templates/default/bower.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "bourbon": "^4.2.3",
     "neat":"^1.7.2",
-    "font-awesome": "^4.3.0"
+    "font-awesome": "^4.5.0"
   },
   "exportsOverride": {
     "bourbon": {


### PR DESCRIPTION
### What does it do ?

Updates font-awesome to ^4.5.0
### Why is it needed ?

Adds the MODX logo the font awesome set :+1: 
### Related issue(s)/PR(s)

modxcms#12770

Closes modxcms#12770 because this will fetch any version of 4.4.x when running `bower update`
