### PR TITLE
Fixing modTransport checks

### DIFF
--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -497,7 +497,8 @@ class modTransportPackage extends xPDOObject {
                 'modTransportPackage',
                 array(
                     array(
-                        "UCASE({$this->xpdo->escape('package_name')}) LIKE UCASE({$this->xpdo->quote($package)})"
+                        "UCASE({$this->xpdo->escape('package_name')}) LIKE UCASE({$this->xpdo->quote($package)})",
+                        'OR:signature:LIKE' => $package . '-%'
                     ),
                     'installed:IS' => null,
                 )

--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -724,7 +724,11 @@ class modTransportPackage extends xPDOObject {
      */
     public function previousVersionInstalled() {
         $this->parseSignature();
-        $count = $this->xpdo->getCount('transport.modTransportPackage', array(array("UCASE({$this->xpdo->escape('package_name')}) LIKE UCASE({$this->xpdo->quote($this->identifier)})"), 'installed:IS NOT' => null, 'signature:!=' => $this->get('signature')));
+        $count = $this->xpdo->getCount('transport.modTransportPackage', array(
+            'signature:LIKE' => $this->identifier . "-%",
+            'installed:IS NOT' => null,
+            'signature:!=' => $this->get('signature')
+        ));
         return $count > 0;
     }
 }


### PR DESCRIPTION
### What does it do?
Changed/enhanced the xPDO Query that locates previous installed package versions and dependent packages.

### Why is it needed?
- The check for previous installed packages did not found any installed packages.
- The dependent package check has issues with package names different than the signature. The dependency has to contain the signature without the version to pass the check.

### Related issue(s)/PR(s)
#12666
