### PR TITLE
Fix system settings pagination issue if default_per_page is > 30

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -151,7 +151,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,primaryKey: 'key'
         ,autosave: true
         ,save_action: 'system/settings/updatefromgrid'
-        ,pageSize: MODx.config.default_per_page > 30 ? MODx.config.default_per_page : 30
+        ,pageSize: parseInt(MODx.config.default_per_page) > 30 ? parseInt(MODx.config.default_per_page) : 30
         ,paging: true
         ,collapseFirst: false
         ,tools: [{


### PR DESCRIPTION
### What does it do ?

Cast the default_per_page setting to integer before using it in the system settings grid.
### Why is it needed ?

The default_per_page config option comes in as a string, and because it isn't cast/parsed to an integer properly, the pagination goes crazy, resulting in page "101" instead of "2".
### Related issue(s)/PR(s)

Fixes #12832
