### PR TITLE
Encode HTML in the template description to prevent potential XSS 

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -359,7 +359,7 @@ MODx.combo.Template = function(config) {
         ,fields: ['id','templatename','description','category_name']
         ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{templatename}</span>'
             ,'<tpl if="category_name"> - <span style="font-style:italic">{category_name}</span></tpl>'
-            ,'<br />{description}</div></tpl>')
+            ,'<br />{description:htmlEncode()}</div></tpl>')
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'element/template/getlist'


### PR DESCRIPTION
### What does it do?
Applies the htmlEncode formatter to the description to prevent breakage per #13290 and a potential XSS (requiring permission to edit templates to exploit)

### Why is it needed?
Security and preventing breakage.

### Related issue(s)/PR(s)
#13290, security helpdesk 15