### PR TITLE
Fix rare database connection setup error (new installs/advanced upgrades)

### DIFF
--- a/setup/processors/connector.php
+++ b/setup/processors/connector.php
@@ -7,6 +7,7 @@
 /* do a little bit of environment cleanup if possible */
 @ini_set('magic_quotes_runtime',0);
 @ini_set('magic_quotes_sybase',0);
+@ini_set('opcache.revalidate_freq', 0);
 
 /* start session */
 session_start();


### PR DESCRIPTION
### What does it do?

It ensures the setup connector does not cache stale database connection settings (core/cache/setup/settings.cache.php) in certain scenarios for some systems.
### Why is it needed?

This fix is an extension of #11202, only this specifically aims to solve occasional database connection errors during new installs or advanced upgrades.
### Related issue(s)/PR(s)

Fixes #6013 #12274 and #12829
