### PR TITLE
Duplicating caption field for TVs

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -135,6 +135,7 @@ $_lang['editing_form'] = 'Editing Form';
 $_lang['element_duplicate'] = 'Duplicate Element';
 $_lang['element_duplicate_values'] = 'Duplicate Resource Values?';
 $_lang['element_name_new'] = 'Name of New Element';
+$_lang['element_caption_new'] = 'Caption of New Element';
 $_lang['elements'] = 'Elements';
 $_lang['email'] = 'Email';
 $_lang['empty_recycle_bin'] = 'Remove Deleted Resources';

--- a/core/model/modx/processors/element/getnodes.class.php
+++ b/core/model/modx/processors/element/getnodes.class.php
@@ -498,6 +498,7 @@ class modElementGetNodesProcessor extends modProcessor {
             if (!$element->checkPolicy('list')) continue;
             /* handle templatename case */
             $name = $elementClassKey == 'modTemplate' ? $element->get('templatename') : $element->get('name');
+            $caption = $elementClassKey == 'modTemplateVar' ? $element->get('caption') : '';
 
             $class = array();
             if ($canNewElement) $class[] = 'pnew';
@@ -525,6 +526,7 @@ class modElementGetNodesProcessor extends modProcessor {
                 'category' => 0,
                 'leaf' => true,
                 'name' => $name,
+                'caption' => $caption,
                 'cls' => implode(' ', $class),
                 'iconCls' => 'icon ' . ($element->get('icon') ? $element->get('icon') : ($element->get('static') ? 'icon-file-text-o' : 'icon-file-o')),
                 'page' => '?a='.$this->actionMap[$map[1]].'&id='.$element->get('id'),

--- a/core/model/modx/processors/element/tv/duplicate.class.php
+++ b/core/model/modx/processors/element/tv/duplicate.class.php
@@ -140,7 +140,7 @@ class modTemplateVarDuplicateProcessor extends modElementDuplicateProcessor {
         $caption = $this->getNewCaption();
         $this->setNewCaption($caption);
 
-        return parent::beforeSet();
+        return parent::beforeSave();
     }
 }
 

--- a/core/model/modx/processors/element/tv/duplicate.class.php
+++ b/core/model/modx/processors/element/tv/duplicate.class.php
@@ -14,6 +14,7 @@ class modTemplateVarDuplicateProcessor extends modElementDuplicateProcessor {
     public $languageTopics = array('tv');
     public $permission = 'new_tv';
     public $objectType = 'tv';
+    public $captionField = 'caption';
 
     public function afterSave() {
         $this->duplicateTemplates();
@@ -104,5 +105,43 @@ class modTemplateVarDuplicateProcessor extends modElementDuplicateProcessor {
             }
         }
     }
+
+    /**
+     * Get the new caption for the duplicate
+     * @return string
+     */
+    public function getNewCaption()
+    {
+        $caption = $this->getProperty($this->captionField);
+        $newCaption = !empty($caption)
+            ? $caption
+            : $this->modx->lexicon('duplicate_of', array('name' => $this->object->get($this->captionField)));
+
+        return $newCaption;
+    }
+
+    /**
+     * Set the new caption to the new object
+     * @param $caption
+     * @return string
+     * @internal param string $name
+     */
+    public function setNewCaption($caption)
+    {
+        return $this->newObject->set($this->captionField, $caption);
+    }
+
+    /**
+     * Run any logic before the object has been duplicated. May return false to prevent duplication.
+     * @return boolean
+     */
+    public function beforeSave()
+    {
+        $caption = $this->getNewCaption();
+        $this->setNewCaption($caption);
+
+        return parent::beforeSet();
+    }
 }
+
 return 'modTemplateVarDuplicateProcessor';

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -142,6 +142,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             id: id
             ,type: type
             ,name: _('duplicate_of',{name: this.cm.activeNode.attributes.name})
+            ,caption: _('duplicate_of',{name: this.cm.activeNode.attributes.caption})
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -126,6 +126,13 @@ MODx.window.DuplicateElement = function(config) {
     }];
     if (config.record.type == 'tv') {
         flds.push({
+            xtype: 'textfield'
+            ,fieldLabel: _('element_caption_new')
+            ,name: 'caption'
+            ,id: 'modx-'+this.ident+'-caption'
+            ,anchor: '100%'
+        });
+        flds.push({
             xtype: 'xcheckbox'
             ,fieldLabel: _('element_duplicate_values')
             ,labelSeparator: ''


### PR DESCRIPTION
### What does it do?

This improvement allows change caption of TV during duplicate it.
### Why is it needed?

It can be useful when you start duplicates one based TV to new and after that, you will get a mess on resource page because all TVs will have the same captions. This change allows avoid it.
### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/issues/10793
