### PR TITLE
Make sure default category when get param is 0 is None for elements

### DIFF
--- a/manager/controllers/default/element/chunk/create.class.php
+++ b/manager/controllers/default/element/chunk/create.class.php
@@ -70,7 +70,7 @@ class ElementChunkCreateManagerController extends modManagerController {
      */
     public function getCategory(array $scriptProperties = array()) {
         /* grab default category if specified */
-        if (isset($scriptProperties['category'])) {
+        if (isset($scriptProperties['category']) and $scriptProperties['category'] !== '0') {
             $this->category = $this->modx->getObject('modCategory',$scriptProperties['category']);
         } else { $this->category = null; }
         return $this->category;

--- a/manager/controllers/default/element/plugin/create.class.php
+++ b/manager/controllers/default/element/plugin/create.class.php
@@ -55,7 +55,7 @@ class ElementPluginCreateManagerController extends modManagerController {
         $placeholders = array();
 
         /* grab category if preset */
-        if (isset($scriptProperties['category'])) {
+        if (isset($scriptProperties['category']) and $scriptProperties['category'] !== '0') {
             $this->category = $this->modx->getObject('modCategory',$scriptProperties['category']);
             if ($this->category != null) {
                 $placeholders['category'] = $this->category;

--- a/manager/controllers/default/element/snippet/create.class.php
+++ b/manager/controllers/default/element/snippet/create.class.php
@@ -54,7 +54,7 @@ class ElementSnippetCreateManagerController extends modManagerController {
         $placeholders = array();
 
         /* grab category if preset */
-        if (isset($scriptProperties['category'])) {
+        if (isset($scriptProperties['category']) and $scriptProperties['category'] !== '0') {
             $this->category = $this->modx->getObject('modCategory',$scriptProperties['category']);
             if ($this->category != null) {
                 $placeholders['category'] = $this->category;

--- a/manager/controllers/default/element/template/create.class.php
+++ b/manager/controllers/default/element/template/create.class.php
@@ -55,7 +55,7 @@ class ElementTemplateCreateManagerController extends modManagerController {
         $placeholders = array();
 
         /* grab category if preset */
-        if (isset($scriptProperties['category'])) {
+        if (isset($scriptProperties['category']) and $scriptProperties['category'] !== '0') {
             $this->category = $this->modx->getObject('modCategory',$scriptProperties['category']);
             if ($this->category != null) {
                 $placeholders['category'] = $this->category;

--- a/manager/controllers/default/element/tv/create.class.php
+++ b/manager/controllers/default/element/tv/create.class.php
@@ -58,7 +58,7 @@ Ext.onReady(function() {
         $placeholders = array();
 
         /* grab category if preset */
-        if (isset($scriptProperties['category'])) {
+        if (isset($scriptProperties['category']) and $scriptProperties['category'] !== '0') {
             $this->category = $this->modx->getObject('modCategory',$scriptProperties['category']);
             if ($this->category != null) {
                 $placeholders['category'] = $this->category;


### PR DESCRIPTION
### What does it do?
For some reason MODX wants to load the default category as the category with the lowest ID. Given the query string `&category=0` the default category should be None. This PR fixes that, HOWEVER, someone should really look into what is going on, because there is something else wrong here I belive, but I was not able to figure out just what is was.

This line:
```
$this->category = $this->modx->getObject('modCategory',$scriptProperties['category']);
```

Did multiple times load a category that had a totally different ID than what the `scriptProperties` array contained.

Current behavior:
![category-before](https://cloud.githubusercontent.com/assets/2326278/20856124/e8f3a692-b907-11e6-8508-464cf4e439f4.gif)

New behavior:
![category-after2](https://cloud.githubusercontent.com/assets/2326278/20856125/efb309b4-b907-11e6-955e-14f010bc8cae.gif)

### Why is it needed?
Fixes a bug.

### Related issue(s)/PR(s)
#13187
