### PR TITLE
Copy the current event so values can be transmitted from one plugin to another

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1583,7 +1583,11 @@ class modX extends xPDO {
             $this->event= new modSystemEvent();
             foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
                 $plugin= null;
-                $this->Event= version_compare(PHP_VERSION, '5.4', '>=') ? clone $this->event : & $this->event;
+                if (!version_compare(PHP_VERSION, '5.4', '>=')) {
+                    $this->Event = & $this->event;
+                } else {
+                    $this->Event = clone $this->event;
+                }
                 $this->event->resetEventObject();
                 $this->event->name= $eventName;
                 if (isset ($this->pluginCache[$pluginId])) {

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1583,7 +1583,7 @@ class modX extends xPDO {
             $this->event= new modSystemEvent();
             foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
                 $plugin= null;
-                $this->Event= & $this->event;
+                $this->Event= clone $this->event;
                 $this->event->resetEventObject();
                 $this->event->name= $eventName;
                 if (isset ($this->pluginCache[$pluginId])) {

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1583,7 +1583,7 @@ class modX extends xPDO {
             $this->event= new modSystemEvent();
             foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
                 $plugin= null;
-                $this->Event= clone $this->event;
+                $this->Event= version_compare(PHP_VERSION, '5.4', '>=') ? clone $this->event : & $this->event;
                 $this->event->resetEventObject();
                 $this->event->name= $eventName;
                 if (isset ($this->pluginCache[$pluginId])) {


### PR DESCRIPTION
### What does it do?

Сopies the current event
### Why is it needed?

To transmit the values of the events in an event
### Example
#### \- first event

```
if ($modx->event->name == 'eventName') {
    $modx->event->returnedValues['param'][] = 'paramValue';
}
```
#### \- second event

```
if ($modx->event->name == 'eventName') {
    $values = $modx->Event->returnedValues;
    $values['param'][] = 'paramValue2';
    $modx->event->returnedValues = $values;
}
```
#### \- third event

```
if ($modx->event->name == 'eventName') {
    $values = $modx->Event->returnedValues;
    $modx->log(1, print_r($values,1 ));
}

/*
Array
(
    [param] => Array
        (
            [0] => paramValue
            [1] => paramValue2
        )

)
*/
```
