### PR TITLE
Make sure we refresh the parent (resource) node when creating the first children

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -462,7 +462,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,listeners: {
                 'success':{
                     fn: function() {
-                        this.refreshNode(this.cm.activeNode.id, true);
+                        this.refreshNode(this.cm.activeNode.id, this.cm.activeNode.childNodes.length > 0);
                     }
                     ,scope: this}
                 ,'hide':{fn:function() {this.destroy();}}


### PR DESCRIPTION
### What does it do?

When creating the first children node for a resource, using the quick create window, make sure we refresh the right tree node

### Why is it needed?

See related issue

### Related issue(s)/PR(s)

Closes #13492 