### PR TITLE
new grunt bump task

### DIFF
--- a/_build/templates/default/package.json
+++ b/_build/templates/default/package.json
@@ -1,22 +1,23 @@
 {
   "name": "revolution-theme-default",
   "title": "MODX Revolution",
-  "version": "2.3.0",
+  "version": "2.5.0",
   "repository": "https://github.com/modxcms/revolution",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^3.0.3",
     "grunt-bower-task": "^0.4.0",
     "grunt-contrib-clean": "^0.5.0",
-    "grunt-contrib-copy": "^0.6.0",
     "grunt-contrib-concat": "^0.5.1",
+    "grunt-contrib-copy": "^0.6.0",
     "grunt-contrib-csslint": "^0.4.0",
     "grunt-contrib-cssmin": "^0.13.0",
-    "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-uglify": "^0.9.2",
+    "grunt-contrib-watch": "^0.6.1",
     "grunt-growl": "^0.1.5",
     "grunt-imageoptim": "^1.4.1",
     "grunt-rename": "^0.1.4",
-    "grunt-sass": "^1.0.0"
+    "grunt-sass": "^1.0.0",
+    "grunt-string-replace": "^1.2.1"
   }
 }


### PR DESCRIPTION
### What does it do?

Added a new `grunt bump` tasks that  will update the README.md copyright messaging to
the current year and update the version to the current MODX version in package.json. It also adds a console log that whenever any grunt tasks will output something like `Grunting MODX-2.5.0-rc2`. 
### Why is it needed?

It isn't critical, but this automates the process of keeping copyright, versioning, and release info up to date.
### Related issue(s)/PR(s)

modxcms/revolution#12930

grunt bump:copyright will update the README.md copyright messaging to
the current year
grunt bump:pkg will update the version to the current MODX version in
package.json

This should be run before tagging new releases.

```
grunt bump
grunt build
```
