### PR TITLE
Patch parsing tag on ellipsis

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -326,6 +326,13 @@ class modOutputFilter {
                             $limit= intval($m_val) ? intval($m_val) : 100;
                             $pad = $this->modx->getOption('ellipsis_filter_pad',null,'&#8230;');
 
+                            /* parse all elements first, avoid MODX's tags get truncated */
+                            if ($this->modx->getParser()) {
+                                $maxIterations = intval($this->modx->getOption('parser_max_iterations', array(), 10));
+                                $this->modx->parser->processElementTags('', $output, true, false, '[[', ']]', array(), $maxIterations);
+                                $this->modx->parser->processElementTags('', $output, true, true, '[[', ']]', array(), $maxIterations);
+                            }
+
                             /* ensure that filter correctly counts special chars */
                             $output = html_entity_decode($output,ENT_COMPAT,$encoding);
                             $len = $usemb ? mb_strlen($output,$encoding) : strlen($output);


### PR DESCRIPTION
### What does it do?
This fixes truncated modx's tag when using ellipsis output filter

### Why is it needed?
To avoid revealing modx's tag because the filter truncates the whole tag's call
eg:
In getResources's tpl, you have this output
```
[[+content:ellipsis=`100`]]
```
If there's a chunk/snippet gets cut off, then it will show
```
Morbi cursus tellus augue, nec mattis magna laoreet non. Aliquam nec [[$chunk?...
```
### Related issue(s)/PR(s)
https://forums.modx.com/thread/96866/ellipsis-not-working-as-expected#dis-post-524087