### PR TITLE
Output filters date/strftime now accept text-formatted datetime #modxbughunt

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -438,18 +438,13 @@ class modOutputFilter {
                         case 'strftime':
                         case 'date':
                             /* See PHP's strftime - http://www.php.net/manual/en/function.strftime.php */
-                            if (empty($m_val))
+                            if (empty($m_val)) {
                                 $m_val = "%A, %d %B %Y %H:%M:%S"; /* @todo this should be modx default date/time format? Lexicon? */
-                            if (is_numeric($output)) {
-                                $value = 0 + $output;
-                            } else {
+                            }
+                            if (($value = filter_var($output, FILTER_VALIDATE_INT)) === false) {
                                 $value = strtotime($output);
                             }
-                            if ($value != 0 && $value != -1) {
-                                $output= strftime($m_val,$value);
-                            } else {
-                                $output= '';
-                            }
+                            $output = ($value !== false) ? strftime($m_val,$value) : '';
                             break;
 
                         case 'strtotime':

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -440,7 +440,11 @@ class modOutputFilter {
                             /* See PHP's strftime - http://www.php.net/manual/en/function.strftime.php */
                             if (empty($m_val))
                                 $m_val = "%A, %d %B %Y %H:%M:%S"; /* @todo this should be modx default date/time format? Lexicon? */
-                            $value = 0 + $output;
+                            if (is_numeric($output)) {
+                                $value = 0 + $output;
+                            } else {
+                                $value = strtotime($output);
+                            }
                             if ($value != 0 && $value != -1) {
                                 $output= strftime($m_val,$value);
                             } else {


### PR DESCRIPTION
### What does it do?
The :date output filter/modifier needs a UNIX timestamp, which in some cases need the user to prepend the strtotime output filter, and sometimes it doesn't depending on the input.

This PR changes that so the :date output filter checks the input to see if it is a unix time stamp (integer) or a other format, and use strtotime when it is in the wrong format.

### Why is it needed?
Added flexibility. Particularly now, we don't always store dates as Unix timestamps.

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)

#8161