### PR TITLE
Fixed issue #13165 Moving directories up/down adds dir as a subdirect…

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -14,9 +14,7 @@ MODx.tree.Directory = function(config) {
         ,rootName: 'Filesystem'
         ,rootId: '/'
         ,title: _('files')
-        ,ddAppendOnly: false
-        ,enableDrag: true
-        ,enableDrop: true
+        ,ddAppendOnly: true
         ,ddGroup: 'modx-treedrop-sources-dd'
         ,url: MODx.config.connector_url
         ,hideSourceCombo: false


### PR DESCRIPTION
…ory #modxbughunt

### What does it do?
Disables the possibility to sort directories or files.

### Why is it needed?
It should only be possible to drag directories/files into other directories (or root).

### Related issue(s)/PR(s)
modxcms/revolution#13165
