### PR TITLE
Bug #13309 Help pages shows old documentation-link

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -117,7 +117,7 @@ $settings['automatic_alias']->fromArray(array (
 $settings['base_help_url']= $xpdo->newObject('modSystemSetting');
 $settings['base_help_url']->fromArray(array (
   'key' => 'base_help_url',
-  'value' => '//rtfm.modx.com/display/revolution20/',
+  'value' => '//docs.modx.com/display/revolution20/',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',


### PR DESCRIPTION
Change rtfm to docs

### What does it do?
Change rtfm to docs

### Why is it needed?
One of many places this needs to be updated

### Related issue(s)/PR(s)
13309 - https://github.com/modxcms/revolution/issues/13309
