### PR TITLE
fix issue Duplicating a context with a a lot of resources may trigger php memory error ( #13217)

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -1067,9 +1067,17 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $duplicateChildren = isset($options['duplicateChildren']) ? $options['duplicateChildren'] : true;
         if ($duplicateChildren) {
             if (!$this->checkPolicy('add_children')) return $newResource;
+    
+            $criteria = array(
+              'context_key' => $this->get('context_key'),
+              'parent' => $this->get('id')
+             );
 
-            $children = $this->getMany('Children');
-            if (is_array($children) && count($children) > 0) {
+            $count = $this->xpdo->getCount('modResource',$criteria);
+         
+            if ($count > 0) {
+                $children = $this->xpdo->getIterator('modResource',$criteria);
+                                
                 /** @var modResource $child */
                 foreach ($children as $child) {
                     $child->duplicate(array(

--- a/core/model/modx/processors/context/duplicate.class.php
+++ b/core/model/modx/processors/context/duplicate.class.php
@@ -105,11 +105,15 @@ class modContextDuplicateProcessor extends modObjectDuplicateProcessor {
      * @return void
      */
     public function duplicateResources() {
-        $resources = $this->modx->getCollection('modResource',array(
+        $criteria = array(
             'context_key' => $this->object->get('key'),
             'parent' => 0,
-        ));
-        if (count($resources) > 0) {
+        );
+        $count = $this->modx->getCount('modResource',$criteria);
+        
+        if ($count > 0) {
+            $resources = $this->modx->getIterator('modResource',$criteria);
+
             /** @var modResource $resource */
             foreach ($resources as $resource) {
                 $resource->duplicate(array(


### PR DESCRIPTION
### What does it do?
replace getCollection with getIterator

### Related issue(s)/PR(s)
Duplicating a context with a a lot of resources may trigger php memory error #13217