### PR TITLE
Set context_tree_sort to true by default

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -360,7 +360,7 @@ $settings['container_suffix']->fromArray(array (
 $settings['context_tree_sort']= $xpdo->newObject('modSystemSetting');
 $settings['context_tree_sort']->fromArray(array (
   'key' => 'context_tree_sort',
-  'value' => false,
+  'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',


### PR DESCRIPTION
### What does it do?
Set the system setting `context_tree_sort` to true by default.

#modxbughunt 

### Why is it needed?
In the manager you can drag and drop the contexts, but their new position will not be saved unless the system setting `context_tree_sort` is true. There is no point of not having this enable by default when the dragging is always enabled. Also, the default value of `context_tree_sortby` is rank, which uses a indexing system similar to how resources are sorted. This means that the sorting will be the same with this patch.

Note that this patch does not alter the value of existing sites (by upgrading). This is to avoid "breaking" a site which relies on sorting being disabled.

### Related issue(s)/PR(s)
#12759
