### PR TITLE
Pass properties to the OnRichTextBrowserInit event

### DIFF
--- a/manager/controllers/default/browser/index.class.php
+++ b/manager/controllers/default/browser/index.class.php
@@ -39,11 +39,13 @@ MODx.ctx = "'.$this->ctx.'";
     public function process(array $scriptProperties = array()) {
         $placeholders = array();
 
-        $rtecallback = $this->modx->invokeEvent('OnRichTextBrowserInit');
+        $scriptProperties['ctx'] = !empty($scriptProperties['ctx']) ? $scriptProperties['ctx'] : 'web';
+        
+        $rtecallback = $this->modx->invokeEvent('OnRichTextBrowserInit', $scriptProperties);
         if (is_array($rtecallback)) $rtecallback = trim(implode(',',$rtecallback),',');
         $placeholders['rtecallback'] = $rtecallback;
 
-        $this->ctx = !empty($scriptProperties['ctx']) ? $scriptProperties['ctx'] : 'web';
+        $this->ctx = $scriptProperties['ctx'];
         $placeholders['_ctx'] = $this->ctx;
 
         $_SERVER['HTTP_MODAUTH'] = $this->modx->user->getUserToken($this->modx->context->get('key'));


### PR DESCRIPTION
### What does it do?

Passes properties to the OnRichTextBrowserInit event.
### Why is it needed?

Currently no information is passed into this event. This makes it impossible to determine the Resource or Context from which the event is fired. With this information passed in, it will be possible to have different RTEs for each Context or Resource.
