### PR TITLE
Fixing #12826 MySQL 5.7 Error ORDER BY clause is not in SELECT list

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -339,6 +339,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $c = $resource->xpdo->newQuery('modTemplateVar');
         $c->query['distinct'] = 'DISTINCT';
         $c->select($resource->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar'));
+        $c->select($resource->xpdo->getSelectColumns('modTemplateVarTemplate', 'tvtpl', '', array('rank')));
         if ($resource->isNew()) {
             $c->select(array(
                 'modTemplateVar.default_text AS value',

--- a/core/model/modx/modtemplate.class.php
+++ b/core/model/modx/modtemplate.class.php
@@ -141,6 +141,7 @@ class modTemplate extends modElement {
             $c = $this->xpdo->newQuery('modTemplateVar');
             $c->query['distinct'] = 'DISTINCT';
             $c->select($this->xpdo->getSelectColumns('modTemplateVar'));
+            $c->select($this->xpdo->getSelectColumns('modTemplateVarTemplate', 'tvtpl', '', array('rank')));
             $c->select(array('value' => $this->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar', '', array('default_text'))));
             $c->innerJoin('modTemplateVarTemplate','tvtpl',array(
                 'tvtpl.tmplvarid = modTemplateVar.id',


### PR DESCRIPTION
### What does it do?

Add a SELECT clause for the ORDER BY clause because of the use of DISTINCT
### Why is it needed?

Fixing a MySQL 5.7.+ error:
`ORDER BY clause is not in SELECT list … this is incompatible with DISTINCT`
### Related issue(s)/PR(s)
#12826
