### PR TITLE
Stop calling generateContext twice on resource update #modxbughunt

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -723,7 +723,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
             }
         }
         $returnArray['class_key'] = $this->object->get('class_key');
-        $this->workingContext->prepare(true);
+        $this->workingContext->prepare(false);
         $returnArray['preview_url'] = '';
         if (!$this->object->get('deleted')) {
             $returnArray['preview_url'] = $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');


### PR DESCRIPTION
### What does it do?
This sets the `$regenerate` flag on the `modContext:prepare()` function to false, which stops the `generateContext()` call in that case. That call is not required, as the resource update processor also calls a `clearCache` function which refreshes the context cache already.

### Why is it needed?
Before, the context cache was regenerated *twice*. This results in very (!) long execution times for larger sites and is totally useless.

### Related issue(s)/PR(s)
We discovered this while working on https://github.com/modxcms/revolution/issues/12520, through it's not related to that.

#modxbughunt
