### PR TITLE
Stop Messing with the Browser's Default Focus outline

### DIFF
--- a/_build/templates/default/sass/_a11y.scss
+++ b/_build/templates/default/sass/_a11y.scss
@@ -1,0 +1,3 @@
+body.ext-webkit *:focus{
+    outline: auto !important;
+}

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -21,6 +21,7 @@ $fa-css-prefix:       icon;
 @import "windows";
 @import "dashboard";
 @import "help";
+@import "a11y";
 
 body {
   color: $mainText;


### PR DESCRIPTION
### What does it do ?

All browsers have a default value they apply to the currently focused item. ExtJS aggressively sets outlines on focused items to none. This is bad for a11y. This overrides ExtJS' dirty hack of setting all focused items to `outline:none`;
### Why is it needed ?

So users can tell if elements have focus.
http://tjvantoll.com/2013/01/28/stop-messing-with-the-browsers-default-focus-outline/
#### Before

![](http://j4p.us/3U3F0E1m0Z0n/Screen%20Shot%202015-12-10%20at%209.42.26%20PM.png)
#### After

![](http://j4p.us/1K2L050B0D1f/Screen%20Shot%202015-12-10%20at%209.41.56%20PM.png)
### Related issue(s)/PR(s)

Closes https://github.com/modxcms/revolution/issues/12791
### Note

I figured I'd start putting a11y improvements in a separate .scss file so it makes it easier to port to things like the a11y theme project.
