### PR TITLE
Enable Resource Group access column to be sorted

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.grid.resource.security.local.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.resource.security.local.js
@@ -4,7 +4,7 @@ MODx.grid.ResourceSecurity = function(config) {
         header: _('access')
         ,dataIndex: 'access'
         ,width: 40
-        ,sortable: false
+        ,sortable: true
         ,hidden: MODx.perm.resourcegroup_resource_edit != 1
     });
     Ext.applyIf(config,{
@@ -24,6 +24,10 @@ MODx.grid.ResourceSecurity = function(config) {
     MODx.grid.ResourceSecurity.superclass.constructor.call(this,config);
     this.propRecord = Ext.data.Record.create(config.fields);
     this.on('rowclick',MODx.fireResourceFormChange);
+    this.store.sortInfo = {
+        field: 'access',
+        direction: 'DESC'
+    };
 };
 Ext.extend(MODx.grid.ResourceSecurity,MODx.grid.LocalGrid);
 Ext.reg('modx-grid-resource-security',MODx.grid.ResourceSecurity);


### PR DESCRIPTION
### What does it do?
- Allows sorting of **Access** column, just like the **Name** column
- List active groups together at top like Plugins for convenience

### Why is it needed?
Currently only 1 of the available 2 grid columns was sortable. Now you can much more easily see what Resource Group(s) a Resource is assigned to.

### Related issue(s)/PR(s)
Fixes #12426
