### PR TITLE
Update the function processEventResponse

### DIFF
--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -317,7 +317,7 @@ abstract class modProcessor {
                     $result[] = $msg;
                 }
             }
-            $result = implode($separator,$result);
+            if ($result) $result = implode($separator,$result);
         } else {
             $result = $response;
         }


### PR DESCRIPTION
### What does it do?

Implode() is executed only if $result is array.
### Why is it needed?

If plugin (when it changes the active status of user) doesn't return any output the response looks like an array `array(0=>'')`. This causes a warning `PHP warning: implode(): Invalid arguments passed` because the second argument of the implode function is not an array.
### Related issue(s)/PR(s)

As I know none.
