### PR TITLE
Fix listing packages with non-utf8 locales (#13079)

### DIFF
--- a/core/model/modx/processors/workspace/packages/rest/getlist.class.php
+++ b/core/model/modx/processors/workspace/packages/rest/getlist.class.php
@@ -26,7 +26,7 @@ class modPackageRemoteGetListProcessor extends modProcessor {
             'sorter' => false,
             'start' => 0,
             'limit' => 10,
-            'dateFormat' => '%b %d, %Y',
+            'dateFormat' => '%Y-%m-%d',
             'supportsSeparator' => ', ',
         ));
         $start = $this->getProperty('start');


### PR DESCRIPTION
Hello,
there is a bug present in modx revo up to last version 2.5.1.
This bug already has an issue discussion:
https://github.com/modxcms/revolution/issues/13079

Conditions:
- OS locale non-english with 8-bit codepage (ru_RU.cp1251 for example)
- Modx locale ru_RU
- modx_charset UTF-8
- PHP 5 >= 5.2.0
- PHP runs as CGI

How to replay a bug:
- Install modx
- Enter "Extras -> Install" page
- Select "modx.com" provider
- Select "Extras" on the left pane
- Select subitem of the "Extras" ("Blogging" for example)
- You should see infinite "Loading..." message and no listing of extras.

Reason why it is happened.
Thereis a code in the file
core\model\modx\processors\workspace\packages\rest\getlist.class.php
=======================
public function initialize() {
...
  $this->setDefaultProperties(array(
...
    'dateFormat' => '%b %d, %Y',
...
=======================

where "%b" date format specifier produces *localized* short month name with OS locale settings.
Then this string falls into following code in the file
core\xpdo\xpdo.class.php
=======================
    public function toJSON($array) {
        $encoded= '';
        if (is_array ($array)) {
            if (!function_exists('json_encode')) {
                if (@ include_once (XPDO_CORE_PATH . 'json/JSON.php')) {
                    $json = new Services_JSON();
                    $encoded= $json->encode($array);
                }
            } else {
                $encoded= json_encode($array); // *** about line 2412
            }
        }
        return $encoded;
    }
=======================

Then built-in function "json_encode" cannot encode 8-bit name of the month in cp1251 and returns empty result in variable "$encoded".

Possible solutions:

1. made 'dateFormat' field numeric only:
=======================
'dateFormat' => '%Y-%m-%d',
=======================
this will work everywhere.

2. add an option to call built-in "json_encode" to ignore errors:
=======================
$encoded= json_encode($array, JSON_PARTIAL_OUTPUT_ON_ERROR);
=======================
then you cannot see the released date, but you can see the extras list

3. Or do not use built-in "json_encode"