### PR TITLE
Fixed issue #13277 - When duplicating context choose if resources should be duplicated #modxbughunt

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -327,6 +327,7 @@ $_lang['po_make_all_unpub'] = 'Make All Unpublished';
 $_lang['po_make_all_pub'] = 'Make All Published';
 $_lang['po_preserve'] = 'Preserve Published Status';
 $_lang['preview'] = 'Preview';
+$_lang['preserve_resources'] = 'Duplicate resources';
 $_lang['preserve_alias'] = 'Preserve duplicated resources alias';
 $_lang['preserve_menuindex'] = 'Preserve duplicated resources menu index';
 $_lang['private'] = 'Private';

--- a/core/model/modx/processors/context/duplicate.class.php
+++ b/core/model/modx/processors/context/duplicate.class.php
@@ -20,7 +20,9 @@ class modContextDuplicateProcessor extends modObjectDuplicateProcessor {
         $this->duplicateSettings();
         $this->duplicateAccessControlLists();
         $this->reloadPermissions();
-        $this->duplicateResources();
+        if (($this->getProperty('preserve_resources') == 'on')) {
+            $this->duplicateResources();
+        }
         return parent::afterSave();
     }
 

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -802,6 +802,25 @@ MODx.window.DuplicateContext = function(config) {
             ,value: ''
         },{
             xtype: 'checkbox'
+            ,id: 'modx-'+this.ident+'-preserveresources'
+            ,hideLabel: true
+            ,boxLabel: _('preserve_resources')
+            ,name: 'preserve_resources'
+            ,anchor: '100%'
+            ,checked: true
+            ,listeners: {
+                'check': {fn: function(cb,checked) {
+                    if (checked) {
+                        this.fp.getForm().findField('modx-'+this.ident+'-preservealias').setValue(true).enable();
+                        this.fp.getForm().findField('modx-'+this.ident+'-preservemenuindex').setValue(true).enable();
+                    } else {
+                        this.fp.getForm().findField('modx-'+this.ident+'-preservealias').setValue(false).disable();
+                        this.fp.getForm().findField('modx-'+this.ident+'-preservemenuindex').setValue(false).disable();
+                    }
+                },scope:this}
+            }
+        },{
+            xtype: 'checkbox'
             ,id: 'modx-'+this.ident+'-preservealias'
             ,hideLabel: true
             ,boxLabel: _('preserve_alias') // Todo: add translation


### PR DESCRIPTION
### What does it do?
Fix issue #13277 
When duplicating context allow user to choose to duplicate resources or not. When un-checking, the options 'Preserve duplicated resources alias' and 'Preserve duplicated resources menu index' are un-checked and disabled.

### Related issue(s)/PR(s)
Issue #13277 
