### PR TITLE
Feature 13196 - Added system setting to clear resource cache partially

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -288,7 +288,7 @@ $settings['cache_resource_expires']->fromArray(array (
 $settings['cache_resource_clear_partial']= $xpdo->newObject('modSystemSetting');
 $settings['cache_resource_clear_partial']->fromArray(array (
      'key' => 'cache_resource_clear_partial',
-     'value' => '',
+     'value' => 0,
      'xtype' => 'combo-boolean',
      'namespace' => 'core',
      'area' => 'caching',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -285,6 +285,15 @@ $settings['cache_resource_expires']->fromArray(array (
   'area' => 'caching',
   'editedon' => null,
 ), '', true, true);
+$settings['cache_resource_clear_partial']= $xpdo->newObject('modSystemSetting');
+$settings['cache_resource_clear_partial']->fromArray(array (
+     'key' => 'cache_resource_clear_partial',
+     'value' => '',
+     'xtype' => 'combo-boolean',
+     'namespace' => 'core',
+     'area' => 'caching',
+     'editedon' => null,
+ ), '', true, true);
 $settings['cache_scripts']= $xpdo->newObject('modSystemSetting');
 $settings['cache_scripts']->fromArray(array (
   'key' => 'cache_scripts',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -157,6 +157,9 @@ $_lang['setting_cache_disabled_err'] = 'Please state whether or not you want the
 $_lang['setting_cache_expires'] = 'Expiration Time for Default Cache';
 $_lang['setting_cache_expires_desc'] = 'This value (in seconds) sets the amount of time cache files last for default caching.';
 
+$_lang['setting_cache_resource_clear_partial'] = 'Clear Partial Resource Cache for provided contexts';
+$_lang['setting_cache_resource_clear_partial_desc'] = 'When enabled, MODX refresh will only clear resource cache for the provided contexts.';
+
 $_lang['setting_cache_format'] = 'Caching Format to Use';
 $_lang['setting_cache_format_desc'] = '0 = PHP, 1 = JSON, 2 = serialize. One of the formats';
 

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -570,6 +570,23 @@ class modCacheManager extends xPDOCacheManager {
                         $results['context_settings'] = false;
                     }
                     break;
+                case 'resource':
+                    $clearPartial = $this->getOption('cache_resource_clear_partial', null, false);
+                    if (!$clearPartial) {
+                        $results[$partition] = $this->clean($partOptions);
+                    } else {
+                        /* Only clear resource cache for the provided contexts. */
+                        foreach ($partOptions['contexts'] as $ctx) {
+                            $this->modx->cacheManager->delete($ctx,
+                                array(
+                                    xPDO::OPT_CACHE_KEY => $this->modx->getOption('cache_resource_key', null, 'resource'),
+                                    xPDO::OPT_CACHE_HANDLER => $this->modx->getOption('cache_resource_handler', null, $this->modx->getOption(xPDO::OPT_CACHE_HANDLER)),
+                                    xPDO::OPT_CACHE_FORMAT => (int) $this->modx->getOption('cache_resource_format', null, $this->modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP))
+                                )
+                            );
+                        }
+                    }
+                    break;
                 case 'scripts':
                     /* clean the configurable source cache and remove the include files */
                     $results[$partition] = $this->clean($partOptions);


### PR DESCRIPTION
### What does it do?
Added a system setting where you can enable to clear resource cache partially by the provided contexts provided to the cache refresh method.

### Why is it needed?
When updating a resource the resources cache for all contexts would always be cleared. This option makes it possible to clear the cache only for the current active context. By default the new options is set to false, so it will not change anything unless the system setting is changed.

### Related issue(s)/PR(s)
Related issue:
#13196 

#modxbughunt
