### PR TITLE
[SECURITY-19] Remove htaccess from allowed file types on new installations

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1805,7 +1805,7 @@ $settings['unauthorized_page']->fromArray(array (
 $settings['upload_files']= $xpdo->newObject('modSystemSetting');
 $settings['upload_files']->fromArray(array (
   'key' => 'upload_files',
-  'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,htaccess,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot',
+  'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',


### PR DESCRIPTION
Reported to security@modx.com by Anti Räis in ticket 19 and Tomáš Melicher in ticket 20, the ability to upload or create .htaccess files can cause code execution. In a way this is a feature, but it being enabled by default can pose a risk to users who are unaware that is possible. 

Similar to how php files are not allowed out of the box, this patch will also prevent htaccess files by default. Users that want to manage htaccess from the manager can still do so by updating the upload_files setting after installation.