### PR TITLE
Fix $containerSuffix is appended twice

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -322,7 +322,7 @@ class modRequest {
                     $found = $this->modx->findResource($identifier);
                 } else {
                     $identifier = "{$identifier}{$containerSuffix}";
-                    $found = $this->modx->findResource("{$identifier}{$containerSuffix}");
+                    $found = $this->modx->findResource($identifier);
                 }
                 if ($found) {
                     $parameters = $this->getParameters();


### PR DESCRIPTION
`$identifier = "{$identifier}{$containerSuffix}";` already appends the `$containerSuffix`. Using `$found = $this->modx->findResource("{$identifier}{$containerSuffix}");` would append it again.
