### PR TITLE
Improved fix of #13038

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -103,8 +103,15 @@
     overflow-y: auto;
     padding: 15px;
   }
-  &.modx-window .x-window-body {
-    padding-top: 0;
+  &.modx-window {
+    .x-window-body {
+      padding-top: 0;
+    }
+    &.modx-console {
+      .x-window-body {
+        padding-top: 15px;
+      }
+    }
   }
 
   .x-panel-bwrap {


### PR DESCRIPTION
### What does it do?
Fixing a padding-top issue in .modx-window.modx-console .x-window-body

### Why is it needed?
Console needs some padding top https://github.com/modxcms/revolution/pull/13038#issuecomment-233030171
