### PR TITLE
Add .x-form-display-field style

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -394,11 +394,15 @@ input::-moz-focus-inner {
 }
 
 /* issue #5505 */
-.x-form-text {
+.x-form-text, .x-form-display-field {
   /*box-sizing: border-box;*/ /* we cannot use this because extjs calculates widths with the old box-model */
   line-height: 20px;
   min-height: 20px; /* + 5px + 5px padding = 30px */
   padding: 5px;
+}
+.x-form-display-field {
+  border: 1px solid transparent;
+  border-radius: $borderRadius;
 }
 
 .x-form-textarea {


### PR DESCRIPTION
### What does it do?

Add a style for x-form-display-field class
### Why is it needed?

The style does not exist at the moment and the height of the displayfield is not the same as the height of a textfield.
