### PR TITLE
Fixing partial import of content with UTF-8 chars inside

### DIFF
--- a/core/model/modx/import/modstaticimport.class.php
+++ b/core/model/modx/import/modstaticimport.class.php
@@ -288,7 +288,7 @@ class modStaticImport extends modImport {
         foreach ($children as $child) {
             $innerHTML .= $element->ownerDocument->saveHTML($child);
         }
-        return utf8_decode($innerHTML);
+        return $innerHTML;
     }
 
     /**


### PR DESCRIPTION
### What does it do ?

Remove utf8_decode call in DOMinnerHTML method.
### Why is it needed ?

Fix partial import i.e. at `&deg;`, `&#176;` or `°` signs (no matter if they are entity encoded or not). The import would be truncated at this UTF-8 character. DOMDocument uses UTF-8 encoding internally and seems to output UTF-8 in saveHTML method, no matter what the original charset was set in the imported file. The docs are not that clear on this behavior.
### Maybe it this needs some tests

During my Tests, the only way to have no truncated content was done by removing utf8_decode. Converting to other charsets, i.e. with iconv to the MODX charset (if different than UTF-8) resulted in truncated content. It seems that modResource::set method has to be filled with an UTF-8 string.
