### PR TITLE
Allowing using keyboard modifiers to open some links in new tabs

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -396,6 +396,12 @@ MODx.LayoutMgr = function() {
             }
             var url = parts.join('&');
             if (MODx.fireEvent('beforeLoadPage', url)) {
+                var e = window.event;
+                if (e && (e.button == 1 || e.ctrlKey == 1 || e.metaKey == 1 || e.shiftKey == 1)) {
+                    // Keyboard key pressed, let the browser handle the way it should be opened (new tab/window)
+                    return window.open(url);
+                }
+
                 location.href = url;
             }
             return false;


### PR DESCRIPTION
### What does it do ?

Modify `MODx.loadPage` to allow opening links in new tab/window using keyboard keys/modifiers and middle mouse (for example when clicking on the "+" icons in elements tree)
