### PR TITLE
Let's not try to create a new DirectoryIterator on non existing folders

### DIFF
--- a/core/model/modx/modlexicon.class.php
+++ b/core/model/modx/modlexicon.class.php
@@ -6,7 +6,7 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- * 
+ *
  * @package modx
  */
 /**
@@ -349,6 +349,9 @@ class modLexicon {
     public function getLanguageList($namespace = 'core') {
         $corePath = $this->getNamespacePath($namespace);
         $lexPath = str_replace('//','/',$corePath.'/lexicon/');
+        if (!is_dir($lexPath)) {
+            return array();
+        }
         $languages = array();
         /** @var DirectoryIterator $language */
         foreach (new DirectoryIterator($lexPath) as $language) {


### PR DESCRIPTION
### What does it do?

Prevents creating a `DirectoryIterator` on non existing directory.
### Why is it needed?

Prevents issues like `Uncaught UnexpectedValueException: DirectoryIterator::__construct(/../core/components/ns-without-lexicon/lexicon/): failed to open dir: No such file or directory` (PHP 7)
