### PR TITLE
Prevent plugins from crashing setup (#9030)

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1575,8 +1575,9 @@ class modX extends xPDO {
      * @return bool|array
      */
     public function invokeEvent($eventName, array $params= array ()) {
-        if (!$eventName)
+        if (!$eventName || xPDO::OPT_SETUP === true) {
             return false;
+        }
         if ($this->eventMap === null && $this->context instanceof modContext)
             $this->_initEventMap($this->context->get('key'));
         if (!isset ($this->eventMap[$eventName])) {

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1575,7 +1575,7 @@ class modX extends xPDO {
      * @return bool|array
      */
     public function invokeEvent($eventName, array $params= array ()) {
-        if (!$eventName || xPDO::OPT_SETUP === true) {
+        if (!$eventName || $this->getOption(xPDO::OPT_SETUP) === true) {
             return false;
         }
         if ($this->eventMap === null && $this->context instanceof modContext)


### PR DESCRIPTION
### What does it do?

Checks for xPDO::OPT_SETUP === true

### Why is it needed?
If an upgrade saves a user or resource and a plugin connected to an invoked event calls get() on one of these, Setup will crash if these are not set. This change prevents plugins from executing during setup.

I've checked all event invocations in the code and the only ones where false would not be acceptable involve RTE events, which would never execute during setup.

### Related issue(s)/PR(s)
   issue #9030