### PR TITLE
Fixes #4039 Add double encoding option to htmlent output filter #modxbughunt

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -225,7 +225,7 @@ class modOutputFilter {
                         case 'htmlent':
                         case 'htmlentities':
                             /* See PHP's htmlentities - http://www.php.net/manual/en/function.htmlentities.php */
-                            $output = htmlentities($output,ENT_QUOTES,$encoding);
+                            $output = htmlentities($output,ENT_QUOTES,$encoding,($m_val == 'true'));
                             break;
                         case 'htmlspecialchars':
                         case 'htmlspecial':


### PR DESCRIPTION
### What does it do?
Add double encoding option to htmlent output filter

### Why is it needed?
It's useful if you have a TV that contains already-encoded data e.g. `He &amp; She` and you want to output the &amp; to be visible on the page.

Using `[[*myvar:htmlent=`true`]]` will now change the above to `He &amp;amp; She`.

### Related issue(s)/PR(s)
#4039

#modxbughunt