### PR TITLE
Fix PHP Undefined index warnings for ext_debug and a due to smarty update

### DIFF
--- a/core/model/modx/smarty/modsmarty.class.php
+++ b/core/model/modx/smarty/modsmarty.class.php
@@ -130,7 +130,7 @@ class modSmarty extends Smarty {
      * @param mixed $compile_id compile id to be used with this template
      * @param object $parent next higher level of Smarty variables
      */
-    public function display($template, $cache_id = null, $compile_id = null, $parent = null) {
+    public function display($template = null, $cache_id = null, $compile_id = null, $parent = null) {
         echo $this->fetch($template, $cache_id, $compile_id, $parent);
     }
 }

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -13,7 +13,7 @@
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/index.css" />
 {/if}
 
-{if $_config.ext_debug}
+{if isset($_config.ext_debug) && $_config.ext_debug}
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
 <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
 {else}
@@ -21,8 +21,8 @@
 <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
 {/if}
 <script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}" type="text/javascript"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
 
 {if $_config.compress_js_groups}
 <script src="{$_config.manager_url}min/index.php?g=coreJs1" type="text/javascript"></script>

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -9,7 +9,7 @@
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
 <link rel="stylesheet" type="text/css" href="{$indexCss}?v={$versionToken}" />
 
-{if $_config.ext_debug}
+{if isset($_config.ext_debug) && $_config.ext_debug}
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
 <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
 {else}

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -9,7 +9,7 @@
     <link rel="stylesheet" type="text/css" href="{$indexCss}" />
     <link rel="stylesheet" type="text/css" href="{$loginCss}" />
 
-{if $_config.ext_debug}
+{if isset($_config.ext_debug) && $_config.ext_debug}
     <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
     <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
 {else}

--- a/manager/templates/default/security/logout.tpl
+++ b/manager/templates/default/security/logout.tpl
@@ -9,7 +9,7 @@
     <link rel="stylesheet" type="text/css" href="{$loginCss}" />
 
 
-    {if $_config.ext_debug}
+    {if isset($_config.ext_debug) && $_config.ext_debug}
     <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
     <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
     {else}


### PR DESCRIPTION
### What does it do ?

Fixed variables in manager smarty templates that throw Undefined index PHP warnings. Fixed till now:
- [x] a
- [x] ext_debug
- [x] match smarty's display() method signature in modsmarty.class.php
### Why is it needed ?

Because smarty was updated to 3.1.27 as of https://github.com/modxcms/revolution/pull/12807 and seems to be more strict now when checking for unset variables. The Problem is, that I'm not getting these warnings, even when my log_level is set to 3...so I'm kind of blind in what else there could be that would throw such warning. The two above were reported by @rtripault 
### Related issue(s)/PR(s)

See the one above.
