### PR TITLE
Fix issue with parent name not showing when creating a new resource under a parent

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -109,7 +109,10 @@ class ResourceCreateManagerController extends ResourceManagerController {
             $newValuesArr = array();
             $allowedFields = array('pagetitle','longtitle','description','introtext','content','link_attributes','alias','menutitle');
             foreach ($allowedFields as $field) {
-                $newValuesArr[$field] = $this->resource->get($field);
+                $value = $this->resource->get($field);
+                if (!empty($value)) {
+                    $newValuesArr[$field] = $value;
+                }
             }
             $this->resourceArray = array_merge($this->resourceArray, $newValuesArr);
 


### PR DESCRIPTION
### What does it do

Fixes an issue (reported as SimpleCart bug, but traced back to core) where the parent is not shown in the parent selector on the resource settings tab when creating a resource under another one. 

After some digging it appears that the logic from line 109-117, where it checks $this->resource for values set in a plugin, was overwriting information on the parent per line 119 (`$this->parent->fromArray($this->resourceArray)`). Because of the missing check if there is an actual value the `pagetitle` field was getting overwritten on the `$this->parent` object. As the pagetitle of the $this->parent object is used on line 166 to set the parent_pagetitle value, this was causing the parent's pagetitle to not be available on create. 
### Why is it needed ?
- Right click a resource in the tree and choose Create > Document to create a resource under that parent. Open the Settings tab and note that the selected parent is not shown in the parent field. 
- Apply this patch
- Try again, and notice the parent now shows. 
### Related issue(s)/PR(s)

modmore support ticket 7647
