### PR TITLE
Feature 10134 Add "Prefix" Output Filter/Modifier #modxbughunt

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -198,6 +198,10 @@ class modOutputFilter {
                             if (!empty($m_val))
                                 $output = $output . $m_val;
                             break;
+                        case 'prefix': /* prepends the options value (if not empty) to the input value */
+                            if (!empty($m_val))
+                                $output = $m_val . $output;
+                            break;
                         case 'lcase':
                         case 'lowercase':
                         case 'strtolower':


### PR DESCRIPTION
### What does it do?
Adds a counterpart to the `cat` output filter. While `cat` appends the value, `prefix` prepends it.

### Why is it needed?
I wrote it because it's so simple, and the ticket has been open since 2013.

I do not think that adding to a minor release is a good idea. If someone has already defined a snipped named `filter:prefix` this addition will break their code (as it's used instead of their custom filter).

But hey, for #modxbughunt we're not discussing first what should be added, even if that would be sensible :)

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)

#10134