### PR TITLE
Update phpThumb to 1.7.14-201608101311

### DIFF
--- a/core/model/phpthumb/phpthumb.bmp.php
+++ b/core/model/phpthumb/phpthumb.bmp.php
@@ -20,10 +20,6 @@
 
 class phpthumb_bmp {
 
-	function phpthumb_bmp() {
-		return true;
-	}
-
 	function phpthumb_bmp2gd(&$BMPdata, $truecolor=true) {
 		$ThisFileInfo = array();
 		if ($this->getid3_bmp($BMPdata, $ThisFileInfo, true, true)) {
@@ -43,8 +39,8 @@ class phpthumb_bmp {
 	}
 
 	function GD2BMPstring(&$gd_image) {
-		$imageX = ImageSX($gd_image);
-		$imageY = ImageSY($gd_image);
+		$imageX = imagesx($gd_image);
+		$imageY = imagesy($gd_image);
 
 		$BMP = '';
 		for ($y = ($imageY - 1); $y >= 0; $y--) {
@@ -85,11 +81,11 @@ class phpthumb_bmp {
 
 	function getid3_bmp(&$BMPdata, &$ThisFileInfo, $ExtractPalette=false, $ExtractData=false) {
 
-	    // shortcuts
-	    $ThisFileInfo['bmp']['header']['raw'] = array();
-	    $thisfile_bmp                         = &$ThisFileInfo['bmp'];
-	    $thisfile_bmp_header                  = &$thisfile_bmp['header'];
-	    $thisfile_bmp_header_raw              = &$thisfile_bmp_header['raw'];
+		// shortcuts
+		$ThisFileInfo['bmp']['header']['raw'] = array();
+		$thisfile_bmp                         = &$ThisFileInfo['bmp'];
+		$thisfile_bmp_header                  = &$thisfile_bmp['header'];
+		$thisfile_bmp_header_raw              = &$thisfile_bmp_header['raw'];
 
 		// BITMAPFILEHEADER [14 bytes] - http://msdn.microsoft.com/library/en-us/gdi/bitmaps_62uq.asp
 		// all versions
@@ -252,9 +248,9 @@ class phpthumb_bmp {
 			// DWORD  biClrUsed;
 			// DWORD  biClrImportant;
 
-			$thisfile_bmp_header_raw['width']            = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['width']            = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
-			$thisfile_bmp_header_raw['height']           = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['height']           = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
 			$thisfile_bmp_header_raw['planes']           = $this->LittleEndian2Int(substr($BMPheader, $offset, 2));
 			$offset += 2;
@@ -264,9 +260,9 @@ class phpthumb_bmp {
 			$offset += 4;
 			$thisfile_bmp_header_raw['bmp_data_size']    = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
-			$thisfile_bmp_header_raw['resolution_h']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['resolution_h']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
-			$thisfile_bmp_header_raw['resolution_v']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4), true);
+			$thisfile_bmp_header_raw['resolution_v']     = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
 			$thisfile_bmp_header_raw['colors_used']      = $this->LittleEndian2Int(substr($BMPheader, $offset, 4));
 			$offset += 4;
@@ -591,7 +587,7 @@ class phpthumb_bmp {
 											// of color indexes that follow. Subsequent bytes contain color indexes in their
 											// high- and low-order 4 bits, one color index for each pixel. In absolute mode,
 											// each run must be aligned on a word boundary.
-											unset($paletteindexes);
+											$paletteindexes = array();
 											for ($i = 0; $i < ceil($secondbyte / 2); $i++) {
 												$paletteindexbyte = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
 												$paletteindexes[] = ($paletteindexbyte & 0xF0) >> 4;
@@ -706,23 +702,23 @@ class phpthumb_bmp {
 
 		if ($truecolor) {
 
-			$gd = @ImageCreateTrueColor($imagewidth, $imageheight);
+			$gd = @imagecreatetruecolor($imagewidth, $imageheight);
 
 		} else {
 
-			$gd = @ImageCreate($imagewidth, $imageheight);
+			$gd = @imagecreate($imagewidth, $imageheight);
 			if (!empty($BMPdata['palette'])) {
 				// create GD palette from BMP palette
 				foreach ($BMPdata['palette'] as $dummy => $color) {
 					list($r, $g, $b) = $this->IntColor2RGB($color);
-					ImageColorAllocate($gd, $r, $g, $b);
+					imagecolorallocate($gd, $r, $g, $b);
 				}
 			} else {
 				// create 216-color websafe palette
 				for ($r = 0x00; $r <= 0xFF; $r += 0x33) {
 					for ($g = 0x00; $g <= 0xFF; $g += 0x33) {
 						for ($b = 0x00; $b <= 0xFF; $b += 0x33) {
-							ImageColorAllocate($gd, $r, $g, $b);
+							imagecolorallocate($gd, $r, $g, $b);
 						}
 					}
 				}
@@ -740,11 +736,11 @@ class phpthumb_bmp {
 			foreach ($colarray as $col => $color) {
 				list($red, $green, $blue) = $this->IntColor2RGB($color);
 				if ($truecolor) {
-					$pixelcolor = ImageColorAllocate($gd, $red, $green, $blue);
+					$pixelcolor = imagecolorallocate($gd, $red, $green, $blue);
 				} else {
-					$pixelcolor = ImageColorClosest($gd, $red, $green, $blue);
+					$pixelcolor = imagecolorclosest($gd, $red, $green, $blue);
 				}
-				ImageSetPixel($gd, $col, $row, $pixelcolor);
+				imagesetpixel($gd, $col, $row, $pixelcolor);
 			}
 		}
 		return $gd;
@@ -762,15 +758,13 @@ class phpthumb_bmp {
 		$im = $this->PlotPixelsGD($BMPinfo['bmp']);
 		if (headers_sent()) {
 			echo 'plotted '.($BMPinfo['resolution_x'] * $BMPinfo['resolution_y']).' pixels in '.(time() - $starttime).' seconds<BR>';
-			ImageDestroy($im);
+			imagedestroy($im);
 			exit;
-		} else {
-			header('Content-Type: image/png');
-			ImagePNG($im);
-			ImageDestroy($im);
-			return true;
 		}
-		return false;
+		header('Content-Type: image/png');
+		imagepng($im);
+		imagedestroy($im);
+		return true;
 	}
 
 	function BMPcompressionWindowsLookup($compressionid) {
@@ -874,5 +868,3 @@ class phpthumb_bmp {
 	}
 
 }
-
-?>

--- a/core/model/phpthumb/phpthumb.filters.php
+++ b/core/model/phpthumb/phpthumb.filters.php
@@ -11,11 +11,12 @@
 
 class phpthumb_filters {
 
+	/**
+	* @var phpthumb
+	*/
+
 	var $phpThumbObject = null;
 
-	function phpthumb_filters() {
-		return true;
-	}
 
 	function DebugMessage($message, $file='', $line='') {
 		if (is_object($this->phpThumbObject)) {
@@ -23,7 +24,6 @@ class phpthumb_filters {
 		}
 		return false;
 	}
-
 
 
 	public function ApplyMask(&$gdimg_mask, &$gdimg_image) {
@@ -34,34 +34,34 @@ class phpthumb_filters {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.2', '>=')) {
 
 			$this->DebugMessage('Using alpha ApplyMask() technique', __FILE__, __LINE__);
-			if ($gdimg_mask_resized = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg_image), ImageSY($gdimg_image))) {
+			if ($gdimg_mask_resized = phpthumb_functions::ImageCreateFunction(imagesx($gdimg_image), imagesy($gdimg_image))) {
 
-				ImageCopyResampled($gdimg_mask_resized, $gdimg_mask, 0, 0, 0, 0, ImageSX($gdimg_image), ImageSY($gdimg_image), ImageSX($gdimg_mask), ImageSY($gdimg_mask));
-				if ($gdimg_mask_blendtemp = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg_image), ImageSY($gdimg_image))) {
+				imagecopyresampled($gdimg_mask_resized, $gdimg_mask, 0, 0, 0, 0, imagesx($gdimg_image), imagesy($gdimg_image), imagesx($gdimg_mask), imagesy($gdimg_mask));
+				if ($gdimg_mask_blendtemp = phpthumb_functions::ImageCreateFunction(imagesx($gdimg_image), imagesy($gdimg_image))) {
 
-					$color_background = ImageColorAllocate($gdimg_mask_blendtemp, 0, 0, 0);
-					ImageFilledRectangle($gdimg_mask_blendtemp, 0, 0, ImageSX($gdimg_mask_blendtemp), ImageSY($gdimg_mask_blendtemp), $color_background);
-					ImageAlphaBlending($gdimg_mask_blendtemp, false);
-					ImageSaveAlpha($gdimg_mask_blendtemp, true);
-					for ($x = 0; $x < ImageSX($gdimg_image); $x++) {
-						for ($y = 0; $y < ImageSY($gdimg_image); $y++) {
+					$color_background = imagecolorallocate($gdimg_mask_blendtemp, 0, 0, 0);
+					imagefilledrectangle($gdimg_mask_blendtemp, 0, 0, imagesx($gdimg_mask_blendtemp), imagesy($gdimg_mask_blendtemp), $color_background);
+					imagealphablending($gdimg_mask_blendtemp, false);
+					imagesavealpha($gdimg_mask_blendtemp, true);
+					for ($x = 0; $x < imagesx($gdimg_image); $x++) {
+						for ($y = 0; $y < imagesy($gdimg_image); $y++) {
 							//$RealPixel = phpthumb_functions::GetPixelColor($gdimg_mask_blendtemp, $x, $y);
 							$RealPixel = phpthumb_functions::GetPixelColor($gdimg_image, $x, $y);
 							$MaskPixel = phpthumb_functions::GrayscalePixel(phpthumb_functions::GetPixelColor($gdimg_mask_resized, $x, $y));
 							$MaskAlpha = 127 - (floor($MaskPixel['red'] / 2) * (1 - ($RealPixel['alpha'] / 127)));
 							$newcolor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg_mask_blendtemp, $RealPixel['red'], $RealPixel['green'], $RealPixel['blue'], $MaskAlpha);
-							ImageSetPixel($gdimg_mask_blendtemp, $x, $y, $newcolor);
+							imagesetpixel($gdimg_mask_blendtemp, $x, $y, $newcolor);
 						}
 					}
-					ImageAlphaBlending($gdimg_image, false);
-					ImageSaveAlpha($gdimg_image, true);
-					ImageCopy($gdimg_image, $gdimg_mask_blendtemp, 0, 0, 0, 0, ImageSX($gdimg_mask_blendtemp), ImageSY($gdimg_mask_blendtemp));
-					ImageDestroy($gdimg_mask_blendtemp);
+					imagealphablending($gdimg_image, false);
+					imagesavealpha($gdimg_image, true);
+					imagecopy($gdimg_image, $gdimg_mask_blendtemp, 0, 0, 0, 0, imagesx($gdimg_mask_blendtemp), imagesy($gdimg_mask_blendtemp));
+					imagedestroy($gdimg_mask_blendtemp);
 
 				} else {
 					$this->DebugMessage('ImageCreateFunction() failed', __FILE__, __LINE__);
 				}
-				ImageDestroy($gdimg_mask_resized);
+				imagedestroy($gdimg_mask_resized);
 
 			} else {
 				$this->DebugMessage('ImageCreateFunction() failed', __FILE__, __LINE__);
@@ -80,16 +80,16 @@ class phpthumb_filters {
         $hexcolor1 = ($hexcolor1 ? $hexcolor1 : 'FFFFFF');
         $hexcolor2 = ($hexcolor2 ? $hexcolor2 : '000000');
 
-        ImageAlphaBlending($gdimg, true);
+        imagealphablending($gdimg, true);
         for ($i = 0; $i < $width; $i++) {
             $alpha = round(($i / $width) * 127);
             $color1 = phpthumb_functions::ImageHexColorAllocate($gdimg, $hexcolor1, false, $alpha);
             $color2 = phpthumb_functions::ImageHexColorAllocate($gdimg, $hexcolor2, false, $alpha);
 
-            ImageLine($gdimg,                   $i,                   $i + 1,                   $i, ImageSY($gdimg) - $i - 1, $color1); // left
-            ImageLine($gdimg,                   $i,                   $i    , ImageSX($gdimg) - $i,                   $i    , $color1); // top
-            ImageLine($gdimg, ImageSX($gdimg) - $i, ImageSY($gdimg) - $i - 1, ImageSX($gdimg) - $i,                   $i + 1, $color2); // right
-            ImageLine($gdimg, ImageSX($gdimg) - $i, ImageSY($gdimg) - $i    ,                   $i, ImageSY($gdimg) - $i    , $color2); // bottom
+            imageline($gdimg,                   $i,                   $i + 1,                   $i, imagesy($gdimg) - $i - 1, $color1); // left
+            imageline($gdimg,                   $i,                   $i    , imagesx($gdimg) - $i,                   $i    , $color1); // top
+            imageline($gdimg, imagesx($gdimg) - $i, imagesy($gdimg) - $i - 1, imagesx($gdimg) - $i,                   $i + 1, $color2); // right
+            imageline($gdimg, imagesx($gdimg) - $i, imagesy($gdimg) - $i    ,                   $i, imagesy($gdimg) - $i    , $color2); // bottom
         }
         return true;
     }
@@ -103,9 +103,9 @@ class phpthumb_filters {
 			return false;
 		}
 
-		$w = ImageSX($gdimg);
-		$h = ImageSY($gdimg);
-		if ($imgBlur = ImageCreateTrueColor($w, $h)) {
+		$w = imagesx($gdimg);
+		$h = imagesy($gdimg);
+		if ($imgBlur = imagecreatetruecolor($w, $h)) {
 			// Gaussian blur matrix:
 			//	1	2	1
 			//	2	4	2
@@ -114,16 +114,16 @@ class phpthumb_filters {
 			// Move copies of the image around one pixel at the time and merge them with weight
 			// according to the matrix. The same matrix is simply repeated for higher radii.
 			for ($i = 0; $i < $radius; $i++)	{
-				ImageCopy     ($imgBlur, $gdimg, 0, 0, 1, 1, $w - 1, $h - 1);            // up left
-				ImageCopyMerge($imgBlur, $gdimg, 1, 1, 0, 0, $w,     $h,     50.00000);  // down right
-				ImageCopyMerge($imgBlur, $gdimg, 0, 1, 1, 0, $w - 1, $h,     33.33333);  // down left
-				ImageCopyMerge($imgBlur, $gdimg, 1, 0, 0, 1, $w,     $h - 1, 25.00000);  // up right
-				ImageCopyMerge($imgBlur, $gdimg, 0, 0, 1, 0, $w - 1, $h,     33.33333);  // left
-				ImageCopyMerge($imgBlur, $gdimg, 1, 0, 0, 0, $w,     $h,     25.00000);  // right
-				ImageCopyMerge($imgBlur, $gdimg, 0, 0, 0, 1, $w,     $h - 1, 20.00000);  // up
-				ImageCopyMerge($imgBlur, $gdimg, 0, 1, 0, 0, $w,     $h,     16.666667); // down
-				ImageCopyMerge($imgBlur, $gdimg, 0, 0, 0, 0, $w,     $h,     50.000000); // center
-				ImageCopy     ($gdimg, $imgBlur, 0, 0, 0, 0, $w,     $h);
+				imagecopy     ($imgBlur, $gdimg, 0, 0, 1, 1, $w - 1, $h - 1);            // up left
+				imagecopymerge($imgBlur, $gdimg, 1, 1, 0, 0, $w,     $h,     50.00000);  // down right
+				imagecopymerge($imgBlur, $gdimg, 0, 1, 1, 0, $w - 1, $h,     33.33333);  // down left
+				imagecopymerge($imgBlur, $gdimg, 1, 0, 0, 1, $w,     $h - 1, 25.00000);  // up right
+				imagecopymerge($imgBlur, $gdimg, 0, 0, 1, 0, $w - 1, $h,     33.33333);  // left
+				imagecopymerge($imgBlur, $gdimg, 1, 0, 0, 0, $w,     $h,     25.00000);  // right
+				imagecopymerge($imgBlur, $gdimg, 0, 0, 0, 1, $w,     $h - 1, 20.00000);  // up
+				imagecopymerge($imgBlur, $gdimg, 0, 1, 0, 0, $w,     $h,     16.666667); // down
+				imagecopymerge($imgBlur, $gdimg, 0, 0, 0, 0, $w,     $h,     50.000000); // center
+				imagecopy     ($gdimg, $imgBlur, 0, 0, 0, 0, $w,     $h);
 			}
 			return true;
 		}
@@ -133,10 +133,10 @@ class phpthumb_filters {
 
 	public function BlurGaussian(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_GAUSSIAN_BLUR)) {
+			if (imagefilter($gdimg, IMG_FILTER_GAUSSIAN_BLUR)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_GAUSSIAN_BLUR)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_GAUSSIAN_BLUR)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 		$this->DebugMessage('FAILED: phpthumb_filters::BlurGaussian($gdimg) [using phpthumb_filters::Blur() instead]', __FILE__, __LINE__);
@@ -146,10 +146,10 @@ class phpthumb_filters {
 
 	public function BlurSelective(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_SELECTIVE_BLUR)) {
+			if (imagefilter($gdimg, IMG_FILTER_SELECTIVE_BLUR)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_SELECTIVE_BLUR)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_SELECTIVE_BLUR)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 		// currently not implemented "the hard way"
@@ -165,23 +165,24 @@ class phpthumb_filters {
 		$amount = max(-255, min(255, $amount));
 
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_BRIGHTNESS, $amount)) {
+			if (imagefilter($gdimg, IMG_FILTER_BRIGHTNESS, $amount)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_BRIGHTNESS, '.$amount.')', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_BRIGHTNESS, '.$amount.')', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 
 		$scaling = (255 - abs($amount)) / 255;
 		$baseamount = (($amount > 0) ? $amount : 0);
-		for ($x = 0; $x < ImageSX($gdimg); $x++) {
-			for ($y = 0; $y < ImageSY($gdimg); $y++) {
+		for ($x = 0; $x < imagesx($gdimg); $x++) {
+			for ($y = 0; $y < imagesy($gdimg); $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
+				$NewPixel = array();
 				foreach ($OriginalPixel as $key => $value) {
 					$NewPixel[$key] = round($baseamount + ($OriginalPixel[$key] * $scaling));
 				}
-				$newColor = ImageColorAllocate($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue']);
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				$newColor = imagecolorallocate($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue']);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
 		return true;
@@ -195,12 +196,12 @@ class phpthumb_filters {
 		$amount = max(-255, min(255, $amount));
 
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			// ImageFilter(IMG_FILTER_CONTRAST) has range +100 to -100 (positive numbers make it darker!)
+			// imagefilter(IMG_FILTER_CONTRAST) has range +100 to -100 (positive numbers make it darker!)
 			$amount = ($amount / 255) * -100;
-			if (ImageFilter($gdimg, IMG_FILTER_CONTRAST, $amount)) {
+			if (imagefilter($gdimg, IMG_FILTER_CONTRAST, $amount)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_CONTRAST, '.$amount.')', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_CONTRAST, '.$amount.')', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 
@@ -209,16 +210,18 @@ class phpthumb_filters {
 		} else {
 			$scaling = (255 - abs($amount)) / 255;
 		}
-		for ($x = 0; $x < ImageSX($gdimg); $x++) {
-			for ($y = 0; $y < ImageSY($gdimg); $y++) {
+		for ($x = 0; $x < imagesx($gdimg); $x++) {
+			for ($y = 0; $y < imagesy($gdimg); $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
+				$NewPixel = array();
 				foreach ($OriginalPixel as $key => $value) {
 					$NewPixel[$key] = min(255, max(0, round($OriginalPixel[$key] * $scaling)));
 				}
-				$newColor = ImageColorAllocate($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue']);
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				$newColor = imagecolorallocate($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue']);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
+		return true;
 	}
 
 
@@ -238,32 +241,34 @@ class phpthumb_filters {
 			$r = round($amountPct * hexdec(substr($targetColor, 0, 2)));
 			$g = round($amountPct * hexdec(substr($targetColor, 2, 2)));
 			$b = round($amountPct * hexdec(substr($targetColor, 4, 2)));
-			if (ImageFilter($gdimg, IMG_FILTER_COLORIZE, $r, $g, $b)) {
+			if (imagefilter($gdimg, IMG_FILTER_COLORIZE, $r, $g, $b)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_COLORIZE)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_COLORIZE)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 
 		// overridden below for grayscale
+		$TargetPixel = array();
 		if ($targetColor != 'gray') {
 			$TargetPixel['red']   = hexdec(substr($targetColor, 0, 2));
 			$TargetPixel['green'] = hexdec(substr($targetColor, 2, 2));
 			$TargetPixel['blue']  = hexdec(substr($targetColor, 4, 2));
 		}
 
-		for ($x = 0; $x < ImageSX($gdimg); $x++) {
-			for ($y = 0; $y < ImageSY($gdimg); $y++) {
+		for ($x = 0; $x < imagesx($gdimg); $x++) {
+			for ($y = 0; $y < imagesy($gdimg); $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				if ($targetColor == 'gray') {
 					$TargetPixel = phpthumb_functions::GrayscalePixel($OriginalPixel);
 				}
+				$NewPixel = array();
 				foreach ($TargetPixel as $key => $value) {
 					$NewPixel[$key] = round(max(0, min(255, ($OriginalPixel[$key] * ((100 - $amount) / 100)) + ($TargetPixel[$key] * $amountPct))));
 				}
 				//$newColor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue'], $OriginalPixel['alpha']);
-				$newColor = ImageColorAllocate($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue']);
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				$newColor = imagecolorallocate($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue']);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
 		return true;
@@ -274,8 +279,8 @@ class phpthumb_filters {
 		if (!$left && !$right && !$top && !$bottom) {
 			return true;
 		}
-		$oldW = ImageSX($gdimg);
-		$oldH = ImageSY($gdimg);
+		$oldW = imagesx($gdimg);
+		$oldH = imagesy($gdimg);
 		if (($left   > 0) && ($left   < 1)) { $left   = round($left   * $oldW); }
 		if (($right  > 0) && ($right  < 1)) { $right  = round($right  * $oldW); }
 		if (($top    > 0) && ($top    < 1)) { $top    = round($top    * $oldH); }
@@ -285,14 +290,14 @@ class phpthumb_filters {
 		$newW = $oldW - $left - $right;
 		$newH = $oldH - $top  - $bottom;
 
-		if ($imgCropped = ImageCreateTrueColor($newW, $newH)) {
-			ImageCopy($imgCropped, $gdimg, 0, 0, $left, $top, $newW, $newH);
-			if ($gdimg = ImageCreateTrueColor($newW, $newH)) {
-				ImageCopy($gdimg, $imgCropped, 0, 0, 0, 0, $newW, $newH);
-				ImageDestroy($imgCropped);
+		if ($imgCropped = imagecreatetruecolor($newW, $newH)) {
+			imagecopy($imgCropped, $gdimg, 0, 0, $left, $top, $newW, $newH);
+			if ($gdimg = imagecreatetruecolor($newW, $newH)) {
+				imagecopy($gdimg, $imgCropped, 0, 0, 0, 0, $newW, $newH);
+				imagedestroy($imgCropped);
 				return true;
 			}
-			ImageDestroy($imgCropped);
+			imagedestroy($imgCropped);
 		}
 		return false;
 	}
@@ -325,29 +330,30 @@ class phpthumb_filters {
 			return true;
 		}
 
-		$width_shadow  = cos(deg2rad($angle)) * ($distance + $width);
-		$height_shadow = sin(deg2rad($angle)) * ($distance + $width);
+		//$width_shadow  = cos(deg2rad($angle)) * ($distance + $width);
+		//$height_shadow = sin(deg2rad($angle)) * ($distance + $width);
+		//$scaling = min(imagesx($gdimg) / (imagesx($gdimg) + abs($width_shadow)), imagesy($gdimg) / (imagesy($gdimg) + abs($height_shadow)));
 
-		$scaling = min(ImageSX($gdimg) / (ImageSX($gdimg) + abs($width_shadow)), ImageSY($gdimg) / (ImageSY($gdimg) + abs($height_shadow)));
-
+		$Offset = array();
 		for ($i = 0; $i < $width; $i++) {
 			$WidthAlpha[$i] = (abs(($width / 2) - $i) / $width);
 			$Offset['x'] = cos(deg2rad($angle)) * ($distance + $i);
 			$Offset['y'] = sin(deg2rad($angle)) * ($distance + $i);
 		}
 
-		$tempImageWidth  = ImageSX($gdimg)  + abs($Offset['x']);
-		$tempImageHeight = ImageSY($gdimg) + abs($Offset['y']);
+		$tempImageWidth  = imagesx($gdimg)  + abs($Offset['x']);
+		$tempImageHeight = imagesy($gdimg) + abs($Offset['y']);
 
 		if ($gdimg_dropshadow_temp = phpthumb_functions::ImageCreateFunction($tempImageWidth, $tempImageHeight)) {
 
-			ImageAlphaBlending($gdimg_dropshadow_temp, false);
-			ImageSaveAlpha($gdimg_dropshadow_temp, true);
+			imagealphablending($gdimg_dropshadow_temp, false);
+			imagesavealpha($gdimg_dropshadow_temp, true);
 			$transparent1 = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg_dropshadow_temp, 0, 0, 0, 127);
-			ImageFill($gdimg_dropshadow_temp, 0, 0, $transparent1);
+			imagefill($gdimg_dropshadow_temp, 0, 0, $transparent1);
 
-			for ($x = 0; $x < ImageSX($gdimg); $x++) {
-				for ($y = 0; $y < ImageSY($gdimg); $y++) {
+			$PixelMap = array();
+			for ($x = 0; $x < imagesx($gdimg); $x++) {
+				for ($y = 0; $y < imagesy($gdimg); $y++) {
 					$PixelMap[$x][$y] = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				}
 			}
@@ -358,31 +364,31 @@ class phpthumb_filters {
 						if (!isset($PixelMap[$x][$y]['alpha']) || ($PixelMap[$x][$y]['alpha'] > 0)) {
 							if (isset($PixelMap[$x + $Offset['x']][$y + $Offset['y']]['alpha']) && ($PixelMap[$x + $Offset['x']][$y + $Offset['y']]['alpha'] < 127)) {
 								$thisColor = phpthumb_functions::ImageHexColorAllocate($gdimg, $hexcolor, false, $PixelMap[$x + $Offset['x']][$y + $Offset['y']]['alpha']);
-								ImageSetPixel($gdimg_dropshadow_temp, $x, $y, $thisColor);
+								imagesetpixel($gdimg_dropshadow_temp, $x, $y, $thisColor);
 							}
 						}
 					}
 				}
 			}
 
-			ImageAlphaBlending($gdimg_dropshadow_temp, true);
-			for ($x = 0; $x < ImageSX($gdimg); $x++) {
-				for ($y = 0; $y < ImageSY($gdimg); $y++) {
+			imagealphablending($gdimg_dropshadow_temp, true);
+			for ($x = 0; $x < imagesx($gdimg); $x++) {
+				for ($y = 0; $y < imagesy($gdimg); $y++) {
 					if ($PixelMap[$x][$y]['alpha'] < 127) {
 						$thisColor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg_dropshadow_temp, $PixelMap[$x][$y]['red'], $PixelMap[$x][$y]['green'], $PixelMap[$x][$y]['blue'], $PixelMap[$x][$y]['alpha']);
-						ImageSetPixel($gdimg_dropshadow_temp, $x, $y, $thisColor);
+						imagesetpixel($gdimg_dropshadow_temp, $x, $y, $thisColor);
 					}
 				}
 			}
 
-			ImageSaveAlpha($gdimg, true);
-			ImageAlphaBlending($gdimg, false);
+			imagesavealpha($gdimg, true);
+			imagealphablending($gdimg, false);
 			//$this->is_alpha = true;
 			$transparent2 = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg, 0, 0, 0, 127);
-			ImageFilledRectangle($gdimg, 0, 0, ImageSX($gdimg), ImageSY($gdimg), $transparent2);
-			ImageCopyResampled($gdimg, $gdimg_dropshadow_temp, 0, 0, 0, 0, ImageSX($gdimg), ImageSY($gdimg), ImageSX($gdimg_dropshadow_temp), ImageSY($gdimg_dropshadow_temp));
+			imagefilledrectangle($gdimg, 0, 0, imagesx($gdimg), imagesy($gdimg), $transparent2);
+			imagecopyresampled($gdimg, $gdimg_dropshadow_temp, 0, 0, 0, 0, imagesx($gdimg), imagesy($gdimg), imagesx($gdimg_dropshadow_temp), imagesy($gdimg_dropshadow_temp));
 
-			ImageDestroy($gdimg_dropshadow_temp);
+			imagedestroy($gdimg_dropshadow_temp);
 		}
 		return true;
 	}
@@ -390,10 +396,10 @@ class phpthumb_filters {
 
 	public function EdgeDetect(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_EDGEDETECT)) {
+			if (imagefilter($gdimg, IMG_FILTER_EDGEDETECT)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_EDGEDETECT)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_EDGEDETECT)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 		// currently not implemented "the hard way"
@@ -407,21 +413,21 @@ class phpthumb_filters {
 			return false;
 		}
 		// generate mask at twice desired resolution and downsample afterwards for easy antialiasing
-		if ($gdimg_ellipsemask_double = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg) * 2, ImageSY($gdimg) * 2)) {
-			if ($gdimg_ellipsemask = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg), ImageSY($gdimg))) {
+		if ($gdimg_ellipsemask_double = phpthumb_functions::ImageCreateFunction(imagesx($gdimg) * 2, imagesy($gdimg) * 2)) {
+			if ($gdimg_ellipsemask = phpthumb_functions::ImageCreateFunction(imagesx($gdimg), imagesy($gdimg))) {
 
-				$color_transparent = ImageColorAllocate($gdimg_ellipsemask_double, 255, 255, 255);
-				ImageFilledEllipse($gdimg_ellipsemask_double, ImageSX($gdimg), ImageSY($gdimg), (ImageSX($gdimg) - 1) * 2, (ImageSY($gdimg) - 1) * 2, $color_transparent);
-				ImageCopyResampled($gdimg_ellipsemask, $gdimg_ellipsemask_double, 0, 0, 0, 0, ImageSX($gdimg), ImageSY($gdimg), ImageSX($gdimg) * 2, ImageSY($gdimg) * 2);
+				$color_transparent = imagecolorallocate($gdimg_ellipsemask_double, 255, 255, 255);
+				imagefilledellipse($gdimg_ellipsemask_double, imagesx($gdimg), imagesy($gdimg), (imagesx($gdimg) - 1) * 2, (imagesy($gdimg) - 1) * 2, $color_transparent);
+				imagecopyresampled($gdimg_ellipsemask, $gdimg_ellipsemask_double, 0, 0, 0, 0, imagesx($gdimg), imagesy($gdimg), imagesx($gdimg) * 2, imagesy($gdimg) * 2);
 
 				phpthumb_filters::ApplyMask($gdimg_ellipsemask, $gdimg);
-				ImageDestroy($gdimg_ellipsemask);
+				imagedestroy($gdimg_ellipsemask);
 				return true;
 
 			} else {
 				$this->DebugMessage('$gdimg_ellipsemask = phpthumb_functions::ImageCreateFunction() failed', __FILE__, __LINE__);
 			}
-			ImageDestroy($gdimg_ellipsemask_double);
+			imagedestroy($gdimg_ellipsemask_double);
 		} else {
 			$this->DebugMessage('$gdimg_ellipsemask_double = phpthumb_functions::ImageCreateFunction() failed', __FILE__, __LINE__);
 		}
@@ -431,10 +437,10 @@ class phpthumb_filters {
 
 	public function Emboss(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_EMBOSS)) {
+			if (imagefilter($gdimg, IMG_FILTER_EMBOSS)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_EMBOSS)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_EMBOSS)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 		// currently not implemented "the hard way"
@@ -447,20 +453,20 @@ class phpthumb_filters {
 		if (!$x && !$y) {
 			return false;
 		}
-		if ($tempImage = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg), ImageSY($gdimg))) {
+		if ($tempImage = phpthumb_functions::ImageCreateFunction(imagesx($gdimg), imagesy($gdimg))) {
 			if ($x) {
-				ImageCopy($tempImage, $gdimg, 0, 0, 0, 0, ImageSX($gdimg), ImageSY($gdimg));
-				for ($x = 0; $x < ImageSX($gdimg); $x++) {
-					ImageCopy($gdimg, $tempImage, ImageSX($gdimg) - 1 - $x, 0, $x, 0, 1, ImageSY($gdimg));
+				imagecopy($tempImage, $gdimg, 0, 0, 0, 0, imagesx($gdimg), imagesy($gdimg));
+				for ($x = 0; $x < imagesx($gdimg); $x++) {
+					imagecopy($gdimg, $tempImage, imagesx($gdimg) - 1 - $x, 0, $x, 0, 1, imagesy($gdimg));
 				}
 			}
 			if ($y) {
-				ImageCopy($tempImage, $gdimg, 0, 0, 0, 0, ImageSX($gdimg), ImageSY($gdimg));
-				for ($y = 0; $y < ImageSY($gdimg); $y++) {
-					ImageCopy($gdimg, $tempImage, 0, ImageSY($gdimg) - 1 - $y, 0, $y, ImageSX($gdimg), 1);
+				imagecopy($tempImage, $gdimg, 0, 0, 0, 0, imagesx($gdimg), imagesy($gdimg));
+				for ($y = 0; $y < imagesy($gdimg); $y++) {
+					imagecopy($gdimg, $tempImage, 0, imagesy($gdimg) - 1 - $y, 0, $y, imagesx($gdimg), 1);
 				}
 			}
-			ImageDestroy($tempImage);
+			imagedestroy($tempImage);
 		}
 		return true;
 	}
@@ -478,21 +484,21 @@ class phpthumb_filters {
 		$color2      = phpthumb_functions::ImageHexColorAllocate($gdimg, $hexcolor2);
 		for ($i = 0; $i < $edge_width; $i++) {
 			// outer bevel
-			ImageLine($gdimg,                   $i,                   $i,                   $i, ImageSY($gdimg) - $i, $color1); // left
-			ImageLine($gdimg,                   $i,                   $i, ImageSX($gdimg) - $i,                   $i, $color1); // top
-			ImageLine($gdimg, ImageSX($gdimg) - $i, ImageSY($gdimg) - $i, ImageSX($gdimg) - $i,                   $i, $color2); // right
-			ImageLine($gdimg, ImageSX($gdimg) - $i, ImageSY($gdimg) - $i,                   $i, ImageSY($gdimg) - $i, $color2); // bottom
+			imageline($gdimg,                   $i,                   $i,                   $i, imagesy($gdimg) - $i, $color1); // left
+			imageline($gdimg,                   $i,                   $i, imagesx($gdimg) - $i,                   $i, $color1); // top
+			imageline($gdimg, imagesx($gdimg) - $i, imagesy($gdimg) - $i, imagesx($gdimg) - $i,                   $i, $color2); // right
+			imageline($gdimg, imagesx($gdimg) - $i, imagesy($gdimg) - $i,                   $i, imagesy($gdimg) - $i, $color2); // bottom
 		}
 		for ($i = 0; $i < $frame_width; $i++) {
 			// actual frame
-			ImageRectangle($gdimg, $edge_width + $i, $edge_width + $i, ImageSX($gdimg) - $edge_width - $i, ImageSY($gdimg) - $edge_width - $i, $color_frame);
+			imagerectangle($gdimg, $edge_width + $i, $edge_width + $i, imagesx($gdimg) - $edge_width - $i, imagesy($gdimg) - $edge_width - $i, $color_frame);
 		}
 		for ($i = 0; $i < $edge_width; $i++) {
 			// inner bevel
-			ImageLine($gdimg,                   $frame_width + $edge_width + $i,                   $frame_width + $edge_width + $i,                   $frame_width + $edge_width + $i, ImageSY($gdimg) - $frame_width - $edge_width - $i, $color2); // left
-			ImageLine($gdimg,                   $frame_width + $edge_width + $i,                   $frame_width + $edge_width + $i, ImageSX($gdimg) - $frame_width - $edge_width - $i,                   $frame_width + $edge_width + $i, $color2); // top
-			ImageLine($gdimg, ImageSX($gdimg) - $frame_width - $edge_width - $i, ImageSY($gdimg) - $frame_width - $edge_width - $i, ImageSX($gdimg) - $frame_width - $edge_width - $i,                   $frame_width + $edge_width + $i, $color1); // right
-			ImageLine($gdimg, ImageSX($gdimg) - $frame_width - $edge_width - $i, ImageSY($gdimg) - $frame_width - $edge_width - $i,                   $frame_width + $edge_width + $i, ImageSY($gdimg) - $frame_width - $edge_width - $i, $color1); // bottom
+			imageline($gdimg,                   $frame_width + $edge_width + $i,                   $frame_width + $edge_width + $i,                   $frame_width + $edge_width + $i, imagesy($gdimg) - $frame_width - $edge_width - $i, $color2); // left
+			imageline($gdimg,                   $frame_width + $edge_width + $i,                   $frame_width + $edge_width + $i, imagesx($gdimg) - $frame_width - $edge_width - $i,                   $frame_width + $edge_width + $i, $color2); // top
+			imageline($gdimg, imagesx($gdimg) - $frame_width - $edge_width - $i, imagesy($gdimg) - $frame_width - $edge_width - $i, imagesx($gdimg) - $frame_width - $edge_width - $i,                   $frame_width + $edge_width + $i, $color1); // right
+			imageline($gdimg, imagesx($gdimg) - $frame_width - $edge_width - $i, imagesy($gdimg) - $frame_width - $edge_width - $i,                   $frame_width + $edge_width + $i, imagesy($gdimg) - $frame_width - $edge_width - $i, $color1); // bottom
 		}
 		return true;
 	}
@@ -502,16 +508,16 @@ class phpthumb_filters {
 		if (number_format($amount, 4) == '1.0000') {
 			return true;
 		}
-		return ImageGammaCorrect($gdimg, 1.0, $amount);
+		return imagegammacorrect($gdimg, 1.0, $amount);
 	}
 
 
 	public function Grayscale(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_GRAYSCALE)) {
+			if (imagefilter($gdimg, IMG_FILTER_GRAYSCALE)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_GRAYSCALE)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_GRAYSCALE)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 		return phpthumb_filters::Colorize($gdimg, 100, 'gray');
@@ -519,8 +525,9 @@ class phpthumb_filters {
 
 
 	public function HistogramAnalysis(&$gdimg, $calculateGray=false) {
-		$ImageSX = ImageSX($gdimg);
-		$ImageSY = ImageSY($gdimg);
+		$ImageSX = imagesx($gdimg);
+		$ImageSY = imagesy($gdimg);
+		$Analysis = array();
 		for ($x = 0; $x < $ImageSX; $x++) {
 			for ($y = 0; $y < $ImageSY; $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
@@ -562,49 +569,46 @@ class phpthumb_filters {
 		// from the limit and allow <threshold> (default = 0.1%) of brightest/darkest
 		// pixels to be clipped to min/max
 		$threshold = floatval($threshold) / 100;
-		$clip_threshold = ImageSX($gdimg) * ImageSX($gdimg) * $threshold;
-		//if ($min >= 0) {
-		//	$range_min = min($min, 255);
-		//} else {
-			$countsum = 0;
-			for ($i = 0; $i <= 255; $i++) {
-				if ($method == 0) {
-					$countsum = max(@$Analysis['red'][$i], @$Analysis['green'][$i], @$Analysis['blue'][$i]);
-				} else {
-					$countsum += @$Analysis[$key][$i];
-				}
-				if ($countsum >= $clip_threshold) {
-					$range_min = $i - 1;
-					break;
-				}
+		$clip_threshold = imagesx($gdimg) * imagesx($gdimg) * $threshold;
+
+		$countsum  = 0;
+		$range_min = 0;
+		for ($i = 0; $i <= 255; $i++) {
+			if ($method == 0) {
+				$countsum = max(@$Analysis['red'][$i], @$Analysis['green'][$i], @$Analysis['blue'][$i]);
+			} else {
+				$countsum += @$Analysis[$key][$i];
 			}
-			$range_min = max($range_min, 0);
-		//}
-		//if ($max > 0) {
-		//	$range_max = max($max, 255);
-		//} else {
-			$countsum = 0;
-			for ($i = 255; $i >= 0; $i--) {
-				if ($method == 0) {
-					$countsum = max(@$Analysis['red'][$i], @$Analysis['green'][$i], @$Analysis['blue'][$i]);
-				} else {
-					$countsum += @$Analysis[$key][$i];
-				}
-				if ($countsum >= $clip_threshold) {
-					$range_max = $i + 1;
-					break;
-				}
+			if ($countsum >= $clip_threshold) {
+				$range_min = $i - 1;
+				break;
 			}
-			$range_max = min($range_max, 255);
-		//}
+		}
+		$range_min = max($range_min, 0);
+
+		$countsum  =   0;
+		$range_max = 255;
+		for ($i = 255; $i >= 0; $i--) {
+			if ($method == 0) {
+				$countsum = max(@$Analysis['red'][$i], @$Analysis['green'][$i], @$Analysis['blue'][$i]);
+			} else {
+				$countsum += @$Analysis[$key][$i];
+			}
+			if ($countsum >= $clip_threshold) {
+				$range_max = $i + 1;
+				break;
+			}
+		}
+		$range_max = min($range_max, 255);
+
 		$range_scale = (($range_max == $range_min) ? 1 : (255 / ($range_max - $range_min)));
 		if (($range_min == 0) && ($range_max == 255)) {
 			// no adjustment neccesary - don't waste CPU time!
 			return true;
 		}
 
-		$ImageSX = ImageSX($gdimg);
-		$ImageSY = ImageSY($gdimg);
+		$ImageSX = imagesx($gdimg);
+		$ImageSY = imagesy($gdimg);
 		for ($x = 0; $x < $ImageSX; $x++) {
 			for ($y = 0; $y < $ImageSY; $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
@@ -618,7 +622,7 @@ class phpthumb_filters {
 					$new[$key] = min(255, max(0, ($OriginalPixel[$key] - $range_min) * $range_scale));
 				}
 				$newColor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg, $new['red'], $new['green'], $new['blue'], $new['alpha']);
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
 
@@ -630,21 +634,21 @@ class phpthumb_filters {
 		$margin_y = (is_null($margin_y) ? $margin_x : $margin_y);
 
 		$Analysis = phpthumb_filters::HistogramAnalysis($gdimg, true);
-		$histW = round(($width > 1) ? min($width, ImageSX($gdimg)) : ImageSX($gdimg) * $width);
-		$histH = round(($width > 1) ? min($width, ImageSX($gdimg)) : ImageSX($gdimg) * $width);
-		if ($gdHist = ImageCreateTrueColor($histW, $histH)) {
+		$histW = round(($width > 1) ? min($width, imagesx($gdimg)) : imagesx($gdimg) * $width);
+		$histH = round(($width > 1) ? min($width, imagesx($gdimg)) : imagesx($gdimg) * $width);
+		if ($gdHist = imagecreatetruecolor($histW, $histH)) {
 			$color_back = phpthumb_functions::ImageColorAllocateAlphaSafe($gdHist, 0, 0, 0, 127);
-			ImageFilledRectangle($gdHist, 0, 0, $histW, $histH, $color_back);
-			ImageAlphaBlending($gdHist, false);
-			ImageSaveAlpha($gdHist, true);
+			imagefilledrectangle($gdHist, 0, 0, $histW, $histH, $color_back);
+			imagealphablending($gdHist, false);
+			imagesavealpha($gdHist, true);
 
 			$HistogramTempWidth  = 256;
 			$HistogramTempHeight = 100;
-			if ($gdHistTemp = ImageCreateTrueColor($HistogramTempWidth, $HistogramTempHeight)) {
+			if ($gdHistTemp = imagecreatetruecolor($HistogramTempWidth, $HistogramTempHeight)) {
 				$color_back_temp = phpthumb_functions::ImageColorAllocateAlphaSafe($gdHistTemp, 255, 0, 255, 127);
-				ImageAlphaBlending($gdHistTemp, false);
-				ImageSaveAlpha($gdHistTemp, true);
-				ImageFilledRectangle($gdHistTemp, 0, 0, ImageSX($gdHistTemp), ImageSY($gdHistTemp), $color_back_temp);
+				imagealphablending($gdHistTemp, false);
+				imagesavealpha($gdHistTemp, true);
+				imagefilledrectangle($gdHistTemp, 0, 0, imagesx($gdHistTemp), imagesy($gdHistTemp), $color_back_temp);
 
 				$DefaultColors = array('r'=>'FF0000', 'g'=>'00FF00', 'b'=>'0000FF', 'a'=>'999999', '*'=>'FFFFFF');
 				$Colors = explode(';', $colors);
@@ -657,19 +661,19 @@ class phpthumb_filters {
 					$PeakValue = max($Analysis[$keys[$band]]);
 					$thisColor = phpthumb_functions::ImageHexColorAllocate($gdHistTemp, phpthumb_functions::IsHexColor(@$Colors[$key]) ? $Colors[$key] : $DefaultColors[$band]);
 					for ($x = 0; $x < $HistogramTempWidth; $x++) {
-						ImageLine($gdHistTemp, $x, $HistogramTempHeight - 1, $x, $HistogramTempHeight - 1 - round(@$Analysis[$keys[$band]][$x] / $PeakValue * $HistogramTempHeight), $thisColor);
+						imageline($gdHistTemp, $x, $HistogramTempHeight - 1, $x, $HistogramTempHeight - 1 - round(@$Analysis[$keys[$band]][$x] / $PeakValue * $HistogramTempHeight), $thisColor);
 					}
-					ImageLine($gdHistTemp, 0, $HistogramTempHeight - 1, $HistogramTempWidth - 1, $HistogramTempHeight - 1, $thisColor);
-					ImageLine($gdHistTemp, 0, $HistogramTempHeight - 2, $HistogramTempWidth - 1, $HistogramTempHeight - 2, $thisColor);
+					imageline($gdHistTemp, 0, $HistogramTempHeight - 1, $HistogramTempWidth - 1, $HistogramTempHeight - 1, $thisColor);
+					imageline($gdHistTemp, 0, $HistogramTempHeight - 2, $HistogramTempWidth - 1, $HistogramTempHeight - 2, $thisColor);
 				}
-				ImageCopyResampled($gdHist, $gdHistTemp, 0, 0, 0, 0, ImageSX($gdHist), ImageSY($gdHist), ImageSX($gdHistTemp), ImageSY($gdHistTemp));
-				ImageDestroy($gdHistTemp);
+				imagecopyresampled($gdHist, $gdHistTemp, 0, 0, 0, 0, imagesx($gdHist), imagesy($gdHist), imagesx($gdHistTemp), imagesy($gdHistTemp));
+				imagedestroy($gdHistTemp);
 			} else {
 				return false;
 			}
 
 			phpthumb_filters::WatermarkOverlay($gdimg, $gdHist, $alignment, $opacity, $margin_x, $margin_y);
-			ImageDestroy($gdHist);
+			imagedestroy($gdHist);
 			return true;
 		}
 		return false;
@@ -681,68 +685,63 @@ class phpthumb_filters {
 		$radius_x     = ($radius_x     ? $radius_x     : 0);
 		$radius_y     = ($radius_y     ? $radius_y     : 0);
 
-		$output_width  = ImageSX($gdimg);
-		$output_height = ImageSY($gdimg);
+		$output_width  = imagesx($gdimg);
+		$output_height = imagesy($gdimg);
 
 		list($new_width, $new_height) = phpthumb_functions::ProportionalResize($output_width, $output_height, $output_width - max($border_width * 2, $radius_x), $output_height - max($border_width * 2, $radius_y));
 		$offset_x = ($radius_x ? $output_width  - $new_width  - $radius_x : 0);
-		$offset_y = ($radius_y ? $output_height - $new_height - $radius_y : 0);
 
-//header('Content-Type: image/png');
-//ImagePNG($gdimg);
-//exit;
 		if ($gd_border_canvas = phpthumb_functions::ImageCreateFunction($output_width, $output_height)) {
 
-			ImageSaveAlpha($gd_border_canvas, true);
-			ImageAlphaBlending($gd_border_canvas, false);
+			imagesavealpha($gd_border_canvas, true);
+			imagealphablending($gd_border_canvas, false);
 			$color_background = phpthumb_functions::ImageColorAllocateAlphaSafe($gd_border_canvas, 255, 255, 255, 127);
-			ImageFilledRectangle($gd_border_canvas, 0, 0, $output_width, $output_height, $color_background);
+			imagefilledrectangle($gd_border_canvas, 0, 0, $output_width, $output_height, $color_background);
 
 			$color_border = phpthumb_functions::ImageHexColorAllocate($gd_border_canvas, (phpthumb_functions::IsHexColor($hexcolor_border) ? $hexcolor_border : '000000'));
 
 			for ($i = 0; $i < $border_width; $i++) {
-				ImageLine($gd_border_canvas,             floor($offset_x / 2) + $radius_x,                      $i, $output_width - $radius_x - ceil($offset_x / 2),                         $i, $color_border); // top
-				ImageLine($gd_border_canvas,             floor($offset_x / 2) + $radius_x, $output_height - 1 - $i, $output_width - $radius_x - ceil($offset_x / 2),    $output_height - 1 - $i, $color_border); // bottom
-				ImageLine($gd_border_canvas,                    floor($offset_x / 2) + $i,               $radius_y,                      floor($offset_x / 2) +  $i, $output_height - $radius_y, $color_border); // left
-				ImageLine($gd_border_canvas, $output_width - 1 - $i - ceil($offset_x / 2),               $radius_y,    $output_width - 1 - $i - ceil($offset_x / 2), $output_height - $radius_y, $color_border); // right
+				imageline($gd_border_canvas,             floor($offset_x / 2) + $radius_x,                      $i, $output_width - $radius_x - ceil($offset_x / 2),                         $i, $color_border); // top
+				imageline($gd_border_canvas,             floor($offset_x / 2) + $radius_x, $output_height - 1 - $i, $output_width - $radius_x - ceil($offset_x / 2),    $output_height - 1 - $i, $color_border); // bottom
+				imageline($gd_border_canvas,                    floor($offset_x / 2) + $i,               $radius_y,                      floor($offset_x / 2) +  $i, $output_height - $radius_y, $color_border); // left
+				imageline($gd_border_canvas, $output_width - 1 - $i - ceil($offset_x / 2),               $radius_y,    $output_width - 1 - $i - ceil($offset_x / 2), $output_height - $radius_y, $color_border); // right
 			}
 
 			if ($radius_x && $radius_y) {
 
-				// PHP bug: ImageArc() with thicknesses > 1 give bad/undesirable/unpredicatable results
+				// PHP bug: imagearc() with thicknesses > 1 give bad/undesirable/unpredicatable results
 				// Solution: Draw multiple 1px arcs side-by-side.
 
 				// Problem: parallel arcs give strange/ugly antialiasing problems
 				// Solution: draw non-parallel arcs, from one side of the line thickness at the start angle
 				//   to the opposite edge of the line thickness at the terminating angle
 				for ($thickness_offset = 0; $thickness_offset < $border_width; $thickness_offset++) {
-					ImageArc($gd_border_canvas, floor($offset_x / 2) + 1 +                 $radius_x,              $thickness_offset - 1 + $radius_y, $radius_x * 2, $radius_y * 2, 180, 270, $color_border); // top-left
-					ImageArc($gd_border_canvas,                     $output_width - $radius_x - 1 - ceil($offset_x / 2),              $thickness_offset - 1 + $radius_y, $radius_x * 2, $radius_y * 2, 270, 360, $color_border); // top-right
-					ImageArc($gd_border_canvas,                     $output_width - $radius_x - 1 - ceil($offset_x / 2), $output_height - $thickness_offset - $radius_y, $radius_x * 2, $radius_y * 2,   0,  90, $color_border); // bottom-right
-					ImageArc($gd_border_canvas, floor($offset_x / 2) + 1 +                 $radius_x, $output_height - $thickness_offset - $radius_y, $radius_x * 2, $radius_y * 2,  90, 180, $color_border); // bottom-left
+					imagearc($gd_border_canvas, floor($offset_x / 2) + 1 +                 $radius_x,              $thickness_offset - 1 + $radius_y, $radius_x * 2, $radius_y * 2, 180, 270, $color_border); // top-left
+					imagearc($gd_border_canvas,                     $output_width - $radius_x - 1 - ceil($offset_x / 2),              $thickness_offset - 1 + $radius_y, $radius_x * 2, $radius_y * 2, 270, 360, $color_border); // top-right
+					imagearc($gd_border_canvas,                     $output_width - $radius_x - 1 - ceil($offset_x / 2), $output_height - $thickness_offset - $radius_y, $radius_x * 2, $radius_y * 2,   0,  90, $color_border); // bottom-right
+					imagearc($gd_border_canvas, floor($offset_x / 2) + 1 +                 $radius_x, $output_height - $thickness_offset - $radius_y, $radius_x * 2, $radius_y * 2,  90, 180, $color_border); // bottom-left
 				}
 				if ($border_width > 1) {
 					for ($thickness_offset = 0; $thickness_offset < $border_width; $thickness_offset++) {
-						ImageArc($gd_border_canvas, floor($offset_x / 2) + $thickness_offset + $radius_x,                                      $radius_y, $radius_x * 2, $radius_y * 2, 180, 270, $color_border); // top-left
-						ImageArc($gd_border_canvas, $output_width - $thickness_offset - $radius_x - 1 - ceil($offset_x / 2),                                      $radius_y, $radius_x * 2, $radius_y * 2, 270, 360, $color_border); // top-right
-						ImageArc($gd_border_canvas, $output_width - $thickness_offset - $radius_x - 1 - ceil($offset_x / 2),                     $output_height - $radius_y, $radius_x * 2, $radius_y * 2,   0,  90, $color_border); // bottom-right
-						ImageArc($gd_border_canvas, floor($offset_x / 2) + $thickness_offset + $radius_x,                     $output_height - $radius_y, $radius_x * 2, $radius_y * 2,  90, 180, $color_border); // bottom-left
+						imagearc($gd_border_canvas, floor($offset_x / 2) + $thickness_offset + $radius_x,                                      $radius_y, $radius_x * 2, $radius_y * 2, 180, 270, $color_border); // top-left
+						imagearc($gd_border_canvas, $output_width - $thickness_offset - $radius_x - 1 - ceil($offset_x / 2),                                      $radius_y, $radius_x * 2, $radius_y * 2, 270, 360, $color_border); // top-right
+						imagearc($gd_border_canvas, $output_width - $thickness_offset - $radius_x - 1 - ceil($offset_x / 2),                     $output_height - $radius_y, $radius_x * 2, $radius_y * 2,   0,  90, $color_border); // bottom-right
+						imagearc($gd_border_canvas, floor($offset_x / 2) + $thickness_offset + $radius_x,                     $output_height - $radius_y, $radius_x * 2, $radius_y * 2,  90, 180, $color_border); // bottom-left
 					}
 				}
 
 			}
 			$this->phpThumbObject->ImageResizeFunction($gd_border_canvas, $gdimg, floor(($output_width - $new_width) / 2), round(($output_height - $new_height) / 2), 0, 0, $new_width, $new_height, $output_width, $output_height);
 
-			ImageDestroy($gdimg);
+			imagedestroy($gdimg);
 			$gdimg = phpthumb_functions::ImageCreateFunction($output_width, $output_height);
-			ImageSaveAlpha($gdimg, true);
-			ImageAlphaBlending($gdimg, false);
+			imagesavealpha($gdimg, true);
+			imagealphablending($gdimg, false);
 			$gdimg_color_background = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg, 255, 255, 255, 127);
-			ImageFilledRectangle($gdimg, 0, 0, $output_width, $output_height, $gdimg_color_background);
+			imagefilledrectangle($gdimg, 0, 0, $output_width, $output_height, $gdimg_color_background);
 
-			ImageCopy($gdimg, $gd_border_canvas, 0, 0, 0, 0, $output_width, $output_height);
-			//$gdimg = $gd_border_canvas;
-			ImageDestroy($gd_border_canvas);
+			imagecopy($gdimg, $gd_border_canvas, 0, 0, 0, 0, $output_width, $output_height);
+			imagedestroy($gd_border_canvas);
 			return true;
 
 
@@ -765,32 +764,33 @@ class phpthumb_filters {
 			if ((phpthumb_functions::gd_version() >= 2) && !$bg && ($rotate_angle % 90)) {
 
 				//$this->DebugMessage('Using alpha rotate', __FILE__, __LINE__);
-				if ($gdimg_rotate_mask = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg_source), ImageSY($gdimg_source))) {
+				if ($gdimg_rotate_mask = phpthumb_functions::ImageCreateFunction(imagesx($gdimg_source), imagesy($gdimg_source))) {
 
+					$color_mask = array();
 					for ($i = 0; $i <= 255; $i++) {
-						$color_mask[$i] = ImageColorAllocate($gdimg_rotate_mask, $i, $i, $i);
+						$color_mask[$i] = imagecolorallocate($gdimg_rotate_mask, $i, $i, $i);
 					}
-					ImageFilledRectangle($gdimg_rotate_mask, 0, 0, ImageSX($gdimg_rotate_mask), ImageSY($gdimg_rotate_mask), $color_mask[255]);
-					$imageX = ImageSX($gdimg_source);
-					$imageY = ImageSY($gdimg_source);
+					imagefilledrectangle($gdimg_rotate_mask, 0, 0, imagesx($gdimg_rotate_mask), imagesy($gdimg_rotate_mask), $color_mask[255]);
+					$imageX = imagesx($gdimg_source);
+					$imageY = imagesy($gdimg_source);
 					for ($x = 0; $x < $imageX; $x++) {
 						for ($y = 0; $y < $imageY; $y++) {
 							$pixelcolor = phpthumb_functions::GetPixelColor($gdimg_source, $x, $y);
-							ImageSetPixel($gdimg_rotate_mask, $x, $y, $color_mask[255 - round($pixelcolor['alpha'] * 255 / 127)]);
+							imagesetpixel($gdimg_rotate_mask, $x, $y, $color_mask[255 - round($pixelcolor['alpha'] * 255 / 127)]);
 						}
 					}
-					$gdimg_rotate_mask  = ImageRotate($gdimg_rotate_mask,  $rotate_angle, $color_mask[0]);
-					$gdimg_source = ImageRotate($gdimg_source, $rotate_angle, $background_color);
+					$gdimg_rotate_mask = imagerotate($gdimg_rotate_mask, $rotate_angle, $color_mask[0]);
+					$gdimg_source      = imagerotate($gdimg_source,      $rotate_angle, $background_color);
 
-					ImageAlphaBlending($gdimg_source, false);
-					ImageSaveAlpha($gdimg_source, true);
+					imagealphablending($gdimg_source, false);
+					imagesavealpha($gdimg_source, true);
 					//$this->is_alpha = true;
 					$phpThumbFilters = new phpthumb_filters();
 					//$phpThumbFilters->phpThumbObject = $this;
 					$phpThumbFilters->phpThumbObject = $phpThumbObject;
 					$phpThumbFilters->ApplyMask($gdimg_rotate_mask, $gdimg_source);
 
-					ImageDestroy($gdimg_rotate_mask);
+					imagedestroy($gdimg_rotate_mask);
 
 				} else {
 					//$this->DebugMessage('ImageCreateFunction() failed', __FILE__, __LINE__);
@@ -808,40 +808,40 @@ class phpthumb_filters {
 					//$this->DebugMessage('Using non-alpha rotate because $this->thumbnailFormat is "'.$this->thumbnailFormat.'"', __FILE__, __LINE__);
 				}
 
-				if (ImageColorTransparent($gdimg_source) >= 0) {
-					// ImageRotate() forgets all about an image's transparency and sets the transparent color to black
+				if (imagecolortransparent($gdimg_source) >= 0) {
+					// imagerotate() forgets all about an image's transparency and sets the transparent color to black
 					// To compensate, flood-fill the transparent color of the source image with the specified background color first
 					// then rotate and the colors should match
 
-					if (!function_exists('ImageIsTrueColor') || !ImageIsTrueColor($gdimg_source)) {
+					if (!function_exists('imageistruecolor') || !imageistruecolor($gdimg_source)) {
 						// convert paletted image to true-color before rotating to prevent nasty aliasing artifacts
 
-						//$this->source_width  = ImageSX($gdimg_source);
-						//$this->source_height = ImageSY($gdimg_source);
-						$gdimg_newsrc = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg_source), ImageSY($gdimg_source));
+						//$this->source_width  = imagesx($gdimg_source);
+						//$this->source_height = imagesy($gdimg_source);
+						$gdimg_newsrc = phpthumb_functions::ImageCreateFunction(imagesx($gdimg_source), imagesy($gdimg_source));
 						$background_color = phpthumb_functions::ImageHexColorAllocate($gdimg_newsrc, $config_background_hexcolor);
-						ImageFilledRectangle($gdimg_newsrc, 0, 0, ImageSX($gdimg_source), ImageSY($gdimg_source), phpthumb_functions::ImageHexColorAllocate($gdimg_newsrc, $config_background_hexcolor));
-						ImageCopy($gdimg_newsrc, $gdimg_source, 0, 0, 0, 0, ImageSX($gdimg_source), ImageSY($gdimg_source));
-						ImageDestroy($gdimg_source);
+						imagefilledrectangle($gdimg_newsrc, 0, 0, imagesx($gdimg_source), imagesy($gdimg_source), phpthumb_functions::ImageHexColorAllocate($gdimg_newsrc, $config_background_hexcolor));
+						imagecopy($gdimg_newsrc, $gdimg_source, 0, 0, 0, 0, imagesx($gdimg_source), imagesy($gdimg_source));
+						imagedestroy($gdimg_source);
 						unset($gdimg_source);
 						$gdimg_source = $gdimg_newsrc;
 						unset($gdimg_newsrc);
 
 					} else {
 
-						ImageColorSet(
+						imagecolorset(
 							$gdimg_source,
-							ImageColorTransparent($gdimg_source),
+							imagecolortransparent($gdimg_source),
 							hexdec(substr($config_background_hexcolor, 0, 2)),
 							hexdec(substr($config_background_hexcolor, 2, 2)),
 							hexdec(substr($config_background_hexcolor, 4, 2)));
 
-						ImageColorTransparent($gdimg_source, -1);
+						imagecolortransparent($gdimg_source, -1);
 
 					}
 				}
 
-				$gdimg_source = ImageRotate($gdimg_source, $rotate_angle, $background_color);
+				$gdimg_source = imagerotate($gdimg_source, $rotate_angle, $background_color);
 
 			}
 		}
@@ -851,10 +851,10 @@ class phpthumb_filters {
 
 	public function MeanRemoval(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_MEAN_REMOVAL)) {
+			if (imagefilter($gdimg, IMG_FILTER_MEAN_REMOVAL)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_MEAN_REMOVAL)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_MEAN_REMOVAL)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 		// currently not implemented "the hard way"
@@ -865,19 +865,19 @@ class phpthumb_filters {
 
 	public function Negative(&$gdimg) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_NEGATE)) {
+			if (imagefilter($gdimg, IMG_FILTER_NEGATE)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_NEGATE)', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_NEGATE)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
-		$ImageSX = ImageSX($gdimg);
-		$ImageSY = ImageSY($gdimg);
+		$ImageSX = imagesx($gdimg);
+		$ImageSY = imagesy($gdimg);
 		for ($x = 0; $x < $ImageSX; $x++) {
 			for ($y = 0; $y < $ImageSY; $y++) {
 				$currentPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				$newColor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg, (~$currentPixel['red'] & 0xFF), (~$currentPixel['green'] & 0xFF), (~$currentPixel['blue'] & 0xFF), $currentPixel['alpha']);
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
 		return true;
@@ -889,27 +889,27 @@ class phpthumb_filters {
 		// mask is generated as a white double-size ellipse on a triple-size black background and copy-paste-resampled
 		// onto a correct-size mask image as 4 corners due to errors when the entire mask is resampled at once (gray edges)
 		if ($gdimg_cornermask_triple = phpthumb_functions::ImageCreateFunction($radius_x * 6, $radius_y * 6)) {
-			if ($gdimg_cornermask = phpthumb_functions::ImageCreateFunction(ImageSX($gdimg), ImageSY($gdimg))) {
+			if ($gdimg_cornermask = phpthumb_functions::ImageCreateFunction(imagesx($gdimg), imagesy($gdimg))) {
 
-				$color_transparent = ImageColorAllocate($gdimg_cornermask_triple, 255, 255, 255);
-				ImageFilledEllipse($gdimg_cornermask_triple, $radius_x * 3, $radius_y * 3, $radius_x * 4, $radius_y * 4, $color_transparent);
+				$color_transparent = imagecolorallocate($gdimg_cornermask_triple, 255, 255, 255);
+				imagefilledellipse($gdimg_cornermask_triple, $radius_x * 3, $radius_y * 3, $radius_x * 4, $radius_y * 4, $color_transparent);
 
-				ImageFilledRectangle($gdimg_cornermask, 0, 0, ImageSX($gdimg), ImageSY($gdimg), $color_transparent);
+				imagefilledrectangle($gdimg_cornermask, 0, 0, imagesx($gdimg), imagesy($gdimg), $color_transparent);
 
-				ImageCopyResampled($gdimg_cornermask, $gdimg_cornermask_triple,                           0,                           0,     $radius_x,     $radius_y, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
-				ImageCopyResampled($gdimg_cornermask, $gdimg_cornermask_triple,                           0, ImageSY($gdimg) - $radius_y,     $radius_x, $radius_y * 3, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
-				ImageCopyResampled($gdimg_cornermask, $gdimg_cornermask_triple, ImageSX($gdimg) - $radius_x, ImageSY($gdimg) - $radius_y, $radius_x * 3, $radius_y * 3, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
-				ImageCopyResampled($gdimg_cornermask, $gdimg_cornermask_triple, ImageSX($gdimg) - $radius_x,                           0, $radius_x * 3,     $radius_y, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
+				imagecopyresampled($gdimg_cornermask, $gdimg_cornermask_triple,                           0,                           0,     $radius_x,     $radius_y, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
+				imagecopyresampled($gdimg_cornermask, $gdimg_cornermask_triple,                           0, imagesy($gdimg) - $radius_y,     $radius_x, $radius_y * 3, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
+				imagecopyresampled($gdimg_cornermask, $gdimg_cornermask_triple, imagesx($gdimg) - $radius_x, imagesy($gdimg) - $radius_y, $radius_x * 3, $radius_y * 3, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
+				imagecopyresampled($gdimg_cornermask, $gdimg_cornermask_triple, imagesx($gdimg) - $radius_x,                           0, $radius_x * 3,     $radius_y, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
 
 				phpthumb_filters::ApplyMask($gdimg_cornermask, $gdimg);
-				ImageDestroy($gdimg_cornermask);
+				imagedestroy($gdimg_cornermask);
 				$this->DebugMessage('RoundedImageCorners('.$radius_x.', '.$radius_y.') succeeded', __FILE__, __LINE__);
 				return true;
 
 			} else {
-				$this->DebugMessage('FAILED: $gdimg_cornermask = phpthumb_functions::ImageCreateFunction('.ImageSX($gdimg).', '.ImageSY($gdimg).')', __FILE__, __LINE__);
+				$this->DebugMessage('FAILED: $gdimg_cornermask = phpthumb_functions::ImageCreateFunction('.imagesx($gdimg).', '.imagesy($gdimg).')', __FILE__, __LINE__);
 			}
-			ImageDestroy($gdimg_cornermask_triple);
+			imagedestroy($gdimg_cornermask_triple);
 
 		} else {
 			$this->DebugMessage('FAILED: $gdimg_cornermask_triple = phpthumb_functions::ImageCreateFunction('.($radius_x * 6).', '.($radius_y * 6).')', __FILE__, __LINE__);
@@ -940,20 +940,20 @@ class phpthumb_filters {
 		}
 
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_GRAYSCALE)) {
+			if (imagefilter($gdimg, IMG_FILTER_GRAYSCALE)) {
 
 				$r = round($amountPct * hexdec(substr($targetColor, 0, 2)));
 				$g = round($amountPct * hexdec(substr($targetColor, 2, 2)));
 				$b = round($amountPct * hexdec(substr($targetColor, 4, 2)));
-				if (ImageFilter($gdimg, IMG_FILTER_COLORIZE, $r, $g, $b)) {
+				if (imagefilter($gdimg, IMG_FILTER_COLORIZE, $r, $g, $b)) {
 					return true;
 				}
-				$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_COLORIZE)', __FILE__, __LINE__);
+				$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_COLORIZE)', __FILE__, __LINE__);
 				// fall through and try it the hard way
 
 			} else {
 
-				$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_GRAYSCALE)', __FILE__, __LINE__);
+				$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_GRAYSCALE)', __FILE__, __LINE__);
 				// fall through and try it the hard way
 
 			}
@@ -963,8 +963,8 @@ class phpthumb_filters {
 		$TargetPixel['green'] = hexdec(substr($targetColor, 2, 2));
 		$TargetPixel['blue']  = hexdec(substr($targetColor, 4, 2));
 
-		$ImageSX = ImageSX($gdimg);
-		$ImageSY = ImageSY($gdimg);
+		$ImageSX = imagesx($gdimg);
+		$ImageSY = imagesy($gdimg);
 		for ($x = 0; $x < $ImageSX; $x++) {
 			for ($y = 0; $y < $ImageSY; $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
@@ -975,11 +975,12 @@ class phpthumb_filters {
 				// the mid-tones: the lighter and darker areas appear to be closer to B&W."
 				$SepiaAmount = ((128 - abs($GrayPixel['red'] - 128)) / 128) * $amountPct;
 
+				$NewPixel = array();
 				foreach ($TargetPixel as $key => $value) {
 					$NewPixel[$key] = round(max(0, min(255, $GrayPixel[$key] * (1 - $SepiaAmount) + ($TargetPixel[$key] * $SepiaAmount))));
 				}
 				$newColor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg, $NewPixel['red'], $NewPixel['green'], $NewPixel['blue'], $OriginalPixel['alpha']);
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
 		return true;
@@ -992,10 +993,10 @@ class phpthumb_filters {
 			return true;
 		}
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
-			if (ImageFilter($gdimg, IMG_FILTER_SMOOTH, $amount)) {
+			if (imagefilter($gdimg, IMG_FILTER_SMOOTH, $amount)) {
 				return true;
 			}
-			$this->DebugMessage('FAILED: ImageFilter($gdimg, IMG_FILTER_SMOOTH, '.$amount.')', __FILE__, __LINE__);
+			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_SMOOTH, '.$amount.')', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
 		// currently not implemented "the hard way"
@@ -1005,9 +1006,9 @@ class phpthumb_filters {
 
 
 	public function SourceTransparentColorMask(&$gdimg, $hexcolor, $min_limit=5, $max_limit=10) {
-		$width  = ImageSX($gdimg);
-		$height = ImageSY($gdimg);
-		if ($gdimg_mask = ImageCreateTrueColor($width, $height)) {
+		$width  = imagesx($gdimg);
+		$height = imagesy($gdimg);
+		if ($gdimg_mask = imagecreatetruecolor($width, $height)) {
 			$R = hexdec(substr($hexcolor, 0, 2));
 			$G = hexdec(substr($hexcolor, 2, 2));
 			$B = hexdec(substr($hexcolor, 4, 2));
@@ -1017,9 +1018,9 @@ class phpthumb_filters {
 				for ($y = 0; $y < $height; $y++) {
 					$currentPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 					$colorDiff = phpthumb_functions::PixelColorDifferencePercent($currentPixel, $targetPixel);
-					$grayLevel = min($cutoffRange, MAX(0, -$min_limit + $colorDiff)) * (255 / MAX(1, $cutoffRange));
-					$newColor = ImageColorAllocate($gdimg_mask, $grayLevel, $grayLevel, $grayLevel);
-					ImageSetPixel($gdimg_mask, $x, $y, $newColor);
+					$grayLevel = min($cutoffRange, max(0, -$min_limit + $colorDiff)) * (255 / max(1, $cutoffRange));
+					$newColor = imagecolorallocate($gdimg_mask, $grayLevel, $grayLevel, $grayLevel);
+					imagesetpixel($gdimg_mask, $x, $y, $newColor);
 				}
 			}
 			return $gdimg_mask;
@@ -1029,8 +1030,8 @@ class phpthumb_filters {
 
 
 	public function Threshold(&$gdimg, $cutoff) {
-		$width  = ImageSX($gdimg);
-		$height = ImageSY($gdimg);
+		$width  = imagesx($gdimg);
+		$height = imagesy($gdimg);
 		$cutoff = min(255, max(0, ($cutoff ? $cutoff : 128)));
 		for ($x = 0; $x < $width; $x++) {
 			for ($y = 0; $y < $height; $y++) {
@@ -1041,7 +1042,7 @@ class phpthumb_filters {
 				} else {
 					$newColor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg, 0xFF, 0xFF, 0xFF, $currentPixel['alpha']);
 				}
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
 		return true;
@@ -1051,21 +1052,21 @@ class phpthumb_filters {
 	public function ImageTrueColorToPalette2(&$image, $dither, $ncolors) {
 		// http://www.php.net/manual/en/function.imagetruecolortopalette.php
 		// zmorris at zsculpt dot com (17-Aug-2004 06:58)
-		$width  = ImageSX($image);
-		$height = ImageSY($image);
-		$image_copy = ImageCreateTrueColor($width, $height);
-		//ImageCopyMerge($image_copy, $image, 0, 0, 0, 0, $width, $height, 100);
-		ImageCopy($image_copy, $image, 0, 0, 0, 0, $width, $height);
-		ImageTrueColorToPalette($image, $dither, $ncolors);
-		ImageColorMatch($image_copy, $image);
-		ImageDestroy($image_copy);
+		$width  = imagesx($image);
+		$height = imagesy($image);
+		$image_copy = imagecreatetruecolor($width, $height);
+		//imagecopymerge($image_copy, $image, 0, 0, 0, 0, $width, $height, 100);
+		imagecopy($image_copy, $image, 0, 0, 0, 0, $width, $height);
+		imagetruecolortopalette($image, $dither, $ncolors);
+		imagecolormatch($image_copy, $image);
+		imagedestroy($image_copy);
 		return true;
 	}
 
 	public function ReduceColorDepth(&$gdimg, $colors=256, $dither=true) {
 		$colors = max(min($colors, 256), 2);
-		// ImageTrueColorToPalette usually makes ugly colors, the replacement is a bit better
-		//ImageTrueColorToPalette($gdimg, $dither, $colors);
+		// imagetruecolortopalette usually makes ugly colors, the replacement is a bit better
+		//imagetruecolortopalette($gdimg, $dither, $colors);
 		phpthumb_filters::ImageTrueColorToPalette2($gdimg, $dither, $colors);
 		return true;
 	}
@@ -1091,8 +1092,8 @@ class phpthumb_filters {
 		$scaleG = $grayValue / $targetPixel['green'];
 		$scaleB = $grayValue / $targetPixel['blue'];
 
-		for ($x = 0; $x < ImageSX($gdimg); $x++) {
-			for ($y = 0; $y < ImageSY($gdimg); $y++) {
+		for ($x = 0; $x < imagesx($gdimg); $x++) {
+			for ($y = 0; $y < imagesy($gdimg); $y++) {
 				$currentPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				$newColor = phpthumb_functions::ImageColorAllocateAlphaSafe(
 					$gdimg,
@@ -1101,7 +1102,7 @@ class phpthumb_filters {
 					max(0, min(255, round($currentPixel['blue']  * $scaleB))),
 					$currentPixel['alpha']
 				);
-				ImageSetPixel($gdimg, $x, $y, $newColor);
+				imagesetpixel($gdimg, $x, $y, $newColor);
 			}
 		}
 		return true;
@@ -1113,7 +1114,7 @@ class phpthumb_filters {
 		if (!$text) {
 			return false;
 		}
-		ImageAlphaBlending($gdimg, true);
+		imagealphablending($gdimg, true);
 
 		if (preg_match('#^([0-9\\.\\-]*)x([0-9\\.\\-]*)(@[LCR])?$#i', $alignment, $matches)) {
 			$originOffsetX = intval($matches[1]);
@@ -1131,8 +1132,8 @@ class phpthumb_filters {
 			'^Fm' => round($this->phpThumbObject->getimagesizeinfo['filesize'] / 1048576),
 			'^X'  => $this->phpThumbObject->getimagesizeinfo[0],
 			'^Y'  => $this->phpThumbObject->getimagesizeinfo[1],
-			'^x'  => ImageSX($gdimg),
-			'^y'  => ImageSY($gdimg),
+			'^x'  => imagesx($gdimg),
+			'^y'  => imagesy($gdimg),
 			'^^'  => '^',
 		);
 		$text = strtr($text, $metaTextArray);
@@ -1149,7 +1150,7 @@ class phpthumb_filters {
 
 			$this->DebugMessage('Using TTF font "'.$ttffont.'"', __FILE__, __LINE__);
 
-			$TTFbox = ImageTTFbBox($size, $angle, $ttffont, $text);
+			$TTFbox = imagettfbbox($size, $angle, $ttffont, $text);
 
 			$min_x = min($TTFbox[0], $TTFbox[2], $TTFbox[4], $TTFbox[6]);
 			$max_x = max($TTFbox[0], $TTFbox[2], $TTFbox[4], $TTFbox[6]);
@@ -1161,7 +1162,7 @@ class phpthumb_filters {
 			//$text_height = round($max_y - $min_y + ($size * 0.5));
 			$text_height = round($max_y - $min_y);
 
-			$TTFboxChar = ImageTTFbBox($size, $angle, $ttffont, 'jH');
+			$TTFboxChar = imagettfbbox($size, $angle, $ttffont, 'jH');
 			$char_min_y = min($TTFboxChar[1], $TTFboxChar[3], $TTFboxChar[5], $TTFboxChar[7]);
 			$char_max_y = max($TTFboxChar[1], $TTFboxChar[3], $TTFboxChar[5], $TTFboxChar[7]);
 			$char_height = round($char_max_y - $char_min_y);
@@ -1169,10 +1170,10 @@ class phpthumb_filters {
 			if ($alignment == '*') {
 
 				$text_origin_y = $char_height + $margin;
-				while (($text_origin_y - $text_height) < ImageSY($gdimg)) {
+				while (($text_origin_y - $text_height) < imagesy($gdimg)) {
 					$text_origin_x = $margin;
-					while ($text_origin_x < ImageSX($gdimg)) {
-						ImageTTFtext($gdimg, $size, $angle, $text_origin_x, $text_origin_y, $letter_color_text, $ttffont, $text);
+					while ($text_origin_x < imagesx($gdimg)) {
+						imagettftext($gdimg, $size, $angle, $text_origin_x, $text_origin_y, $letter_color_text, $ttffont, $text);
 						$text_origin_x += ($text_width + $margin);
 					}
 					$text_origin_y += ($text_height + $margin);
@@ -1182,34 +1183,36 @@ class phpthumb_filters {
 
 				// this block for background color only
 
+				$text_origin_x = 0;
+				$text_origin_y = 0;
 				switch ($alignment) {
 					case '*':
 						// handled separately
 						break;
 
 					case 'T':
-						$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width / 2) : round((ImageSX($gdimg) - $text_width) / 2));
+						$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width / 2) : round((imagesx($gdimg) - $text_width) / 2));
 						$text_origin_y = $char_height + $margin + $originOffsetY;
 						break;
 
 					case 'B':
-						$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width / 2) : round((ImageSX($gdimg) - $text_width) / 2));
-						$text_origin_y = ImageSY($gdimg) + $TTFbox[1] - $margin + $originOffsetY;
+						$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width / 2) : round((imagesx($gdimg) - $text_width) / 2));
+						$text_origin_y = imagesy($gdimg) + $TTFbox[1] - $margin + $originOffsetY;
 						break;
 
 					case 'L':
 						$text_origin_x = $margin + $originOffsetX;
-						$text_origin_y = ($originOffsetY ? $originOffsetY : round((ImageSY($gdimg) - $text_height) / 2) + $char_height);
+						$text_origin_y = ($originOffsetY ? $originOffsetY : round((imagesy($gdimg) - $text_height) / 2) + $char_height);
 						break;
 
 					case 'R':
-						$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width : ImageSX($gdimg) - $text_width  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
-						$text_origin_y = ($originOffsetY ? $originOffsetY : round((ImageSY($gdimg) - $text_height) / 2) + $char_height);
+						$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width : imagesx($gdimg) - $text_width  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
+						$text_origin_y = ($originOffsetY ? $originOffsetY : round((imagesy($gdimg) - $text_height) / 2) + $char_height);
 						break;
 
 					case 'C':
-						$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width / 2) : round((ImageSX($gdimg) - $text_width) / 2));
-						$text_origin_y = ($originOffsetY ? $originOffsetY : round((ImageSY($gdimg) - $text_height) / 2) + $char_height);
+						$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width / 2) : round((imagesx($gdimg) - $text_width) / 2));
+						$text_origin_y = ($originOffsetY ? $originOffsetY : round((imagesy($gdimg) - $text_height) / 2) + $char_height);
 						break;
 
 					case 'TL':
@@ -1218,23 +1221,22 @@ class phpthumb_filters {
 						break;
 
 					case 'TR':
-						$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width : ImageSX($gdimg) - $text_width  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
+						$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width : imagesx($gdimg) - $text_width  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
 						$text_origin_y = $char_height + $margin + $originOffsetY;
 						break;
 
 					case 'BL':
 						$text_origin_x = $margin + $originOffsetX;
-						$text_origin_y = ImageSY($gdimg) + $TTFbox[1] - $margin + $originOffsetY;
+						$text_origin_y = imagesy($gdimg) + $TTFbox[1] - $margin + $originOffsetY;
 						break;
 
 					case 'BR':
 					default:
-						$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width : ImageSX($gdimg) - $text_width  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
-						$text_origin_y = ImageSY($gdimg) + $TTFbox[1] - $margin + $originOffsetY;
+						$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width : imagesx($gdimg) - $text_width  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
+						$text_origin_y = imagesy($gdimg) + $TTFbox[1] - $margin + $originOffsetY;
 						break;
 				}
 
-				//ImageRectangle($gdimg, $text_origin_x + $min_x, $text_origin_y + $TTFbox[1], $text_origin_x + $min_x + $text_width, $text_origin_y + $TTFbox[1] - $text_height, $letter_color_text);
 				if (phpthumb_functions::IsHexColor($bg_color)) {
 					$text_background_alpha = round(127 * ((100 - min(max(0, $bg_opacity), 100)) / 100));
 					$text_color_background = phpthumb_functions::ImageHexColorAllocate($gdimg, $bg_color, false, $text_background_alpha);
@@ -1247,15 +1249,10 @@ class phpthumb_filters {
 				$y2 = $text_origin_y + $TTFbox[1] - $text_height;
 				$x_TL = preg_match('#x#i', $fillextend) ?               0 : min($x1, $x2);
 				$y_TL = preg_match('#y#i', $fillextend) ?               0 : min($y1, $y2);
-				$x_BR = preg_match('#x#i', $fillextend) ? ImageSX($gdimg) : max($x1, $x2);
-				$y_BR = preg_match('#y#i', $fillextend) ? ImageSY($gdimg) : max($y1, $y2);
-				//while ($y_BR > ImageSY($gdimg)) {
-				//	$y_TL--;
-				//	$y_BR--;
-				//	$text_origin_y--;
-				//}
-				$this->DebugMessage('WatermarkText() calling ImageFilledRectangle($gdimg, '.$x_TL.', '.$y_TL.', '.$x_BR.', '.$y_BR.', $text_color_background)', __FILE__, __LINE__);
-				ImageFilledRectangle($gdimg, $x_TL, $y_TL, $x_BR, $y_BR, $text_color_background);
+				$x_BR = preg_match('#x#i', $fillextend) ? imagesx($gdimg) : max($x1, $x2);
+				$y_BR = preg_match('#y#i', $fillextend) ? imagesy($gdimg) : max($y1, $y2);
+				$this->DebugMessage('WatermarkText() calling imagefilledrectangle($gdimg, '.$x_TL.', '.$y_TL.', '.$x_BR.', '.$y_BR.', $text_color_background)', __FILE__, __LINE__);
+				imagefilledrectangle($gdimg, $x_TL, $y_TL, $x_BR, $y_BR, $text_color_background);
 
 				// end block for background color only
 
@@ -1263,16 +1260,10 @@ class phpthumb_filters {
 				$y_offset = 0;
 				foreach ($textlines as $dummy => $line) {
 
-					$TTFboxLine = ImageTTFbBox($size, $angle, $ttffont, $line);
+					$TTFboxLine = imagettfbbox($size, $angle, $ttffont, $line);
 					$min_x_line = min($TTFboxLine[0], $TTFboxLine[2], $TTFboxLine[4], $TTFboxLine[6]);
 					$max_x_line = max($TTFboxLine[0], $TTFboxLine[2], $TTFboxLine[4], $TTFboxLine[6]);
-					//$text_width = round($max_x - $min_x + ($size * 0.5));
 					$text_width_line = round($max_x_line - $min_x_line);
-
-					$min_y_line = min($TTFboxLine[1], $TTFboxLine[3], $TTFboxLine[5], $TTFboxLine[7]);
-					$max_y_line = max($TTFboxLine[1], $TTFboxLine[3], $TTFboxLine[5], $TTFboxLine[7]);
-					//$text_height = round($max_y - $min_y + ($size * 0.5));
-					$text_height_line = round($max_y_line - $min_y_line);
 
 					switch ($alignment) {
 						// $text_origin_y set above, just re-set $text_origin_x here as needed
@@ -1286,19 +1277,19 @@ class phpthumb_filters {
 						case 'C':
 						case 'T':
 						case 'B':
-							$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width_line / 2) : round((ImageSX($gdimg) - $text_width_line) / 2));
+							$text_origin_x = ($originOffsetX ? $originOffsetX - round($text_width_line / 2) : round((imagesx($gdimg) - $text_width_line) / 2));
 							break;
 
 						case 'R':
 						case 'TR':
 						case 'BR':
-							$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width_line : ImageSX($gdimg) - $text_width_line  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
+							$text_origin_x = ($originOffsetX ? $originOffsetX - $text_width_line : imagesx($gdimg) - $text_width_line  + $TTFbox[0] - $min_x + round($size * 0.25) - $margin);
 							break;
 					}
 
-					//ImageTTFtext($gdimg, $size, $angle, $text_origin_x, $text_origin_y, $letter_color_text, $ttffont, $text);
-					$this->DebugMessage('WatermarkText() calling ImageTTFtext($gdimg, '.$size.', '.$angle.', '.$text_origin_x.', '.($text_origin_y + $y_offset).', $letter_color_text, '.$ttffont.', '.$line.')', __FILE__, __LINE__);
-					ImageTTFtext($gdimg, $size, $angle, $text_origin_x, $text_origin_y + $y_offset, $letter_color_text, $ttffont, $line);
+					//imagettftext($gdimg, $size, $angle, $text_origin_x, $text_origin_y, $letter_color_text, $ttffont, $text);
+					$this->DebugMessage('WatermarkText() calling imagettftext($gdimg, '.$size.', '.$angle.', '.$text_origin_x.', '.($text_origin_y + $y_offset).', $letter_color_text, '.$ttffont.', '.$line.')', __FILE__, __LINE__);
+					imagettftext($gdimg, $size, $angle, $text_origin_x, $text_origin_y + $y_offset, $letter_color_text, $ttffont, $line);
 
 					$y_offset += $char_height;
 				}
@@ -1314,55 +1305,59 @@ class phpthumb_filters {
 			$text_width  = 0;
 			$text_height = 0;
 			foreach ($textlines as $dummy => $line) {
-				$text_width   = max($text_width, ImageFontWidth($size) * strlen($line));
-				$text_height += ImageFontHeight($size);
+				$text_width   = max($text_width, imagefontwidth($size) * strlen($line));
+				$text_height += imagefontheight($size);
 			}
 			if ($img_watermark = phpthumb_functions::ImageCreateFunction($text_width, $text_height)) {
-				ImageAlphaBlending($img_watermark, false);
+				imagealphablending($img_watermark, false);
 				if (phpthumb_functions::IsHexColor($bg_color)) {
 					$text_background_alpha = round(127 * ((100 - min(max(0, $bg_opacity), 100)) / 100));
 					$text_color_background = phpthumb_functions::ImageHexColorAllocate($img_watermark, $bg_color, false, $text_background_alpha);
 				} else {
 					$text_color_background = phpthumb_functions::ImageHexColorAllocate($img_watermark, 'FFFFFF', false, 127);
 				}
-				$this->DebugMessage('WatermarkText() calling ImageFilledRectangle($img_watermark, 0, 0, '.ImageSX($img_watermark).', '.ImageSY($img_watermark).', $text_color_background)', __FILE__, __LINE__);
-				ImageFilledRectangle($img_watermark, 0, 0, ImageSX($img_watermark), ImageSY($img_watermark), $text_color_background);
+				$this->DebugMessage('WatermarkText() calling imagefilledrectangle($img_watermark, 0, 0, '.imagesx($img_watermark).', '.imagesy($img_watermark).', $text_color_background)', __FILE__, __LINE__);
+				imagefilledrectangle($img_watermark, 0, 0, imagesx($img_watermark), imagesy($img_watermark), $text_color_background);
 
-				if ($angle && function_exists('ImageRotate')) {
-					// using $img_watermark_mask is pointless if ImageRotate function isn't available
+				$img_watermark_mask    = false;
+				$mask_color_background = false;
+				$mask_color_watermark  = false;
+				if ($angle && function_exists('imagerotate')) {
+					// using $img_watermark_mask is pointless if imagerotate function isn't available
 					if ($img_watermark_mask = phpthumb_functions::ImageCreateFunction($text_width, $text_height)) {
-						$mask_color_background = ImageColorAllocate($img_watermark_mask, 0, 0, 0);
-						ImageAlphaBlending($img_watermark_mask, false);
-						ImageFilledRectangle($img_watermark_mask, 0, 0, ImageSX($img_watermark_mask), ImageSY($img_watermark_mask), $mask_color_background);
-						$mask_color_watermark = ImageColorAllocate($img_watermark_mask, 255, 255, 255);
+						$mask_color_background = imagecolorallocate($img_watermark_mask, 0, 0, 0);
+						imagealphablending($img_watermark_mask, false);
+						imagefilledrectangle($img_watermark_mask, 0, 0, imagesx($img_watermark_mask), imagesy($img_watermark_mask), $mask_color_background);
+						$mask_color_watermark = imagecolorallocate($img_watermark_mask, 255, 255, 255);
 					}
 				}
 
 				$text_color_watermark = phpthumb_functions::ImageHexColorAllocate($img_watermark, $hex_color);
+				$x_offset = 0;
 				foreach ($textlines as $key => $line) {
 					switch ($alignment) {
 						case 'C':
-							$x_offset = round(($text_width - (ImageFontWidth($size) * strlen($line))) / 2);
-							$originOffsetX = (ImageSX($gdimg) - ImageSX($img_watermark)) / 2;
-							$originOffsetY = (ImageSY($gdimg) - ImageSY($img_watermark)) / 2;
+							$x_offset = round(($text_width - (imagefontwidth($size) * strlen($line))) / 2);
+							$originOffsetX = (imagesx($gdimg) - imagesx($img_watermark)) / 2;
+							$originOffsetY = (imagesy($gdimg) - imagesy($img_watermark)) / 2;
 							break;
 
 						case 'T':
-							$x_offset = round(($text_width - (ImageFontWidth($size) * strlen($line))) / 2);
-							$originOffsetX = (ImageSX($gdimg) - ImageSX($img_watermark)) / 2;
+							$x_offset = round(($text_width - (imagefontwidth($size) * strlen($line))) / 2);
+							$originOffsetX = (imagesx($gdimg) - imagesx($img_watermark)) / 2;
 							$originOffsetY = $margin;
 							break;
 
 						case 'B':
-							$x_offset = round(($text_width - (ImageFontWidth($size) * strlen($line))) / 2);
-							$originOffsetX = (ImageSX($gdimg) - ImageSX($img_watermark)) / 2;
-							$originOffsetY = ImageSY($gdimg) - ImageSY($img_watermark) - $margin;
+							$x_offset = round(($text_width - (imagefontwidth($size) * strlen($line))) / 2);
+							$originOffsetX = (imagesx($gdimg) - imagesx($img_watermark)) / 2;
+							$originOffsetY = imagesy($gdimg) - imagesy($img_watermark) - $margin;
 							break;
 
 						case 'L':
 							$x_offset = 0;
 							$originOffsetX = $margin;
-							$originOffsetY = (ImageSY($gdimg) - ImageSY($img_watermark)) / 2;
+							$originOffsetY = (imagesy($gdimg) - imagesy($img_watermark)) / 2;
 							break;
 
 						case 'TL':
@@ -1374,18 +1369,18 @@ class phpthumb_filters {
 						case 'BL':
 							$x_offset = 0;
 							$originOffsetX = $margin;
-							$originOffsetY = ImageSY($gdimg) - ImageSY($img_watermark) - $margin;
+							$originOffsetY = imagesy($gdimg) - imagesy($img_watermark) - $margin;
 							break;
 
 						case 'R':
-							$x_offset = $text_width - (ImageFontWidth($size) * strlen($line));
-							$originOffsetX = ImageSX($gdimg) - ImageSX($img_watermark) - $margin;
-							$originOffsetY = (ImageSY($gdimg) - ImageSY($img_watermark)) / 2;
+							$x_offset = $text_width - (imagefontwidth($size) * strlen($line));
+							$originOffsetX = imagesx($gdimg) - imagesx($img_watermark) - $margin;
+							$originOffsetY = (imagesy($gdimg) - imagesy($img_watermark)) / 2;
 							break;
 
 						case 'TR':
-							$x_offset = $text_width - (ImageFontWidth($size) * strlen($line));
-							$originOffsetX = ImageSX($gdimg) - ImageSX($img_watermark) - $margin;
+							$x_offset = $text_width - (imagefontwidth($size) * strlen($line));
+							$originOffsetX = imagesx($gdimg) - imagesx($img_watermark) - $margin;
 							$originOffsetY = $margin;
 							break;
 
@@ -1394,28 +1389,28 @@ class phpthumb_filters {
 							if (!empty($originOffsetX) || !empty($originOffsetY)) {
 								// absolute pixel positioning
 							} else {
-								$x_offset = $text_width - (ImageFontWidth($size) * strlen($line));
-								$originOffsetX = ImageSX($gdimg) - ImageSX($img_watermark) - $margin;
-								$originOffsetY = ImageSY($gdimg) - ImageSY($img_watermark) - $margin;
+								$x_offset = $text_width - (imagefontwidth($size) * strlen($line));
+								$originOffsetX = imagesx($gdimg) - imagesx($img_watermark) - $margin;
+								$originOffsetY = imagesy($gdimg) - imagesy($img_watermark) - $margin;
 							}
 							break;
 					}
-					$this->DebugMessage('WatermarkText() calling ImageString($img_watermark, '.$size.', '.$x_offset.', '.($key * ImageFontHeight($size)).', '.$line.', $text_color_watermark)', __FILE__, __LINE__);
-					ImageString($img_watermark, $size, $x_offset, $key * ImageFontHeight($size), $line, $text_color_watermark);
+					$this->DebugMessage('WatermarkText() calling imagestring($img_watermark, '.$size.', '.$x_offset.', '.($key * imagefontheight($size)).', '.$line.', $text_color_watermark)', __FILE__, __LINE__);
+					imagestring($img_watermark, $size, $x_offset, $key * imagefontheight($size), $line, $text_color_watermark);
 					if ($angle && $img_watermark_mask) {
-						$this->DebugMessage('WatermarkText() calling ImageString($img_watermark_mask, '.$size.', '.$x_offset.', '.($key * ImageFontHeight($size)).', '.$text.', $mask_color_watermark)', __FILE__, __LINE__);
-						ImageString($img_watermark_mask, $size, $x_offset, $key * ImageFontHeight($size), $text, $mask_color_watermark);
+						$this->DebugMessage('WatermarkText() calling imagestring($img_watermark_mask, '.$size.', '.$x_offset.', '.($key * imagefontheight($size)).', '.$text.', $mask_color_watermark)', __FILE__, __LINE__);
+						imagestring($img_watermark_mask, $size, $x_offset, $key * imagefontheight($size), $text, $mask_color_watermark);
 					}
 				}
 				if ($angle && $img_watermark_mask) {
-					$img_watermark      = ImageRotate($img_watermark,      $angle, $text_color_background);
-					$img_watermark_mask = ImageRotate($img_watermark_mask, $angle, $mask_color_background);
+					$img_watermark      = imagerotate($img_watermark,      $angle, $text_color_background);
+					$img_watermark_mask = imagerotate($img_watermark_mask, $angle, $mask_color_background);
 					phpthumb_filters::ApplyMask($img_watermark_mask, $img_watermark);
 				}
 				//phpthumb_filters::WatermarkOverlay($gdimg, $img_watermark, $alignment, $opacity, $margin);
 				$this->DebugMessage('WatermarkText() calling phpthumb_filters::WatermarkOverlay($gdimg, $img_watermark, '.($originOffsetX.'x'.$originOffsetY).', '.$opacity.', 0)', __FILE__, __LINE__);
 				phpthumb_filters::WatermarkOverlay($gdimg, $img_watermark, $originOffsetX.'x'.$originOffsetY, $opacity, 0);
-				ImageDestroy($img_watermark);
+				imagedestroy($img_watermark);
 				return true;
 			}
 
@@ -1427,16 +1422,16 @@ class phpthumb_filters {
 	public function WatermarkOverlay(&$gdimg_dest, &$img_watermark, $alignment='*', $opacity=50, $margin_x=5, $margin_y=null) {
 
 		if (is_resource($gdimg_dest) && is_resource($img_watermark)) {
-			$watermark_source_x        = 0;
-			$watermark_source_y        = 0;
-			$img_source_width          = ImageSX($gdimg_dest);
-			$img_source_height         = ImageSY($gdimg_dest);
-			$watermark_source_width    = ImageSX($img_watermark);
-			$watermark_source_height   = ImageSY($img_watermark);
+			$img_source_width          = imagesx($gdimg_dest);
+			$img_source_height         = imagesy($gdimg_dest);
+			$watermark_source_width    = imagesx($img_watermark);
+			$watermark_source_height   = imagesy($img_watermark);
 			$watermark_opacity_percent = max(0, min(100, $opacity));
 			$margin_y = (is_null($margin_y) ? $margin_x : $margin_y);
 			$watermark_margin_x = ((($margin_x > 0) && ($margin_x < 1)) ? round((1 - $margin_x) * $img_source_width)  : $margin_x);
 			$watermark_margin_y = ((($margin_y > 0) && ($margin_y < 1)) ? round((1 - $margin_y) * $img_source_height) : $margin_y);
+			$watermark_destination_x = 0;
+			$watermark_destination_y = 0;
 			if (preg_match('#^([0-9\\.\\-]*)x([0-9\\.\\-]*)$#i', $alignment, $matches)) {
 				$watermark_destination_x = intval($matches[1]);
 				$watermark_destination_y = intval($matches[2]);
@@ -1445,24 +1440,24 @@ class phpthumb_filters {
 					case '*':
 						if ($gdimg_tiledwatermark = phpthumb_functions::ImageCreateFunction($img_source_width, $img_source_height)) {
 
-							ImageAlphaBlending($gdimg_tiledwatermark, false);
-							ImageSaveAlpha($gdimg_tiledwatermark, true);
+							imagealphablending($gdimg_tiledwatermark, false);
+							imagesavealpha($gdimg_tiledwatermark, true);
 							$text_color_transparent = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg_tiledwatermark, 255, 0, 255, 127);
-							ImageFill($gdimg_tiledwatermark, 0, 0, $text_color_transparent);
+							imagefill($gdimg_tiledwatermark, 0, 0, $text_color_transparent);
 
 							// set the tiled image transparent color to whatever the untiled image transparency index is
-	//						ImageColorTransparent($gdimg_tiledwatermark, ImageColorTransparent($img_watermark));
+	//						imagecolortransparent($gdimg_tiledwatermark, imagecolortransparent($img_watermark));
 
 							// a "cleaner" way of doing it, but can't handle the margin feature :(
-	//						ImageSetTile($gdimg_tiledwatermark, $img_watermark);
-	//						ImageFill($gdimg_tiledwatermark, 0, 0, IMG_COLOR_TILED);
+	//						imagesettile($gdimg_tiledwatermark, $img_watermark);
+	//						imagefill($gdimg_tiledwatermark, 0, 0, IMG_COLOR_TILED);
 	//						break;
 
-	//						ImageFill($gdimg_tiledwatermark, 0, 0, ImageColorTransparent($gdimg_tiledwatermark));
+	//						imagefill($gdimg_tiledwatermark, 0, 0, imagecolortransparent($gdimg_tiledwatermark));
 							// tile the image as many times as can fit
 							for ($x = $watermark_margin_x; $x < ($img_source_width + $watermark_source_width); $x += ($watermark_source_width + $watermark_margin_x)) {
 								for ($y = $watermark_margin_y; $y < ($img_source_height + $watermark_source_height); $y += ($watermark_source_height + $watermark_margin_y)) {
-									ImageCopy(
+									imagecopy(
 										$gdimg_tiledwatermark,
 										$img_watermark,
 										$x,
@@ -1475,12 +1470,12 @@ class phpthumb_filters {
 								}
 							}
 
-							$watermark_source_width  = ImageSX($gdimg_tiledwatermark);
-							$watermark_source_height = ImageSY($gdimg_tiledwatermark);
+							$watermark_source_width  = imagesx($gdimg_tiledwatermark);
+							$watermark_source_height = imagesy($gdimg_tiledwatermark);
 							$watermark_destination_x = 0;
 							$watermark_destination_y = 0;
 
-							ImageDestroy($img_watermark);
+							imagedestroy($img_watermark);
 							$img_watermark = $gdimg_tiledwatermark;
 						}
 						break;
@@ -1521,13 +1516,6 @@ class phpthumb_filters {
 						break;
 
 					case 'BL':
-	//echo '<pre>';
-	////var_dump($watermark_destination_x);
-	////var_dump($watermark_destination_y);
-	//var_dump($watermark_margin_x);
-	//var_dump($img_source_height);
-	//var_dump($watermark_source_height);
-	//var_dump($watermark_margin_y);
 						$watermark_destination_x = $watermark_margin_x;
 						$watermark_destination_y = $img_source_height - $watermark_source_height - $watermark_margin_y;
 						break;
@@ -1539,9 +1527,9 @@ class phpthumb_filters {
 						break;
 				}
 			}
-			ImageAlphaBlending($gdimg_dest, false);
-			ImageSaveAlpha($gdimg_dest, true);
-			ImageSaveAlpha($img_watermark, true);
+			imagealphablending($gdimg_dest, false);
+			imagesavealpha($gdimg_dest, true);
+			imagesavealpha($img_watermark, true);
 			phpthumb_functions::ImageCopyRespectAlpha($gdimg_dest, $img_watermark, $watermark_destination_x, $watermark_destination_y, 0, 0, $watermark_source_width, $watermark_source_height, $watermark_opacity_percent);
 
 			return true;

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -229,9 +229,9 @@ class phpthumb_functions {
 
 	static function ImageColorAllocateAlphaSafe(&$gdimg_hexcolorallocate, $R, $G, $B, $alpha=false) {
 		if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.2', '>=') && ($alpha !== false)) {
-			return ImageColorAllocateAlpha($gdimg_hexcolorallocate, $R, $G, $B, intval($alpha));
+			return imagecolorallocatealpha($gdimg_hexcolorallocate, $R, $G, $B, intval($alpha));
 		} else {
-			return ImageColorAllocate($gdimg_hexcolorallocate, $R, $G, $B);
+			return imagecolorallocate($gdimg_hexcolorallocate, $R, $G, $B);
 		}
 	}
 
@@ -248,7 +248,7 @@ class phpthumb_functions {
 		if ($dieOnInvalid) {
 			die('Invalid hex color string: "'.$HexColorString.'"');
 		}
-		return ImageColorAllocate($gdimg_hexcolorallocate, 0x00, 0x00, 0x00);
+		return imagecolorallocate($gdimg_hexcolorallocate, 0x00, 0x00, 0x00);
 	}
 
 
@@ -261,7 +261,7 @@ class phpthumb_functions {
 		if (!is_resource($img)) {
 			return false;
 		}
-		return @ImageColorsForIndex($img, @ImageColorAt($img, $x, $y));
+		return @imagecolorsforindex($img, @imagecolorat($img, $x, $y));
 	}
 
 
@@ -323,7 +323,7 @@ class phpthumb_functions {
 		$scaleX2 = $scaleX / 2.0;
 		$scaleY2 = $scaleY / 2.0;
 
-		$isTrueColor = ImageIsTrueColor($src_img);
+		$isTrueColor = imageistruecolor($src_img);
 
 		for ($y = $src_y; $y < $src_y + $dst_h; $y++) {
 			$sY   = $y * $scaleY;
@@ -337,10 +337,10 @@ class phpthumb_functions {
 
 				if ($isTrueColor) {
 
-					$c1 = ImageColorAt($src_img, $siX, $siY2);
-					$c2 = ImageColorAt($src_img, $siX, $siY);
-					$c3 = ImageColorAt($src_img, $siX2, $siY2);
-					$c4 = ImageColorAt($src_img, $siX2, $siY);
+					$c1 = imagecolorat($src_img, $siX, $siY2);
+					$c2 = imagecolorat($src_img, $siX, $siY);
+					$c3 = imagecolorat($src_img, $siX2, $siY2);
+					$c4 = imagecolorat($src_img, $siX2, $siY);
 
 					$r = (( $c1             +  $c2             +  $c3             +  $c4            ) >> 2) & 0xFF0000;
 					$g = ((($c1 & 0x00FF00) + ($c2 & 0x00FF00) + ($c3 & 0x00FF00) + ($c4 & 0x00FF00)) >> 2) & 0x00FF00;
@@ -348,17 +348,17 @@ class phpthumb_functions {
 
 				} else {
 
-					$c1 = ImageColorsForIndex($src_img, ImageColorAt($src_img, $siX, $siY2));
-					$c2 = ImageColorsForIndex($src_img, ImageColorAt($src_img, $siX, $siY));
-					$c3 = ImageColorsForIndex($src_img, ImageColorAt($src_img, $siX2, $siY2));
-					$c4 = ImageColorsForIndex($src_img, ImageColorAt($src_img, $siX2, $siY));
+					$c1 = imagecolorsforindex($src_img, imagecolorat($src_img, $siX, $siY2));
+					$c2 = imagecolorsforindex($src_img, imagecolorat($src_img, $siX, $siY));
+					$c3 = imagecolorsforindex($src_img, imagecolorat($src_img, $siX2, $siY2));
+					$c4 = imagecolorsforindex($src_img, imagecolorat($src_img, $siX2, $siY));
 
 					$r = ($c1['red']   + $c2['red']   + $c3['red']   + $c4['red'] )  << 14;
 					$g = ($c1['green'] + $c2['green'] + $c3['green'] + $c4['green']) <<  6;
 					$b = ($c1['blue']  + $c2['blue']  + $c3['blue']  + $c4['blue'] ) >>  2;
 
 				}
-				ImageSetPixel($dst_img, $dst_x + $x - $src_x, $dst_y + $y - $src_y, $r+$g+$b);
+				imagesetpixel($dst_img, $dst_x + $x - $src_x, $dst_y + $y - $src_y, $r+$g+$b);
 			}
 		}
 		return true;
@@ -366,9 +366,9 @@ class phpthumb_functions {
 
 
 	static function ImageCreateFunction($x_size, $y_size) {
-		$ImageCreateFunction = 'ImageCreate';
+		$ImageCreateFunction = 'imagecreate';
 		if (phpthumb_functions::gd_version() >= 2.0) {
-			$ImageCreateFunction = 'ImageCreateTrueColor';
+			$ImageCreateFunction = 'imagecreatetruecolor';
 		}
 		if (!function_exists($ImageCreateFunction)) {
 			return phpthumb::ErrorImage($ImageCreateFunction.'() does not exist - no GD support?');
@@ -397,7 +397,7 @@ class phpthumb_functions {
 					//$RealPixel['alpha']);
 					0);
 
-				ImageSetPixel($dst_im, $dst_x + $x, $dst_y + $y, $newcolor);
+				imagesetpixel($dst_im, $dst_x + $x, $dst_y + $y, $newcolor);
 			}
 		}
 		return true;
@@ -659,7 +659,7 @@ class phpthumb_functions {
 					$Data_body .= $line;
 				}
 				if (preg_match('#^HTTP/[\\.0-9]+ ([0-9]+) (.+)$#i', rtrim($line), $matches)) {
-					list($dummy, $errno, $errstr) = $matches;
+					list( , $errno, $errstr) = $matches;
 					$errno = intval($errno);
 				} elseif (preg_match('#^Location: (.*)$#i', rtrim($line), $matches)) {
 					$header_newlocation = $matches[1];
@@ -744,7 +744,9 @@ class phpthumb_functions {
 	}
 
 	static function SafeURLread($url, &$error, $timeout=10, $followredirects=true) {
-		$error = '';
+		$error   = '';
+		$errstr  = '';
+		$rawData = '';
 
 		$parsed_url = phpthumb_functions::ParseURLbetter($url);
 		$alreadyLookedAtURLs[trim($url)] = true;
@@ -752,7 +754,7 @@ class phpthumb_functions {
 		while (true) {
 			$tryagain = false;
 			$rawData = phpthumb_functions::URLreadFsock(@$parsed_url['host'], @$parsed_url['path'].'?'.@$parsed_url['query'], $errstr, true, (@$parsed_url['port'] ? @$parsed_url['port'] : 80), $timeout);
-			if (preg_match('#302 [a-z ]+; Location\\: (http.*)#i', $errstr, $matches)) {
+			if ($followredirects && preg_match('#302 [a-z ]+; Location\\: (http.*)#i', $errstr, $matches)) {
 				$matches[1] = trim(@$matches[1]);
 				if (!@$alreadyLookedAtURLs[$matches[1]]) {
 					// loop through and examine new URL
@@ -786,6 +788,7 @@ class phpthumb_functions {
 			curl_setopt($ch, CURLOPT_BINARYTRANSFER, true);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, (bool) $followredirects);
 			curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
 			$rawData = curl_exec($ch);
 			curl_close($ch);
@@ -828,7 +831,7 @@ class phpthumb_functions {
 		return false;
 	}
 
-	static function EnsureDirectoryExists($dirname) {
+	static function EnsureDirectoryExists($dirname, $mask = 0755) {
 		$directory_elements = explode(DIRECTORY_SEPARATOR, $dirname);
 		$startoffset = (!$directory_elements[0] ? 2 : 1);  // unix with leading "/" then start with 2nd element; Windows with leading "c:\" then start with 1st element
 		$open_basedirs = preg_split('#[;:]#', ini_get('open_basedir'));
@@ -850,8 +853,8 @@ class phpthumb_functions {
 					// directory name already exists as a file
 					return false;
 				}
-				@mkdir($test_directory, 0755);
-				@chmod($test_directory, 0755);
+				@mkdir($test_directory, $mask);
+				@chmod($test_directory, $mask);
 				if (!@is_dir($test_directory) || !@is_writeable($test_directory)) {
 					return false;
 				}
@@ -949,8 +952,8 @@ if (!function_exists('gd_info')) {
 			}
 			if (empty($gd_info['GD Version'])) {
 				// probable cause: "phpinfo() disabled for security reasons"
-				if (function_exists('ImageTypes')) {
-					$imagetypes = ImageTypes();
+				if (function_exists('imagetypes')) {
+					$imagetypes = imagetypes();
 					if ($imagetypes & IMG_PNG) {
 						$gd_info['PNG Support'] = true;
 					}
@@ -964,22 +967,23 @@ if (!function_exists('gd_info')) {
 						$gd_info['WBMP Support'] = true;
 					}
 				}
-				// to determine capability of GIF creation, try to use ImageCreateFromGIF on a 1px GIF
-				if (function_exists('ImageCreateFromGIF')) {
+				// to determine capability of GIF creation, try to use imagecreatefromgif on a 1px GIF
+				if (function_exists('imagecreatefromgif')) {
 					if ($tempfilename = phpthumb::phpThumb_tempnam()) {
 						if ($fp_tempfile = @fopen($tempfilename, 'wb')) {
 							fwrite($fp_tempfile, base64_decode('R0lGODlhAQABAIAAAH//AP///ywAAAAAAQABAAACAUQAOw==')); // very simple 1px GIF file base64-encoded as string
 							fclose($fp_tempfile);
+							@chmod($tempfilename, $this->getParameter('config_file_create_mask'));
 
 							// if we can convert the GIF file to a GD image then GIF create support must be enabled, otherwise it's not
-							$gd_info['GIF Read Support'] = (bool) @ImageCreateFromGIF($tempfilename);
+							$gd_info['GIF Read Support'] = (bool) @imagecreatefromgif($tempfilename);
 						}
 						unlink($tempfilename);
 					}
 				}
-				if (function_exists('ImageCreateTrueColor') && @ImageCreateTrueColor(1, 1)) {
+				if (function_exists('imagecreatetruecolor') && @imagecreatetruecolor(1, 1)) {
 					$gd_info['GD Version'] = '2.0.1 or higher (assumed)';
-				} elseif (function_exists('ImageCreate') && @ImageCreate(1, 1)) {
+				} elseif (function_exists('imagecreate') && @imagecreate(1, 1)) {
 					$gd_info['GD Version'] = '1.6.0 or higher (assumed)';
 				}
 			}
@@ -1061,5 +1065,3 @@ if (!function_exists('imagesavealpha')) {
 		return true;
 	}
 }
-
-?>

--- a/core/model/phpthumb/phpthumb.ico.php
+++ b/core/model/phpthumb/phpthumb.ico.php
@@ -12,18 +12,20 @@
 
 class phpthumb_ico {
 
-	function phpthumb_ico() {
-		return true;
-	}
-
-
 	function GD2ICOstring(&$gd_image_array) {
+		$ImageWidths  = array();
+		$ImageHeights = array();
+		$bpp          = array();
+		$totalcolors  = array();
+		$icXOR        = array();
+		$icAND        = array();
+		$icANDmask    = array();
 		foreach ($gd_image_array as $key => $gd_image) {
 
-			$ImageWidths[$key]  = ImageSX($gd_image);
-			$ImageHeights[$key] = ImageSY($gd_image);
-	    	$bpp[$key]          = ImageIsTrueColor($gd_image) ? 32 : 24;
-	    	$totalcolors[$key]  = ImageColorsTotal($gd_image);
+			$ImageWidths[$key]  = imagesx($gd_image);
+			$ImageHeights[$key] = imagesy($gd_image);
+			$bpp[$key]          = imageistruecolor($gd_image) ? 32 : 24;
+			$totalcolors[$key]  = imagecolorstotal($gd_image);
 
 			$icXOR[$key] = '';
 			for ($y = $ImageHeights[$key] - 1; $y >= 0; $y--) {
@@ -60,24 +62,24 @@ class phpthumb_ico {
 
 		}
 
-	    foreach ($gd_image_array as $key => $gd_image) {
+		foreach ($gd_image_array as $key => $gd_image) {
 			$biSizeImage = $ImageWidths[$key] * $ImageHeights[$key] * ($bpp[$key] / 8);
 
-	    	// BITMAPINFOHEADER - 40 bytes
+			// BITMAPINFOHEADER - 40 bytes
 			$BitmapInfoHeader[$key]  = '';
 			$BitmapInfoHeader[$key] .= "\x28\x00\x00\x00";                              // DWORD  biSize;
 			$BitmapInfoHeader[$key] .= phpthumb_functions::LittleEndian2String($ImageWidths[$key], 4);      // LONG   biWidth;
 			// The biHeight member specifies the combined
 			// height of the XOR and AND masks.
 			$BitmapInfoHeader[$key] .= phpthumb_functions::LittleEndian2String($ImageHeights[$key] * 2, 4); // LONG   biHeight;
-	    	$BitmapInfoHeader[$key] .= "\x01\x00";                                      // WORD   biPlanes;
-	   		$BitmapInfoHeader[$key] .= chr($bpp[$key])."\x00";                          // wBitCount;
+			$BitmapInfoHeader[$key] .= "\x01\x00";                                      // WORD   biPlanes;
+			$BitmapInfoHeader[$key] .= chr($bpp[$key])."\x00";                          // wBitCount;
 			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biCompression;
 			$BitmapInfoHeader[$key] .= phpthumb_functions::LittleEndian2String($biSizeImage, 4);            // DWORD  biSizeImage;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biXPelsPerMeter;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biYPelsPerMeter;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrUsed;
-	    	$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrImportant;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biXPelsPerMeter;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // LONG   biYPelsPerMeter;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrUsed;
+			$BitmapInfoHeader[$key] .= "\x00\x00\x00\x00";                              // DWORD  biClrImportant;
 		}
 
 
@@ -87,34 +89,32 @@ class phpthumb_ico {
 
 		$dwImageOffset = 6 + (count($gd_image_array) * 16);
 		foreach ($gd_image_array as $key => $gd_image) {
-	    	// ICONDIRENTRY   idEntries[1]; // An entry for each image (idCount of 'em)
+			// ICONDIRENTRY   idEntries[1]; // An entry for each image (idCount of 'em)
 
-	    	$icondata .= chr($ImageWidths[$key]);                     // bWidth;          // Width, in pixels, of the image
-	    	$icondata .= chr($ImageHeights[$key]);                    // bHeight;         // Height, in pixels, of the image
-	    	$icondata .= chr($totalcolors[$key]);                     // bColorCount;     // Number of colors in image (0 if >=8bpp)
-	    	$icondata .= "\x00";                                      // bReserved;       // Reserved ( must be 0)
+			$icondata .= chr($ImageWidths[$key]);                     // bWidth;          // Width, in pixels, of the image
+			$icondata .= chr($ImageHeights[$key]);                    // bHeight;         // Height, in pixels, of the image
+			$icondata .= chr($totalcolors[$key]);                     // bColorCount;     // Number of colors in image (0 if >=8bpp)
+			$icondata .= "\x00";                                      // bReserved;       // Reserved ( must be 0)
 
-	    	$icondata .= "\x01\x00";                                  // wPlanes;         // Color Planes
+			$icondata .= "\x01\x00";                                  // wPlanes;         // Color Planes
 			$icondata .= chr($bpp[$key])."\x00";                      // wBitCount;       // Bits per pixel
 
 			$dwBytesInRes = 40 + strlen($icXOR[$key]) + strlen($icAND[$key]);
 			$icondata .= phpthumb_functions::LittleEndian2String($dwBytesInRes, 4);       // dwBytesInRes;    // How many bytes in this resource?
 
-		    $icondata .= phpthumb_functions::LittleEndian2String($dwImageOffset, 4);      // dwImageOffset;   // Where in the file is this image?
+			$icondata .= phpthumb_functions::LittleEndian2String($dwImageOffset, 4);      // dwImageOffset;   // Where in the file is this image?
 			$dwImageOffset += strlen($BitmapInfoHeader[$key]);
 			$dwImageOffset += strlen($icXOR[$key]);
 			$dwImageOffset += strlen($icAND[$key]);
-	    }
+		}
 
-	    foreach ($gd_image_array as $key => $gd_image) {
+		foreach ($gd_image_array as $key => $gd_image) {
 			$icondata .= $BitmapInfoHeader[$key];
 			$icondata .= $icXOR[$key];
 			$icondata .= $icAND[$key];
-	    }
+		}
 
-	    return $icondata;
+		return $icondata;
 	}
 
 }
-
-?>

--- a/core/model/phpthumb/phpthumb.unsharp.php
+++ b/core/model/phpthumb/phpthumb.unsharp.php
@@ -55,10 +55,10 @@ class phpUnsharpMask {
 		if ($radius == 0) {
 			return true;
 		}
-		$w = ImageSX($img);
-		$h = ImageSY($img);
-		$imgCanvas = ImageCreateTrueColor($w, $h);
-		$imgBlur   = ImageCreateTrueColor($w, $h);
+		$w = imagesx($img);
+		$h = imagesy($img);
+		$imgCanvas = imagecreatetruecolor($w, $h);
+		$imgBlur   = imagecreatetruecolor($w, $h);
 
 		// Gaussian blur matrix:
 		//
@@ -74,20 +74,20 @@ class phpUnsharpMask {
 				array(2, 4, 2),
 				array(1, 2, 1)
 			);
-			ImageCopy($imgBlur, $img, 0, 0, 0, 0, $w, $h);
-			ImageConvolution($imgBlur, $matrix, 16, 0);
+			imagecopy($imgBlur, $img, 0, 0, 0, 0, $w, $h);
+			imageconvolution($imgBlur, $matrix, 16, 0);
 
 		} else {
 
 			// Move copies of the image around one pixel at the time and merge them with weight
 			// according to the matrix. The same matrix is simply repeated for higher radii.
 			for ($i = 0; $i < $radius; $i++)    {
-				ImageCopy(     $imgBlur,   $img,       0, 0, 1, 0, $w - 1, $h);               // left
-				ImageCopyMerge($imgBlur,   $img,       1, 0, 0, 0, $w    , $h,     50);       // right
-				ImageCopyMerge($imgBlur,   $img,       0, 0, 0, 0, $w    , $h,     50);       // center
-				ImageCopy(     $imgCanvas, $imgBlur,   0, 0, 0, 0, $w    , $h);
-				ImageCopyMerge($imgBlur,   $imgCanvas, 0, 0, 0, 1, $w    , $h - 1, 33.33333); // up
-				ImageCopyMerge($imgBlur,   $imgCanvas, 0, 1, 0, 0, $w    , $h,     25);       // down
+				imagecopy(     $imgBlur,   $img,       0, 0, 1, 0, $w - 1, $h);               // left
+				imagecopymerge($imgBlur,   $img,       1, 0, 0, 0, $w    , $h,     50);       // right
+				imagecopymerge($imgBlur,   $img,       0, 0, 0, 0, $w    , $h,     50);       // center
+				imagecopy(     $imgCanvas, $imgBlur,   0, 0, 0, 0, $w    , $h);
+				imagecopymerge($imgBlur,   $imgCanvas, 0, 0, 0, 1, $w    , $h - 1, 33.33333); // up
+				imagecopymerge($imgBlur,   $imgCanvas, 0, 1, 0, 0, $w    , $h,     25);       // down
 			}
 		}
 
@@ -97,12 +97,12 @@ class phpUnsharpMask {
 			for ($x = 0; $x < $w-1; $x++)    { // each row
 				for ($y = 0; $y < $h; $y++)    { // each pixel
 
-					$rgbOrig = ImageColorAt($img, $x, $y);
+					$rgbOrig = imagecolorat($img, $x, $y);
 					$rOrig = (($rgbOrig >> 16) & 0xFF);
 					$gOrig = (($rgbOrig >>  8) & 0xFF);
 					$bOrig =  ($rgbOrig        & 0xFF);
 
-					$rgbBlur = ImageColorAt($imgBlur, $x, $y);
+					$rgbBlur = imagecolorat($imgBlur, $x, $y);
 
 					$rBlur = (($rgbBlur >> 16) & 0xFF);
 					$gBlur = (($rgbBlur >>  8) & 0xFF);
@@ -115,20 +115,20 @@ class phpUnsharpMask {
 					$bNew = ((abs($bOrig - $bBlur) >= $threshold) ? max(0, min(255, ($amount * ($bOrig - $bBlur)) + $bOrig)) : $bOrig);
 
 					if (($rOrig != $rNew) || ($gOrig != $gNew) || ($bOrig != $bNew)) {
-						$pixCol = ImageColorAllocate($img, $rNew, $gNew, $bNew);
-						ImageSetPixel($img, $x, $y, $pixCol);
+						$pixCol = imagecolorallocate($img, $rNew, $gNew, $bNew);
+						imagesetpixel($img, $x, $y, $pixCol);
 					}
 				}
 			}
 		} else {
 			for ($x = 0; $x < $w; $x++)    { // each row
 				for ($y = 0; $y < $h; $y++)    { // each pixel
-					$rgbOrig = ImageColorAt($img, $x, $y);
+					$rgbOrig = imagecolorat($img, $x, $y);
 					$rOrig = (($rgbOrig >> 16) & 0xFF);
 					$gOrig = (($rgbOrig >>  8) & 0xFF);
 					$bOrig =  ($rgbOrig        & 0xFF);
 
-					$rgbBlur = ImageColorAt($imgBlur, $x, $y);
+					$rgbBlur = imagecolorat($imgBlur, $x, $y);
 
 					$rBlur = (($rgbBlur >> 16) & 0xFF);
 					$gBlur = (($rgbBlur >>  8) & 0xFF);
@@ -138,13 +138,12 @@ class phpUnsharpMask {
 					$gNew = min(255, max(0, ($amount * ($gOrig - $gBlur)) + $gOrig));
 					$bNew = min(255, max(0, ($amount * ($bOrig - $bBlur)) + $bOrig));
 					$rgbNew = ($rNew << 16) + ($gNew <<8) + $bNew;
-					ImageSetPixel($img, $x, $y, $rgbNew);
+					imagesetpixel($img, $x, $y, $rgbNew);
 				}
 			}
 		}
-		ImageDestroy($imgCanvas);
-		ImageDestroy($imgBlur);
+		imagedestroy($imgCanvas);
+		imagedestroy($imgBlur);
 		return true;
 	}
 }
-?>


### PR DESCRIPTION
### What does it do?

Update the phpThumb classfiles from 1.7.14-201604151303 to 1.7.14-201608101311
### Why is it needed?

Have the phpThumb class uptodate. The main reason is PHP7 compatibility.
### Related issue(s)/PR(s)

Could be a fix for those issues (has to be confirmed) 
https://forums.modx.com/thread/100091/no-thumbnails-in-media-browser-with-php-7-0-4
https://forums.modx.com/thread/86791/support-comments-for-ajaxupload?page=15#dis-post-544909
