### PR TITLE
Remove cached session variables when updating usergroups

### DIFF
--- a/core/model/modx/processors/security/user/update.class.php
+++ b/core/model/modx/processors/security/user/update.class.php
@@ -185,6 +185,8 @@ class modUserUpdateProcessor extends modObjectUpdateProcessor {
             $this->object->addMany($memberships,'UserGroupMembers');
             $this->object->set('primary_group',$primaryGroupId);
             $this->object->save();
+            unset($_SESSION["modx.user.{$this->object->get('id')}.userGroupNames"],
+                $_SESSION["modx.user.{$this->object->get('id')}.userGroups"]);
         }
         return $memberships;
     }


### PR DESCRIPTION
### What does it do?
Removes cached session variables after updating usergroups when updating a user.

### Why is it needed?
Need logout after flushing permissions for changes to take effect when using `$modx->isMember()`

### Related issue(s)/PR(s)
none known
