### PR TITLE
List empty as default template in system settings

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -363,6 +363,7 @@ MODx.combo.Template = function(config) {
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'element/template/getlist'
+            ,combo: 1
         }
         // ,listWidth: 350
         ,allowBlank: true


### PR DESCRIPTION
### What does it do?

In system settings you can set the default template. This can be any template, except `(empty)`. This pull request adds functionality for setting `(empty)` as well. 

As far as I can tell, this addition in the default combo does not conflict with anywhere else it is loaded.
### Why is it needed?

Some people want that functionality.
### Related issue(s)/PR(s)

Reported in #8927
