### PR TITLE
Access chunk array instead of chunk object instance

### DIFF
--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -131,7 +131,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
         $this->onChunkFormPrerender = $this->modx->invokeEvent('OnChunkFormPrerender',array(
-            'id' => $this->chunk->get('id'),
+            'id' => $this->chunkArray['id'],
             'mode' => modSystemEvent::MODE_UPD,
             'chunk' => $this->chunk,
         ));
@@ -181,7 +181,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('chunk').': '.$this->chunk->get('name');
+        return $this->modx->lexicon('chunk').': '.$this->chunkArray['name'];
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Change update controller for chunks to mirror the behavior of snippets. This fixes an issue where the controller will throw a fatal error if you try to enter a ID for a chunk that does not exist.

<img width="396" alt="skarmavbild 2016-12-24 kl 16 37 30" src="https://cloud.githubusercontent.com/assets/2326278/21467699/939baa7c-c9f7-11e6-9267-fb986cf11e50.png">

### Why is it needed?
Fix fatal error, and replace it with an error message.

### Related issue(s)/PR(s)
Reported in #13210 