### PR TITLE
Respect new_file_permissions setting when create/upload files in manager

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -387,6 +387,7 @@ class modFile extends modFileSystemResource {
             @fclose($fp);
 
             $result = file_exists($this->path);
+            if ($result and $mode = $this->fileHandler->modx->getOption('new_file_permissions')) $this->chmod($mode);
         }
         return $result;
     }


### PR DESCRIPTION
### What does it do?
Apply chmod to files created/uploaded in manager with "new_file_permissions" system setting.

### Why is it needed?
"new_file_permissions" had no effect on new files created/uploaded in manager.

### Related issue(s)/PR(s)
Fixes #9343 
