### PR TITLE
Default value for the "error_page"

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1180,7 +1180,7 @@ class modX extends xPDO {
             $options
         );
         $this->invokeEvent('OnPageNotFound', $options);
-        $this->sendForward($this->getOption('error_page', $options, '404'), $options);
+        $this->sendForward($this->getOption('error_page', $options, $this->getOption('site_start')), $options);
     }
 
     /**


### PR DESCRIPTION
### What does it do?

Sets the default value of the "error_page" to the "site_start" setting instead of '404'.
### Why is it needed?

It's not easy task to create resource with ID = 404 for unauthorized users.
### Related issue(s)/PR(s)

Similar to #13101
