### PR TITLE
#10267 Fixed issue with double dots in the file name #modxbughunt

### DIFF
--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -129,17 +129,17 @@ class modStaticResource extends modResource implements modResourceInterface {
                 } elseif ($this->get('alias')) {
                     $name= $this->get('alias');
                     if ($ext= $this->ContentType->getExtension()) {
-                        $name .= ".{$ext}";
+                        $name .= "{$ext}";
                     }
                 } elseif ($name= $this->get('pagetitle')) {
                     $name= $this->cleanAlias($name);
                     if ($ext= $this->ContentType->getExtension()) {
-                        $name .= ".{$ext}";
+                        $name .= "{$ext}";
                     }
                 } else {
                     $name= 'download';
                     if ($ext= $this->ContentType->getExtension()) {
-                        $name .= ".{$ext}";
+                        $name .= "{$ext}";
                     }
                 }
                 $header= 'Content-Type: ' . $type;


### PR DESCRIPTION
### What does it do?
Removes redundant dots from string which creates filenames using name of resouce and extension from content types.

### Why is it needed?
When you create static resouce with binary content type and mode Attachment, MODX will try to send header for downloading this file. But in case, when FURL turned off, URI param is empty and will be used alias or title, that use formula `$name .= ".{$ext}";`. But currently all content types contains extensions with dots as a result `name` + `.{$ext}` where ext is `.jar` will produce `name..jar`, but should be `name.jar`.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/10267
