### PR TITLE
Set temporary directory for files processing in phpThumb

### DIFF
--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -31,6 +31,7 @@ class modPhpThumb extends phpThumb {
         $cachePath = $this->modx->getOption('core_path',null,MODX_CORE_PATH).'cache/phpthumb/';
         if (!is_dir($cachePath)) $this->modx->cacheManager->writeTree($cachePath);
         $this->setParameter('config_cache_directory',$cachePath);
+        $this->setParameter('config_temp_directory',$cachePath);
         $this->setCacheDirectory();
 
         $this->setParameter('config_allow_src_above_docroot',(boolean)$this->modx->getOption('phpthumb_allow_src_above_docroot',$this->config,false));


### PR DESCRIPTION
### What does it do?

Set temporary directory for files processing in phpThumb
### Why is it needed?

Otherwise you will get warnings on servers with open_basedir enabled on MODX 2.5.1

```
[2016-09-16 16:02:15] (ERROR @ /home/****/www/core/model/phpthumb/phpthumb.class.php : 1215) PHP warning: realpath(): open_basedir restriction in effect. File(/tmp) is not within the allowed path(s): (/home/****)
```
