### PR TITLE
Add after(append) and before(prepend) output filters.

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -214,6 +214,7 @@ class modOutputFilter {
                         case 'append': /* appends the options value to the input value (if both not empty) */
                             if (!empty($m_val) && !empty($output))
                                 $output = $output.$m_val;
+                            break;
                         case 'before':
                         case 'prepend': /* prepends the options value to the input value (if both not empty) */
                             if (!empty($m_val) && !empty($output))

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -210,6 +210,15 @@ class modOutputFilter {
                             if (!empty($m_val))
                                 $output = $output . $m_val;
                             break;
+                        case 'after':
+                        case 'append': /* appends the options value to the input value (if both not empty) */
+                            if (!empty($m_val) && !empty($output))
+                                $output = $output.$m_val;
+                        case 'before':
+                        case 'prepend': /* prepends the options value to the input value (if both not empty) */
+                            if (!empty($m_val) && !empty($output))
+                                $output = $m_val.$output;
+                            break;
                         case 'lcase':
                         case 'lowercase':
                         case 'strtolower':


### PR DESCRIPTION
### What does it do?

Add after(append) and before(prepend) output filters to able append or prepend values if output not empty. 
### Why is it needed?

Many times did this by separate snippets, maybe it should be built?
