### PR TITLE
Fixing padding-top issue in MODx.Window

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -103,6 +103,9 @@
     overflow-y: auto;
     padding: 15px;
   }
+  &.modx-window .x-window-body {
+    padding-top: 0;
+  }
 
   .x-panel-bwrap {
     background: $winBodyBg;


### PR DESCRIPTION
### What does it do?

Fixing a padding-top issue in .modx-window .x-window-body
### Why is it needed?

Since #12973 there is no reduced padding on the first label and the padding-top is too large there at the moment. The issue is visible i.e. during editing a system setting:

![screen](https://cloud.githubusercontent.com/assets/148371/15633057/f575e882-25a3-11e6-9a66-c3c6daa16488.png)

I hope the side effects are low, since there could be a .modx-window that does not start with a label. The ones I have checked in the pages of the core starts with a label. I will look for side effects in the next days on my develop installation.
### Related issue(s)/PR(s)
#12973
