### PR TITLE
Adding $this->modx->stripTags() to pagetitle combo box #13017

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -163,12 +163,12 @@ class ResourceCreateManagerController extends ResourceManagerController {
         $this->resourceArray['syncsite'] = isset($this->resourceArray['syncsite']) && intval($this->resourceArray['syncsite']) == 1 ? true : false;
         if (!empty($this->resourceArray['parent'])) {
             if ($this->parent->get('id') == $this->resourceArray['parent']) {
-                $this->resourceArray['parent_pagetitle'] = $this->parent->get('pagetitle');
+                $this->resourceArray['parent_pagetitle'] = $this->modx->stripTags($this->parent->get('pagetitle'));
             } else {
                 /** @var modResource $overriddenParent */
                 $overriddenParent = $this->modx->getObject('modResource',$this->resourceArray['parent']);
                 if ($overriddenParent) {
-                    $this->resourceArray['parent_pagetitle'] = $overriddenParent->get('pagetitle');
+                    $this->resourceArray['parent_pagetitle'] = $this->modx->stripTags($overriddenParent->get('pagetitle'));
                 }
             }
         }

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -124,11 +124,11 @@ class ResourceUpdateManagerController extends ResourceManagerController {
             : intval($this->context->getOption('syncsite_default', 1, $this->modx->_userConfig)) == 1 ? true : false;
         if (!empty($this->resourceArray['parent'])) {
             if ($this->parent->get('id') == $this->resourceArray['parent']) {
-                $this->resourceArray['parent_pagetitle'] = $this->parent->get('pagetitle');
+                $this->resourceArray['parent_pagetitle'] = $this->modx->stripTags($this->parent->get('pagetitle'));
             } else {
                 $overriddenParent = $this->modx->getObject('modResource',$this->resourceArray['parent']);
                 if ($overriddenParent) {
-                    $this->resourceArray['parent_pagetitle'] = $overriddenParent->get('pagetitle');
+                    $this->resourceArray['parent_pagetitle'] = $this->modx->stripTags($overriddenParent->get('pagetitle'));
                 }
             }
         }


### PR DESCRIPTION
### What does it do?

Added a strip tag process to the page title combobox from on a resource settings tab. 
### Why is it needed?

Save process doesn't stop spinning if a parent has elements in the name e.g. `<span>Overproduced <sup>®</sup></span> Pagetitle`
### Related issue(s)/PR(s)

Closes issue #13017 
