### PR TITLE
modRest refactoring

### DIFF
--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -593,7 +593,6 @@ class RestClientResponse {
      */
     public function _parse($result) {
         $headers = array();
-        $httpVer = strtok($result, "\n");
 
         while($line = strtok("\n")){
             if(strlen(trim($line)) == 0) break;
@@ -645,7 +644,6 @@ class RestClientResponse {
         if($valueKey && !is_string($valueKey)){$valueKey = '@values';}
 
         $return = array();
-        $name = $xml->getName();
         $_value = trim((string)$xml);
         if(!strlen($_value)){$_value = null;};
 

--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -497,7 +497,7 @@ class RestClientRequest {
                     }
                 }
             } elseif (is_object($val)) {
-                $this->_populateXmlDoc($doc,$node,$val);
+                $this->_populateXmlDoc($doc,$node,array($val));
             } else {
                 $node->appendChild($doc->createElement($key, $val));
             }

--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -473,7 +473,7 @@ class RestClientRequest {
      * @param array $parameters
      */
     protected function _populateXmlDoc(&$doc, &$node, &$parameters) {
-        /** @var $val DOMNode */
+        /** @var DOMnode/array $val */
         foreach ($parameters as $key => $val) {
             if (is_array($val)) {
                 if (empty($val)) {
@@ -497,7 +497,7 @@ class RestClientRequest {
                     }
                 }
             } elseif (is_object($val)) {
-                $this->_populateXmlDoc($doc,$node,array($val));
+                $this->_populateXmlDoc($doc,$node,$val);
             } else {
                 $node->appendChild($doc->createElement($key, $val));
             }

--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -470,10 +470,9 @@ class RestClientRequest {
     /**
      * @param DOMDocument $doc
      * @param DOMNode $node
-     * @param array $parameters
+     * @param array|DOMNode $parameters
      */
     protected function _populateXmlDoc(&$doc, &$node, &$parameters) {
-        /** @var DOMnode/array $val */
         foreach ($parameters as $key => $val) {
             if (is_array($val)) {
                 if (empty($val)) {

--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -438,10 +438,8 @@ abstract class modRestController {
     }
 
     /**
-     * Abstract method for routing GET requests without a primary key passed. Must be defined in your derivative
-     * controller. Handles fetching of collections of objects.
-     *
-     * @abstract
+     * Default method for routing GET requests without a primary key passed. Can be overridden; default behavior
+     * automates xPDOObject, class-based requests. Handles fetching of collections of objects.
      */
     public function getList() {
         $this->getProperties();
@@ -534,9 +532,8 @@ abstract class modRestController {
     }
 
     /**
-     * Abstract method for routing GET requests with a primary key passed. Must be defined in your derivative
-     * controller.
-     * @abstract
+     * Default method for routing GET requests with a primary key passed. Can be overridden; default behavior automates
+     * xPDOObject, class-based requests.
      * @param $id
      */
     public function read($id) {
@@ -546,6 +543,7 @@ abstract class modRestController {
             )));
             return;
         }
+
         /** @var xPDOObject $object */
         $c = $this->getPrimaryKeyCriteria($id);
         $this->object = $this->modx->getObject($this->classKey,$c);
@@ -575,8 +573,8 @@ abstract class modRestController {
         return !$this->hasErrors();
     }
     /**
-     * Method for routing POST requests. Can be overridden; default behavior automates xPDOObject, class-based requests.
-     * @abstract
+     * Default Method for routing POST requests. Can be overridden; default behavior automates xPDOObject, class-based
+     * requests.
      */
     public function post() {
         $properties = $this->getProperties();

--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -288,9 +288,10 @@ abstract class modRestController {
      */
     protected function process($success = true,$message = '',$object = array(),$status = 200) {
         $response = array(
+            $this->getOption('responseSuccessKey','success') => $success,
             $this->getOption('responseMessageKey','message') => $message,
             $this->getOption('responseObjectKey','object') => is_object($object) ? $object->toArray() : $object,
-            $this->getOption('responseSuccessKey','success') => $success,
+            'code' => $status
         );
         if (empty($success) && !empty($this->errors)) {
             $response[$this->getOption('responseErrorsKey','errors')] = $this->errors;

--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -427,14 +427,14 @@ abstract class modRestController {
 
     /**
      * Route GET requests
-     * @return array
      */
     public function get() {
         $pk = $this->getProperty($this->primaryKeyField);
         if (empty($pk)) {
-            return $this->getList();
+            $this->getList();
+        } else {
+            $this->read($pk);
         }
-        return $this->read($pk);
     }
 
     /**
@@ -442,7 +442,6 @@ abstract class modRestController {
      * controller. Handles fetching of collections of objects.
      *
      * @abstract
-     * @return array
      */
     public function getList() {
         $this->getProperties();
@@ -466,7 +465,7 @@ abstract class modRestController {
         foreach ($objects as $object) {
             $list[] = $this->prepareListObject($object);
         }
-        return $this->collection($list,$total);
+        $this->collection($list,$total);
     }
 
     /**
@@ -542,26 +541,29 @@ abstract class modRestController {
      */
     public function read($id) {
         if (empty($id)) {
-            return $this->failure($this->modx->lexicon('rest.err_field_ns',array(
+            $this->failure($this->modx->lexicon('rest.err_field_ns',array(
                 'field' => $this->primaryKeyField,
             )));
+            return;
         }
         /** @var xPDOObject $object */
         $c = $this->getPrimaryKeyCriteria($id);
         $this->object = $this->modx->getObject($this->classKey,$c);
         if (empty($this->object)) {
-            return $this->failure($this->modx->lexicon('rest.err_obj_nf',array(
+            $this->failure($this->modx->lexicon('rest.err_obj_nf',array(
                 'class_key' => $this->classKey,
             )));
+            return;
         }
         $objectArray = $this->object->toArray();
 
         $afterRead = $this->afterRead($objectArray);
         if ($afterRead !== true && $afterRead !== null) {
-            return $this->failure($afterRead === false ? $this->errorMessage : $afterRead);
+            $this->failure($afterRead === false ? $this->errorMessage : $afterRead);
+            return;
         }
-
-        return $this->success('',$objectArray);
+        $this->success('',$objectArray);
+        return;
     }
     /**
      * Fires after reading the object. Override to provide custom functionality.
@@ -581,13 +583,15 @@ abstract class modRestController {
 
         if (!empty($this->postRequiredFields)) {
             if (!$this->checkRequiredFields($this->postRequiredFields)) {
-                return $this->failure($this->modx->lexicon('error'));
+                $this->failure($this->modx->lexicon('error'));
+                return;
             }
         }
 
         if (!empty($this->postRequiredRelatedObjects)) {
             if (!$this->checkRequiredRelatedObjects($this->postRequiredRelatedObjects)) {
-                return $this->failure();
+                $this->failure();
+                return;
             }
         }
 
@@ -596,22 +600,25 @@ abstract class modRestController {
         $this->object->fromArray($properties);
         $beforePost = $this->beforePost();
         if ($beforePost !== true && $beforePost !== null) {
-            return $this->failure($beforePost === false ? $this->errorMessage : $beforePost);
+            $this->failure($beforePost === false ? $this->errorMessage : $beforePost);
+            return;
         }
         if (!$this->object->{$this->postMethod}()) {
             $this->setObjectErrors();
             if ($this->hasErrors()) {
-                return $this->failure();
+                $this->failure();
+                return;
             } else {
-                return $this->failure($this->modx->lexicon('rest.err_class_save',array(
+                $this->failure($this->modx->lexicon('rest.err_class_save',array(
                     'class_key' => $this->classKey,
                 )));
+                return;
             }
-
         }
         $objectArray = $this->object->toArray();
         $this->afterPost($objectArray);
-        return $this->success('',$objectArray);
+        $this->success('',$objectArray);
+        return;
     }
     /**
      * Fires before saving the new object. Override to provide custom functionality.
@@ -629,32 +636,35 @@ abstract class modRestController {
 
     /**
      * Handles updating of objects
-     * @return array
      */
     public function put() {
         $id = $this->getProperty($this->primaryKeyField,false);
         if (empty($id)) {
-            return $this->failure($this->modx->lexicon('rest.err_field_ns',array(
+            $this->failure($this->modx->lexicon('rest.err_field_ns',array(
                 'field' => $this->primaryKeyField,
             )));
+            return;
         }
         $c = $this->getPrimaryKeyCriteria($id);
         $this->object = $this->modx->getObject($this->classKey,$c);
         if (empty($this->object)) {
-            return $this->failure($this->modx->lexicon('rest.err_obj_nf',array(
+            $this->failure($this->modx->lexicon('rest.err_obj_nf',array(
                 'class_key' => $this->classKey,
             )));
+            return;
         }
 
         if (!empty($this->putRequiredFields)) {
             if (!$this->checkRequiredFields($this->putRequiredFields)) {
-                return $this->failure();
+                $this->failure();
+                return;
             }
         }
 
         if (!empty($this->putRequiredRelatedObjects)) {
             if (!$this->checkRequiredRelatedObjects($this->putRequiredRelatedObjects)) {
-                return $this->failure();
+                $this->failure();
+                return;
             }
         }
 
@@ -662,23 +672,27 @@ abstract class modRestController {
 
         $beforePut = $this->beforePut();
         if ($beforePut !== true && $beforePut !== null) {
-            return $this->failure($beforePut === false ? $this->errorMessage : $beforePut);
+            $this->failure($beforePut === false ? $this->errorMessage : $beforePut);
+            return;
         }
         if (!$this->object->{$this->putMethod}()) {
             $this->setObjectErrors();
             if ($this->hasErrors()) {
-                return $this->failure();
+                $this->failure();
+                return;
             } else {
-                return $this->failure($this->modx->lexicon('rest.err_class_save',array(
+                $this->failure($this->modx->lexicon('rest.err_class_save',array(
                     'class_key' => $this->classKey,
                 )));
+                return;
             }
         }
 
         $objectArray = $this->object->toArray();
         $this->afterPut($objectArray);
 
-        return $this->success('',$objectArray);
+        $this->success('',$objectArray);
+        return;
     }
     /**
      * Fires before saving an existing object. Override to provide custom functionality.
@@ -695,26 +709,28 @@ abstract class modRestController {
 
     /**
      * Handle DELETE requests
-     * @return array
      */
     public function delete() {
         $id = $this->getProperty($this->primaryKeyField,false);
         if (empty($id)) {
-            return $this->failure($this->modx->lexicon('rest.err_field_ns',array(
+            $this->failure($this->modx->lexicon('rest.err_field_ns',array(
                 'field' => $this->primaryKeyField,
             )));
+            return;
         }
         $c = $this->getPrimaryKeyCriteria($id);
         $this->object = $this->modx->getObject($this->classKey,$c);
         if (empty($this->object)) {
-            return $this->failure($this->modx->lexicon('rest.err_obj_nf',array(
+             $this->failure($this->modx->lexicon('rest.err_obj_nf',array(
                 'class_key' => $this->classKey,
             )));
+            return;
         }
 
         if (!empty($this->deleteRequiredFields)) {
             if (!$this->checkRequiredFields($this->deleteRequiredFields)) {
-                return $this->failure();
+                $this->failure();
+                return;
             }
         }
 
@@ -722,19 +738,22 @@ abstract class modRestController {
 
         $beforeDelete = $this->beforeDelete();
         if ($beforeDelete !== true) {
-            return $this->failure($beforeDelete === false ? $this->errorMessage : $beforeDelete);
+            $this->failure($beforeDelete === false ? $this->errorMessage : $beforeDelete);
+            return;
         }
         if (!$this->object->{$this->deleteMethod}()) {
             $this->setObjectErrors();
-            return $this->failure($this->modx->lexicon('rest.err_class_remove',array(
+            $this->failure($this->modx->lexicon('rest.err_class_remove',array(
                 'class_key' => $this->classKey,
             )));
+            return;
         }
 
         $objectArray = $this->object->toArray();
         $this->afterDelete($objectArray);
 
-        return $this->success('',$objectArray);
+        $this->success('',$objectArray);
+        return;
     }
     /**
      * Fires before deleting an existing object. Override to provide custom functionality.

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -407,7 +407,7 @@ class modRestServiceRequest {
             case 'application/xml':
             case 'text/xml':
                 $xml = simplexml_load_string($data);
-                $params = $this->_xml2Array($xml);
+                $params = $this->_xml2array($xml);
                 break;
             case 'application/json':
             case 'text/json':

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -211,7 +211,7 @@ class modRestService {
         $expectedArray = explode('/',$expectedFile);
         if (empty($expectedArray)) $expectedArray = array(rtrim($expectedFile,'/').'/');
         $id = array_pop($expectedArray);
-        if (!file_exists($basePath.$expectedFile.$controllerClassFilePostfix) && intval($id) > 0) {
+        if (!file_exists($basePath.$expectedFile.$controllerClassFilePostfix) && !empty($id)) {
             $expectedFile = implode('/',$expectedArray);
             if (empty($expectedFile)) {
                 $expectedFile = $id;

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -452,7 +452,6 @@ class modRestServiceRequest {
         if ($valueKey && !is_string($valueKey)) $valueKey = '@values';
 
         $return = array();
-        $name = $xml->getName();
         $_value = trim((string)$xml);
         if (!strlen($_value)) $_value = null;
 

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -325,8 +325,9 @@ class modRestServiceRequest {
      * Check for a format suffix (.json, .xml, etc) on the request, properly setting the format if found
      */
     public function checkForSuffix() {
-		$formatPos = strpos($this->action,'.');
-		if ($formatPos !== false) {
+        $checkForSuffix = $this->service->getOption('checkForSuffix', true);
+        $formatPos = strpos($this->action,'.');
+		if ($checkForSuffix && $formatPos !== false) {
 		    $this->format = substr($this->action,$formatPos+1);
 		    $this->action = substr($this->action,0,$formatPos);
 		}

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -174,7 +174,8 @@ class modRestService {
 		$contentType = $this->getResponseContentType($this->request->format);
 		$this->response->setContentType($contentType);
 		$this->response->prepare();
-		return $this->response->send();
+        $this->response->send();
+        return;
 	}
 
     /**


### PR DESCRIPTION
### What does it do?

Some code refactoring
### Why is it needed?
- The return values don't match the PHPDoc definitions and the usage was different too
- Wrong phpDoc type in recursive method call
- Removed unused variables
- Updated property descriptions
- Method names are case sensitive
