### PR TITLE
Replace hard-coded charset with MODX setting

### DIFF
--- a/setup/templates/base_template.tpl
+++ b/setup/templates/base_template.tpl
@@ -3,7 +3,7 @@
 <head>
     <title>[[*pagetitle]] - [[++site_name]]</title>
     <base href="[[!++site_url]]" />
-    <meta charset="utf-8" />
+    <meta charset="[[++modx_charset]]" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 


### PR DESCRIPTION
### What does it do ?

Replace hard-coded charset with MODX setting in new default template
### Why is it needed ?

Because MODX tags are dynamic and preferred over hard coded string.
### Related issue(s)/PR(s)

Resolves #12915
