### PR TITLE
Automatically change tab when saving resource and invalid values/states are present in another tab

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -295,6 +295,8 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                     }
                 });
             } else {
+                o.form.fireEvent('failureSubmit');
+
                 Ext.Msg.alert(_('error'),_('correct_errors'));
             }
         } else {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -137,7 +137,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     }
 
     ,beforeSubmit: function(o) {
-        console.log('done');
         var ta = Ext.get('ta');
         if (ta) {
             var v = ta.dom.value;
@@ -236,7 +235,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
 
         // The next check needs the tabs index value to check if it is hidden or not
         if (tabs && tabs.items && tabs.items.keys) {
-            tabs_index = tabs.items.keys.indexOf(tab_name)
+            tabs_index = tabs.items.keys.indexOf(tab_name);
         }
 
         // We are already on a tab that has an invalid state. No need to switch
@@ -272,6 +271,8 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             var btn = Ext.getCmp('modx-abtn-save');
             if (btn) { btn.enable(); }
         }
+
+        this.fireEvent('failureSubmit');
     }
 
     ,freezeUri: function(cb) {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -20,6 +20,7 @@ MODx.panel.Resource = function(config) {
             ,'failure': {fn:this.failure,scope:this}
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
             ,'fieldChange': {fn:this.onFieldChange,scope:this}
+            ,'failureSubmit': {fn:this.failureSubmit,scope:this}
         }
     });
     MODx.panel.Resource.superclass.constructor.call(this,config);
@@ -136,6 +137,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     }
 
     ,beforeSubmit: function(o) {
+        console.log('done');
         var ta = Ext.get('ta');
         if (ta) {
             var v = ta.dom.value;
@@ -200,33 +202,75 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             Ext.getCmp('modx-page-update-resource').config.preview_url = object.preview_url;
         }
     }
+    ,failureSubmit: function() {
+        // This array contains the components we want to traverse in the order we prioritize them
+        var forms = [
+            'modx-resource-settings', // Document
+            'modx-page-settings', // Settings
+            'modx-panel-resource-tv' // Template Variables
+        ];
+
+        var tab_name = null;
+
+        // Loop each component and traverse the children recursively
+        for (var i = 0; i < forms.length; i++) {
+            var component = Ext.getCmp(forms[i]);
+            if (component && component.el && component.el.dom) {
+                if (this.traverseNode(component.el.dom)) {
+                    tab_name = forms[i];
+
+                    // We want to switch to the first tab that has an invalid state, no matter if the current
+                    // or any later tabs also have such states. We can therefore quit early here.
+                    break;
+                }
+            }
+        }
+
+        // If no invalid states were found, this check makes sure we don't switch tabs for no reason
+        if (tab_name === null) {
+            return;
+        }
+
+        var tabs = Ext.getCmp('modx-resource-tabs');
+        var tabs_index = null;
+
+        // The next check needs the tabs index value to check if it is hidden or not
+        if (tabs && tabs.items && tabs.items.keys) {
+            tabs_index = tabs.items.keys.indexOf(tab_name)
+        }
+
+        // We are already on a tab that has an invalid state. No need to switch
+        if (!tabs.items.items[tabs_index].hidden)  {
+            return;
+        }
+
+        // Activate the tab (this is done by passing the name of the tab)
+        tabs.activate(tab_name);
+    }
+
+    ,traverseNode: function(node) {
+        if (typeof node.classList !== 'undefined' && node.classList.contains('x-form-invalid')) {
+            return true;
+        }
+
+        if (typeof node.children == 'undefined') {
+            return false;
+        }
+
+        for (var i = 0; i < node.children.length; i++) {
+            if (this.traverseNode(node.children[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     ,failure: function(o) {
         this.warnUnsavedChanges = true;
         if(this.getForm().baseParams.action == 'resource/create') {
             var btn = Ext.getCmp('modx-abtn-save');
             if (btn) { btn.enable(); }
-        }
-
-        // If there is an error concerning alias/uri and we are not on the first tab (Document) we are going to help
-        // the user by switching automatically.
-        var tabs = Ext.getCmp('modx-resource-tabs');
-        if (!tabs || !tabs.items.items[0].hidden)  {
-            // We're currently on the Document tab
-            return;
-        }
-
-        // Check if the error is about alias/uri
-        var valid_error_ids = ['uri', 'alias'];
-        for (var i = 0; i < o.result.errors.length; i++) {
-            if (valid_error_ids.indexOf(o.result.errors[i]['id']) === -1) {
-                continue;
-            }
-
-            // If we got here, it means that out error is either about uri or alias. We should switch to the
-            // settings tab to help the user.
-            tabs.activate('modx-resource-settings');
-
-            break;
         }
     }
 

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -206,6 +206,28 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             var btn = Ext.getCmp('modx-abtn-save');
             if (btn) { btn.enable(); }
         }
+
+        // If there is an error concerning alias/uri and we are not on the first tab (Document) we are going to help
+        // the user by switching automatically.
+        var tabs = Ext.getCmp('modx-resource-tabs');
+        if (!tabs || !tabs.items.items[0].hidden)  {
+            // We're currently on the Document tab
+            return;
+        }
+
+        // Check if the error is about alias/uri
+        var valid_error_ids = ['uri', 'alias'];
+        for (var i = 0; i < o.result.errors.length; i++) {
+            if (valid_error_ids.indexOf(o.result.errors[i]['id']) === -1) {
+                continue;
+            }
+
+            // If we got here, it means that out error is either about uri or alias. We should switch to the
+            // settings tab to help the user.
+            tabs.activate('modx-resource-settings');
+
+            break;
+        }
     }
 
     ,freezeUri: function(cb) {


### PR DESCRIPTION
### What does it do?
Implement an extension of the current tab behavior when updating/creating a resource. If you happen to have a duplicated alias/uri and the processor returns an error, you will not automatically see the correct tab where the error is, if you are not already on that tab. See gif below.

**NOTE: This illustration is no longer valid. This PR now handles illegal states for all fields in the form, not only uri/alias.**

New behavior:
![alias-new-behavior](https://cloud.githubusercontent.com/assets/2326278/20855898/1c638212-b904-11e6-949b-251da02127b9.gif)

### Why is it needed?
Solves an annoying issue that most of us have experienced at some point.

### Related issue(s)/PR(s)
#13202 

