### PR TITLE
Example rule to restrict the manager to one hostname

### DIFF
--- a/ht.access
+++ b/ht.access
@@ -35,10 +35,11 @@ RewriteBase /
 
 
 
-# Redirect the manager to a specific domain
-RewriteCond %{HTTP_HOST} !^example-domain-please-change\.com$ [NC]
-RewriteCond %{REQUEST_URI} ^/manager [NC]
-RewriteRule ^(.*)$ https://example-domain-please-change.com/$1 [R=301,L]
+# Redirect the manager to a specific domain - don't rename the ht.access file
+# in the manager folder to use this this rule
+#RewriteCond %{HTTP_HOST} !^example-domain-please-change\.com$ [NC]
+#RewriteCond %{REQUEST_URI} ^/manager [NC]
+#RewriteRule ^(.*)$ https://example-domain-please-change.com/$1 [R=301,L]
 
 
 

--- a/ht.access
+++ b/ht.access
@@ -16,7 +16,7 @@ RewriteBase /
 # Rewrite www.domain.com -> domain.com -- used with SEO Strict URLs plugin
 #RewriteCond %{HTTP_HOST} .
 #RewriteCond %{HTTP_HOST} ^www.(.*)$ [NC]
-#RewriteRule ^(.*)$ http://%1/$1 [R=301,L]
+#RewriteRule ^(.*)$ https://%1/$1 [R=301,L]
 #
 # or for the opposite domain.com -> www.domain.com use the following
 # DO NOT USE BOTH
@@ -24,7 +24,7 @@ RewriteBase /
 #RewriteCond %{HTTP_HOST} !^$
 #RewriteCond %{HTTP_HOST} !^www\. [NC]
 #RewriteCond %{HTTP_HOST} (.+)$
-#RewriteRule ^(.*)$ http://www.%1/$1 [R=301,L] .
+#RewriteRule ^(.*)$ https://www.%1/$1 [R=301,L] .
 
 
 
@@ -32,6 +32,13 @@ RewriteBase /
 # https://www.domain.com when your cert only allows https://secure.domain.com
 #RewriteCond %{SERVER_PORT} !^443
 #RewriteRule (.*) https://example-domain-please-change.com/$1 [R=301,L]
+
+
+
+# Redirect the manager to a specific domain
+RewriteCond %{HTTP_HOST} !^example-domain-please-change\.com$ [NC]
+RewriteCond %{REQUEST_URI} ^/manager [NC]
+RewriteRule ^(.*)$ https://example-domain-please-change.com/$1 [R=301,L]
 
 
 


### PR DESCRIPTION
### What does it do?
Added an example rule to restrict the manager to one hostname.

### Why is it needed?
- Solving preview issues with the manager with/without www. prefix 
- Solving license issues with commercial package providers, checking licenses on base of the manager hostname.

### Related issue(s)/PR(s)
none known