### PR TITLE
Fix wrong FontAwesome icon "icon-coffee"

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -604,7 +604,7 @@
   content: $fa-var-file-code-o;
 }
 .icon-js:before,
-.icon-coffee:before {
+.icon-coffeescript:before {
   @extend %pseudo-font;
   content: $fa-var-file-code-o;
 }


### PR DESCRIPTION
### What does it do ?

Allows the icon-coffee icon to be used in the Elements tree. Closes modxcms/revolution#12676.
### Why is it needed ?

icon-coffee would incorrectly show the "code" icon instead. Now use `icon-cofeescript` to show the code icon.
### Related issue(s)/PR(s)

modxcms/revolution#12676
### Before

![](http://j4p.us/image/0G043L1e0D34/Screen%20Shot%202015-11-29%20at%204.56.04%20AM.png)
### After

![](http://j4p.us/image/0C0g1G2f181a/Screen%20Shot%202015-11-29%20at%204.55.52%20AM.png)
