### PR TITLE
PHP 5.3 compatibility fix

### DIFF
--- a/core/model/modx/processors/security/message/getlist.class.php
+++ b/core/model/modx/processors/security/message/getlist.class.php
@@ -44,11 +44,11 @@ class modUserMessageGetListProcessor extends modObjectGetListProcessor
 
         switch ($this->getProperty('type')) {
             case 'outbox':
-                $where = ['sender' => $this->modx->user->get('id')];
+                $where = array('sender' => $this->modx->user->get('id'));
                 break;
             case 'inbox':
             default:
-                $where = ['recipient' => $this->modx->user->get('id')];
+                $where = array('recipient' => $this->modx->user->get('id'));
                 break;
         }
 


### PR DESCRIPTION
### What does it do?
This PR fixes issue with code compatibility with php 5.3

### Why is it needed?
It prevents issues in MODX core in case running MODX on PHP 5.3.

### Related issue(s)/PR(s)
It's related to the comment in original pull request https://github.com/modxcms/revolution/pull/13390#pullrequestreview-46069157