### PR TITLE
Make sure uberbar resource search respects ACLs

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -147,7 +147,7 @@ class modSearchProcessor extends modProcessor
         $typeLabel = $this->modx->lexicon('search_resulttype_' . $type);
 
         $contextKeys = array();
-        $contexts = $this->modx->getCollection('modContext', array('key:NOT IN' => array('mgr')));
+        $contexts = $this->modx->getCollection('modContext', array('key:!=' => 'mgr'));
         foreach ($contexts as $context) {
             $contextKeys[] = $context->get('key');
         }

--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -146,14 +146,25 @@ class modSearchProcessor extends modProcessor
         $type = 'resources';
         $typeLabel = $this->modx->lexicon('search_resulttype_' . $type);
 
+        $contextKeys = array();
+        $contexts = $this->modx->getCollection('modContext', array('key:NOT IN' => array('mgr')));
+        foreach ($contexts as $context) {
+            $contextKeys[] = $context->get('key');
+        }
+
         $c = $this->modx->newQuery('modResource');
         $c->where(array(
-            'pagetitle:LIKE' => '%' . $this->query .'%',
-            'OR:longtitle:LIKE' => '%' . $this->query .'%',
-            'OR:alias:LIKE' => '%' . $this->query .'%',
-            'OR:description:LIKE' => '%' . $this->query .'%',
-            'OR:introtext:LIKE' => '%' . $this->query .'%',
-            'OR:id:=' => $this->query,
+            array(
+                'pagetitle:LIKE' => '%' . $this->query .'%',
+                'OR:longtitle:LIKE' => '%' . $this->query .'%',
+                'OR:alias:LIKE' => '%' . $this->query .'%',
+                'OR:description:LIKE' => '%' . $this->query .'%',
+                'OR:introtext:LIKE' => '%' . $this->query .'%',
+                'OR:id:=' => $this->query,
+            ),
+            array(
+                'context_key:IN' => $contextKeys,
+            )
         ));
         $c->sortby('createdon', 'DESC');
 


### PR DESCRIPTION
### What does it do?

Adds a context_key check to the query for searching through resources.
### Why is it needed?

Previously it was possible to find resources that belong to a context where a user didn't have access permissions for. By calling `getCollection('modContext')` MODX checks the context ACLs and returns only contexts that are accessible for the current user.
### Related issue(s)/PR(s)

https://modxcommunity.slack.com/archives/general/p1460634256003370
