### PR TITLE
Make sure we have a field before trying to store the focused resource field

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -265,12 +265,14 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         }
     }
     ,onFieldChange: function(o) {
-    	//a11y - Set Active Input
-        if(o){
+        //a11y - Set Active Input
+        if (o && o.field) {
             Ext.state.Manager.set('curFocus', o.field.id);
-        }
 
-        if (o && o.field && o.field.name == 'syncsite') return;
+            if (o.field.name === 'syncsite') {
+                return;
+            }
+        }
 
         if (this.isReady || MODx.request.reload) {
             this.warnUnsavedChanges = true;


### PR DESCRIPTION
## What does it do?

Makes sure `field` is defined

## Why is it needed?

When the "field" involved is not a field (in example the resource group grid), it causes a JS error because `o.field` is `undefined`