### PR TITLE
Add timings for admins into Chrome dev tools

### DIFF
--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -94,6 +94,13 @@ class modResponse {
             $queryTime= $this->modx->queryTime;
             $queries= isset ($this->modx->executedQueries) ? $this->modx->executedQueries : 0;
             $phpTime= $totalTime - $queryTime;
+            if ($this->modx->user->hasSessionContext('mgr')) {
+                header('Server-Timing:' . implode(', ', array(
+                    't=' . number_format($totalTime, 6) . '; "Total time"',
+                    'qt=' . number_format($queryTime, 6) . '; "Database time"',
+                    'p=' . number_format($phpTime, 6) . '; "PHP Time"',
+                )));
+            }
             $queryTime= sprintf("%2.4f s", $queryTime);
             $totalTime= sprintf("%2.4f s", $totalTime);
             $phpTime= sprintf("%2.4f s", $phpTime);


### PR DESCRIPTION
### What does it do?
This code will add special response header with timings for users, that logged into manager.

### Why is it needed?
Admins will able to quickly look to the speed of page generation.

![devtools](https://cloud.githubusercontent.com/assets/1257284/22790471/e558ecee-ef18-11e6-95c6-bb17116a30b3.png)

