### PR TITLE
Log clear cache action to the manager log 12949 #modxbughunt

### DIFF
--- a/core/model/modx/processors/system/clearcache.class.php
+++ b/core/model/modx/processors/system/clearcache.class.php
@@ -63,12 +63,19 @@ class modSystemClearCacheProcessor extends modProcessor {
             $partition = key($results);
         }
         $this->modx->log(modX::LOG_LEVEL_INFO, 'COMPLETED');
+        
+        $this->runAfterEvents();
+        
         return $this->success($o);
     }
 
     public function runBeforeEvents() {
         /* invoke OnBeforeCacheUpdate event */
         $this->modx->invokeEvent('OnBeforeCacheUpdate');
+    }
+    
+    public function runAfterEvents() {
+	    $this->modx->logManagerAction('clear_cache', '', $this->modx->context->key);
     }
 
     public function getPartitions() {


### PR DESCRIPTION
### What does it do?
It logs the clear cache action to the manager log.

### Why is it needed?
n/a

### Related issue(s)/PR(s)
n/a
