### PR TITLE
Updating user setting for the wrong user

### DIFF
--- a/core/model/modx/processors/security/user/setting/update.class.php
+++ b/core/model/modx/processors/security/user/setting/update.class.php
@@ -39,7 +39,7 @@ class modUserSettingUpdateProcessor extends modSystemSettingsUpdateProcessor {
             return $this->modx->lexicon('access_denied');
         }
 
-        return parent::initialize();
+        return true;
     }
 
 }


### PR DESCRIPTION
### What does it do?

Fixing updating user setting for the wrong user
### Why is it needed?

At the moment changing a user setting updates this for the first user found instead of updating the setting for the edited user.
### Related issue(s)/PR(s)

See #12966 and the discussion on https://forums.modx.com/thread/100020/user-settings-bug#dis-post-540910
