### PR TITLE
Fixed issue #13298 #modxbughunt

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -166,7 +166,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         );
         $this->itemClass= 'modResource';
         $c= $this->modx->newQuery($this->itemClass);
-        $c->leftJoin('modResource', 'Child', array('modResource.id = Child.parent AND Child.show_in_tree = 1'));
+        $c->leftJoin('modResource', 'Child', array('modResource.id = Child.parent'));
         $c->select($this->modx->getSelectColumns('modResource', 'modResource', '', $resourceColumns));
         $c->select(array(
             'childrenCount' => 'COUNT(Child.id)',
@@ -365,7 +365,7 @@ class modResourceGetNodesProcessor extends modProcessor {
         $nodeFieldFallback = $this->getProperty('nodeFieldFallback');
         $noHref = $this->getProperty('noHref',false);
 
-        $hasChildren = $resource->get('childrenCount') > 0 && !$resource->get('hide_children_in_tree');
+        $hasChildren = $resource->get('childrenCount') > 0;
 
         $class = array();
         if (!$resource->isfolder) {
@@ -505,6 +505,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             $itemArray['expanded'] = true;
         } else {
             $itemArray['hasChildren'] = true;
+            $itemArray['childCount']  = $resource->get('childrenCount');
         }
         $itemArray = $resource->prepareTreeNode($itemArray);
         return $itemArray;

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -123,7 +123,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,duplicateResource: function(item,e) {
         var node = this.cm.activeNode;
         var id = node.id.split('_');id = id[1];
-
+        
         var r = {
             resource: id
             ,is_folder: node.getUI().hasClass('folder')
@@ -132,8 +132,13 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             xtype: 'modx-window-resource-duplicate'
             ,resource: id
             ,hasChildren: node.attributes.hasChildren
+            ,childCount: node.attributes.childCount
             ,listeners: {
-                'success': {fn:function() {this.refreshNode(node.id);},scope:this}
+                'success': {fn:function() {
+                    node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
+                    this.refreshNode(node.id);
+                },scope:this
+                }
             }
         });
         w.config.hasChildren = node.attributes.hasChildren;

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -39,7 +39,7 @@ Ext.extend(MODx.window.DuplicateResource,MODx.Window,{
         if (this.config.hasChildren) {
             items.push({
                 xtype: 'xcheckbox'
-                ,boxLabel: _('duplicate_children')
+                ,boxLabel: _('duplicate_children') + '  ('+this.config.childCount+')'
                 ,hideLabel: true
                 ,name: 'duplicate_children'
                 ,id: 'modx-'+this.ident+'-duplicate-children'


### PR DESCRIPTION
### What does it do?
If you duplicate a resource with resources which are hidden from the tree, the duplicate children option is now also shown. Also I've added a children count next to the duplicate children checkbox.

### Why is it needed?
It wasn't possible to duplicate children of a resource when they where set to hidden in the tree (show_in_tree) because the Duplicate children options was not shown. Now the duplicate children option is also being shown when the children are not being shown in the tree.

### Related issue(s)/PR(s)
Issue #13298 