### PR TITLE
Make sure a bunch of processors have a permission check

### DIFF
--- a/core/model/modx/processors/element/category/getlist.class.php
+++ b/core/model/modx/processors/element/category/getlist.class.php
@@ -15,6 +15,7 @@ class modElementCategoryGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'modCategory';
     public $languageTopics = array('category');
     public $defaultSortField = 'category';
+    public $permission = 'view_category';
 
     public function initialize() {
         $initialized = parent::initialize();

--- a/core/model/modx/processors/element/chunk/getlist.class.php
+++ b/core/model/modx/processors/element/chunk/getlist.class.php
@@ -15,5 +15,6 @@ require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
 class modChunkGetListProcessor extends modElementGetListProcessor {
     public $classKey = 'modChunk';
     public $languageTopics = array('chunk','category');
+    public $permission = 'view_chunk';
 }
 return 'modChunkGetListProcessor';

--- a/core/model/modx/processors/element/plugin/getlist.class.php
+++ b/core/model/modx/processors/element/plugin/getlist.class.php
@@ -15,5 +15,6 @@ require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
 class modPluginGetListProcessor extends modElementGetListProcessor {
     public $classKey = 'modPlugin';
     public $languageTopics = array('plugin','category');
+    public $permission = 'view_plugin';
 }
 return 'modPluginGetListProcessor';

--- a/core/model/modx/processors/element/snippet/getlist.class.php
+++ b/core/model/modx/processors/element/snippet/getlist.class.php
@@ -15,5 +15,6 @@ require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
 class modSnippetGetListProcessor extends modElementGetListProcessor {
     public $classKey = 'modSnippet';
     public $languageTopics = array('snippet','category');
+    public $permission = 'view_snippet';
 }
 return 'modSnippetGetListProcessor';

--- a/core/model/modx/processors/element/template/getlist.class.php
+++ b/core/model/modx/processors/element/template/getlist.class.php
@@ -16,6 +16,7 @@ class modTemplateGetListProcessor extends modElementGetListProcessor {
     public $classKey = 'modTemplate';
     public $languageTopics = array('template','category');
     public $defaultSortField = 'templatename';
+    public $permission = 'view_template';
 
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $c = parent::prepareQueryBeforeCount($c);

--- a/core/model/modx/processors/element/tv/getlist.class.php
+++ b/core/model/modx/processors/element/tv/getlist.class.php
@@ -14,5 +14,6 @@ require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
 class modTemplateVarGetListProcessor extends modElementGetListProcessor {
     public $classKey = 'modTemplateVar';
     public $languageTopics = array('tv','category');
+    public $permission = 'view_tv';
 }
 return 'modTemplateVarGetListProcessor';

--- a/core/model/modx/processors/resource/get.class.php
+++ b/core/model/modx/processors/resource/get.class.php
@@ -12,6 +12,7 @@ class modResourceGetProcessor extends modObjectGetProcessor {
     public $classKey = 'modResource';
     public $languageTopics = array('resource');
     public $objectType = 'resource';
+    public $permission = 'view';
 
     public function process() {
         $resourceArray = $this->object->toArray();

--- a/core/model/modx/processors/resource/getlist.class.php
+++ b/core/model/modx/processors/resource/getlist.class.php
@@ -16,6 +16,7 @@ class modResourceGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'modResource';
     public $languageTopics = array('resource');
     public $defaultSortField = 'pagetitle';
+    public $permission = 'view';
 
     public function prepareRow(xPDOObject $object) {
         $charset = $this->modx->getOption('modx_charset',null,'UTF-8');

--- a/core/model/modx/processors/resource/locks/release.class.php
+++ b/core/model/modx/processors/resource/locks/release.class.php
@@ -6,11 +6,14 @@
  * @subpackage processors.resource.locks
  */
 class modResourceLocksReleaseProcessor extends modProcessor {
+    public function checkPermissions() {
+        return $this->modx->hasPermission('view');
+    }
     public function process() {
         $released = false;
         $id = $this->getProperty('id');
         $id = intval($id);
-        
+
         if (!empty($id)) {
             /** @var modResource $resource */
             $resource = $this->modx->getObject('modResource',$id);

--- a/core/model/modx/processors/resource/reload.class.php
+++ b/core/model/modx/processors/resource/reload.class.php
@@ -3,6 +3,9 @@
  * save resource form data for reload
  */
 class modResourceReloadProcessor extends modProcessor {
+    public function checkPermissions() {
+        return $this->modx->hasPermission('save_document');
+    }
 
     /** @var modRegister registry */
     private $reg;

--- a/core/model/modx/processors/resource/translit.class.php
+++ b/core/model/modx/processors/resource/translit.class.php
@@ -9,6 +9,9 @@
  * @subpackage processors.resource
  */
 class modTranslitProcessor extends modProcessor {
+    public function checkPermissions() {
+        return $this->modx->hasPermission('view');
+    }
 
 	public function process() {
 		$string = $this->getProperty('string');

--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -12,6 +12,10 @@ class modSearchProcessor extends modProcessor
     protected $query;
     public $results = array();
 
+    public function checkPermissions() {
+        return $this->modx->hasPermission('search');
+    }
+
     /**
      * @return string JSON formatted results
      */
@@ -328,7 +332,7 @@ class modSearchProcessor extends modProcessor
 
         /** @var modUserProfile[] $collection */
         $collection = $this->modx->getCollection($class, $c);
-        
+
         foreach ($collection as $record) {
             $this->results[] = array(
                 'name' => $record->get('username'),

--- a/core/model/modx/processors/system/event/grouplist.class.php
+++ b/core/model/modx/processors/system/event/grouplist.class.php
@@ -6,22 +6,26 @@
  * @subpackage processors.system.events
  */
 class modSystemEventsGroupListProcessor extends modProcessor {
-	public function process() {
-	
+    public function checkPermissions() {
+        return $this->modx->hasPermission('events');
+    }
+
+    public function process() {
+
 		$list = array();
-		
+
 		$c = $this->modx->newQuery('modEvent');
 		$c->distinct();
 		$c->select(array('groupname'));
 		$c->sortby('groupname', 'ASC');
-		
+
 		$query = $this->getProperty('query');
 		if (!empty($query)) {
 			$c->where(array(
 				'groupname:LIKE' => '%' . $query . '%',
 			));
 		}
-		
+
 		if ($c->prepare() && $c->stmt->execute()) {
 			foreach ($c->stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
 				$list[] = array(
@@ -29,12 +33,12 @@ class modSystemEventsGroupListProcessor extends modProcessor {
 				);
 			}
 		}
-		
+
 		$total = count($list);
 		$start = $this->getProperty('start');
 		$limit = $this->getProperty('limit');
 		$list = array_slice($list, $start, $limit);
-		
+
 		return $this->outputArray($list, $total);
 	}
 }

--- a/core/model/modx/processors/system/phpinfo.class.php
+++ b/core/model/modx/processors/system/phpinfo.class.php
@@ -6,6 +6,10 @@
  * @subpackage processors.system
  */
 class modSystemPhpInfoProcessor extends modProcessor {
+    public function checkPermissions() {
+        return $this->modx->hasPermission('view_sysinfo');
+    }
+
     public function process() {
         echo '<div style="font-size: 1.3em;">';
         phpinfo();

--- a/core/model/modx/processors/workspace/getlist.php
+++ b/core/model/modx/processors/workspace/getlist.php
@@ -11,6 +11,8 @@
  * @package modx
  * @subpackage processors.workspace
  */
+if (!$modx->hasPermission('workspaces')) return $modx->error->failure($modx->lexicon('permission_denied'));
+
 $modx->lexicon->load('workspace');
 
 /* setup default properties */

--- a/core/model/modx/processors/workspace/theme/getlist.class.php
+++ b/core/model/modx/processors/workspace/theme/getlist.class.php
@@ -7,6 +7,7 @@
  */
 
 class managerThemeGetListProcessor extends modObjectProcessor {
+    public $permission = 'settings';
     public function process() {
         $themePath = $this->modx->config['manager_path'] . 'templates/';
         $themes = array();


### PR DESCRIPTION
### What does it do?
Adds a permission check to the following processors that previously had none:

```
- workspace/getlist		set to workspaces
- workspace/theme/getlist	set to settings
- system/phpinfo			set to view_sysinfo
- system/event/grouplist 	set to events
- search/search			set to search
- resource/translit			set to view
- resource/getlist			set to view
- resource/get 			set to view
- resource/reload			set to save_document
- resource/locks/release	set to view
- element/tv/getlist 		set to view_tv
- element/template/getlist 	set to view_template
- element/plugin/getlist 	set to view_plugin
- element/chunk/getlist 	set to view_chunk
- element/category/getlist 	set to view_category
- element/snippet/getlist	set to view_snippet
```

There's a couple more processors lacking a permission check, however I'm not sure if or how those should be resolved. These are:

```
- system/downloadoutput 	possibly allows downloading files from core or cache?
- system/console 			not sure what this needs?
- system/registry/register/read same ^ 
- system/registry/register/send same ^
- system/contenttype/getlist	not sure on required permission, possibly content_types or view_document?
- system/rte/getlist			not sure on req permission
- system/phpthumb				not sure if or how to fix => possible vulnerability or breaking change => has a check on the source tho, so safe?
- element/tv/renders/* 		seems to return a php error for missing class, ignore?
- browser/directory/getlist has no permision check directly, but does check on the media source. Ignore?
```

Feedback on the permissions those processors should check for is welcome.

### Why is it needed?
Combined with a vulnerability that allows access to processors that shouldn't be accessible (#13173), some of these processors may be abused into providing access to other vulnerabilities that expose information or do other Bad Things (r). By adding in a permission check to these processors this sort of attack is prevented (however, other fixes are also already made on both ends of the hoop). 

This PR also makes sure that certain information that authenticated manager users aren't supposed to have access to, also can't be accessed by forging specific requests. 

### Related issue(s)/PR(s)
#13173 