### PR TITLE
Fix travis builds on PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ mysql:
   encoding: utf8
 
 before_script: 'cd _build/test && ./generateConfigs.sh'
+
+before_install:
+  -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -s -o $HOME/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.9.phar; chmod +x $HOME/.phpenv/versions/5.5/bin/phpunit; fi


### PR DESCRIPTION
### What does it do ?

Based on fix in http://andreas.heigl.org/2015/11/12/testing-code-with-phpunit-on-travis-ci-for-php-5-5-and-php7/ and the discussion in https://github.com/travis-ci/travis-ci/issues/5206#issuecomment-162041397, this adjustment makes sure that on PHP 5.5, phpunit 4.x is loaded rather than 5.x which is not compatible with PHP 5.5, but required for PHP7.
### Why is it needed ?

The travis build indicates it fails on PHP 5.5 due to an unsupported version of phpunit. 
### Related issue(s)/PR(s)

Brief discussion here: https://github.com/modxcms/revolution/pull/12803#issuecomment-162224698
