### PR TITLE
Checking for redirects in the config check for open core directories

### DIFF
--- a/core/model/modx/processors/system/config_check.inc.php
+++ b/core/model/modx/processors/system/config_check.inc.php
@@ -102,8 +102,18 @@ if (substr( $real_core, 0,  strlen($real_base)) == $real_base) {
             curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP + CURLPROTO_HTTPS);
         } else {
-            $modx->log(modX::LOG_LEVEL_DEBUG, "[configcheck] open_basedir restriction in effect. May not follow redirects.");
-            /* TODO: implement manual redirect algo here */
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+            $rch = curl_copy_handle($ch);
+            // Check for redirects
+            curl_setopt($rch, CURLOPT_URL, $url);
+            curl_exec($rch);
+            if (!curl_errno($rch)) {
+                $newurl = curl_getinfo($rch, CURLINFO_REDIRECT_URL);
+                curl_close($rch);
+                curl_setopt($ch, CURLOPT_URL, $newurl);
+            } else {
+                $modx->log(modX::LOG_LEVEL_DEBUG, "[configcheck] open_basedir restriction in effect. May not follow redirects.");
+            }
         }
 
         /* do not download anything */

--- a/core/model/modx/processors/system/config_check.inc.php
+++ b/core/model/modx/processors/system/config_check.inc.php
@@ -111,8 +111,6 @@ if (substr( $real_core, 0,  strlen($real_base)) == $real_base) {
                 $newurl = curl_getinfo($rch, CURLINFO_REDIRECT_URL);
                 curl_close($rch);
                 curl_setopt($ch, CURLOPT_URL, $newurl);
-            } else {
-                $modx->log(modX::LOG_LEVEL_DEBUG, "[configcheck] open_basedir restriction in effect. May not follow redirects.");
             }
         }
 


### PR DESCRIPTION
### What does it do?

Add a single redirect check for open_basedir restricted servers. It works with PHP 5.3.7+, maybe better than nothing. It resolves one redirect. More redirects should be done better using recursion.
### Why is it needed?

Proposal to remove the TODO
