### PR TITLE
Added unpub_date to publishingResults

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -609,13 +609,13 @@ class modCacheManager extends xPDOCacheManager {
         $timeNow= time();
         
         /* generate list of resources that are going to be published */
-        $stmt = $this->modx->prepare("SELECT id, context_key, pub_date FROM {$tblResource} WHERE pub_date IS NOT NULL AND pub_date < {$timeNow} AND pub_date > 0");
+        $stmt = $this->modx->prepare("SELECT id, context_key, pub_date, unpub_date FROM {$tblResource} WHERE pub_date IS NOT NULL AND pub_date < {$timeNow} AND pub_date > 0");
         if ($stmt->execute()) {
             $publishingResults['published_resources'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
         }
 
         /* generate list of resources that are going to be unpublished */
-        $stmt = $this->modx->prepare("SELECT id, context_key, pub_date FROM {$tblResource} WHERE unpub_date IS NOT NULL AND unpub_date < {$timeNow} AND unpub_date > 0");
+        $stmt = $this->modx->prepare("SELECT id, context_key, pub_date, unpub_date FROM {$tblResource} WHERE unpub_date IS NOT NULL AND unpub_date < {$timeNow} AND unpub_date > 0");
         if ($stmt->execute()) {
             $publishingResults['unpublished_resources'] = $stmt->fetchAll(PDO::FETCH_ASSOC);
         }


### PR DESCRIPTION
### What does it do ?

Extend $publishingResults with `unpub_date` which is returned during the autoPublish event.
### Why is it needed ?

`unpub_date` should be handy for unpublished resources…
### Related issue(s)/PR(s)

As suggested by @Mark-H here: https://github.com/modxcms/revolution/pull/12747#issuecomment-161269192
