### PR TITLE
Display PHP errors during setup with a browser

### DIFF
--- a/setup/includes/request/modinstallrequest.class.php
+++ b/setup/includes/request/modinstallrequest.class.php
@@ -18,6 +18,10 @@
  *
  * @package setup
  */
+
+error_reporting(E_ALL & ~E_NOTICE);
+@ ini_set('display_errors', 1);
+
 class modInstallRequest {
     /**
      * @var modInstall $install A reference to the modInstall object.


### PR DESCRIPTION
### What does it do?

Enable display_errors PHP setting and set the error level.
### Why is it needed?

At the moment, all error 500 are not displayed by default in some host configurations. The change makes this possible.
