### PR TITLE
add top bar for TV grid in Template's form

### DIFF
--- a/core/lexicon/en/tv.inc.php
+++ b/core/lexicon/en/tv.inc.php
@@ -7,6 +7,7 @@
  * @subpackage lexicon
  */
 $_lang['has_access'] = 'Has Access?';
+$_lang['filter_by_category'] = 'Filter by Category...';
 $_lang['rank'] = 'Rank';
 $_lang['rendering_options'] = 'Rendering Options';
 $_lang['tv'] = 'Template Variable';

--- a/core/model/modx/processors/element/tv/template/getlist.class.php
+++ b/core/model/modx/processors/element/tv/template/getlist.class.php
@@ -56,6 +56,20 @@ class modElementTvTemplateGetList extends modProcessor {
 
         /* query for templates */
         $c = $this->modx->newQuery('modTemplate');
+        $query = $this->getProperty('query');
+        if (!empty($query)) {
+            $c->where(array(
+                'templatename:LIKE' => "%$query%"
+            ));
+        }
+        $c->leftJoin('modCategory','Category');
+        $category = $this->getProperty('category');
+        if (!empty($category)) {
+            $c->where(array(
+                'Category.id' => $category
+            ));
+        }
+        
         $data['total'] = $this->modx->getCount('modTemplate',$c);
         
         $c->leftJoin('modTemplateVarTemplate','TemplateVarTemplates',array(
@@ -64,6 +78,9 @@ class modElementTvTemplateGetList extends modProcessor {
         ));
         
         $c->select($this->modx->getSelectColumns('modTemplate','modTemplate'));
+        $c->select(array(
+            'category_name' => 'Category.category',
+        ));
         $c->select($this->modx->getSelectColumns('modTemplateVarTemplate','TemplateVarTemplates','',array('tmplvarid')));
         $c->sortby($this->getProperty('sort'),$this->getProperty('dir'));
         if ($isLimit) $c->limit($limit,$this->getProperty('start'));
@@ -82,6 +99,7 @@ class modElementTvTemplateGetList extends modProcessor {
         $templateArray = $template->toArray();
         $templateArray['access'] = $template->get('tmplvarid');
         $templateArray['access'] = empty($templateArray['access']) ? false : true;
+        $templateArray['category_name']= $template->get('category_name');
         unset($templateArray['content']);
         return $templateArray;
     }

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -17,7 +17,7 @@ MODx.grid.TemplateVarTemplate = function(config) {
     Ext.applyIf(config,{
         id: 'modx-grid-tv-template'
         ,url: MODx.config.connector_url
-        ,fields: ['id','templatename','description','access','menu']
+        ,fields: ['id','templatename','category','category_name','description','access','menu']
         ,baseParams: {
             action: 'element/tv/template/getList'
             ,tv: config.tv
@@ -35,12 +35,74 @@ MODx.grid.TemplateVarTemplate = function(config) {
             ,width: 150
             ,sortable: true
         },{
+            header: _('category')
+            ,dataIndex: 'category_name'
+            ,width: 300
+        },{
             header: _('description')
             ,dataIndex: 'description'
             ,width: 300
         },tt]
+        ,tbar: ['->',{
+            xtype: 'modx-combo-category'
+            ,name: 'filter_category'
+            ,hiddenName: 'filter_category'
+            ,id: 'modx-tvtemp-filter-category'
+            ,emptyText: _('filter_by_category')
+            ,value: ''
+            ,allowBlank: true
+            ,width: 150
+            ,listeners: {
+                'select': {fn: this.filterByCategory, scope:this}
+            }
+        },'-',{
+            xtype: 'textfield'
+            ,name: 'query'
+            ,id: 'modx-tvtemp-search'
+            ,emptyText: _('search_ellipsis')
+            ,listeners: {
+                'change': {fn: this.search, scope: this}
+                ,'render': {fn: function(cmp) {
+                    new Ext.KeyMap(cmp.getEl(), {
+                        key: Ext.EventObject.ENTER
+                        ,fn: this.blur
+                        ,scope: cmp
+                    });
+                },scope:this}
+            }
+        },{
+            xtype: 'button'
+            ,id: 'modx-filter-clear'
+            ,text: _('filter_clear')
+            ,listeners: {
+                'click': {fn: this.clearFilter, scope: this}
+            }
+        }]
     });
     MODx.grid.TemplateVarTemplate.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid);
+Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
+    filterByCategory: function(cb,rec,ri) {
+        this.getStore().baseParams['category'] = cb.getValue();
+        this.getBottomToolbar().changePage(1);
+        this.refresh();
+    }
+    ,search: function(tf,newValue,oldValue) {
+        var nv = newValue || tf;
+        this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
+        Ext.getCmp('modx-tvtemp-filter-category').setValue('');
+        this.getBottomToolbar().changePage(1);
+        this.refresh();
+        return true;
+    }
+    ,clearFilter: function() {
+    	this.getStore().baseParams = {
+            action: 'getList'
+    	};
+        Ext.getCmp('modx-tvtemp-filter-category').reset();
+        Ext.getCmp('modx-tvtemp-search').setValue('');
+    	this.getBottomToolbar().changePage(1);
+        this.refresh();
+    }    
+});
 Ext.reg('modx-grid-tv-template',MODx.grid.TemplateVarTemplate);

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -97,7 +97,7 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'getList'
+            action: 'element/tv/template/getList'
     	};
         Ext.getCmp('modx-tvtemp-filter-category').reset();
         Ext.getCmp('modx-tvtemp-search').setValue('');

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -1,6 +1,6 @@
 /**
  * Loads a grid of TVs assigned to the Template.
- * 
+ *
  * @class MODx.grid.TemplateVarTemplate
  * @extends MODx.grid.Grid
  * @param {Object} config An object of options.
@@ -85,14 +85,14 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
     filterByCategory: function(cb,rec,ri) {
         this.getStore().baseParams['category'] = cb.getValue();
         this.getBottomToolbar().changePage(1);
-        this.refresh();
+        //this.refresh();
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         Ext.getCmp('modx-tvtemp-filter-category').setValue('');
         this.getBottomToolbar().changePage(1);
-        this.refresh();
+        //this.refresh();
         return true;
     }
     ,clearFilter: function() {
@@ -102,7 +102,7 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
         Ext.getCmp('modx-tvtemp-filter-category').reset();
         Ext.getCmp('modx-tvtemp-search').setValue('');
     	this.getBottomToolbar().changePage(1);
-        this.refresh();
-    }    
+        //this.refresh();
+    }
 });
 Ext.reg('modx-grid-tv-template',MODx.grid.TemplateVarTemplate);


### PR DESCRIPTION
### What does it do ?

Adding filters (by category or searching) for TV grid in Template edit mode

![tvtemplatetopbar](https://cloud.githubusercontent.com/assets/308524/12489251/f184b378-c0a1-11e5-9340-c00af6269d2f.png)
### Why is it needed ?

Number of Template Variables can raise to hundreds on a big site, especially for multilingual sites.
Having filter helps out the selection.
