### PR TITLE
Add User Group description to UserGroups grid (with row toggle)

### DIFF
--- a/core/model/modx/processors/security/user/get.class.php
+++ b/core/model/modx/processors/security/user/get.class.php
@@ -37,6 +37,7 @@ class modUserGetProcessor extends modObjectGetProcessor {
         $c->select(array(
             'role_name' => 'UserGroupRole.name',
             'user_group_name' => 'UserGroup.name',
+            'user_group_desc' => 'UserGroup.description',
         ));
         $c->leftJoin('modUserGroupRole','UserGroupRole');
         $c->innerJoin('modUserGroup','UserGroup');
@@ -59,6 +60,7 @@ class modUserGetProcessor extends modObjectGetProcessor {
                 empty($roleName) ? '' : $roleName,
                 $this->object->get('primary_group') == $member->get('user_group') ? true : false,
                 $member->get('rank'),
+                $member->get('user_group_desc'),
             );
         }
         $this->object->set('groups','(' . $this->modx->toJSON($data) . ')');

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -8,6 +8,11 @@
  */
 MODx.grid.UserGroups = function(config) {
     config = config || {};
+    this.exp = new Ext.grid.RowExpander({
+        tpl : new Ext.Template(
+            '<p class="desc">{user_group_desc}</p>'
+        )
+    });
     Ext.applyIf(config,{
         title: ''
         ,id: 'modx-grid-user-groups'
@@ -15,9 +20,10 @@ MODx.grid.UserGroups = function(config) {
         ,baseParams: {
             action: 'security/group/getlist'
         }
-        ,fields: ['usergroup','name','member','role','rolename','primary_group','rank']
+        ,fields: ['usergroup','name','member','role','rolename','primary_group','rank','user_group_desc']
         ,cls: 'modx-grid modx-grid-draggable'
-        ,columns: [{
+        ,columns: [this.exp,
+        {
             header: _('user_group')
             ,dataIndex: 'name'
             ,width: 175
@@ -39,7 +45,8 @@ MODx.grid.UserGroups = function(config) {
                 'afterrowmove': {fn:this.onAfterRowMove,scope:this}
                 ,'beforerowmove': {fn:this.onBeforeRowMove,scope:this}
             }
-        })]
+        }),
+        this.exp]
         ,tbar: [{
             text: _('user_group_user_add')
             ,cls:'primary-button'


### PR DESCRIPTION
### What does it do?

Adds User Group description (with row toggle) to the `UserGroups` grid in the Access Permissions tab when editing a user.
### Why is it needed?

When working with _a lot_ of User Groups, particularly when using a naming convention resulting in seemingly similar entries, having the User Group description available in this view can be very helpful to help distinguish / differentiate like-entries.
