### PR TITLE
Fix truncating filename at space by downloading via filemanager

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -535,7 +535,7 @@ class modFile extends modFileSystemResource {
     public function download($options = array()) {
         $options = array_merge(array(
             'mimetype' => 'application/octet-stream',
-            'filename' => $this->getBasename(),
+            'filename' => '"' . $this->getBasename() . '"',
         ), $options);
 
         $output = $this->getContents();


### PR DESCRIPTION
### What does it do?
Wraps a filename to download in double quotes.

### Why is it needed?
It fixes truncating filename to download at space. For example, downloading file with name "Aaa aaa.pdf" by right-clicking in filemanager (and then "Download file") gives result filename as "Aaa". This behavior is peculiar to Firefox. Related link: https://bugzilla.mozilla.org/show_bug.cgi?id=221028.