### PR TITLE
File Unzip feature broken #13223

### DIFF
--- a/core/model/modx/processors/browser/file/unpack.class.php
+++ b/core/model/modx/processors/browser/file/unpack.class.php
@@ -29,7 +29,7 @@ class modUnpackProcessor extends modProcessor {
 
         $this->modx->getService('fileHandler', 'modFileHandler');
 
-        $target = $this->properties['path'] . $this->properties['file'];
+        $target = $this->modx->getOption('base_path') . $this->properties['path'] . $this->properties['file'];
         $target = preg_replace('/(\.+\/)+/', '', htmlspecialchars($target));
         $fileobj = $this->modx->fileHandler->make($target);
 
@@ -38,7 +38,7 @@ class modUnpackProcessor extends modProcessor {
         }
 
         // currently the archive content is extracted to the folder where the archive is stored
-        if (!$fileobj->unpack($this->properties['path'] . dirname($this->properties['file']))) {
+        if (!$fileobj->unpack(dirname($target))) {
             return $this->failure($this->modx->lexicon('file_err_unzip'));
         }
 
@@ -52,7 +52,8 @@ class modUnpackProcessor extends modProcessor {
      */
     public function validate(modFileSystemResource $fileobj) {
 
-        if (empty($this->properties['path'])) {
+        $path = $fileobj->getPath();
+        if (empty($path)) {
             $this->addFieldError('path', $this->modx->lexicon('file_folder_err_invalid_path'));
         }
 

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -601,7 +601,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,file: node.attributes.id
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
-                ,path: MODx.config.base_path + node.attributes.directory
+                ,path: node.attributes.directory
             }
             ,listeners: {
                 'success':{fn:this.refreshParentNode,scope:this}


### PR DESCRIPTION
### What does it do?
Removed MODx.config.base_path, which is undefined client-side.
Added base_path to the path server-side.

### Why is it needed?
File Unzip was broken as result of  #13170 and #13180

### Related issue(s)/PR(s)
Related to #13223 and #13183
