### PR TITLE
Automatic flush of permissions on group update, create/update/remove policy

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -607,7 +607,7 @@ class modCacheManager extends xPDOCacheManager {
         $publishingResults= array();
         $tblResource= $this->modx->getTableName('modResource');
         $timeNow= time();
-        
+
         /* generate list of resources that are going to be published */
         $stmt = $this->modx->prepare("SELECT id, context_key, pub_date, unpub_date FROM {$tblResource} WHERE pub_date IS NOT NULL AND pub_date < {$timeNow} AND pub_date > 0");
         if ($stmt->execute()) {
@@ -760,7 +760,7 @@ class modCacheManager extends xPDOCacheManager {
     /**
      * Flush permissions for users
      *
-     * @return string|array The success response
+     * @return bool True if successful
      */
     public function flushPermissions() {
         $ctxQuery = $this->modx->newQuery('modContext');
@@ -769,9 +769,11 @@ class modCacheManager extends xPDOCacheManager {
             $contexts = $ctxQuery->stmt->fetchAll(PDO::FETCH_COLUMN);
             if ($contexts) {
                 $serialized = serialize($contexts);
-                $this->modx->exec("UPDATE {$this->modx->getTableName('modUser')} SET {$this->modx->escape('session_stale')} = {$this->modx->quote($serialized)}");
+                if ($this->modx->exec("UPDATE {$this->modx->getTableName('modUser')} SET {$this->modx->escape('session_stale')} = {$this->modx->quote($serialized)}")) {
+                    return true;
+                }
             }
         }
-        return $this->modx->error->success('');
+        return false;
     }
 }

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -756,4 +756,23 @@ class modCacheManager extends xPDOCacheManager {
 
         return $results;
     }
+
+    /**
+     * Flush permissions for users
+     *
+     * @todo Implement flushing permissions for single user
+     * @return string|array The success response
+     */
+    public function flushPermissions() {
+        $ctxQuery = $this->modx->newQuery('modContext');
+        $ctxQuery->select($this->modx->getSelectColumns('modContext', '', '', array('key')));
+        if ($ctxQuery->prepare() && $ctxQuery->stmt->execute()) {
+            $contexts = $ctxQuery->stmt->fetchAll(PDO::FETCH_COLUMN);
+            if ($contexts) {
+                $serialized = serialize($contexts);
+                $this->modx->exec("UPDATE {$this->modx->getTableName('modUser')} SET {$this->modx->escape('session_stale')} = {$this->modx->quote($serialized)}");
+            }
+        }
+        return $this->modx->error->success('');
+    }
 }

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -760,7 +760,6 @@ class modCacheManager extends xPDOCacheManager {
     /**
      * Flush permissions for users
      *
-     * @todo Implement flushing permissions for single user
      * @return string|array The success response
      */
     public function flushPermissions() {

--- a/core/model/modx/processors/security/access/flush.class.php
+++ b/core/model/modx/processors/security/access/flush.class.php
@@ -11,16 +11,7 @@ class modFlushPermissionsProcessor extends modProcessor {
     }
 
     public function process() {
-        $ctxQuery = $this->modx->newQuery('modContext');
-        $ctxQuery->select($this->modx->getSelectColumns('modContext', '', '', array('key')));
-        if ($ctxQuery->prepare() && $ctxQuery->stmt->execute()) {
-            $contexts = $ctxQuery->stmt->fetchAll(PDO::FETCH_COLUMN);
-            if ($contexts) {
-                $serialized = serialize($contexts);
-                $this->modx->exec("UPDATE {$this->modx->getTableName('modUser')} SET {$this->modx->escape('session_stale')} = {$this->modx->quote($serialized)}");
-            }
-        }
-        return $this->success();
+        $this->modx->cacheManager->flushPermissions();
     }
 }
 return 'modFlushPermissionsProcessor';

--- a/core/model/modx/processors/security/access/policy/create.class.php
+++ b/core/model/modx/processors/security/access/policy/create.class.php
@@ -47,5 +47,10 @@ class modAccessPolicyCreateProcessor extends modObjectCreateProcessor {
         }
         return parent::beforeSave();
     }
+
+    public function afterSave() {
+        $this->modx->cacheManager->flushPermissions();
+        return parent::afterSave();
+    }
 }
 return 'modAccessPolicyCreateProcessor';

--- a/core/model/modx/processors/security/access/policy/remove.class.php
+++ b/core/model/modx/processors/security/access/policy/remove.class.php
@@ -12,5 +12,10 @@ class modAccessPolicyRemoveProcessor extends modObjectRemoveProcessor {
     public $languageTopics = array('policy');
     public $permission = 'policy_delete';
     public $objectType = 'policy';
+
+    public function afterRemove() {
+        $this->modx->cacheManager->flushPermissions();
+        return parent::afterRemove();
+    }
 }
 return 'modAccessPolicyRemoveProcessor';

--- a/core/model/modx/processors/security/access/policy/update.class.php
+++ b/core/model/modx/processors/security/access/policy/update.class.php
@@ -33,5 +33,10 @@ class modAccessPolicyUpdateProcessor extends modObjectUpdateProcessor {
 
         return parent::beforeSave();
     }
+
+    public function afterSave() {
+        $this->modx->cacheManager->flushPermissions();
+        return parent::afterSave();
+    }
 }
 return 'modAccessPolicyUpdateProcessor';

--- a/core/model/modx/processors/security/group/create.class.php
+++ b/core/model/modx/processors/security/group/create.class.php
@@ -88,7 +88,7 @@ class modUserGroupCreateProcessor extends modObjectCreateProcessor {
         }
 
         if ($flush) {
-            $this->flushPermissions();
+            $this->modx->cacheManager->flushPermissions();
         }
 
         return parent::afterSave();
@@ -291,19 +291,6 @@ class modUserGroupCreateProcessor extends modObjectCreateProcessor {
             }
         }
         return true;
-    }
-
-    public function flushPermissions() {
-        $ctxQuery = $this->modx->newQuery('modContext');
-        $ctxQuery->select($this->modx->getSelectColumns('modContext', '', '', array('key')));
-        if ($ctxQuery->prepare() && $ctxQuery->stmt->execute()) {
-            $contexts = $ctxQuery->stmt->fetchAll(PDO::FETCH_COLUMN);
-            if ($contexts) {
-                $serialized = serialize($contexts);
-                $this->modx->exec("UPDATE {$this->modx->getTableName('modUser')} SET {$this->modx->escape('session_stale')} = {$this->modx->quote($serialized)}");
-            }
-        }
-        return $this->success();
     }
 
     /**

--- a/core/model/modx/processors/security/group/update.class.php
+++ b/core/model/modx/processors/security/group/update.class.php
@@ -64,7 +64,8 @@ class modUserGroupUpdateProcessor extends modObjectUpdateProcessor {
         $users = $this->getProperty('users',null);
         $id = $this->getProperty('id');
         $memberships = array();
-        
+        $flush = false;
+
         if ($users !== null && !empty($id)) {
             $oldMemberships = $this->object->getMany('UserGroupMembers');
             /** @var modUserGroupMember $oldMembership */
@@ -84,6 +85,10 @@ class modUserGroupUpdateProcessor extends modObjectUpdateProcessor {
                     $memberships[] = $membership;
                 }
             }
+            $flush = true;
+        }
+        if ($flush) {
+            $this->modx->cacheManager->flushPermissions();
         }
         return $memberships;
     }


### PR DESCRIPTION
### What does it do?
Added automatic flush of permission on updating a group, creating/updating/removing policy

### Why is it needed?
It is needed to not manually flush permissions every time when you update a group, create/update/remove a policy

