### PR TITLE
Space before a questionmark is somehow wrong

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
-### What does it do ?
+### What does it do?
 Describe the technical changes you did.
 
-### Why is it needed ?
+### Why is it needed?
 Describe the issue you are solving.
 
 ### Related issue(s)/PR(s)


### PR DESCRIPTION
### Why is it needed ?

Fixing typos.
