### PR TITLE
Fixing #12596 Media Sources getting wrong name

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -226,14 +226,13 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             value: this.config.source || MODx.config.default_media_source
             ,listWidth: 236
             ,listeners: {
-                'select':{
+                select:{
                     fn: this.changeSource
                     ,scope: this
                 }
-                ,'loaded': {
+                ,loaded: {
                     fn: function(combo) {
-                        var id = combo.store.find('id', this.config.source);
-                        var rec = combo.store.getAt(id);
+                        var rec = combo.store.getById(this.config.source);
                         var rn = this.getRootNode();
                         if (rn && rec) { rn.setText(rec.data.name); }
                     }


### PR DESCRIPTION
### What does it do?
Change the javascript code to get the name of the right media source.

### Why is it needed?
At the moment some media sources get a wrong name from a different media source in the file tree.

### Related issue(s)/PR(s)
#12596 

