### PR TITLE
[SECURITY-20] Prevent stored XSS in resource pagetitle

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -47,7 +47,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 pcmb.setValue(this.config.record.parent_pagetitle+' ('+this.config.record.parent+')');
             }
             if (!Ext.isEmpty(this.config.record.pagetitle)) {
-                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+Ext.util.Format.stripTags(this.config.record.pagetitle)+'</h2>');
+                var title = Ext.util.Format.stripTags(this.config.record.pagetitle);
+                title = Ext.util.Format.htmlEncode(title);
+                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
             }
             // initial check to enable realtime alias
             if (Ext.isEmpty(this.config.record.alias)) {
@@ -476,6 +478,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 'keyup': {fn: function(f,e) {
                     var titlePrefix = MODx.request.a == 'resource/create' ? _('new_document') : _('document');
                     var title = Ext.util.Format.stripTags(f.getValue());
+                    title = Ext.util.Format.htmlEncode(title);
                     Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
 
                     // check some system settings before doing real time alias transliteration


### PR DESCRIPTION
Reported by Tomáš Melicher via security@modx.com, ticket 20

### What does it do?
Prevent a stored XSS in the manager, limited to authenticated users with resource edit permissions. Details of the vulnerability and CVE assignment will follow. 

### Why is it needed?
Security.

### Related issue(s)/PR(s)
Security report 20.