### PR TITLE
Update login.class.php

### DIFF
--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -29,7 +29,7 @@ class modSecurityLoginProcessor extends modProcessor {
             return $this->modx->lexicon('login_cannot_locate_account');
         }
 
-        $this->rememberme = ($this->getProperty('rememberme', false) == 'on');
+        $this->rememberme = ($this->getProperty('rememberme', false) == true);
         $this->lifetime = (int)$this->getProperty('lifetime', $this->modx->getOption('session_cookie_lifetime', null,0));
         $this->loginContext = $this->getProperty('login_context', $this->modx->context->get('key'));
         $this->addContexts = $this->getProperty('add_contexts', array());


### PR DESCRIPTION
### What does it do ?

Fix a tiny mistake in Login processor, which is not allows users to save session for "session_cookie_lifetime" value.
### Why is it needed ?

Fix the problem with session saving when remember me value is not "on" (manager login form passed a value of remember me "1").
### Related issue(s)/PR(s)

[Issue #12754](https://github.com/modxcms/revolution/issues/12754)
