### PR TITLE
fixed fatal error

### DIFF
--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -149,7 +149,7 @@ abstract class ResourceManagerController extends modManagerController {
      * @return array|bool|string
      */
     public function firePreRenderEvents() {
-        $resourceId = !empty($this->resource) ? $this->resource->get('id') : (!empty($this->scriptProperties['id']) ? $this->scriptProperties['id'] : 0);
+        $resourceId = !empty($this->resource) && ($this->resource instanceof $this->resourceClass) ? $this->resource->get('id') : (!empty($this->scriptProperties['id']) ? $this->scriptProperties['id'] : 0);
         $properties = array(
             'id' => $resourceId,
             'mode' => !empty($resourceId) ? modSystemEvent::MODE_UPD : modSystemEvent::MODE_NEW,


### PR DESCRIPTION
when opened a resource, manager goes blank, because $this->resource is an array
`
[Wed Apr 26 12:41:37.170177 2017] [:error] [pid 7050] [client 127.0.0.1:38750] PHP Fatal error:  Call to a member function get() on array in /var/www/html/modx-revo-addons-dev/www/manager-dev/controllers/default/resource/resource.class.php on line 152, referer: http://localhost/modx-revo-addons-dev/www/manager-dev/index.php
`

### What does it do?
Conditional checking.

### Why is it needed?
Fixes fatal error.

### Related issue(s)/PR(s)
-
