### PR TITLE
Fix positioning of TVs on the first tab #13318 #modxbughunt

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -137,6 +137,25 @@ input::-moz-focus-inner {
   &.modx-tv {
     padding: 0 0 0 0px !important;
   }
+        
+div#modx-resource-main-columns {
+         .modx-tv textarea {
+                box-sizing: border-box;
+                width: 100%!important;
+                min-width: 200px;
+        }
+        .modx-tv input[type="text"] {
+                line-height: 20px;
+                height: auto;
+        }    
+        .modx-tv input[type="text"] {
+                line-height: 20px;
+                height: auto;
+        }       
+        .modx-tv .x-superboxselect-input-field {
+                min-width: 200px;
+        }
+ }
 
   /* is outside of the label */
   .modx-tv-inherited {

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -101,7 +101,7 @@ input::-moz-focus-inner {
       opacity: 0;
       filter: alpha(opacity=0); /* for IE <= 8 */
       padding: 17px 8px 0 0;
-      position: absolute; top: 0; left: -8px;
+      position: relative; top: 0; right: 0px;
       transition: all 0.25s;
       width: 16px;
 
@@ -112,7 +112,8 @@ input::-moz-focus-inner {
         color: $coreFieldLabelColor;
         content: $fa-var-refresh;
         font-size: 16px;
-        position: absolute; bottom: 0; left: 0;
+        position: relative; bottom: 0; left: 0;
+        padding-left: 4px;
         text-align: center;
         vertical-align: middle;
         width: 16px; height: 16px;
@@ -134,7 +135,7 @@ input::-moz-focus-inner {
   } /* label.x-form-item-label */
 
   &.modx-tv {
-    padding: 0 0 0 15px !important; /* account for the tv reset icon */
+    padding: 0 0 0 0px !important;
   }
 
   /* is outside of the label */
@@ -394,15 +395,11 @@ input::-moz-focus-inner {
 }
 
 /* issue #5505 */
-.x-form-text, .x-form-display-field {
+.x-form-text {
   /*box-sizing: border-box;*/ /* we cannot use this because extjs calculates widths with the old box-model */
   line-height: 20px;
   min-height: 20px; /* + 5px + 5px padding = 30px */
   padding: 5px;
-}
-.x-form-display-field {
-  border: 1px solid transparent;
-  border-radius: $borderRadius;
 }
 
 .x-form-textarea {

--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -8,7 +8,7 @@
     <div id="modx-tv-tab{$category.id}" class="x-tab{if $category.hidden}-hidden{/if}" title="{$category.category}">
     {foreach from=$category.tvs item=tv name='tv'}
 {if $tv->type NEQ "hidden"}
-    <div class="x-form-item x-tab-item {cycle values=",alt"} modx-tv{if $smarty.foreach.tv.first} tv-first{/if}{if $smarty.foreach.tv.last} tv-last{/if}" id="tv{$tv->id}-tr">
+    <div class="modx-tv-type-{$tv->type} x-form-item x-tab-item {cycle values=",alt"} modx-tv{if $smarty.foreach.tv.first} tv-first{/if}{if $smarty.foreach.tv.last} tv-last{/if}" id="tv{$tv->id}-tr">
         <label for="tv{$tv->id}" class="x-form-item-label modx-tv-label">
             <div class="modx-tv-label-title">
                 {if $showCheckbox|default}<input type="checkbox" name="tv{$tv->id}-checkbox" class="modx-tv-checkbox" value="1" />{/if}


### PR DESCRIPTION
Fixes positioning of tvs on the first tab and moves the resetTV link to the right side of the tv label.

### What does it do?
Remove padding left on tv formfields and move the resettv link to the right side of the tv label.

The details are described here: https://github.com/modxcms/revolution/issues/13318

### Why is it needed?
TVs moved to the first tab have a padding left thats not in line with other form fields. The padding was necessary so the reset TV link could be positioned to the left. Moving the link to the right side of the label and setting padding-left of the formfield to 0 solves the problem.  

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13318