### PR TITLE
Fixing #12937 Import HTML regex breaks if newlines in title

### DIFF
--- a/core/model/modx/import/modstaticimport.class.php
+++ b/core/model/modx/import/modstaticimport.class.php
@@ -101,7 +101,7 @@ class modStaticImport extends modImport {
                     } else {
                         $file= $this->getFileContent("{$filepath}{$filename}");
                         if ($filetype->get('mime_type') == 'text/html') {
-                            if (preg_match("/<title>(.*)<\/title>/i", $file, $matches)) {
+                            if (preg_match("/<title>\s*(.*?)\s*<\/title>/is", $file, $matches)) {
                                 $pagetitle= $matches[1];
                             } else
                                 $pagetitle= $value;


### PR DESCRIPTION
### What does it do?

Change the regular expression that detects the title tag and extracts the title
### Why is it needed?

When importing an HTML document the regex that parses the title tags breaks if there are newlines in the title.
### Related issue(s)/PR(s)
#12937
