### PR TITLE
Add security/login support for action based connector

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -93,7 +93,7 @@ class modConnectorResponse extends modResponse {
         $target = str_replace('../','', htmlspecialchars($options['action']));
 
         $siteId = $this->modx->user->getUserToken($this->modx->context->get('key'));
-        $isLogin = $target == 'login';
+        $isLogin = $target == 'login' || $target == 'security/login';
 
         /* ensure headers are sent for proper authentication */
         if (!$isLogin && !isset($_SERVER['HTTP_MODAUTH']) && (!isset($_REQUEST['HTTP_MODAUTH']) || empty($_REQUEST['HTTP_MODAUTH']))) {


### PR DESCRIPTION
### What does it do?

Adds required support for `security/login` in `modConnectorResponse`
### Why is it needed?

To prevent internal 401 Unauthorized / Access Denied error for new action based connector request.
### Related issue(s)/PR(s)

Builds on #13157
Fixes #13144
