### PR TITLE
[SECURITY-20] Prevent XSS by cache poisoning via Host header

### DIFF
--- a/core/docs/config.inc.tpl
+++ b/core/docs/config.inc.tpl
@@ -60,7 +60,7 @@ if (!defined('MODX_HTTP_HOST')) {
         $http_host='{http_host}';
         define('MODX_HTTP_HOST', $http_host);
     } else {
-        $http_host= array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : '{http_host}';
+        $http_host= array_key_exists('HTTP_HOST', $_SERVER) ? htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES) : '{http_host}';
         if ($_SERVER['SERVER_PORT'] != 80) {
             $http_host= str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
         }


### PR DESCRIPTION
### What does it do?
Prevents cache poisoning via Host header which can lead to XSS vulnerabilities.

### Why is it needed?
This issue was reported in a recent security issue.

### Related issue(s)/PR(s)
N/A