### PR TITLE
Modify MODx.renameLabel to handle hidemenu field

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -65,7 +65,7 @@ Ext.extend(MODx,Ext.Component,{
      */
     ,add: function(cmp) {
         if (typeof cmp === 'string') {
-            cmp = { xtype: cmp }
+            cmp = { xtype: cmp };
         }
         var ctr = Ext.getCmp('modx-content');
         if (ctr) {
@@ -393,6 +393,11 @@ Ext.extend(MODx,Ext.Component,{
                 } else {
                     cto.label.update(vals[0]);
                 }
+            }
+        } else if (ct == 'modx-panel-resource' && flds[0] === 'hidemenu') {
+            cto = Ext.getCmp('modx-resource-hidemenu');
+            if (cto && typeof cto.setBoxLabel === 'function') {
+                cto.setBoxLabel(vals[0]);
             }
         } else {
             cto = Ext.getCmp(ct);
@@ -754,7 +759,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         if (state instanceof Object) {
             Ext.iterate(state, function(name, value, o) {
                 this.state[name] = value;//this.decodeValue(value);
-            }, this)
+            }, this);
         } else {
             this.state = {};
         }


### PR DESCRIPTION
### What does it do?

`manager/assets/modext/core/modx.js` line 397 added check for "hidemenu" in `flds` argument to fetch different Cmp object and use different method for changing the field label.
### Why is it needed?

Before this patch, the hidemenu would not conform to Form Customization field label changes. Steps to reproduce:
1. Install MODX
2. Make a FC rule to change the hidemenu field label.
3. Make another FC rule to change the adjacent published field label.
4. Load the default Resource Edit View.

The hidemenu label would not be changed but the published field label would conform to the custom labels.

Why would this be? I checked the files in `manager/assets/modext/widgets/resource/` and couldn't find anything different about how the hidemenu widget is implemented, versus the published widget. I checked the DOM and they render similarly. After a couple hours of digging around I went for a patch. 
### Related issue(s)/PR(s)

n/a
