### PR TITLE
Enhancement: Allow search for resource ID in Uberbar

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -153,6 +153,7 @@ class modSearchProcessor extends modProcessor
             'OR:alias:LIKE' => '%' . $this->query .'%',
             'OR:description:LIKE' => '%' . $this->query .'%',
             'OR:introtext:LIKE' => '%' . $this->query .'%',
+            'OR:id:=' => $this->query,
         ));
         $c->sortby('createdon', 'DESC');
 

--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -163,7 +163,7 @@ class modSearchProcessor extends modProcessor
         /** @var modResource $record */
         foreach ($collection as $record) {
             $this->results[] = array(
-                'name' => $record->get('pagetitle'),
+                'name' => $this->modx->hasPermission('tree_show_resource_ids') ? $record->get('pagetitle') . ' (' . $record->get('id') . ')' : $record->get('pagetitle'),
                 '_action' => 'resource/update&id=' . $record->get('id'),
                 'description' => $record->get('description'),
                 'type' => $type,


### PR DESCRIPTION
### What does it do ?

Added one line to the where query in the search processor that also looks up the ID column for resources.

![modx enhancement search resid](https://cloud.githubusercontent.com/assets/445501/11445457/7a2129f6-952c-11e5-8987-ce1276cefb81.gif)
### Why is it needed ?

Many times feedback from MODX involves resource ID's (ex. duplicate resource URIs when clearing cache etc.) and the only way to find resources like that is via the hidden ?a=search URL (you have to know that to get to the advanced search page where you could enter the resource ID)...this tiny PR just adds this very necessary and IMO useful functionality to the uberbar.
### Related issue(s)/PR(s)

This is by far not as nice as what @pepebe suggested in https://github.com/modxcms/revolution/pull/12515 or what's currently discussed in https://github.com/modxcms/revolution/pull/12533 but it's a start... also related are other issues in the two just mentioned: https://github.com/modxcms/revolution/issues/12283, https://github.com/modxcms/revolution/issues/11117
