### PR TITLE
Fixed issue #13292 Files Tree images broken when media source above doc root #modxbughunt

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -220,6 +220,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                     if (in_array($ext, $imagesExts)) {
 
+                        $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
+
                         $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
                         $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
                         $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -215,8 +215,49 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                 // trough tree config we can request a tree without image-preview tooltips, don't do any work if not necessary
                 if (!$hideTooltips) {
-                    $files[$fileName]['qtip'] = in_array($ext,$imagesExts) ? '<img src="'.$fromManagerUrl.'" alt="'.$fileName.'" />' : '';
+
+                    $files[$fileName]['qtip'] = '';
+
+                    if (in_array($ext, $imagesExts)) {
+
+                        $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
+                        $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
+                        $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
+                        $thumbnailQuality = $this->getOption('thumbnailQuality', $properties, 90);
+
+                        // get original image size for proportions
+                        $size = @getimagesize($bases['pathAbsoluteWithPath'].$fileName);
+                        if (is_array($size)) {
+                            if ($size[0] > $size[1]) {
+                                // landscape
+                                $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                $imageHeight = 0;
+                            } else {
+                                // portrait or square
+                                $imageWidth = 0;
+                                $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                            }
+                        }
+
+                        $imageQuery = http_build_query(array(
+                            'src' => $bases['urlRelative'].$fileName,
+                            'w' => $imageWidth,
+                            'h' => $imageHeight,
+                            'HTTP_MODAUTH' => $modAuth,
+                            'f' => $thumbnailType,
+                            'q' => $thumbnailQuality,
+                            'wctx' => $this->ctx->get('key'),
+                            'source' => $this->get('id'),
+                        ));
+
+                        $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+
+                        $files[$fileName]['qtip'] = '<img src="'.$image.'" alt="'.$fileName.'" />';
+
+                    }
+
                 }
+
             }
         }
 


### PR DESCRIPTION
### What does it do?
Images for the file tree are now rendered with the phpthumb connector.
- This will also display thumbnails for images in media sources that sit above the doc root (when system setting phpthumb_allow_src_above_docroot Yes).
- Before, the displayed images where the "original" images. Now, they are scaled down with phpthumb if larger than system setting filemanager_image_width or filemanager_image_height.

### Why is it needed?
Fix for Files Tree images broken when media source above doc root.
Scale down images with phpthumb for a faster manager.

### Related issue(s)/PR(s)
modxcms/revolution#13292
