### PR TITLE
Prevent unauthenticated access to processors

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -95,30 +95,39 @@ class modConnectorResponse extends modResponse {
         $siteId = $this->modx->user->getUserToken($this->modx->context->get('key'));
         $isLogin = $target == 'login' || $target == 'security/login';
 
-        /* ensure headers are sent for proper authentication */
-        if (!$isLogin && !isset($_SERVER['HTTP_MODAUTH']) && (!isset($_REQUEST['HTTP_MODAUTH']) || empty($_REQUEST['HTTP_MODAUTH']))) {
+        /* Block the user if there's no user token for the current context, and permissions are in fact required */
+        if (empty($siteId) && (!defined('MODX_REQP') || MODX_REQP === TRUE)) {
             $this->responseCode = 401;
             $this->body = $modx->error->failure($modx->lexicon('access_denied'),array('code' => 401));
-
-        } else if (!$isLogin && isset($_SERVER['HTTP_MODAUTH']) && $_SERVER['HTTP_MODAUTH'] != $siteId) {
+        }
+        /* Make sure we've got a token */
+        elseif (!$isLogin && !isset($_SERVER['HTTP_MODAUTH']) && (!isset($_REQUEST['HTTP_MODAUTH']) || empty($_REQUEST['HTTP_MODAUTH']))) {
             $this->responseCode = 401;
             $this->body = $modx->error->failure($modx->lexicon('access_denied'),array('code' => 401));
-
-        } else if (!$isLogin && isset($_REQUEST['HTTP_MODAUTH']) && $_REQUEST['HTTP_MODAUTH'] != $siteId) {
+        }
+        /* If the token was passed as a request header (like in the manager), check if it's right */
+        else if (!$isLogin && isset($_SERVER['HTTP_MODAUTH']) && $_SERVER['HTTP_MODAUTH'] != $siteId) {
             $this->responseCode = 401;
             $this->body = $modx->error->failure($modx->lexicon('access_denied'),array('code' => 401));
-
+        }
+        /* If the token was passed a request variable, check if it's right */
+        else if (!$isLogin && isset($_REQUEST['HTTP_MODAUTH']) && $_REQUEST['HTTP_MODAUTH'] != $siteId) {
+            $this->responseCode = 401;
+            $this->body = $modx->error->failure($modx->lexicon('access_denied'), array('code' => 401));
+        }
         /* verify the location and action */
-        } /*else if (!isset($options['location']) || !isset($options['action'])) {
+        /*else if (!isset($options['location']) || !isset($options['action'])) {
             $this->responseCode = 404;
             $this->body = $this->modx->error->failure($modx->lexicon('action_err_ns'),array('code' => 404));
 
-        }*/ else if (empty($options['action'])) {
+        }*/
+        /* If we don't have an action, 404 out */
+        else if (empty($options['action'])) {
             $this->responseCode = 404;
-            $this->body = $this->modx->error->failure($modx->lexicon('action_err_ns'),array('code' => 404));
-
+            $this->body = $this->modx->error->failure($modx->lexicon('action_err_ns'), array('code' => 404));
+        }
         /* execute a processor and format the response */
-        } else {
+        else {
             /* create scriptProperties array from HTTP GPC vars */
             if (!isset($_POST)) $_POST = array();
             if (!isset($_GET) || $isLogin) $_GET = array();


### PR DESCRIPTION
First reported by Nikolay Lanets on November 7th with additional information received on November 12th/13th. Through specially crafted requests to core or third party connectors, it was possible to bypass checks for a valid token. This allowed unauthorized execution of certain core processors that had no other specific permission checks, but were intended for manager use only.

This vulnerability could be combined with other issues identified recently to allow further unauthorized access to the database.

Certain third party extras require unauthorized access to specific (third party) processors; for this purpose the MODX_REQP constant (set to false in their connector) can continue to be used.