### PR TITLE
Let's create a new "please wait" windows on any package download

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -85,7 +85,7 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
         var r;
         var g = Ext.getCmp('modx-package-grid');
         if (!g) return false;
-        
+
         if (va.signature != undefined && va.signature != '') {
             r = {signature: va.signature};
         } else {
@@ -222,8 +222,10 @@ Ext.extend(MODx.panel.PackagesBrowser,MODx.Panel,{
 		this.wait.show();
 	}
 
-	,hideWait: function(){
-		this.wait.hide();
-	}
+    ,hideWait: function() {
+        if (this.wait) {
+            this.wait.destroy();
+        }
+    }
 });
 Ext.reg('modx-panel-packages-browser',MODx.panel.PackagesBrowser);


### PR DESCRIPTION
### What does it do?

It destroys existing "waiting window" instead of hiding it, as well as creates a new one instead of showing the existing (if any)

### Why is it needed?

Solves a rare case where a package installation could alter the content of the window.

### Related issue(s)/PR(s)

Closes #13503
