### PR TITLE
Allow overriding the resource template on OnDocFormRender #13049 #modxbughunt

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -82,6 +82,11 @@ class ResourceCreateManagerController extends ResourceManagerController {
         $placeholders['parentname'] = $this->setParent();
         $this->fireOnRenderEvent();
 
+        /* set template */
+        if (!is_null($this->resource->get('template')) && $this->resource->get('template') !== 0) {
+            $this->scriptProperties['template'] = $this->resource->get('template');
+        }
+
         /* check permissions */
         $this->setPermissions();
 


### PR DESCRIPTION
### What does it do?
Override document template in OnDocFormRender event.

### Why is it needed?
Add template to scriptproperties if set in OnDocFormRender event.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13049
