### PR TITLE
Added new output filter 'stripmodxtags'

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -271,7 +271,7 @@ class modOutputFilter {
                             }
                             break;
                         case 'stripmodxtags':
-                            $output = $modx->stripTags($input, '', array('/(\[\[([^\[\]]++|(?R))*?\]\])/sg', 1));
+                            $output = preg_replace("/\\[\\[([^\\[\\]]++|(?R))*?\\]\\]/s", '', $input);
                             break;
                         case 'length':
                         case 'len':

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -270,6 +270,9 @@ class modOutputFilter {
                                 $output= strip_tags($output);
                             }
                             break;
+                        case 'stripmodxtags':
+                            $output = $modx->stripTags($input, '', array('/(\[\[([^\[\]]++|(?R))*?\]\])/sg', 1));
+                            break;
                         case 'length':
                         case 'len':
                         case 'strlen':


### PR DESCRIPTION
### What does it do ?

The output filter strips (recursive) all MODX tags in a string. Credits go to Josh Curtis (https://github.com/jcdm).
### Why is it needed ?

The default stripTags output filter does not clear MODX tags and there is no possibility to filter that tags away i.e. in a meta description with the following call for the content field.

```
<meta name="description" content="[[*description:default=`[[*content]]`]]">
```

The default regex in MODX does not catch nested tags. The proposed one does this. See: https://regex101.com/r/lW5gX6/1

```
<meta name="description" content="[[*description:default=`[[* content:stripmodxtags]]`]]">
```

strips all MODX tags before they are parsed.
