### PR TITLE
html-first autofocus on login screen

### DIFF
--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -65,7 +65,7 @@
             <div class="x-form-item login-form-item login-form-item-first">
                 <label for="modx-login-username">{$_lang.login_username}</label>
                 <div class="x-form-element login-form-element">
-                    <input type="text" id="modx-login-username" name="username" tabindex="1" autocomplete="on" value="{$_post.username|default}" class="x-form-text x-form-field" placeholder="{$_lang.login_username}" />
+                    <input type="text" id="modx-login-username" name="username" tabindex="1" autocomplete="on" autofocus value="{$_post.username|default}" class="x-form-text x-form-field" placeholder="{$_lang.login_username}" />
                 </div>
             </div>
 


### PR DESCRIPTION
currently the username receives focus via js, this does the same with
html5 by making use of the autofocus attribute

![](http://j4p.us/image/272m2P3X363d/Screen%20Shot%202015-11-29%20at%2010.36.03%20AM.png)
