### PR TITLE
[SECURITY-20] Improve local file inclusion protections

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -90,7 +90,7 @@ class modConnectorResponse extends modResponse {
         /* backwards compat */
         $error =& $this->modx->error;
         /* prevent browsing of subdirectories for security */
-        $target = preg_replace('/(\.+\/)+/', '', htmlspecialchars($options['action']));
+        $target = preg_replace('/[\.]{2,}/', '', htmlspecialchars($options['action']));
 
         $siteId = $this->modx->user->getUserToken($this->modx->context->get('key'));
         $isLogin = $target == 'login' || $target == 'security/login';

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1663,7 +1663,7 @@ class modX extends xPDO {
         if (isset($options['location']) && !empty($options['location'])) $processorsPath .= ltrim($options['location'],'/') . '/';
 
         // Prevent path traversal through the action
-        $action = preg_replace('/(\.+\/)+/', '', htmlspecialchars($action));
+        $action = preg_replace('/[\.]{2,}/', '', htmlspecialchars($action));
 
         // Find the processor file, preferring class based processors over old-style processors
         $processorFile = $processorsPath.ltrim($action . '.class.php','/');

--- a/core/model/modx/processors/browser/directory/chmod.class.php
+++ b/core/model/modx/processors/browser/directory/chmod.class.php
@@ -39,7 +39,7 @@ class modBrowserFolderChmodProcessor extends modProcessor {
         $this->source->initialize();
 
         $dir = $this->getProperty('dir');
-        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        $dir = preg_replace('/[\.]{2,}/', '', htmlspecialchars($dir));
         $success = $this->source->chmodContainer($dir, $this->getProperty('mode'));
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/directory/create.class.php
+++ b/core/model/modx/processors/browser/directory/create.class.php
@@ -41,10 +41,10 @@ class modBrowserFolderCreateProcessor extends modProcessor {
         }
 
         $parent = rawurldecode($this->getProperty('parent',''));
-        $parent = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($parent))),'/');
+        $parent = ltrim(strip_tags(preg_replace('/[\.]{2,}/', '', htmlspecialchars($parent))),'/');
 
         $name = $this->getProperty('name');
-        $name = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($name))),'/');
+        $name = ltrim(strip_tags(preg_replace('/[\.]{2,}/', '', htmlspecialchars($name))),'/');
         $success = $this->source->createContainer($name, $parent);
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/directory/getfiles.class.php
+++ b/core/model/modx/processors/browser/directory/getfiles.class.php
@@ -49,7 +49,7 @@ class modBrowserFolderGetFilesProcessor extends modProcessor {
         }
 
         $dir = $this->getProperty('dir');
-        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        $dir = preg_replace('/[\.]{2,}/', '', htmlspecialchars($dir));
         if ($dir === 'root') {
             $dir = '';
         }

--- a/core/model/modx/processors/browser/directory/getlist.class.php
+++ b/core/model/modx/processors/browser/directory/getlist.class.php
@@ -29,7 +29,7 @@ class modBrowserFolderGetListProcessor extends modProcessor {
             'id' => '',
         ));
         $dir = $this->getProperty('id');
-        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        $dir = preg_replace('/[\.]{2,}/', '', htmlspecialchars($dir));
         if (empty($dir) || $dir === 'root') {
             $this->setProperty('id','');
         } else if (strpos($dir, 'n_') === 0) {

--- a/core/model/modx/processors/browser/directory/remove.class.php
+++ b/core/model/modx/processors/browser/directory/remove.class.php
@@ -41,7 +41,7 @@ class modBrowserFolderRemoveProcessor extends modProcessor {
         }
 
         $dir = $this->getProperty('dir');
-        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($dir));
+        $dir = preg_replace('/[\.]{2,}/', '', htmlspecialchars($dir));
         $success = $this->source->removeContainer($dir);
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/directory/rename.class.php
+++ b/core/model/modx/processors/browser/directory/rename.class.php
@@ -45,9 +45,9 @@ class modBrowserFolderRenameProcessor extends modProcessor {
         }
 
         $path = $this->getProperty('path');
-        $path = preg_replace('/(\.+\/)+/', '', htmlspecialchars($path));
+        $path = preg_replace('/[\.]{2,}/', '', htmlspecialchars($path));
         $name = $this->getProperty('name');
-        $name = preg_replace('/(\.+\/)+/', '', htmlspecialchars($name));
+        $name = preg_replace('/[\.]{2,}/', '', htmlspecialchars($name));
         $response = $this->source->renameContainer($path, $name);
         return $this->handleResponse($response);
     }

--- a/core/model/modx/processors/browser/directory/sort.class.php
+++ b/core/model/modx/processors/browser/directory/sort.class.php
@@ -18,9 +18,9 @@ class modBrowserFolderSortProcessor extends modProcessor {
     }
     public function process() {
         $from = $this->getProperty('from');
-        $from = preg_replace('/(\.+\/)+/', '', htmlspecialchars($from));
+        $from = preg_replace('/[\.]{2,}/', '', htmlspecialchars($from));
         $to = $this->getProperty('to');
-        $to = preg_replace('/(\.+\/)+/', '', htmlspecialchars($to));
+        $to = preg_replace('/[\.]{2,}/', '', htmlspecialchars($to));
         $point = $this->getProperty('point','append');
         if (empty($from)) return $this->failure($this->modx->lexicon('file_folder_err_ns'));
         if (empty($to)) return $this->failure($this->modx->lexicon('file_folder_err_ns'));

--- a/core/model/modx/processors/browser/directory/update.class.php
+++ b/core/model/modx/processors/browser/directory/update.class.php
@@ -38,8 +38,8 @@ class modBrowserFolderUpdateProcessor extends modProcessor {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
 
-        $dir = preg_replace('/(\.+\/)+/', '', htmlspecialchars($this->getProperty('dir')));
-        $name = preg_replace('/(\.+\/)+/', '', htmlspecialchars($this->getProperty('name')));
+        $dir = preg_replace('/[\.]{2,}/', '', htmlspecialchars($this->getProperty('dir')));
+        $name = preg_replace('/[\.]{2,}/', '', htmlspecialchars($this->getProperty('name')));
         $success = $source->renameContainer($dir, $name);
 
         if (!$success) {

--- a/core/model/modx/processors/browser/file/create.class.php
+++ b/core/model/modx/processors/browser/file/create.class.php
@@ -21,10 +21,10 @@ class modBrowserFileCreateProcessor extends modProcessor {
     public function process() {
         /* get base paths and sanitize incoming paths */
         $directory = rawurldecode($this->getProperty('directory',''));
-        $directory = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($directory))),'/');
+        $directory = ltrim(strip_tags(preg_replace('/[\.]{2,}/', '', htmlspecialchars($directory))),'/');
 
         $name = $this->getProperty('name');
-        $name = ltrim(strip_tags(preg_replace('/(\.+\/)+/', '', htmlspecialchars($name))),'/');
+        $name = ltrim(strip_tags(preg_replace('/[\.]{2,}/', '', htmlspecialchars($name))),'/');
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/download.class.php
+++ b/core/model/modx/processors/browser/file/download.class.php
@@ -28,7 +28,7 @@ class modBrowserFileDownloadProcessor extends modProcessor {
     public function getObjectUrl() {
         /* format filename */
         $file = rawurldecode($this->getProperty('file',''));
-        $file = preg_replace('/(\.+\/)+/', '', htmlspecialchars($file));
+        $file = preg_replace('/[\.]{2,}/', '', htmlspecialchars($file));
         $url = $this->source->getObjectUrl($file);
         return $this->success('',array('url' => $url));
     }

--- a/core/model/modx/processors/browser/file/get.class.php
+++ b/core/model/modx/processors/browser/file/get.class.php
@@ -20,7 +20,7 @@ class modBrowserFileGetProcessor extends modProcessor {
     public function process() {
         /* format filename */
         $file = rawurldecode($this->getProperty('file',''));
-        $file = preg_replace('/(\.+\/)+/', '', htmlspecialchars($file));
+        $file = preg_replace('/[\.]{2,}/', '', htmlspecialchars($file));
 
         $loaded = $this->getSource();
         if ($loaded !== true) {

--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -24,7 +24,7 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (empty($file)) {
             return $this->modx->error->failure($this->modx->lexicon('file_err_ns'));
         }
-        $file = preg_replace('/(\.+\/)+/', '', htmlspecialchars($file));
+        $file = preg_replace('/[\.]{2,}/', '', htmlspecialchars($file));
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/rename.class.php
+++ b/core/model/modx/processors/browser/file/rename.class.php
@@ -31,9 +31,9 @@ class modBrowserFileRenameProcessor extends modProcessor {
         }
 
         $oldFile = $this->getProperty('path');
-        $oldFile = preg_replace('/(\.+\/)+/', '', htmlspecialchars($oldFile));
+        $oldFile = preg_replace('/[\.]{2,}/', '', htmlspecialchars($oldFile));
         $name = $this->getProperty('name');
-        $name = preg_replace('/(\.+\/)+/', '', htmlspecialchars($name));
+        $name = preg_replace('/[\.]{2,}/', '', htmlspecialchars($name));
         $success = $this->source->renameObject($oldFile, $name);
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/file/unpack.class.php
+++ b/core/model/modx/processors/browser/file/unpack.class.php
@@ -30,7 +30,7 @@ class modUnpackProcessor extends modProcessor {
         $this->modx->getService('fileHandler', 'modFileHandler');
 
         $target = $this->modx->getOption('base_path') . $this->properties['path'] . $this->properties['file'];
-        $target = preg_replace('/(\.+\/)+/', '', htmlspecialchars($target));
+        $target = preg_replace('/[\.]{2,}/', '', htmlspecialchars($target));
         $fileobj = $this->modx->fileHandler->make($target);
 
         if (!$this->validate($fileobj)) {

--- a/core/model/modx/processors/browser/file/update.class.php
+++ b/core/model/modx/processors/browser/file/update.class.php
@@ -21,7 +21,7 @@ class modBrowserFileUpdateProcessor extends modProcessor {
     public function process() {
         /* get base paths and sanitize incoming paths */
         $filePath = rawurldecode($this->getProperty('file',''));
-        $filePath = preg_replace('/(\.+\/)+/', '', htmlspecialchars($filePath));
+        $filePath = preg_replace('/[\.]{2,}/', '', htmlspecialchars($filePath));
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/upload.class.php
+++ b/core/model/modx/processors/browser/file/upload.class.php
@@ -37,7 +37,7 @@ class modBrowserFileUploadProcessor extends modProcessor {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
 
-        $path = preg_replace('/(\.+\/)+/', '', htmlspecialchars($this->getProperty('path')));
+        $path = preg_replace('/[\.]{2,}/', '', htmlspecialchars($this->getProperty('path')));
         $success = $this->source->uploadObjectsToContainer($path,$_FILES);
 
         if (empty($success)) {

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -52,7 +52,7 @@ class modInstall {
      */
     function __construct(array $options = array()) {
         if (isset ($_REQUEST['action'])) {
-            $this->action = preg_replace('/(\.+\/)+/', '', htmlspecialchars($_REQUEST['action']));
+            $this->action = preg_replace('/[\.]{2,}/', '', htmlspecialchars($_REQUEST['action']));
         }
         if (is_array($options)) {
             $this->options = $options;


### PR DESCRIPTION
### What does it do?
This commit improves the LFI protections throughout the core to remove any sequence of 2 or more `.` characters regardless of the path delimiter that precedes or follows it.

### Why is it needed?
The existing protections would not work on Windows platforms with backslash path delimiters.

### Related issue(s)/PR(s)
N/A