### PR TITLE
Fix for #13136

### DIFF
--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -89,11 +89,19 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             xtype: 'modx-window-category-create'
             ,record: r
             ,listeners: {
-                'success': {fn:function() {
-                    var node = (this.cm.activeNode) ? this.cm.activeNode.id : 'n_category';
-                    this.refreshNode(node,true);
-                },scope:this}
-                ,'hide':{fn:function() {this.destroy();}}
+                success: {
+                    fn: function() {
+                        var node = (this.cm.activeNode) ? this.cm.activeNode.id : 'n_category'
+                            ,self = node.indexOf('_category_') !== -1;
+                        this.refreshNode(node, self);
+                    }
+                    ,scope: this
+                }
+                ,hide: {
+                    fn: function() {
+                        this.destroy();
+                    }
+                }
             }
         });
         w.show(e.target);


### PR DESCRIPTION
### What does it do?

Refresh the selected element tree node only if it's a category node, else refresh the selected parent node.
### Why is it needed?

Prevents some visual glitches (duplicated nodes) as described in #13136
### Related issue(s)/PR(s)

Closes #13136
