### PR TITLE
Added stream based uploads and file handle for binary uploads

### DIFF
--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -420,6 +420,7 @@ class modRestServiceRequest {
                 $data = stream_get_contents($filehandle);
                 fclose($filehandle);
                 $params = $this->service->modx->fromJSON($data);
+                $params = (!is_array($params)) ? array() : $params;
                 break;
             case 'application/x-www-form-urlencoded':
             default:
@@ -430,9 +431,6 @@ class modRestServiceRequest {
         }
         if ($this->service->getOption('trimParameters', false)) {
             array_walk_recursive($this->parameters, array('modRestServiceRequest', '_trimString'));
-        }
-        if (empty($params)) {
-            $params = array();
         }
         return $params;
 	}

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -395,13 +395,13 @@ class modRestServiceRequest {
      * @return array
      */
 	protected function _collectRequestParameters() {
-            $filehandle = fopen('php://input', "r");
-	    $params = array();
-	    $contentType = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
-	    $spPos = strpos($contentType,';');
-	    if ($spPos !== false) {
-	        $contentType = substr($contentType,0,$spPos);
-	    }
+        $filehandle = fopen('php://input', "r");
+        $params = array();
+        $contentType = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
+        $spPos = strpos($contentType, ';');
+        if ($spPos !== false) {
+            $contentType = substr($contentType, 0, $spPos);
+        }
         switch ($contentType) {
             case 'image/jpeg':
             case 'image/png':
@@ -428,10 +428,12 @@ class modRestServiceRequest {
                 parse_str($data, $params);
                 break;
         }
-        if ($this->service->getOption('trimParameters',false)) {
-		    array_walk_recursive($this->parameters,array('modRestServiceRequest','_trimString'));
+        if ($this->service->getOption('trimParameters', false)) {
+            array_walk_recursive($this->parameters, array('modRestServiceRequest', '_trimString'));
         }
-        if (empty($params)) $params = array();
+        if (empty($params)) {
+            $params = array();
+        }
         return $params;
 	}
 

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -395,7 +395,7 @@ class modRestServiceRequest {
      * @return array
      */
 	protected function _collectRequestParameters() {
-	    $data = @file_get_contents('php://input');
+        $filehandle = fopen('php://input', "r");
 	    $params = array();
 	    $contentType = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
 	    $spPos = strpos($contentType,';');
@@ -403,17 +403,28 @@ class modRestServiceRequest {
 	        $contentType = substr($contentType,0,$spPos);
 	    }
         switch ($contentType) {
+            case 'image/jpeg':
+            case 'image/png':
+            case 'image/gif':
+                $params['filehandle'] = $filehandle;
+                break;
             case 'application/xml':
             case 'text/xml':
+                $data = stream_get_contents($filehandle);
+                fclose($filehandle);
                 $xml = simplexml_load_string($data);
-                $params = $this->_xml2Array($xml);
+                $params = $this->_xml2array($xml);
                 break;
             case 'application/json':
             case 'text/json':
+                $data = stream_get_contents($filehandle);
+                fclose($filehandle);
                 $params = $this->service->modx->fromJSON($data);
                 break;
             case 'application/x-www-form-urlencoded':
             default:
+                $data = stream_get_contents($filehandle);
+                fclose($filehandle);
                 parse_str($data, $params);
                 break;
         }

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -395,7 +395,7 @@ class modRestServiceRequest {
      * @return array
      */
 	protected function _collectRequestParameters() {
-        $filehandle = fopen('php://input', "r");
+            $filehandle = fopen('php://input', "r");
 	    $params = array();
 	    $contentType = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
 	    $spPos = strpos($contentType,';');


### PR DESCRIPTION
### What does it do?
The file upload (in the post/put request) is changed to support streams. The handle for the stream is set as parameter value for the modRestController and could be handled there (at the moment for the contentType 'image/jpeg', 'image/png' and 'image/gif' (could be extended).

### Why is it needed?
The filehandle parameter is needed to support fileuploads via the REST API. Switching the file handling to streams is needed to decrease the memory usage on the server.

### Related issue(s)/PR(s)
None