### PR TITLE
Extend SmartyBC in modSmarty to ensure backwards compatibility

### DIFF
--- a/core/model/modx/smarty/modsmarty.class.php
+++ b/core/model/modx/smarty/modsmarty.class.php
@@ -34,7 +34,7 @@ include_once (strtr(realpath(dirname(__FILE__)) . '/../../smarty/Smarty.class.ph
  * @package modx
  * @subpackage smarty
  */
-class modSmarty extends Smarty {
+class modSmarty extends SmartyBC {
     /**
      * A reference to the modX instance
      * @var modX


### PR DESCRIPTION
### What does it do?

Restores backwards compatibility with the previously used version of Smarty by using the special `SmartyBC` class. 
### Why is it needed?

When Smarty was updated for 2.5.0-rc1 (to get PHP 7 compatibility), this included some unintentional breaking changes (methods were renamed). Smarty ships with a special SmartyBC class that wraps those breaking changes, we just weren't using that. 
### Related issue(s)/PR(s)

This fixes #12895 and potentially other issues that rely on the old naming structure in Smarty (none logged yet that I'm aware of). 
