### PR TITLE
Fix featured flag in package listing not interpreting the string value

### DIFF
--- a/core/model/modx/transport/modtransportprovider.class.php
+++ b/core/model/modx/transport/modtransportprovider.class.php
@@ -284,7 +284,6 @@ class modTransportProvider extends xPDOSimpleObject {
             foreach ($package->supports as $support) {
                 $supports .= (string)$support.$this->arg('supportsSeparator', $where);
             }
-
             $results[] = array(
                 'id' => (string)$package->id,
                 'version' => (string)$package->version,
@@ -308,8 +307,8 @@ class modTransportProvider extends xPDOSimpleObject {
                 'location' => (string)$package->location,
                 'version-compiled' => $versionCompiled,
                 'downloaded' => !empty($installed) ? true : false,
-                'featured' => (boolean)$package->featured,
-                'audited' => (boolean)$package->audited,
+                'featured' => ((string)$package->featured == 'true'),
+                'audited' => ((string)$package->audited == 'true'),
                 'dlaction-icon' => $installed ? 'package-installed' : 'package-download',
                 'dlaction-text' => $installed ? $this->xpdo->lexicon('downloaded') : $this->xpdo->lexicon('download'),
             );


### PR DESCRIPTION
### What does it do?

The new package UI introduced in #13274 highlights packages listed as featured. As mentioned in that PR, all packages were incorrectly getting this flag, and the assumption this was an issue with the MODX.com package provider.

Turns out, it wasn't :D 

The package provider XML response contains a string "true" or "false", so the cast to bool was not sufficient to accurately set the flag. 

### Why is it needed?

To make sure only featured extras show up as featured, instead of every single one.

### Related issue(s)/PR(s)

#13274