### PR TITLE
Change new installs to create tables with InnoDB engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: precise
+dist: trusty
+sudo: required
 language: php
 script:
   - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
   - nightly
   - 5.5
   - 5.4
-  - 5.3
+#  - 5.3
   - hhvm
 
 matrix:

--- a/core/model/modx/mysql/modaccess.map.inc.php
+++ b/core/model/modx/mysql/modaccess.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modAccess']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'target' => '',

--- a/core/model/modx/mysql/modaccessaction.map.inc.php
+++ b/core/model/modx/mysql/modaccessaction.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessAction']= array (
   'version' => '1.1',
   'table' => 'access_actions',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modaccessactiondom.map.inc.php
+++ b/core/model/modx/mysql/modaccessactiondom.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessActionDom']= array (
   'version' => '1.1',
   'table' => 'access_actiondom',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modaccesscategory.map.inc.php
+++ b/core/model/modx/mysql/modaccesscategory.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessCategory']= array (
   'version' => '1.1',
   'table' => 'access_category',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => '',

--- a/core/model/modx/mysql/modaccesscontext.map.inc.php
+++ b/core/model/modx/mysql/modaccesscontext.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessContext']= array (
   'version' => '1.1',
   'table' => 'access_context',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modaccesselement.map.inc.php
+++ b/core/model/modx/mysql/modaccesselement.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessElement']= array (
   'version' => '1.1',
   'table' => 'access_elements',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => '',

--- a/core/model/modx/mysql/modaccessibleobject.map.inc.php
+++ b/core/model/modx/mysql/modaccessibleobject.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modAccessibleObject']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modaccessiblesimpleobject.map.inc.php
+++ b/core/model/modx/mysql/modaccessiblesimpleobject.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modAccessibleSimpleObject']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'modAccessibleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'id' => NULL,

--- a/core/model/modx/mysql/modaccessmenu.map.inc.php
+++ b/core/model/modx/mysql/modaccessmenu.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessMenu']= array (
   'version' => '1.1',
   'table' => 'access_menus',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modaccessnamespace.map.inc.php
+++ b/core/model/modx/mysql/modaccessnamespace.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessNamespace']= array (
   'version' => '1.1',
   'table' => 'access_namespace',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => '',

--- a/core/model/modx/mysql/modaccesspermission.map.inc.php
+++ b/core/model/modx/mysql/modaccesspermission.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessPermission']= array (
   'version' => '1.1',
   'table' => 'access_permissions',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'template' => 0,

--- a/core/model/modx/mysql/modaccesspolicy.map.inc.php
+++ b/core/model/modx/mysql/modaccesspolicy.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessPolicy']= array (
   'version' => '1.1',
   'table' => 'access_policies',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => NULL,

--- a/core/model/modx/mysql/modaccesspolicytemplate.map.inc.php
+++ b/core/model/modx/mysql/modaccesspolicytemplate.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessPolicyTemplate']= array (
   'version' => '1.1',
   'table' => 'access_policy_templates',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'template_group' => 0,

--- a/core/model/modx/mysql/modaccesspolicytemplategroup.map.inc.php
+++ b/core/model/modx/mysql/modaccesspolicytemplategroup.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessPolicyTemplateGroup']= array (
   'version' => '1.1',
   'table' => 'access_policy_template_groups',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modaccessresource.map.inc.php
+++ b/core/model/modx/mysql/modaccessresource.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessResource']= array (
   'version' => '1.1',
   'table' => 'access_resources',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => '',

--- a/core/model/modx/mysql/modaccessresourcegroup.map.inc.php
+++ b/core/model/modx/mysql/modaccessresourcegroup.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessResourceGroup']= array (
   'version' => '1.1',
   'table' => 'access_resource_groups',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => '',

--- a/core/model/modx/mysql/modaccesstemplatevar.map.inc.php
+++ b/core/model/modx/mysql/modaccesstemplatevar.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessTemplateVar']= array (
   'version' => '1.1',
   'table' => 'access_templatevars',
   'extends' => 'modAccessElement',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modaction.map.inc.php
+++ b/core/model/modx/mysql/modaction.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAction']= array (
   'version' => '1.1',
   'table' => 'actions',
   'extends' => 'modAccessibleSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'namespace' => 'core',

--- a/core/model/modx/mysql/modactiondom.map.inc.php
+++ b/core/model/modx/mysql/modactiondom.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modActionDom']= array (
   'version' => '1.1',
   'table' => 'actiondom',
   'extends' => 'modAccessibleSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'set' => 0,

--- a/core/model/modx/mysql/modactionfield.map.inc.php
+++ b/core/model/modx/mysql/modactionfield.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modActionField']= array (
   'version' => '1.1',
   'table' => 'actions_fields',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'action' => '',

--- a/core/model/modx/mysql/modactiveuser.map.inc.php
+++ b/core/model/modx/mysql/modactiveuser.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modActiveUser']= array (
   'version' => '1.1',
   'table' => 'active_users',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'internalKey' => 0,

--- a/core/model/modx/mysql/modcategory.map.inc.php
+++ b/core/model/modx/mysql/modcategory.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modCategory']= array (
   'version' => '1.1',
   'table' => 'categories',
   'extends' => 'modAccessibleSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'parent' => 0,

--- a/core/model/modx/mysql/modcategoryclosure.map.inc.php
+++ b/core/model/modx/mysql/modcategoryclosure.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modCategoryClosure']= array (
   'version' => '1.1',
   'table' => 'categories_closure',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'ancestor' => 0,

--- a/core/model/modx/mysql/modchunk.map.inc.php
+++ b/core/model/modx/mysql/modchunk.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modChunk']= array (
   'version' => '1.1',
   'table' => 'site_htmlsnippets',
   'extends' => 'modElement',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modclassmap.map.inc.php
+++ b/core/model/modx/mysql/modclassmap.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modClassMap']= array (
   'version' => '1.1',
   'table' => 'class_map',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'class' => '',

--- a/core/model/modx/mysql/modcontenttype.map.inc.php
+++ b/core/model/modx/mysql/modcontenttype.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modContentType']= array (
   'version' => '1.1',
   'table' => 'content_type',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => NULL,

--- a/core/model/modx/mysql/modcontext.map.inc.php
+++ b/core/model/modx/mysql/modcontext.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modContext']= array (
   'version' => '1.1',
   'table' => 'context',
   'extends' => 'modAccessibleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'key' => NULL,

--- a/core/model/modx/mysql/modcontextresource.map.inc.php
+++ b/core/model/modx/mysql/modcontextresource.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modContextResource']= array (
   'version' => '1.1',
   'table' => 'context_resource',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => NULL,

--- a/core/model/modx/mysql/modcontextsetting.map.inc.php
+++ b/core/model/modx/mysql/modcontextsetting.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modContextSetting']= array (
   'version' => '1.1',
   'table' => 'context_setting',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => NULL,

--- a/core/model/modx/mysql/moddashboard.map.inc.php
+++ b/core/model/modx/mysql/moddashboard.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDashboard']= array (
   'version' => '1.1',
   'table' => 'dashboard',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/moddashboardwidget.map.inc.php
+++ b/core/model/modx/mysql/moddashboardwidget.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDashboardWidget']= array (
   'version' => '1.1',
   'table' => 'dashboard_widget',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/moddashboardwidgetplacement.map.inc.php
+++ b/core/model/modx/mysql/moddashboardwidgetplacement.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDashboardWidgetPlacement']= array (
   'version' => '1.1',
   'table' => 'dashboard_widget_placement',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'dashboard' => 0,

--- a/core/model/modx/mysql/moddocument.map.inc.php
+++ b/core/model/modx/mysql/moddocument.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modDocument']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'modResource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modelement.map.inc.php
+++ b/core/model/modx/mysql/modelement.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modElement']= array (
   'version' => '1.1',
   'table' => 'site_element',
   'extends' => 'modAccessibleSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'source' => 0,

--- a/core/model/modx/mysql/modelementpropertyset.map.inc.php
+++ b/core/model/modx/mysql/modelementpropertyset.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modElementPropertySet']= array (
   'version' => '1.1',
   'table' => 'element_property_sets',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'element' => 0,

--- a/core/model/modx/mysql/modevent.map.inc.php
+++ b/core/model/modx/mysql/modevent.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modEvent']= array (
   'version' => '1.1',
   'table' => 'system_eventnames',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => NULL,

--- a/core/model/modx/mysql/modextensionpackage.map.inc.php
+++ b/core/model/modx/mysql/modextensionpackage.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modExtensionPackage']= array (
   'version' => '1.1',
   'table' => 'extension_packages',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'namespace' => 'core',

--- a/core/model/modx/mysql/modformcustomizationprofile.map.inc.php
+++ b/core/model/modx/mysql/modformcustomizationprofile.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modFormCustomizationProfile']= array (
   'version' => '1.1',
   'table' => 'fc_profiles',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modformcustomizationprofileusergroup.map.inc.php
+++ b/core/model/modx/mysql/modformcustomizationprofileusergroup.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modFormCustomizationProfileUserGroup']= array (
   'version' => '1.1',
   'table' => 'fc_profiles_usergroups',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'usergroup' => 0,

--- a/core/model/modx/mysql/modformcustomizationset.map.inc.php
+++ b/core/model/modx/mysql/modformcustomizationset.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modFormCustomizationSet']= array (
   'version' => '1.1',
   'table' => 'fc_sets',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'profile' => 0,

--- a/core/model/modx/mysql/modjsonrpcresource.map.inc.php
+++ b/core/model/modx/mysql/modjsonrpcresource.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modJSONRPCResource']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'modXMLRPCResource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modlexiconentry.map.inc.php
+++ b/core/model/modx/mysql/modlexiconentry.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modLexiconEntry']= array (
   'version' => '1.1',
   'table' => 'lexicon_entries',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modmanagerlog.map.inc.php
+++ b/core/model/modx/mysql/modmanagerlog.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modManagerLog']= array (
   'version' => '1.1',
   'table' => 'manager_log',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'user' => 0,

--- a/core/model/modx/mysql/modmenu.map.inc.php
+++ b/core/model/modx/mysql/modmenu.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modMenu']= array (
   'version' => '1.1',
   'table' => 'menus',
   'extends' => 'modAccessibleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'text' => '',

--- a/core/model/modx/mysql/modnamespace.map.inc.php
+++ b/core/model/modx/mysql/modnamespace.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modNamespace']= array (
   'version' => '1.1',
   'table' => 'namespaces',
   'extends' => 'modAccessibleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modplugin.map.inc.php
+++ b/core/model/modx/mysql/modplugin.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modPlugin']= array (
   'version' => '1.1',
   'table' => 'site_plugins',
   'extends' => 'modScript',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'cache_type' => 0,

--- a/core/model/modx/mysql/modpluginevent.map.inc.php
+++ b/core/model/modx/mysql/modpluginevent.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modPluginEvent']= array (
   'version' => '1.1',
   'table' => 'site_plugin_events',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'pluginid' => 0,

--- a/core/model/modx/mysql/modprincipal.map.inc.php
+++ b/core/model/modx/mysql/modprincipal.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modPrincipal']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modpropertyset.map.inc.php
+++ b/core/model/modx/mysql/modpropertyset.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modPropertySet']= array (
   'version' => '1.1',
   'table' => 'property_set',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modresource.map.inc.php
+++ b/core/model/modx/mysql/modresource.map.inc.php
@@ -9,6 +9,10 @@ $xpdo_meta_map['modResource']= array (
   'table' => 'site_content',
   'extends' => 'modAccessibleSimpleObject',
   'inherit' => 'single',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'type' => 'document',

--- a/core/model/modx/mysql/modresource.map.inc.php
+++ b/core/model/modx/mysql/modresource.map.inc.php
@@ -9,11 +9,11 @@ $xpdo_meta_map['modResource']= array (
   'table' => 'site_content',
   'extends' => 'modAccessibleSimpleObject',
   'inherit' => 'single',
-  'tableMeta' => 
+  'tableMeta' =>
   array (
     'engine' => 'InnoDB',
   ),
-  'fields' => 
+  'fields' =>
   array (
     'type' => 'document',
     'contentType' => 'text/html',
@@ -58,9 +58,9 @@ $xpdo_meta_map['modResource']= array (
     'show_in_tree' => 1,
     'properties' => NULL,
   ),
-  'fieldMeta' => 
+  'fieldMeta' =>
   array (
-    'type' => 
+    'type' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '20',
@@ -68,7 +68,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 'document',
     ),
-    'contentType' => 
+    'contentType' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '50',
@@ -76,7 +76,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 'text/html',
     ),
-    'pagetitle' => 
+    'pagetitle' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '255',
@@ -86,7 +86,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'longtitle' => 
+    'longtitle' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '255',
@@ -96,7 +96,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'description' => 
+    'description' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '255',
@@ -106,7 +106,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'alias' => 
+    'alias' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '255',
@@ -115,7 +115,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => '',
       'index' => 'index',
     ),
-    'link_attributes' => 
+    'link_attributes' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '255',
@@ -123,7 +123,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => '',
     ),
-    'published' => 
+    'published' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -133,7 +133,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'pub_date' => 
+    'pub_date' =>
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -142,7 +142,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'unpub_date' => 
+    'unpub_date' =>
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -151,7 +151,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'parent' => 
+    'parent' =>
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -160,7 +160,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'isfolder' => 
+    'isfolder' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -170,21 +170,21 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'introtext' => 
+    'introtext' =>
     array (
       'dbtype' => 'text',
       'phptype' => 'string',
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'content' => 
+    'content' =>
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'string',
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'richtext' => 
+    'richtext' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -193,7 +193,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 1,
     ),
-    'template' => 
+    'template' =>
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -202,7 +202,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'menuindex' => 
+    'menuindex' =>
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -211,17 +211,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'searchable' => 
-    array (
-      'dbtype' => 'tinyint',
-      'precision' => '1',
-      'attributes' => 'unsigned',
-      'phptype' => 'boolean',
-      'null' => false,
-      'default' => 1,
-      'index' => 'index',
-    ),
-    'cacheable' => 
+    'searchable' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -231,7 +221,17 @@ $xpdo_meta_map['modResource']= array (
       'default' => 1,
       'index' => 'index',
     ),
-    'createdby' => 
+    'cacheable' =>
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'attributes' => 'unsigned',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'createdby' =>
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -239,7 +239,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'createdon' => 
+    'createdon' =>
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -247,7 +247,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'editedby' => 
+    'editedby' =>
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -255,7 +255,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'editedon' => 
+    'editedon' =>
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -263,7 +263,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'deleted' => 
+    'deleted' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -272,7 +272,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'deletedon' => 
+    'deletedon' =>
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -280,7 +280,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'deletedby' => 
+    'deletedby' =>
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -288,7 +288,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'publishedon' => 
+    'publishedon' =>
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -296,7 +296,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'publishedby' => 
+    'publishedby' =>
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -304,7 +304,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'menutitle' => 
+    'menutitle' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '255',
@@ -312,7 +312,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => '',
     ),
-    'donthit' => 
+    'donthit' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -321,7 +321,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'privateweb' => 
+    'privateweb' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -330,7 +330,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'privatemgr' => 
+    'privatemgr' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -339,7 +339,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'content_dispo' => 
+    'content_dispo' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -347,7 +347,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'hidemenu' => 
+    'hidemenu' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -357,7 +357,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'class_key' => 
+    'class_key' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '100',
@@ -366,7 +366,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 'modDocument',
       'index' => 'index',
     ),
-    'context_key' => 
+    'context_key' =>
     array (
       'dbtype' => 'varchar',
       'precision' => '100',
@@ -375,7 +375,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 'web',
       'index' => 'index',
     ),
-    'content_type' => 
+    'content_type' =>
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -384,14 +384,14 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 1,
     ),
-    'uri' => 
+    'uri' =>
     array (
       'dbtype' => 'text',
       'phptype' => 'string',
       'null' => true,
       'index' => 'index',
     ),
-    'uri_override' => 
+    'uri_override' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -400,7 +400,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'hide_children_in_tree' => 
+    'hide_children_in_tree' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -409,7 +409,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'show_in_tree' => 
+    'show_in_tree' =>
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -418,24 +418,24 @@ $xpdo_meta_map['modResource']= array (
       'default' => 1,
       'index' => 'index',
     ),
-    'properties' => 
+    'properties' =>
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'json',
       'null' => true,
     ),
   ),
-  'indexes' => 
+  'indexes' =>
   array (
-    'alias' => 
+    'alias' =>
     array (
       'alias' => 'alias',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'alias' => 
+        'alias' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -443,15 +443,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'published' => 
+    'published' =>
     array (
       'alias' => 'published',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'published' => 
+        'published' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -459,15 +459,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'pub_date' => 
+    'pub_date' =>
     array (
       'alias' => 'pub_date',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'pub_date' => 
+        'pub_date' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -475,15 +475,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'unpub_date' => 
+    'unpub_date' =>
     array (
       'alias' => 'unpub_date',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'unpub_date' => 
+        'unpub_date' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -491,15 +491,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'parent' => 
+    'parent' =>
     array (
       'alias' => 'parent',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'parent' => 
+        'parent' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -507,15 +507,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'isfolder' => 
+    'isfolder' =>
     array (
       'alias' => 'isfolder',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'isfolder' => 
+        'isfolder' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -523,15 +523,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'template' => 
+    'template' =>
     array (
       'alias' => 'template',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'template' => 
+        'template' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -539,15 +539,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'menuindex' => 
+    'menuindex' =>
     array (
       'alias' => 'menuindex',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'menuindex' => 
+        'menuindex' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -555,15 +555,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'searchable' => 
+    'searchable' =>
     array (
       'alias' => 'searchable',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'searchable' => 
+        'searchable' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -571,15 +571,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'cacheable' => 
+    'cacheable' =>
     array (
       'alias' => 'cacheable',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'cacheable' => 
+        'cacheable' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -587,15 +587,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'hidemenu' => 
+    'hidemenu' =>
     array (
       'alias' => 'hidemenu',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'hidemenu' => 
+        'hidemenu' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -603,15 +603,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'class_key' => 
+    'class_key' =>
     array (
       'alias' => 'class_key',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'class_key' => 
+        'class_key' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -619,15 +619,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'context_key' => 
+    'context_key' =>
     array (
       'alias' => 'context_key',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'context_key' => 
+        'context_key' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -635,31 +635,31 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'uri' => 
+    'uri' =>
     array (
       'alias' => 'uri',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'uri' => 
+        'uri' =>
         array (
-          'length' => '333',
+          'length' => '255',
           'collation' => 'A',
           'null' => true,
         ),
       ),
     ),
-    'uri_override' => 
+    'uri_override' =>
     array (
       'alias' => 'uri_override',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'uri_override' => 
+        'uri_override' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -667,15 +667,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'hide_children_in_tree' => 
+    'hide_children_in_tree' =>
     array (
       'alias' => 'hide_children_in_tree',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'hide_children_in_tree' => 
+        'hide_children_in_tree' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -683,15 +683,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'show_in_tree' => 
+    'show_in_tree' =>
     array (
       'alias' => 'show_in_tree',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'show_in_tree' => 
+        'show_in_tree' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -699,39 +699,39 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'content_ft_idx' => 
+    'content_ft_idx' =>
     array (
       'alias' => 'content_ft_idx',
       'primary' => false,
       'unique' => false,
       'type' => 'FULLTEXT',
-      'columns' => 
+      'columns' =>
       array (
-        'pagetitle' => 
+        'pagetitle' =>
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'longtitle' => 
+        'longtitle' =>
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'description' => 
+        'description' =>
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'introtext' => 
+        'introtext' =>
         array (
           'length' => '',
           'collation' => 'A',
           'null' => true,
         ),
-        'content' => 
+        'content' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -739,27 +739,27 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'cache_refresh_idx' => 
+    'cache_refresh_idx' =>
     array (
       'alias' => 'cache_refresh_index',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' => 
+      'columns' =>
       array (
-        'parent' => 
+        'parent' =>
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'menuindex' => 
+        'menuindex' =>
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'id' => 
+        'id' =>
         array (
           'length' => '',
           'collation' => 'A',
@@ -768,9 +768,9 @@ $xpdo_meta_map['modResource']= array (
       ),
     ),
   ),
-  'composites' => 
+  'composites' =>
   array (
-    'Children' => 
+    'Children' =>
     array (
       'class' => 'modResource',
       'local' => 'id',
@@ -778,7 +778,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarResources' => 
+    'TemplateVarResources' =>
     array (
       'class' => 'modTemplateVarResource',
       'local' => 'id',
@@ -786,7 +786,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'ResourceGroupResources' => 
+    'ResourceGroupResources' =>
     array (
       'class' => 'modResourceGroupResource',
       'local' => 'id',
@@ -794,7 +794,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'Acls' => 
+    'Acls' =>
     array (
       'class' => 'modAccessResource',
       'local' => 'id',
@@ -802,7 +802,7 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'local',
       'cardinality' => 'many',
     ),
-    'ContextResources' => 
+    'ContextResources' =>
     array (
       'class' => 'modContextResource',
       'local' => 'id',
@@ -811,9 +811,9 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'local',
     ),
   ),
-  'aggregates' => 
+  'aggregates' =>
   array (
-    'Parent' => 
+    'Parent' =>
     array (
       'class' => 'modResource',
       'local' => 'parent',
@@ -821,7 +821,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'CreatedBy' => 
+    'CreatedBy' =>
     array (
       'class' => 'modUser',
       'local' => 'createdby',
@@ -829,7 +829,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'EditedBy' => 
+    'EditedBy' =>
     array (
       'class' => 'modUser',
       'local' => 'editedby',
@@ -837,7 +837,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'DeletedBy' => 
+    'DeletedBy' =>
     array (
       'class' => 'modUser',
       'local' => 'deletedby',
@@ -845,7 +845,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'PublishedBy' => 
+    'PublishedBy' =>
     array (
       'class' => 'modUser',
       'local' => 'publishedby',
@@ -853,7 +853,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'Template' => 
+    'Template' =>
     array (
       'class' => 'modTemplate',
       'local' => 'template',
@@ -861,7 +861,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'TemplateVars' => 
+    'TemplateVars' =>
     array (
       'class' => 'modTemplateVar',
       'local' => 'id:template',
@@ -869,7 +869,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarTemplates' => 
+    'TemplateVarTemplates' =>
     array (
       'class' => 'modTemplateVarTemplate',
       'local' => 'template',
@@ -877,7 +877,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'ContentType' => 
+    'ContentType' =>
     array (
       'class' => 'modContentType',
       'local' => 'content_type',
@@ -885,7 +885,7 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'foreign',
       'cardinality' => 'one',
     ),
-    'Context' => 
+    'Context' =>
     array (
       'class' => 'modContext',
       'local' => 'context_key',

--- a/core/model/modx/mysql/modresourcegroup.map.inc.php
+++ b/core/model/modx/mysql/modresourcegroup.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modResourceGroup']= array (
   'version' => '1.1',
   'table' => 'documentgroup_names',
   'extends' => 'modAccessibleSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modresourcegroupresource.map.inc.php
+++ b/core/model/modx/mysql/modresourcegroupresource.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modResourceGroupResource']= array (
   'version' => '1.1',
   'table' => 'document_groups',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'document_group' => 0,

--- a/core/model/modx/mysql/modscript.map.inc.php
+++ b/core/model/modx/mysql/modscript.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modScript']= array (
   'version' => '1.1',
   'table' => 'site_script',
   'extends' => 'modElement',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modsession.map.inc.php
+++ b/core/model/modx/mysql/modsession.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modSession']= array (
   'version' => '1.1',
   'table' => 'session',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'id' => '',

--- a/core/model/modx/mysql/modsnippet.map.inc.php
+++ b/core/model/modx/mysql/modsnippet.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modSnippet']= array (
   'version' => '1.1',
   'table' => 'site_snippets',
   'extends' => 'modScript',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'cache_type' => 0,

--- a/core/model/modx/mysql/modstaticresource.map.inc.php
+++ b/core/model/modx/mysql/modstaticresource.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modStaticResource']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'modResource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modsymlink.map.inc.php
+++ b/core/model/modx/mysql/modsymlink.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modSymLink']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'modResource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modsystemsetting.map.inc.php
+++ b/core/model/modx/mysql/modsystemsetting.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modSystemSetting']= array (
   'version' => '1.1',
   'table' => 'system_settings',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'key' => '',

--- a/core/model/modx/mysql/modtemplate.map.inc.php
+++ b/core/model/modx/mysql/modtemplate.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modTemplate']= array (
   'version' => '1.1',
   'table' => 'site_templates',
   'extends' => 'modElement',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'templatename' => '',

--- a/core/model/modx/mysql/modtemplatevar.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevar.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modTemplateVar']= array (
   'version' => '1.1',
   'table' => 'site_tmplvars',
   'extends' => 'modElement',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'type' => '',

--- a/core/model/modx/mysql/modtemplatevarresource.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevarresource.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modTemplateVarResource']= array (
   'version' => '1.1',
   'table' => 'site_tmplvar_contentvalues',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'tmplvarid' => 0,

--- a/core/model/modx/mysql/modtemplatevarresourcegroup.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevarresourcegroup.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modTemplateVarResourceGroup']= array (
   'version' => '1.1',
   'table' => 'site_tmplvar_access',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'tmplvarid' => 0,

--- a/core/model/modx/mysql/modtemplatevartemplate.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevartemplate.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modTemplateVarTemplate']= array (
   'version' => '1.1',
   'table' => 'site_tmplvar_templates',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'tmplvarid' => 0,

--- a/core/model/modx/mysql/moduser.map.inc.php
+++ b/core/model/modx/mysql/moduser.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUser']= array (
   'version' => '1.1',
   'table' => 'users',
   'extends' => 'modPrincipal',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'username' => '',

--- a/core/model/modx/mysql/modusergroup.map.inc.php
+++ b/core/model/modx/mysql/modusergroup.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUserGroup']= array (
   'version' => '1.1',
   'table' => 'membergroup_names',
   'extends' => 'modPrincipal',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modusergroupmember.map.inc.php
+++ b/core/model/modx/mysql/modusergroupmember.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUserGroupMember']= array (
   'version' => '1.1',
   'table' => 'member_groups',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'user_group' => 0,

--- a/core/model/modx/mysql/modusergrouprole.map.inc.php
+++ b/core/model/modx/mysql/modusergrouprole.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUserGroupRole']= array (
   'version' => '1.1',
   'table' => 'user_group_roles',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => NULL,

--- a/core/model/modx/mysql/modusergroupsetting.map.inc.php
+++ b/core/model/modx/mysql/modusergroupsetting.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUserGroupSetting']= array (
   'version' => '1.1',
   'table' => 'user_group_settings',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'group' => 0,

--- a/core/model/modx/mysql/modusermessage.map.inc.php
+++ b/core/model/modx/mysql/modusermessage.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUserMessage']= array (
   'version' => '1.1',
   'table' => 'user_messages',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'type' => '',

--- a/core/model/modx/mysql/moduserprofile.map.inc.php
+++ b/core/model/modx/mysql/moduserprofile.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUserProfile']= array (
   'version' => '1.1',
   'table' => 'user_attributes',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'internalKey' => NULL,

--- a/core/model/modx/mysql/modusersetting.map.inc.php
+++ b/core/model/modx/mysql/modusersetting.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modUserSetting']= array (
   'version' => '1.1',
   'table' => 'user_settings',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'user' => 0,

--- a/core/model/modx/mysql/modweblink.map.inc.php
+++ b/core/model/modx/mysql/modweblink.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modWebLink']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'modResource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/mysql/modworkspace.map.inc.php
+++ b/core/model/modx/mysql/modworkspace.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modWorkspace']= array (
   'version' => '1.1',
   'table' => 'workspaces',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/mysql/modxmlrpcresource.map.inc.php
+++ b/core/model/modx/mysql/modxmlrpcresource.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modXMLRPCResource']= array (
   'package' => 'modx',
   'version' => '1.1',
   'extends' => 'modResource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/registry/db/mysql/moddbregistermessage.map.inc.php
+++ b/core/model/modx/registry/db/mysql/moddbregistermessage.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDbRegisterMessage']= array (
   'version' => '1.1',
   'table' => 'register_messages',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'topic' => NULL,

--- a/core/model/modx/registry/db/mysql/moddbregisterqueue.map.inc.php
+++ b/core/model/modx/registry/db/mysql/moddbregisterqueue.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDbRegisterQueue']= array (
   'version' => '1.1',
   'table' => 'register_queues',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => NULL,

--- a/core/model/modx/registry/db/mysql/moddbregistertopic.map.inc.php
+++ b/core/model/modx/registry/db/mysql/moddbregistertopic.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDbRegisterTopic']= array (
   'version' => '1.1',
   'table' => 'register_topics',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'queue' => NULL,

--- a/core/model/modx/registry/db/sqlsrv/moddbregistermessage.map.inc.php
+++ b/core/model/modx/registry/db/sqlsrv/moddbregistermessage.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDbRegisterMessage']= array (
   'version' => '1.1',
   'table' => 'register_messages',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
     'topic' => NULL,

--- a/core/model/modx/registry/db/sqlsrv/moddbregisterqueue.map.inc.php
+++ b/core/model/modx/registry/db/sqlsrv/moddbregisterqueue.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDbRegisterQueue']= array (
   'version' => '1.1',
   'table' => 'register_queues',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
     'name' => NULL,

--- a/core/model/modx/registry/db/sqlsrv/moddbregistertopic.map.inc.php
+++ b/core/model/modx/registry/db/sqlsrv/moddbregistertopic.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modDbRegisterTopic']= array (
   'version' => '1.1',
   'table' => 'register_topics',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'MyISAM',
+  ),
   'fields' => 
   array (
     'queue' => NULL,

--- a/core/model/modx/sources/mysql/modaccessmediasource.map.inc.php
+++ b/core/model/modx/sources/mysql/modaccessmediasource.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modAccessMediaSource']= array (
   'version' => '1.1',
   'table' => 'access_media_source',
   'extends' => 'modAccess',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'context_key' => '',

--- a/core/model/modx/sources/mysql/modfilemediasource.map.inc.php
+++ b/core/model/modx/sources/mysql/modfilemediasource.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modFileMediaSource']= array (
   'package' => 'modx.sources',
   'version' => '1.1',
   'extends' => 'modMediaSource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/sources/mysql/modmediasource.map.inc.php
+++ b/core/model/modx/sources/mysql/modmediasource.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modMediaSource']= array (
   'version' => '1.1',
   'table' => 'media_sources',
   'extends' => 'modAccessibleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => '',

--- a/core/model/modx/sources/mysql/modmediasourcecontext.map.inc.php
+++ b/core/model/modx/sources/mysql/modmediasourcecontext.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modMediaSourceContext']= array (
   'version' => '1.1',
   'table' => 'media_sources_contexts',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'source' => 0,

--- a/core/model/modx/sources/mysql/modmediasourceelement.map.inc.php
+++ b/core/model/modx/sources/mysql/modmediasourceelement.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modMediaSourceElement']= array (
   'version' => '1.1',
   'table' => 'media_sources_elements',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'source' => 0,

--- a/core/model/modx/sources/mysql/mods3mediasource.map.inc.php
+++ b/core/model/modx/sources/mysql/mods3mediasource.map.inc.php
@@ -7,6 +7,10 @@ $xpdo_meta_map['modS3MediaSource']= array (
   'package' => 'modx.sources',
   'version' => '1.1',
   'extends' => 'modMediaSource',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
   ),

--- a/core/model/modx/transport/mysql/modtransportpackage.map.inc.php
+++ b/core/model/modx/transport/mysql/modtransportpackage.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modTransportPackage']= array (
   'version' => '1.1',
   'table' => 'transport_packages',
   'extends' => 'xPDOObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'signature' => NULL,

--- a/core/model/modx/transport/mysql/modtransportprovider.map.inc.php
+++ b/core/model/modx/transport/mysql/modtransportprovider.map.inc.php
@@ -8,6 +8,10 @@ $xpdo_meta_map['modTransportProvider']= array (
   'version' => '1.1',
   'table' => 'transport_providers',
   'extends' => 'xPDOSimpleObject',
+  'tableMeta' => 
+  array (
+    'engine' => 'InnoDB',
+  ),
   'fields' => 
   array (
     'name' => NULL,

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -951,7 +951,7 @@
             <column key="context_key" length="" collation="A" null="false" />
         </index>
         <index alias="uri" name="uri" primary="false" unique="false" type="BTREE">
-            <column key="uri" length="333" collation="A" null="true" />
+            <column key="uri" length="255" collation="A" null="true" />
         </index>
         <index alias="uri_override" name="uri_override" primary="false" unique="false" type="BTREE">
             <column key="uri_override" length="" collation="A" null="false" />

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -21,7 +21,7 @@
  */
  -->
 <!-- The following xPDO model represents an object-relational map structure of MODX -->
-<model package="modx" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="modx" phpdoc-subpackage="" version="1.1">
+<model package="modx" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="modx" phpdoc-subpackage="" version="1.1">
     <object class="modAccess" extends="xPDOSimpleObject">
         <field key="target" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />
         <field key="principal_class" dbtype="varchar" precision="100" phptype="string" null="false" default="modPrincipal" index="index" />

--- a/core/model/schema/modx.registry.db.mysql.schema.xml
+++ b/core/model/schema/modx.registry.db.mysql.schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
 /*
  * This file is part of MODX Revolution.
  *
@@ -10,7 +10,7 @@
  */
  -->
 <!-- The following xPDO model represents an object-relational map structure of the MODX db registry package -->
-<model package="modx.registry.db" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="modx" phpdoc-subpackage="registry.db" version="1.1">
+<model package="modx.registry.db" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="modx" phpdoc-subpackage="registry.db" version="1.1">
     <object class="modDbRegisterQueue" table="register_queues" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="unique" />
         <field key="options" dbtype="mediumtext" phptype="array" />

--- a/core/model/schema/modx.sources.mysql.schema.xml
+++ b/core/model/schema/modx.sources.mysql.schema.xml
@@ -10,7 +10,7 @@
  */
  -->
 <!-- The following xPDO model represents an object-relational map structure of the MODX db registry package -->
-<model package="modx.sources" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="modx" phpdoc-subpackage="sources" version="1.1">
+<model package="modx.sources" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="modx" phpdoc-subpackage="sources" version="1.1">
 
     <object class="modAccessMediaSource" table="access_media_source" extends="modAccess">
         <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />

--- a/core/model/schema/modx.transport.mysql.schema.xml
+++ b/core/model/schema/modx.transport.mysql.schema.xml
@@ -21,7 +21,7 @@
  */
  -->
 <!-- The following xPDO model represents an object-relational map structure of the MODX transport package -->
-<model package="modx.transport" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="modx" phpdoc-subpackage="transport" version="1.1">
+<model package="modx.transport" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="modx" phpdoc-subpackage="transport" version="1.1">
     <object class="modTransportProvider" table="transport_providers" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="unique" />
         <field key="description" dbtype="mediumtext" phptype="string" />

--- a/core/xpdo/changelog.txt
+++ b/core/xpdo/changelog.txt
@@ -2,6 +2,7 @@ This file shows the changes in this release of xPDO.
 
 xPDO 2.6.0-pl (TBD)
 ====================================
+- Make InnoDB the default engine for MySQL
 - Add missing return statements to built-in validation classes
 - Remove all embedded escape characters when escape() is used on a string
 - Make sure empty cache file does not return true in PHP format

--- a/core/xpdo/changelog.txt
+++ b/core/xpdo/changelog.txt
@@ -2,6 +2,7 @@ This file shows the changes in this release of xPDO.
 
 xPDO 2.6.0-pl (TBD)
 ====================================
+- Generate engine into the map files for MySQL
 - Make InnoDB the default engine for MySQL
 - Add missing return statements to built-in validation classes
 - Remove all embedded escape characters when escape() is used on a string

--- a/core/xpdo/changelog.txt
+++ b/core/xpdo/changelog.txt
@@ -2,6 +2,7 @@ This file shows the changes in this release of xPDO.
 
 xPDO 2.6.0-pl (TBD)
 ====================================
+- Add missing return statements to built-in validation classes
 - Remove all embedded escape characters when escape() is used on a string
 - Make sure empty cache file does not return true in PHP format
 - Make sure FileCache uses file/folder permissions options + add optional overrides

--- a/core/xpdo/om/mysql/xpdogenerator.class.php
+++ b/core/xpdo/om/mysql/xpdogenerator.class.php
@@ -96,7 +96,7 @@ class xPDOGenerator_mysql extends xPDOGenerator {
         $schemaVersion = xPDO::SCHEMA_VERSION;
         $xmlContent = array();
         $xmlContent[] = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
-        $xmlContent[] = "<model package=\"{$package}\" baseClass=\"{$baseClass}\" platform=\"mysql\" defaultEngine=\"MyISAM\" version=\"{$schemaVersion}\">";
+        $xmlContent[] = "<model package=\"{$package}\" baseClass=\"{$baseClass}\" platform=\"mysql\" defaultEngine=\"InnoDB\" version=\"{$schemaVersion}\">";
         //read list of tables
         $dbname= $this->manager->xpdo->escape($this->manager->xpdo->config['dbname']);
         $tableLike= ($tablePrefix && $restrictPrefix) ? " LIKE '{$tablePrefix}%'" : '';

--- a/core/xpdo/om/mysql/xpdomanager.class.php
+++ b/core/xpdo/om/mysql/xpdomanager.class.php
@@ -134,7 +134,7 @@ class xPDOManager_mysql extends xPDOManager {
                 }
                 $modelVersion= $this->xpdo->getModelVersion($className);
                 $tableMeta= $this->xpdo->getTableMeta($className);
-                $tableType= isset($tableMeta['engine']) ? $tableMeta['engine'] : 'MyISAM';
+                $tableType= isset($tableMeta['engine']) ? $tableMeta['engine'] : 'InnoDB';
                 $tableType= $this->xpdo->getOption(xPDO::OPT_OVERRIDE_TABLE_TYPE, null, $tableType);
                 $legacyIndexes= version_compare($modelVersion, '1.1', '<');
                 $fulltextIndexes= array ();

--- a/core/xpdo/om/xpdogenerator.class.php
+++ b/core/xpdo/om/xpdogenerator.class.php
@@ -227,6 +227,8 @@ abstract class xPDOGenerator {
                     $engine = (string) $object['engine'];
                     if (!empty($engine)) {
                         $this->map[$class]['tableMeta'] = array('engine' => $engine);
+                    } elseif (isset($this->model['defaultEngine'])) {
+                        $this->map[$class]['tableMeta'] = array('engine' => $this->model['defaultEngine']);
                     }
 
                     $this->map[$class]['fields']= array();

--- a/core/xpdo/validation/xpdovalidator.class.php
+++ b/core/xpdo/validation/xpdovalidator.class.php
@@ -259,6 +259,7 @@ class xPDOMaxLengthValidationRule extends xPDOValidationRule {
         if ($result === false) {
             $this->validator->addMessage($this->field, $this->name, $this->message);
         }
+        return $result;
     }
 }
 class xPDOMinValueValidationRule extends xPDOValidationRule {
@@ -269,6 +270,7 @@ class xPDOMinValueValidationRule extends xPDOValidationRule {
         if ($result === false) {
             $this->validator->addMessage($this->field, $this->name, $this->message);
         }
+        return $result;
     }
 }
 class xPDOMaxValueValidationRule extends xPDOValidationRule {
@@ -279,6 +281,7 @@ class xPDOMaxValueValidationRule extends xPDOValidationRule {
         if ($result === false) {
             $this->validator->addMessage($this->field, $this->name, $this->message);
         }
+        return $result;
     }
 }
 class xPDOObjectExistsValidationRule extends xPDOValidationRule {

--- a/setup/includes/drivers/modinstalldriver_mysql.class.php
+++ b/setup/includes/drivers/modinstalldriver_mysql.class.php
@@ -130,6 +130,11 @@ class modInstallDriver_mysql extends modInstallDriver {
         $mysqlVersion = $this->xpdo->getAttribute(PDO::ATTR_SERVER_VERSION);
         $mysqlVersion = $this->_sanitizeVersion($mysqlVersion);
         if (empty($mysqlVersion)) {
+            $config_options = $this->install->settings->get('config_options');
+            $config_options[xPDO::OPT_OVERRIDE_TABLE_TYPE] = 'MyISAM';
+            $this->install->settings->set('config_options', $config_options);
+            $this->install->settings->store();
+
             return array('result' => 'warning', 'message' => $this->install->lexicon('mysql_version_server_nf'),'version' => $mysqlVersion);
         }
 

--- a/setup/includes/drivers/modinstalldriver_mysql.class.php
+++ b/setup/includes/drivers/modinstalldriver_mysql.class.php
@@ -127,8 +127,10 @@ class modInstallDriver_mysql extends modInstallDriver {
      * {@inheritDoc}
      */
     public function verifyServerVersion() {
-        $mysqlVersion = $this->xpdo->getAttribute(PDO::ATTR_SERVER_VERSION);
-        $mysqlVersion = $this->_sanitizeVersion($mysqlVersion);
+        $version = $this->getServerVersion();
+        $isMariaDB = stripos($version, 'mariadb') !== false;
+
+        $mysqlVersion = $this->_sanitizeVersion($version);
         if (empty($mysqlVersion)) {
             $config_options = $this->install->settings->get('config_options');
             $config_options[xPDO::OPT_OVERRIDE_TABLE_TYPE] = 'MyISAM';
@@ -141,7 +143,12 @@ class modInstallDriver_mysql extends modInstallDriver {
         $mysql_ver_comp = version_compare($mysqlVersion,'4.1.20','>=');
         $mysql_ver_comp_5051 = version_compare($mysqlVersion,'5.0.51','==');
         $mysql_ver_comp_5051a = version_compare($mysqlVersion,'5.0.51a','==');
-        $mysql_ver_comp_myisam = version_compare($mysqlVersion, '5.6', '<');
+
+        if ($isMariaDB) {
+            $mysql_ver_comp_myisam = version_compare($mysqlVersion, '10.0.5', '<');
+        } else {
+            $mysql_ver_comp_myisam = version_compare($mysqlVersion, '5.6', '<');
+        }
 
         if ($mysql_ver_comp_myisam) {
             $config_options = $this->install->settings->get('config_options');
@@ -194,6 +201,16 @@ class modInstallDriver_mysql extends modInstallDriver {
         return 'ALTER TABLE '.$this->xpdo->escape($table).' DROP INDEX '.$this->xpdo->escape($index);
     }
 
+    protected function getServerVersion() {
+        try {
+            $stmt = $this->xpdo->query('SELECT VERSION();');
+            $value = $this->xpdo->getValue($stmt);
+        } catch (Exception $e) {
+            $value = $this->xpdo->getAttribute(PDO::ATTR_SERVER_VERSION);
+        }
+
+        return $value;
+    }
 
     /**
      * Cleans a mysql version string that often has extra junk in certain distros

--- a/setup/includes/drivers/modinstalldriver_mysql.class.php
+++ b/setup/includes/drivers/modinstalldriver_mysql.class.php
@@ -136,6 +136,14 @@ class modInstallDriver_mysql extends modInstallDriver {
         $mysql_ver_comp = version_compare($mysqlVersion,'4.1.20','>=');
         $mysql_ver_comp_5051 = version_compare($mysqlVersion,'5.0.51','==');
         $mysql_ver_comp_5051a = version_compare($mysqlVersion,'5.0.51a','==');
+        $mysql_ver_comp_myisam = version_compare($mysqlVersion, '5.6', '<');
+
+        if ($mysql_ver_comp_myisam) {
+            $config_options = $this->install->settings->get('config_options');
+            $config_options[xPDO::OPT_OVERRIDE_TABLE_TYPE] = 'MyISAM';
+            $this->install->settings->set('config_options', $config_options);
+            $this->install->settings->store();
+        }
 
         if (!$mysql_ver_comp) { /* ancient driver warning */
             return array('result' => 'failure','message' => $this->install->lexicon('mysql_version_fail',array('version' => $mysqlVersion)),'version' => $mysqlVersion);

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -162,7 +162,11 @@ class modInstall {
             if (!($this->xpdo instanceof xPDO)) { return $this->xpdo; }
 
             $this->xpdo->setOption('cache_path',MODX_CORE_PATH . 'cache/');
-            $this->xpdo->setOption(xPDO::OPT_OVERRIDE_TABLE_TYPE, 'InnoDB');
+
+            $config_options = (array)$this->settings->get('config_options');
+            foreach ($config_options as $config_option => $config_value) {
+                $this->xpdo->setOption($config_option, $config_value);
+            }
 
             if ($mode === modInstall::MODE_UPGRADE_REVO_ADVANCED) {
                 if ($this->xpdo->connect()) {

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -162,6 +162,7 @@ class modInstall {
             if (!($this->xpdo instanceof xPDO)) { return $this->xpdo; }
 
             $this->xpdo->setOption('cache_path',MODX_CORE_PATH . 'cache/');
+            $this->xpdo->setOption(xPDO::OPT_OVERRIDE_TABLE_TYPE, 'InnoDB');
 
             if ($mode === modInstall::MODE_UPGRADE_REVO_ADVANCED) {
                 if ($this->xpdo->connect()) {


### PR DESCRIPTION
### What does it do?
Creates tables using InnoDB table type in new MySQL installations.

### Why is it needed?
MyISAM is an obsolete MySQL table type/engine and we should be using InnoDB moving forward.

### Related issue(s)/PR(s)
N/A