### PR TITLE
Add sortBy and sortDir for initial grid config

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -329,6 +329,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,root: 'results'
                 ,totalProperty: 'total'
                 ,remoteSort: this.config.remoteSort || false
+                ,sortInfo:{
+                    field: this.config.sortBy || 'id'
+                    ,direction: this.config.sortDir || 'ASC'
+                }
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
 				,listeners:{


### PR DESCRIPTION
### What does it do?

Added sortBy and sortDir for initial grid config.
### Why is it needed?

These options as said in RTFM are used for grids unconditionally, but implemented only for grouped grid.
