### PR TITLE
Performance fix for #12692

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -233,7 +233,7 @@ class modCacheManager extends xPDOCacheManager {
                 $matches= array();
                 if (preg_match_all('~\{(.*?)\}~', $v, $matches, PREG_SET_ORDER)) {
                     foreach ($matches as $match) {
-                        if (array_key_exists("{$match[1]}", $this->modx->config)) {
+                        if (isset ($this->modx->config["{$match[1]}"])) {
                             $matchValue= $this->modx->config["{$match[1]}"];
                             $v= str_replace($match[0], $matchValue, $v);
                         }


### PR DESCRIPTION
### What does it do?

Replace array_key_exists with isset
### Why is it needed?

Restore better performance
### Related issue(s)/PR(s)
#12692
