### PR TITLE
Fix showing image preview in qtip for S3 media source file tree

### DIFF
--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -144,6 +144,11 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $useMultiByte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
 
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imagesExts = explode(',',$imagesExts);
+
+        $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
+        
         $directories = array();
         $dirnames = array();
         $files = array();
@@ -209,6 +214,10 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                     'file' => $currentPath,
                 );
                 $files[$currentPath]['menu'] = array('items' => $this->getListContextMenu($currentPath,$isDir,$files[$currentPath]));
+
+                if (!$hideTooltips) {
+                    $files[$currentPath]['qtip'] = in_array($ext,$imagesExts) ? '<img src="'.$url.'" alt="'.$fileName.'" />' : '';
+                }
             }
         }
 


### PR DESCRIPTION
### What does it do?

Shows image preview in file tree for S3 media source.
### Why is it needed?

Image preview is there for filesystem media source and was missing in S3.
