### PR TITLE
Change to action based connector call

### DIFF
--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -830,7 +830,8 @@ MODx.window.Login = function(config) {
     Ext.applyIf(config,{
         title: _('login')
         ,id: this.ident
-        ,url: MODx.config.connectors_url + 'security/login.php'
+        ,url: MODx.config.connectors_url
+        ,action: 'security/login'
         // ,width: 400
         ,fields: [{
             html: '<p>'+_('session_logging_out')+'</p>'


### PR DESCRIPTION
### What does it do?

Changed the direct call of a connector to the action based default connector
### Why is it needed?

The old connector don't exist anymore
### Related issue(s)/PR(s)
#13144
