### PR TITLE
#12951 References of passed scriptProperties gets lost on its way to …

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -294,11 +294,11 @@ class modParser {
             if (is_string($propSource)) {
                 $properties = $this->parsePropertyString($propSource, true);
             } elseif (is_array($propSource)) {
-                foreach ($propSource as $propName => $property) {
+                foreach ($propSource as $propName => &$property) {
                     if (is_array($property) && array_key_exists('value', $property)) {
                         $properties[$propName]= $property['value'];
                     } else {
-                        $properties[$propName]= $property;
+                        $properties[$propName]= &$property;
                     }
                 }
             }


### PR DESCRIPTION
### What does it do?

$property as reference
### Why is it needed?

Reference to values passed by reference got lost and could not longer be manupulated within plugins
### Related issue(s)/PR(s)
#12951
