### PR TITLE
Set correct title to edit fc set

### DIFF
--- a/core/lexicon/en/formcustomization.inc.php
+++ b/core/lexicon/en/formcustomization.inc.php
@@ -93,6 +93,7 @@ $_lang['set_import_msg'] = 'Select an XML file to import a Form Customization Se
 $_lang['set_import_template_err_nf'] = 'Template not found while import Form Customization Set.';
 $_lang['set_msg'] = 'Here you can edit what fields, tabs and Template Variables show for this page, as well as their labels and default values. Just double-click on a column to edit its value. You can also use the tab key to progress through the grid. Leave a field blank to use the default setting.';
 $_lang['set_new'] = 'Create New Set';
+$_lang['set_edit'] = 'Edit Set';
 $_lang['set_remove'] = 'Delete Set';
 $_lang['set_remove_confirm'] = 'Are you sure you want to permanently remove this set? This is irreversable.';
 $_lang['set_remove_multiple'] = 'Delete Multiple Sets';

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -15,7 +15,7 @@ MODx.panel.FCSet = function(config) {
         ,class_key: 'modFormCustomizationSet'
         ,cls: 'container'
         ,items: [{
-            html: '<h2>'+_('set_new')+'</h2>'
+            html: '<h2>'+_('set_edit')+'</h2>'
             ,border: false
             ,cls: 'modx-page-header'
             ,id: 'modx-fcs-header'


### PR DESCRIPTION
### What does it do?

The title for edit fc set is wrong. It says `Create New Set`. While in the popup at `security/forms/profile/edit` this is correct, it is impossible to access this view in the browser (there is no `security/forms/set/new`, only `security/forms/set/update`.
### Why is it needed?

Misleading title
### Related issue(s)/PR(s)

Reported in #12557
