### PR TITLE
Change view_ permissions to edit_ permissions for elements in uberbar search

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -24,7 +24,9 @@ class modSearchProcessor extends modProcessor
                 //$this->searchActions();
             } else {
                 // Search elements & resources
-                $this->searchResources();
+                if ($this->modx->hasPermission('edit_document')) {
+                    $this->searchResources();
+                }
                 if ($this->modx->hasPermission('edit_chunk')) {
                     $this->searchChunks();
                 }

--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -25,22 +25,22 @@ class modSearchProcessor extends modProcessor
             } else {
                 // Search elements & resources
                 $this->searchResources();
-                if ($this->modx->hasPermission('view_chunk')) {
+                if ($this->modx->hasPermission('edit_chunk')) {
                     $this->searchChunks();
                 }
-                if ($this->modx->hasPermission('view_template')) {
+                if ($this->modx->hasPermission('edit_template')) {
                     $this->searchTemplates();
                 }
-                if ($this->modx->hasPermission('view_tv')) {
+                if ($this->modx->hasPermission('edit_tv')) {
                     $this->searchTVs();
                 }
-                if ($this->modx->hasPermission('view_snippet')) {
+                if ($this->modx->hasPermission('edit_snippet')) {
                     $this->searchSnippets();
                 }
-                if ($this->modx->hasPermission('view_plugin')) {
+                if ($this->modx->hasPermission('edit_plugin')) {
                     $this->searchPlugins();
                 }
-                if ($this->modx->hasPermission('view_user')) {
+                if ($this->modx->hasPermission('edit_user')) {
                     $this->searchUsers();
                 }
             }


### PR DESCRIPTION
### What does it do?

Actually quite a simple change, all it does is changing the view_<element> permissions in the search processor to edit_<element> permissions.
### Why is it needed?

If we assume you have some access policies in place where users cannot and should not be confronted with elements nor edit them, so they don't have the permissions to edit, but to view they have, as otherwise they wouldn't be able to fill content into templates, or drag chunks into the content field etc., but for these things, no edit permission is allowed.
So the problem appears when searching with the uberbar and then elements with the search sting in their name pop up as results and the user is tempted to click on them sometimes (at least once...), but what they get then is a nasty, ugly looking "Access denied"-white-error-page-that-looks-broken. And consequentially they assume the system is broken...and I get unnecessary calls over and over (nobody else has that??) =)
The (IMHO) simple solution is to adjust the needed permissions to "edit_" as the search-result-links only function is to EDIT the result right? Hopefully I'm not overlooking something critical here...please enlighten me!

For the more visual types:
![modx uberbar permissions](https://cloud.githubusercontent.com/assets/445501/17853773/ebc3562c-686e-11e6-87aa-758ea6d978dc.gif)
### Related issue(s)/PR(s)

none that I know of, but will update if I find one!
