### PR TITLE
Ensure compatibility of more mobile-friendly manager with custom mgr themes

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -115,7 +115,7 @@ MODx.toolbar.ActionButtons = function(config) {
         ,id: 'modx-action-buttons'
         ,params: {}
         ,items: []
-        ,renderTo: 'modx-action-buttons-container'
+        ,renderTo: Ext.get('modx-action-buttons-container') ? 'modx-action-buttons-container' : 'modx-container'
     });
     if (config.formpanel) {
         this.setupDirtyButtons(config.formpanel);


### PR DESCRIPTION
### What does it do?

Dynamically chooses the target renderTo div. It checks if the new `modx-action-buttons-container` div exists from #12776 , otherwise it falls back to the prior `modx-container`.  
### Why is it needed?

The more mobile-friendly manager introduced in #12776 relies on a new div with id modx-action-buttons-container being present in the header.tpl, however with custom manager themes that have their own header.tpl file that may not always be the case. With this commit in place, it ensures the action buttons are still inserted into the page (albeit in the wrong page), rather than throwing a js error if it can't find the new div.
### Related issue(s)/PR(s)
#12776 and in particular @rtripault's comment here: https://github.com/modxcms/revolution/commit/ed1b82f34520ed9ce762e5ee533a339731eaf71e#commitcomment-14759192
