### PR TITLE
Fix modResourceGetNodesProcessor show_in_tree error (sqlsrv)

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -166,7 +166,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         );
         $this->itemClass= 'modResource';
         $c= $this->modx->newQuery($this->itemClass);
-        $c->leftJoin('modResource', 'Child', array('modResource.id = Child.parent AND Child.show_in_tree = true'));
+        $c->leftJoin('modResource', 'Child', array('modResource.id = Child.parent AND Child.show_in_tree = 1'));
         $c->select($this->modx->getSelectColumns('modResource', 'modResource', '', $resourceColumns));
         $c->select(array(
             'childrenCount' => 'COUNT(Child.id)',
@@ -415,7 +415,7 @@ class modResourceGetNodesProcessor extends modProcessor {
 
         // Check for an icon class on the resource template
         $tplIcon = $resource->Template ? $resource->Template->icon : '';
-        
+
         // Assign an icon class based on the class_key
         $classKey = strtolower($resource->get('class_key'));
         if (substr($classKey, 0, 3) == 'mod') {
@@ -423,7 +423,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         }
 
         $classKeyIcon = $this->modx->getOption('mgr_tree_icon_' . $classKey, null, 'tree-resource', true);
-        
+
         if (!empty($tplIcon)) {
             $iconCls[] = $tplIcon;
         } else {


### PR DESCRIPTION
### What does it do?

Fixes Resources not loading in the tree (due to SQL Server query error).
### Why is it needed?

To remain compatible with SQL Server, and fix reported issues of front-end + manager tree not loading when using SQL Server 2008 R2 (likely other versions, too).
### Related issue(s)/PR(s)

Fixes #12845 
