### PR TITLE
Enhanced the delete confirm alert (fixes parts of #764, #13448) #modxbughunt

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -498,6 +498,12 @@ class modResourceGetNodesProcessor extends modProcessor {
             'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), $sessionEnabled, 'full', array('xhtml_urls' => false)) : '',
             'page' => empty($noHref) ? '?a='.(!empty($this->permissions['edit_document']) ? 'resource/update' : 'resource/data').'&id='.$resource->id : '',
             'allowDrop' => true,
+
+            // the following are added for convenience to enable direct
+            // access to the values without the need to split the 'id' string above
+            'resource_id'           => $resource->id,
+            'resource_pagetitle'    => $resource->pagetitle,
+            'resource_context_key'  => $resource->context_key,
         );
         if (!$hasChildren) {
             $itemArray['hasChildren'] = false;

--- a/core/model/modx/processors/resource/getpath.class.php
+++ b/core/model/modx/processors/resource/getpath.class.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Gets the parents of a resource and constructs a breadcrumb path to the resource.
+ *
+ * @param integer $id The ID of the resource
+ *
+ * @package modx
+ * @subpackage processors.resource
+ */
+class modResourceGetPathProcessor extends modProcessor {
+    /** @var modResource $resource */
+    public $resource;
+
+    /** @var bool $returnNodeList */
+    private $returnNodeList;
+
+    public function initialize() {
+        $id = $this->getProperty('id',false);
+        if (empty($id)) return $this->modx->lexicon('resource_err_ns');
+        $this->resource = $this->modx->getObject('modResource', $id);
+        if (empty($this->resource)) return $this->modx->lexicon('resource_err_nfs',array('id' => $id));
+
+        // whether we should include the list of id,pagetitle for every parent object
+        $this->returnNodeList = $this->getProperty('nodelist', false);
+
+        return true;
+    }
+
+    public function process() {
+        $pathData = array();
+
+        $path = ""; // path could also be generated on the client via js, but doing it here
+                    // seems to be better performance
+        $parentId = $this->resource->parent;
+        while ($parentId!=0) {
+            $parent = $this->modx->getObject('modResource', $parentId);
+            $path = $parent->pagetitle . " > " . $path;
+            $pathData[] = array('id' => $parentId, 'pagetitle' => $parent->pagetitle);
+            $parentId = $parent->parent;
+        }
+        $idNote = $this->modx->hasPermission('tree_show_resource_ids') ? ' <span dir="ltr">(' . $this->resource->id . ')</span>' : '';
+        $path .= '<strong>' . $this->resource->pagetitle . $idNote . '</strong>';
+
+        if ($this->returnNodeList) {
+            return $this->success('', [ 'path' => $path, 'parents' => $pathData ]);
+        }
+
+        return $this->success('', [ 'path' => $path ]);
+
+    }
+
+}
+return 'modResourceGetPathProcessor';

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -195,39 +195,57 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
 
     ,deleteDocument: function(itm,e) {
         var node = this.cm.activeNode;
-        var id = node.id.split('_');id = id[1];
-        MODx.msg.confirm({
-            title: _('resource_delete')
-            ,text: _('resource_delete_confirm')
-            ,url: MODx.config.connector_url
+        var id = node.attributes.resource_id;
+
+        MODx.Ajax.request({
+            url: MODx.config.connector_url
             ,params: {
-                action: 'resource/delete'
+                action: 'resource/getpath'
                 ,id: id
             }
             ,listeners: {
                 'success': {fn:function(data) {
-                    var trashButton = this.getTopToolbar().findById('emptifier');
-                    if (trashButton) {
-                        if (data.object.deletedCount == 0) {
-                            trashButton.disable();
-                        } else {
-                            trashButton.enable();
+
+
+                    MODx.msg.confirm({
+                        title: _('resource_delete')
+                        ,text: _('resource_delete_confirm') + "<hr/>"
+                            + "<p>" + _('context') + ": " + node.attributes.resource_context_key + "</p><br/>"
+                            + "<p>" + data.object.path +"</p>"
+                        ,url: MODx.config.connector_url
+                        ,params: {
+                            action: 'resource/delete'
+                            ,id: id
+                            ,nodelist: false
                         }
+                        ,listeners: {
+                            'success': {fn:function(data) {
+                                var trashButton = this.getTopToolbar().findById('emptifier');
+                                if (trashButton) {
+                                    if (data.object.deletedCount == 0) {
+                                        trashButton.disable();
+                                    } else {
+                                        trashButton.enable();
+                                    }
 
-                        trashButton.setTooltip(_('empty_recycle_bin') + ' (' + data.object.deletedCount + ')');
-                    }
+                                    trashButton.setTooltip(_('empty_recycle_bin') + ' (' + data.object.deletedCount + ')');
+                                }
 
-                    var n = this.cm.activeNode;
-                    var ui = n.getUI();
+                                var n = this.cm.activeNode;
+                                var ui = n.getUI();
 
-                    ui.addClass('deleted');
-                    n.cascade(function(nd) {
-                        nd.getUI().addClass('deleted');
-                    },this);
-                    Ext.get(ui.getEl()).frame();
+                                ui.addClass('deleted');
+                                n.cascade(function(nd) {
+                                    nd.getUI().addClass('deleted');
+                                },this);
+                                Ext.get(ui.getEl()).frame();
+                            },scope:this}
+                        }
+                    });
                 },scope:this}
             }
         });
+
     }
 
     ,undeleteDocument: function(itm,e) {

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -216,7 +216,6 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                         ,params: {
                             action: 'resource/delete'
                             ,id: id
-                            ,nodelist: false
                         }
                         ,listeners: {
                             'success': {fn:function(data) {


### PR DESCRIPTION
### What does it do?
Adds two lines to the delete confirmation dialogue which show the context the resource is in and the path to and the name of the resource. If the permission to view the ids in the tree is set, also shows the id of the resource in question. 

### Why is it needed?
The confirmation alert does not show the resource to delete, therefore it may happen that you don't see any more if you clicked on the right resource to delete.

### Related issue(s)/PR(s)
The issue was partly described and mentioned in #764 and #13448.
