### PR TITLE
2.5.x Fix for 500 error after install using STRICT_TRANS_TABLES mode in mySQL

### DIFF
--- a/core/config/config.inc.tpl
+++ b/core/config/config.inc.tpl
@@ -1,0 +1,91 @@
+<?php
+/**
+ *  MODX Configuration file
+ */
+$database_type = '{database_type}';
+$database_server = '{database_server}';
+$database_user = '{database_user}';
+$database_password = '';
+$database_connection_charset = '{database_connection_charset}';
+$dbase = '{dbase}';
+$table_prefix = '{table_prefix}';
+$database_dsn = '{database_dsn}';
+$config_options = {config_options};
+$driver_options = {driver_options};
+
+$lastInstallTime = 1462392522;
+
+$site_id = 'modx572a56ca5961e6.56115357';
+$site_sessionname = '{site_sessionname}';
+$https_port = '{https_port}';
+$uuid = '79501b56-a52c-4ab6-ab5f-9296422a0273';
+
+if (!defined('MODX_CORE_PATH')) {
+    $modx_core_path= '{core_path}';
+    define('MODX_CORE_PATH', $modx_core_path);
+}
+if (!defined('MODX_PROCESSORS_PATH')) {
+    $modx_processors_path= '{processors_path}';
+    define('MODX_PROCESSORS_PATH', $modx_processors_path);
+}
+if (!defined('MODX_CONNECTORS_PATH')) {
+    $modx_connectors_path= '{connectors_path}';
+    $modx_connectors_url= '{connectors_url}';
+    define('MODX_CONNECTORS_PATH', $modx_connectors_path);
+    define('MODX_CONNECTORS_URL', $modx_connectors_url);
+}
+if (!defined('MODX_MANAGER_PATH')) {
+    $modx_manager_path= '{mgr_path}';
+    $modx_manager_url= '{mgr_url}';
+    define('MODX_MANAGER_PATH', $modx_manager_path);
+    define('MODX_MANAGER_URL', $modx_manager_url);
+}
+if (!defined('MODX_BASE_PATH')) {
+    $modx_base_path= '{web_path}';
+    $modx_base_url= '{web_url}';
+    define('MODX_BASE_PATH', $modx_base_path);
+    define('MODX_BASE_URL', $modx_base_url);
+}
+if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
+    $isSecureRequest = false;
+} else {
+    $isSecureRequest = ((isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $https_port);
+}
+if (!defined('MODX_URL_SCHEME')) {
+    $url_scheme=  $isSecureRequest ? 'https://' : 'http://';
+    define('MODX_URL_SCHEME', $url_scheme);
+}
+if (!defined('MODX_HTTP_HOST')) {
+    if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
+        $http_host='{http_host}';
+        define('MODX_HTTP_HOST', $http_host);
+    } else {
+        $http_host= array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : '{http_host}';
+        if ($_SERVER['SERVER_PORT'] != 80) {
+            $http_host= str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
+        }
+        $http_host .= ($_SERVER['SERVER_PORT'] == 80 || $isSecureRequest) ? '' : ':' . $_SERVER['SERVER_PORT'];
+        define('MODX_HTTP_HOST', $http_host);
+    }
+}
+if (!defined('MODX_SITE_URL')) {
+    $site_url= $url_scheme . $http_host . MODX_BASE_URL;
+    define('MODX_SITE_URL', $site_url);
+}
+if (!defined('MODX_ASSETS_PATH')) {
+    $modx_assets_path= '{assets_path}';
+    $modx_assets_url= '{assets_url}';
+    define('MODX_ASSETS_PATH', $modx_assets_path);
+    define('MODX_ASSETS_URL', $modx_assets_url);
+}
+if (!defined('MODX_LOG_LEVEL_FATAL')) {
+    define('MODX_LOG_LEVEL_FATAL', 0);
+    define('MODX_LOG_LEVEL_ERROR', 1);
+    define('MODX_LOG_LEVEL_WARN', 2);
+    define('MODX_LOG_LEVEL_INFO', 3);
+    define('MODX_LOG_LEVEL_DEBUG', 4);
+}
+if (!defined('MODX_CACHE_DISABLED')) {
+    $modx_cache_disabled= {cache_disabled};
+    define('MODX_CACHE_DISABLED', $modx_cache_disabled);
+}

--- a/core/model/modx/mysql/modcontextsetting.map.inc.php
+++ b/core/model/modx/mysql/modcontextsetting.map.inc.php
@@ -4,117 +4,188 @@
  * @subpackage mysql
  */
 $xpdo_meta_map['modContextSetting']= array (
-  'package' => 'modx',
-  'version' => '1.1',
-  'table' => 'context_setting',
-  'extends' => 'xPDOObject',
-  'fields' => 
-  array (
-    'context_key' => NULL,
-    'key' => NULL,
-    'value' => NULL,
-    'xtype' => 'textfield',
-    'namespace' => 'core',
-    'area' => '',
-    'editedon' => '0',
+
+ 	'package' => 'modx',
+
+ 	'version' => '1.1',
+
+ 	'table' => 'context_setting',
+
+ 	'extends' => 'xPDOObject',
+
+ 	'fields' =>		array (
+
+ 					'context_key' => NULL,
+
+ 					'key' => NULL,
+ 					'value' => NULL,
+
+ 					'xtype' => 'textfield',
+
+ 					'namespace' => 'core',
+
+ 					'area' => '',
+
+ 					'editedon' => NULL,
   ),
-  'fieldMeta' => 
-  array (
-    'context_key' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '255',
-      'phptype' => 'string',
-      'null' => false,
-      'index' => 'pk',
+
+ 	'fieldMeta' =>	array (
+
+ 					'context_key' =>	array (
+
+ 											'dbtype' => 'varchar',
+
+ 											'precision' => '255',
+
+ 											'phptype' => 'string',
+
+ 											'null' => false,
+
+ 											'index' => 'pk',
     ),
-    'key' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '50',
-      'phptype' => 'string',
-      'null' => false,
-      'index' => 'pk',
+
+ 					'key' =>			array (
+
+ 											'dbtype' => 'varchar',
+
+ 											'precision' => '50',
+
+ 											'phptype' => 'string',
+
+ 											'null' => false,
+
+ 											'index' => 'pk',
     ),
-    'value' => 
-    array (
-      'dbtype' => 'mediumtext',
-      'phptype' => 'string',
+
+ 					'value' =>			array (
+
+ 											'dbtype' => 'mediumtext',
+
+ 											'phptype' => 'string',
     ),
-    'xtype' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '75',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => 'textfield',
+
+ 					'xtype' =>			array (
+
+ 											'dbtype' => 'varchar',
+
+ 											'precision' => '75',
+
+ 											'phptype' => 'string',
+
+ 											'null' => false,
+
+ 											'default' => 'textfield',
     ),
-    'namespace' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '40',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => 'core',
+
+ 					'namespace' =>		array (
+
+ 											'dbtype' => 'varchar',
+
+ 											'precision' => '40',
+
+ 											'phptype' => 'string',
+
+ 											'null' => false,
+
+ 											'default' => 'core',
     ),
-    'area' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '255',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => '',
+
+ 					'area' =>			array (
+
+ 											'dbtype' => 'varchar',
+
+ 											'precision' => '255',
+
+ 											'phptype' => 'string',
+
+ 											'null' => false,
+
+ 											'default' => '',
     ),
-    'editedon' => 
-    array (
-      'dbtype' => 'timestamp',
-      'phptype' => 'timestamp',
-      'null' => false,
-      'default' => '0',
-      'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+
+ 					'editedon' =>		array (
+
+ 											'dbtype' => 'timestamp',
+
+ 											'phptype' => 'timestamp',
+
+ 											'null' => true,
+
+ 											'default' => NULL,
+
+ 											'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
-  ),
-  'indexes' => 
-  array (
-    'PRIMARY' => 
+
+ 					),
+
+ 	'indexes' =>	array (
+
+ 					'PRIMARY' => 
     array (
-      'alias' => 'PRIMARY',
-      'primary' => true,
-      'unique' => true,
-      'columns' => 
+
+ 											'alias' => 'PRIMARY',
+
+ 											'primary' => true,
+
+ 											'unique' => true,
+
+ 											'columns' => 
       array (
-        'context_key' => 
-        array (
-          'collation' => 'A',
-          'null' => false,
+
+ 																	'context_key' =>	array (
+
+ 																						'collation' => 'A',
+
+ 																						'null' => false,
         ),
-        'key' => 
-        array (
-          'collation' => 'A',
-          'null' => false,
+
+ 																	'key' =>			array (
+
+ 																						'collation' => 'A',
+
+ 																						'null' => false,
         ),
-      ),
-    ),
-  ),
+
+ 																),
+
+ 									),
+
+ 					),
   'aggregates' => 
   array (
-    'Context' => 
+
+ 											'Context' => 
     array (
-      'class' => 'modContext',
-      'key' => 'context_key',
-      'local' => 'context_key',
-      'foreign' => 'key',
-      'cardinality' => 'one',
-      'owner' => 'foreign',
+
+ 																	'class' => 'modContext',
+
+ 																	'key' => 'context_key',
+
+ 																	'local' => 'context_key',
+
+ 																	'foreign' => 'key',
+
+ 																	'cardinality' => 'one',
+
+ 																	'owner' => 'foreign',
     ),
-    'SystemSetting' => 
+
+ 											'SystemSetting' => 
     array (
-      'class' => 'modSystemSetting',
-      'key' => 'key',
-      'local' => 'key',
-      'foreign' => 'key',
-      'cardinality' => 'one',
-      'owner' => 'foreign',
+
+ 																	'class' => 'modSystemSetting',
+
+ 																	'key' => 'key',
+
+ 																	'local' => 'key',
+
+ 																	'foreign' => 'key',
+
+ 																	'cardinality' => 'one',
+
+ 																	'owner' => 'foreign',
     ),
-  ),
-);
+
+ 										),
+
+ );

--- a/core/model/modx/mysql/modlexiconentry.map.inc.php
+++ b/core/model/modx/mysql/modlexiconentry.map.inc.php
@@ -16,7 +16,7 @@ $xpdo_meta_map['modLexiconEntry']= array (
     'namespace' => 'core',
     'language' => 'en',
     'createdon' => NULL,
-    'editedon' => '0',
+    'editedon' => NULL,
   ),
   'fieldMeta' => 
   array (
@@ -72,8 +72,8 @@ $xpdo_meta_map['modLexiconEntry']= array (
     array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
-      'null' => false,
-      'default' => '0',
+      'null' => true,
+      'default' => NULL,
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/modx/mysql/modsystemsetting.map.inc.php
+++ b/core/model/modx/mysql/modsystemsetting.map.inc.php
@@ -3,107 +3,108 @@
  * @package modx
  * @subpackage mysql
  */
-$xpdo_meta_map['modSystemSetting']= array (
-  'package' => 'modx',
-  'version' => '1.1',
-  'table' => 'system_settings',
-  'extends' => 'xPDOObject',
-  'fields' => 
-  array (
-    'key' => '',
-    'value' => '',
-    'xtype' => 'textfield',
-    'namespace' => 'core',
-    'area' => '',
-    'editedon' => '0',
-  ),
-  'fieldMeta' => 
-  array (
-    'key' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '50',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => '',
-      'index' => 'pk',
-    ),
-    'value' => 
-    array (
-      'dbtype' => 'text',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => '',
-    ),
-    'xtype' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '75',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => 'textfield',
-    ),
-    'namespace' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '40',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => 'core',
-    ),
-    'area' => 
-    array (
-      'dbtype' => 'varchar',
-      'precision' => '255',
-      'phptype' => 'string',
-      'null' => false,
-      'default' => '',
-    ),
-    'editedon' => 
-    array (
-      'dbtype' => 'timestamp',
-      'phptype' => 'timestamp',
-      'null' => false,
-      'default' => '0',
-      'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
-    ),
-  ),
-  'indexes' => 
-  array (
-    'PRIMARY' => 
-    array (
-      'alias' => 'PRIMARY',
-      'primary' => true,
-      'unique' => true,
-      'type' => 'BTREE',
-      'columns' => 
-      array (
-        'key' => 
-        array (
-          'length' => '',
-          'collation' => 'A',
-          'null' => false,
-        ),
-      ),
-    ),
-  ),
-  'aggregates' => 
-  array (
-    'ContextSetting' => 
-    array (
-      'class' => 'modContextSetting',
-      'local' => 'key',
-      'foreign' => 'key',
-      'cardinality' => 'one',
-      'owner' => 'local',
-    ),
-    'Namespace' => 
-    array (
-      'class' => 'modNamespace',
-      'local' => 'namespace',
-      'foreign' => 'name',
-      'cardinality' => 'one',
-      'owner' => 'foreign',
-    ),
-  ),
-);
+$xpdo_meta_map['modSystemSetting']=
+	array (
+  		'package' => 'modx',
+  		'version' => '1.1',
+  		'table' => 'system_settings',
+  		'extends' => 'xPDOObject',
+  		'fields' => 
+  			array (
+    			'key' => '',
+    			'value' => '',
+    			'xtype' => 'textfield',
+    			'namespace' => 'core',
+    			'area' => '',
+    			'editedon' => NULL,
+  			),
+  		'fieldMeta' => 
+  			array (
+    			'key' => 
+    				array (
+      					'dbtype' => 'varchar',
+      					'precision' => '50',
+      					'phptype' => 'string',
+      					'null' => false,
+      					'default' => '',
+      					'index' => 'pk',
+					),
+    			'value' => 
+    				array (
+      					'dbtype' => 'text',
+      					'phptype' => 'string',
+      					'null' => false,
+      					'default' => '',
+    				),
+    			'xtype' => 
+    				array (
+      					'dbtype' => 'varchar',
+      					'precision' => '75',
+      					'phptype' => 'string',
+      					'null' => false,
+      					'default' => 'textfield',
+    				),
+    			'namespace' => 
+    				array (
+      					'dbtype' => 'varchar',
+      					'precision' => '40',
+      					'phptype' => 'string',
+      					'null' => false,
+      					'default' => 'core',
+    				),
+    			'area' => 
+    				array (
+      					'dbtype' => 'varchar',
+      					'precision' => '255',
+      					'phptype' => 'string',
+      					'null' => false,
+      					'default' => '',
+    				),
+    			'editedon' => 
+    				array (
+      					'dbtype' => 'timestamp',
+      					'phptype' => 'timestamp',
+      					'null' => true,
+      					'default' => NULL,
+      					'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+    				),
+  			),
+  		'indexes' => 
+  			array (
+    			'PRIMARY' => 
+    				array (
+      					'alias' => 'PRIMARY',
+      					'primary' => true,
+      					'unique' => true,
+      					'type' => 'BTREE',
+      					'columns' => 
+      						array (
+        						'key' => 
+        							array (
+          								'length' => '',
+          								'collation' => 'A',
+          								'null' => false,
+        							),
+      						),
+    				),
+  			),
+  		'aggregates' => 
+  			array (
+    			'ContextSetting' => 
+    				array 	(
+      					'class' => 'modContextSetting',
+      					'local' => 'key',
+      					'foreign' => 'key',
+      					'cardinality' => 'one',
+      					'owner' => 'local',
+    				),
+    			'Namespace' => 
+    				array (
+      					'class' => 'modNamespace',
+      					'local' => 'namespace',
+      					'foreign' => 'name',
+      					'cardinality' => 'one',
+      					'owner' => 'foreign',
+    				),
+  			),
+	);

--- a/core/model/modx/mysql/modusergroupsetting.map.inc.php
+++ b/core/model/modx/mysql/modusergroupsetting.map.inc.php
@@ -16,7 +16,7 @@ $xpdo_meta_map['modUserGroupSetting']= array (
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => '',
-    'editedon' => '0',
+    'editedon' => NULL,
   ),
   'fieldMeta' => 
   array (
@@ -70,8 +70,8 @@ $xpdo_meta_map['modUserGroupSetting']= array (
     array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
-      'null' => false,
-      'default' => '0',
+      'null' => true,
+      'default' => NULL,
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/modx/mysql/modusersetting.map.inc.php
+++ b/core/model/modx/mysql/modusersetting.map.inc.php
@@ -16,7 +16,7 @@ $xpdo_meta_map['modUserSetting']= array (
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => '',
-    'editedon' => '0',
+    'editedon' => NULL,
   ),
   'fieldMeta' => 
   array (
@@ -71,8 +71,8 @@ $xpdo_meta_map['modUserSetting']= array (
     array (
       'dbtype' => 'timestamp',
       'phptype' => 'timestamp',
-      'null' => false,
-      'default' => '0',
+      'null' => true,
+      'default' => NULL,
       'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
     ),
   ),

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -476,7 +476,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="0" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default=NULL attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
             <column key="context_key" collation="A" null="false" />
@@ -670,7 +670,7 @@
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" index="index" />
         <field key="language" dbtype="varchar" precision="20" phptype="string" null="false" default="en" index="index" />
         <field key="createdon" dbtype="datetime" phptype="datetime" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="0" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default=NULL attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="name" name="name" primary="false" unique="false" type="BTREE">
             <column key="name" length="" collation="A" null="false" />
@@ -697,7 +697,7 @@
 
         <index alias="user_occurred" name="user_occurred" primary="false" unique="false" type="BTREE">
             <column key="user" length="" collation="A" null="false" />
-            <column key="occurred" length="" collation="A" null="false" />
+            <column key="occurred" length="" collation="A" null="false" default="0000-00-00 00:00:00"/>
         </index>
 
         <aggregate alias="User" class="modUser" local="user" foreign="id" owner="foreign" cardinality="one" />
@@ -1096,7 +1096,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="0" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default=NULL attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="key" length="" collation="A" null="false" />
@@ -1348,7 +1348,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="0" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default=NULL attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="group" length="" collation="A" null="false" />
@@ -1414,7 +1414,7 @@
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
         <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" default="0" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default=NULL attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="user" length="" collation="A" null="false" />
@@ -1430,7 +1430,7 @@
     <object class="modWorkspace" table="workspaces" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
         <field key="path" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="unique" />
-        <field key="created" dbtype="datetime" phptype="timestamp" null="false" />
+        <field key="created" dbtype="datetime" phptype="timestamp" null="true" default=NULL/>
         <field key="active" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="attributes" dbtype="mediumtext" phptype="array" />
 


### PR DESCRIPTION
### What does it do?

Changed the default field values for time based fields to NULL to comply with mySQL strict mode.
### Why is it needed?

Strict mode does not allow "zero" values for time based fields.
### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/issues/12838#issuecomment-217008404
