### PR TITLE
Fix to dirty buggy css hack.

### DIFF
--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -299,8 +299,7 @@ ul.x-tab-strip-bottom {
     background: $coreFieldBg !important; /* ovverride extjs default theme */
     border-right: 1px solid $borderColor !important; /* ovverride extjs default theme */
     float: left;
-    margin-bottom: -10000px; /* dirty hack to make vertical tabs container stretch to bottom */
-    padding-bottom: 10000px !important; /* dirty hack to make vertical tabs container stretch to bottom */
+    margin-right:-170px;
     width: 169px !important; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
 
     .x-tab-strip-wrap {
@@ -374,6 +373,11 @@ ul.x-tab-strip-bottom {
 
   /* this is the area where the TV form fields are displayed */
   .x-tab-panel-bwrap {
+    float: left;
+    padding-left:170px;
+    padding-right: 15px;
+    width: 100%;
+    box-sizing: border-box;
     box-shadow: none;
 
     .x-tab-panel-body {


### PR DESCRIPTION
### What does it do?
This hack very buggy, and can be fixed. 
Key of this fix - `margin-right:-170px;` and `float: left;padding-left:170px;`. 
`width: 100%;padding-right: 15px;box-sizing: border-box;` - is for better visiblity of panel.

### Why is it needed?
Because of that: 
![2017-02-17_17-25-00](https://cloud.githubusercontent.com/assets/801823/23068966/b6414e5a-f536-11e6-8dbb-d8fab5032681.png)

And what happened after this fix:
![2017-02-17_17-27-47](https://cloud.githubusercontent.com/assets/801823/23068986/c32679e2-f536-11e6-8055-99f74d4e606a.png)

### Related issue(s)/PR(s)
n/a
