### PR TITLE
Pass the namespace to OnManagerPageInit event

### DIFF
--- a/core/model/modx/modmanagerrequest.class.php
+++ b/core/model/modx/modmanagerrequest.class.php
@@ -124,7 +124,10 @@ class modManagerRequest extends modRequest {
         $this->namespace = trim(trim(str_replace('//','',$this->namespace),'/'));
 
         /* invoke OnManagerPageInit event */
-        $this->modx->invokeEvent('OnManagerPageInit',array('action' => $this->action));
+        $this->modx->invokeEvent('OnManagerPageInit', array(
+            'action' => $this->action,
+            'namespace' => $this->namespace,
+        ));
         $this->prepareResponse();
     }
 


### PR DESCRIPTION
### What does it do ?

Pass the namespace as property when invoking `OnManagerPageInit`
### Why is it needed ?

Mostly give some convenience for developers (it's still possible to get that value using `$modx->request->namespace`)
