### PR TITLE
Improvement for #13057 Fix with of install button after text change

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -68,6 +68,8 @@ MODx.panel.Packages = function(config) {
 			,hidden: true
 			,handler: this.onSetupOptions
 			,scope: this
+			,autoWidth: true
+			,autoHeight: true
 		}]
 	});
 	MODx.panel.Packages.superclass.constructor.call(this,config);

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -324,11 +324,8 @@ MODx.grid.PackageDependencies = function(config) {
 
     this.store.on('load', function () {
         if (!this.checkDependencies()) {
-            Ext.getCmp('package-show-setupoptions-btn').setText(_('install_dependencies_first'));
-            Ext.getCmp('package-show-setupoptions-btn').disable();
-            
-            Ext.getCmp('package-install-btn').setText(_('install_dependencies_first'));
-            Ext.getCmp('package-install-btn').disable();
+            Ext.getCmp('package-show-setupoptions-btn').disable().setText(_('install_dependencies_first')).syncSize();
+            Ext.getCmp('package-install-btn').disable().setText(_('install_dependencies_first')).syncSize();
         }
     }, this);
 };


### PR DESCRIPTION
### What does it do?

Applying autoWidth/autoHeight to the setupOptions button
Applying syncSize after a text change in store load.
### Why is it needed?

The setupOptions button was too small. See Mikes comment on #13057
### Related issue(s)/PR(s)
#13057, #13048
