### PR TITLE
Added new line and spaces regex to input filter

### DIFF
--- a/core/model/modx/filters/modinputfilter.class.php
+++ b/core/model/modx/filters/modinputfilter.class.php
@@ -30,7 +30,7 @@ class modInputFilter {
 
     /**
      * Constructor for modInputFilter
-     * 
+     *
      * @param modX $modx A reference to the modX instance.
      */
     function __construct(modX &$modx) {
@@ -49,9 +49,9 @@ class modInputFilter {
         $splitPos= strpos($output, ':');
         if ($splitPos !== false && $splitPos > 0) {
             $matches= array ();
-            $name= substr($output, 0, $splitPos);
+            $name= trim(substr($output, 0, $splitPos));
             $modifiers= substr($output, $splitPos);
-            if (preg_match_all('~:([^:=]+)(?:=`(.*?)`(?=:[^:=]+|$))?~s', $modifiers, $matches)) {
+            if (preg_match_all('~:([^:=]+)(?:=`(.*?)`[\r\n\s]*(?=:[^:=]+|$))?~s', $modifiers, $matches)) {
                 $this->_commands = $matches[1]; /* modifier commands */
                 $this->_modifiers = $matches[2]; /* modifier values */
             }


### PR DESCRIPTION
### What does it do?

Enable multi line outfilter's tagging
Eg:
Previous:

``` html
[[*id:is=`[[++site_start]]`:then=`<title>Home Title</title>`:else=`<title>[[++site_name]] | [[*pagetitle]]</title>`]]
```

PR:

``` html
[[*id
:is=`[[++site_start]]`
:then=`<title>Home Title</title>`
:else=`<title>[[++site_name]] | [[*pagetitle]]</title>`
]]
```

Or

``` html
    [[*id
    :is=`[[++site_start]]`
    :then=`<title>Home Title</title>`
    :else=`<title>[[++site_name]] | [[*pagetitle]]</title>`
    ]]
```

(notice the spaces up front)
### Why is it needed?

Just easy reading.
### Related issue(s)/PR(s)

AFAIK, none, unless specified.
