### PR TITLE
Fix the consistency of error messages when getResource fails

### DIFF
--- a/core/error/fatal.include.php
+++ b/core/error/fatal.include.php
@@ -3,7 +3,7 @@ header('HTTP/1.1 500 Internal Server Error');
 ?>
 <html>
 <head>
-<title>Error 500: Internal Server Error</title>
+<title><?php echo $errorPageTitle ? $errorPageTitle : 'Error 500: Internal Server Error'; ?></title>
 <style type="text/css">
 * {
     margin: 0;
@@ -35,8 +35,7 @@ a {
 </head>
 <body>
 <div class="message">
-    <h1>500 Error</h1>
-    <p><?php echo $errorMessage ? $errorMessage : 'A fatal application error has been encountered.'; ?></p>
+    <?php echo $errorMessage ? $errorMessage : '<h1>' . ($errorPageTitle ? $errorPageTitle : 'Error 500: Internal Server Error') . '</h1><p>A fatal application error has been encountered.</p>'; ?>
 </div>
 </body>
 <?php

--- a/core/error/unavailable.include.php
+++ b/core/error/unavailable.include.php
@@ -3,7 +3,7 @@ header('HTTP/1.1 503 Service Unavailable');
 ?>
 <html>
 <head>
-<title>Error 503: Service Unavailable</title>
+<title><?php echo $errorPageTitle ? $errorPageTitle : 'Error 503: Service Unavailable'; ?></title>
 <style type="text/css">
 * {
     margin: 0;
@@ -35,8 +35,7 @@ a {
 </head>
 <body>
 <div class="message">
-    <h1>503 Error</h1>
-    <p><?php echo $errorMessage ? $errorMessage : 'Site temporarily unavailable.'; ?></p>
+    <?php echo $errorMessage ? $errorMessage : '<p>Site temporarily unavailable.</p>'; ?>
 </div>
 </body>
 <?php

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1051,7 +1051,7 @@ class modX extends xPDO {
                 @include(MODX_CORE_PATH . "error/{$type}.include.php");
             }
             header($this->getOption('error_header', $options, 'HTTP/1.1 503 Service Unavailable'));
-            echo "<html><head><title>{$errorPageTitle}</title></head><body><h1>503 Error</h1><p>{$errorMessage}</p></body></html>";
+            echo "<html><head><title>{$errorPageTitle}</title></head><body>{$errorMessage}</body></html>";
             @session_write_close();
         } else {
             echo ucfirst($type) . "\n";


### PR DESCRIPTION
### What does it do?

Make sure error messages are consistent based on type, and removes wrapping HTML tags from the error_message, as error_message is typically provided with it's own HTML tags.
### Why is it needed?

When a page cannot be found in the database, mixed error messages were being returned which displayed Error 503 with a message saying Page Not Found and a 404 header.
### Related issue(s)/PR(s)

None related.
