### PR TITLE
Setting fa-css-prefix back to default

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1,7 +1,6 @@
 @import "bourbon/bourbon";
 $border-box-sizing:false;
 @import "neat/neat";
-$fa-css-prefix:       icon;
 @import "font-awesome/font-awesome";
 .#{$fa-css-prefix}-large { @extend .#{$fa-css-prefix}-lg; }
 @import "image-set";


### PR DESCRIPTION
### What does it do ?

Removes `$fa-css-prefix:       icon;` which changes the font-awesome prefix from the default `.fa` to `.icon`. This is a breaking change and targets 3.x.
### Why is it needed ?

So that when people include plugins in the manager our icon classes are
compatible with the assumed default `.fa`. This fixes the issue of blank/missing icons in the manager for plugins that assume icon classes of `.fa` will be present.
### Related issue(s)/PR(s)

n/a

This PR does not update all the references to `.icon` throughout the codebase as I figured this should be discussed first. It is expected that if this were tested as is all the icons in the manager would disappear. It would be an effort to update the references but if this is agreed upon I think it would be worthwhile. 

Another solution would be to ship "double CSS" so there are classes for both `.fa` and `.icon` but that feels kind of lousy.

This issue has been discussed at MODX.org https://modxcommunity.slack.com/archives/development/p1448917321000397
