### PR TITLE
[in progress] Implement distributions into the setup (for new installs)

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1316,7 +1316,7 @@ class modX extends xPDO {
      */
     public function getVersionData() {
         if ($this->version === null) {
-            $this->version= @ include_once MODX_CORE_PATH . "docs/version.inc.php";
+            $this->version = include MODX_CORE_PATH . "docs/version.inc.php";
         }
         return $this->version;
     }

--- a/setup/assets/css/style.css
+++ b/setup/assets/css/style.css
@@ -223,3 +223,18 @@ input, button, select {
   position: relative;
   top: -10px;
 }
+
+.distributions {
+	overflow: hidden;
+	padding-bottom: 2em;
+}
+.distribution {
+	float: left;
+	width: 25%;
+}
+.distribution label {
+	width: 100%;
+}
+.packages {
+	padding-top: 2em;
+}

--- a/setup/assets/js/sections/distribution.js
+++ b/setup/assets/js/sections/distribution.js
@@ -1,0 +1,36 @@
+Ext.onReady(function() {
+    MODx.Distributions.packages = Ext.select('.packages');
+    MODx.Distributions.packages.setVisibilityMode(Ext.Element.DISPLAY);
+    MODx.Distributions.packages.hide();
+
+    var distributions = Ext.select('.distribution input');
+    distributions.on('change', MODx.Distributions.selectDistribution);
+
+    Ext.select('#distribution').on('submit', function() {
+        Ext.select('.setup_navbar input').hide();
+    });
+});
+
+MODx.Distributions = function() {
+    return {
+        selectDistribution: function() {
+            var el = Ext.getDom(this);
+            var packages = el.getAttribute('data-packages');
+            if (packages === '*') {
+                MODx.Distributions.packages.show();
+            }
+            else {
+                MODx.Distributions.packages.hide();
+                packages = packages.split(',');
+                var inputs = Ext.select('.packages input');
+                inputs.each(function(i,v) {
+                    var el = Ext.getDom(i);
+                    el.checked = packages.indexOf(i.getAttribute('value')) !== -1;
+                })
+            }
+
+        },
+        packages: false,
+    };
+}();
+

--- a/setup/controllers/distribution.php
+++ b/setup/controllers/distribution.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @var modInstall $install
+ * @var modInstallParser $parser
+ * @var modInstallRequest $this
+ * @package setup
+ */
+if (!empty($_POST['proceed'])) {
+    // Try to increase the time limit as installing a lot of packages may take a while
+    @set_time_limit(0);
+
+    // Install selected packages
+    $packages = array_key_exists('packages', $_POST) && is_array($_POST['packages']) ? $_POST['packages'] : array();
+
+    foreach ($packages as $package) {
+        $this->install->downloadAndInstallPackage($package, array());
+    }
+
+    $this->proceed('complete');
+}
+
+return $parser->render('distribution.tpl');

--- a/setup/controllers/install.php
+++ b/setup/controllers/install.php
@@ -9,7 +9,13 @@ $install->settings->check();
 if (!empty($_POST['proceed'])) {
     unset($_POST['proceed']);
     $install->settings->store($_POST);
-    $this->proceed('complete');
+    $installmode = $install->settings->get('installmode', modInstall::MODE_NEW);
+    if ($installmode == modInstall::MODE_NEW) {
+        $this->proceed('distribution');
+    }
+    else {
+        $this->proceed('complete');
+    }
 }
 
 $mode = $install->settings->get('installmode');

--- a/setup/templates/distribution.tpl
+++ b/setup/templates/distribution.tpl
@@ -1,0 +1,50 @@
+<script type="text/javascript" src="assets/js/sections/distribution.js"></script>
+<form id="distribution" action="?action=distribution" method="post">
+    <h2>Distribution</h2>
+    <p>To get started quickly, you can choose one of the following distributions for your MODX site. This will automatically install third party extras and, if desired, a theme. </p>
+
+    <div class="distributions">
+        <div class="distribution">
+            <label><input type="radio" name="distribution" value="advanced" data-packages="-" checked="checked"> None</label>
+        </div>
+        <div class="distribution">
+            <label><input type="radio" name="distribution" value="blog" data-packages="getresources,wayfinder,tagger,quip"> Personal Blog</label>
+        </div>
+        <div class="distribution">
+            <label><input type="radio" name="distribution" value="business" data-packages="getresources,wayfinder"> Business</label>
+        </div>
+        <div class="distribution">
+            <label><input type="radio" name="distribution" value="advanced" data-packages="*"> Advanced</label>
+        </div>
+    </div>
+
+    <div class="packages">
+        <h2>Choose Extras</h2>
+        <p class="description">Choose the extras you would like to install. </p>
+        <div class="package">
+            <label><input type="checkbox" name="packages[]" value="getresources"> getResources</label>
+            <p class="description">Used for generating listings of resources or menus.</p>
+        </div>
+        <div class="package">
+            <label><input type="checkbox" name="packages[]" value="tagger"> Tagger</label>
+            <p class="description">Used for assigning tags to resources, and filtering resource listings.</p>
+        </div>
+        <div class="package">
+            <label><input type="checkbox" name="packages[]" value="wayfinder"> Wayfinder</label>
+            <p class="description">Generates hierarchical menus.</p>
+        </div>
+        <div class="package">
+            <label><input type="checkbox" name="packages[]" value="versionx"> VersionX</label>
+            <p class="description">Keeps track of changes to your resources and elements.</p>
+        </div>
+        <div class="package">
+            <label><input type="checkbox" name="packages[]" value="..."> ...</label>
+            <p class="description">... some more packages ...</p>
+        </div>
+    </div>
+
+    <div class="setup_navbar">
+        <input type="submit" name="proceed" id="modx-next" class="modx-hidden" value="{$_lang.next}" />
+        <input type="button" onclick="MODx.go('options');" value="{$_lang.back}" />
+    </div>
+</form>


### PR DESCRIPTION
This pull request is not done, I've opened it early to allow discussion on the topic and implementation.

### What does it do?
This adds an extra step to the setup that allows packages to be installed to get a quick site up and running. 

### Why is it needed?
At the MODX Meetup/Hackathon in Malta we sat down with people who never used MODX before to see how MODX could be made better. What are their challenges, how can we improve things with a fresh look. We split up into teams, and the team I was on decided to focus on the setup. 

One thing we discussed was that it should be easier for a new user to get a fully functional site. We've had a nicer base template for some time now, but that's still limited in showing how MODX works. So we thought that adding starter sites of sorts would be a really nice way to showcase that. 

At the same time, advanced users really don't care about starter themes. Some want the blank slate, or have their own starter sites they use to kick-start projects. But, some might still enjoy being able of quickly installing recommended packages. In the future this could be expanded with more advanced features for power users.

For now, this should be seen as a minimum viable implementation. 

It offers a selection of different site types which I labelled "distributions". These are kinda abstract, but they should offer a functional site out of the box that is properly set up (structured templates/chunks/assets). In the current iteration there's 2 distributions:

- Personal Blog (should be a chronological blog-style site, with Collections, perhaps comments (Quip or Disqus?), tagging with Tagger etc, archives?, author profiles?)
- Business (sort of standard business catalog site, home/services/team/contact us etc)

Others could be imagined and added over time (e.g. restaurant site, community site, one-page placeholder site etc). This functionality is ideal for new users that want to set up a site and see how MODX works to start tweaking things. 

The way these distributions work is that they specify a (comma separated) list of packages to install. Right now it's a (functional) proof of concept where just certain packages are used, so it doesn't actually install those sites yet, but the idea is that when we have some nice starter sites on the modx extras repo we can set those up.

The _Advanced_ distribution allows users to select packages from a list of recommended packages. See section below on core vs extras considerations. These extras are listed with a short (1 sentence) description/elevator pitch of what they do, as names alone like "Wayfinder" are not immediately clear on the function. 

#### Core vs Extras considerations

Back in evo, the core shipped with extras. They were actually included in the download. This meant the core required updates when an extra was updated, which is not ideal. 

In this PR, the packages are not included, they are just referred to by name. This makes sure it always downloads the latest version and the core does not need to be updated when an extra is.

It is still mean referring to extras from within the core. This means that when an extra goes in or out of favour over time, that the list should change. 

There's been some discussions on wether this perhaps should depend on an API so it's not "hardcoded" but I personally think using the existing contributor process and just keep it in the core.

To objectively determine what extras should or should not be listed, I think we should draft a set of guidelines on what extras can be accepted. I think this could take the form of something like "extras hosted on MODX.com with at least X downloads, which serve a specific need not covered by other more generic extras, and for which the author is not an alien". This might be something the MAB can help draft. 

This should also not be an infinitely growing list. If there's 10-15, I think that's more than enough. Perhaps the guidelines should include a hard maximum (want to add one more? Then one also needs to be removed, so you need to provide some really good reasoning), or in another way the guidelines should be made specific enough that it doesn't grow out of control. 

The page could link to MODX.com (and other extra providers like modmore and modstore) for more packages which can then be installed the normal way. 

### In progress

Still left to do before this can be considered for merging:

- [ ] Build some actual starter sites, available as packages on modx.com, that can be installed. 
- [ ] Lexicon all the text 
- [ ] Determine the list of packages to start with. There are some extras that might require some more debate (Wayfinder/getResources vs pdoResources, pthumb(of/on/up) etc), so I think it might be best to NOT have that discussion within this pull request. For starters I think we should build the starter sites, and use the bare minimum extras used to make those work.
- [ ] Design is pretty simple, might need a bit of a touch-up.

### Related issue(s)/PR(s)
N/a
