### PR TITLE
package.grid.js // default_per_page items in Package-Overview-List

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -83,7 +83,7 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
-        ,pageSize: MODx.config.default_per_page > 10 ? MODx.config.default_per_page : 10
+        ,pageSize: parseInt(MODx.config.default_per_page) > 10 ? parseInt(MODx.config.default_per_page) : 10
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -83,7 +83,7 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
-        ,pageSize: 10
+        ,pageSize: MODx.config.default_per_page > 10 ? MODx.config.default_per_page : 10
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true


### PR DESCRIPTION
### What does it do?

Updated package.grid.js, so that it not statically always show 10 entries, 
but acknowledges the _default_per_page_ system-setting the user provided, 
if it is larger than 10.
### Why is it needed?

The Package-Overview statically shows 10 entries. 
I was expecting it to behave as all the other grids in the manager.
### Related issue(s)/PR(s)
#12518 Default Per Page number of packages listed not related to the Default Per Page System Setting
#12613 Add "Updatable" Column to packages grid
#12601 [Request] Updatable Packages first in Package Manager
#8906   Set amount of list grid-items in system settings
