### PR TITLE
Added ability to use bindings in default values

### DIFF
--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -313,10 +313,7 @@ abstract class ResourceManagerController extends modManagerController {
                             $tv->set('inherited',true);
                         }
                         if ($tv->get('value') === null) {
-                            $v = $tv->get('default_text');
-                            if ($tv->get('type') == 'checkbox' && $tv->get('value') == '') {
-                                $v = '';
-                            }
+                            $v = $default;
                             $tv->set('value',$v);
                         }
                     }


### PR DESCRIPTION
### What does it do?

Use the processed default value for TVs being rendered in the manager

### Why is it needed?

It allows using bindings to generate a TV default value.

### Related issue(s)/PR(s)

Should closes #3454
