### PR TITLE
Implement logging when calling snippets that does not exist

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2086,4 +2086,13 @@ $settings['preserve_menuindex']->fromArray(array (
     'area' => 'manager',
     'editedon' => null,
 ), '', true, true);
+$settings['log_snippet_not_found']= $xpdo->newObject('modSystemSetting');
+$settings['log_snippet_not_found']->fromArray(array (
+    'key' => 'log_snippet_not_found',
+    'value' => false,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'site',
+    'editedon' => null,
+), '', true, true);
 return $settings;

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -813,3 +813,6 @@ $_lang['setting_default_username_desc'] = 'Default username for an unauthenticat
 
 $_lang['setting_manager_use_fullname'] = 'Show fullname in manager header ';
 $_lang['setting_manager_use_fullname_desc'] = 'If set to yes, the content of the "fullname" field will be shown in manager instead of "loginname"';
+
+$_lang['log_snippet_not_found'] = 'Log snippets not found';
+$_lang['log_snippet_not_found_desc'] = 'If set to yes, snippets that are called but not found will be logged to the error log.';

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -520,6 +520,11 @@ class modParser {
                         $element->setCacheable($cacheable);
                         $elementOutput= $element->process($tagPropString);
                     }
+                    else {
+                        if ($this->modx->getOption('log_snippet_not_found', null, false)) {
+                            $this->modx->log(xPDO::LOG_LEVEL_ERROR, "Could not find snippet with name {$tagName}.");
+                        }
+                    }
             }
         }
         if (($elementOutput === null || $elementOutput === false) && $outerTag !== $tag[0]) {


### PR DESCRIPTION
### What does it do?

This pull request adds functionality to log snippets that are called but not found in the system to the error log.

A new system setting called `log_snippet_not_found` is added, which is `No` by default to avoid breaking changes. The description for this system setting is: 

> Log snippets not found
> If set to yes, snippets that are called but not found will be logged to the error log.

If turned to `Yes` the following is added to the error.log when a snippet that is not found is called:

> Could not find snippet with name SNIPPET-NAME-HERE.
### Why is it needed?

During development, one of the most common errors to make is to misspell snippets and chunks. Misspelling of chunks can be identified by the lack of HTML output, while misspelling of snippets may be harder to debug efficiently.

This pull request offers a better way to deal with this problem. While this functionality could be handled by a plugin, it feels a bit unnecessary to write a plugin or install an Extra to keep track of misspellings during development.

The implementation suggested here is opt-in, so people that does not want to use this functionality can keep living their lives without it without having to do anything.
### Related issue(s)/PR(s)

Discussed in #12467 (duplicate of #12694).
### Sidenotes

Open for suggestions to both the system setting name, the description and the actual error.log text.
