### PR TITLE
Fix issue deleting resource from resource groups tree if it is in multiple groups (#12842)

### DIFF
--- a/core/model/modx/processors/security/resourcegroup/getnodes.class.php
+++ b/core/model/modx/processors/security/resourcegroup/getnodes.class.php
@@ -56,7 +56,7 @@ class modResourceGroupGetNodesProcessor extends modProcessor {
                     foreach ($resources as $resource) {
                         $list[] = array(
                             'text' => $resource->get('pagetitle').' ('.$resource->get('id').')',
-                            'id' => 'n_'.$resource->get('id'),
+                            'id' => 'n_' . $resource->get('id') . '_' . $resourceGroup->get('id'),
                             'leaf' => true,
                             'type' => 'modResource',
                             'cls' => 'icon-'.$resource->get('class_key'),


### PR DESCRIPTION
### What does it do?
Adds the resource group ID to the ID used in the tree markup. 

### Why is it needed?
Go to Content > Resource Groups and assign a resource to two different resource groups. Because the ID was solely based on the resource ID, there was an ID conflict that ExtJS can't handle, so anything you try to do is only applied to one of the resource IDs. 

By adding in the resource group ID, they have unique IDs again, and everyone's happy. Even ExtJS.

### Related issue(s)/PR(s)
Reported in #12842 