### PR TITLE
Update resource.class.php

### DIFF
--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -149,7 +149,7 @@ abstract class ResourceManagerController extends modManagerController {
      * @return array|bool|string
      */
     public function firePreRenderEvents() {
-        $resourceId = !empty($this->resource) ? $this->resource->get('id') : (!empty($this->scriptProperties['id']) ? $this->scriptProperties['id'] : 0);
+        $resourceId = is_object($this->resource) && method_exists($this->resource, 'get') ? $this->resource->get('id') : (!empty($this->scriptProperties['id']) ? $this->scriptProperties['id'] : 0);
         $properties = array(
             'id' => $resourceId,
             'mode' => !empty($resourceId) ? modSystemEvent::MODE_UPD : modSystemEvent::MODE_NEW,


### PR DESCRIPTION
### What does it do?

Changes `!empty` into `is_object && method_exists`
### Why is it needed?

At that point in the script the `$this->resource` can still be an Array instead a full fledged XPDOSimpleObject
### Related issue(s)/PR(s)

Just checking if a variable is not empty is not enough to conclude it has a certain method.
