### PR TITLE
[3.x] Fix warnings and errors in processors due to missing `use` statements

### DIFF
--- a/core/model/modx/processors/element/category/getlist.class.php
+++ b/core/model/modx/processors/element/category/getlist.class.php
@@ -1,4 +1,5 @@
 <?php
+use xPDO\Om\xPDOQuery;
 /**
  * Grabs a list of Categories.
  *

--- a/core/model/modx/processors/element/template/getlist.class.php
+++ b/core/model/modx/processors/element/template/getlist.class.php
@@ -1,5 +1,6 @@
 <?php
 use xPDO\Om\xPDOObject;
+use xPDO\Om\xPDOQuery;
 
 require_once (dirname(dirname(__FILE__)).'/getlist.class.php');
 /**

--- a/core/model/modx/processors/security/access/usergroup/namespace/getlist.class.php
+++ b/core/model/modx/processors/security/access/usergroup/namespace/getlist.class.php
@@ -1,4 +1,6 @@
 <?php
+use xPDO\Om\xPDOObject;
+use xPDO\Om\xPDOQuery;
 /**
  * Gets a list of ACLs.
  *


### PR DESCRIPTION
### What does it do?
Resolves E_WARN errors triggered by incorrect method signatures on a few processors. These were caused by the xPDO 3 refactor and were missed in updating the processors to use the right xPDO/Om/* classes. 

### Why is it needed?
Broken functionality and warnings that pop up and/or get logged. 

### Related issue(s)/PR(s)
None. 

Logged errors/warnings that are fixed in this pull request:

- PHP warning: Declaration of modElementCategoryGetListProcessor::prepareQueryBeforeCount(xPDOQuery $c) should be compatible with modObjectGetListProcessor::prepareQueryBeforeCount(xPDO\Om\xPDOQuery $c)
- PHP warning: Declaration of modTemplateGetListProcessor::prepareQueryBeforeCount(xPDOQuery $c) should be compatible with modElementGetListProcessor::prepareQueryBeforeCount(xPDO\Om\xPDOQuery $c)
- PHP warning: Declaration of modUserGroupAccessNamespaceGetListProcessor::prepareQueryBeforeCount(xPDOQuery $c) should be compatible with modObjectGetListProcessor::prepareQueryBeforeCount(xPDO\Om\xPDOQuery $c)