### PR TITLE
store and restore plugin-event-name before running inner plugins

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1583,6 +1583,7 @@ class modX extends xPDO {
             //$this->log(modX::LOG_LEVEL_DEBUG,'System event '.$eventName.' was executed but does not exist.');
             return false;
         }
+        $oldEventName = $this->event->name;//store current eventname        
         $results= array ();
         if (count($this->eventMap[$eventName])) {
             $this->event= new modSystemEvent();
@@ -1626,6 +1627,7 @@ class modX extends xPDO {
                 }
             }
         }
+        $this->event->name= $oldEventName;//get eventname back after looping        
         return $results;
     }
 


### PR DESCRIPTION
### What does it do?

stores modx->event->name and restores it after running plugins invoked by other plugins
### Why is it needed?

event->name gets lost, when a plugin is invoked within another plugin. 
For reference see 
https://forums.modx.com/thread/97694/support-comments-for-tinymcewrapper?page=10#dis-post-532301
### Related issue(s)/PR(s)
