### PR TITLE
[3.0.0-dev]Fix bug in _build/build.properties.sample.php

### DIFF
--- a/_build/build.properties.sample.php
+++ b/_build/build.properties.sample.php
@@ -1,4 +1,5 @@
 <?php
+use xPDO\xPDO;
 /* define some properties */
 $properties['cache_path'] = MODX_CORE_PATH . '/' . (MODX_CONFIG_KEY === 'config' ? '' : MODX_CONFIG_KEY . '/') . 'cache/';
 


### PR DESCRIPTION
### What does it do ?

Add 

``` php
use xPDO\xPDO;
```

to _build/build.properties.sample.php
### Why is it needed ?

This solving error when build modx package
I use php 5.6  
### Related issue(s)/PR(s)

php 5.5 issue we dealt with in #12804
