### PR TITLE
Fixing session warning on HHVM

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2423,10 +2423,10 @@ class modX extends xPDO {
         $contextKey= $this->context instanceof modContext ? $this->context->get('key') : null;
         if ($this->getOption('session_enabled', $options, true) || isset($_GET['preview'])) {
             if (!in_array($this->getSessionState(), array(modX::SESSION_STATE_INITIALIZED, modX::SESSION_STATE_EXTERNAL, modX::SESSION_STATE_UNAVAILABLE), true)) {
-                $sh= false;
+                $sh = false;
                 if ($sessionHandlerClass = $this->getOption('session_handler_class', $options)) {
-                    if ($shClass= $this->loadClass($sessionHandlerClass, '', false, true)) {
-                        if ($sh= new $shClass($this)) {
+                    if ($shClass = $this->loadClass($sessionHandlerClass, '', false, true)) {
+                        if ($sh = new $shClass($this)) {
                             session_set_save_handler(
                                 array (& $sh, 'open'),
                                 array (& $sh, 'close'),
@@ -2438,7 +2438,10 @@ class modX extends xPDO {
                         }
                     }
                 }
-                if (!$sh) {
+                if (
+                    (is_string($sessionHandlerClass) && !$sh instanceof $sessionHandlerClass) ||
+                    !is_string($sessionHandlerClass)
+                ) {
                     $sessionSavePath = $this->getOption('session_save_path', $options);
                     if ($sessionSavePath && is_writable($sessionSavePath)) {
                         session_save_path($sessionSavePath);
@@ -2454,7 +2457,7 @@ class modX extends xPDO {
                 if ($gcMaxlifetime > 0) {
                     ini_set('session.gc_maxlifetime', $gcMaxlifetime);
                 }
-                $site_sessionname= $this->getOption('session_name', $options, '');
+                $site_sessionname = $this->getOption('session_name', $options, '');
                 if (!empty($site_sessionname)) session_name($site_sessionname);
                 session_set_cookie_params($cookieLifetime, $cookiePath, $cookieDomain, $cookieSecure, $cookieHttpOnly);
                 if ($this->getOption('anonymous_sessions', $options, true) || isset($_COOKIE[session_name()])) {
@@ -2493,7 +2496,7 @@ class modX extends xPDO {
      * @return boolean True if successful.
      */
     protected function _loadConfig() {
-        $this->config= $this->_config;
+        $this->config = $this->_config;
 
         $this->getCacheManager();
         $config = $this->cacheManager->get('config', array(
@@ -2506,7 +2509,7 @@ class modX extends xPDO {
         }
         if (empty($config)) {
             $config = array();
-            if (!$settings= $this->getCollection('modSystemSetting')) {
+            if (!$settings = $this->getCollection('modSystemSetting')) {
                 return false;
             }
             foreach ($settings as $setting) {
@@ -2514,7 +2517,7 @@ class modX extends xPDO {
             }
         }
         $this->config = array_merge($this->config, $config);
-        $this->_systemConfig= $this->config;
+        $this->_systemConfig = $this->config;
         return true;
     }
 


### PR DESCRIPTION
### What does it do ?

Fixed the modx.class.php because it threw the following error:

Warning: Session callback expects true/false return value in /var/www/vhosts/domain.com/production/core/model/modx/modx.class.php on line 2441
### Why is it needed ?

Because it now triggers an warning.
### Related issue(s)/PR(s)

This should fix the following issue partially. 

https://github.com/modxcms/revolution/issues/12821
