### PR TITLE
You cant delete/unpublish the start_page anymore by the checkboxes on update resource page #10218 #modxbughunt

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -452,6 +452,18 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
      * @return boolean
      */
     public function checkDeletedStatus() {
+	    if (1 == $this->getProperty('deleted', null)) {
+	    	if ($this->modx->getOption('site_start') == $this->getProperty('id')) {
+            	return $this->failure($this->modx->lexicon('resource_err_delete_sitestart'));
+        	}
+        }
+        
+        if (1 != $this->getProperty('published')) {
+	    	if ($this->modx->getOption('site_start') == $this->getProperty('id')) {
+            	return $this->failure($this->modx->lexicon('resource_err_unpublish_sitestart'));
+        	}
+        }
+        
         $deleted = $this->getProperty('deleted',null);
         if ($deleted !== null && $deleted != $this->object->get('deleted')) {
             if ($this->object->get('deleted')) { /* undelete */


### PR DESCRIPTION
### What does it do?
You cant delete/unpublish the start_page anymore by the checkboxes on update resource page

### Why is it needed?
Describe the issue you are solving.

### Related issue(s)/PR(s)
#10218 
