### PR TITLE
Make sure the package provider attempts different methods of downloading packages

### DIFF
--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -384,9 +384,10 @@ class modTransportPackage extends xPDOObject {
                         'source' => $source,
                     )));
                 }
+            }
 
             /* if not, try curl */
-            } else if (function_exists('curl_init')) {
+            if (empty($content) && function_exists('curl_init')) {
                 $ch = curl_init();
                 curl_setopt($ch, CURLOPT_URL, $source);
                 curl_setopt($ch, CURLOPT_HEADER, 0);
@@ -417,9 +418,10 @@ class modTransportPackage extends xPDOObject {
                 }
                 $content = curl_exec($ch);
                 curl_close($ch);
+            }
 
             /* and as last-ditch resort, try fsockopen */
-            } else {
+            if (empty($content)) {
                 $content = $this->_getByFsockopen($source);
             }
 
@@ -433,7 +435,7 @@ class modTransportPackage extends xPDOObject {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'MODX could not download the file. You must enable allow_url_fopen, cURL or fsockopen to use remote transport packaging.');
             }
         } else {
-             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$this->xpdo->lexicon('package_err_target_write',array(
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$this->xpdo->lexicon('package_err_target_write',array(
                 'targetDir' => $targetDir,
             )));
         }


### PR DESCRIPTION
### What does it do?
If the package provider can't download a package using file_get_contents, it tries with curl, if that fails it tries it with sockets. 

### Why is it needed?
Before it would only try one of the methods, causing package downloads to fail if for example file_get_contents failed. 

This is part of a potentially wider problem described in #13417, but at least makes sure that package downloads are more resilient against potential server configuration issues. 

### Related issue(s)/PR(s)
#13417 