### PR TITLE
Proper use of json_encode and error handling for outputArray() in processors #modxsnowup

### DIFF
--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -247,7 +247,16 @@ abstract class modProcessor {
      */
     public function outputArray(array $array,$count = false) {
         if ($count === false) { $count = count($array); }
-        return '{"success":true,"total":"'.$count.'","results":'.$this->modx->toJSON($array).'}';
+        $output = json_encode(array(
+            'success' => true,
+            'total' => $count,
+            'results' => $array
+        ));
+        if ($output === false) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'Processor failed creating output array due to JSON error '.json_last_error());
+            return json_encode(array('success' => false));
+        }
+        return $output;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
This PR replaces the `$modx->toJSON()` and the hardcoded string in `modProcessor::outputArray()` with a full `json_encode()` call. It also adds a log message to the MODX error log if `json_encode()` fails and makes sure the processor still returns valid JSON.

### Why is it needed?
If the `$array` was for any reason malformed (in our case it contained illegal UTF-8 characters), the `$modx->toJSON()` returns `false` instead of valid JSON. Due to the fact that the rest of the JSON response was hardcoded as a string the processor returned invalid JSON like
```
{"success":true,"total":"3","results":}
```
(notice the missing data after `"results":`)

### Related issue(s)/PR(s)
(none known)

PR powered by the #modxsnowup