### PR TITLE
Semantic Placeholders on Login Screen

### DIFF
--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -59,14 +59,14 @@
             <div class="x-form-item login-form-item login-form-item-first">
                 <label for="modx-login-username">{$_lang.login_username}</label>
                 <div class="x-form-element login-form-element">
-                    <input type="text" id="modx-login-username" name="username" autocomplete="on" autofocus value="{$_post.username|default}" class="x-form-text x-form-field" placeholder="{$_lang.login_username}" aria-required="true" required />
+                    <input type="text" id="modx-login-username" name="username" autocomplete="on" autofocus value="{$_post.username|default}" class="x-form-text x-form-field" placeholder="admin" aria-required="true" required />
                 </div>
             </div>
 
             <div class="x-form-item login-form-item">
                 <label for="modx-login-password">{$_lang.login_password}</label>
                 <div class="x-form-element login-form-element">
-                    <input type="password" id="modx-login-password" name="password" autocomplete="on" class="x-form-text x-form-field" placeholder="{$_lang.login_password}" aria-required="true" required />
+                    <input type="password" id="modx-login-password" name="password" autocomplete="on" class="x-form-text x-form-field" placeholder="notanotherwordpresssite" aria-required="true" required />
                 </div>
             </div>
 


### PR DESCRIPTION
![](http://j4p.us/3W2b3i1T4111/Screen%20Shot%202016-11-22%20at%2010.22.00%20AM.png)

### What does it do?
Changed placeholder attributes for username and password on MODX login screen to be examples of valid input.

### Why is it needed?
The placeholder attribute is not meant to describe an input.
Placeholder is meant to offer an example of a valid entry.

### Related issue(s)/PR(s)
An alternative to https://github.com/modxcms/revolution/pull/13186

Did not hook the placeholders up to Lexicons. Seems unnecessary.