### PR TITLE
Allow "log_target" setting to be empty and default to "FILE"

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2363,7 +2363,7 @@ class modX extends xPDO {
         }
         if ($initialized) {
             $this->setLogLevel($this->getOption('log_level', $options, xPDO::LOG_LEVEL_ERROR));
-            $this->setLogTarget($this->getOption('log_target', $options, 'FILE'));
+            $this->setLogTarget($this->getOption('log_target', $options, 'FILE', true));
             $debug = $this->getOption('debug');
             if (!is_null($debug) && $debug !== '') {
                 $this->setDebug($debug);


### PR DESCRIPTION
### What does it do?

Checks for empty value when trying to get `log_target` setting.

### Why is it needed?

It allows the setting value to be empty and still default to `FILE` as stated in the setting description (xPDO default being `ECHO`), preventing to crash the connector responses.

### Related issue(s)/PR(s)

Should closes #7659
