### PR TITLE
Duplicate array index, and description is missing

### DIFF
--- a/core/lexicon/de/formcustomization.inc.php
+++ b/core/lexicon/de/formcustomization.inc.php
@@ -93,6 +93,7 @@ $_lang['set_import_msg'] = 'Wählen Sie eine XML-Datei, aus der ein Formular-Anp
 $_lang['set_import_template_err_nf'] = 'Beim Importieren des Formular-Anpassungs-Sets wurde das Template nicht gefunden.';
 $_lang['set_msg'] = 'Hier können Sie festlegen, welche Felder, Reiter und Template-Variablen für diese Seite angezeigt werden, ebenso ihre Beschriftungen und Standardwerte. Klicken Sie einfach doppelt auf eine Spalte, um ihren Wert zu ändern. Sie können auch die Tabulator-Taste verwenden, um durch die Felder zu navigieren. Bei leergelassenen Feldern kommen die Standardeinstellungen zur Anwendung.';
 $_lang['set_new'] = 'Neues Set erstellen';
+$_lang['set_edit'] = 'Set bearbeiten';
 $_lang['set_remove'] = 'Set löschen';
 $_lang['set_remove_confirm'] = 'Sind Sie sicher, dass Sie dieses Set endgültig löschen möchten? Dies lässt sich nicht rückgängig machen.';
 $_lang['set_remove_multiple'] = 'Mehrere Sets löschen';

--- a/core/lexicon/de/setting.inc.php
+++ b/core/lexicon/de/setting.inc.php
@@ -96,7 +96,7 @@ $_lang['setting_allow_tags_in_post'] = 'Tags in POST-Requests erlauben';
 $_lang['setting_allow_tags_in_post_desc'] = 'Wenn diese Einstellung auf "Nein" gesetzt ist, werden HTML-Script-Tags, numerische HTML-Entities und MODX-Tags aus allen POST-Variablen entfernt. MODX empfiehlt, diese Einstellung für alle Kontexte auf "Nein" zu belassen, außer für den Kontext mgr, für den diese Einstellung standardmäßig auf "Ja" gesetzt ist.';
 
 $_lang['setting_anonymous_sessions'] = 'Anonyme Sessions';
-$_lang['setting_anonymous_sessions'] = 'Anonyme Sessions';
+$_lang['setting_anonymous_sessions_desc'] = 'Wenn diese Einstellung deaktiviert ist, haben nur authentifizierte Benutzer Zugriff auf eine PHP-Session. Dies kann unnötigen Aufwand, den das System für anonyme Benutzer betreiben muss, vermeiden und die Last, die dadurch für die MODX-Site entsteht, reduzieren, wenn anonyme Benutzer keinen Zugriff auf eine eigene Session benötigen. Wenn session_enabled auf "Nein" steht, hat diese Einstellung keinen Effekt, da Sessions dann ohnehin nicht zur Verfügung stehen.';
 
 $_lang['setting_archive_with'] = 'Erzwinge PCLZip-Archive';
 $_lang['setting_archive_with_desc'] = 'Wählen Sie "Ja", um PCLZip anstatt ZipArchive als ZIP-Extension zu nutzen. Wählen Sie diese Einstellung, falls Sie "extractTo"-Fehler erhalten oder Probleme beim Entpacken in der Package-Verwaltung haben.';

--- a/core/lexicon/de/source.inc.php
+++ b/core/lexicon/de/source.inc.php
@@ -80,6 +80,7 @@ $_lang['prop_s3.thumbnailQuality_desc'] = 'Die Qualität der generierten Thumbna
 $_lang['prop_s3.thumbnailType_desc'] = 'Der Bildtyp der generierten Thumbnails.';
 $_lang['prop_s3.url_desc'] = 'Die URL der Amazon-S3-Instanz.';
 $_lang['s3_no_move_folder'] = 'Der S3-Treiber unterstützt das Verschieben von Ordnern zu diesem Zeitpunkt nicht.';
+$_lang['prop_s3.region_desc'] = 'Region des Buckets. Beispiel: us-west-1';
 
 /* file type */
 $_lang['PNG'] = 'PNG';


### PR DESCRIPTION
### What does it do?

Removes a duplicated phrase and adds a missing one (translation of the English version).
### Why is it needed?

The needed second phrase can't be added via crowdin or in any other way.

The second $_lang['setting_anonymous_sessions'] should be $_lang['setting_anonymous_sessions_desc'] with a different text. While this is correct in the 2.x branch, it isn't in the 2.5.x branch for some reason, and the language file delivered with MODX 2.5.1-pl contains the wrong version, too. This is why I corrected it this way, not via crowdin (which is impossible).

As I just saw, it's the same in the other language files (except the English one)! Sorry, I don't have the time to fix them all...
