### PR TITLE
Added new output filter 'htmlspecial'

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -239,6 +239,11 @@ class modOutputFilter {
                             /* See PHP's htmlentities - http://www.php.net/manual/en/function.htmlentities.php */
                             $output = htmlentities($output,ENT_QUOTES,$encoding);
                             break;
+                        case 'htmlspecialchars':
+                        case 'htmlspecial':
+                            /* See PHP's htmlspecialchars - http://www.php.net/manual/en/function.htmlspecialchars.php */
+                            $output = htmlspecialchars($output,ENT_QUOTES,$encoding);
+                            break;
                         case 'esc':
                         case 'escape':
                             $output = preg_replace("/&amp;(#[0-9]+|[a-z]+);/i", "&$1;", htmlspecialchars($output));


### PR DESCRIPTION
### What does it do ?

The output filter simply executes htmlspecialchars on the input.
### Why is it needed ?

The output filter does not exist and htmlentities replaces all chars and not the needed chars for avoiding XSS.
