### PR TITLE
Fixed page size for grids #13461 #modxbughunt

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -151,7 +151,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,primaryKey: 'key'
         ,autosave: true
         ,save_action: 'system/settings/updatefromgrid'
-        ,pageSize: parseInt(MODx.config.default_per_page) > 30 ? parseInt(MODx.config.default_per_page) : 30
+        ,pageSize: parseInt(MODx.config.default_per_page) || 20
         ,paging: true
         ,collapseFirst: false
         ,tools: [{

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -83,7 +83,7 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
-        ,pageSize: parseInt(MODx.config.default_per_page) || 20
+        ,pageSize: Math.min(parseInt(MODx.config.default_per_page), 25)
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -83,7 +83,7 @@ MODx.grid.Package = function(config) {
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
         ,plugins: [this.exp]
-        ,pageSize: Math.min(parseInt(MODx.config.default_per_page), 25)
+        ,pageSize: parseInt(MODx.config.default_per_page) || 20
         ,columns: cols
         ,primaryKey: 'signature'
         ,paging: true


### PR DESCRIPTION
### What does it do?
Use the correct value that is set in the system setting default_per_page for all grids.

### Why is it needed?
Fix the pagination for grids (system settings, context settings, user overview, etc).

The code `parseInt(MODx.config.default_per_page) > 30 ? parseInt(MODx.config.default_per_page) : 30` would not allow you to set a page size of 10 or 20 as `parseInt(MODx.config.default_per_page) > 30` will always return false if the value is lower then 30. So the default_per_page setting will only work of you use higher values.

### Related issue(s)/PR(s)
Related issue #13461
