### PR TITLE
Proposed fix to bug #12835 (2.4.x branch)

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -450,6 +450,23 @@ class modParser {
         if ($cacheable && $token !== '+') {
             $elementOutput= $this->loadFromCache($outerTag);
         }
+        $_restoreProcessingUncacheable = $this->_processingUncacheable;
+        // temporarily disable processing uncacheable elements so they don't get put into this cached element's cache
+        // caching an uncacheable tag could lead to serious problems like caching user-submitted data and exposing it to other users
+        // See bug https://github.com/modxcms/revolution/issues/12835
+        // New system setting:
+        //   Because this fix changes the tag-parsing order, this might cause some sites with
+        //   complex tag nesting to experience bugs as a result of even more complex tag nesting.
+        //   This is probably not a result of this fix but is a result of the different tag parsing
+        //   order. The parsing order changes because uncached tags vulnerable to
+        //   the bug will now remain unparsed until the next parsing pass. Thus, a system
+        //   setting is needed to allow sites to disable this fix temporarily on production sites.
+        // Also, parsing speed may decrease. Again, this is not a result of this fix but
+        // a result of the unparsed tags that are vulnerable to this bug getting their
+        // parsing delayed until the next pass.
+        if ($this->_processingUncacheable && $cacheable && $this->modx->getOption('core.parser_recurse_uncacheable', null, true)) {
+            $this->_processingUncacheable = false;
+        }
         if ($elementOutput === null) {
             switch ($token) {
                 case '+':
@@ -522,6 +539,7 @@ class modParser {
             /* $this->modx->cacheManager->writeFile(MODX_BASE_PATH . 'parser.log', "Processing {$outerTag} as {$innerTag}:\n" . print_r($elementOutput, 1) . "\n\n", 'a'); */
         }
         $this->_processingTag = false;
+        $this->_processingUncacheable = $_restoreProcessingUncacheable;
         return $elementOutput;
     }
 


### PR DESCRIPTION
Rebase for https://github.com/modxcms/revolution/pull/12874

This fixes a bug that can expose user-submitted form data and other user-specific or request-specific data to the public, particularly in sites that use many nesting levels of elements. See https://github.com/modxcms/revolution/issues/12835

Because this fix changes the tag-parsing order, this might cause some sites with
complex tag nesting to experience bugs as a result of even more complex tag nesting.
This is probably not a result of this fix but is a result of the different tag parsing
order. The parsing order changes because uncached tags vulnerable to
the bug will now remain unparsed until the next parsing pass. Thus, a system
setting is needed to allow sites to disable this fix temporarily on production sites.

Also, parsing speed may decrease. Again, this is not a result of this fix but a result of the unparsed tags that are vulnerable to this bug getting their parsing delayed until the next pass.

Sites that do not have any vulnerable unparsed elements should remain unaffected by this fix, but testing is recommended. 
