### PR TITLE
Fix missing connectors/security/ directory for download distributions

### DIFF
--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -535,6 +535,10 @@ $attributes = array (
     'vehicle_class' => 'xPDOFileVehicle',
 );
 $files[] = array (
+    'source' => MODX_BASE_PATH . 'connectors/security',
+    'target' => "return MODX_CONNECTORS_PATH;",
+);
+$files[] = array (
     'source' => MODX_BASE_PATH . 'connectors/system',
     'target' => "return MODX_CONNECTORS_PATH;",
 );

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -6,7 +6,6 @@ MODX Revolution 2.5.2-pl (unreleased)
 ====================================
 - Don't create a DirectoryIterator on non existing folders [#13127]
 - Fixing tvLabel output filter empty needle warning [#13138]
-- Fix session extension call using action based connector [#13146]
 - Select modTemplateVarTemplate.rank for MySQL 5.7 ONLY_FULL_GROUP_BY SQL Mode [#13098]
 - Fix new category option duplicating view of elements [#13137]
 - Consistency in error messages, based on error type [#13126]

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -830,8 +830,7 @@ MODx.window.Login = function(config) {
     Ext.applyIf(config,{
         title: _('login')
         ,id: this.ident
-        ,url: MODx.config.connectors_url
-        ,action: 'security/login'
+        ,url: MODx.config.connectors_url + 'security/login.php'
         // ,width: 400
         ,fields: [{
             html: '<p>'+_('session_logging_out')+'</p>'


### PR DESCRIPTION
### What does it do?

Ensures **connectors/security/**\* is no longer missing for download distribution based installs.
### Why is it needed?

Because the expired session / session extension handling relies on it.
### Related issue(s)/PR(s)

Fixes #13144

Reverts 5c9e11ac61826c52e022f9e67869a24424265055 (#13146)
