### PR TITLE
Fix: Edit context in grid adds context key multiple #13371

### DIFF
--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -59,7 +59,6 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
         if (!empty($contextArray['name'])) {
             $contextArray['name'] .= ' ';
         }
-        $contextArray['name'] .= "({$contextArray['key']})";
         $contextArray['perm'] = array();
         if ($this->canEdit) {
             $contextArray['perm'][] = 'pedit';

--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -56,9 +56,6 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
      */
     public function prepareRow(xPDOObject $object) {
         $contextArray = $object->toArray();
-        if (!empty($contextArray['name'])) {
-            $contextArray['name'] .= ' ';
-        }
         $contextArray['perm'] = array();
         if ($this->canEdit) {
             $contextArray['perm'][] = 'pedit';


### PR DESCRIPTION
The name field in the grid was concatenated from context-name and context-key. PR removes the concatenation. Only the context name is shown in the name field.