### PR TITLE
Remove deprecated curl option

### DIFF
--- a/core/model/aws/lib/requestcore/requestcore.class.php
+++ b/core/model/aws/lib/requestcore/requestcore.class.php
@@ -607,7 +607,6 @@ class RequestCore
 		curl_setopt($curl_handle, CURLOPT_URL, $this->request_url);
 		curl_setopt($curl_handle, CURLOPT_FILETIME, true);
 		curl_setopt($curl_handle, CURLOPT_FRESH_CONNECT, false);
-		curl_setopt($curl_handle, CURLOPT_CLOSEPOLICY, CURLCLOSEPOLICY_LEAST_RECENTLY_USED);
 		curl_setopt($curl_handle, CURLOPT_MAXREDIRS, 5);
 		curl_setopt($curl_handle, CURLOPT_HEADER, true);
 		curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
### What does it do?

Removes curl option that was removed in php 5.6
### Why is it needed?

Breaks stuff...
