### PR TITLE
Fixed #12417 #modxbughunt - please specify a valid directory error

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -610,7 +610,11 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
      * @access public
      */
     ,refreshParentNode: function() {
-        this.getLoader().load(this.cm.activeNode.parentNode,this.cm.activeNode.expand);
+        if (this.cm.activeNode) {
+            this.getLoader().load(this.cm.activeNode.parentNode, this.cm.activeNode.expand);
+        } else {
+            this.refresh();
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do?
The error was caused if activenode was not set. I've added a check if activenode is set else refresh the MODX tree.

### Why is it needed?
If activenode was not set, the removed file was not removed from the view and the error "please specify a valid directory error" was displayed.

### Related issue(s)/PR(s)
Related issue:
https://github.com/modxcms/revolution/issues/12417

#modxbughunt