### PR TITLE
Fix #13382 - Checking for blocked user on password reset

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -4,6 +4,7 @@ development release, and is only shown to give an idea of what's currently in th
 
 MODX Revolution 2.5.6-pl (TBD)
 ====================================
+- Reduce log level to INFO for links not found by modContext->makeUrl() [#13268]
 - Fix error in Firefox preventing using enter in the uberbar [#12714]
 - Fix error when deleting a file from a TV [#12417]
 - On new installs set base_help_url setting to the new docs subdomain [#13309]

--- a/core/model/modx/modcontext.class.php
+++ b/core/model/modx/modcontext.class.php
@@ -313,7 +313,7 @@ class modContext extends modAccessibleObject {
                 }
             } else {
                 $this->xpdo->log(
-                    xPDO::LOG_LEVEL_ERROR,
+                    xPDO::LOG_LEVEL_INFO,
                     "Resource with id {$id} was not found in context {$this->key}",
                     '',
                     __METHOD__,

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -120,6 +120,14 @@ class modSecurityLoginProcessor extends modProcessor {
     }
 
     /**
+     * Check if user is not active or blocked
+     * @return bool|null|string
+     */
+    public function checkIsBlocked() {
+        return $this->user->checkIsBlocked();
+    }
+
+    /**
      * Check user settings related to authentication
      * @return bool|null|string
      */
@@ -164,7 +172,7 @@ class modSecurityLoginProcessor extends modProcessor {
             return $preventLogin;
         }
 
-        $preventLogin = $this->user->checkIsBlocked();
+        $preventLogin = $this->checkIsBlocked();
         if (!empty($preventLogin)) {
             return $preventLogin;
         }

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -120,48 +120,6 @@ class modSecurityLoginProcessor extends modProcessor {
     }
 
     /**
-     * Check if user is not active or blocked
-     * @return bool|null|string
-     */
-    public function checkIsBlocked() {
-        if (!$this->user->get('active')) {
-            return $this->modx->lexicon('login_user_inactive');
-        }
-
-        /** @var modUserProfile $profile */
-        $profile = $this->user->Profile;
-
-        if ($profile->get('failed_logins') >= $this->modx->getOption('failed_login_attempts') &&
-            $profile->get('blockeduntil') > time()) {
-            return $this->modx->lexicon('login_blocked_too_many_attempts');
-        }
-
-        if ($profile->get('failedlogincount') >= $this->modx->getOption('failed_login_attempts')) {
-            $profile->set('failedlogincount', 0);
-            $profile->set('blocked', 1);
-            $profile->set('blockeduntil', time() + (60 * $this->modx->getOption('blocked_minutes')));
-            $profile->save();
-        }
-        if ($profile->get('blockeduntil') != 0 && $profile->get('blockeduntil') < time()) {
-            $profile->set('failedlogincount', 0);
-            $profile->set('blocked', 0);
-            $profile->set('blockeduntil', 0);
-            $profile->save();
-        }
-        if ($profile->get('blocked')) {
-            return $this->modx->lexicon('login_blocked_admin');
-        }
-        if ($profile->get('blockeduntil') > time()) {
-            return $this->modx->lexicon('login_blocked_error');
-        }
-        if ($profile->get('blockedafter') > 0 && $profile->get('blockedafter') < time()) {
-            return $this->modx->lexicon('login_blocked_error');
-        }
-
-        return false;
-    }
-
-    /**
      * Check user settings related to authentication
      * @return bool|null|string
      */
@@ -206,7 +164,7 @@ class modSecurityLoginProcessor extends modProcessor {
             return $preventLogin;
         }
 
-        $preventLogin = $this->checkIsBlocked();
+        $preventLogin = $this->user->checkIsBlocked();
         if (!empty($preventLogin)) {
             return $preventLogin;
         }


### PR DESCRIPTION
### What does it do?
In manager login page checking if user is blocked and show error message

### Why is it needed?
Don't need to reset password for inactive and blocked users

### Related issue(s)/PR(s)
Issue #13382 
