### PR TITLE
Added new logTarget ARRAY_EXTENDED

### DIFF
--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -2062,6 +2062,15 @@ class xPDO {
                 $this->cacheManager->writeFile($filepath . $filename, $content, 'a');
             } elseif ($target=='ARRAY' && isset($targetOptions['var']) && is_array($targetOptions['var'])) {
                 $targetOptions['var'][] = $content;
+            } elseif ($target=='ARRAY_EXTENDED' && isset($targetOptions['var']) && is_array($targetOptions['var'])) {
+                $targetOptions['var'][] = array(
+                    'content' => $content,
+                    'level' => $this->_getLogLevel($level),
+                    'msg' => $msg,
+                    'def' => $def,
+                    'file' => $file,
+                    'line' => $line
+                );
             } else {
                 echo $content;
             }


### PR DESCRIPTION
### What does it do ?

Implemented new logTarget `ARRAY_EXTENDED` besides the already existing `ARRAY` type, that stores an array with multiple fields (message, file, line, level, etc) instead of just the log message.
### Why is it needed ?

I'm implementing a remote logging service (phpconsole.com), therefor it's needed to get all those fields separately from MODX.
### Related issue(s)/PR(s)
## 
### Usage

Now you can set the logTarget somewhere at the beging of your code (like in the index.php file or in a plugin) like this:

```
$myCustomErrorLog = array();
$modx->setLogTarget(array(
    'target' => 'ARRAY_EXTENDED',
    'options' => array(
        'var' => &$myCustomErrorLog
    )
));
```
