### PR TITLE
Make modphpthumb.class.php compatible with PHP 7

### DIFF
--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -156,7 +156,7 @@ class modPhpThumb extends phpThumb {
             if ($getimagesize) {
                 $this->DebugMessage('* Would have sent headers (2): Content-Type: '.phpthumb_functions::ImageTypeToMIMEtype($getimagesize[2]), __FILE__, __LINE__);
             }
-            if (preg_match('/^'.preg_quote($nice_docroot).'(.*)$/', $nice_cachefile, $matches)) {
+            if (preg_match('/^'.preg_quote($nice_docroot, '/').'(.*)$/', $nice_cachefile, $matches)) {
                 $this->DebugMessage('* Would have sent headers (3): Location: '.dirname($matches[1]).'/'.urlencode(basename($matches[1])), __FILE__, __LINE__);
             } else {
                 $this->DebugMessage('* Would have sent data: readfile('.$this->cache_filename.')', __FILE__, __LINE__);
@@ -182,7 +182,7 @@ class modPhpThumb extends phpThumb {
             } elseif (preg_match('#\.ico$#i', $this->cache_filename)) {
                 header('Content-Type: image/x-icon');
             }
-            if (!$this->config_cache_force_passthru && preg_match('#^'.preg_quote($nice_docroot).'(.*)$#', $nice_cachefile, $matches)) {
+            if (!$this->config_cache_force_passthru && preg_match('#^'.preg_quote($nice_docroot, '/').'(.*)$#', $nice_cachefile, $matches)) {
                 header('Location: '.dirname($matches[1]).'/'.urlencode(basename($matches[1])));
             } else {
                 @readfile($this->cache_filename);

--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -179,10 +179,10 @@ class modPhpThumb extends phpThumb {
             $getimagesize = @GetImageSize($this->cache_filename);
             if ($getimagesize) {
                 header('Content-Type: '.phpthumb_functions::ImageTypeToMIMEtype($getimagesize[2]));
-            } elseif (eregi('\.ico$', $this->cache_filename)) {
+            } elseif (preg_match('#\.ico$#i', $this->cache_filename)) {
                 header('Content-Type: image/x-icon');
             }
-            if (!$this->config_cache_force_passthru && ereg('^'.preg_quote($nice_docroot).'(.*)$', $nice_cachefile, $matches)) {
+            if (!$this->config_cache_force_passthru && preg_match('#^'.preg_quote($nice_docroot).'(.*)$#', $nice_cachefile, $matches)) {
                 header('Location: '.dirname($matches[1]).'/'.urlencode(basename($matches[1])));
             } else {
                 @readfile($this->cache_filename);

--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -156,7 +156,7 @@ class modPhpThumb extends phpThumb {
             if ($getimagesize) {
                 $this->DebugMessage('* Would have sent headers (2): Content-Type: '.phpthumb_functions::ImageTypeToMIMEtype($getimagesize[2]), __FILE__, __LINE__);
             }
-            if (ereg('^'.preg_quote($nice_docroot).'(.*)$', $nice_cachefile, $matches)) {
+            if (preg_match('/^'.preg_quote($nice_docroot).'(.*)$/', $nice_cachefile, $matches)) {
                 $this->DebugMessage('* Would have sent headers (3): Location: '.dirname($matches[1]).'/'.urlencode(basename($matches[1])), __FILE__, __LINE__);
             } else {
                 $this->DebugMessage('* Would have sent data: readfile('.$this->cache_filename.')', __FILE__, __LINE__);


### PR DESCRIPTION
### What does it do ?

Replaces removed functions ereg() and eregi() with preg_replace() equivalents (hopefully, somebody with more PHP skills please verify this =D).
### Why is it needed ?

To make MODX PHP 7 compatible, the media browser is broken without this...
### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/issues/12797, https://github.com/modxcms/revolution/pull/12810
