### PR TITLE
Prevent reflected XSS in connector's JSONP support

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -168,7 +168,7 @@ class modConnectorResponse extends modResponse {
             ));
 
             if (!empty($_GET['callback'])) {
-                $json = $_GET['callback'] . '(' . $json . ')';
+                $json = $modx->stripTags($_GET['callback']) . '(' . $json . ')';
             }
             die($json);
         } else {


### PR DESCRIPTION
### What does it do?

Ensure no reflected XSS can be triggered through the JSONP support introduced in #12420 
### Why is it needed?

This is a low risk security issue. It allows a client (browser) to potentially execute javascript when a specifically forged request was present. If an attacker is able of forging such a request, they already have access to the client in a way that renders XSS attempts like these fairly.. well.. pointless. Nevertheless, can't hurt to make sure it can't be abused anyway.
### Related issue(s)/PR(s)

Introduced in #12420 

Reported by Kacper Szurek in security ticket 28 on May 29th
