### PR TITLE
Improve logging of bad links

### DIFF
--- a/core/model/modx/modcontext.class.php
+++ b/core/model/modx/modcontext.class.php
@@ -311,6 +311,15 @@ class modContext extends modAccessibleObject {
                     }
                     $url= $host . $url;
                 }
+            } else {
+                $this->xpdo->log(
+                    xPDO::LOG_LEVEL_ERROR,
+                    "Resource with id {$id} was not found in context {$this->key}",
+                    '',
+                    __METHOD__,
+                    $this->xpdo->resource ? "resource {$this->xpdo->resource->id}" : __FILE__,
+                    $this->xpdo->resource ? '' : __LINE__
+                );
             }
         }
         if ($this->xpdo->getDebug() === true) {

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -1342,6 +1342,16 @@ class modLinkTag extends modTag {
                 $this->cache();
                 $this->_processed= true;
             }
+            if (empty($this->_output)) {
+                $this->modx->log(
+                    modX::LOG_LEVEL_ERROR,
+                    'Bad link tag `' . $this->_tag . '` encountered',
+                    '',
+                    $this->modx->resource
+                        ? "resource {$this->modx->resource->id}"
+                        : ($_SERVER['REQUEST_URI'] ? "uri {$_SERVER['REQUEST_URI']}" : '')
+                );
+            }
         }
         /* finally, return the processed element content */
         return $this->_output;


### PR DESCRIPTION
Addresses issue described in #13265

### What does it do?
Add error logging with references to the resource (or REQUEST_URI if the resource is not set) a bad link tag or call to makeUrl is made on.

### Why is it needed?
It's currently difficult to find bad link tags or calls to makeUrl with invalid resource ids.

### Related issue(s)/PR(s)
#13265 