### PR TITLE
Prevent inline edit on recently edited dashboard widget causing aliases to change #12129 #modxbughunt

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -28,7 +28,6 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
             header: _('pagetitle')
             ,dataIndex: 'pagetitle'
             //,width: 150
-            ,editor: { xtype: 'textfield' ,allowBlank: false }
         },{
             header: _('published')
             ,dataIndex: 'published'


### PR DESCRIPTION
…hboard widget #modxbughunt

### What does it do?
In the recent edited resources widget you can edit the pagetitle on double click. But by doing that you also change the alias automaticaly. So i turned the editor function off for the pagetitle. Right click still works ofcourse.

### Why is it needed?
So that clients don't change their urls of pages by accident.

### Related issue(s)/PR(s)
#12129 
