### PR TITLE
very basic try to fix #12380 #modbughunt.

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1137,6 +1137,8 @@ class modX extends xPDO {
                 }
                 $this->request->prepareResponse();
                 exit();
+            } else {
+                $this->sendErrorPage();
             }
             $options= array_merge(
                 array(
@@ -1883,7 +1885,7 @@ class modX extends xPDO {
                 $userId = $this->user->get('id');
         	}
         }
-        
+
         $ml = $this->newObject('modManagerLog');
         $ml->set('user', (integer) $userId);
         $ml->set('occurred', strftime('%Y-%m-%d %H:%M:%S'));


### PR DESCRIPTION
### What does it do?
symlink to non existent resource id leads to a sendError() instead of sendErrorPage()

### Why is it needed?
I think it is just a esthetic problem?

### Related issue(s)/PR(s)
related to Issue #12380
