### PR TITLE
Prevent local file inclusion/traversal/manipulation

### DIFF
--- a/core/model/modx/processors/browser/directory/chmod.class.php
+++ b/core/model/modx/processors/browser/directory/chmod.class.php
@@ -20,7 +20,7 @@ class modBrowserFolderChmodProcessor extends modProcessor {
     public function getLanguageTopics() {
         return array('file');
     }
-    
+
     public function initialize() {
         $this->setDefaultProperties(array(
             'mode' => false,
@@ -38,7 +38,9 @@ class modBrowserFolderChmodProcessor extends modProcessor {
         $this->source->setRequestProperties($this->getProperties());
         $this->source->initialize();
 
-        $success = $this->source->chmodContainer($this->getProperty('dir'),$this->getProperty('mode'));
+        $dir = $this->getProperty('dir');
+        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        $success = $this->source->chmodContainer($dir, $this->getProperty('mode'));
 
         if (empty($success)) {
             $msg = '';

--- a/core/model/modx/processors/browser/directory/create.class.php
+++ b/core/model/modx/processors/browser/directory/create.class.php
@@ -40,7 +40,12 @@ class modBrowserFolderCreateProcessor extends modProcessor {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
 
-        $success = $this->source->createContainer($this->getProperty('name'),$this->getProperty('parent'));
+        $parent = rawurldecode($this->getProperty('parent',''));
+        $parent = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($parent))),'/');
+
+        $name = $this->getProperty('name');
+        $name = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($name))),'/');
+        $success = $this->source->createContainer($name, $parent);
 
         if (empty($success)) {
             $msg = '';

--- a/core/model/modx/processors/browser/directory/getfiles.class.php
+++ b/core/model/modx/processors/browser/directory/getfiles.class.php
@@ -30,9 +30,6 @@ class modBrowserFolderGetFilesProcessor extends modProcessor {
         $this->setDefaultProperties(array(
             'dir' => '',
         ));
-        if ($this->getProperty('dir') == 'root') {
-            $this->setProperty('dir','');
-        }
         return true;
     }
 
@@ -51,7 +48,12 @@ class modBrowserFolderGetFilesProcessor extends modProcessor {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
 
-        $list = $this->source->getObjectsInContainer($this->getProperty('dir'));
+        $dir = $this->getProperty('dir');
+        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        if ($dir === 'root') {
+            $dir = '';
+        }
+        $list = $this->source->getObjectsInContainer($dir);
         return $this->outputArray($list);
     }
 

--- a/core/model/modx/processors/browser/directory/getlist.class.php
+++ b/core/model/modx/processors/browser/directory/getlist.class.php
@@ -29,7 +29,8 @@ class modBrowserFolderGetListProcessor extends modProcessor {
             'id' => '',
         ));
         $dir = $this->getProperty('id');
-        if (empty($dir) || $dir == 'root') {
+        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        if (empty($dir) || $dir === 'root') {
             $this->setProperty('id','');
         } else if (strpos($dir, 'n_') === 0) {
             $dir = substr($dir, 2);

--- a/core/model/modx/processors/browser/directory/remove.class.php
+++ b/core/model/modx/processors/browser/directory/remove.class.php
@@ -40,7 +40,9 @@ class modBrowserFolderRemoveProcessor extends modProcessor {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
 
-        $success = $this->source->removeContainer($this->getProperty('dir'));
+        $dir = $this->getProperty('dir');
+        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        $success = $this->source->removeContainer($dir);
 
         if (empty($success)) {
             $msg = '';

--- a/core/model/modx/processors/browser/directory/rename.class.php
+++ b/core/model/modx/processors/browser/directory/rename.class.php
@@ -44,13 +44,17 @@ class modBrowserFolderRenameProcessor extends modProcessor {
             return $this->failure();
         }
 
-        $response = $this->source->renameContainer($fields['path'],$fields['name']);
+        $path = $this->getProperty('path');
+        $path = preg_replace('/(\.+\/)+/', '', htmlspecialchars($path));
+        $name = $this->getProperty('name');
+        $name = preg_replace('/(\.+\/)+/', '', htmlspecialchars($name));
+        $response = $this->source->renameContainer($path, $name);
         return $this->handleResponse($response);
     }
 
     /**
      * Validate the fields passed in
-     * 
+     *
      * @param array $fields
      * @return boolean
      */

--- a/core/model/modx/processors/browser/directory/sort.class.php
+++ b/core/model/modx/processors/browser/directory/sort.class.php
@@ -18,7 +18,9 @@ class modBrowserFolderSortProcessor extends modProcessor {
     }
     public function process() {
         $from = $this->getProperty('from');
+        $from = preg_replace('/(\.+\/)+/', '', htmlspecialchars($from));
         $to = $this->getProperty('to');
+        $to = preg_replace('/(\.+\/)+/', '', htmlspecialchars($to));
         $point = $this->getProperty('point','append');
         if (empty($from)) return $this->failure($this->modx->lexicon('file_folder_err_ns'));
         if (empty($to)) return $this->failure($this->modx->lexicon('file_folder_err_ns'));

--- a/core/model/modx/processors/browser/directory/update.class.php
+++ b/core/model/modx/processors/browser/directory/update.class.php
@@ -37,7 +37,10 @@ class modBrowserFolderUpdateProcessor extends modProcessor {
         if (!$source->checkPolicy('save')) {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
-        $success = $source->renameContainer($this->getProperty('dir'),$this->getProperty('name'));
+
+        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($this->getProperty('dir')));
+        $name = preg_replace('/(\.+\/)+/', '', htmlspecialchars($this->getProperty('name')));
+        $success = $source->renameContainer($dir, $name);
 
         if (!$success) {
             $msg = '';

--- a/core/model/modx/processors/browser/file/create.class.php
+++ b/core/model/modx/processors/browser/file/create.class.php
@@ -21,10 +21,10 @@ class modBrowserFileCreateProcessor extends modProcessor {
     public function process() {
         /* get base paths and sanitize incoming paths */
         $directory = rawurldecode($this->getProperty('directory',''));
-        $directory = ltrim(strip_tags(str_replace(array('../','./'),'',$directory)),'/');
-        
+        $directory = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($directory))),'/');
+
         $name = $this->getProperty('name');
-        $name = ltrim(strip_tags(str_replace(array('../','./'),'',$name)),'/');
+        $name = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($name))),'/');
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/download.class.php
+++ b/core/model/modx/processors/browser/file/download.class.php
@@ -17,7 +17,7 @@ class modBrowserFileDownloadProcessor extends modProcessor {
         if (!$this->source->checkPolicy('view')) {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
-        
+
         if ($this->getProperty('download',false)) {
             return $this->download();
         } else {
@@ -28,6 +28,7 @@ class modBrowserFileDownloadProcessor extends modProcessor {
     public function getObjectUrl() {
         /* format filename */
         $file = rawurldecode($this->getProperty('file',''));
+        $file = preg_replace('/(\.+\/)+/', '', htmlspecialchars($file));
         $url = $this->source->getObjectUrl($file);
         return $this->success('',array('url' => $url));
     }

--- a/core/model/modx/processors/browser/file/get.class.php
+++ b/core/model/modx/processors/browser/file/get.class.php
@@ -20,7 +20,7 @@ class modBrowserFileGetProcessor extends modProcessor {
     public function process() {
         /* format filename */
         $file = rawurldecode($this->getProperty('file',''));
-
+        $file = preg_replace('/(\.+\/)+/', '', htmlspecialchars($file));
 
         $loaded = $this->getSource();
         if ($loaded !== true) {

--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -24,6 +24,7 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (empty($file)) {
             return $this->modx->error->failure($this->modx->lexicon('file_err_ns'));
         }
+        $file = preg_replace('/(\.+\/)+/', '', htmlspecialchars($file));
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/rename.class.php
+++ b/core/model/modx/processors/browser/file/rename.class.php
@@ -21,7 +21,6 @@ class modBrowserFileRenameProcessor extends modProcessor {
         if (!$this->validate()) {
             return $this->failure();
         }
-        $oldFile = $this->getProperty('path');
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {
@@ -31,7 +30,11 @@ class modBrowserFileRenameProcessor extends modProcessor {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
 
-        $success = $this->source->renameObject($oldFile,$this->getProperty('name'));
+        $oldFile = $this->getProperty('path');
+        $oldFile = preg_replace('/(\.+\/)+/', '', htmlspecialchars($oldFile));
+        $name = $this->getProperty('name');
+        $name = preg_replace('/(\.+\/)+/', '', htmlspecialchars($name));
+        $success = $this->source->renameObject($oldFile, $name);
 
         if (empty($success)) {
             $msg = '';

--- a/core/model/modx/processors/browser/file/unpack.class.php
+++ b/core/model/modx/processors/browser/file/unpack.class.php
@@ -29,12 +29,14 @@ class modUnpackProcessor extends modProcessor {
 
         $this->modx->getService('fileHandler', 'modFileHandler');
 
-        $fileobj = $this->modx->fileHandler->make($this->properties['path'] . $this->properties['file']);
+        $target = $this->properties['path'] . $this->properties['file'];
+        $target = preg_replace('/(\.+\/)+/', '', htmlspecialchars($target));
+        $fileobj = $this->modx->fileHandler->make($target);
 
         if (!$this->validate($fileobj)) {
             return $this->failure($this->modx->lexicon('file_err_unzip_invalid_path') . ': ' . $fileobj->getPath());
         }
-        
+
         // currently the archive content is extracted to the folder where the archive is stored
         if (!$fileobj->unpack($this->properties['path'] . dirname($this->properties['file']))) {
             return $this->failure($this->modx->lexicon('file_err_unzip'));
@@ -61,7 +63,7 @@ class modUnpackProcessor extends modProcessor {
         if (!$fileobj->exists()) {
              $this->addFieldError('path', $this->modx->lexicon('file_err_nf'));
         }
-        
+
         return !$this->hasErrors();
     }
 }

--- a/core/model/modx/processors/browser/file/update.class.php
+++ b/core/model/modx/processors/browser/file/update.class.php
@@ -21,6 +21,7 @@ class modBrowserFileUpdateProcessor extends modProcessor {
     public function process() {
         /* get base paths and sanitize incoming paths */
         $filePath = rawurldecode($this->getProperty('file',''));
+        $filePath = preg_replace('/(\.+\/)+/', '', htmlspecialchars($filePath));
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/upload.class.php
+++ b/core/model/modx/processors/browser/file/upload.class.php
@@ -36,7 +36,9 @@ class modBrowserFileUploadProcessor extends modProcessor {
         if (!$this->source->checkPolicy('create')) {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
-        $success = $this->source->uploadObjectsToContainer($this->getProperty('path'),$_FILES);
+
+        $path = preg_replace('/(\.+\/)+/', '', htmlspecialchars($this->getProperty('path')));
+        $success = $this->source->uploadObjectsToContainer($path,$_FILES);
 
         if (empty($success)) {
             $msg = '';


### PR DESCRIPTION
Based on a report received September 8th from Chen Ruiqi there were several local file inclusion or manipulation vulnerabilities. This requires a valid manager session and access to a media source to exploit; so this was not possible with #13175.  

In this pull request the found vulnerabilities are fixed, and the other relevant processors have also been updated to be extra careful about specially crafted requests attempting to break out of the media source paths.

The reported vulnerabilities were in (1) browser/directory/getlist which allowed moving out of the media source base with `../`, and a similar issue (2) in browser/directory/remove. On further investigation this was also found in browser/directory/getfiles.

The other files updated in this pull request were not found to be vulnerable, as the calls to the (file) media source would sanitise the provided path/file names sufficiently. However, as there are different media sources available both core and third party, I've also updated other calls to the media source APIs to provide sanitised paths and file names.