### PR TITLE
Remove scollbar in header window #modxbughunt

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -145,7 +145,7 @@
       /*border-radius: 0;*/
       overflow: visible;
       padding: 0;
-    } 
+    }
   }
 
   form.x-panel-body:first-of-type {
@@ -184,7 +184,7 @@
 
         .x-panel-bwrap {
           padding: 0;
-        
+
           .tab-panel-wrapper {
 
           }
@@ -383,6 +383,10 @@
 
 .ext-el-mask-msg.modx-lockmask div {
   color: $red;
+}
+
+.modx-help-pane .x-window-body {
+  overflow-y: hidden;
 }
 
 /* the loading indicator when refreshing a grid or component */

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -280,6 +280,7 @@ Ext.extend(MODx,Ext.Component,{
 
         MODx.helpWindow = new Ext.Window({
             title: _('help')
+            ,cls: 'modx-help-pane'
             ,width: 850
             ,height: 500
             ,resizable: true


### PR DESCRIPTION
### What does it do?
Add class to the manager help window popup (opened by clicking Help in the Resource editing/creation view). This class hides vertical overflow, which hides the scrollbar outside the iframe.

Current:
![modx-help-current](https://cloud.githubusercontent.com/assets/2326278/23557739/50eaacb2-0031-11e7-90c1-2a51198aa5b4.png)

With patch:
![modx-help-new](https://cloud.githubusercontent.com/assets/2326278/23557738/50e719d0-0031-11e7-924a-08d474826fb4.png)

### Why is it needed?
Remove redundant scrollbar that has no function.

### Related issue(s)/PR(s)
#12914
