### PR TITLE
Shows a 'please wait' message while modSystemRefreshurisProcessor runs.

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -187,6 +187,11 @@ Ext.extend(MODx,Ext.Component,{
 
     ,refreshURIs: function() {
         var topic = '/refreshuris/';
+        MODx.msg.status({
+            title: _('please_wait'),
+            message: _('refreshuris_desc'),
+            dontHide: true
+        });
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
@@ -888,4 +893,3 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         Ext.Ajax.request(o);
     }
 });
-


### PR DESCRIPTION
### What does it do ?

Shows a **Please Wait...** message status window while modSystemRefreshurisProcessor is running. _(via Clear Cache > Refresh URIs)_
### Why is it needed ?

Provides feedback to the user that something is happening and in progress.
### Related issue(s)/PR(s)

Fixes #12642
