### PR TITLE
Update title in element tree after renaming resource [#4581] #modxbughunt

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -295,7 +295,7 @@ Ext.extend(MODx.panel.Chunk,MODx.FormPanel,{
 
         var c = Ext.getCmp('modx-chunk-category').getValue();
         var n = c !== '' && c !== null && c != 0 ? 'n_chunk_category_'+c : 'n_type_chunk';
-        var t = Ext.getCmp('modx-element-tree');
+        var t = Ext.getCmp('modx-tree-element');
         if (t) {
         	var node = t.getNodeById('n_chunk_element_' + Ext.getCmp('modx-chunk-id').getValue() + '_' + r.result.object.previous_category);
         	if (node) node.destroy();

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -323,7 +323,7 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
         Ext.getCmp('modx-grid-plugin-event').getStore().commitChanges();
         this.getForm().setValues(o.result.object);
 
-        var t = Ext.getCmp('modx-element-tree');
+        var t = Ext.getCmp('modx-tree-element');
         if (t) {
             var c = Ext.getCmp('modx-plugin-category').getValue();
             var u = c != '' && c != null && c != 0 ? 'n_plugin_category_'+c : 'n_type_plugin';

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -291,7 +291,7 @@ Ext.extend(MODx.panel.Snippet,MODx.FormPanel,{
         if (MODx.request.id) Ext.getCmp('modx-grid-element-properties').save();
         this.getForm().setValues(r.result.object);
 
-        var t = Ext.getCmp('modx-element-tree');
+        var t = Ext.getCmp('modx-tree-element');
         if (t) {
             var c = Ext.getCmp('modx-snippet-category').getValue();
             var u = c != '' && c != null && c != 0 ? 'n_snippet_category_'+c : 'n_type_snippet';

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -336,7 +336,7 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         Ext.getCmp('modx-grid-template-tv').getStore().commitChanges();
         this.getForm().setValues(r.result.object);
 
-        var t = Ext.getCmp('modx-element-tree');
+        var t = Ext.getCmp('modx-tree-element');
         if (t) {
             var c = Ext.getCmp('modx-template-category').getValue();
             var u = c != '' && c != null && c != 0 ? 'n_template_category_'+c : 'n_type_template';

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -402,7 +402,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
         if (MODx.request.id) Ext.getCmp('modx-grid-element-properties').save();
         this.getForm().setValues(r.result.object);
 
-        var t = Ext.getCmp('modx-element-tree');
+        var t = Ext.getCmp('modx-tree-element');
         if (t) {
             var c = Ext.getCmp('modx-tv-category').getValue();
             var u = c != '' && c != null && c != 0 ? 'n_tv_category_'+c : 'n_type_tv';


### PR DESCRIPTION
### What does it do?
Corrected tree component lookup in  various manager elements on on successful save event.

### Why is it needed?
Element tree did not refresh after renaming chunks, snippets, templates, tvs or plugins.
