### PR TITLE
Fix #12567 - Install "undefined" on package management breadcrumb

### DIFF
--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -123,8 +123,15 @@ Ext.extend(MODx.panel.PackageBeforeInstall, MODx.panel.PackageMetaPanel,{
             bd.trail[bd.trail.length - 1].install = true;
         }
 
+        /* Get the package name. By default it's stored in data.name,
+         but in case of package update, the name is stored in data.package_name. */
+        var name = rec.data.name;
+        if (name === undefined) {
+            name = rec.data.package_name
+        }
+
         var newBcItem = {
-            text : _('install') + ' ' + rec.data.name
+            text : _('install') + ' ' + name
             ,rec: rec
         };
 


### PR DESCRIPTION
### What does it do?
Checks if the 'rec.data.name' variable is undefined, if so, it uses the 'rec.data.package_name' for the name in the breadcrumb, which is the variable which holds the package name when updating a package.

### Related issue(s)/PR(s)
Issue #12567 
