### PR TITLE
Fix scrolling on non-mobile displays

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -450,8 +450,10 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
     }
   }
   .x-panel-body {
-	  height:auto !important;
-	  width:auto !important;
+	@include media($mobile) {
+	  height: auto !important;
+	  width: auto !important;
+	}
   }
 }
 


### PR DESCRIPTION
### What does it do?

Limit the width/height: auto to small displays only. 
### Why is it needed?

These lines cause it to be impossible to scroll on larger displays. By limiting the css to mobile media, scrolling is brought back to the manager on larger displays. 
### Related issue(s)/PR(s)
#12776 and in particular @rtripault's comments here: https://github.com/modxcms/revolution/commit/b9d4e741278c024243fb288218ed12ec6502ceb7#commitcomment-14759403
