### PR TITLE
Added option to disable EVAL binding in TVs

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -618,7 +618,7 @@ class modTemplateVar extends modElement {
                         }
                     }
                 }
-                
+
                 switch ($rule->get('rule')) {
                     case 'tvVisible':
                         if ($rule->get('value') == 0) {
@@ -830,7 +830,10 @@ class modTemplateVar extends modElement {
 
             case 'EVAL':        /* evaluates text as php codes return the results */
                 if ($preProcess) {
-                    $output = eval($param);
+                    $output = $param;
+                    if ($this->xpdo->getOption('allow_tv_eval', null, true)) {
+                        $output = eval($param);
+                    }
                 }
                 break;
 


### PR DESCRIPTION
Note : this is just a proposal for a first review, we might want to create a system setting at some point.

### What does it do?

Adds a setting to disable `eval` in TV binding, keeping the default behavior as it currently is.
When the option is disabled, the code/value will just be handled as regular text.

### Why is it needed?

Allowing code to be `eval()`'ed can lead to some security issue. While we always assumed people with access to the manager are trust worthy, it could be different on some other projects.
