### PR TITLE
Removing placeholders from login screen

### DIFF
--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -59,14 +59,14 @@
             <div class="x-form-item login-form-item login-form-item-first">
                 <label for="modx-login-username">{$_lang.login_username}</label>
                 <div class="x-form-element login-form-element">
-                    <input type="text" id="modx-login-username" name="username" autocomplete="on" autofocus value="{$_post.username|default}" class="x-form-text x-form-field" placeholder="{$_lang.login_username}" aria-required="true" required />
+                    <input type="text" id="modx-login-username" name="username" autocomplete="on" autofocus value="{$_post.username|default}" class="x-form-text x-form-field" aria-required="true" required />
                 </div>
             </div>
 
             <div class="x-form-item login-form-item">
                 <label for="modx-login-password">{$_lang.login_password}</label>
                 <div class="x-form-element login-form-element">
-                    <input type="password" id="modx-login-password" name="password" autocomplete="on" class="x-form-text x-form-field" placeholder="{$_lang.login_password}" aria-required="true" required />
+                    <input type="password" id="modx-login-password" name="password" autocomplete="on" class="x-form-text x-form-field" aria-required="true" required />
                 </div>
             </div>
 


### PR DESCRIPTION
![](http://j4p.us/2E2b2W0H172c/Screen%20Shot%202016-11-22%20at%201.22.49%20PM.png)

### What does it do?
Removed placeholders from the login screen inputs.

### Why is it needed?
The placeholders are redundant both audibly and visually as they are the same as the corresponding labels.

### Related issue(s)/PR(s)
An alternative to https://github.com/modxcms/revolution/pull/13184