### PR TITLE
Enhance delete resource dialog

### DIFF
--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -70,7 +70,8 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
 
     ,deleteResource: function(btn,e) {
         MODx.msg.confirm({
-            text: _('resource_delete_confirm')
+            title: this.config.pagetitle ? _('resource_delete') + ' ' + this.config.pagetitle + ' (' + this.config.resource + ')' : _('resource_delete')
+            ,text: _('resource_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {
                 action: 'resource/delete'
@@ -103,7 +104,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
 
     ,getButtons: function(cfg) {
         var btns = [];
-        
+
         btns.push({
             text: cfg.lockedText || _('locked')
             ,id: 'modx-abtn-locked'
@@ -125,7 +126,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 ,ctrl: true
             }]
         });
-	    
+
         if (cfg.canDuplicate == 1 && (cfg.record.parent !== parseInt(MODx.config.tree_root_id) || cfg.canCreateRoot == 1)) {
             btns.push({
                 text: _('duplicate')

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -206,8 +206,9 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,deleteDocument: function(itm,e) {
         var node = this.cm.activeNode;
         var id = node.id.split('_');id = id[1];
+        var pagetitle = node.ui.textNode.innerText;
         MODx.msg.confirm({
-            title: _('resource_delete')
+            title: pagetitle ? _('resource_delete') + ' ' + pagetitle : _('resource_delete')
             ,text: _('resource_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -42,6 +42,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
             MODx.load({
                 xtype: "modx-page-resource-update"
                 ,resource: "'.$this->resource->get('id').'"
+                ,pagetitle: "'.$this->resource->get('pagetitle').'"
                 ,record: '.$this->modx->toJSON($this->resourceArray).'
                 ,publish_document: "'.$this->canPublish.'"
                 ,preview_url: "'.$this->previewUrl.'"


### PR DESCRIPTION
### What does it do?
Added pagetitle and ID of the deleted resource to the delete dialog

### Why is it needed?
Just a continuation of #13475. The default UI for 'Delete' dialog doesn't show the name and ID and it is pretty easy to forget which resource you are trying to delete.

### Related issue(s)/PR(s)
#13475 #13448 