### PR TITLE
Update MODX Transport Provider to use SSL URL

### DIFF
--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -167,8 +167,8 @@ $collection['1'] = $xpdo->newObject('transport.modTransportProvider');
 $collection['1']->fromArray(array (
     'id' => 1,
     'name' => 'modx.com',
-    'description' => 'The official MODX transport facility for 3rd party components.',
-    'service_url' => 'http://rest.modx.com/extras/',
+    'description' => 'The official MODX transport provider for 3rd party components.',
+    'service_url' => 'https://rest.modx.com/extras/',
     'created' => strftime('%Y-%m-%d %H:%M:%S'),
 ), '', true, true);
 $attributes = array (
@@ -181,7 +181,7 @@ foreach ($collection as $c) {
 }
 unset ($collection, $c, $attributes);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in modxcms.com provisioner reference.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged modx.com transport provider.'); flush();
 
 /* modMenu */
 $collection = include MODX_BUILD_DIR . 'data/transport.core.menus.php';

--- a/setup/includes/upgrades/common/2.5.5-ssl-provider.php
+++ b/setup/includes/upgrades/common/2.5.5-ssl-provider.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Common upgrade script for 2.5.5 to update provider URL to SSL
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$nonSSLProvider = $modx->getObject('transport.modTransportProvider', array('service_url' => 'http://rest.modx.com/extras/'));
+if ($nonSSLProvider) {
+    $nonSSLProvider->set('service_url', 'https://rest.modx.com/extras/');
+    $nonSSLProvider->save();
+}

--- a/setup/includes/upgrades/mysql/2.5.5-pl.php
+++ b/setup/includes/upgrades/mysql/2.5.5-pl.php
@@ -1,0 +1,11 @@
+<?php
+/*1
+ * Specific upgrades for Revolution 2.5.5-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(dirname(__FILE__)) . '/common/2.5.5-ssl-provider.php';

--- a/setup/includes/upgrades/sqlsrv/2.5.5-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.5.5-pl.php
@@ -1,0 +1,11 @@
+<?php
+/*1
+ * Specific upgrades for Revolution 2.5.5-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(dirname(__FILE__)) . '/common/2.5.5-ssl-provider.php';


### PR DESCRIPTION
### What does it do?
Updates the MODX Transport Provider to use the SSL URL.

### Why is it needed?
Using a non-SSL URL has the potential to allow MITM attacks.

### Related issue(s)/PR(s)
N/A