### PR TITLE
Fix #9492 Allow value ‘0’ for multi select TV items (checkbox/listbox)

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -572,7 +572,9 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
                         if (is_array($value)) {
                             $featureInsert = array();
                             while (list($featureValue, $featureItem) = each($value)) {
-                                if(empty($featureItem)) { continue; }
+                                if (isset($featureItem) && $featureItem === '') {
+                                    continue;
+                                }
                                 $featureInsert[count($featureInsert)] = $featureItem;
                             }
                             $value = implode('||',$featureInsert);


### PR DESCRIPTION
### What does it do?
When for example having a Checkbox TV with input option values `Item==0||Item2==1||Item3==2||Item4==3`, checking the item with value 0 does not get saved when saving the resource. This PR fixes that.

### Related issue(s)/PR(s)
Issue #9492 
