### PR TITLE
Fixed issue #12701 #modxbughunt

### DIFF
--- a/manager/assets/modext/widgets/source/modx.grid.source.access.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.access.js
@@ -203,9 +203,8 @@ Ext.extend(MODx.window.CreateSourceAccess,MODx.Window,{
                 this.hide();
                 return true;
             }
-        } else {
-            MODx.msg.alert(_('error'),_('user_err_ns'));
         }
+
         return true;
     }
 });


### PR DESCRIPTION
### What does it do?
Removed the empty error pop up. The error pop up was empty because of a missing lexicon. 
I made the choice to remove this pop up because in similar actions which you can do in Modx there is also no error pop up. Besides the error is clear and visible beneath the policy field.

### Why is it needed?
Empty error pop ups gives it a messy look.

### Related issue(s)/PR(s)
#12701 
