### PR TITLE
Making manager more mobile friendly

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -276,30 +276,8 @@ button {
 	  bottom: auto;
 	  width: 100%;
 	  
-	  table table { // ExtJS is crazy
-		  display:block;
-		  tbody {
-			  display:block;
-			  tr {
-				  display:block;
-				  @include outer-container;
-				  @include display(flex);
-				  @include flex-wrap(wrap);
-				  td {
-				  	display:inline-block;
-					float:left;
-					margin-bottom:1em;
-					@include flex-grow(1);
-					&:first-of-type {
-						@include flex-basis(100%);
-					}
-					.x-btn {
-						margin-left:3px;
-						margin-right:3px;
-					}
-				  }
-			  }
-		  }
+	  table {
+	  	@include responsive-table-bar;
 	  }
   }
 
@@ -307,6 +285,43 @@ button {
     width: auto !important;
     zoom: 1;
   }
+}
+
+.tab-panel-wrapper .x-panel-tbar {
+	@include media($mobile) {
+	    @include responsive-table-bar;
+		.x-toolbar-left, .x-toolbar-right {
+		    input {
+		  	  height:auto !important;
+		  	  width:100%;
+		  	  box-sizing:border-box;
+			  margin-left:0;
+		    }
+		}
+	}
+}
+
+html.ext-strict body #modx-container .x-small-editor .x-form-text { // #janky
+	@include media($mobile) {
+		height:auto !important;
+	}
+}
+
+#modx-grid-element-properties {
+	@include media($mobile) {
+		@include responsive-table-bar;
+		.x-toolbar-left {
+			margin-bottom:0;
+		}
+		.x-toolbar-cell {
+			> * {
+				width:100% !important;
+				box-sizing:border-box;
+				margin-left:auto;
+				margin-right:auto;
+			}
+		}
+	}
 }
 
 /*.x-window-footer {

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -268,6 +268,41 @@ button {
   border-radius: 0 0 5px 5px;
   z-index: 11; /* prevent panel collaps arrows from overlapping */
 
+  @include media($mobile) {
+	  position: relative;
+	  top: auto;
+	  left: auto;
+	  right: auto;
+	  bottom: auto;
+	  width: 100%;
+	  
+	  table table { // ExtJS is crazy
+		  display:block;
+		  tbody {
+			  display:block;
+			  tr {
+				  display:block;
+				  @include outer-container;
+				  @include display(flex);
+				  @include flex-wrap(wrap);
+				  td {
+				  	display:inline-block;
+					float:left;
+					margin-bottom:1em;
+					@include flex-grow(1);
+					&:first-of-type {
+						@include flex-basis(100%);
+					}
+					.x-btn {
+						margin-left:3px;
+						margin-right:3px;
+					}
+				  }
+			  }
+		  }
+	  }
+  }
+
   .x-toolbar-left {
     width: auto !important;
     zoom: 1;

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -22,11 +22,14 @@
 }
 
 #modx-topnav {
+  @extend %outer-container;
   float: left;
   list-style: none;
   margin: 0;
   padding: 0;
-
+  @include media($mobile) {
+	  float:none;
+  }
   li {
     border-right: 1px solid $navbarBorder;
   }

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -2,6 +2,9 @@
 #modx-header {
   background: rgb(63,72,80);
   min-height: 55px; /* #janky #extjs */
+  @include media($mobile) {
+	  height:auto !important;
+  }
 }
 #modx-navbar {
   @include background-image(linear-gradient(to right, rgb(63,72,80) 0%, rgb(54,84,98) 46%, rgb(62,85,84) 60%, rgb(66,85,77) 68%, rgb(87,61,78) 100%));
@@ -9,6 +12,9 @@
   height: 100%;
   position: relative;
   z-index: 20;
+  @include media($mobile) {
+	  box-shadow:none;
+  }
 }
 
 #modx-user-menu {

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -3,6 +3,20 @@
 
 #modx-leftbar {
   /* the main container + bg behind the tabs */
+  @include media($mobile) {
+    position:relative !important;		
+	top:auto !important;
+	left:auto !important;
+	width:100% !important;
+	height:auto !important;
+  }
+  
+  .x-plain-body {
+	  @include media($mobile) {
+		  height:auto !important;
+	  }
+  }
+  
   & .x-tab-panel-noborder {
     margin: 26px 10px 26px 26px;
   }
@@ -39,10 +53,14 @@
   margin-left: 16px;
 }
 
-#modx-leftbar-tabpanel {
+#modx-leftbar #modx-leftbar-tabpanel { // janky
+	@include media($mobile) {
+		width:auto !important;
+		margin:0 auto;
+		padding:0.5em;
+	}
 }
 
-/* tree menu splitter / tree expander */
 .x-layout-split,
 #modx-leftbar-tabs-xcollapsed {
   overflow: visible;
@@ -94,6 +112,57 @@
       top: 69px;
     }
   }
+}
+
+/* tree menu splitter / tree expander */
+#modx-leftbar-tabs-xsplit, #modx-leftbar-tabs-xcollapsed {
+	@include media($mobile) {
+		position:relative;
+		top:auto !important;
+		left:auto !important;
+		right:auto;
+		bottom:auto;
+		visibility:visible;
+		width:auto !important;
+		height:auto !important;
+	}
+	.x-layout-mini {
+		@include media($mobile) {
+			position: relative;
+			right: auto;
+			width: auto !important;
+			top:auto !important;
+			&:before {
+				display:block;
+				line-height:42px;
+				padding-left:2em;
+			}
+			&:after {
+				right:24px !important;
+			}
+			
+		}
+	}
+}
+
+#modx-leftbar-tabs-xsplit {
+	.x-layout-mini {
+		@include media($mobile) {
+			&:before { 
+				content:"Collapse Sidebar";
+			}
+		}
+	}
+}
+
+#modx-leftbar-tabs-xcollapsed {
+	.x-layout-mini {
+		@include media($mobile) {
+			&:before { 
+				content:"Expand Sidebar";
+			}
+		}
+	}
 }
 
 /* style for the collapsed tree expander */

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -53,11 +53,16 @@
   margin-left: 16px;
 }
 
-#modx-leftbar #modx-leftbar-tabpanel { // janky
+#modx-leftbar {
 	@include media($mobile) {
-		width:auto !important;
-		margin:0 auto;
-		padding:0.5em;
+		margin:1em auto;
+	}
+	#modx-leftbar-tabpanel { // janky
+		@include media($mobile) {
+			width:auto !important;
+			margin:0 auto;
+			padding:0.5em;
+		}
 	}
 }
 

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -137,34 +137,27 @@
 			right: auto;
 			width: auto !important;
 			top:auto !important;
-			&:before {
-				display:block;
-				line-height:42px;
-				padding-left:2em;
-			}
 			&:after {
-				right:24px !important;
+				text-align:center;
+				top:auto !important;
+				left:0 !important;
+				right:0 !important;
 			}
 			
 		}
 	}
 }
 
-#modx-leftbar-tabs-xsplit {
+#modx-leftbar-tabs-xsplit, #modx-leftbar-tabs-xcollapsed {
 	.x-layout-mini {
 		@include media($mobile) {
-			&:before { 
-				content:"Collapse Sidebar";
-			}
-		}
-	}
-}
-
-#modx-leftbar-tabs-xcollapsed {
-	.x-layout-mini {
-		@include media($mobile) {
-			&:before { 
-				content:"Expand Sidebar";
+			left:0 !important;
+			&:after { 
+				border:none;
+				@include awesome-font();
+				line-height:42px;
+				content:"\f0db"; // absolutely no idea why $fa-var-columns won't work
+				font-size:16px;
 			}
 		}
 	}
@@ -178,6 +171,9 @@
     &:after {
       border-right: 0;
       border-left: 5px solid $treeColor;
+	  @include media($mobile) {
+		  border:none;
+	  }
     }
 
     &:hover:after {

--- a/_build/templates/default/sass/_uberbar.scss
+++ b/_build/templates/default/sass/_uberbar.scss
@@ -27,6 +27,38 @@
   position: absolute;
   top: 55px;
   left: 26px;
+  
+  @include media($mobile) {
+	  padding-right:25px;
+	  top:auto;
+	  left:0;
+	  right:0;
+	  min-width:0;
+	  &.visible {
+		position: relative;
+	  	visibility: visible;
+	  }
+  }
+  
+  .x-form-field-wrap {
+	  @include media($mobile) {
+		  width:auto !important;
+		  @include display(flex);
+		  #modx-uberbar {
+			  @include flex-grow(1);
+		  }
+		  .x-form-arrow-trigger {
+			  position:relative;
+			  top:auto;
+			  &:before {
+				  position: relative;
+				  margin-top:0;
+				  top:auto;
+				  line-height:30px;
+			  }
+		  }
+	  }
+  }
 
   /* up arrow connecting modx-manager-search-icon to the search field */
   &:after {
@@ -37,6 +69,9 @@
     left: 235px;
     @include media($desktop) {
       left: 60px;
+    }
+    @include media($mobile) {
+        left:15px;
     }
     border: 11px solid transparent;
     border-bottom: 11px solid $searchResultsBg;
@@ -55,6 +90,9 @@
   }*/
   .x-form-text {
     background: none; /* prevent white searchfield background */
+	@include media($mobile) {
+		width:auto !important;
+	}
   }
 }
 
@@ -124,6 +162,9 @@
   width: 457px !important; height: auto !important;
   z-index: 15 !important; /* show beneath subnav and modals */
 
+  @include media($mobile) {
+	  left:0 !important;
+  }
   .loading-indicator{
     background: none;
     color: $searchResultsColor;
@@ -146,6 +187,16 @@
     margin: 12px 0 0;
     overflow: auto;
     width: 100% !important;
+	@include media($mobile) {
+		height:auto !important;
+		line-height:4em;
+		.section {
+			> * {
+				padding-top:1em;
+				padding-bottom:1em;
+			}
+		}
+	}
   }
 
     .section {

--- a/_build/templates/default/sass/_utility.scss
+++ b/_build/templates/default/sass/_utility.scss
@@ -170,3 +170,31 @@
     }
   }
 }
+
+@mixin responsive-table-bar() {
+  table:not(#modx-tree-panel-usergroup table, #modx-grid-lexicon table, #modx-panel-property-sets) { // #janky
+	  display:block;
+	  tbody {
+		  display:block;
+		  tr {
+			  display:block;
+			  @include outer-container;
+			  @include display(flex);
+			  @include flex-wrap(wrap);
+			  td {
+			  	display:inline-block;
+				float:left;
+				margin-bottom:1em;
+				@include flex-grow(1);
+				&:first-of-type {
+					@include flex-basis(100%);
+				}
+				.x-btn {
+					margin-left:3px;
+					margin-right:3px;
+				}
+			  }
+		  }
+	  }
+  }
+}

--- a/_build/templates/default/sass/_utility.scss
+++ b/_build/templates/default/sass/_utility.scss
@@ -22,6 +22,10 @@
     @include ir;
 }
 
+%outer-container {
+	@include outer-container;
+}
+
 @mixin awesome-font() {
     display: inline-block;
     font-family: FontAwesome;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -229,6 +229,12 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 /* Error container */
 
 #modx-content {
+  @include media($mobile) {
+    position:relative;
+    width:auto !important;
+    top:auto !important;
+    left:auto !important;
+  }
   .modx_error {
     width: 95%;
     margin: 26px 0 0 15px;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -210,6 +210,22 @@ hr {
   }
 }
 
+#modx-resource-main-left, #modx-page-settings-left {
+	margin-bottom:2em;
+}
+
+#modx-resource-main-left, #modx-resource-main-right, #modx-page-settings-left, #modx-page-settings-right {
+	@include media($mobile) {
+		width:100% !important;
+	}
+}
+
+.x-column-inner > .x-column ~ .x-column {
+	@include media($mobile) {
+		margin-left:0;
+	}
+}
+
 .x-panel-header {
   background: none;
   border-bottom: 1px solid #ddd;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -190,10 +190,24 @@ hr {
 	}
 }
 
+.x-viewport {
+	@include media($mobile) {
+		overflow-y:auto;
+	}
+	body {
+		@include media($mobile) {
+			height:auto;
+		}
+	}
+}
+
 #modx-container {
-  height: 100%;
+  height: 100%; //maybe this should be min-height instead? - jp
   width: 100%;
   background: $mainBg;
+  @include media($mobile) {
+	  height:auto;
+  }
 }
 
 .x-panel-header {
@@ -265,6 +279,10 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
         }
       }
     }
+  }
+  .x-panel-body {
+	  height:auto !important;
+	  width:auto !important;
   }
 }
 

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -220,9 +220,162 @@ hr {
 	}
 }
 
+#modx-template-form, #modx-chunk-form, #modx-tv-tabs, #modx-snippet-form, #modx-panel-plugin {
+	.main-wrapper {
+		@include media($mobile) {
+			width:100% !important;
+			padding:0;
+			> .x-panel-bwrap {
+				padding:1em;
+			}
+		}
+	}
+}
+
+#modx-grid-lexicon {
+	.x-toolbar-ct {
+		@include media($mobile) {
+			display:block;
+			tbody {
+				display:block;
+				tr {
+					display:block;
+					td {
+						display:block;
+						width:100%;
+						table {
+							width:100%;
+							.x-form-field-wrap {
+								width:100% !important;
+								margin-bottom:1em;
+							}
+							.x-btn, .x-form-text {
+								width:100% !important;
+								margin-bottom:1em;
+								box-sizing:border-box;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+#modx-panel-contexts, #modx-panel-namespaces {
+	.main-wrapper {
+		> .x-panel-bwrap {
+			> .x-panel-tbar {
+				@include media($mobile) {
+					width:auto !important;
+					@include responsive-table-bar;
+					
+					#modx-ctx-search {
+						width:100% !important;
+						box-sizing:border-box;
+						margin-left:0;
+					}
+				}
+			}
+		}
+	}
+}
+
+#modx-panel-namespaces {
+	@include media($mobile) {
+		.main-wrapper {
+			.x-toolbar-left {
+				margin-bottom:0 !important;
+			}
+		}
+	}
+}
+
+#modx-namespace-search {
+	@include media($mobile) {
+		width:100% !important;
+		margin-left:0;
+		box-sizing:border-box;
+	}
+}
+
+#modx-filter-clear {
+	@include media($mobile) {
+		width:100% !important;
+		box-sizing:border-box;
+	}
+}
+
+#modx-tree-panel-usergroup {
+	.main-wrapper {
+		@include media($mobile) {
+			position:relative;
+		}
+	}
+}
+
+#modx-property-set-form {
+	@include media($mobile) {
+		.left-col, .x-col {
+			float:none;
+		}
+		#right-column, #modx-grid-element-properties {
+			width:100% !important;
+		}
+	}
+}
+
+.x-window {
+	@include media($mobile) {
+		width:auto !important;
+		max-width:100vh !important;
+		left:0.5em !important;
+		right:0.5em !important;
+		.x-window-body {
+			width:100% !important;
+			height:auto !important;
+			box-sizing:border-box !important;
+		}
+		.x-form-field-wrap {
+			width:auto !important;
+		}
+		input {
+			width:100% !important;
+			box-sizing:border-box;
+			height:auto !important;
+		}
+	}
+}
+
+#modx-template-form .main-wrapper {
+	input {
+		max-width:100% !important;
+	}
+}
+
 .x-column-inner > .x-column ~ .x-column {
 	@include media($mobile) {
 		margin-left:0;
+	}
+}
+
+.x-form-item label.x-form-item-label[for="modx-import-base-path"], .x-form-item label.x-form-item-label[for="modx-import-resource-class"], .x-form-item label.x-form-item-label[for="modx-import-element"], .x-form-item label.x-form-item-label[for="modx-import-parent"], .x-form-item label.x-form-item-label[for="modx-import-allowed-extensions"], #modx-import-base-path {
+	@include media($mobile) {
+		width:auto !important;
+		float:none;
+	}
+}
+
+#modx-import-base-path, #modx-import-resource-class, #modx-import-allowed-extensions, #modx-import-element {
+	height:auto;
+	width:100% !important;
+	box-sizing:border-box;
+}
+
+#x-form-el-modx-import-base-path, #x-form-el-modx-import-resource-class, #x-form-el-modx-import-allowed-extensions, #x-form-el-modx-import-element {
+	@include media($mobile) {
+		width:100% !important;
+		padding-left:0 !important;
 	}
 }
 

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -7,8 +7,8 @@ MODx.Component = function(config) {
     if (this.config.tabs) {
         this._loadTabs();
     }
-    this._loadComponents();
     this._loadActionButtons();
+	this._loadComponents();
     MODx.activePage = this;
 };
 Ext.extend(MODx.Component,Ext.Component,{
@@ -104,7 +104,7 @@ Ext.extend(MODx.Component,Ext.Component,{
         return true;
     }
 });
-Ext.reg('modx-component',MODx.Component);
+
 
 
 MODx.toolbar.ActionButtons = function(config) {
@@ -115,7 +115,7 @@ MODx.toolbar.ActionButtons = function(config) {
         ,id: 'modx-action-buttons'
         ,params: {}
         ,items: []
-        ,renderTo: 'modx-container'
+        ,renderTo: 'modx-action-buttons-container'
     });
     if (config.formpanel) {
         this.setupDirtyButtons(config.formpanel);
@@ -355,3 +355,5 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
     }
 });
 Ext.reg('modx-actionbuttons',MODx.toolbar.ActionButtons);
+
+Ext.reg('modx-component',MODx.Component);

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -7,8 +7,8 @@ MODx.Component = function(config) {
     if (this.config.tabs) {
         this._loadTabs();
     }
+    this._loadComponents();
     this._loadActionButtons();
-	this._loadComponents();
     MODx.activePage = this;
 };
 Ext.extend(MODx.Component,Ext.Component,{
@@ -104,7 +104,7 @@ Ext.extend(MODx.Component,Ext.Component,{
         return true;
     }
 });
-
+Ext.reg('modx-component',MODx.Component);
 
 
 MODx.toolbar.ActionButtons = function(config) {
@@ -355,5 +355,3 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
     }
 });
 Ext.reg('modx-actionbuttons',MODx.toolbar.ActionButtons);
-
-Ext.reg('modx-component',MODx.Component);

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -262,11 +262,11 @@ Ext.extend(MODx.SearchBar, Ext.form.ComboBox, {
      */
     ,toggle: function( hide ){
         var uberbar = Ext.get( this.container.id );
-        if( uberbar.isVisible() || hide ){
+        if( uberbar.hasClass('visible') || hide ){
             this.blurBar();
-            uberbar.hide();
+			uberbar.removeClass('visible');
         } else {
-            uberbar.show();
+			uberbar.addClass('visible');
             this.focusBar();
         }
     }

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -87,5 +87,6 @@
     </div>
         <div id="modAB"></div>
         <div id="modx-leftbar"></div>
+		<div id="modx-action-buttons-container"></div>
         <div id="modx-content">
             <div id="modx-panel-holder"></div>


### PR DESCRIPTION
### What does it do ?
- Gets the fixed and absolute positioned silliness out of the way on
  small screens by combatting ExtJS' nature of aggressively preventing usability on small viewports
- fights :fire: with :fire: 
- Makes the left hand tree more responsive (can expand and collapse with a button at the bottom of the page)
- Make the resource edit screen mobile friendly
### Why is it needed ?

So it is more feasible to navigate the manager and edit resources on mobile devices.
### Related issue(s)/PR(s)

n/a
### Before

![](http://j4p.us/image/3W3V2M0d1h2b/Screen%20Shot%202015-11-21%20at%208.38.57%20PM.png)
### After

![](http://j4p.us/image/1w3D401U1y0X/Screen%20Shot%202015-11-21%20at%208.34.26%20PM.png)
