### PR TITLE
Fix #9854 System Info database tables are missing on SQLSRV #modxbughunt

### DIFF
--- a/core/model/modx/processors/system/databasetable/getlist.class.php
+++ b/core/model/modx/processors/system/databasetable/getlist.class.php
@@ -106,7 +106,8 @@ class modDatabaseTableGetListProcessor_sqlsrv extends modDatabaseTableGetListPro
             $row['Index_length'] = $row['index_size'];
             $dt[] = $row;
         }
-    
+
+        return $dt;
     }
 }
 return 'modDatabaseTableGetListProcessor';


### PR DESCRIPTION
### What does it do?
Ensures the tables are created

### Why is it needed?
MySQL has this functionality; SQL Server needs it too

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)

#9854 

#modxbughunt
