### PR TITLE
Make sure to call processElementTags with correct $maxIterations value

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -428,7 +428,8 @@ class modParser {
         }
 
         /* collect any nested element tags in the innerTag and process them */
-        $this->processElementTags($outerTag, $innerTag, $processUncacheable);
+        $maxIterations= intval($this->modx->getOption('parser_max_iterations',null,10));
+        $this->processElementTags($outerTag, $innerTag, $processUncacheable, $this->modx->parser->isRemovingUnprocessed(), "[[", "]]", array (), $maxIterations);
         $this->_processingTag = true;
         $outerTag= '[[' . $innerTag . ']]';
 

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -429,7 +429,7 @@ class modParser {
 
         /* collect any nested element tags in the innerTag and process them */
         $maxIterations= intval($this->modx->getOption('parser_max_iterations',null,10));
-        $this->processElementTags($outerTag, $innerTag, $processUncacheable, $this->isRemovingUnprocessed(), "[[", "]]", array (), $maxIterations);
+        $this->processElementTags($outerTag, $innerTag, $processUncacheable, $this->modx->parser->isRemovingUnprocessed(), "[[", "]]", array (), $maxIterations);
         $this->_processingTag = true;
         $outerTag= '[[' . $innerTag . ']]';
 

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -429,7 +429,7 @@ class modParser {
 
         /* collect any nested element tags in the innerTag and process them */
         $maxIterations= intval($this->modx->getOption('parser_max_iterations',null,10));
-        $this->processElementTags($outerTag, $innerTag, $processUncacheable, $this->modx->parser->isRemovingUnprocessed(), "[[", "]]", array (), $maxIterations);
+        $this->processElementTags($outerTag, $innerTag, $processUncacheable, $this->isRemovingUnprocessed(), "[[", "]]", array (), $maxIterations);
         $this->_processingTag = true;
         $outerTag= '[[' . $innerTag . ']]';
 


### PR DESCRIPTION
### What does it do?

Call `processElementTags()` in the modParser always with the `$maxIterations` / `$depth` value from the `parser_max_iterations` system setting (default 10), instead of the "function default" of 0.
### Why is it needed?

Fixes a parser bug for special nested tags. See #13043 for steps to reproduce the bug.
### Related issue(s)/PR(s)

Directly related to the issues reported in #13043

I've tested it already on 1 production site where it fixed my issue from #13043 and didn't trigger any other issues so far.
