### PR TITLE
Solving 'was requested but no alias was located' on copy document in logs by change logic of getResourceURI method

### DIFF
--- a/core/model/modx/modcontext.class.php
+++ b/core/model/modx/modcontext.class.php
@@ -407,7 +407,8 @@ class modContext extends modAccessibleObject {
     public function getResourceURI($id) {
         if ($this->getOption('cache_alias_map') && isset($this->aliasMap)) {
             $uri = array_search($id, $this->aliasMap);
-        } else {
+        }
+        if (!isset($uri) || $uri == '') {
             $query = $this->xpdo->newQuery('modResource', array(
                 'id' => $id,
                 'deleted' => false,


### PR DESCRIPTION
I have an issue near to #13278. Let me give a little explanation. When i work with MODX i prefer to make copy of document in container, beacause it is shorter way to publish new document (you dont need to choose template, what field is used etc). With 2.5.5 when i make a copy of a document i get error message like this:

(WARN @ ...\core\model\modx\modcontext.class.php : 244) `126` was requested but no alias was located.
(ERROR in modContext::makeUrl @ ..\core\model\modx\modcontext.class.php : 321) Resource with id 126 was not found in context web

I make some investigation and detect, what on line 241 we check if document exist by checking his alias by executing getResourceURI($id). If this method return nothing, we think that document not exist and dont change $found variable to true. When we did not do this, we have this error message in logs, because error message forms if $found variable is false. But this is not right, because our document exist and have alias.

Continuing investigation i found, what the logic of getResourceURI method is check if cache_alias_map is set to true and if aliasMap is generated we get uri from aliasMap otherwise method request document from database. But in my case (when i copy document) aliasMap is formed, but document not added in it. I think where is two solution of it: 1. Theoretically using plugin what will renewing aliasMap after coping document or other actions with document. 2. Change the logic of getResourceURI to be sure, what document really don't exist or dont have uri (this situation is like an error for me, i want to know what documents have empty alias). 

When i propose to change a logic of execution of getResourceURI. In case if document not fing in aliasMap, we will check if document exist in database. This solution will not give alot of additional load, because if aliasMap is formed and contains document inside the database execution will be skipped. This solution tested by me and work fine.

As i right understand the logic this pull request will solve issue #13278, but dont test it on multi Contexts.