### PR TITLE
Remove excess brace from copyright on login page

### DIFF
--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -108,7 +108,7 @@
         <br class="clear" />
     </div>
 
-    <p class="loginLicense">{$_lang.login_copyright|replace:'[[+current_year]]':{'Y'|date}}}</p>
+    <p class="loginLicense">{$_lang.login_copyright|replace:'[[+current_year]]':{'Y'|date}}</p>
 </div>
 
 <div id="modx-login-language-select-div">


### PR DESCRIPTION
### What does it do?

Removes excess brace from copyright line.
### Why is it needed?

Because of OCD? :stuck_out_tongue:
### Related issue(s)/PR(s)

n/a

![screenshot_041416_052317_pm](https://cloud.githubusercontent.com/assets/114390/14527766/9581574c-0265-11e6-957d-ec7531ce740b.jpg)
