### PR TITLE
Remove path related settings from MODx.config, partial revert of #13170

### DIFF
--- a/core/model/modx/processors/system/config.js.php
+++ b/core/model/modx/processors/system/config.js.php
@@ -90,13 +90,7 @@ if (isset($scriptProperties['action']) && $scriptProperties['action'] != '' && i
 
 $c = array_merge($modx->config,$workingContext->config,$modx->_userConfig,$c);
 
-unset($c['password'],$c['username'],$c['mail_smtp_pass'],$c['mail_smtp_user'],$c['proxy_password'],$c['proxy_username'],$c['connections'],$c['connection_init'],$c['connection_mutable'],$c['dbname'],$c['database'],$c['table_prefix'],$c['driverOptions'],$c['dsn'],$c['session_name']);
-
-foreach($c as $k => $v){
-    if(preg_match("/(_path|_dir|pass)/u", $k)){
-        unset($c[$k]);
-    }
-}
+unset($c['password'],$c['username'],$c['mail_smtp_pass'],$c['mail_smtp_user'],$c['proxy_password'],$c['proxy_username'],$c['connections'],$c['connection_init'],$c['connection_mutable'],$c['dbname'],$c['database'],$c['table_prefix'],$c['driverOptions'],$c['dsn'],$c['session_name'], $c['assets_path'], $c['base_path'], $c['cache_path'], $c['connectors_path'], $c['core_path'], $c['friendly_alias_translit_class_path'], $c['manager_path'], $c['processors_path']);
 
 $o = "Ext.namespace('MODx'); MODx.config = ";
 $o .= $modx->toJSON($c);


### PR DESCRIPTION
### What does it do?
Hardcodes specific setting values that need to be removed from the MODx.config array in the manager, instead of the partial match on path/dir/pass. 

### Why is it needed?
The previous fix from #13170 was a bit too aggressive, causing a break in Collections (modxcms/Collections#220). It can't be ruled out that other extras are also affected, so part of the fix there has been reverted in favour of a more specific.

The goal of #13170 and this pull request is to keep confidential information (server file paths) away from the frontend. While not a direct vulnerability, the value of some of these settings could potentially aid future attacks by simplifying retrieving information about the server. 

### Related issue(s)/PR(s)
#13170, modxcms/Collections#220