### PR TITLE
Fix modX->getUser to force load settings when parameter is passed

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1234,7 +1234,7 @@ class modX extends xPDO {
         }
         if ($this->user !== null && is_object($this->user)) {
             if ($this->user->hasSessionContext($contextKey) || $forceLoadSettings) {
-                if (isset ($_SESSION["modx.{$contextKey}.user.config"])) {
+                if (!$forceLoadSettings && isset ($_SESSION["modx.{$contextKey}.user.config"])) {
                     $this->_userConfig= $_SESSION["modx.{$contextKey}.user.config"];
                 } else {
                     $this->_userConfig= array();


### PR DESCRIPTION
### What does it do ?

Fix modX->getUser to force load settings when `forceLoadSettings` is passed
### Why is it needed ?

Currently settings are obtained from session, even when they should be reloaded from database.
