### PR TITLE
Session callback expects true/false

### DIFF
--- a/core/model/modx/modsessionhandler.class.php
+++ b/core/model/modx/modsessionhandler.class.php
@@ -140,8 +140,8 @@ class modSessionHandler {
      */
     public function gc($max) {
         $maxtime= time() - $this->gcMaxLifetime;
-        $result = $this->modx->removeCollection('modSession', array("{$this->modx->escape('access')} < {$maxtime}"));
-        return $result;
+        $this->modx->removeCollection('modSession', array("{$this->modx->escape('access')} < {$maxtime}"));
+        return true;
     }
 
     /**

--- a/core/model/modx/modsessionhandler.class.php
+++ b/core/model/modx/modsessionhandler.class.php
@@ -140,8 +140,8 @@ class modSessionHandler {
      */
     public function gc($max) {
         $maxtime= time() - $this->gcMaxLifetime;
-        $this->modx->removeCollection('modSession', array("{$this->modx->escape('access')} < {$maxtime}"));
-        return true;
+        $result = $this->modx->removeCollection('modSession', array("{$this->modx->escape('access')} < {$maxtime}"));
+        return $result !== false;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
It forces modSessionHandler to return boolean instead of integer.

### Why is it needed?
This will fix PHP7 warnings in logs
```
session_start(): Session callback expects true/false
```

### Related issue(s)/PR(s)
#13073 and #13041