### PR TITLE
Validate file extension when renaming files in file browser

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -494,6 +494,21 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
             return false;
         }
 
+        // Check that the new file has a file type that is allowed
+        $allowedFileTypes = explode(',',$this->xpdo->getOption('upload_files',null,''));
+        $allowedFileTypes = array_merge(explode(',',$this->xpdo->getOption('upload_images')),explode(',',$this->xpdo->getOption('upload_media')),explode(',',$this->xpdo->getOption('upload_flash')),$allowedFileTypes);
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
+        $file_split = explode('.', $newName);
+        $ext = $file_split[count($file_split) - 1];
+        if (count($file_split) > 1 and !in_array($ext, $allowedFileTypes)) {
+            $this->addError('path',$this->xpdo->lexicon('file_err_ext_not_allowed',array(
+                'ext' => $ext,
+            )));
+
+            return false;
+        }
+
         /* sanitize new path */
         $newPath = $this->fileHandler->sanitizePath($newName);
         $newPath = dirname($oldPath).'/'.$newPath;

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -597,6 +597,22 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
             $this->addError('file',$this->xpdo->lexicon('file_folder_err_ns').': '.$oldPath);
             return false;
         }
+
+        // Check that the new file has a file type that is allowed
+        $allowedFileTypes = explode(',',$this->xpdo->getOption('upload_files',null,''));
+        $allowedFileTypes = array_merge(explode(',',$this->xpdo->getOption('upload_images')),explode(',',$this->xpdo->getOption('upload_media')),explode(',',$this->xpdo->getOption('upload_flash')),$allowedFileTypes);
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
+        $file_split = explode('.', $newName);
+        $ext = $file_split[count($file_split) - 1];
+        if (count($file_split) > 1 and !in_array($ext, $allowedFileTypes)) {
+            $this->addError('path',$this->xpdo->lexicon('file_err_ext_not_allowed',array(
+                'ext' => $ext,
+            )));
+
+            return false;
+        }
+
         $dir = dirname($oldPath);
         $newPath = ($dir != '.' ? $dir.'/' : '').$newName;
 


### PR DESCRIPTION
### What does it do?
Do validation of file extension when renaming objects. Fixing potential security issue.

NOTE: I have not actually been able to test the S3 media source, but I belive they share the same code for this method up to the point where I do the check, so it should work as intended.

### Why is it needed?
Security.

### Related issue(s)/PR(s)
#13178

