### PR TITLE
Fix refresh media browser tree after creating a directory #13495 #modxbughunt

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -508,18 +508,26 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
     ,createDirectory: function(item,e) {
         var node = this.cm && this.cm.activeNode ? this.cm.activeNode : false;
         var r = {
-            'parent': node && node.attributes.type == 'dir' ? node.attributes.pathRelative : '/'
+            ‘parent’: node && node.attributes.type == 'dir' ? node.attributes.pathRelative : '/'
             ,source: this.getSource()
         };
-        if (r.parent === '') {
-            r.parent = '/';
-        }
+
         var w = MODx.load({
             xtype: 'modx-window-directory-create'
             ,record: r
             ,listeners: {
-                'success':{fn:this.refreshActiveNode,scope:this}
-                ,'hide':{fn:function() {this.destroy();}}
+                ‘success’: {
+                    fn:function() {
+                        var parent = Ext.getCmp('folder-parent').getValue();
+
+                        if (this.cm.activeNode.constructor.name === 'constructor' || parent === '' || parent === '/') {
+                            this.refresh();
+                        } else {
+                            this.refreshActiveNode();
+                        }
+                    },scope:this
+                }
+                ,‘hide’:{fn:function() {this.destroy();}}
             }
         });
         w.show(e ? e.target : Ext.getBody());
@@ -730,6 +738,7 @@ MODx.window.CreateDirectory = function(config) {
             ,allowBlank: false
         },{
             fieldLabel: _('file_folder_parent')
+            ,id: 'folder-parent'
             ,name: 'parent'
             ,xtype: 'textfield'
             ,anchor: '100%'

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -511,6 +511,9 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             'parent': node && node.attributes.type == 'dir' ? node.attributes.pathRelative : '/'
             ,source: this.getSource()
         };
+        if (r.parent === '') {
+            r.parent = '/';
+        }
         var w = MODx.load({
             xtype: 'modx-window-directory-create'
             ,record: r

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -508,7 +508,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
     ,createDirectory: function(item,e) {
         var node = this.cm && this.cm.activeNode ? this.cm.activeNode : false;
         var r = {
-            ‘parent’: node && node.attributes.type == 'dir' ? node.attributes.pathRelative : '/'
+            parent: node && node.attributes.type == 'dir' ? node.attributes.pathRelative : '/'
             ,source: this.getSource()
         };
 
@@ -516,7 +516,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             xtype: 'modx-window-directory-create'
             ,record: r
             ,listeners: {
-                ‘success’: {
+                'success': {
                     fn:function() {
                         var parent = Ext.getCmp('folder-parent').getValue();
 
@@ -527,7 +527,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                         }
                     },scope:this
                 }
-                ,‘hide’:{fn:function() {this.destroy();}}
+                ,'hide':{fn:function() {this.destroy();}}
             }
         });
         w.show(e ? e.target : Ext.getBody());


### PR DESCRIPTION
### What does it do?
Check if the parent node is empty. If its empty add a slash so the whole directory is refreshed correctly.

### Why is it needed?
After a new directory is created it is not visible. This might confuse the user that will most likely try to create the directory again.

### Related issue(s)/PR(s)
Related issue #13495
