### PR TITLE
Fixed issue #13256 #modxbughunt

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -48,7 +48,6 @@ class modFileHandler {
     public function make($path, array $options = array(), $overrideClass = '') {
         $path = $this->sanitizePath($path);
 
-        $class = 'modFile';
         if (!empty($overrideClass)) {
             $class = $overrideClass;
         } else {

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -455,6 +455,12 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $newPath = $this->fileHandler->postfixSlash($newPath);
         $newPath = dirname($oldPath).'/'.$newPath;
 
+        /* check to see if the new resource already exists */
+        if (file_exists($newPath)) {
+            $this->addError('name',$this->xpdo->lexicon('file_folder_err_ae'));
+            return false;
+        }
+
         /* rename the dir */
         if (!$oldDirectory->rename($newPath)) {
             $this->addError('name',$this->xpdo->lexicon('file_folder_err_rename'));
@@ -531,6 +537,16 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         /* sanitize new path */
         $newPath = $this->fileHandler->sanitizePath($newName);
         $newPath = dirname($oldPath).'/'.$newPath;
+
+        /* check to see if the new resource already exists */
+        if (file_exists($newPath)) {
+            if (is_dir($newPath)) {
+                $this->addError('name',$this->xpdo->lexicon('file_folder_err_ae'));
+                return false;
+            }
+            $this->addError('name',sprintf($this->xpdo->lexicon('file_err_ae'),$newName));
+            return false;
+        }
 
         /* rename the file */
         if (!$oldFile->rename($newPath)) {


### PR DESCRIPTION
### What does it do?
Add check before renaming a file or directory to see if the new path not already exists and give the correct response to the client.

### Why is it needed?
To show the correct response for renaming a file or directory.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13256
