### PR TITLE
Fixed addEventListener function

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1945,15 +1945,8 @@ class modX extends xPDO {
             if (!isset($this->eventMap[$event]) || empty ($this->eventMap[$event])) {
                 $this->eventMap[$event]= array();
             }
-            $ElementPropertySetTbl= $this->getTableName('modElementPropertySet');
-            $propsetTbl= $this->getTableName('modPropertySet');
-            $sql= "SELECT PropertySet.name 
-                FROM {$ElementPropertySetTbl} ElementPropSet 
-                LEFT JOIN {$propsetTbl} PropertySet ON ElementPropSet.property_set = PropertySet.id 
-                WHERE ElementPropSet.element = {$pluginId} AND ElementPropSet.element_class='modPlugin' AND PropertySet.name = '{$propertySetName}' ";
-            $propertySetName = $this->getValue($this->prepare($sql));
             $this->eventMap[$event][$pluginId]= $pluginId . (!empty($propertySetName) ? ':' . $propertySetName : '');
-            $added= true;
+            $added = true;
         }
         return $added;
     }

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1939,11 +1939,20 @@ class modX extends xPDO {
      */
     public function addEventListener($event, $pluginId) {
         $added = false;
+        $pluginId = intval($pluginId);
         if ($event && $pluginId) {
             if (!isset($this->eventMap[$event]) || empty ($this->eventMap[$event])) {
                 $this->eventMap[$event]= array();
             }
-            $this->eventMap[$event][$pluginId]= $pluginId;
+            $pluginEventTbl= $this->getTableName('modPluginEvent');
+            $propsetTbl= $this->getTableName('modPropertySet');
+            $sql= "SELECT PropertySet.name AS propertyset 
+                FROM {$pluginEventTbl} PluginEvent 
+                LEFT JOIN {$propsetTbl} PropertySet ON PluginEvent.propertyset = PropertySet.id 
+                WHERE PluginEvent.event = '{$event}' AND PluginEvent.pluginid = {$pluginId}
+            ";
+            $propset = $this->getValue($this->prepare($sql));
+            $this->eventMap[$event][$pluginId]= $pluginId . (!empty($propset) ? ':' . $propset : '');
             $added= true;
         }
         return $added;

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1943,7 +1943,7 @@ class modX extends xPDO {
             if (!isset($this->eventMap[$event]) || empty ($this->eventMap[$event])) {
                 $this->eventMap[$event]= array();
             }
-            $this->eventMap[$event][]= $pluginId;
+            $this->eventMap[$event][$pluginId]= $pluginId;
             $added= true;
         }
         return $added;

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1935,24 +1935,24 @@ class modX extends xPDO {
      *
      * @param string $event Name of the event.
      * @param integer $pluginId Plugin identifier to add to the event.
+     * @param string $propertySetName The name of property set bound to the plugin
      * @return boolean true if the event is successfully added, otherwise false.
      */
-    public function addEventListener($event, $pluginId) {
+    public function addEventListener($event, $pluginId, $propertySetName = '') {
         $added = false;
         $pluginId = intval($pluginId);
         if ($event && $pluginId) {
             if (!isset($this->eventMap[$event]) || empty ($this->eventMap[$event])) {
                 $this->eventMap[$event]= array();
             }
-            $pluginEventTbl= $this->getTableName('modPluginEvent');
+            $ElementPropertySetTbl= $this->getTableName('modElementPropertySet');
             $propsetTbl= $this->getTableName('modPropertySet');
-            $sql= "SELECT PropertySet.name AS propertyset 
-                FROM {$pluginEventTbl} PluginEvent 
-                LEFT JOIN {$propsetTbl} PropertySet ON PluginEvent.propertyset = PropertySet.id 
-                WHERE PluginEvent.event = '{$event}' AND PluginEvent.pluginid = {$pluginId}
-            ";
-            $propset = $this->getValue($this->prepare($sql));
-            $this->eventMap[$event][$pluginId]= $pluginId . (!empty($propset) ? ':' . $propset : '');
+            $sql= "SELECT PropertySet.name 
+                FROM {$ElementPropertySetTbl} ElementPropSet 
+                LEFT JOIN {$propsetTbl} PropertySet ON ElementPropSet.property_set = PropertySet.id 
+                WHERE ElementPropSet.element = {$pluginId} AND ElementPropSet.element_class='modPlugin' AND PropertySet.name = '{$propertySetName}' ";
+            $propertySetName = $this->getValue($this->prepare($sql));
+            $this->eventMap[$event][$pluginId]= $pluginId . (!empty($propertySetName) ? ':' . $propertySetName : '');
             $added= true;
         }
         return $added;


### PR DESCRIPTION
### What does it do?

Added the plugin ID to the plugin map as an array key.
### Why is it needed?

Now this method adds a plugin to the plugin map without any key - 
`$this->eventMap[$event][]= $pluginId;`
But the "InvokeEvent" method uses the array key to get the plugin object - 

```
foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
    ...
    $plugin= $this->getObject('modPlugin', array ('id' => intval($pluginId), 'disabled' => '0'), true);
    ...
}
```

So the plugin added via the "addEventListener" method will not run.
### Related issue(s)/PR(s)

None.
