### PR TITLE
CSS - Remove ugly outline from navbar search

### DIFF
--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -6023,7 +6023,8 @@ ul.x-tab-strip-bottom {
   float: left;
   margin: 0;
   padding: 0;
-  position: relative; }
+  position: relative;
+  outline: 0; }
 
 #modx-navbar li:hover {
   z-index: 10000; }


### PR DESCRIPTION
### What does it do ?

Removes outline property from the navbar search icon in the manager.
### Why is it needed ?

Purely aesthetics
