### PR TITLE
Use (but limit) system setting for results per page in package management grid #modxbughunt

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -74,7 +74,6 @@ MODx.grid.Package = function(config) {
         };
     }
 
-    var pageSize = parseInt(MODx.config.default_per_page)
     Ext.applyIf(config,{
         title: _('packages')
         ,id: 'modx-package-grid'

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -83,7 +83,6 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
-        ,pageSize: 10
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -84,7 +84,7 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
-        ,pageSize: new Number(parseInt(MODx.config.default_per_page)).constrain(1, 25)
+        ,pageSize: Math.min(parseInt(MODx.config.default_per_page), 25)
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -74,6 +74,7 @@ MODx.grid.Package = function(config) {
         };
     }
 
+    var pageSize = parseInt(MODx.config.default_per_page)
     Ext.applyIf(config,{
         title: _('packages')
         ,id: 'modx-package-grid'
@@ -83,6 +84,7 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
+        ,pageSize: new Number(parseInt(MODx.config.default_per_page)).constrain(1, 25)
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -410,4 +410,3 @@ Ext.extend(MODx.grid.PackageDependencies,MODx.grid.Package, {
     }
 });
 Ext.reg('modx-grid-package-dependencies',MODx.grid.PackageDependencies);
-


### PR DESCRIPTION
Fixes #12518 #modxbughunt

Package management results per page was hard-coded to 10. The bug report suggested using the system setting `default_per_page` but there could be performance problems if this number was really high (since that grid may cause remote requests out to the package provider). So a default cap of 25 was applied to the system setting in this case.