### PR TITLE
Re-enable resource save buttons after clearing the locks #12028 #modxbughunt

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -227,7 +227,7 @@ $childrenOfClearCache[0]->fromArray(array (
 $children[1]->addMany($childrenOfClearCache, 'Children');
 
 /* Remove Locks */
-$children[2]= $xpdo->newObject('modMenu');
+/*$children[2]= $xpdo->newObject('modMenu');
 $children[2]->fromArray(array (
   'menuindex' => 2,
   'text' => 'remove_locks',
@@ -252,6 +252,17 @@ MODx.msg.confirm({
          },scope:this}
     }
 });',
+), '', true, true);*/
+
+$children[2]= $xpdo->newObject('modMenu');
+$children[2]->fromArray(array (
+  'menuindex' => 2,
+  'text' => 'remove_locks',
+  'description' => 'remove_locks_desc',
+  'parent' => 'manage',
+  'permissions' => 'remove_locks',
+  'action' => '',
+  'handler' => 'MODx.removeLocks();return false;',
 ), '', true, true);
 
 /* Flush Permissions */

--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -227,33 +227,6 @@ $childrenOfClearCache[0]->fromArray(array (
 $children[1]->addMany($childrenOfClearCache, 'Children');
 
 /* Remove Locks */
-/*$children[2]= $xpdo->newObject('modMenu');
-$children[2]->fromArray(array (
-  'menuindex' => 2,
-  'text' => 'remove_locks',
-  'description' => 'remove_locks_desc',
-  'parent' => 'manage',
-  'permissions' => 'remove_locks',
-  'action' => '',
-  'handler' => '
-MODx.msg.confirm({
-    title: _(\'remove_locks\')
-    ,text: _(\'confirm_remove_locks\')
-    ,url: MODx.config.connectors_url
-    ,params: {
-        action: \'system/remove_locks\'
-    }
-    ,listeners: {
-        \'success\': {fn:function() {
-            var tree = Ext.getCmp("modx-resource-tree");
-            if (tree && tree.rendered) {
-                tree.refresh();
-            }
-         },scope:this}
-    }
-});',
-), '', true, true);*/
-
 $children[2]= $xpdo->newObject('modMenu');
 $children[2]->fromArray(array (
   'menuindex' => 2,

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -227,6 +227,35 @@ Ext.extend(MODx,Ext.Component,{
             });
         }
     }
+    ,removeLocks: function(id) {
+		MODx.msg.confirm({
+			title: _('remove_locks')
+			,text: _('confirm_remove_locks')
+			,url: MODx.config.connectors_url
+			,params: {
+				action: 'system/remove_locks'
+			}
+			,listeners: {
+				'success': {
+					fn:function() {
+						var tree = Ext.getCmp("modx-resource-tree"); 
+						
+						if (tree && tree.rendered) {
+							tree.refresh();
+						}
+
+						var cmp = Ext.getCmp("modx-panel-resource");
+						
+						if (cmp) {
+							Ext.getCmp('modx-abtn-locked').hide();
+							Ext.getCmp('modx-abtn-save').show();	
+						}
+					},
+					scope:this
+				}
+			}
+		});  
+    }
 
     ,sleep: function(ms) {
         var s = new Date().getTime();

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -103,27 +103,33 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
 
     ,getButtons: function(cfg) {
         var btns = [];
-        if (cfg.canSave == 1) {
+        
+        //if (cfg.locked) {
+            btns.push({
+                text: cfg.lockedText || _('locked')
+                ,id: 'modx-abtn-locked'
+                ,handler: Ext.emptyFn
+                ,hidden: (cfg.canSave == 1)
+                ,disabled: true
+            });
+        //}
+        
+        //if (cfg.canSave == 1) {
             btns.push({
                 process: 'resource/update'
                 ,text: _('save')
                 ,id: 'modx-abtn-save'
                 ,cls: 'primary-button'
                 ,method: 'remote'
+                ,hidden: !(cfg.canSave == 1)
                 //,checkDirty: MODx.request.reload ? false : true
                 ,keys: [{
                     key: MODx.config.keymap_save || 's'
                     ,ctrl: true
                 }]
             });
-        } else if (cfg.locked) {
-            btns.push({
-                text: cfg.lockedText || _('locked')
-                ,id: 'modx-abtn-locked'
-                ,handler: Ext.emptyFn
-                ,disabled: true
-            });
-        }
+        //} else if (cfg.locked) {
+	    
         if (cfg.canDuplicate == 1 && (cfg.record.parent !== parseInt(MODx.config.tree_root_id) || cfg.canCreateRoot == 1)) {
             btns.push({
                 text: _('duplicate')

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -104,31 +104,27 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
     ,getButtons: function(cfg) {
         var btns = [];
         
-        //if (cfg.locked) {
-            btns.push({
-                text: cfg.lockedText || _('locked')
-                ,id: 'modx-abtn-locked'
-                ,handler: Ext.emptyFn
-                ,hidden: (cfg.canSave == 1)
-                ,disabled: true
-            });
-        //}
-        
-        //if (cfg.canSave == 1) {
-            btns.push({
-                process: 'resource/update'
-                ,text: _('save')
-                ,id: 'modx-abtn-save'
-                ,cls: 'primary-button'
-                ,method: 'remote'
-                ,hidden: !(cfg.canSave == 1)
-                //,checkDirty: MODx.request.reload ? false : true
-                ,keys: [{
-                    key: MODx.config.keymap_save || 's'
-                    ,ctrl: true
-                }]
-            });
-        //} else if (cfg.locked) {
+        btns.push({
+            text: cfg.lockedText || _('locked')
+            ,id: 'modx-abtn-locked'
+            ,handler: Ext.emptyFn
+            ,hidden: (cfg.canSave == 1)
+            ,disabled: true
+        });
+
+        btns.push({
+            process: 'resource/update'
+            ,text: _('save')
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            ,hidden: !(cfg.canSave == 1)
+            //,checkDirty: MODx.request.reload ? false : true
+            ,keys: [{
+                key: MODx.config.keymap_save || 's'
+                ,ctrl: true
+            }]
+        });
 	    
         if (cfg.canDuplicate == 1 && (cfg.record.parent !== parseInt(MODx.config.tree_root_id) || cfg.canCreateRoot == 1)) {
             btns.push({


### PR DESCRIPTION
### What does it do?
Added the UI of the resource update panel, when you remove resource lockes the save button will show up again (12028) #modxbughunting

### Why is it needed?
You could not save a resource when you removed the resources locks because the save button did not appear.

### Related issue(s)/PR(s)
n/a
