### PR TITLE
Enhancement: modFileHandler getList() method

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -651,7 +651,7 @@ class modDirectory extends modFileSystemResource {
         $mbencoding = $this->fileHandler->modx->getOption('modx_charset', null, 'UTF-8');
         $extensions = !is_array($options['extensions']) ? explode(',', $options['extensions']) : $options['extensions'];
         $skip = !is_array($options['skip']) ? explode(',', $options['skip']) : $options['skip'];
-        $iterator = $options['recursive'] ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->path)) : new DirectoryIterator($this->path);
+        $iterator = $options['recursive'] ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->path, FilesystemIterator::CURRENT_AS_SELF)) : new DirectoryIterator($this->path);
 
         foreach ($iterator as $item) {
             $skipfile = !empty($skip) ? in_array($item->getFilename(), $skip) : false;

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -588,10 +588,10 @@ class modDirectory extends modFileSystemResource {
      * optionally runs recursive, filters by file extension(s) and sorts the resulting list according to a specified sort flag
      *
      * @param array $options Options for iterating the directory.
-     *      boolean recursive If also subfolders should be scanned for files
-     *      boolean ignorehidden If folders and files starting with a dot . (hidden files/folders in unix envirionments) should be ignored, defaults to true
-     *      boolean sort If the resulting filelist array should be sorted with the specified flag like SORT_ASC, SORT_DESC, SORT_REGULAR, SORT_NATURAL, SORT_NUMERIC
-     *      string extensions Comma separated list of file extensions to filter files by
+     * @param boolean recursive If also subfolders should be scanned for files
+     * @param boolean ignorehidden If folders and files starting with a dot . (hidden files/folders in unix envirionments) should be ignored, defaults to true
+     * @param boolean sort If the resulting filelist array should be sorted with the specified flag like SORT_ASC, SORT_DESC, SORT_REGULAR, SORT_NATURAL, SORT_NUMERIC
+     * @param string extensions Comma separated list of file extensions to filter files by
      *      
      * @return array of filepaths
      */
@@ -606,36 +606,57 @@ class modDirectory extends modFileSystemResource {
         $files = array();
         $extensions = explode(',', $options['extensions']);
         
-        if ($options['recursive']) {
-            $iterator = new RecursiveDirectoryIterator($this->path);
+        // if ($options['recursive']) {
+        //     $iterator = new RecursiveDirectoryIterator($this->path);
 
-            foreach (new RecursiveIteratorIterator($iterator) as $file) {
-                $dirname = explode(DIRECTORY_SEPARATOR, $file->getPath()); // PHP Strict warning if we put end() around here
+        //     foreach (new RecursiveIteratorIterator($iterator) as $file) {
+        //         $dirname = explode(DIRECTORY_SEPARATOR, $file->getPath()); // PHP Strict warning if we put end() around here
                 
-                if (($options['ignorehidden'] ? (substr($file->getFilename(), 0, 1) !== '.' && substr(end($dirname), 0, 1) !== '.') : true) && $file->isFile()) {
-                    if (!empty($options['extensions'])) {
-                        if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
-                            $files[] = $file->getPathname();
-                        }
-                    } else {
+        //         if (($options['ignorehidden'] ? (substr($file->getFilename(), 0, 1) !== '.' && substr(end($dirname), 0, 1) !== '.') : true) && $file->isFile()) {
+        //             if (!empty($options['extensions'])) {
+        //                 if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
+        //                     $files[] = $file->getPathname();
+        //                 }
+        //             } else {
+        //                 $files[] = $file->getPathname();
+        //             }
+        //         }
+        //     }
+        // } else {
+        //     $iterator = new DirectoryIterator($this->path);
+
+        //     foreach ($iterator as $file) {
+        //         if (($options['ignorehidden'] ? substr($file->getFilename(), 0, 1) !== '.' : true) && $file->isFile()) {
+        //             if (!empty($options['extensions'])) {
+        //                 if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
+        //                     $files[] = $file->getPathname();
+        //                 }
+        //             } else {
+        //                 if ($file->isFile()) {
+        //                     $files[] = $file->getPathname();
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+
+        $iterator = $options['recursive'] ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->path)) : new DirectoryIterator($this->path);
+
+        foreach ($iterator as $file) {
+            if ($options['ignorehidden']) {
+                $dirname = explode(DIRECTORY_SEPARATOR, $file->getPath()); // PHP Strict warning if we put end() around here
+                $ishidden = substr($file->getFilename(), 0, 1) === '.' || substr(end($dirname), 0, 1) === '.';
+            } else {
+                $ishidden = false;
+            }
+
+            if ($file->isFile() && ($options['ignorehidden'] ? !$ishidden : true)) {
+                if (!empty($options['extensions'])) {
+                    if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
                         $files[] = $file->getPathname();
                     }
-                }
-            }
-        } else {
-            $iterator = new DirectoryIterator($this->path);
-
-            foreach ($iterator as $file) {
-                if (($options['ignorehidden'] ? substr($file->getFilename(), 0, 1) !== '.' : true) && $file->isFile()) {
-                    if (!empty($options['extensions'])) {
-                        if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
-                            $files[] = $file->getPathname();
-                        }
-                    } else {
-                        if ($file->isFile()) {
-                            $files[] = $file->getPathname();
-                        }
-                    }
+                } else {
+                    $files[] = $file->getPathname();
                 }
             }
         }

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -584,71 +584,89 @@ class modDirectory extends modFileSystemResource {
     }
 
     /**
-     * Iterates over a modDirectory object and returns an array of all containing files,
-     * optionally runs recursive, filters by file extension(s) and sorts the resulting list according to a specified sort flag
+     * Iterates over a modDirectory object and returns an array of all containing files and optionally directories,
+     * can run recursive, filter by file extension(s) or filenames and sort the resulting list with the specified sort options
+     * an anonymous callback function can be passed to modify the output on the fly, by default an array of paths is returned
      *
      * @param array $options Options for iterating the directory.
-     * @option boolean recursive If also subfolders should be scanned for files
-     * @option boolean|string sort If the resulting filelist array should be sorted with the specified flag like SORT_ASC, SORT_DESC, SORT_REGULAR, SORT_NATURAL, SORT_NUMERIC
-     * @option boolean skiphidden If folders and files starting with a dot . (hidden files/folders in unix envirionments) should be ignored, defaults to true
+     * @option boolean recursive If subdirectories should be scanned as well
+     * @option boolean|string sort If the resulting array should be sorted
+     * @option string sortdir What sort order should be applied: SORT_ASC|SORT_DESC
+     * @optoin string sortflag What sort flag should be applied: SORT_REGULAR, SORT_NATURAL, SORT_NUMERIC etc
+     * @option boolean skiphidden If hidden directories and files should be ignored, defaults to true
+     * @option boolean skipdirs If directories should be skipped in the resulting array, defaults to true
      * @option string|array skip Comma separated list or array of filenames (including extension) that should be ignored
      * @option string|array extensions Comma separated list or array of file extensions to filter files by
-     * @option boolean|function callback Anonymous function to modify each output item, $file will be passed / accessible
+     * @option boolean|function callback Anonymous function to modify each output item, $item will be passed / accessible
      *      
      * @return array
      */
-    public function getFiles($options = array()) {
+    public function list($options = array()) {
         $options = array_merge(array(
             'recursive' => false,
             'sort' => false,
+            'sortdir' => SORT_ASC,
+            'sortflag' => SORT_REGULAR,
             'skiphidden' => true,
+            'skipdirs' => true,
             'skip' => array(),
             'extensions' => array(),
             'callback' => false,
         ), $options);
 
-        $files = array();
+        $items = array();
+
+        $mb = $this->fileHandler->modx->getOption('use_multibyte', null, false);
+        $mbencoding = $this->fileHandler->modx->getOption('modx_charset', null, 'UTF-8');
         $extensions = !is_array($options['extensions']) ? explode(',', $options['extensions']) : $options['extensions'];
         $skip = !is_array($options['skip']) ? explode(',', $options['skip']) : $options['skip'];
         $iterator = $options['recursive'] ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->path)) : new DirectoryIterator($this->path);
 
-        foreach ($iterator as $file) {
+        foreach ($iterator as $item) {
+            $skipfile = !empty($skip) ? in_array($item->getFilename(), $skip) : false;
             $ishidden = false;
 
             if ($options['skiphidden']) {
                 // check for hidden folder, also hide with visible ones inside
                 // but don't skip weird filenames like "...and-there-was-silence.avi"
-                if (preg_match('/(\/\.\w+|\\\.\w+)/', $file->getPath())) {
+                if ($item->isDot() || preg_match('/(\/\.\w+|\\\.\w+)/', $item->getPath())) {
                     continue;
                 }
                 // check for hidden file (probably works only on UNIX filesystems)
-                $ishidden = preg_match('/^(\.\w+)/i', $file->getFilename());
+                $ishidden = preg_match('/^(\.\w+)/i', $item->getFilename());
+            } else if (!$options['skipdirs']) {
+                // always exclude . and .. directory navigators, only relevant when including folders
+                $ishidden = $item->isDot();
             }
 
-            if ($file->isFile() && ($options['skiphidden'] ? !$ishidden : true) && (!empty($skip) ? !in_array($file->getFilename(), $skip) : true)) {
+            if (($item->isFile() || $item->isDir() && !$options['skipdirs']) && !$ishidden && !$skipfile) {
                 $addfile = true;
                 
                 if (!empty($options['extensions'])) {
-                    if (!in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
+                    // if min PHP version is 5.3.6 we can use $item->getExtension()
+                    $extension = pathinfo($item->getPathname(), PATHINFO_EXTENSION);
+                    $extension = $mb ? mb_strtolower($extension, $mbencoding) : strtolower($extension);
+
+                    if (!in_array($extension, $extensions)) {
                         $addfile = false;
                     }
                 }
 
                 if ($addfile) {
                     if (is_object($options['callback']) && ($options['callback'] instanceof Closure)) {
-                        $files[] = $options['callback']($file);
+                        $items[] = $options['callback']($item);
                     } else {
-                        $files[] = $file->getPathname();
+                        $items[] = $item->isDir() ? $item->getPathname() . DIRECTORY_SEPARATOR : $item->getPathname();
                     }
                 }
             }
         }
 
         if (!empty($options['sort'])) {
-            array_multisort($files, $options['sort'], $files);
+            array_multisort($items, $options['sortdir'], $options['sortflag'], $items);
         }
 
-        return $files;
+        return $items;
     }
 
     /**

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -584,6 +584,37 @@ class modDirectory extends modFileSystemResource {
     }
 
     /**
+     * Removes the directory from the file system, recursively removing
+     * subdirectories and files.
+     *
+     * @param array $options Options for removal.
+     * @return boolean True if successful
+     */
+    public function remove($options = array()) {
+        if ($this->path == '/') return false;
+
+        $options = array_merge(array(
+            'deleteTop' => true,
+            'skipDirs' => false,
+            'extensions' => '',
+        ), $options);
+
+        $this->fileHandler->modx->getCacheManager();
+        return $this->fileHandler->modx->cacheManager->deleteTree($this->path, $options);
+    }
+
+    /**
+     * @see modFileSystemResource::parseMode
+     *
+     * @param string $mode
+     * @return boolean
+     */
+    protected function parseMode($mode = '') {
+        if (empty($mode)) $mode = $this->fileHandler->context->getOption('new_folder_permissions', '0755', $this->fileHandler->config);
+        return parent::parseMode($mode);
+    }
+
+    /**
      * Iterates over a modDirectory object and returns an array of all containing files and optionally directories,
      * can run recursive, filter by file extension(s) or filenames and sort the resulting list with the specified sort options
      * an anonymous callback function can be passed to modify the output on the fly, by default an array of paths is returned
@@ -601,7 +632,7 @@ class modDirectory extends modFileSystemResource {
      *      
      * @return array
      */
-    public function list($options = array()) {
+    public function getList($options = array()) {
         $options = array_merge(array(
             'recursive' => false,
             'sort' => false,
@@ -640,7 +671,7 @@ class modDirectory extends modFileSystemResource {
             }
 
             if (($item->isFile() || $item->isDir() && !$options['skipdirs']) && !$ishidden && !$skipfile) {
-                $addfile = true;
+                $additem = true;
                 
                 if (!empty($options['extensions'])) {
                     // if min PHP version is 5.3.6 we can use $item->getExtension()
@@ -648,11 +679,11 @@ class modDirectory extends modFileSystemResource {
                     $extension = $mb ? mb_strtolower($extension, $mbencoding) : strtolower($extension);
 
                     if (!in_array($extension, $extensions)) {
-                        $addfile = false;
+                        $additem = false;
                     }
                 }
 
-                if ($addfile) {
+                if ($additem) {
                     if (is_object($options['callback']) && ($options['callback'] instanceof Closure)) {
                         $items[] = $options['callback']($item);
                     } else {
@@ -667,36 +698,5 @@ class modDirectory extends modFileSystemResource {
         }
 
         return $items;
-    }
-
-    /**
-     * @see modFileSystemResource::parseMode
-     *
-     * @param string $mode
-     * @return boolean
-     */
-    protected function parseMode($mode = '') {
-        if (empty($mode)) $mode = $this->fileHandler->context->getOption('new_folder_permissions', '0755', $this->fileHandler->config);
-        return parent::parseMode($mode);
-    }
-
-    /**
-     * Removes the directory from the file system, recursively removing
-     * subdirectories and files.
-     *
-     * @param array $options Options for removal.
-     * @return boolean True if successful
-     */
-    public function remove($options = array()) {
-        if ($this->path == '/') return false;
-
-        $options = array_merge(array(
-            'deleteTop' => true,
-            'skipDirs' => false,
-            'extensions' => '',
-        ), $options);
-
-        $this->fileHandler->modx->getCacheManager();
-        return $this->fileHandler->modx->cacheManager->deleteTree($this->path, $options);
     }
 }

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -621,14 +621,14 @@ class modDirectory extends modFileSystemResource {
      *
      * @param array $options Options for iterating the directory.
      * @option boolean recursive If subdirectories should be scanned as well
-     * @option boolean|string sort If the resulting array should be sorted
+     * @option boolean sort If the resulting array should be sorted
      * @option string sortdir What sort order should be applied: SORT_ASC|SORT_DESC
      * @optoin string sortflag What sort flag should be applied: SORT_REGULAR, SORT_NATURAL, SORT_NUMERIC etc
      * @option boolean skiphidden If hidden directories and files should be ignored, defaults to true
      * @option boolean skipdirs If directories should be skipped in the resulting array, defaults to true
      * @option string|array skip Comma separated list or array of filenames (including extension) that should be ignored
      * @option string|array extensions Comma separated list or array of file extensions to filter files by
-     * @option boolean|function callback Anonymous function to modify each output item, $item will be passed / accessible
+     * @option boolean|function callback Anonymous function to modify each output item, $item will be passed as argument
      *      
      * @return array
      */
@@ -683,12 +683,16 @@ class modDirectory extends modFileSystemResource {
                     }
                 }
 
-                if ($additem) {
-                    if (is_object($options['callback']) && ($options['callback'] instanceof Closure)) {
-                        $items[] = $options['callback']($item);
-                    } else {
-                        $items[] = $item->isDir() ? $item->getPathname() . DIRECTORY_SEPARATOR : $item->getPathname();
+                if (!$additem) {
+                    continue;
+                } else if (is_callable($options['callback'])) {
+                    $callback = call_user_func($options['callback'], $item);
+
+                    if (!empty($callback)) {
+                        $items[] = $callback;
                     }
+                } else {
+                    $items[] = $item->isDir() ? $item->getPathname() . DIRECTORY_SEPARATOR : $item->getPathname();  
                 }
             }
         }

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -584,8 +584,8 @@ class modDirectory extends modFileSystemResource {
     }
 
     /**
-     * Iterates (optionally recursively) over a modDirectory object and returns an array of all containing files,
-     * optionally filtered by file extensions and alphabetically sorted
+     * Iterates over a modDirectory object and returns an array of all containing files,
+     * optionally runs recursive, filters by file extension(s) and sorts the resulting list according to a specified sort flag
      *
      * @param array $options Options for iterating the directory.
      *      boolean recursive If also subfolders should be scanned for files

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -590,7 +590,7 @@ class modDirectory extends modFileSystemResource {
      * @param array $options Options for iterating the directory.
      *      boolean recursive If also subfolders should be scanned for files
      *      boolean ignorehidden If folders and files starting with a dot . (hidden files/folders in unix envirionments) should be ignored, defaults to true
-     *      boolean sort If the resulting filelist array should be alphabeticall sorted (could also be removed and let the user do this with the result himself)
+     *      boolean sort If the resulting filelist array should be sorted with the specified flag like SORT_ASC, SORT_DESC, SORT_REGULAR, SORT_NATURAL, SORT_NUMERIC
      *      string extensions Comma separated list of file extensions to filter files by
      *      
      * @return array of filepaths
@@ -604,16 +604,17 @@ class modDirectory extends modFileSystemResource {
         ), $options);
 
         $files = array();
+        $extensions = explode(',', $options['extensions']);
         
         if ($options['recursive']) {
-            $iterator = new RecursiveDirectoryIterator($this->path, FilesystemIterator::SKIP_DOTS);
+            $iterator = new RecursiveDirectoryIterator($this->path);
 
             foreach (new RecursiveIteratorIterator($iterator) as $file) {
                 $dirname = explode(DIRECTORY_SEPARATOR, $file->getPath()); // PHP Strict warning if we put end() around here
                 
-                if (($options['ignorehidden'] ? (substr($file->getFilename(), 0, 1) !== '.' && substr(end($dirname), 0, 1) !== '.') : true)) {
+                if (($options['ignorehidden'] ? (substr($file->getFilename(), 0, 1) !== '.' && substr(end($dirname), 0, 1) !== '.') : true) && $file->isFile()) {
                     if (!empty($options['extensions'])) {
-                        if (in_array($file->getExtension(), explode(',', $options['extensions']))) {
+                        if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
                             $files[] = $file->getPathname();
                         }
                     } else {
@@ -622,13 +623,12 @@ class modDirectory extends modFileSystemResource {
                 }
             }
         } else {
-            $iterator = new FilesystemIterator($this->path, FilesystemIterator::SKIP_DOTS);
+            $iterator = new DirectoryIterator($this->path);
 
             foreach ($iterator as $file) {
-
-                if (($options['ignorehidden'] ? substr($file->getFilename(), 0, 1) !== '.' : true)) {
+                if (($options['ignorehidden'] ? substr($file->getFilename(), 0, 1) !== '.' : true) && $file->isFile()) {
                     if (!empty($options['extensions'])) {
-                        if (in_array($file->getExtension(), explode(',', $options['extensions'])) && $file->isFile()) {
+                        if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
                             $files[] = $file->getPathname();
                         }
                     } else {
@@ -640,8 +640,8 @@ class modDirectory extends modFileSystemResource {
             }
         }
 
-        if ($options['sort']) {
-            array_multisort($files, SORT_ASC, $files);
+        if (!empty($options['sort'])) {
+            array_multisort($files, $options['sort'], $files);
         }
 
         return $files;

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -598,13 +598,15 @@ class modDirectory extends modFileSystemResource {
     public function getFiles($options = array()) {
         $options = array_merge(array(
             'recursive' => false,
-            'skiphidden' => true,
             'sort' => false,
-            'extensions' => ''
+            'skiphidden' => true,
+            'skip' => array(),
+            'extensions' => array()
         ), $options);
 
         $files = array();
-        $extensions = explode(',', $options['extensions']);
+        $extensions = !is_array($options['extensions']) ? explode(',', $options['extensions']) : $options['extensions'];
+        $skip = !is_array($options['skip']) ? explode(',', $options['skip']) : $options['skip'];
         $iterator = $options['recursive'] ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->path)) : new DirectoryIterator($this->path);
 
         foreach ($iterator as $file) {
@@ -620,7 +622,7 @@ class modDirectory extends modFileSystemResource {
                 $ishidden = false;
             }
 
-            if ($file->isFile() && ($options['skiphidden'] ? !$ishidden : true)) {
+            if ($file->isFile() && ($options['skiphidden'] ? !$ishidden : true) && (!empty($skip) ? !in_array($file->getFilename(), $skip) : true)) {
                 if (!empty($options['extensions'])) {
                     if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
                         $files[] = $file->getPathname();

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -613,6 +613,8 @@ class modDirectory extends modFileSystemResource {
         $iterator = $options['recursive'] ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->path)) : new DirectoryIterator($this->path);
 
         foreach ($iterator as $file) {
+            $ishidden = false;
+
             if ($options['skiphidden']) {
                 // check for hidden folder, also hide with visible ones inside
                 // but don't skip weird filenames like "...and-there-was-silence.avi"
@@ -621,19 +623,15 @@ class modDirectory extends modFileSystemResource {
                 }
                 // check for hidden file (probably works only on UNIX filesystems)
                 $ishidden = preg_match('/^(\.\w+)/i', $file->getFilename());
-            } else {
-                $ishidden = false;
             }
 
             if ($file->isFile() && ($options['skiphidden'] ? !$ishidden : true) && (!empty($skip) ? !in_array($file->getFilename(), $skip) : true)) {
-                $addfile = false;
+                $addfile = true;
                 
                 if (!empty($options['extensions'])) {
-                    if (in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
-                        $addfile = true;
+                    if (!in_array(pathinfo($file->getPathname(), PATHINFO_EXTENSION), $extensions)) {
+                        $addfile = false;
                     }
-                } else {
-                    $addfile = true;
                 }
 
                 if ($addfile) {

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -584,6 +584,70 @@ class modDirectory extends modFileSystemResource {
     }
 
     /**
+     * Iterates (optionally recursively) over a modDirectory object and returns an array of all containing files,
+     * optionally filtered by file extensions and alphabetically sorted
+     *
+     * @param array $options Options for iterating the directory.
+     *      boolean recursive If also subfolders should be scanned for files
+     *      boolean ignorehidden If folders and files starting with a dot . (hidden files/folders in unix envirionments) should be ignored, defaults to true
+     *      boolean sort If the resulting filelist array should be alphabeticall sorted (could also be removed and let the user do this with the result himself)
+     *      string extensions Comma separated list of file extensions to filter files by
+     *      
+     * @return array of filepaths
+     */
+    public function getFiles($options = array()) {
+        $options = array_merge(array(
+            'recursive' => false,
+            'ignorehidden' => true,
+            'sort' => false,
+            'extensions' => ''
+        ), $options);
+
+        $files = array();
+        
+        if ($options['recursive']) {
+            $iterator = new RecursiveDirectoryIterator($this->path, FilesystemIterator::SKIP_DOTS);
+
+            foreach (new RecursiveIteratorIterator($iterator) as $file) {
+                $dirname = explode(DIRECTORY_SEPARATOR, $file->getPath()); // PHP Strict warning if we put end() around here
+                
+                if (($options['ignorehidden'] ? (substr($file->getFilename(), 0, 1) !== '.' && substr(end($dirname), 0, 1) !== '.') : true)) {
+                    if (!empty($options['extensions'])) {
+                        if (in_array($file->getExtension(), explode(',', $options['extensions']))) {
+                            $files[] = $file->getPathname();
+                        }
+                    } else {
+                        $files[] = $file->getPathname();
+                    }
+                }
+            }
+        } else {
+            $iterator = new FilesystemIterator($this->path, FilesystemIterator::SKIP_DOTS);
+
+            foreach ($iterator as $file) {
+
+                if (($options['ignorehidden'] ? substr($file->getFilename(), 0, 1) !== '.' : true)) {
+                    if (!empty($options['extensions'])) {
+                        if (in_array($file->getExtension(), explode(',', $options['extensions'])) && $file->isFile()) {
+                            $files[] = $file->getPathname();
+                        }
+                    } else {
+                        if ($file->isFile()) {
+                            $files[] = $file->getPathname();
+                        }
+                    }
+                }
+            }
+        }
+
+        if ($options['sort']) {
+            array_multisort($files, SORT_ASC, $files);
+        }
+
+        return $files;
+    }
+
+    /**
      * @see modFileSystemResource::parseMode
      *
      * @param string $mode


### PR DESCRIPTION
### What does it do?

It seemed not to be possible to get a list of all files in a folder represented by a modDirectory object, this method adds this functionality. It can do several things:

1) Scan the modDirectory path recursively or normally (non-recursive) with folders ignored (only filepaths are returned)
2) It can return or ignore (default) hidden (unix filesystems) files and folders starting with a dot (e.g. .htaccess etc.)
3) It can filter the returned filelist by file extensions passed via $options
4) It can sort the resulting filelist array alphabetically if desired (this maybe should be done by the user him/herself when working with the returned filelist array...but I thought it's maybe handy)

I think this could may be also of use for file mediasources, as they may implement a directoryiterator themselves, like this they could just make use of this method already provided by the filehandler...

usage example:

```
// get the filehandler service
$modx->getService('file','modFileHandler');

// create modFileHandler object, in this case we need a modDirectory object, eg. pass a folder path
$fileobj = $modx->file->make(MODX_ASSETS_PATH . 'site/test/');

// this most simple usage of this method just returns ALL files inside the $fileobj / modDirectory path non-recursively, unfiltered and unsorted BUT ignoring hidden files
$files = $fileobj->getFiles();

// now we want all files contained inside this folder, recursively but unsorted, filtered by css file extension
$files = $fileobj->getFiles(array('recursive' => true, 'sort' => false, 'extensions' => 'css', 'ignorehidden' => true));

// if we would like to sort the resulting filelist, the flags of array_multisort() can be passed, e.g. SORT_ASC, SORT_DESC, SORT_NUMERIC, SORT_NATURAL, SORT_REGULAR, note: they have to be passed WITHOUT quotes, e.g.
$files = $fileobj->getFiles(array('recursive' => true, 'sort' => SORT_ASC, 'extensions' => 'css', 'ignorehidden' => true));

echo '<pre>' . print_r($files,1) . '</pre>';
```

which then gives something like that:
![bildschirmfoto 2014-04-19 um 20 19 49](https://cloud.githubusercontent.com/assets/445501/2749160/46fcd0c2-c7ef-11e3-8206-6cf1391881c0.png)

with sort flag = true:
![bildschirmfoto 2014-04-19 um 20 21 10](https://cloud.githubusercontent.com/assets/445501/2749162/70f67f7c-c7ef-11e3-9564-8b6298d2107b.png)

with recursive flag = false, sort = true:
![bildschirmfoto 2014-04-19 um 20 22 02](https://cloud.githubusercontent.com/assets/445501/2749164/94fd77ae-c7ef-11e3-81ae-4c3a34d787e9.png)

you get the picture I hope =)

_UPDATE_

Alright, took a second jump at this thing and improved it a bit more (hopefully). The whole method now looks like this:

``` php
    /**
     * Iterates over a modDirectory object and returns an array of all containing files and optionally directories,
     * can run recursive, filter by file extension(s) or filenames and sort the resulting list with the specified sort options
     * an anonymous callback function can be passed to modify the output on the fly, by default an array of paths is returned
     *
     * @param array $options Options for iterating the directory.
     * @option boolean recursive If subdirectories should be scanned as well
     * @option boolean|string sort If the resulting array should be sorted
     * @option string sortdir What sort order should be applied: SORT_ASC|SORT_DESC
     * @optoin string sortflag What sort flag should be applied: SORT_REGULAR, SORT_NATURAL, SORT_NUMERIC etc
     * @option boolean skiphidden If hidden directories and files should be ignored, defaults to true
     * @option boolean skipdirs If directories should be skipped in the resulting array, defaults to true
     * @option string|array skip Comma separated list or array of filenames (including extension) that should be ignored
     * @option string|array extensions Comma separated list or array of file extensions to filter files by
     * @option boolean|function callback Anonymous function to modify each output item, $item will be passed / accessible
     *      
     * @return array
     */
    public function getList($options = array()) {
        $options = array_merge(array(
            'recursive' => false,
            'sort' => false,
            'sortdir' => SORT_ASC,
            'sortflag' => SORT_REGULAR,
            'skiphidden' => true,
            'skipdirs' => true,
            'skip' => array(),
            'extensions' => array(),
            'callback' => false,
        ), $options);

        $items = array();

        $mb = $this->fileHandler->modx->getOption('use_multibyte', null, false);
        $mbencoding = $this->fileHandler->modx->getOption('modx_charset', null, 'UTF-8');
        $extensions = !is_array($options['extensions']) ? explode(',', $options['extensions']) : $options['extensions'];
        $skip = !is_array($options['skip']) ? explode(',', $options['skip']) : $options['skip'];
        $iterator = $options['recursive'] ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->path)) : new DirectoryIterator($this->path);

        foreach ($iterator as $item) {
            $skipfile = !empty($skip) ? in_array($item->getFilename(), $skip) : false;
            $ishidden = false;

            if ($options['skiphidden']) {
                // check for hidden folder, also hide with visible ones inside
                // but don't skip weird filenames like "...and-there-was-silence.avi"
                if ($item->isDot() || preg_match('/(\/\.\w+|\\\.\w+)/', $item->getPath())) {
                    continue;
                }
                // check for hidden file (probably works only on UNIX filesystems)
                $ishidden = preg_match('/^(\.\w+)/i', $item->getFilename());
            } else if (!$options['skipdirs']) {
                // always exclude . and .. directory navigators, only relevant when including folders
                $ishidden = $item->isDot();
            }

            if (($item->isFile() || $item->isDir() && !$options['skipdirs']) && !$ishidden && !$skipfile) {
                $additem = true;

                if (!empty($options['extensions'])) {
                    // if min PHP version is 5.3.6 we can use $item->getExtension()
                    $extension = pathinfo($item->getPathname(), PATHINFO_EXTENSION);
                    $extension = $mb ? mb_strtolower($extension, $mbencoding) : strtolower($extension);

                    if (!in_array($extension, $extensions)) {
                        $additem = false;
                    }
                }

                if ($additem) {
                    if (is_object($options['callback']) && ($options['callback'] instanceof Closure)) {
                        $items[] = $options['callback']($item);
                    } else {
                        $items[] = $item->isDir() ? $item->getPathname() . DIRECTORY_SEPARATOR : $item->getPathname();
                    }
                }
            }
        }

        if (!empty($options['sort'])) {
            array_multisort($items, $options['sortdir'], $options['sortflag'], $items);
        }

        return $items;
    }
```

The method is around the same length (but less code duplication) and much more powerful and hopefully also a bit more readable, what do you think @Mark-H? As MODX now has a minimal required PHP version of 5.3.3, we can use anonymous functions, which allow for a "callback" functionality, which puts this method on a whole new level...the normal behaviour is still like explained in the initial message, only skipping hidden files and folders was improved a bit (it listed files in visible folders inside hidden folders... e.g. /somedir/.somehiddendir/visibledir/file.txt) and:
- now it's also possible to filter out very specific files by filename (not just inclusion/filtering by extension) via the "skip" option.
- the "extensions" and "skip" options also accept php arrays and not only comma separated strings.
- the sort options are split up in "sort" (enable sort, boolean), "sortdir" and "sortflag" to  be able to fully configure array_multisort()
- the method now respects multibyte settings from modx
- the method now supports optional listing of sub-directories, not only files!
- ah, and I switched the method name to getList() as it now also lists directories and not just files which makes the name getFiles() not suitable anymore.

An advanced call could look like this:

``` php
// get the filehandler service
$modx->getService('file', 'modFileHandler');

// create modFileHandler object, in this case we need a modDirectory object, eg. pass a folder path
$dirobj = $modx->file->make(MODX_ASSETS_PATH . 'site/test/');

// get a sample object to work with in the callback
$obj = $modx->getObject('modResource', 1);

$list = $dirobj->getList(array(
    'recursive' => true,
    'sort' => false,
    'extensions' => '',
    'skiphidden' => true,
    'skip' => 'image_a.png,Image_A.png',
    'callback' => function($file) use (&$obj) { 
        return array(
            'user' => $this->modx->user->id,
            'filename' => $file->getFilename(),
            'path' => $file->getPathname(),
            'perms' => $file->getPerms(),
            'obj' => $obj->get('pagetitle')
        );
    }
));

// which would result in something like that:

Array
(
    [0] => Array
        (
            [user] => 1
            [filename] => IMAGE_A.png
            [path] => /path/to/media/media.test/IMAGE_A.png
            [perms] => 33188
            [obj] => Home
        )

    [1] => Array
        (
            [user] => 1
            [filename] => image_b.png
            [path] => /path/to/media/media.test/image_b.png
            [perms] => 33188
            [obj] => Home
        )

    [2] => Array
        (
            [user] => 1
            [filename] => Image_B.png
            [path] => /path/to/media/media.test/Image_B.png
            [perms] => 33188
            [obj] => Home
        )

    [3] => Array
        (
            [user] => 1
            [filename] => IMAGE_B.png
            [path] => /path/to/media/media.test/IMAGE_B.png
            [perms] => 33188
            [obj] => Home
        )

    [4] => Array
        (
            [user] => 1
            [filename] => image_c.png
            [path] => /path/to/media/media.test/image_c.png
            [perms] => 33188
            [obj] => Home
        )

    [5] => Array
        (
            [user] => 1
            [filename] => Image_C.png
            [path] => /path/to/media/media.test/Image_C.png
            [perms] => 33188
            [obj] => Home
        )

    [6] => Array
        (
            [user] => 1
            [filename] => IMAGE_C.png
            [path] => /path/to/media/media.test/IMAGE_C.png
            [perms] => 33188
            [obj] => Home
        )
)
```

as you can see we are now not anymore limited to "just" getting a list of filepaths, we can completely customize the output of the method with the callback function, that makes it very suitable as a replacement for directory listings in media source code, for example...or basically wherever the files of a directory need to be listed...in the core that could be following classes:

```
core/model/modx/modlexicon.class.php
core/model/modx/modtemplatevar.class.php
core/model/modx/processors/element/tv/renders/getinputs.class.php
core/model/modx/processors/element/tv/renders/getoutputs.class.php
core/model/modx/processors/workspace/theme/getlist.class.php
core/model/modx/registry/modfileregister.class.php
core/model/modx/sources/modfilemediasource.class.php
```

they all implement the DirectoryIterator used by this method as well...
### Why is it needed?

Adding the possibility to get a custom list/array of files inside a modDirectory instance.
### Related issue(s)/PR(s)

This is a re-up from #11295
