### PR TITLE
Broken "Uploaded Versions"

### DIFF
--- a/core/model/modx/transport/mysql/modtransportpackage.class.php
+++ b/core/model/modx/transport/mysql/modtransportpackage.class.php
@@ -57,7 +57,7 @@ class modTransportPackage_mysql extends modTransportPackage {
         $c->sortby('modTransportPackage.version_major', 'DESC');
         $c->sortby('modTransportPackage.version_minor', 'DESC');
         $c->sortby('modTransportPackage.version_patch', 'DESC');
-        $c->sortby('IF(modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl","z",IF(modTransportPackage.release = "dev","a",modTransportPackage.release)) DESC','');
+        $c->sortby('IF(modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl","z",IF(modTransportPackage.release = "dev","a",modTransportPackage.release))','DESC');
         $c->sortby('modTransportPackage.release_index', 'DESC');
         if((int)$limit > 0) {
             $c->limit((int)$limit, (int)$offset);


### PR DESCRIPTION
### What does it do?
Fix Package Manager -> View Details -> Uploaded Versions view.

### Why is it needed?
No issue yet.

### Related issue(s)/PR(s)
No issue yet.

After upgrading to 2.5.2 found what if i use View Details in Package Manager i get error in error.log: "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ASC, modTransportPackage.release_index DESC LIMIT 20' at line 1" and Uploaded Versions tab is empty. While investigating this problem found, what new sortby function from xpdoquery.class.php (commit 067cb74d41af6419120f87d98f576a97be820d95) now require second argument obligatory. This change back Package Manager to work normaly.