### PR TITLE
Add DKIM attributes of PHPMailer to modPHPMailer/modMail

### DIFF
--- a/core/model/modx/mail/modmail.class.php
+++ b/core/model/modx/mail/modmail.class.php
@@ -129,6 +129,30 @@ abstract class modMail {
      * @const An option for setting the mail subject
      */
     const MAIL_SUBJECT = 'mail_subject';
+    /**
+     * @const An option for setting the mail DKIM selector
+     */
+    const MAIL_DKIM_SELECTOR = 'mail_dkim_selector';
+    /**
+     * @const An option for setting the DKIM identity you're signing as - usually your From address
+     */
+    const MAIL_DKIM_IDENTITY = 'mail_dkim_identity';
+    /**
+     * @const An option for setting DKIM domain name
+     */
+    const MAIL_DKIM_DOMAIN = 'mail_dkim_domain';
+    /**
+     * @const An option for setting DKIM private key file path
+     */
+    const MAIL_DKIM_PRIVATEKEYFILE = 'mail_dkim_privatekeyfile';
+    /**
+     * @const An option for setting DKIM private key string - takes precedence over MAIL_DKIM_PRIVATEKEYFILE
+     */
+    const MAIL_DKIM_PRIVATEKEYSTRING = 'mail_dkim_privatekeystring';
+    /**
+     * @const An option for setting DKIM passphrase - used if your private key has a passphrase
+     */
+    const MAIL_DKIM_PASSPHRASE = 'mail_dkim_passphrase';
 
     /**
      * A reference to the modX instance communicating with this service instance.
@@ -358,7 +382,7 @@ abstract class modMail {
     public function attach($file) {
         array_push($this->files,$file);
     }
-    
+
     /**
      * Add an embedded image.
      *
@@ -370,7 +394,7 @@ abstract class modMail {
     public function embedImage($image, $cid) {
         array_push($this->images,array('image' => $image, 'cid' => $cid));
     }
-    
+
     /**
      * Clear all embedded images.
      *
@@ -388,20 +412,20 @@ abstract class modMail {
     public function clearAttachments() {
         $this->files = array();
     }
-    
+
     /**
      * Check if there is any error.
-     * 
+     *
      * @access public
      * @return boolean Indicates if there is error.
      */
     public function hasError() {
         return $this->error !== null && $this->error instanceof modError && $this->error->hasError();
     }
-    
+
     /**
      * Get error object
-     * 
+     *
      * @access public
      * @return null|modError
      */

--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -113,6 +113,24 @@ class modPHPMailer extends modMail {
             case modMail::MAIL_SUBJECT :
                 $this->mailer->Subject= $this->attributes[$key];
                 break;
+            case modMail::MAIL_DKIM_SELECTOR :
+                $this->mailer->DKIM_selector= $this->attributes[$key];
+                break;
+            case modMail::MAIL_DKIM_IDENTITY :
+                $this->mailer->DKIM_identity= $this->attributes[$key];
+                break;
+            case modMail::MAIL_DKIM_DOMAIN :
+                $this->mailer->DKIM_domain= $this->attributes[$key];
+                break;
+            case modMail::MAIL_DKIM_PRIVATEKEYFILE :
+                $this->mailer->DKIM_private= $this->attributes[$key];
+                break;
+            case modMail::MAIL_DKIM_PRIVATEKEYSTRING :
+                $this->mailer->DKIM_private_string= $this->attributes[$key];
+                break;
+            case modMail::MAIL_DKIM_PASSPHRASE :
+                $this->mailer->DKIM_passphrase= $this->attributes[$key];
+                break;
             default :
                 $this->modx->log(modX::LOG_LEVEL_WARN, $this->modx->lexicon('mail_err_attr_nv',array('attr' => $key)));
                 break;


### PR DESCRIPTION
### What does it do?
Added constants to modMail for the corresponding DKIM name-fields of PHPMailer. Also added the same constants to the set() method of modPHPMailer for assigning the values to the internal PHPMailer variables. 

Everyone who uses modPHPMailer can use this addition to implement DKIM. 
Code example: $this->modx->mail->set(modMail::MAIL_DKIM_SELECTOR, 'prefix');

### Why is it needed?
Provide Modx with base DKIM functionality. The next step is to implement this in snippets, packages, ...


