### PR TITLE
Avoid empty manager theme

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -126,7 +126,7 @@ abstract class modManagerController {
             'action' => $this->config,
         ));
 
-        $this->theme = $this->modx->getOption('manager_theme',null,'default');
+        $this->theme = $this->modx->getOption('manager_theme',null,'default',true);
 
         $this->prepareLanguage();
         $this->setPlaceholder('_ctx',$this->modx->context->get('key'));


### PR DESCRIPTION
### What does it do?

Adds a fourth parameter to the getOption that decides what manager theme to load. With this setting it will return the "default" theme even if the setting is empty.
### Why is it needed?

Might crash the manager. Only way to fix it is via database.
### Related issue(s)/PR(s)

Reported in #12355. Looks like it was fixed in [this fork](https://github.com/Lefthandmedia/revolution/commit/63c584e8a9e01e9da52aa25430a7dc1cf4c60563), but it was never pull requested or merged.
