### PR TITLE
Fix #12910 - Duplicate button is missing when editing Weblinks

### DIFF
--- a/manager/controllers/default/resource/symlink/update.class.php
+++ b/manager/controllers/default/resource/symlink/update.class.php
@@ -33,9 +33,11 @@ class SymlinkUpdateManagerController extends ResourceUpdateManagerController {
                 ,locked: '.($this->locked ? 1 : 0).'
                 ,lockedText: "'.$this->lockedText.'"
                 ,canSave: '.($this->canSave ? 1 : 0).'
-                ,canEdit: "'.($this->modx->hasPermission('edit_document') ? 1 : 0).'"
-                ,canCreate: "'.($this->modx->hasPermission('new_document') ? 1 : 0).'"
-                ,canDelete: "'.($this->modx->hasPermission('delete_document') ? 1 : 0).'"
+                ,canEdit: '.($this->canEdit ? 1 : 0).'
+                ,canCreate: '.($this->canCreate ? 1 : 0).'
+                ,canCreateRoot: '.($this->canCreateRoot ? 1 : 0).'
+                ,canDuplicate: '.($this->canDuplicate ? 1 : 0).'
+                ,canDelete: '.($this->canDelete ? 1 : 0).'
                 ,show_tvs: '.(!empty($this->tvCounts) ? 1 : 0).'
             });
         });

--- a/manager/controllers/default/resource/weblink/update.class.php
+++ b/manager/controllers/default/resource/weblink/update.class.php
@@ -33,9 +33,11 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController {
                 ,locked: '.($this->locked ? 1 : 0).'
                 ,lockedText: "'.$this->lockedText.'"
                 ,canSave: '.($this->canSave ? 1 : 0).'
-                ,canEdit: "'.($this->modx->hasPermission('edit_document') ? 1 : 0).'"
-                ,canCreate: "'.($this->modx->hasPermission('new_document') ? 1 : 0).'"
-                ,canDelete: "'.($this->modx->hasPermission('delete_document') ? 1 : 0).'"
+                ,canEdit: '.($this->canEdit ? 1 : 0).'
+                ,canCreate: '.($this->canCreate ? 1 : 0).'
+                ,canCreateRoot: '.($this->canCreateRoot ? 1 : 0).'
+                ,canDuplicate: '.($this->canDuplicate ? 1 : 0).'
+                ,canDelete: '.($this->canDelete ? 1 : 0).'
                 ,show_tvs: '.(!empty($this->tvCounts) ? 1 : 0).'
             });
         });


### PR DESCRIPTION
### What does it do?

Added the missing checks for user rights "resource_duplicate" and "new_document_in_root" in the specific controllers. Those settings are passed to "revolution/manager/assets/modext/sections/resource/update.js" which adds the button when the user passes these checks.

I also did some cleanup on the code, the function $this->modx->hasPermission(...) is not needed here as it already runs in "revolution/manager/controllers/default/resource/resource.class.php".
### Why is it needed?

Duplicate button is missing when editing Weblinks and Symlinks.
### Related issue(s)/PR(s)
#12910
