### PR TITLE
Make sure only recipient can mark user messages read/unread

### DIFF
--- a/core/model/modx/processors/security/message/read.class.php
+++ b/core/model/modx/processors/security/message/read.class.php
@@ -16,6 +16,10 @@ class modMessageReadProcessor extends modObjectUpdateProcessor {
     public $languageTopics = array('messages');
 
     public function beforeSave() {
+        if ($this->object->get('recipient') != $this->modx->user->get('id')) {
+            return $this->modx->lexicon($this->objectType.'_err_nfs');
+        }
+
         $this->object->set('read', true);
         return parent::beforeSave();
     }

--- a/core/model/modx/processors/security/message/unread.class.php
+++ b/core/model/modx/processors/security/message/unread.class.php
@@ -16,6 +16,10 @@ class modMessageUnreadProcessor extends modObjectUpdateProcessor {
     public $languageTopics = array('messages');
 
     public function beforeSave() {
+        if ($this->object->get('recipient') != $this->modx->user->get('id')) {
+            return $this->modx->lexicon($this->objectType.'_err_nfs');
+        }
+
         $this->object->set('read', false);
         return parent::beforeSave();
     }


### PR DESCRIPTION
### What does it do?

Prevents other manager users from being able to mark any user messages read/unread by changing the id parameter.
### Why is it needed?

Because only the recipient should be able to mark their own messages as read/unread.
### Related issue(s)/PR(s)

This is a low-risk, low-priority security issue.
