### PR TITLE
Fix logging an empty value

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -679,7 +679,7 @@ class modUser extends modPrincipal {
             $rolePk = is_string($roleId) ? array('name' => $roleId) : $roleId;
             $role = $this->xpdo->getObject('modUserGroupRole',$rolePk);
             if (empty($role)) {
-                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'Role not found with key: '.$role);
+                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Role not found with key: ' . $roleId);
                 return $joined;
             }
         }


### PR DESCRIPTION
### What does it do?
Use the right variable.

### Why is it needed?
At the moment, only an empty variable is logged.

### Related issue(s)/PR(s)
None known.
