### PR TITLE
Paging issue in the "New event create" dialog

### DIFF
--- a/core/model/modx/processors/system/event/grouplist.class.php
+++ b/core/model/modx/processors/system/event/grouplist.class.php
@@ -30,7 +30,12 @@ class modSystemEventsGroupListProcessor extends modProcessor {
 			}
 		}
 		
-		return $this->outputArray($list, count($list));
+		$total = count($list);
+		$start = $this->getProperty('start');
+		$limit = $this->getProperty('limit');
+                $list = array_slice($list, $start, $limit);
+		
+		return $this->outputArray($list, $total);
 	}
 }
 


### PR DESCRIPTION
### What does it do?

Creating an output array according the "start" and the "limit" properties.
### Why is it needed?

Fixing the paging issue of the "Group" combo-box in the "New event create" dialog.
