### PR TITLE
Fixing ‘Code: 200 OK’ message in modx-combo-country

### DIFF
--- a/core/model/modx/processors/system/country/getlist.class.php
+++ b/core/model/modx/processors/system/country/getlist.class.php
@@ -16,9 +16,6 @@ class modCountryGetListProcessor extends modProcessor
     public function process()
     {
         $countryList = $this->getCountryList();
-        if (empty($countryList)) {
-            return $this->failure();
-        }
 
         $countries = array();
         foreach ($countryList as $iso => $country) {
@@ -47,6 +44,16 @@ class modCountryGetListProcessor extends modProcessor
                     unset($_country_lang[$key]);
                 }
             }
+            return $_country_lang;
+        }
+        $iso = $this->getProperty('iso', '');
+        if (!empty($iso)) {
+            foreach ($_country_lang as $key => $value) {
+                if ($key != strtolower($iso)) {
+                    unset($_country_lang[$key]);
+                }
+            }
+            return $_country_lang;
         }
 
         return $_country_lang;


### PR DESCRIPTION
### What does it do?
Don't return `return $this->failure();` if $countryList is empty.

### Why is it needed?
Fixing a `Code: 200 OK {"success":false,"message":"","total":0,"data":[],"object":[]}` message generated by the `modx-combo-country` if i.e. the query string does not match any country in the list. It should return an empty array (or at least an error message in `$this->failure` - overkill in my opinion).

The filtering of the list by the iso property shortens the request answer, if a country is already preselected.

### Related issue(s)/PR(s)
Don't know any.