### PR TITLE
Fixes the DocBlock comment for leaveGroup()

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -708,7 +708,7 @@ class modUser extends modPrincipal {
      * Removes the User from the specified User Group.
      *
      * @access public
-     * @param mixed $groupId Either the name or ID of the User Group to join.
+     * @param mixed $groupId Either the name or ID of the User Group to leave.
      * @return boolean True if successful.
      */
     public function leaveGroup($groupId) {


### PR DESCRIPTION
### What does it do ?

Corrects invalid DocBlock reference to "join" for `leaveGroup()` method.
### Why is it needed ?

Because the user is removed (e.g. leaves) from the User Group, not added (e.g. join).
### Related issue(s)/PR(s)

Updated per reminder from #12410
