### PR TITLE
Fixing PHP 7 issue with eval of an empty conditional

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -144,7 +144,7 @@ class modOutputFilter {
                         case 'hide':
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
+                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if ($m_con) {
                                     $output= null;
@@ -154,7 +154,7 @@ class modOutputFilter {
                         case 'show':
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
+                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if (!$m_con) {
                                     $output= null;
@@ -165,7 +165,7 @@ class modOutputFilter {
                             $output = null;
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
+                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if ($m_con) {
                                     $output= $m_val;
@@ -175,7 +175,7 @@ class modOutputFilter {
                         case 'else':
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
+                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if (!$m_con) {
                                     $output= $m_val;

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -144,7 +144,7 @@ class modOutputFilter {
                         case 'hide':
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = @eval("return (" . $conditional . ");");
+                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if ($m_con) {
                                     $output= null;
@@ -154,7 +154,7 @@ class modOutputFilter {
                         case 'show':
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = @eval("return (" . $conditional . ");");
+                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if (!$m_con) {
                                     $output= null;
@@ -165,7 +165,7 @@ class modOutputFilter {
                             $output = null;
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = @eval("return (" . $conditional . ");");
+                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if ($m_con) {
                                     $output= $m_val;
@@ -175,7 +175,7 @@ class modOutputFilter {
                         case 'else':
                             $conditional = join(' ', $condition);
                             try {
-                                $m_con = @eval("return (" . $conditional . ");");
+                                $m_con = (!empty($conditional)) ? @eval("return (" . $conditional . ");") : false;
                                 $m_con = intval($m_con);
                                 if (!$m_con) {
                                     $output= $m_val;


### PR DESCRIPTION
### What does it do?

Execute eval only if $conditional is not an empty string (implies that the $condition array is not empty).
### Why is it needed?

PHP 7 now throws a ParseError if the eval-ed code is invalid, see http://php.net/manual/en/function.eval.php
### Related issue(s)/PR(s)
#13086
