### PR TITLE
Fix branch for travis badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MODX Revolution
 
-[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=develop)](https://travis-ci.org/modxcms/revolution) [![Slack Status](https://modx.org/badge.svg)](https://modx.org)
+[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=2.x)](https://travis-ci.org/modxcms/revolution) [![Slack Status](https://modx.org/badge.svg)](https://modx.org)
 
 ## Content Management System and Application Framework
 


### PR DESCRIPTION
### What does it do

The travis badge shows the build status. This was set to the develop branch, but after changing the branching strategy, this needs to be updated for the 2.x branch. 
### Why is it needed

Showing the accurate build status. 
### Related issue(s)/PR(s)

None, though while merging #12801 I noticed it was set wrong. 
