### PR TITLE
Avoid empty manager theme

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -126,7 +126,7 @@ abstract class modManagerController {
             'action' => $this->config,
         ));
 
-        $this->theme = $this->modx->getOption('manager_theme',null,'default');
+        $this->theme = $this->modx->getOption('manager_theme',null,'default',true);
 
         $this->prepareLanguage();
         $this->setPlaceholder('_ctx',$this->modx->context->get('key'));


### PR DESCRIPTION
### What does it do?

Defaults to theme 'default' when the manager-theme is empty
### Why is it needed?

to prevent an empty manager when theme is empty
### Related issue(s)/PR(s)

Fixes issue #12355

Prevent empty manager theme to lock up manager
