### PR TITLE
Fixed Fatal error.

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -100,6 +100,12 @@ class modOutputFilter {
                         case 'equaltoorlessthan':
                             $condition[]= intval(($output <= $m_val));
                             break;
+						case 'inarray':
+						case 'in_array':
+						case 'ia':
+							$m_val = explode(',', $m_val);
+							$condition[]= in_array($output, $m_val);
+							break;
                         case 'gt':
                         case 'isgt':
                         case 'greaterthan':

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -149,7 +149,7 @@ abstract class ResourceManagerController extends modManagerController {
      * @return array|bool|string
      */
     public function firePreRenderEvents() {
-        $resourceId = !empty($this->resource) ? $this->resource->get('id') : (!empty($this->scriptProperties['id']) ? $this->scriptProperties['id'] : 0);
+        $resourceId = (is_object($this->resource)) ? $this->resource->get('id') : (!empty($this->scriptProperties['id']) ? $this->scriptProperties['id'] : 0);
         $properties = array(
             'id' => $resourceId,
             'mode' => !empty($resourceId) ? modSystemEvent::MODE_UPD : modSystemEvent::MODE_NEW,


### PR DESCRIPTION
### What does it do?
Fixes «Fatal error: Call to a member function get() on array in /.../manager/controllers/default/resource/resource.class.php on line 152»

### Why is it needed?
I upgraded from 2.5.4 to 2.5.7 and was getting page with error when I click on a resource to edit it. 

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13085
https://forums.modx.com/thread/100583/upgrade-to-2-5-1-white-screens-when-editing-resources