### PR TITLE
Ensure $restarted in templates/language.tpl always exists

### DIFF
--- a/setup/controllers/language.php
+++ b/setup/controllers/language.php
@@ -37,5 +37,8 @@ $parser->set('languages',$languages);
 if (!empty($_REQUEST['restarted'])) {
     $parser->set('restarted',true);
 }
+else {
+    $parser->set('restarted', false);
+}
 
 return $parser->render('language.tpl');

--- a/setup/controllers/language.php
+++ b/setup/controllers/language.php
@@ -34,11 +34,6 @@ foreach ($langs as $language) {
 }
 $parser->set('languages',$languages);
 
-if (!empty($_REQUEST['restarted'])) {
-    $parser->set('restarted',true);
-}
-else {
-    $parser->set('restarted', false);
-}
+$parser->set('restarted', !empty($_REQUEST['restarted']));
 
 return $parser->render('language.tpl');


### PR DESCRIPTION
### What does it do ?

Makes sure the $restarted variable in templates/language.tpl always exists. If it wasn't set, it would trigger two E_NOTICE errors. 
### Why is it needed ?

Make sure the setup doesn't throw any E_NOTICE errors
### Related issue(s)/PR(s)
#12846
