### PR TITLE
Allow manually editing rank-order of contexts

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -57,7 +57,7 @@ MODx.panel.Context = function(config) {
 					xtype: 'numberfield'
 					,fieldLabel: _('rank')
 					,name: 'rank'
-					,allowBlank: false
+					,allowBlank: true
 					,width: 300
 				},{
 					html: MODx.onContextFormRender

--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -54,6 +54,12 @@ MODx.panel.Context = function(config) {
 					,width: 300
 					,grow: true
 				},{
+					xtype: 'numberfield'
+					,fieldLabel: _('rank')
+					,name: 'rank'
+					,allowBlank: false
+					,width: 300
+				},{
 					html: MODx.onContextFormRender
 					,border: false
 				}]


### PR DESCRIPTION
### What does it do?

Add a numberfield for the rank-value of a context: 

![image](https://cloud.githubusercontent.com/assets/3798871/17861244/8596d6f4-6890-11e6-8f85-afac8a8e8498.png)
### Why is it needed?

Right now this setting can only be seen in the DB, 
it would be convenient to also see it were expected.
### Related issue(s)/PR(s)

not sure - will update if found
