### PR TITLE
Lower log level for 'resource with id not found in context' to info [#13278]

### DIFF
--- a/core/model/modx/modcontext.class.php
+++ b/core/model/modx/modcontext.class.php
@@ -313,7 +313,7 @@ class modContext extends modAccessibleObject {
                 }
             } else {
                 $this->xpdo->log(
-                    xPDO::LOG_LEVEL_ERROR,
+                    xPDO::LOG_LEVEL_INFO,
                     "Resource with id {$id} was not found in context {$this->key}",
                     '',
                     __METHOD__,


### PR DESCRIPTION
### What does it do?
Changes the modContext->makeUrl resource-not-found logging introduced in #13268 from an ERROR to an INFO message. 

### Why is it needed?
As detailed and discussed in #13278, the message triggers a fair amount of false-negatives on multi-context sites where you're linking from one context to the other without explicitly referring to the right context. `modX->makeUrl` will automatically fetch the right context after the message is logged. This gets annoying, fast. 

While it's a useful message, the logging in modLinkTag (also added in #13268) is more accurate for the majority of use cases and continues to be logged as an ERROR. 

### Related issue(s)/PR(s)
Introduced in #13268 
Problem discussed in #13278