### PR TITLE
Remove :first-of-type, reduce padding on container

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -252,10 +252,6 @@ input::-moz-focus-inner {
     padding-bottom: 0; /* override extjs default theme styles */
 
     &:first-of-type {
-      /* do not add the top padding for the first .x-form-item-label */
-      label.x-form-item-label {
-        padding: 0 0 4px 0;
-
         .modx-tv-reset {
           padding: 2px 8px 0 0;
         }

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -981,6 +981,10 @@ iframe[classname="x-hidden"] {
   padding-left: 15px;
 }
 
+#modx-resource-settings .main-wrapper {
+  padding-top: 0px;
+}
+
 /*
 #modx-resource-settings .modx-tv-label,
 #modx-page-settings .modx-tv-label {


### PR DESCRIPTION
### What does it do?

As noted in #12221, if you hide the template dropdown using form customization, you will have a weird offline padding on the left and right panels. This is due to the line of css that reduces the padding for the `:first-of-type` element, which will still be the template dropdown.

This pull removes this reduced padding (it is only used in the resource interface), and instead removes the padding given to the entire resource container.
### Why is it needed?

Argument given above
### Related issue(s)/PR(s)
#12221
