### PR TITLE
gives margin to the resource's form title

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -403,6 +403,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 /* panel stylings */
 .modx-page-header, .modx-page-header div {
   background-color: transparent !important;
+  margin-top: 60px;
 }
 
 #modx-content form.x-panel-body {


### PR DESCRIPTION
it overlaps with buttons

### What does it do?

Fixing this.
<img width="770" alt="screen shot 2017-03-08 at 7 44 19 am" src="https://cloud.githubusercontent.com/assets/308524/23685680/f1690e82-03d7-11e7-8e33-dcbb8377297e.png">

To this.
<img width="771" alt="screen shot 2017-03-08 at 7 45 59 am" src="https://cloud.githubusercontent.com/assets/308524/23685690/090f9628-03d8-11e7-877e-e565e69e0810.png">

### Why is it needed?
To avoid curses from our clients.

### Related issue(s)/PR(s)
