### PR TITLE
Prevent path traversal in modConnectorResponse action param

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -24,7 +24,7 @@ class modConnectorResponse extends modResponse {
 
     public $responseCode = 200;
 
-	protected $_responseCodes = array(
+    protected $_responseCodes = array(
         100 => 'Continue',
         101 => 'Switching Protocols',
         200 => 'OK',
@@ -90,7 +90,7 @@ class modConnectorResponse extends modResponse {
         /* backwards compat */
         $error =& $this->modx->error;
         /* prevent browsing of subdirectories for security */
-        $target = str_replace('../','', htmlspecialchars($options['action']));
+        $target = preg_replace('/\.+\/*/', '', htmlspecialchars($options['action']));
 
         $siteId = $this->modx->user->getUserToken($this->modx->context->get('key'));
         $isLogin = $target == 'login' || $target == 'security/login';


### PR DESCRIPTION
### What does it do?
Prevents path traversal in the action parameter of modConnectorResponse.

### Why is it needed?
To prevent users from accessing processors in unintended locations.

### Related issue(s)/PR(s)
Not applicable.

Thanks to @Fi1osof for a security report describing the problem and the solution.