### PR TITLE
Extended selector to show folder icon for empty containers

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -234,7 +234,7 @@
   @extend %pseudo-font;
   content:$fa-var-folder-open;
 }
-.x-tree-node-collapsed .tree-folder:before {
+.x-tree-node-collapsed .tree-folder:before, .x-tree-node .tree-folder:before {
   @extend %pseudo-font;
   content:$fa-var-folder;
 }


### PR DESCRIPTION
### What does it do?

Extended selector that resources marked as container but without children show the container icon
### Why is it needed?

Even resources without children are containers. This should be reflected by the icon in the tree
### Related issue(s)/PR(s)

Fix for #12742

Ps. only the .scss file was changed. Please process to file to css.
