### PR TITLE
Better sanitizing of conditionals before eval'ing #modbughunt

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -36,7 +36,7 @@ class modOutputFilter {
 
     /**
      * Filters the output
-     * 
+     *
      * @param modElement $element The element to filter
      */
     public function filter(&$element) {
@@ -142,45 +142,26 @@ class modOutputFilter {
                             $condition[]= "&&";
                             break;
                         case 'hide':
-                            $conditional = join(' ', $condition);
-                            try {
-                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
-                                $m_con = intval($m_con);
-                                if ($m_con) {
-                                    $output= null;
-                                }
-                            } catch (Exception $e) {}
+                            if ($this->validateConditionals($condition)) {
+                                $output = self::parseConditions($condition, null, $output);
+                            }
                             break;
                         case 'show':
-                            $conditional = join(' ', $condition);
-                            try {
-                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
-                                $m_con = intval($m_con);
-                                if (!$m_con) {
-                                    $output= null;
-                                }
-                            } catch (Exception $e) {}
+                            if ($this->validateConditionals($condition)) {
+                                $output = self::parseConditions($condition, null, $output, true);
+                            }
+
                             break;
                         case 'then':
-                            $output = null;
-                            $conditional = join(' ', $condition);
-                            try {
-                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
-                                $m_con = intval($m_con);
-                                if ($m_con) {
-                                    $output= $m_val;
-                                }
-                            } catch (Exception $e) {}
+                            if ($this->validateConditionals($condition)) {
+                                $output = self::parseConditions($condition, $m_val, null);
+                            }
+
                             break;
                         case 'else':
-                            $conditional = join(' ', $condition);
-                            try {
-                                $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
-                                $m_con = intval($m_con);
-                                if (!$m_con) {
-                                    $output= $m_val;
-                                }
-                            } catch (Exception $e) {}
+                            if ($this->validateConditionals($condition)) {
+                                $output = self::parseConditions($condition, $m_val, $output, true);
+                            }
                             break;
                         case 'select':
                             $raw= explode("&", $m_val);
@@ -701,6 +682,107 @@ class modOutputFilter {
             // convert $output to string if there were any processing
             $output = (string)$output;
         }
+    }
+
+    /**
+     * Parse a set of conditions
+     *
+     * @param array $conditions Conditionals to parse
+     * @param null|mixed $value The value to set if our parsing matches
+     * @param null|mixed $default The default value to set if our conditions were false
+     * @param bool $negate Negate the comparison
+     * @return bool
+     */
+    private static function parseConditions($conditions, $value = null, $default = null, $negate = false)
+    {
+        $conditional = join(' ', $conditions);
+        try {
+            $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
+            $m_con = intval($m_con);
+            
+            // If negate is true, we want the value of $m_con to be false
+            if (!$negate) {
+                if ($m_con) {
+                    return $value;
+                }
+
+                return $default;
+            }
+
+            if (!$m_con) {
+                return $value;
+            }
+
+        } catch (Exception $e) {
+        }
+
+        return $default;
+    }
+
+    /**
+     * Validate conditionals before running eval
+     *
+     * @param array $conditions Conditionals to validate
+     * @return bool
+     */
+    private function validateConditionals($conditions)
+    {
+        // Check if we have any conditions at all
+        if (count($conditions) == 0) {
+            return false;
+        }
+
+        // Check that first and last element is values and not conditional operators
+        $last_condition = $conditions[count($conditions) - 1];
+        if (!self::isValue($conditions[0]) or !self::isValue($last_condition)) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'Encountered incorrect use of output conditions');
+            return false;
+        }
+
+        // We now loop the conditions to make sure they have the following patter [value, condition, value, ...]
+        for ($i = 0; $i < count($conditions); $i++) {
+            $current_condition = $conditions[$i];
+            if ($i % 2 === 0) {
+                // Even elements in the array should be values
+                if (!self::isValue($current_condition)) {
+                    $this->modx->log(modX::LOG_LEVEL_ERROR, 'Encountered incorrect use of output conditions');
+                    return false;
+                }
+            }
+            else {
+                // Odd elements in the array should be conditions
+                if (!self::isCondition($current_condition)) {
+                    $this->modx->log(modX::LOG_LEVEL_ERROR, 'Encountered incorrect use of output conditions');
+                    return false;
+                }
+            }
+        }
+
+        // If we got here, it means we found no incorrect or unexpected values in the array, the conditions should be
+        // legal.
+        return true;
+    }
+
+    /**
+     * Checks if input is integer og boolean
+     *
+     * @param mixed $input Value from conditions
+     * @return bool
+     */
+    private static function isValue($input)
+    {
+        return is_bool($input) or is_int($input);
+    }
+
+    /**
+     * Checks if input is a condition
+     *
+     * @param mixed $input Value from conditions
+     * @return bool
+     */
+    private static function isCondition($input)
+    {
+        return $input === '&&' or $input === '||';
     }
 
     /**


### PR DESCRIPTION
### What does it do?
This PR fixes a crash that occur if output modifiers are used incorrectly.

The following code causes a PHP error:

```
[[!+modx.user.id:mo=`Administrator`:eq=`1`:then=`Member`:else=`Not member`]]
```

The reason is that the output modifiers uses PHPs `eval` to parse the conditions and their values. In the example above, we try to eval an expression that ends up being `1 1`. This is incorrect syntax. This PR introduces better handling of sanitizing these expressions. The expressions should be on the format `[integer, operator, integer, operator, integer, ...]` where the first and last values has to be integers (or bools), and every odd value has to be operators (either `||` or `&&`). Every even value also has to be integer/bools.

This PR also cleans up some code and removes duplicated code blocks. 

### Why is it needed?
Fixes error

### Related issue(s)/PR(s)
Reported in #13167