### PR TITLE
No addition on a JS string!

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.system.settings.js
+++ b/manager/assets/modext/widgets/system/modx.panel.system.settings.js
@@ -14,7 +14,7 @@ MODx.panel.SystemSettings = function(config) {
         ,bodyStyle: ''
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
-            html: +_('system_settings')+' & '+_('events')
+            html: _('system_settings')+' & '+_('events')
             ,id: 'modx-system-settings-header'
             ,xtype: 'modx-header'
         },MODx.getPageStructure([{


### PR DESCRIPTION
### What does it do?

Removes an addition on a string (system setting page title)

### Why is it needed?

Part of title was displayed as "NaN".

### Related issue(s)/PR(s)

Mess added by yours in #13118