### PR TITLE
Fix issue #13448 - Enhance duplicate dialog

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -133,6 +133,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,duplicateResource: function(item,e) {
         var node = this.cm.activeNode;
         var id = node.id.split('_');id = id[1];
+        var name = node.ui.textNode.innerText;
 
         var r = {
             resource: id
@@ -141,6 +142,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         var w = MODx.load({
             xtype: 'modx-window-resource-duplicate'
             ,resource: id
+            ,pagetitle: name
             ,hasChildren: node.attributes.hasChildren
             ,childCount: node.attributes.childCount
             ,listeners: {

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -10,7 +10,7 @@ MODx.window.DuplicateResource = function(config) {
     config = config || {};
     this.ident = config.ident || 'dupres'+Ext.id();
     Ext.applyIf(config,{
-        title: _('duplication_options')
+        title: config.pagetitle ? _('duplicate') + ' ' + config.pagetitle : _('duplication_options')
         ,id: this.ident
         // ,width: 500
     });


### PR DESCRIPTION
### What does it do?
It shows the pagetitle and ID of the resource in the 'Duplicate' dialog

### Why is it needed?
The default UI for 'Duplicate' dialog doesn't show the name and ID and it is pretty easy to forget which reource you are trying to duplicate. 

### Related issue(s)/PR(s)
Issue #13448 
