### PR TITLE
Solve #12890 - fixed form customization for checkbox labels

### DIFF
--- a/manager/assets/modext/widgets/core/modx.panel.js
+++ b/manager/assets/modext/widgets/core/modx.panel.js
@@ -282,7 +282,7 @@ Ext.extend(MODx.FormPanel,Ext.FormPanel,{
 
             if (!f) return;
             v = String.format('{0}',vals[i]);
-            if ((f.xtype == 'checkbox' || f.xtype == 'xcheckbox' || f.xtype == 'radio') && flds[i] == 'published') {
+            if (f.xtype == 'checkbox' || f.xtype == 'xcheckbox' || f.xtype == 'radio') {
                 f.setBoxLabel(v);
             } else if (f.label) {
                 f.label.update(v);


### PR DESCRIPTION
### What does it do?

Removed check for fieldname "published".
### Why is it needed?

Labels for checkboxes could not be overridden via form customization.
### Related issue(s)/PR(s)
#12890
