### PR TITLE
Bug 12542 getTVValue/setTVValue consider numeric TV names as IDs #modxbughunt

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -823,7 +823,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      * TV is not found.
      */
     public function getTVValue($pk) {
-        $byName = (is_numeric($pk)) ? false : true;
+        $byName = !is_numeric($pk);
 
         /** @var modTemplateVar $tv */
         if ($byName && $this->xpdo instanceof modX) {

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -823,10 +823,8 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      * TV is not found.
      */
     public function getTVValue($pk) {
-        $byName = false;
-        if (is_string($pk)) {
-            $byName = true;
-        }
+        $byName = (is_numeric($pk)) ? false : true;
+
         /** @var modTemplateVar $tv */
         if ($byName && $this->xpdo instanceof modX) {
             $tv = $this->xpdo->getParser()->getElement('modTemplateVar', $pk);
@@ -845,7 +843,9 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      */
     public function setTVValue($pk,$value) {
         $success = false;
-        if (is_string($pk)) {
+        if (is_numeric($pk)) {
+            $pk = intval($pk);
+        } elseif (is_string($pk)) {
             $pk = array('name' => $pk);
         }
         /** @var modTemplateVar $tv */


### PR DESCRIPTION
### What does it do?
Previously any strings received by getTVValue/setTVValue were considered to be the name of a template variable. This caused problems when an identifier like `"240"`. 

### Why is it needed?
As PHP users are used to typecasting on the fly, and as users are unlikely to name TVs as numbers, I've made it check for numeric TV names and treat them as strings.

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)

#12542