### PR TITLE
Removing Disable Compress Checkbox from Setup Installer

### DIFF
--- a/setup/templates/options.tpl
+++ b/setup/templates/options.tpl
@@ -76,15 +76,6 @@
     </th>
     <td style="padding-top: 2em;">{$_lang.options_new_file_permissions_note}</td>
 </tr>
-<tr>
-    <th>
-        <label>
-            <input type="checkbox" name="nocompress" id="nocompress" value="1" />
-            {$_lang.options_nocompress}
-        </label>
-    </th>
-    <td>{$_lang.options_nocompress_note}</td>
-</tr>
 </tbody>
 </table>
 {/if}


### PR DESCRIPTION
### What does it do ?

Removes the "Disable CSS/JS compression" checkbox from the Setup screen. It does not remove the associated lexicons, let me know if it should.

![](http://j4p.us/2H2H443H3t3t/Screen%20Shot%202016-01-16%20at%2010.38.30%20AM.png)
### Why is it needed ?

Assuming #12778 is merged, MODX 3.x will no longer have a min API. So, the setting to disable it is no longer needed.
### Related issue(s)/PR(s)

See modxcms/revolution#12778
See modxcms/revolution#12538
See modxcms/revolution#12610
