### PR TITLE
Disable dd of contexts if context_tree_sort is false

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -49,6 +49,16 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 wn.expand();
             }
         } else {
+            // If we have disabled context sort, make sure dragging and dropping is disabled on the root elements
+            // in the tree. This corresponds to the context nodes.
+            if (MODx.config.context_tree_sort !== '1') {
+                if (typeof(this.root) !== 'undefined' && typeof(this.root.childNodes) !== 'undefined') {
+                    for (var i = 0; i < this.root.childNodes.length; i++) {
+                        this.root.childNodes[i].draggable = false;
+                    }
+                }
+            }
+
             for (var i=0;i<treeState.length;i++) {
                 this.expandPath(treeState[i]);
             }
@@ -123,7 +133,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,duplicateResource: function(item,e) {
         var node = this.cm.activeNode;
         var id = node.id.split('_');id = id[1];
-        
+
         var r = {
             resource: id
             ,is_folder: node.getUI().hasClass('folder')
@@ -178,11 +188,11 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,listeners: {
                 'success': {fn:function() {
 	            	var cmp = Ext.getCmp('modx-grid-context');
-	            	
+
 	            	if (cmp) {
 		            	cmp.refresh();
-	            	} 
-	            	
+	            	}
+
 	                this.refresh();
 	            },scope:this}
             }


### PR DESCRIPTION
### What does it do / Why is it needed?
With the current implementation contexts can be reordered by dragging and dropping them. However, if the system setting `context_tree_sort` is false the state will not be saved. This behavior is counter intuitive as it "fools" the user to belive dragging and dropping is enabled and works.

This PR checks the value of the system setting `context_tree_sort` and if it is disabled it will make the root nodes in the resource tree undraggable. These nodes corresponds to the context nodes (top level).

### Related issue(s)/PR(s)
#13363
