### PR TITLE
Remove extra ellipsis from system setting search / filter input

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -56,7 +56,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,name: 'filter_key'
         ,id: 'modx-filter-key'
         ,cls: 'x-form-filter'
-        ,emptyText: _('search_by_key')+'...'
+        ,emptyText: _('search_by_key')
         ,listeners: {
             'change': {fn: this.filterByKey, scope: this}
             ,'render': {fn: function(cmp) {


### PR DESCRIPTION
### What does it do?

Remove the hard-coded ellipsis (...) from `MODx.grid.SettingsGrid` JavaScript, changing it from 6 dots to the more standard 3.
#### BEFORE:

![ellipsis](https://cloud.githubusercontent.com/assets/352182/19810809/1c68d3ea-9cec-11e6-8659-ca6f650172cb.jpg)
#### AFTER:

![ellipsis_after](https://cloud.githubusercontent.com/assets/352182/19810796/0efb2532-9cec-11e6-8c63-ce8a89652cc9.jpg)

_(Please disregard the blue hover state pictured above.)_
### Why is it needed?

The ellipsis is already included as part of the setting lexicon entries: [search_by_key](https://github.com/modxcms/revolution/blob/e4853ef34c0b502ce7278634455c8d4535d048d8/core/lexicon/en/setting.inc.php#L37), and similarly default lexicon: [filter_by_key](https://github.com/modxcms/revolution/blob/e4853ef34c0b502ce7278634455c8d4535d048d8/core/lexicon/en/default.inc.php#L203), and is therefore redundant also being defined (hard-coded) in the JavaScript.
### Related issue(s)/PR(s)

N/A
