### PR TITLE
Validate file extension when renaming/creating files in file browser

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -4,6 +4,7 @@ development release, and is only shown to give an idea of what's currently in th
 
 MODX Revolution 2.5.3-pl (insert date here)
 ====================================
+- Fix truncating filename at space by downloading via filemanager [#13171]
 - Fix listing packages on systems with non-utf8 locales [#13182]
 - Update PHPMailer to 5.2.21 for CVE-2016-10045 patch [#13229]
 - Access chunk array instead of chunk object instance [#13210]

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -535,7 +535,7 @@ class modFile extends modFileSystemResource {
     public function download($options = array()) {
         $options = array_merge(array(
             'mimetype' => 'application/octet-stream',
-            'filename' => $this->getBasename(),
+            'filename' => '"' . $this->getBasename() . '"',
         ), $options);
 
         $output = $this->getContents();

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -671,6 +671,28 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
         $fullPath = $bases['pathAbsolute'].ltrim($objectPath,'/').ltrim($name,'/');
 
+        // Check that the new file has a file type that is allowed
+        $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
+        $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
+        $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+
+        if ($this->getOption('allowedFileTypes')) {
+            $allowedFileTypes = array_intersect($allowedFileTypes, explode(',', $this->getOption('allowedFileTypes')));
+        }
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
+        $ext = pathinfo($fullPath, PATHINFO_EXTENSION);
+        $ext = strtolower($ext);
+        if (!empty($allowedFileTypes) && !in_array($ext, $allowedFileTypes)) {
+            $this->addError('path',$this->xpdo->lexicon('file_err_ext_not_allowed',array(
+                'ext' => $ext,
+            )));
+
+            return false;
+        }
+
         /** @var modFile $file */
         $file = $this->fileHandler->make($fullPath,array(),'modFile');
 
@@ -727,6 +749,12 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
         $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
         $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+
+        if ($this->getOption('allowedFileTypes')) {
+            $allowedFileTypes = array_intersect($allowedFileTypes, explode(',', $this->getOption('allowedFileTypes')));
+        }
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
         $maxFileSize = $this->xpdo->getOption('upload_maxsize',null,1048576);
 
         /* loop through each file and upload */

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -494,6 +494,28 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
             return false;
         }
 
+        // Check that the new file has a file type that is allowed
+        $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
+        $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
+        $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+
+        if ($this->getOption('allowedFileTypes')) {
+            $allowedFileTypes = array_intersect($allowedFileTypes, explode(',', $this->getOption('allowedFileTypes')));
+        }
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
+        $ext = pathinfo($newName, PATHINFO_EXTENSION);
+        $ext = strtolower($ext);
+        if (!empty($allowedFileTypes) && !in_array($ext, $allowedFileTypes)) {
+            $this->addError('path',$this->xpdo->lexicon('file_err_ext_not_allowed',array(
+                'ext' => $ext,
+            )));
+
+            return false;
+        }
+
         /* sanitize new path */
         $newPath = $this->fileHandler->sanitizePath($newName);
         $newPath = dirname($oldPath).'/'.$newPath;
@@ -699,9 +721,12 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         }
 
         $this->xpdo->context->prepare();
-        $allowedFileTypes = explode(',',$this->xpdo->getOption('upload_files',null,''));
-        $allowedFileTypes = array_merge(explode(',',$this->xpdo->getOption('upload_images')),explode(',',$this->xpdo->getOption('upload_media')),explode(',',$this->xpdo->getOption('upload_flash')),$allowedFileTypes);
-        $allowedFileTypes = array_unique($allowedFileTypes);
+        // Check that the new file has a file type that is allowed
+        $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
+        $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
+        $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
         $maxFileSize = $this->xpdo->getOption('upload_maxsize',null,1048576);
 
         /* loop through each file and upload */

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -597,6 +597,29 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
             $this->addError('file',$this->xpdo->lexicon('file_folder_err_ns').': '.$oldPath);
             return false;
         }
+
+        // Check that the new file has a file type that is allowed
+        $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
+        $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
+        $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+
+        if ($this->getOption('allowedFileTypes')) {
+            $allowedFileTypes = array_intersect($allowedFileTypes, explode(',', $this->getOption('allowedFileTypes')));
+        }
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
+        $ext = pathinfo($newName, PATHINFO_EXTENSION);
+        $ext = strtolower($ext);
+        if (!empty($allowedFileTypes) && !in_array($ext, $allowedFileTypes)) {
+            $this->addError('path',$this->xpdo->lexicon('file_err_ext_not_allowed',array(
+                'ext' => $ext,
+            )));
+
+            return false;
+        }
+
         $dir = dirname($oldPath);
         $newPath = ($dir != '.' ? $dir.'/' : '').$newName;
 
@@ -630,9 +653,11 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
     public function uploadObjectsToContainer($container,array $objects = array()) {
         if ($container == '/' || $container == '.') $container = '';
 
-        $allowedFileTypes = explode(',',$this->xpdo->getOption('upload_files',null,''));
-        $allowedFileTypes = array_merge(explode(',',$this->xpdo->getOption('upload_images')),explode(',',$this->xpdo->getOption('upload_media')),explode(',',$this->xpdo->getOption('upload_flash')),$allowedFileTypes);
-        $allowedFileTypes = array_unique($allowedFileTypes);
+        $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
+        $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
+        $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
         $maxFileSize = $this->xpdo->getOption('upload_maxsize',null,1048576);
 
         /* loop through each file and upload */

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -523,6 +523,28 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
             return false;
         }
 
+        // Check that the new file has a file type that is allowed
+        $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+        $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
+        $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
+        $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+
+        if ($this->getOption('allowedFileTypes')) {
+            $allowedFileTypes = array_intersect($allowedFileTypes, explode(',', $this->getOption('allowedFileTypes')));
+        }
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
+        $ext = pathinfo($objectPath.$name, PATHINFO_EXTENSION);
+        $ext = strtolower($ext);
+        if (!empty($allowedFileTypes) && !in_array($ext, $allowedFileTypes)) {
+            $this->addError('path',$this->xpdo->lexicon('file_err_ext_not_allowed',array(
+                'ext' => $ext,
+            )));
+
+            return false;
+        }
+
         /* create empty file that acts as folder */
         $created = $this->driver->create_object($this->bucket,$objectPath.$name,array(
                 'body' => $content,
@@ -658,13 +680,19 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
         $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
         $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+
+        if ($this->getOption('allowedFileTypes')) {
+            $allowedFileTypes = array_intersect($allowedFileTypes, explode(',', $this->getOption('allowedFileTypes')));
+        }
+        $allowedFileTypes = array_unique($allowedFileTypes);
+
         $maxFileSize = $this->xpdo->getOption('upload_maxsize',null,1048576);
 
         /* loop through each file and upload */
         foreach ($objects as $file) {
             if ($file['error'] != 0) continue;
             if (empty($file['name'])) continue;
-            $ext = @pathinfo($file['name'],PATHINFO_EXTENSION);
+            $ext = pathinfo($file['name'],PATHINFO_EXTENSION);
             $ext = strtolower($ext);
 
             if (empty($ext) || !in_array($ext,$allowedFileTypes)) {
@@ -673,7 +701,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 )));
                 continue;
             }
-            $size = @filesize($file['tmp_name']);
+            $size = filesize($file['tmp_name']);
 
             if ($size > $maxFileSize) {
                 $this->addError('path',$this->xpdo->lexicon('file_err_too_large',array(


### PR DESCRIPTION
### What does it do?
Improved validation of file extension when renaming/creating file objects in file browser. Fixing potential security issue.

### Why is it needed?
Security.

### Related issue(s)/PR(s)
#13208, #13178

