### PR TITLE
Fix issue - not showing resources tree in modx manager.

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -417,7 +417,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
                 var f = false;
                 var sr;
                 for (i=0;i<s.length;i++) {
-                    if (s[i] == undefined || s[i] == 'undefined') { s.splice(i,1); continue; }
+                    if (s[i] == undefined || typeof s[i] != 'string' ) { s.splice(i,1); continue; }
                     sr = s[i].search(p);
                     if (sr !== -1 && s[sr]) { /* dont add if already in */
                         if (s[sr].length > s[i].length) {
@@ -433,7 +433,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
             s = s.remove(p);
             /* remove all children of node */
             for (i=0;i<s.length;i++) {
-                if (s[i] == undefined || s[i] == 'undefined') { s.splice(i,1); continue; }
+                if (s[i] == undefined || typeof s[i] != 'string') { s.splice(i,1); continue; }
                 if (s[i].search(p) !== -1) {
                     delete s[i];
                 }
@@ -441,7 +441,7 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
         }
         /* clear out undefineds */
         for (i=0;i<s.length;i++) {
-            if (s[i] == undefined || s[i] == 'undefined') { s.splice(i,1); continue; }
+            if (s[i] == undefined || typeof s[i] != 'string') { s.splice(i,1); continue; }
         }
         Ext.state.Manager.set(this.treestate_id,s);
     }


### PR DESCRIPTION
### What does it do?
This fix for error `TypeError: s[i].search is not a function` 
in  file `manager/assets/modext/widgets/core/tree/modx.tree.js`
 on line 421 `sr = s[i].search(p);`

### Why is it needed?
This is because first argument of `s` is not string. Better check "if `s[i]` is string or not" fix this issue.
Screenshot from chrome debugger: 
![2017-01-24_12-50-31](https://cloud.githubusercontent.com/assets/801823/22243038/bd086948-e236-11e6-9251-f36678c27459.png)
