### PR TITLE
Replace dirname(dirname(__FILE__)) with dirname(__DIR__)

### DIFF
--- a/_build/build.config.sample.php
+++ b/_build/build.config.sample.php
@@ -1,6 +1,6 @@
 <?php
 /* define the MODX path constants necessary for core installation */
-define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
 define('MODX_CONFIG_KEY', 'config');
 
 /* define the connection variables */

--- a/_build/build.xml
+++ b/_build/build.xml
@@ -194,14 +194,14 @@
         <copy file="${build.templates.dir}/config.core.php.txt" tofile="${build.image.dir}/manager/config.core.php">
             <filterchain>
                 <replacetokens>
-                    <token key="core-path" value="dirname(dirname(__FILE__)) . '/core/'" />
+                    <token key="core-path" value="dirname(__DIR__) . '/core/'" />
                 </replacetokens>
             </filterchain>
         </copy>
         <copy file="${build.templates.dir}/config.core.php.txt" tofile="${build.image.dir}/connectors/config.core.php">
             <filterchain>
                 <replacetokens>
-                    <token key="core-path" value="dirname(dirname(__FILE__)) . '/core/'" />
+                    <token key="core-path" value="dirname(__DIR__) . '/core/'" />
                 </replacetokens>
             </filterchain>
         </copy>
@@ -271,14 +271,14 @@
         <copy file="${build.templates.dir}/config.core.php.txt" tofile="${build.image.dir}/manager/config.core.php">
             <filterchain>
                 <replacetokens>
-                    <token key="core-path" value="dirname(dirname(__FILE__)) . '/core/'" />
+                    <token key="core-path" value="dirname(__DIR__) . '/core/'" />
                 </replacetokens>
             </filterchain>
         </copy>
         <copy file="${build.templates.dir}/config.core.php.txt" tofile="${build.image.dir}/connectors/config.core.php">
             <filterchain>
                 <replacetokens>
-                    <token key="core-path" value="dirname(dirname(__FILE__)) . '/core/'" />
+                    <token key="core-path" value="dirname(__DIR__) . '/core/'" />
                 </replacetokens>
             </filterchain>
         </copy>

--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -57,7 +57,7 @@ class MODxTestHarness {
             $fixture =& self::$fixtures[$name];
         } else {
             $properties = array();
-            include_once dirname(dirname(dirname(__FILE__))) . '/core/model/modx/modx.class.php';
+            include_once dirname(dirname(__DIR__)) . '/core/model/modx/modx.class.php';
             include dirname(__FILE__) . '/properties.inc.php';
             self::$properties = $properties;
             if (array_key_exists('debug', self::$properties)) {

--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -41,7 +41,7 @@ if (!$included)
 unset($included);
 
 if (!defined('MODX_CORE_PATH'))
-    define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+    define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
 
 require_once MODX_CORE_PATH . 'xpdo/xpdo.class.php';
 

--- a/_build/transport.data.php
+++ b/_build/transport.data.php
@@ -13,7 +13,7 @@ set_time_limit(0);
 @ require_once dirname(__FILE__) . '/build.config.php';
 
 if (!defined('MODX_CORE_PATH'))
-    define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+    define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
 if (!defined('MODX_CONFIG_KEY'))
     define('MODX_CONFIG_KEY', 'config');
 require_once (MODX_CORE_PATH . 'model/modx/modx.class.php');

--- a/connectors/index.php
+++ b/connectors/index.php
@@ -17,7 +17,7 @@ if (!defined('MODX_CORE_PATH')) {
     if (file_exists(dirname(__FILE__) . '/config.core.php')) {
         include dirname(__FILE__) . '/config.core.php';
     } else {
-        define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+        define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
     }
 }
 

--- a/connectors/security/login.php
+++ b/connectors/security/login.php
@@ -1,5 +1,5 @@
 <?php
 define('MODX_CONNECTOR_INCLUDED', 1);
 define('MODX_REQP',false);
-require_once dirname(dirname(__FILE__)).'/index.php';
+require_once dirname(__DIR__).'/index.php';
 $modx->request->handleRequest(array('location' => 'security','action' => 'login'));

--- a/connectors/system/phpthumb.php
+++ b/connectors/system/phpthumb.php
@@ -4,6 +4,6 @@
  * @package modx
  */
 define('MODX_CONNECTOR_INCLUDED', 1);
-require_once dirname(dirname(__FILE__)).'/index.php';
+require_once dirname(__DIR__).'/index.php';
 $_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));
 $modx->request->handleRequest(array('location' => 'system','action' => 'phpthumb'));

--- a/core/model/aws/utilities/info.class.php
+++ b/core/model/aws/utilities/info.class.php
@@ -37,7 +37,7 @@ class CFInfo
 	{
 		$existing_classes = get_declared_classes();
 
-		foreach (glob(dirname(dirname(__FILE__)) . '/services/*.class.php') as $file)
+		foreach (glob(dirname(__DIR__) . '/services/*.class.php') as $file)
 		{
 			include $file;
 		}

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -22,7 +22,7 @@ if (strstr(str_replace('.','',serialize(array_merge($_GET, $_POST, $_COOKIE))), 
 }
 
 if (!defined('MODX_CORE_PATH')) {
-    define('MODX_CORE_PATH', dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR);
+    define('MODX_CORE_PATH', dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR);
 }
 require_once (MODX_CORE_PATH . 'xpdo/xpdo.class.php');
 

--- a/core/model/modx/mysql/modaccess.class.php
+++ b/core/model/modx/mysql/modaccess.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccess.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccess.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessaction.class.php
+++ b/core/model/modx/mysql/modaccessaction.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccessaction.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccessaction.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessactiondom.class.php
+++ b/core/model/modx/mysql/modaccessactiondom.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccessactiondom.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccessactiondom.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesscategory.class.php
+++ b/core/model/modx/mysql/modaccesscategory.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccesscategory.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccesscategory.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesscontext.class.php
+++ b/core/model/modx/mysql/modaccesscontext.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccesscontext.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccesscontext.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesselement.class.php
+++ b/core/model/modx/mysql/modaccesselement.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccesselement.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccesselement.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessibleobject.class.php
+++ b/core/model/modx/mysql/modaccessibleobject.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccessibleobject.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccessibleobject.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessiblesimpleobject.class.php
+++ b/core/model/modx/mysql/modaccessiblesimpleobject.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccessiblesimpleobject.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccessiblesimpleobject.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessmenu.class.php
+++ b/core/model/modx/mysql/modaccessmenu.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccessmenu.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccessmenu.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessnamespace.class.php
+++ b/core/model/modx/mysql/modaccessnamespace.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessnamespace.class.php');
+require_once (dirname(__DIR__) . '/modaccessnamespace.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesspermission.class.php
+++ b/core/model/modx/mysql/modaccesspermission.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccesspermission.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccesspermission.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesspolicy.class.php
+++ b/core/model/modx/mysql/modaccesspolicy.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccesspolicy.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccesspolicy.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesspolicytemplate.class.php
+++ b/core/model/modx/mysql/modaccesspolicytemplate.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesspolicytemplate.class.php');
+require_once (dirname(__DIR__) . '/modaccesspolicytemplate.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesspolicytemplategroup.class.php
+++ b/core/model/modx/mysql/modaccesspolicytemplategroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesspolicytemplategroup.class.php');
+require_once (dirname(__DIR__) . '/modaccesspolicytemplategroup.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessresource.class.php
+++ b/core/model/modx/mysql/modaccessresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccessresource.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccessresource.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccessresourcegroup.class.php
+++ b/core/model/modx/mysql/modaccessresourcegroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccessresourcegroup.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccessresourcegroup.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaccesstemplatevar.class.php
+++ b/core/model/modx/mysql/modaccesstemplatevar.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaccesstemplatevar.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaccesstemplatevar.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modaction.class.php
+++ b/core/model/modx/mysql/modaction.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modaction.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modaction.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modactiondom.class.php
+++ b/core/model/modx/mysql/modactiondom.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modactiondom.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modactiondom.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modactionfield.class.php
+++ b/core/model/modx/mysql/modactionfield.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modactionfield.class.php');
+require_once (dirname(__DIR__) . '/modactionfield.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modcategoryclosure.class.php
+++ b/core/model/modx/mysql/modcategoryclosure.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modcategoryclosure.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modcategoryclosure.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modclassmap.class.php
+++ b/core/model/modx/mysql/modclassmap.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modclassmap.class.php');
+require_once (dirname(__DIR__) . '/modclassmap.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modcontenttype.class.php
+++ b/core/model/modx/mysql/modcontenttype.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modcontenttype.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modcontenttype.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modcontextresource.class.php
+++ b/core/model/modx/mysql/modcontextresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modcontextresource.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modcontextresource.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/moddashboard.class.php
+++ b/core/model/modx/mysql/moddashboard.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/moddashboard.class.php');
+require_once (dirname(__DIR__) . '/moddashboard.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/moddashboardwidget.class.php
+++ b/core/model/modx/mysql/moddashboardwidget.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/moddashboardwidget.class.php');
+require_once (dirname(__DIR__) . '/moddashboardwidget.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/moddashboardwidgetplacement.class.php
+++ b/core/model/modx/mysql/moddashboardwidgetplacement.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/moddashboardwidgetplacement.class.php');
+require_once (dirname(__DIR__) . '/moddashboardwidgetplacement.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modelementpropertyset.class.php
+++ b/core/model/modx/mysql/modelementpropertyset.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modelementpropertyset.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modelementpropertyset.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modextensionpackage.class.php
+++ b/core/model/modx/mysql/modextensionpackage.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modextensionpackage.class.php');
+require_once (dirname(__DIR__) . '/modextensionpackage.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modformcustomizationprofile.class.php
+++ b/core/model/modx/mysql/modformcustomizationprofile.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modformcustomizationprofile.class.php');
+require_once (dirname(__DIR__) . '/modformcustomizationprofile.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modformcustomizationprofileusergroup.class.php
+++ b/core/model/modx/mysql/modformcustomizationprofileusergroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modformcustomizationprofileusergroup.class.php');
+require_once (dirname(__DIR__) . '/modformcustomizationprofileusergroup.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modformcustomizationset.class.php
+++ b/core/model/modx/mysql/modformcustomizationset.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modformcustomizationset.class.php');
+require_once (dirname(__DIR__) . '/modformcustomizationset.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modjsonrpcresource.class.php
+++ b/core/model/modx/mysql/modjsonrpcresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modjsonrpcresource.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modjsonrpcresource.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modlexiconentry.class.php
+++ b/core/model/modx/mysql/modlexiconentry.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modlexiconentry.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modlexiconentry.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modmanagerlog.class.php
+++ b/core/model/modx/mysql/modmanagerlog.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modmanagerlog.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modmanagerlog.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modmenu.class.php
+++ b/core/model/modx/mysql/modmenu.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modmenu.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modmenu.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modnamespace.class.php
+++ b/core/model/modx/mysql/modnamespace.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modnamespace.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modnamespace.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modprincipal.class.php
+++ b/core/model/modx/mysql/modprincipal.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modprincipal.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modprincipal.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modpropertyset.class.php
+++ b/core/model/modx/mysql/modpropertyset.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modpropertyset.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modpropertyset.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modresourcegroup.class.php
+++ b/core/model/modx/mysql/modresourcegroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modresourcegroup.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modresourcegroup.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modresourcegroupresource.class.php
+++ b/core/model/modx/mysql/modresourcegroupresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modresourcegroupresource.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modresourcegroupresource.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modstaticresource.class.php
+++ b/core/model/modx/mysql/modstaticresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modstaticresource.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modstaticresource.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modsymlink.class.php
+++ b/core/model/modx/mysql/modsymlink.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modsymlink.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modsymlink.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modtemplatevarresource.class.php
+++ b/core/model/modx/mysql/modtemplatevarresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modtemplatevarresource.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modtemplatevarresource.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modtemplatevarresourcegroup.class.php
+++ b/core/model/modx/mysql/modtemplatevarresourcegroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modtemplatevarresourcegroup.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modtemplatevarresourcegroup.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modusergrouprole.class.php
+++ b/core/model/modx/mysql/modusergrouprole.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modusergrouprole.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modusergrouprole.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modusergroupsetting.class.php
+++ b/core/model/modx/mysql/modusergroupsetting.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modusergroupsetting.class.php');
+require_once (dirname(__DIR__) . '/modusergroupsetting.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modworkspace.class.php
+++ b/core/model/modx/mysql/modworkspace.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modworkspace.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modworkspace.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/mysql/modxmlrpcresource.class.php
+++ b/core/model/modx/mysql/modxmlrpcresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage mysql
  */
-include_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modxmlrpcresource.class.php');
+include_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modxmlrpcresource.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/processors/element/chunk/create.class.php
+++ b/core/model/modx/processors/element/chunk/create.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/create.class.php');
+require_once (dirname(__DIR__).'/create.class.php');
 /**
  * Creates a chunk.
  *

--- a/core/model/modx/processors/element/chunk/duplicate.class.php
+++ b/core/model/modx/processors/element/chunk/duplicate.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/duplicate.class.php');
+require_once (dirname(__DIR__).'/duplicate.class.php');
 /**
  * Duplicates a chunk.
  *

--- a/core/model/modx/processors/element/chunk/get.class.php
+++ b/core/model/modx/processors/element/chunk/get.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/get.class.php');
+require_once (dirname(__DIR__).'/get.class.php');
 /**
  * Gets a chunk.
  *

--- a/core/model/modx/processors/element/chunk/getlist.class.php
+++ b/core/model/modx/processors/element/chunk/getlist.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
+require_once (dirname(__DIR__).'/getlist.class.php');
 /**
  * Grabs a list of chunks.
  *

--- a/core/model/modx/processors/element/chunk/remove.class.php
+++ b/core/model/modx/processors/element/chunk/remove.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/remove.class.php');
+require_once (dirname(__DIR__).'/remove.class.php');
 /**
  * Removes a chunk.
  *

--- a/core/model/modx/processors/element/chunk/update.class.php
+++ b/core/model/modx/processors/element/chunk/update.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/update.class.php');
+require_once (dirname(__DIR__).'/update.class.php');
 /**
  * Updates a chunk.
  *

--- a/core/model/modx/processors/element/plugin/create.class.php
+++ b/core/model/modx/processors/element/plugin/create.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/create.class.php');
+require_once (dirname(__DIR__).'/create.class.php');
 /**
  * Creates a plugin
  *

--- a/core/model/modx/processors/element/plugin/duplicate.class.php
+++ b/core/model/modx/processors/element/plugin/duplicate.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/duplicate.class.php');
+require_once (dirname(__DIR__).'/duplicate.class.php');
 /**
  * Duplicate a plugin
  *

--- a/core/model/modx/processors/element/plugin/get.class.php
+++ b/core/model/modx/processors/element/plugin/get.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/get.class.php');
+require_once (dirname(__DIR__).'/get.class.php');
 /**
  * Get a plugin
  *

--- a/core/model/modx/processors/element/plugin/getlist.class.php
+++ b/core/model/modx/processors/element/plugin/getlist.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
+require_once (dirname(__DIR__).'/getlist.class.php');
 /**
  * Grabs a list of plugins.
  *

--- a/core/model/modx/processors/element/plugin/remove.class.php
+++ b/core/model/modx/processors/element/plugin/remove.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/remove.class.php');
+require_once (dirname(__DIR__).'/remove.class.php');
 /**
  * Delete a plugin.
  *

--- a/core/model/modx/processors/element/plugin/update.class.php
+++ b/core/model/modx/processors/element/plugin/update.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/update.class.php');
+require_once (dirname(__DIR__).'/update.class.php');
 /**
  * Update a plugin.
  *

--- a/core/model/modx/processors/element/snippet/create.class.php
+++ b/core/model/modx/processors/element/snippet/create.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/create.class.php');
+require_once (dirname(__DIR__).'/create.class.php');
 /**
  * Create a snippet.
  *

--- a/core/model/modx/processors/element/snippet/duplicate.class.php
+++ b/core/model/modx/processors/element/snippet/duplicate.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/duplicate.class.php');
+require_once (dirname(__DIR__).'/duplicate.class.php');
 /**
  * Duplicate a snippet.
  *

--- a/core/model/modx/processors/element/snippet/get.class.php
+++ b/core/model/modx/processors/element/snippet/get.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/get.class.php');
+require_once (dirname(__DIR__).'/get.class.php');
 /**
  * Get a snippet.
  *

--- a/core/model/modx/processors/element/snippet/getlist.class.php
+++ b/core/model/modx/processors/element/snippet/getlist.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
+require_once (dirname(__DIR__).'/getlist.class.php');
 /**
  * Grabs a list of snippets.
  *

--- a/core/model/modx/processors/element/snippet/remove.class.php
+++ b/core/model/modx/processors/element/snippet/remove.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/remove.class.php');
+require_once (dirname(__DIR__).'/remove.class.php');
 /**
  * Delete a snippet.
  *

--- a/core/model/modx/processors/element/snippet/update.class.php
+++ b/core/model/modx/processors/element/snippet/update.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/update.class.php');
+require_once (dirname(__DIR__).'/update.class.php');
 /**
  * Update a snippet
  *

--- a/core/model/modx/processors/element/template/create.class.php
+++ b/core/model/modx/processors/element/template/create.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/create.class.php');
+require_once (dirname(__DIR__).'/create.class.php');
 /**
  * Create a template
  *

--- a/core/model/modx/processors/element/template/duplicate.class.php
+++ b/core/model/modx/processors/element/template/duplicate.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/duplicate.class.php');
+require_once (dirname(__DIR__).'/duplicate.class.php');
 /**
  * Duplicate a Template.
  *

--- a/core/model/modx/processors/element/template/get.class.php
+++ b/core/model/modx/processors/element/template/get.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/get.class.php');
+require_once (dirname(__DIR__).'/get.class.php');
 /**
  * Gets a template
  *

--- a/core/model/modx/processors/element/template/getlist.class.php
+++ b/core/model/modx/processors/element/template/getlist.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
+require_once (dirname(__DIR__).'/getlist.class.php');
 /**
  * Grabs a list of templates.
  *

--- a/core/model/modx/processors/element/template/remove.class.php
+++ b/core/model/modx/processors/element/template/remove.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/remove.class.php');
+require_once (dirname(__DIR__).'/remove.class.php');
 /**
  * Deletes a template.
  *

--- a/core/model/modx/processors/element/template/update.class.php
+++ b/core/model/modx/processors/element/template/update.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/update.class.php');
+require_once (dirname(__DIR__).'/update.class.php');
 /**
  * Update a template
  *

--- a/core/model/modx/processors/element/tv/create.class.php
+++ b/core/model/modx/processors/element/tv/create.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/create.class.php');
+require_once (dirname(__DIR__).'/create.class.php');
 /**
  * Create a Template Variable.
  *

--- a/core/model/modx/processors/element/tv/duplicate.class.php
+++ b/core/model/modx/processors/element/tv/duplicate.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/duplicate.class.php');
+require_once (dirname(__DIR__).'/duplicate.class.php');
 /**
  * Duplicate a TV
  *

--- a/core/model/modx/processors/element/tv/get.class.php
+++ b/core/model/modx/processors/element/tv/get.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/get.class.php');
+require_once (dirname(__DIR__).'/get.class.php');
 /**
  * Gets a TV
  *

--- a/core/model/modx/processors/element/tv/getlist.class.php
+++ b/core/model/modx/processors/element/tv/getlist.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
+require_once (dirname(__DIR__).'/getlist.class.php');
 /**
  * Grabs a list of TVs.
  *

--- a/core/model/modx/processors/element/tv/remove.class.php
+++ b/core/model/modx/processors/element/tv/remove.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/remove.class.php');
+require_once (dirname(__DIR__).'/remove.class.php');
 /**
  * Delete a TV
  *

--- a/core/model/modx/processors/element/tv/update.class.php
+++ b/core/model/modx/processors/element/tv/update.class.php
@@ -1,5 +1,5 @@
 <?php
-require_once (dirname(dirname(__FILE__)).'/update.class.php');
+require_once (dirname(__DIR__).'/update.class.php');
 /**
  * Updates a TV
  *

--- a/core/model/modx/registry/db/mysql/moddbregistermessage.class.php
+++ b/core/model/modx/registry/db/mysql/moddbregistermessage.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage registry.db.mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/moddbregistermessage.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/moddbregistermessage.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/registry/db/mysql/moddbregisterqueue.class.php
+++ b/core/model/modx/registry/db/mysql/moddbregisterqueue.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage registry.db.mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/moddbregisterqueue.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/moddbregisterqueue.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/registry/db/mysql/moddbregistertopic.class.php
+++ b/core/model/modx/registry/db/mysql/moddbregistertopic.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage registry.db.mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/moddbregistertopic.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/moddbregistertopic.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/registry/db/sqlsrv/moddbregistermessage.class.php
+++ b/core/model/modx/registry/db/sqlsrv/moddbregistermessage.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage registry.db.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moddbregistermessage.class.php');
+require_once (dirname(__DIR__) . '/moddbregistermessage.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/registry/db/sqlsrv/moddbregisterqueue.class.php
+++ b/core/model/modx/registry/db/sqlsrv/moddbregisterqueue.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage registry.db.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moddbregisterqueue.class.php');
+require_once (dirname(__DIR__) . '/moddbregisterqueue.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/registry/db/sqlsrv/moddbregistertopic.class.php
+++ b/core/model/modx/registry/db/sqlsrv/moddbregistertopic.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage registry.db.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moddbregistertopic.class.php');
+require_once (dirname(__DIR__) . '/moddbregistertopic.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sources/mysql/modaccessmediasource.class.php
+++ b/core/model/modx/sources/mysql/modaccessmediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessmediasource.class.php');
+require_once (dirname(__DIR__) . '/modaccessmediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.mysql

--- a/core/model/modx/sources/mysql/modfilemediasource.class.php
+++ b/core/model/modx/sources/mysql/modfilemediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modfilemediasource.class.php');
+require_once (dirname(__DIR__) . '/modfilemediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.mysql

--- a/core/model/modx/sources/mysql/modmediasource.class.php
+++ b/core/model/modx/sources/mysql/modmediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modmediasource.class.php');
+require_once (dirname(__DIR__) . '/modmediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.mysql

--- a/core/model/modx/sources/mysql/modmediasourcecontext.class.php
+++ b/core/model/modx/sources/mysql/modmediasourcecontext.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modmediasourcecontext.class.php');
+require_once (dirname(__DIR__) . '/modmediasourcecontext.class.php');
 /**
  * @package modx
  * @subpackage sources.mysql

--- a/core/model/modx/sources/mysql/modmediasourceelement.class.php
+++ b/core/model/modx/sources/mysql/modmediasourceelement.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/modmediasourceelement.class.php');
+require_once (dirname(__DIR__) . '/modmediasourceelement.class.php');
 /**
  * @package modx
  * @subpackage sources.mysql

--- a/core/model/modx/sources/mysql/mods3mediasource.class.php
+++ b/core/model/modx/sources/mysql/mods3mediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.mysql
  */
-require_once (dirname(dirname(__FILE__)) . '/mods3mediasource.class.php');
+require_once (dirname(__DIR__) . '/mods3mediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.mysql

--- a/core/model/modx/sources/sqlsrv/modaccessmediasource.class.php
+++ b/core/model/modx/sources/sqlsrv/modaccessmediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessmediasource.class.php');
+require_once (dirname(__DIR__) . '/modaccessmediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.sqlsrv

--- a/core/model/modx/sources/sqlsrv/modfilemediasource.class.php
+++ b/core/model/modx/sources/sqlsrv/modfilemediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modfilemediasource.class.php');
+require_once (dirname(__DIR__) . '/modfilemediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.sqlsrv

--- a/core/model/modx/sources/sqlsrv/modmediasource.class.php
+++ b/core/model/modx/sources/sqlsrv/modmediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modmediasource.class.php');
+require_once (dirname(__DIR__) . '/modmediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.sqlsrv

--- a/core/model/modx/sources/sqlsrv/modmediasourcecontext.class.php
+++ b/core/model/modx/sources/sqlsrv/modmediasourcecontext.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modmediasourcecontext.class.php');
+require_once (dirname(__DIR__) . '/modmediasourcecontext.class.php');
 /**
  * @package modx
  * @subpackage sources.sqlsrv

--- a/core/model/modx/sources/sqlsrv/modmediasourceelement.class.php
+++ b/core/model/modx/sources/sqlsrv/modmediasourceelement.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modmediasourceelement.class.php');
+require_once (dirname(__DIR__) . '/modmediasourceelement.class.php');
 /**
  * @package modx
  * @subpackage sources.sqlsrv

--- a/core/model/modx/sources/sqlsrv/mods3mediasource.class.php
+++ b/core/model/modx/sources/sqlsrv/mods3mediasource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sources.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/mods3mediasource.class.php');
+require_once (dirname(__DIR__) . '/mods3mediasource.class.php');
 /**
  * @package modx
  * @subpackage sources.sqlsrv

--- a/core/model/modx/sqlsrv/modaccess.class.php
+++ b/core/model/modx/sqlsrv/modaccess.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccess.class.php');
+require_once (dirname(__DIR__) . '/modaccess.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccessaction.class.php
+++ b/core/model/modx/sqlsrv/modaccessaction.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessaction.class.php');
+require_once (dirname(__DIR__) . '/modaccessaction.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccessactiondom.class.php
+++ b/core/model/modx/sqlsrv/modaccessactiondom.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessactiondom.class.php');
+require_once (dirname(__DIR__) . '/modaccessactiondom.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesscategory.class.php
+++ b/core/model/modx/sqlsrv/modaccesscategory.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesscategory.class.php');
+require_once (dirname(__DIR__) . '/modaccesscategory.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesscontext.class.php
+++ b/core/model/modx/sqlsrv/modaccesscontext.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesscontext.class.php');
+require_once (dirname(__DIR__) . '/modaccesscontext.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesselement.class.php
+++ b/core/model/modx/sqlsrv/modaccesselement.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesselement.class.php');
+require_once (dirname(__DIR__) . '/modaccesselement.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccessibleobject.class.php
+++ b/core/model/modx/sqlsrv/modaccessibleobject.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessibleobject.class.php');
+require_once (dirname(__DIR__) . '/modaccessibleobject.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccessiblesimpleobject.class.php
+++ b/core/model/modx/sqlsrv/modaccessiblesimpleobject.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessiblesimpleobject.class.php');
+require_once (dirname(__DIR__) . '/modaccessiblesimpleobject.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccessmenu.class.php
+++ b/core/model/modx/sqlsrv/modaccessmenu.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessmenu.class.php');
+require_once (dirname(__DIR__) . '/modaccessmenu.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesspermission.class.php
+++ b/core/model/modx/sqlsrv/modaccesspermission.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesspermission.class.php');
+require_once (dirname(__DIR__) . '/modaccesspermission.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesspolicy.class.php
+++ b/core/model/modx/sqlsrv/modaccesspolicy.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesspolicy.class.php');
+require_once (dirname(__DIR__) . '/modaccesspolicy.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesspolicytemplate.class.php
+++ b/core/model/modx/sqlsrv/modaccesspolicytemplate.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesspolicytemplate.class.php');
+require_once (dirname(__DIR__) . '/modaccesspolicytemplate.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesspolicytemplategroup.class.php
+++ b/core/model/modx/sqlsrv/modaccesspolicytemplategroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesspolicytemplategroup.class.php');
+require_once (dirname(__DIR__) . '/modaccesspolicytemplategroup.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccessresource.class.php
+++ b/core/model/modx/sqlsrv/modaccessresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessresource.class.php');
+require_once (dirname(__DIR__) . '/modaccessresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccessresourcegroup.class.php
+++ b/core/model/modx/sqlsrv/modaccessresourcegroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccessresourcegroup.class.php');
+require_once (dirname(__DIR__) . '/modaccessresourcegroup.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaccesstemplatevar.class.php
+++ b/core/model/modx/sqlsrv/modaccesstemplatevar.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaccesstemplatevar.class.php');
+require_once (dirname(__DIR__) . '/modaccesstemplatevar.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modaction.class.php
+++ b/core/model/modx/sqlsrv/modaction.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modaction.class.php');
+require_once (dirname(__DIR__) . '/modaction.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modactiondom.class.php
+++ b/core/model/modx/sqlsrv/modactiondom.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modactiondom.class.php');
+require_once (dirname(__DIR__) . '/modactiondom.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modactionfield.class.php
+++ b/core/model/modx/sqlsrv/modactionfield.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modactionfield.class.php');
+require_once (dirname(__DIR__) . '/modactionfield.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modactiveuser.class.php
+++ b/core/model/modx/sqlsrv/modactiveuser.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modactiveuser.class.php');
+require_once (dirname(__DIR__) . '/modactiveuser.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modcategory.class.php
+++ b/core/model/modx/sqlsrv/modcategory.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modcategory.class.php');
+require_once (dirname(__DIR__) . '/modcategory.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modcategoryclosure.class.php
+++ b/core/model/modx/sqlsrv/modcategoryclosure.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modcategoryclosure.class.php');
+require_once (dirname(__DIR__) . '/modcategoryclosure.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modchunk.class.php
+++ b/core/model/modx/sqlsrv/modchunk.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modchunk.class.php');
+require_once (dirname(__DIR__) . '/modchunk.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modclassmap.class.php
+++ b/core/model/modx/sqlsrv/modclassmap.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modclassmap.class.php');
+require_once (dirname(__DIR__) . '/modclassmap.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modcontenttype.class.php
+++ b/core/model/modx/sqlsrv/modcontenttype.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modcontenttype.class.php');
+require_once (dirname(__DIR__) . '/modcontenttype.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modcontext.class.php
+++ b/core/model/modx/sqlsrv/modcontext.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modcontext.class.php');
+require_once (dirname(__DIR__) . '/modcontext.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modcontextresource.class.php
+++ b/core/model/modx/sqlsrv/modcontextresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modcontextresource.class.php');
+require_once (dirname(__DIR__) . '/modcontextresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modcontextsetting.class.php
+++ b/core/model/modx/sqlsrv/modcontextsetting.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modcontextsetting.class.php');
+require_once (dirname(__DIR__) . '/modcontextsetting.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/moddashboard.class.php
+++ b/core/model/modx/sqlsrv/moddashboard.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moddashboard.class.php');
+require_once (dirname(__DIR__) . '/moddashboard.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/moddashboardwidget.class.php
+++ b/core/model/modx/sqlsrv/moddashboardwidget.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moddashboardwidget.class.php');
+require_once (dirname(__DIR__) . '/moddashboardwidget.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/moddashboardwidgetplacement.class.php
+++ b/core/model/modx/sqlsrv/moddashboardwidgetplacement.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moddashboardwidgetplacement.class.php');
+require_once (dirname(__DIR__) . '/moddashboardwidgetplacement.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/moddocument.class.php
+++ b/core/model/modx/sqlsrv/moddocument.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moddocument.class.php');
+require_once (dirname(__DIR__) . '/moddocument.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modelement.class.php
+++ b/core/model/modx/sqlsrv/modelement.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modelement.class.php');
+require_once (dirname(__DIR__) . '/modelement.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modelementpropertyset.class.php
+++ b/core/model/modx/sqlsrv/modelementpropertyset.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modelementpropertyset.class.php');
+require_once (dirname(__DIR__) . '/modelementpropertyset.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modevent.class.php
+++ b/core/model/modx/sqlsrv/modevent.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modevent.class.php');
+require_once (dirname(__DIR__) . '/modevent.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modextensionpackage.class.php
+++ b/core/model/modx/sqlsrv/modextensionpackage.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modextensionpackage.class.php');
+require_once (dirname(__DIR__) . '/modextensionpackage.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modformcustomizationprofile.class.php
+++ b/core/model/modx/sqlsrv/modformcustomizationprofile.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modformcustomizationprofile.class.php');
+require_once (dirname(__DIR__) . '/modformcustomizationprofile.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modformcustomizationprofileusergroup.class.php
+++ b/core/model/modx/sqlsrv/modformcustomizationprofileusergroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modformcustomizationprofileusergroup.class.php');
+require_once (dirname(__DIR__) . '/modformcustomizationprofileusergroup.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modformcustomizationset.class.php
+++ b/core/model/modx/sqlsrv/modformcustomizationset.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modformcustomizationset.class.php');
+require_once (dirname(__DIR__) . '/modformcustomizationset.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modjsonrpcresource.class.php
+++ b/core/model/modx/sqlsrv/modjsonrpcresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modjsonrpcresource.class.php');
+require_once (dirname(__DIR__) . '/modjsonrpcresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modlexiconentry.class.php
+++ b/core/model/modx/sqlsrv/modlexiconentry.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modlexiconentry.class.php');
+require_once (dirname(__DIR__) . '/modlexiconentry.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modmanagerlog.class.php
+++ b/core/model/modx/sqlsrv/modmanagerlog.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modmanagerlog.class.php');
+require_once (dirname(__DIR__) . '/modmanagerlog.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modmenu.class.php
+++ b/core/model/modx/sqlsrv/modmenu.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modmenu.class.php');
+require_once (dirname(__DIR__) . '/modmenu.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modnamespace.class.php
+++ b/core/model/modx/sqlsrv/modnamespace.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modnamespace.class.php');
+require_once (dirname(__DIR__) . '/modnamespace.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modplugin.class.php
+++ b/core/model/modx/sqlsrv/modplugin.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modplugin.class.php');
+require_once (dirname(__DIR__) . '/modplugin.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modpluginevent.class.php
+++ b/core/model/modx/sqlsrv/modpluginevent.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modpluginevent.class.php');
+require_once (dirname(__DIR__) . '/modpluginevent.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modprincipal.class.php
+++ b/core/model/modx/sqlsrv/modprincipal.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modprincipal.class.php');
+require_once (dirname(__DIR__) . '/modprincipal.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modpropertyset.class.php
+++ b/core/model/modx/sqlsrv/modpropertyset.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modpropertyset.class.php');
+require_once (dirname(__DIR__) . '/modpropertyset.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modresource.class.php
+++ b/core/model/modx/sqlsrv/modresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modresource.class.php');
+require_once (dirname(__DIR__) . '/modresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modresourcegroup.class.php
+++ b/core/model/modx/sqlsrv/modresourcegroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modresourcegroup.class.php');
+require_once (dirname(__DIR__) . '/modresourcegroup.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modresourcegroupresource.class.php
+++ b/core/model/modx/sqlsrv/modresourcegroupresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modresourcegroupresource.class.php');
+require_once (dirname(__DIR__) . '/modresourcegroupresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modscript.class.php
+++ b/core/model/modx/sqlsrv/modscript.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modscript.class.php');
+require_once (dirname(__DIR__) . '/modscript.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modsession.class.php
+++ b/core/model/modx/sqlsrv/modsession.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modsession.class.php');
+require_once (dirname(__DIR__) . '/modsession.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modsnippet.class.php
+++ b/core/model/modx/sqlsrv/modsnippet.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modsnippet.class.php');
+require_once (dirname(__DIR__) . '/modsnippet.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modstaticresource.class.php
+++ b/core/model/modx/sqlsrv/modstaticresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modstaticresource.class.php');
+require_once (dirname(__DIR__) . '/modstaticresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modsymlink.class.php
+++ b/core/model/modx/sqlsrv/modsymlink.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modsymlink.class.php');
+require_once (dirname(__DIR__) . '/modsymlink.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modsystemsetting.class.php
+++ b/core/model/modx/sqlsrv/modsystemsetting.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modsystemsetting.class.php');
+require_once (dirname(__DIR__) . '/modsystemsetting.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modtemplate.class.php
+++ b/core/model/modx/sqlsrv/modtemplate.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modtemplate.class.php');
+require_once (dirname(__DIR__) . '/modtemplate.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modtemplatevar.class.php
+++ b/core/model/modx/sqlsrv/modtemplatevar.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modtemplatevar.class.php');
+require_once (dirname(__DIR__) . '/modtemplatevar.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modtemplatevarresource.class.php
+++ b/core/model/modx/sqlsrv/modtemplatevarresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modtemplatevarresource.class.php');
+require_once (dirname(__DIR__) . '/modtemplatevarresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modtemplatevarresourcegroup.class.php
+++ b/core/model/modx/sqlsrv/modtemplatevarresourcegroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modtemplatevarresourcegroup.class.php');
+require_once (dirname(__DIR__) . '/modtemplatevarresourcegroup.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modtemplatevartemplate.class.php
+++ b/core/model/modx/sqlsrv/modtemplatevartemplate.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modtemplatevartemplate.class.php');
+require_once (dirname(__DIR__) . '/modtemplatevartemplate.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/moduser.class.php
+++ b/core/model/modx/sqlsrv/moduser.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moduser.class.php');
+require_once (dirname(__DIR__) . '/moduser.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modusergroup.class.php
+++ b/core/model/modx/sqlsrv/modusergroup.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modusergroup.class.php');
+require_once (dirname(__DIR__) . '/modusergroup.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modusergroupmember.class.php
+++ b/core/model/modx/sqlsrv/modusergroupmember.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modusergroupmember.class.php');
+require_once (dirname(__DIR__) . '/modusergroupmember.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modusergrouprole.class.php
+++ b/core/model/modx/sqlsrv/modusergrouprole.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modusergrouprole.class.php');
+require_once (dirname(__DIR__) . '/modusergrouprole.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modusergroupsetting.class.php
+++ b/core/model/modx/sqlsrv/modusergroupsetting.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modusergroupsetting.class.php');
+require_once (dirname(__DIR__) . '/modusergroupsetting.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modusermessage.class.php
+++ b/core/model/modx/sqlsrv/modusermessage.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modusermessage.class.php');
+require_once (dirname(__DIR__) . '/modusermessage.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/moduserprofile.class.php
+++ b/core/model/modx/sqlsrv/moduserprofile.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/moduserprofile.class.php');
+require_once (dirname(__DIR__) . '/moduserprofile.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modusersetting.class.php
+++ b/core/model/modx/sqlsrv/modusersetting.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modusersetting.class.php');
+require_once (dirname(__DIR__) . '/modusersetting.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modweblink.class.php
+++ b/core/model/modx/sqlsrv/modweblink.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modweblink.class.php');
+require_once (dirname(__DIR__) . '/modweblink.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modworkspace.class.php
+++ b/core/model/modx/sqlsrv/modworkspace.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modworkspace.class.php');
+require_once (dirname(__DIR__) . '/modworkspace.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/sqlsrv/modxmlrpcresource.class.php
+++ b/core/model/modx/sqlsrv/modxmlrpcresource.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modxmlrpcresource.class.php');
+require_once (dirname(__DIR__) . '/modxmlrpcresource.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/transport/mysql/modtransportpackage.class.php
+++ b/core/model/modx/transport/mysql/modtransportpackage.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage transport.mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modtransportpackage.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modtransportpackage.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/transport/mysql/modtransportprovider.class.php
+++ b/core/model/modx/transport/mysql/modtransportprovider.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage transport.mysql
  */
-require_once (strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/modtransportprovider.class.php');
+require_once (strtr(realpath(dirname(__DIR__)), '\\', '/') . '/modtransportprovider.class.php');
 /**
  * @package modx
  * @subpackage mysql

--- a/core/model/modx/transport/sqlsrv/modtransportpackage.class.php
+++ b/core/model/modx/transport/sqlsrv/modtransportpackage.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage transport.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modtransportpackage.class.php');
+require_once (dirname(__DIR__) . '/modtransportpackage.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/modx/transport/sqlsrv/modtransportprovider.class.php
+++ b/core/model/modx/transport/sqlsrv/modtransportprovider.class.php
@@ -3,7 +3,7 @@
  * @package modx
  * @subpackage transport.sqlsrv
  */
-require_once (dirname(dirname(__FILE__)) . '/modtransportprovider.class.php');
+require_once (dirname(__DIR__) . '/modtransportprovider.class.php');
 /**
  * @package modx
  * @subpackage sqlsrv

--- a/core/model/schema/build.modx.php
+++ b/core/model/schema/build.modx.php
@@ -5,9 +5,9 @@ $mtime= $mtime[1] + $mtime[0];
 $tstart= $mtime;
 
 $properties = array();
-include_once (dirname(dirname(dirname(__FILE__))) . '/xpdo/xpdo.class.php');
-require_once (dirname(dirname(dirname(dirname(__FILE__)))) . '/config.core.php');
-require_once (dirname(dirname(dirname(dirname(__FILE__)))) . '/_build/build.properties.php');
+include_once (dirname(dirname(__DIR__)) . '/xpdo/xpdo.class.php');
+require_once (dirname(dirname(dirname(__DIR__))) . '/config.core.php');
+require_once (dirname(dirname(dirname(__DIR__))) . '/_build/build.properties.php');
 
 foreach (array('mysql', 'sqlsrv') as $driver) {
     $xpdo= new xPDO(
@@ -42,7 +42,7 @@ EOD;
  * [+phpdoc-package+]
  * [+phpdoc-subpackage+]
  */
-require_once (dirname(dirname(__FILE__)) . '/[+class-lowercase+].class.php');
+require_once (dirname(__DIR__) . '/[+class-lowercase+].class.php');
 /**
  * [+phpdoc-package+]
  * [+phpdoc-subpackage+]

--- a/core/xpdo/om/mysql/xpdodriver.class.php
+++ b/core/xpdo/om/mysql/xpdodriver.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDODriver} class.
  */
-require_once (dirname(dirname(__FILE__)) . '/xpdodriver.class.php');
+require_once (dirname(__DIR__) . '/xpdodriver.class.php');
 
 /**
  * Provides mysql driver abstraction for an xPDO instance.

--- a/core/xpdo/om/mysql/xpdogenerator.class.php
+++ b/core/xpdo/om/mysql/xpdogenerator.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDOGenerator} class.
  */
-include_once (dirname(dirname(__FILE__)) . '/xpdogenerator.class.php');
+include_once (dirname(__DIR__) . '/xpdogenerator.class.php');
 
 /**
  * An extension for generating {@link xPDOObject} class and map files for MySQL.

--- a/core/xpdo/om/mysql/xpdomanager.class.php
+++ b/core/xpdo/om/mysql/xpdomanager.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDOManager} class.
  */
-require_once (dirname(dirname(__FILE__)) . '/xpdomanager.class.php');
+require_once (dirname(__DIR__) . '/xpdomanager.class.php');
 
 /**
  * Provides MySQL data source management for an xPDO instance.

--- a/core/xpdo/om/mysql/xpdoobject.class.php
+++ b/core/xpdo/om/mysql/xpdoobject.class.php
@@ -31,7 +31,7 @@
 
 if (!class_exists('xPDOObject')) {
     /** Include the parent {@link xPDOObject} class. */
-    include_once (dirname(dirname(__FILE__)) . '/xpdoobject.class.php');
+    include_once (dirname(__DIR__) . '/xpdoobject.class.php');
 }
 
 /**

--- a/core/xpdo/om/mysql/xpdoquery.class.php
+++ b/core/xpdo/om/mysql/xpdoquery.class.php
@@ -26,7 +26,7 @@
  */
 
 /** Include the base {@see xPDOQuery} class */
-include_once (dirname(dirname(__FILE__)) . '/xpdoquery.class.php');
+include_once (dirname(__DIR__) . '/xpdoquery.class.php');
 
 /**
  * An implementation of xPDOQuery for the MySQL database engine.

--- a/core/xpdo/om/sqlite/xpdodriver.class.php
+++ b/core/xpdo/om/sqlite/xpdodriver.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDODriver} class.
  */
-require_once (dirname(dirname(__FILE__)) . '/xpdodriver.class.php');
+require_once (dirname(__DIR__) . '/xpdodriver.class.php');
 
 /**
  * Provides sqlite driver abstraction for an xPDO instance.

--- a/core/xpdo/om/sqlite/xpdogenerator.class.php
+++ b/core/xpdo/om/sqlite/xpdogenerator.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDOGenerator} class.
  */
-include_once (dirname(dirname(__FILE__)) . '/xpdogenerator.class.php');
+include_once (dirname(__DIR__) . '/xpdogenerator.class.php');
 
 /**
  * An extension for generating {@link xPDOObject} class and map files for SQLite.

--- a/core/xpdo/om/sqlite/xpdomanager.class.php
+++ b/core/xpdo/om/sqlite/xpdomanager.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDOManager} class.
  */
-require_once (dirname(dirname(__FILE__)) . '/xpdomanager.class.php');
+require_once (dirname(__DIR__) . '/xpdomanager.class.php');
 
 /**
  * Provides SQLite data source management for an xPDO instance.

--- a/core/xpdo/om/sqlite/xpdoquery.class.php
+++ b/core/xpdo/om/sqlite/xpdoquery.class.php
@@ -26,7 +26,7 @@
  */
 
 /** Include the base {@see xPDOQuery} class */
-include_once (dirname(dirname(__FILE__)) . '/xpdoquery.class.php');
+include_once (dirname(__DIR__) . '/xpdoquery.class.php');
 
 /**
  * An implementation of xPDOQuery for the SQLite database engine.

--- a/core/xpdo/om/sqlsrv/xpdodriver.class.php
+++ b/core/xpdo/om/sqlsrv/xpdodriver.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDODriver} class.
  */
-require_once (dirname(dirname(__FILE__)) . '/xpdodriver.class.php');
+require_once (dirname(__DIR__) . '/xpdodriver.class.php');
 
 /**
  * Provides sqlsrv driver abstraction for an xPDO instance.

--- a/core/xpdo/om/sqlsrv/xpdogenerator.class.php
+++ b/core/xpdo/om/sqlsrv/xpdogenerator.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDOGenerator} class.
  */
-include_once (dirname(dirname(__FILE__)) . '/xpdogenerator.class.php');
+include_once (dirname(__DIR__) . '/xpdogenerator.class.php');
 
 /**
  * An extension for generating {@link xPDOObject} class and map files for sqlsrv.

--- a/core/xpdo/om/sqlsrv/xpdomanager.class.php
+++ b/core/xpdo/om/sqlsrv/xpdomanager.class.php
@@ -28,7 +28,7 @@
 /**
  * Include the parent {@link xPDOManager} class.
  */
-require_once (dirname(dirname(__FILE__)) . '/xpdomanager.class.php');
+require_once (dirname(__DIR__) . '/xpdomanager.class.php');
 
 /**
  * Provides sqlsrv data source management for an xPDO instance.

--- a/core/xpdo/om/sqlsrv/xpdoobject.class.php
+++ b/core/xpdo/om/sqlsrv/xpdoobject.class.php
@@ -31,7 +31,7 @@
 
 if (!class_exists('xPDOObject')) {
     /** Include the parent {@link xPDOObject} class. */
-    include_once (dirname(dirname(__FILE__)) . '/xpdoobject.class.php');
+    include_once (dirname(__DIR__) . '/xpdoobject.class.php');
 }
 
 /**

--- a/core/xpdo/om/sqlsrv/xpdoquery.class.php
+++ b/core/xpdo/om/sqlsrv/xpdoquery.class.php
@@ -26,7 +26,7 @@
  */
 
 /** Include the base {@see xPDOQuery} class */
-include_once (dirname(dirname(__FILE__)) . '/xpdoquery.class.php');
+include_once (dirname(__DIR__) . '/xpdoquery.class.php');
 
 /**
  * An implementation of xPDOQuery for the sqlsrv database driver.

--- a/core/xpdo/om/xpdogenerator.class.php
+++ b/core/xpdo/om/xpdogenerator.class.php
@@ -722,7 +722,7 @@ EOD;
         if ($this->platformTemplate) return $this->platformTemplate;
         $template= <<<EOD
 <?php
-require_once (dirname(dirname(__FILE__)) . '/[+class-lowercase+].class.php');
+require_once (dirname(__DIR__) . '/[+class-lowercase+].class.php');
 class [+class+]_$platform extends [+class+] {}
 EOD;
         return $template;

--- a/core/xpdo/tools/schema/upgrade-mysql-1.1.php
+++ b/core/xpdo/tools/schema/upgrade-mysql-1.1.php
@@ -33,7 +33,7 @@ $scriptTitle = basename(__FILE__, '.php');
 /**
  * @var string The xPDO root path, where the xpdo.class.php file is located.
  */
-$xpdo_path= realpath(dirname(dirname(dirname(__FILE__)))) . DIRECTORY_SEPARATOR;
+$xpdo_path= realpath(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR;
 /**
  * @var string The name of the model package.
  */

--- a/manager/index.php
+++ b/manager/index.php
@@ -14,7 +14,7 @@
  * @subpackage manager
  */
 @include dirname(__FILE__) . '/config.core.php';
-if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
 
 /* define this as true in another entry file, then include this file to simply access the API
  * without executing the MODX request handler */

--- a/manager/min/index.php
+++ b/manager/min/index.php
@@ -4,8 +4,8 @@
  * @package modx
  * @subpackage minify
  */
-@include dirname(dirname(__FILE__)) . '/config.core.php';
-if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+@include dirname(__DIR__) . '/config.core.php';
+if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
 
 /* set the document_root */
 if(!isset($_SERVER['DOCUMENT_ROOT']) || empty($_SERVER['DOCUMENT_ROOT'])) {

--- a/manager/min/lib/Minify/HTML/Helper.php
+++ b/manager/min/lib/Minify/HTML/Helper.php
@@ -99,7 +99,7 @@ class Minify_HTML_Helper {
         $this->_groupKey = $key;
         if ($checkLastModified) {
             if (! $this->groupsConfigFile) {
-                $this->groupsConfigFile = dirname(dirname(dirname(dirname(__FILE__)))) . '/groupsConfig.php';
+                $this->groupsConfigFile = dirname(dirname(dirname(__DIR__))) . '/groupsConfig.php';
             }
             if (is_file($this->groupsConfigFile)) {
                 $gc = (require $this->groupsConfigFile);

--- a/setup/includes/modinstalllexicon.class.php
+++ b/setup/includes/modinstalllexicon.class.php
@@ -31,7 +31,7 @@ class modInstallLexicon {
     function __construct(modInstall &$install,array $config = array()) {
         $this->install =& $install;
         $this->config = array_merge(array(
-            'lexiconPath' => dirname(dirname(__FILE__)).'/lang/',
+            'lexiconPath' => dirname(__DIR__).'/lang/',
         ),$config);
     }
 
@@ -158,7 +158,7 @@ class modInstallLexicon {
      * @return array An array of available languages
      */
     public function getLanguageList() {
-        $path = dirname(dirname(__FILE__)).'/lang/';
+        $path = dirname(__DIR__).'/lang/';
         $languages = array();
         /** @var DirectoryIterator $file */
         foreach (new DirectoryIterator($path) as $file) {

--- a/setup/includes/upgrades/mysql/2.2.0-rc1.php
+++ b/setup/includes/upgrades/mysql/2.2.0-rc1.php
@@ -85,7 +85,7 @@ $description = $this->install->lexicon('add_index',array('index' => 'rank','tabl
 $this->processResults($class, $description, array($modx->manager, 'addIndex'), array($class, 'rank'));
 
 /* media sources upgrades */
-include dirname(dirname(__FILE__)).'/common/2.2-media-sources.php';
+include dirname(__DIR__).'/common/2.2-media-sources.php';
 
 /* add static field and index to all modElement derivatives */
 $class = 'modChunk';

--- a/setup/includes/upgrades/mysql/2.2.0-rc2.php
+++ b/setup/includes/upgrades/mysql/2.2.0-rc2.php
@@ -8,4 +8,4 @@
  * @subpackage upgrades
  */
 /* TV renders upgrades */
-include dirname(dirname(__FILE__)).'/common/2.2-tv-renders.php';
+include dirname(__DIR__).'/common/2.2-tv-renders.php';

--- a/setup/includes/upgrades/mysql/2.2.6-pl.php
+++ b/setup/includes/upgrades/mysql/2.2.6-pl.php
@@ -1,3 +1,3 @@
 <?php
 /* disable allow_tags_in_post System Setting */
-include dirname(dirname(__FILE__)).'/common/2.2-disable-allowtagsinpost.php';
+include dirname(__DIR__).'/common/2.2-disable-allowtagsinpost.php';

--- a/setup/includes/upgrades/mysql/2.3.0-rc1.php
+++ b/setup/includes/upgrades/mysql/2.3.0-rc1.php
@@ -43,7 +43,7 @@ $description = $this->install->lexicon('modify_column',array('column' => 'action
 $this->processResults($class, $description, array($modx->manager, 'alterField'), array($class, 'action'));
 
 /* update data map for FC fields upgrades */
-include dirname(dirname(__FILE__)).'/common/2.3-fc-action.php';
+include dirname(__DIR__).'/common/2.3-fc-action.php';
 
 /* change modMenu.action to a VARCHAR */
 $class = 'modMenu';
@@ -55,7 +55,7 @@ $description = $this->install->lexicon('add_column',array('column' => 'namespace
 $this->processResults($class, $description, array($modx->manager, 'addField'), array($class, 'namespace'));
 
 /* migrate extension_packages setting to DB table */
-include dirname(dirname(__FILE__)).'/common/2.3-extension-packages.php';
+include dirname(__DIR__).'/common/2.3-extension-packages.php';
 
 /* add modContext.name field */
 $class = 'modContext';

--- a/setup/includes/upgrades/mysql/2.3.1-pl.php
+++ b/setup/includes/upgrades/mysql/2.3.1-pl.php
@@ -8,6 +8,6 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.3.1-oninitculture.php';
-include dirname(dirname(__FILE__)) . '/common/2.3.1-feed_modx_security.php';
-include dirname(dirname(__FILE__)) . '/common/2.3.1-base_help_url.php';
+include dirname(__DIR__) . '/common/2.3.1-oninitculture.php';
+include dirname(__DIR__) . '/common/2.3.1-feed_modx_security.php';
+include dirname(__DIR__) . '/common/2.3.1-base_help_url.php';

--- a/setup/includes/upgrades/mysql/2.4.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.4.0-pl.php
@@ -8,10 +8,10 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.4-package-provider.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-categories-rank.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-namespace-access.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-principal-index.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-tmplvar-index.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-manager-index.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-user-country-iso.php';
+include dirname(__DIR__) . '/common/2.4-package-provider.php';
+include dirname(__DIR__) . '/common/2.4-categories-rank.php';
+include dirname(__DIR__) . '/common/2.4-namespace-access.php';
+include dirname(__DIR__) . '/common/2.4-principal-index.php';
+include dirname(__DIR__) . '/common/2.4-tmplvar-index.php';
+include dirname(__DIR__) . '/common/2.4-manager-index.php';
+include dirname(__DIR__) . '/common/2.4-user-country-iso.php';

--- a/setup/includes/upgrades/mysql/2.4.1-pl.php
+++ b/setup/includes/upgrades/mysql/2.4.1-pl.php
@@ -8,4 +8,4 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.4.1-namespace-access.php';
+include dirname(__DIR__) . '/common/2.4.1-namespace-access.php';

--- a/setup/includes/upgrades/mysql/2.5.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.5.0-pl.php
@@ -8,5 +8,5 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.5-user-createdon.php';
-include dirname(dirname(__FILE__)) . '/common/2.5-cleanup-script.php';
+include dirname(__DIR__) . '/common/2.5-user-createdon.php';
+include dirname(__DIR__) . '/common/2.5-cleanup-script.php';

--- a/setup/includes/upgrades/sqlsrv/2.2.0-rc1.php
+++ b/setup/includes/upgrades/sqlsrv/2.2.0-rc1.php
@@ -87,7 +87,7 @@ if ($setting) {
 }
 
 /* media sources upgrades */
-include dirname(dirname(__FILE__)).'/common/2.2-media-sources.php';
+include dirname(__DIR__).'/common/2.2-media-sources.php';
 
 /* add static field and index to all modElement derivatives */
 $class = 'modChunk';

--- a/setup/includes/upgrades/sqlsrv/2.2.0-rc2.php
+++ b/setup/includes/upgrades/sqlsrv/2.2.0-rc2.php
@@ -8,4 +8,4 @@
  * @subpackage upgrades
  */
 /* TV renders upgrades */
-include dirname(dirname(__FILE__)).'/common/2.2-tv-renders.php';
+include dirname(__DIR__).'/common/2.2-tv-renders.php';

--- a/setup/includes/upgrades/sqlsrv/2.2.6-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.2.6-pl.php
@@ -1,3 +1,3 @@
 <?php
 /* disable allow_tags_in_post System Setting */
-include dirname(dirname(__FILE__)).'/common/2.2-disable-allowtagsinpost.php';
+include dirname(__DIR__).'/common/2.2-disable-allowtagsinpost.php';

--- a/setup/includes/upgrades/sqlsrv/2.3.0-rc1.php
+++ b/setup/includes/upgrades/sqlsrv/2.3.0-rc1.php
@@ -35,7 +35,7 @@ $description = $this->install->lexicon('modify_column',array('column' => 'action
 $this->processResults($class, $description, array($modx->manager, 'alterField'), array($class, 'action'));
 
 /* update data map for FC fields upgrades */
-include dirname(dirname(__FILE__)).'/common/2.3-fc-action.php';
+include dirname(__DIR__).'/common/2.3-fc-action.php';
 
 /* change modMenu.action to a VARCHAR */
 $class = 'modMenu';
@@ -47,7 +47,7 @@ $description = $this->install->lexicon('add_column',array('column' => 'namespace
 $this->processResults($class, $description, array($modx->manager, 'addField'), array($class, 'namespace'));
 
 /* migrate extension_packages setting to DB table */
-include dirname(dirname(__FILE__)).'/common/2.3-extension-packages.php';
+include dirname(__DIR__).'/common/2.3-extension-packages.php';
 
 /* add modContext.name field */
 $class = 'modContext';

--- a/setup/includes/upgrades/sqlsrv/2.3.1-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.3.1-pl.php
@@ -8,6 +8,6 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.3.1-oninitculture.php';
-include dirname(dirname(__FILE__)) . '/common/2.3.1-feed_modx_security.php';
-include dirname(dirname(__FILE__)) . '/common/2.3.1-base_help_url.php';
+include dirname(__DIR__) . '/common/2.3.1-oninitculture.php';
+include dirname(__DIR__) . '/common/2.3.1-feed_modx_security.php';
+include dirname(__DIR__) . '/common/2.3.1-base_help_url.php';

--- a/setup/includes/upgrades/sqlsrv/2.4.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.4.0-pl.php
@@ -8,7 +8,7 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.4-package-provider.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-categories-rank.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-namespace-access.php';
-include dirname(dirname(__FILE__)) . '/common/2.4-user-country-iso.php';
+include dirname(__DIR__) . '/common/2.4-package-provider.php';
+include dirname(__DIR__) . '/common/2.4-categories-rank.php';
+include dirname(__DIR__) . '/common/2.4-namespace-access.php';
+include dirname(__DIR__) . '/common/2.4-user-country-iso.php';

--- a/setup/includes/upgrades/sqlsrv/2.4.1-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.4.1-pl.php
@@ -8,4 +8,4 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.4.1-namespace-access.php';
+include dirname(__DIR__) . '/common/2.4.1-namespace-access.php';

--- a/setup/includes/upgrades/sqlsrv/2.5.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.5.0-pl.php
@@ -8,5 +8,5 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/2.5-user-createdon.php';
-include dirname(dirname(__FILE__)) . '/common/2.5-cleanup-script.php';
+include dirname(__DIR__) . '/common/2.5-user-createdon.php';
+include dirname(__DIR__) . '/common/2.5-cleanup-script.php';

--- a/setup/index.php
+++ b/setup/index.php
@@ -81,7 +81,7 @@ if (!$isCommandLine && (!isset($_GET['s']) || $_GET['s'] != 'set') && !isset($_S
 
 $setupPath= strtr(realpath(dirname(__FILE__)), '\\', '/') . '/';
 define('MODX_SETUP_PATH', $setupPath);
-$installPath= strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/';
+$installPath= strtr(realpath(dirname(__DIR__)), '\\', '/') . '/';
 define('MODX_INSTALL_PATH', $installPath);
 
 if (!include(MODX_SETUP_PATH . 'includes/config.core.php')) {

--- a/setup/processors/connector.php
+++ b/setup/processors/connector.php
@@ -15,9 +15,9 @@ session_start();
 /* set error reporting */
 error_reporting(E_ALL & ~E_NOTICE);
 
-$setupPath= strtr(realpath(dirname(dirname(__FILE__))), '\\', '/') . '/';
+$setupPath= strtr(realpath(dirname(__DIR__)), '\\', '/') . '/';
 define('MODX_SETUP_PATH', $setupPath);
-$installPath= strtr(realpath(dirname(dirname(dirname(__FILE__)))), '\\', '/') . '/';
+$installPath= strtr(realpath(dirname(dirname(__DIR__))), '\\', '/') . '/';
 define('MODX_INSTALL_PATH', $installPath);
 
 if (!@include(MODX_SETUP_PATH . 'includes/config.core.php')) die('Error loading core files!');


### PR DESCRIPTION
### What does it do?

I have done a global replace of `dirname(dirname(__FILE__))` with `dirname(__DIR__)`.
### Why is it needed?

`__DIR__` was introduced in PHP 5.3 to reduce the need for convoluted `dirname(dirname())` constructs.

The change is syntactically identical, but makes the code clearer - it is shorter, easier to read, and easier to understand.

It might also make things slightly quicker, it's just one less function call but it is called quite a lot of times. But that going to be marginal at best; the real reason for doing this is to make the code easier to work with.
### Related issue(s)/PR(s)
