### PR TITLE
Add `uglify:jsgrps` (and `growl:uglify`)  to `grunt build`

### DIFF
--- a/_build/templates/default/gruntfile.js
+++ b/_build/templates/default/gruntfile.js
@@ -273,6 +273,6 @@ module.exports = function(grunt) {
 
     // Tasks
     grunt.registerTask('default', ['growl:watch', 'watch']);
-    grunt.registerTask('build', ['clean:prebuild','bower', 'copy', 'sass:dev','autoprefixer', 'growl:prefixes', 'growl:sass','cssmin:compress','clean:postbuild']);
+    grunt.registerTask('build', ['clean:prebuild', 'bower', 'copy', 'sass:dev', 'autoprefixer', 'growl:prefixes', 'growl:sass', 'cssmin:compress', 'uglify:jsgrps', 'growl:uglify', 'clean:postbuild']);
     grunt.registerTask('compress', ['uglify:jsgrps', 'growl:uglify']);
 };


### PR DESCRIPTION
### What does it do?

Added the `uglify:jsgrps` and `growl:uglify` tasks to the primary `grunt build` command. These two tasks make up the current `grunt compress` command introduced in #12611 which is used to combine and minify the core javascript files used when compress_js is enabled. 
### Why is it needed?

When using grunt on different projects my usual expectation is that a `grunt build` will process all assets, however previously this would only work on the CSS. The primary "jsgrps" file would only get built when calling `grunt compress` specifically. This command still exists as a means of quickly only processing those files, but now a grunt build will do it all.
### Related issue(s)/PR(s)

None. Noticed this while merging other PRs that involved changes to core javascript files but the jsgrps file wasn't getting updated. 
