### PR TITLE
Fixed issue #13302 #modxbughunt

### DIFF
--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -49,6 +49,7 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             id: this.record.id
             ,type: 'tv'
             ,name: _('duplicate_of',{name: this.record.name})
+            ,caption: _('duplicate_of',{name: this.record.caption})
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'


### PR DESCRIPTION
### What does it do?
The caption field now has a placeholder once you click the duplicate button (at the TV screen itself not the tree).

### Why is it needed?
Because the tree duplicate option did it but the TV screen duplicate button did not.

### Related issue(s)/PR(s)
Fixes #13302 

![template_variable__testname___modx_revolution](https://cloud.githubusercontent.com/assets/8382746/23545999/fa0c3038-fffd-11e6-9489-bf7b9c937557.png)

changed to:

![template_variable__testname___modx_revolution](https://cloud.githubusercontent.com/assets/8382746/23546002/fcb375a8-fffd-11e6-8b93-a91b171f281a.png)
