### PR TITLE
Fix uberbar user search returning invalid User ID

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -331,7 +331,7 @@ class modSearchProcessor extends modProcessor
         foreach ($collection as $record) {
             $this->results[] = array(
                 'name' => $record->get('username'),
-                '_action' => 'security/user/update&id=' . $record->get('id'),
+                '_action' => 'security/user/update&id=' . $record->get('internalKey'),
                 'description' => $record->get('fullname') .' / '. $record->get('email'),
                 'type' => $type,
             );


### PR DESCRIPTION
### What does it do?

`search/search` processor now returns valid User ID from modSearchProcessor::searchUsers should `modx_user_attributes` id/internalKey records become out of sync.
### Why is it needed?

`internalKey` is the correct reference to the `modUser` ID from `modUserProfile`, not `id`.
### Related issue(s)/PR(s)

Fixes #13055
