### PR TITLE
Improve keyboard nav & screen reader a11y of login screen

### DIFF
--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -165,6 +165,12 @@ a {
   white-space: nowrap;
 }
 
+#modx-fl-link {
+    &:focus {
+  	  color:$red;
+    }
+}
+
 #modx-login-language-select-div {
   bottom: 0;
   color: #888;

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -28,13 +28,6 @@
 </head>
 
 <body id="login">
-<div id="modx-login-language-select-div">
-    <label>{$language_str}:
-        <select name="cultureKey" id="modx-login-language-select">
-{$languages|indent:12}
-        </select>
-    </label>
-</div>
 {$onManagerLoginFormPrerender}
 <br />
 
@@ -65,14 +58,14 @@
             <div class="x-form-item login-form-item login-form-item-first">
                 <label for="modx-login-username">{$_lang.login_username}</label>
                 <div class="x-form-element login-form-element">
-                    <input type="text" id="modx-login-username" name="username" tabindex="1" autocomplete="on" value="{$_post.username|default}" class="x-form-text x-form-field" placeholder="{$_lang.login_username}" />
+                    <input type="text" id="modx-login-username" name="username" autocomplete="on" value="{$_post.username|default}" class="x-form-text x-form-field" placeholder="{$_lang.login_username}" aria-required="true" required />
                 </div>
             </div>
 
             <div class="x-form-item login-form-item">
                 <label for="modx-login-password">{$_lang.login_password}</label>
                 <div class="x-form-element login-form-element">
-                    <input type="password" id="modx-login-password" name="password" tabindex="2" autocomplete="on" class="x-form-text x-form-field" placeholder="{$_lang.login_password}" />
+                    <input type="password" id="modx-login-password" name="password" autocomplete="on" class="x-form-text x-form-field" placeholder="{$_lang.login_password}" aria-required="true" required />
                 </div>
             </div>
 
@@ -86,10 +79,10 @@
                 </div>
                 <div class="login-cb-col two">
                     <div class="x-form-check-wrap modx-login-rm-cb">
-                        <input type="checkbox" id="modx-login-rememberme" name="rememberme" tabindex="3" autocomplete="on" {if $_post.rememberme|default}checked="checked"{/if} class="x-form-checkbox x-form-field" value="1" />
+                        <input type="checkbox" id="modx-login-rememberme" name="rememberme" autocomplete="on" {if $_post.rememberme|default}checked="checked"{/if} class="x-form-checkbox x-form-field" value="1" />
                         <label for="modx-login-rememberme" class="x-form-cb-label">{$_lang.login_remember}</label>
                     </div>
-                    <button class="x-btn x-btn-small x-btn-icon-small-left primary-button x-btn-noicon login-form-btn" name="login" type="submit" value="1" id="modx-login-btn" tabindex="4">{$_lang.login_button}</button>
+                    <button class="x-btn x-btn-small x-btn-icon-small-left primary-button x-btn-noicon login-form-btn" name="login" type="submit" value="1" id="modx-login-btn">{$_lang.login_button}</button>
                 </div>
             </div>
 
@@ -118,5 +111,12 @@
     <p class="loginLicense">{$_lang.login_copyright}</p>
 </div>
 
+<div id="modx-login-language-select-div">
+    <label id="modx-login-language-select-label">{$language_str}:
+        <select name="cultureKey" id="modx-login-language-select" aria-labeled-by="modx-login-language-select-label">
+{$languages|indent:12}
+        </select>
+    </label>
+</div>
 </body>
 </html>


### PR DESCRIPTION
### What does it do ?
- Moves elements on login screen to be correct order in DOM.
- Removes `tabindex` attributes.
- Added `required` and `aria-required="true"` to required inputs.
- Styles focused forgot link.
- Adds `aria-labeled-by` to language select box

View a screencast with VoiceOver audio of tabbing through the login page here:
http://j4p.us/0v1I1t17203e :+1: 
### Why is it needed ?

So users using keyboard navigation and/or VoiceOver can more accessibly login to the default theme.

Tab order is now:
- username
- password
- forgot your login
- remember me
- login
- MODX link
- language select
### Related issue(s)/PR(s)

Closes modxcms/revolution#12145 (for reals)
Closes modxcms/revolution#12146 (for reals)
Closes modxcms/revolution#12147 (for reals)

Also see modxcms/revolution#12782
Also see modxcms/revolution#12791
Also see modxcms/revolution#12793
### Notes

Adds both `aria-required="true"` and `required` attributes although i think only `required` may be needed.
This may conflict with https://github.com/modxcms/revolution/pull/12787 but all https://github.com/modxcms/revolution/pull/12787 does is add the autofocus attribute to the username input.

An additional improvement would be to update the language select boxes to have the full name of the language in the `<option>` innerHTML so they are displayed and read aloud. See https://github.com/modxcms/revolution/issues/12793.
