### PR TITLE
Fix buckets with dots

### DIFF
--- a/core/lexicon/en/source.inc.php
+++ b/core/lexicon/en/source.inc.php
@@ -80,6 +80,7 @@ $_lang['prop_s3.thumbnailQuality_desc'] = 'The quality of the rendered thumbnail
 $_lang['prop_s3.thumbnailType_desc'] = 'The image type to render thumbnails as.';
 $_lang['prop_s3.url_desc'] = 'The URL of the Amazon S3 instance.';
 $_lang['s3_no_move_folder'] = 'The S3 driver does not support moving of folders at this time.';
+$_lang['prop_s3.region_desc'] = 'Region of the bucket. Example: us-west-1';
 
 /* file type */
 $_lang['PNG'] = 'PNG';

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -51,7 +51,14 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         include_once $this->xpdo->getOption('core_path',null,MODX_CORE_PATH).'model/aws/sdk.class.php';
 
         $this->getDriver();
+
+        $region = $this->xpdo->getOption('region',$properties,'');
+        if (!empty($region)) {
+            $this->driver->set_region($region);
+        }
+        
         $this->setBucket($this->xpdo->getOption('bucket',$properties,''));
+        
         return true;
     }
 
@@ -999,6 +1006,14 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 'type' => 'textfield',
                 'options' => '',
                 'value' => '.svn,.git,_notes,nbproject,.idea,.DS_Store',
+                'lexicon' => 'core:source',
+            ),
+            'region' => array(
+                'name' => 'region',
+                'desc' => 'prop_s3.region_desc',
+                'type' => 'textfield',
+                'options' => '',
+                'value' => '',
                 'lexicon' => 'core:source',
             ),
         );


### PR DESCRIPTION
### What does it do?

Fixes displaying files from S3 buckets with dots. New region property were added to S3 media source.
### Why is it needed?

Because it doesn't work otherwise :)
### Related issue(s)/PR(s)
#12034

👏 to @garryn for finding the solution!
