### PR TITLE
Add missing viewport meta tag needed to enable the responsive manager

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -3,8 +3,9 @@
 <head>
 <title>{if $_pagetitle}{$_pagetitle} | {/if}{$_config.site_name|strip_tags|escape}</title>
 <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 
-{if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
+    {if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
 
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
 <link rel="stylesheet" type="text/css" href="{$indexCss}?v={$versionToken}" />

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -3,6 +3,7 @@
 <head>
     <title>{$_lang.login_title}</title>
     <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     {if $_config.manager_favicon_url}<link rel="shortcut icon" type="image/x-icon" href="{$_config.manager_favicon_url}" />{/if}
 
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />


### PR DESCRIPTION
### What does it do?

Adds the viewport meta tag to the header of the manager template and the login template. Using the options `width=device-width, initial-scale=1` per the recommendation at CSS Tricks https://css-tricks.com/snippets/html/responsive-meta-tag/
### Why is it needed?

The responsive manager features are not currently working on all mobile/tablet devices because the viewport meta tag is missing. It would work as responsive when using a desktop and resizing the browser or using responsive preview modes, but not on real mobile devices. 

Not sure how this went unnoticed until now but as the integrator that merged the original PR, I'm sorry for not testing this thoroughly enough on different devices. 
### Related issue(s)/PR(s)

There is no separate issue for this bug. 
