### PR TITLE
Remove double quote from extended fields containers and attributes

### DIFF
--- a/manager/assets/modext/widgets/core/modx.orm.js
+++ b/manager/assets/modext/widgets/core/modx.orm.js
@@ -130,7 +130,7 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
     ,addContainer: function(btn,e,node) {
         var r = {};
         if (node) { r.parent = node.id; }
-
+        
         if (!this.windows.addContainer) {
             this.windows.addContainer = MODx.load({
                 xtype: 'modx-orm-window-container-add'
@@ -138,6 +138,10 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
                 ,tree: this
                 ,listeners: {
                     'success': {fn:function(r) {
+                        if (typeof(r.name) !== 'undefined') {
+                            r.name = r.name.replace(/"/g, '');
+                        }
+                        
                         var n = new Ext.tree.TreeNode({
                             text: r.name
                             ,id: r.name
@@ -162,13 +166,17 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
     ,renameContainer: function(btn,e,node) {
         var r = {};
         if (node) { r.parent = node.id; }
-
+        
         if (!this.windows.renameContainer) {
             this.windows.renameContainer = MODx.load({
                 xtype: 'modx-orm-window-container-rename'
                 ,record: r
                 ,listeners: {
                     'success': {fn:function(r) {
+                        if (typeof(r.name) !== 'undefined') {
+                            r.name = r.name.replace(/"/g, '');
+                        }
+                        
                         var nd = this.getSelectedNode();
                         nd.setId(r.name);
                         nd.setText(r.name);
@@ -191,6 +199,10 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
                 ,tree: this
                 ,listeners: {
                     'success': {fn:function(r) {
+                        if (typeof(r.name) !== 'undefined') {
+                            r.name = r.name.replace(/"/g, '');
+                        }
+                        
                         var n = new Ext.tree.TreeNode({
                             text: r.name+' - <i>'+r.value+'</i>'
                             ,id: r.id
@@ -301,7 +313,7 @@ Ext.extend(MODx.orm.Form,Ext.Panel,{
         var f = fp.getForm();
         var n = t.getSelectionModel().getSelectedNode();
 
-        var txt = f.findField(this.config.prefix+'_name').getValue();
+        var txt = f.findField(this.config.prefix+'_name').getValue().replace(/"/g, '');
         var val = f.findField(this.config.prefix+'_value').getValue();
         n.attributes.id = f.findField(this.config.prefix+'_id').getValue();
         n.attributes.text = txt;


### PR DESCRIPTION
### What does it do?

Makes it impossible to add `"` (double quote) to the name of containers or attributes for users' extended fields.
### Why is it needed?

Because the name is used as a part of the id for the ext object, it is a part of the DOM. Adding something in the DOM with a `"` will break it. It does not work to escape it either (using "\"), so it has to be removed.
#### Tested:
- Adding new container with a quote in the name
- Renaming a container to contain a quote in the name
- Adding an attribute with a quote in the name
- Renaming an attribute to contain a quote in the name
### Related issue(s)/PR(s)
#13012
### Somehow Related
#12841
