### PR TITLE
Fix incorrect/inconsistent handling of non-existing TV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ _build/templates/default/sass/font-awesome
 *.css.map
 *.js.map
 
-#ignore composer files
+# ignore composer files
+composer.phar
 composer.json
 composer.lock
+
+# ignore composer vendor dir
+/vendor

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -461,4 +461,11 @@ class modParserTest extends MODxTestCase {
             array("name", "name@propset:filter=`name@propset:filter`"),
         );
     }
+
+    public function testDefaultNonExistingTvValue() {
+        $output = "[[*foo:default=`bar`]]";
+        $this->modx->parser->processElementTags('', $output, true, false, '[[', ']]', array(), 10);
+        $this->assertEquals($output, "bar", "Did not parse non-existing TV with default modifier correctly");
+
+    }
 }

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -505,7 +505,16 @@ class modParser {
                         $element->setCacheable($cacheable);
                         $elementOutput= $element->process($tagPropString);
                     }
-                    elseif ($element= $this->getElement('modTemplateVar', $tagName)) {
+                    else {
+                        $element = $this->getElement('modTemplateVar', $tagName);
+
+                        // If our element tag was not found (e.i. not an existing TV), create a new instance of
+                        // modFieldTag. We do this to make it possible to use output modifiers such as default. This
+                        // mirrors the behavior of placeholders.
+                        if ($element === false) {
+                            $element = new modFieldTag($this->modx);
+                        }
+
                         $element->set('name', $tagName);
                         $element->setTag($outerTag);
                         $element->setCacheable($cacheable);


### PR DESCRIPTION
### What does it do?
Before, if a TV (or attribute of a resource) was called, it would silently be ignored by the parser. This made it impossible to use output modifiers such as default on them. This behavior differs from how placeholders are handled.

Illustration. The following content field on a template which renders nothing but the content. Two template variables are created, `hello` and `hello2`. The former is non-empty, while the latter is. Content content:

```
Pagetitle = [[*pagetitle]].
Pagetitle with default:foo = [[*pagetitle:default=`foo`]].
Existing (non-empty) TV with default:bar = [[*hello:default=`bar`]].
Existing (empty) TV with default:bar = [[*hello2:default=`bar`]].
Non-existing TV with default:bar = [[*foo:default=`bar`]]. 
Placeholder that is not sat with default:bar = [[+foo:default=`bar`]].
```

Previous output:
```
Pagetitle = Home.
Pagetitle with default:foo = Home.
Existing (non-empty) TV with default:bar = hello.
Existing (empty) TV with default:bar = bar.
Non-existing TV with default:bar = . 
Placeholder that is not sat with default:bar = bar.
```

Output with patch:
```
Pagetitle = Home.
Pagetitle with default:foo = Home.
Existing (non-empty) TV with default:bar = hello.
Existing (empty) TV with default:bar = bar.
Non-existing TV with default:bar = bar. 
Placeholder that is not sat with default:bar = bar.
```

PS: I ignored composer.phar and the vendor dir. It made testing a lot easier. I also added a test to make sure this behavior is not altered without a heads up.

### Why is it needed?
As reported in the related issue, this behavior is inconsistent with how similar markup is parsed. It could also look like this behavior has changed recently, although I was not able to figure out how or why. In 2.4.x the behavior introduced in this PR is present.

### Related issue(s)/PR(s)
#13203 and perhaps others (?)
