### PR TITLE
Fixing the tvLabel PHP warning empty needle

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -640,7 +640,7 @@ class modOutputFilter {
                             break;
                         case 'tvLabel':
                             $name = $element->get('name');
-                            if (isset($m_val) && strpos($name, $m_val) === 0) {
+                            if (!empty($m_val) && strpos($name, $m_val) === 0) {
                                 $name = substr($name, strlen($m_val));
                             }
                             $tv = $this->modx->getObject('modTemplateVar', array('name' => $name));


### PR DESCRIPTION
### What does it do?

Checkin if m_val is not empty instead of isset
### Why is it needed?

To not produce the PHP warning empty needle
