### PR TITLE
Fixed misprint

### DIFF
--- a/_build/templates/default/sass/_help.scss
+++ b/_build/templates/default/sass/_help.scss
@@ -79,7 +79,7 @@
   display: block;
   margin: 0 auto;
   padding: 0 0 10px;
-  wdith: auto;
+  width: auto;
 }
 
 #managerbuttons ul li a:hover span.icon {


### PR DESCRIPTION
### What does it do?

Fix misprint from `wdith` to `width`
