### PR TITLE
Fix #10299: let developers know that config files will be overwritten #modxbughunt

### DIFF
--- a/_build/resolvers/resolve.core.php
+++ b/_build/resolvers/resolve.core.php
@@ -10,7 +10,7 @@ switch (MODX_SETUP_KEY) {
                 $configContent= "<?php\n"
                     . "/*\n"
                     . " * This file is managed by the installation process.  Any modifications to it may get overwritten.\n"
-                    . " * Add customizations to the $config_options array in `core/config/config.inc.php`.\n"
+                    . " * Add customizations to the \$config_options array in `core/config/config.inc.php`.\n"
                     . " *\n"
                     . " */\n"
                     . "define('MODX_CORE_PATH', '" . MODX_CORE_PATH . "');\n"

--- a/_build/resolvers/resolve.core.php
+++ b/_build/resolvers/resolve.core.php
@@ -8,6 +8,11 @@ switch (MODX_SETUP_KEY) {
         if ($cacheManager= $transport->xpdo->getCacheManager()) {
             if ($targetFile= @ eval($fileMeta['target'])) {
                 $configContent= "<?php\n"
+                    . "/*\n"
+                    . " * This file is managed by the installation process.  Any modifications to it may get overwritten.\n"
+                    . " * Add customizations to the $config_options array in `core/config/config.inc.php`.\n"
+                    . " *\n"
+                    . " */\n"
                     . "define('MODX_CORE_PATH', '" . MODX_CORE_PATH . "');\n"
                     . "define('MODX_CONFIG_KEY', '" . MODX_CONFIG_KEY . "');\n"
                     . "?>";

--- a/_build/templates/config.core.php.txt
+++ b/_build/templates/config.core.php.txt
@@ -1,3 +1,8 @@
 <?php
+/*
+ * This file is managed by the installation process.  Any modifications to it may get overwritten.
+ * Add customizations to the $config_options array in `core/config/config.inc.php`.
+ *
+ */
 define('MODX_CORE_PATH', @core-path@);
 define('MODX_CONFIG_KEY', 'config');


### PR DESCRIPTION
### What does it do?
Adds a comment to the top of autogenerated config files

### Why is it needed?
Most frameworks do not overwrite config files when you upgrade. I have customised them in the past (substituting `__DIR__` for hardcoded paths, so they work on different servers) only to lose the changes when I upgrade. This issue doesn't fix that, but it reminds everyone not to rely on the files.

### Related issues
#10299 

#modxbughunt