### PR TITLE
Default value for the "unauthorized_page"

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1204,7 +1204,7 @@ class modX extends xPDO {
             $options
         );
         $this->invokeEvent('OnPageUnauthorized', $options);
-        $this->sendForward($this->getOption('unauthorized_page', $options, '401'), $options);
+        $this->sendForward($this->getOption('unauthorized_page', $options, $this->getOption('site_start')), $options);
     }
 
     /**


### PR DESCRIPTION
### What does it do?

Sets the default value of the "unauthorized_page" to the "site_start" setting instead of '401'.
### Why is it needed?

It's not easy task to create resource with ID = 401 for unauthorized users.
### Related issue(s)/PR(s)

None.
