### PR TITLE
Turning of the feeds to gain some more privacy

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -549,7 +549,7 @@ $settings['feed_modx_news']->fromArray(array (
 $settings['feed_modx_news_enabled']= $xpdo->newObject('modSystemSetting');
 $settings['feed_modx_news_enabled']->fromArray(array (
   'key' => 'feed_modx_news_enabled',
-  'value' => '1',
+  'value' => '0',
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
@@ -567,7 +567,7 @@ $settings['feed_modx_security']->fromArray(array (
 $settings['feed_modx_security_enabled']= $xpdo->newObject('modSystemSetting');
 $settings['feed_modx_security_enabled']->fromArray(array (
   'key' => 'feed_modx_security_enabled',
-  'value' => '1',
+  'value' => '0',
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',


### PR DESCRIPTION
### What does it do?
Turning off the news feeds in the manager by default.

### Why is it needed?
After installing a fresh MODX and logging into the manager, google gets connected. So, before a website is even started being build, it is already "in the index". This causes some privacy issues because maybe the URL of the website should not be made public or for other reason. Having the feeds turned on by default is done without asking the user and getting his OK. 


### Related issue(s)/PR(s)
none

#13498 

#modxbughunt 
