### PR TITLE
[3.x] Prevent uncaught E_FATAL if core/vendor/autoload.php doesn't exist

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -24,6 +24,13 @@ if (strstr(str_replace('.','',serialize(array_merge($_GET, $_POST, $_COOKIE))), 
 if (!defined('MODX_CORE_PATH')) {
     define('MODX_CORE_PATH', dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR);
 }
+
+if (!file_exists(MODX_CORE_PATH . 'vendor/autoload.php')) {
+    $errorMessage = 'Site temporarily unavailable; missing dependencies.';
+    @include(MODX_CORE_PATH . 'error/unavailable.include.php');
+    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
+    exit();
+}
 require MODX_CORE_PATH . 'vendor/autoload.php';
 
 use xPDO\xPDO;
@@ -1896,7 +1903,7 @@ class modX extends xPDO {
                 $userId = $this->user->get('id');
         	}
         }
-        
+
         $ml = $this->newObject('modManagerLog');
         $ml->set('user', (integer) $userId);
         $ml->set('occurred', strftime('%Y-%m-%d %H:%M:%S'));


### PR DESCRIPTION
### What does it do?
In normal usage this condition shouldn't, like, ever trigger. However during development it's easy to forget to run `composer install` and you're presented with a blank manager and frontend. This fix catches that oversight and subtly reminds people to install dependencies.

### Why is it needed?
I'm familiar with using composer on different projects, and I was stumped for about a minute trying to get the 3.x branch running because I forgot to run `composer install`. Now imagine someone who never used composer before trying to get the 3.x branch running and forgetting about that; they'll spend a lot longer than a minute figuring it out. The error shown now should point them in the right direction. 

### Related issue(s)/PR(s)
N/a

