### PR TITLE
Wrap the output of the error log message

### DIFF
--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -2068,7 +2068,8 @@ class xPDO {
         }
         switch ($target) {
             case 'HTML' :
-                echo '<h5>[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ')</h5><pre>' . $msg . '</pre>' . "\n";
+                $debugBlockClass = $this->getOption('debug_block_class',NULL,'modx-debug-block');
+                echo '<div class="' . $debugBlockClass . '">' . '<h5>[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ')</h5><pre>' . $msg . '</pre></div>' . "\n";
                 break;
             default :
                 echo '[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n";


### PR DESCRIPTION
### What does it do?
Wrap the output of the error log message.

### Why is it needed?
To be able to cutomize the block of error messages if it's displayed on the site page when the log target is 'HTML'.

### Related issue(s)/PR(s)
I think none.