### PR TITLE
move OnFileManagerBeforeUpload event call

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -706,6 +706,14 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
         /* loop through each file and upload */
         foreach ($objects as $file) {
+            /* invoke event */
+            $this->xpdo->invokeEvent('OnFileManagerBeforeUpload',array(
+                'files' => &$objects,
+                'file' => &$file,
+                'directory' => $container,
+                'source' => &$this,
+            ));
+            
             if ($file['error'] != 0) continue;
             if (empty($file['name'])) continue;
             $ext = pathinfo($file['name'],PATHINFO_EXTENSION);
@@ -729,14 +737,6 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
             $newPath = $this->fileHandler->sanitizePath($file['name']);
             $newPath = $directory->getPath().$newPath;
-
-        /* invoke event */
-        $this->xpdo->invokeEvent('OnFileManagerBeforeUpload',array(
-            'files' => &$objects,
-            'file' => &$file,
-            'directory' => $container,
-            'source' => &$this,
-        ));
 
             if (!move_uploaded_file($file['tmp_name'],$newPath)) {
                 $this->addError('path',$this->xpdo->lexicon('file_err_upload'));


### PR DESCRIPTION
### What does it do?

This PR changes the time of invoking OnFileManagerBeforeUpload event. 
### Why is it needed?

It allows more flexible pre-processing of uploaded files: skip files by any critetia or change file format, file name and so on. It also fixes this:

```
/* invoke event */
        $this->xpdo->invokeEvent('OnFileManagerBeforeUpload',array(
            'files' => &$objects,
            'file' => &$file,
            'directory' => $container,
            'source' => &$this,
        ));
// $newPath is set before event call, so nothing to do with file name in OnFileManagerBeforeUpload plugins
            if (!move_uploaded_file($file['tmp_name'],$newPath)) {
                $this->addError('path',$this->xpdo->lexicon('file_err_upload'));
                continue;
            }
        }
```
