### PR TITLE
fix: expression is always true

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -334,7 +334,7 @@ class modOutputFilter {
                                 foreach ($matches[1] as $tag) {
                                     if (preg_match("/^[a-z]+$/i", $tag, $regs)) {
                                         $strLower = $usemb ? mb_strtolower($regs[0],$encoding) : strtolower($regs[0]);
-                                        if ($strLower != 'br' || $strLower != 'hr') {
+                                        if ($strLower != 'br' && $strLower != 'hr') {
                                             $opened[] = $regs[0];
                                         }
                                     } elseif (preg_match("/^\/([a-z]+)$/i", $tag, $regs)) {

--- a/core/model/modx/processors/system/filesys/file/unzip.php
+++ b/core/model/modx/processors/system/filesys/file/unzip.php
@@ -25,7 +25,7 @@ function unzip($file, $path) {
 	global $amode;
 	// added by Raymond
 	$r = substr($path,strlen($path)-1,1);
-	if ($r!="\\"||$r!="/") $path .="/";
+	if ($r!="\\" && $r!="/") $path .="/";
 	if (!extension_loaded('zip')) {
 	   if (strtoupper(substr(PHP_OS, 0,3) == 'WIN')) {
 			if(!@dl('php_zip.dll')) return 0;


### PR DESCRIPTION
### What does it do?

Operator "||" replaced by operator "&&"
### Why is it needed?

We checked this project with code analyzer [AppChecker](cnpo.ru/en/solutions/appchecker.php) and found that:

These expressions are always true.
1) ($strLower != 'br' || $strLower != 'hr')
if $strLower is 'br' -> ($strLower != 'hr') - true ->   ($strLower != 'br' || $strLower != 'hr') - true
if $strLower is 'hr' -> ($strLower != 'br') - true ->   ($strLower != 'br' || $strLower != 'hr') - true
if $strLower is 'some_other' -> ($strLower != 'br') - true ->   ($strLower != 'br' || $strLower != 'hr') - true

Similarly, ($r!="\"||$r!="/") is always true
### Related issue(s)/PR(s)

n/a
