### PR TITLE
Update modx.treedrop.js

### DIFF
--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -99,7 +99,11 @@ Ext.extend(MODx.TreeDrop,Ext.Component,{
                         }
                         if (el.dom.id == 'modx-symlink-content' || el.dom.id == 'modx-weblink-content') {
                             Ext.getCmp(el.dom.id).setValue('');
-                            MODx.insertAtCursor(ddTargetEl,data.node.attributes.pk,cfg.onInsert);
+                            if(typeof data.node.attributes.pk !== undefined && data.node.attributes.pk !== undefined){
+                                MODx.insertAtCursor(ddTargetEl,data.node.attributes.pk,cfg.onInsert);
+                            }else{
+                                MODx.insertAtCursor(ddTargetEl,v,cfg.onInsert);
+                            }
                         } else if (el.dom.id == 'modx-resource-parent') {
                             v = data.node.attributes.pk;
                             var pf = Ext.getCmp('modx-resource-parent');


### PR DESCRIPTION
### What does it do?
It adds a check to weblink and symlink fields in case an item being dragged is not a resource.

### Why is it needed?
When dragging a file into a weblink it would cause an "Undefined" issue because it was looking for a resource ID that doesn't exist on files. 

### Related issue(s)/PR(s)
I want to resolve issue #13212