### PR TITLE
Fixed permissions for new files

### DIFF
--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -129,7 +129,7 @@ class xPDOCacheManager {
      */
     public function getFilePermissions() {
         $perms = 0666;
-        $perms = $perms & (0666 - $this->_umask);
+        $perms = $perms & (0777 - $this->_umask);
         return $perms;
     }
 

--- a/setup/includes/runner/modinstallrunner.class.php
+++ b/setup/includes/runner/modinstallrunner.class.php
@@ -194,7 +194,7 @@ abstract class modInstallRunner {
                 }
             }
         }
-        $perms = $this->install->settings->get('new_file_permissions', sprintf("%04o", 0666 & (0666 - umask())));
+        $perms = $this->install->settings->get('new_file_permissions', sprintf("%04o", 0666 & (0777 - umask())));
         if (is_string($perms)) $perms = octdec($perms);
         $chmodSuccess = @ chmod($configFile, $perms);
         if ($written) {


### PR DESCRIPTION
### What does it do?

Perms for new files will be correct
### Why is it needed?

If umask is 0077, files creates with rights 0466

```
<?php
$perms = 0666;
$perms = $perms & (0666 - 0077);
print 'Rights: ' . decoct($perms) . '<br><br>';
// Rights: 466
```

Now it will be correct:

```
0666 & (0777 - 0277) = 400
0666 & (0777 - 0077) = 600
0666 & (0777 - 0022) = 644
```
### Related issue(s)/PR(s)
