### PR TITLE
Let's try to get back on tracks with PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
 language: php
-script: "phpunit -c ./phpunit.xml"
+script:
+  - phpunit --version
+  - "phpunit -c ./phpunit.xml"
 
 # Set php versions
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
+  - 7.1
   - 7.0
+  - 5.6
+  - nightly
+  - 5.5
+  - 5.4
+  - 5.3
   - hhvm
 
 matrix:
   allow_failures:
+    - php: nightly
     - php: hhvm
 
 # database credentials
@@ -23,4 +28,5 @@ mysql:
 before_script: 'cd _build/test && ./generateConfigs.sh'
 
 before_install:
-  -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -s -o $HOME/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.9.phar; chmod +x $HOME/.phpenv/versions/5.5/bin/phpunit; fi
+  -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi
+  -  if [[ "(7.0 7.1 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi


### PR DESCRIPTION
## What does it do

* use PHPunit 5.7 to run tests on PHP 7.0+
* added PHP 7.1 (latest stable) & 7.2 (nightly) to the test "matrix"

## Why is it needed

We love green... and our test suite in not ready for PHPunit 6.0 (https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0 & https://github.com/sebastianbergmann/phpunit/wiki/Preparing-for-PHPUnit-6)