### PR TITLE
Fix issue #12510 (mgr performance large installations), #modxbughunt

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -143,12 +143,21 @@ $settings['cache_action_map']->fromArray(array (
 ), '', true, true);
 $settings['cache_alias_map']= $xpdo->newObject('modSystemSetting');
 $settings['cache_alias_map']->fromArray(array (
-  'key' => 'cache_alias_map',
-  'value' => '1',
-  'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'caching',
-  'editedon' => null,
+    'key' => 'cache_alias_map',
+    'value' => '1',
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'caching',
+    'editedon' => null,
+), '', true, true);
+$settings['use_context_resource_table']= $xpdo->newObject('modSystemSetting');
+$settings['use_context_resource_table']->fromArray(array (
+    'key' => 'use_context_resource_table',
+    'value' => '1',
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'caching',
+    'editedon' => null,
 ), '', true, true);
 $settings['cache_context_settings']= $xpdo->newObject('modSystemSetting');
 $settings['cache_context_settings']->fromArray(array (

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -131,6 +131,9 @@ $_lang['setting_cache_action_map_desc'] = 'When enabled, actions (or controller 
 $_lang['setting_cache_alias_map'] = 'Enable Context Alias Map Cache';
 $_lang['setting_cache_alias_map_desc'] = 'When enabled, all Resource URIs are cached into the Context. Enable on smaller sites and disable on larger sites for better performance.';
 
+$_lang['setting_use_context_resource_table'] = 'Use the context resource table';
+$_lang['setting_use_context_resource_table_desc'] = 'When enabled, context refreshes use the context_resource table. This enables you to programmatically have one resource in multiple contexts. If you do not use those multiple resource contexts via the API, you can set this to false. On large sites you will get a potential performance boost in the manager then.';
+
 $_lang['setting_cache_context_settings'] = 'Enable Context Setting Cache';
 $_lang['setting_cache_context_settings_desc'] = 'When enabled, context settings will be cached to reduce load times.';
 

--- a/core/model/modx/mysql/modcontext.class.php
+++ b/core/model/modx/mysql/modcontext.class.php
@@ -22,7 +22,9 @@ class modContext_mysql extends modContext {
             $resourceFields= array('id','parent','uri');
 
             // we do not need to select uri if cache_alias_map is set to false
-            if ($cache_alias_map==0) $resourceFields = array('id','parent');
+            if ($cache_alias_map == 0) {
+                $resourceFields = array('id','parent');
+            }
 
             $resourceCols= $context->xpdo->getSelectColumns('modResource', 'r', '', $resourceFields);
             $contextKey = $context->get('key');
@@ -50,7 +52,9 @@ class modContext_mysql extends modContext {
 
             // output warning if query is too slow
             $time = ((microtime(true)-$time));
-            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            if ($time >= 1.0 && $use_context_resource_table==1) {
+                $context->xpdo->log(modX::LOG_LEVEL_WARN,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            }
         }
         return $stmt;
     }
@@ -93,7 +97,9 @@ class modContext_mysql extends modContext {
             }
 
             $time = ((microtime(true)-$time));
-            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            if ($time >= 1.0 && $use_context_resource_table==1) {
+                $context->xpdo->log(modX::LOG_LEVEL_WARN,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            }
         }
         return $stmt;
     }

--- a/core/model/modx/mysql/modcontext.class.php
+++ b/core/model/modx/mysql/modcontext.class.php
@@ -48,10 +48,9 @@ class modContext_mysql extends modContext {
                 $stmt =& $criteria->stmt;
             }
 
-            // $context->xpdo->log(1,"[BUGHUNT] context: ".$context->get('key'). " sql = ".$sql);
+            // output warning if query is too slow
             $time = ((microtime(true)-$time));
-            $context->xpdo->log(1,"[BUGHUNT] context: ".$context->get('key'). " time = ".$time);
-
+            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
         }
         return $stmt;
     }
@@ -94,7 +93,7 @@ class modContext_mysql extends modContext {
             }
 
             $time = ((microtime(true)-$time));
-            $context->xpdo->log(1,"[BUGHUNT] context weblink: ".$context->get('key'). " time = ".$time);
+            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
         }
         return $stmt;
     }

--- a/core/model/modx/mysql/modcontext.class.php
+++ b/core/model/modx/mysql/modcontext.class.php
@@ -12,16 +12,41 @@ class modContext_mysql extends modContext {
     public static function getResourceCacheMapStmt(&$context) {
         $stmt = false;
         if ($context instanceof modContext) {
+            $time=microtime(true);
+            $cache_alias_map = $context->getOption('cache_alias_map');
+            $use_context_resource_table = $context->getOption('use_context_resource_table',null,1);
+
             $tblResource= $context->xpdo->getTableName('modResource');
             $tblContextResource= $context->xpdo->getTableName('modContextResource');
+
             $resourceFields= array('id','parent','uri');
+
+            // we do not need to select uri if cache_alias_map is set to false
+            if ($cache_alias_map==0) $resourceFields = array('id','parent');
+
             $resourceCols= $context->xpdo->getSelectColumns('modResource', 'r', '', $resourceFields);
-            $bindings = array($context->get('key'), $context->get('key'));
-            $sql = "SELECT {$resourceCols} FROM {$tblResource} `r` FORCE INDEX (`cache_refresh_idx`) LEFT JOIN {$tblContextResource} `cr` ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` WHERE `r`.`id` != `r`.`parent` AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) AND `r`.`deleted` = 0 GROUP BY `r`.`parent`, `r`.`menuindex`, `r`.`id`, `r`.`uri`";
+            $contextKey = $context->get('key');
+            $bindings = array($contextKey, $contextKey);
+
+            $sql  = "SELECT {$resourceCols} FROM {$tblResource} `r` ";
+            if ($use_context_resource_table) {
+                $sql .= "FORCE INDEX (`cache_refresh_idx`) ";
+                $sql .= "LEFT JOIN {$tblContextResource} `cr` ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` ";
+            }
+            $sql .= "WHERE `r`.`deleted` = 0 "; //"AND `r`.`id` != `r`.`parent`";
+            if ($use_context_resource_table) {
+                $sql .= "AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) ";
+                $sql .= "GROUP BY `r`.`parent`, `r`.`menuindex`, `r`.`id`, `r`.`uri` ";
+            }
+
             $criteria = new xPDOCriteria($context->xpdo, $sql, $bindings, false);
             if ($criteria && $criteria->stmt && $criteria->stmt->execute()) {
                 $stmt =& $criteria->stmt;
             }
+
+            // output warning if query is too slow
+            $time = ((microtime(true)-$time));
+            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
         }
         return $stmt;
     }
@@ -29,16 +54,38 @@ class modContext_mysql extends modContext {
     public static function getWebLinkCacheMapStmt(&$context) {
         $stmt = false;
         if ($context instanceof modContext) {
+            $time=microtime(true);
+            $use_context_resource_table = $context->getOption('use_context_resource_table',null,1);
+
             $tblResource = $context->xpdo->getTableName('modResource');
             $tblContextResource = $context->xpdo->getTableName('modContextResource');
             $resourceFields= array('id','content');
+
             $resourceCols= $context->xpdo->getSelectColumns('modResource', 'r', '', $resourceFields);
-            $bindings = array($context->get('key'), $context->get('key'));
-            $sql = "SELECT {$resourceCols} FROM {$tblResource} `r` LEFT JOIN {$tblContextResource} `cr` ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` WHERE `r`.`id` != `r`.`parent` AND `r`.`class_key` = 'modWebLink' AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) AND `r`.`deleted` = 0 GROUP BY `r`.`id`";
+            $contextKey = $context->get('key');
+            $bindings = array($contextKey, $contextKey);
+
+            $sql  = "SELECT {$resourceCols} ";
+            $sql .= "FROM {$tblResource} `r` ";
+            if ($use_context_resource_table) {
+                $sql .= "LEFT JOIN {$tblContextResource} `cr` ";
+                $sql .= "ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` ";
+            }
+            $sql .= "WHERE `r`.`deleted` = 0 "; //"`r`.`id` != `r`.`parent` ";
+            $sql .= "AND `r`.`class_key` = 'modWebLink' ";
+
+            if ($use_context_resource_table) {
+                $sql .= "AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) ";
+                $sql .= "GROUP BY `r`.`id`";
+            }
+
             $criteria = new xPDOCriteria($context->xpdo, $sql, $bindings, false);
             if ($criteria && $criteria->stmt && $criteria->stmt->execute()) {
                 $stmt =& $criteria->stmt;
             }
+
+            $time = ((microtime(true)-$time));
+            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
         }
         return $stmt;
     }

--- a/core/model/modx/mysql/modcontext.class.php
+++ b/core/model/modx/mysql/modcontext.class.php
@@ -26,10 +26,11 @@ class modContext_mysql extends modContext {
 
             $resourceCols= $context->xpdo->getSelectColumns('modResource', 'r', '', $resourceFields);
             $contextKey = $context->get('key');
-            $bindings = array($contextKey, $contextKey);
 
+            $bindings = array();
             $sql  = "SELECT {$resourceCols} FROM {$tblResource} `r` ";
             if ($use_context_resource_table) {
+                $bindings = array($contextKey, $contextKey);
                 $sql .= "FORCE INDEX (`cache_refresh_idx`) ";
                 $sql .= "LEFT JOIN {$tblContextResource} `cr` ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` ";
             }
@@ -37,6 +38,9 @@ class modContext_mysql extends modContext {
             if ($use_context_resource_table) {
                 $sql .= "AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) ";
                 $sql .= "GROUP BY `r`.`parent`, `r`.`menuindex`, `r`.`id`, `r`.`uri` ";
+            } else {
+                $bindings = array($contextKey);
+                $sql .= "   AND `r`.`context_key` = ?";
             }
 
             $criteria = new xPDOCriteria($context->xpdo, $sql, $bindings, false);
@@ -44,9 +48,10 @@ class modContext_mysql extends modContext {
                 $stmt =& $criteria->stmt;
             }
 
-            // output warning if query is too slow
+            // $context->xpdo->log(1,"[BUGHUNT] context: ".$context->get('key'). " sql = ".$sql);
             $time = ((microtime(true)-$time));
-            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            $context->xpdo->log(1,"[BUGHUNT] context: ".$context->get('key'). " time = ".$time);
+
         }
         return $stmt;
     }
@@ -63,11 +68,12 @@ class modContext_mysql extends modContext {
 
             $resourceCols= $context->xpdo->getSelectColumns('modResource', 'r', '', $resourceFields);
             $contextKey = $context->get('key');
-            $bindings = array($contextKey, $contextKey);
 
+            $bindings = array();
             $sql  = "SELECT {$resourceCols} ";
             $sql .= "FROM {$tblResource} `r` ";
             if ($use_context_resource_table) {
+                $bindings = array($contextKey, $contextKey);
                 $sql .= "LEFT JOIN {$tblContextResource} `cr` ";
                 $sql .= "ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` ";
             }
@@ -77,6 +83,9 @@ class modContext_mysql extends modContext {
             if ($use_context_resource_table) {
                 $sql .= "AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) ";
                 $sql .= "GROUP BY `r`.`id`";
+            } else {
+                $bindings = array($contextKey);
+                $sql .= "   AND `r`.`context_key` = ?";
             }
 
             $criteria = new xPDOCriteria($context->xpdo, $sql, $bindings, false);
@@ -85,7 +94,7 @@ class modContext_mysql extends modContext {
             }
 
             $time = ((microtime(true)-$time));
-            if ($time >= 1.0 && $use_context_resource_table==1) $context->xpdo->log(2,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            $context->xpdo->log(1,"[BUGHUNT] context weblink: ".$context->get('key'). " time = ".$time);
         }
         return $stmt;
     }


### PR DESCRIPTION
(cherry picked from commit 78b915ce278fd3fb9743776f732542a76ba98a94)
Replaces wrongly based PR 13354

### What does it do?
Introduces a new system setting 'use_context_resource_table' (set to true by default) which enables you to disable inefficient and unnecessary queries for context refreshes. 
It also logs a warning message when long running queries are detected and gives a hint in the log message to use the system setting.

### Why is it needed?
The mysql/modcontext class implements statements with legacy queries. Those queries contain the context_resource table, which is never populated except you do that with a custom api call (details described in #12520). On large sites with a lot of resources and multiple contexts this makes the manager quite unusable (times measured e.g. to save a resource: +6s, or to save a system setting over 60s in system with 280K resources and 12 contexts). Also the queries do not respect the cache_alias_map setting und return unnecessary data. 

### Related issue(s)/PR(s)
Loose relationship to #13347, which "doubles" the performance problem from here by doing every query twice. 