### PR TITLE
Load feeds on dashboard with AJAX instead of on page render

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -147,6 +147,7 @@ $_lang['err_self_parent'] = 'Cannot make something its own parent!';
 $_lang['error'] = 'Error';
 $_lang['error_sending_email'] = 'Error sending email';
 $_lang['error_sending_email_to'] = 'Error while sending mail to ';
+$_lang['error_loading_feed'] = 'An error occurred loading the feed.';
 $_lang['event_id'] = 'Event Id';
 $_lang['existing_category'] = 'Existing Category';
 $_lang['expand_all'] = 'Expand All';

--- a/core/model/modx/processors/system/dashboard/widget/feed.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/feed.class.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Class modDashboardWidgetFeedProcessor
+ *
+ * Used to load the news and security feeds on the dashboard over AJAX. The processed feed content
+ * (i.e. HTML) is returned in object->html.
+ */
+class modDashboardWidgetFeedProcessor extends modProcessor
+{
+    /**
+     * @var modRSSParser
+     */
+    protected $rss;
+
+    public function process()
+    {
+        $feed = $this->getProperty('feed', 'news');
+        if (!in_array($feed, array('news', 'security'), true)) {
+            return $this->failure('Invalid feed type');
+        }
+
+        sleep(5);
+        $enabled = $this->modx->getOption('feed_modx_' . $feed . '_enabled', null, true);
+        if (!$enabled) {
+            return $this->failure();
+        }
+
+        $url = $this->modx->getOption('feed_modx_' . $feed);
+        // Check if the domain is valid before attempting to load it
+        $feedHost = parse_url($url, PHP_URL_HOST);
+        if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
+            return $this->failure();
+        }
+
+        return $this->loadFeed($url);
+    }
+
+    public function loadFeed($url)
+    {
+        $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
+        $this->rss = new modRSSParser($this->modx);
+
+        $o = array();
+        $rss = $this->rss->parse($url);
+        if (is_object($rss)) {
+            foreach (array_keys($rss->items) as $key) {
+                $item= &$rss->items[$key];
+                $item['pubdate'] = strftime('%c',$item['date_timestamp']);
+                $o[] = $this->getFileChunk('dashboard/rssitem.tpl',$item);
+            }
+        }
+        return $this->success('', array('html' => implode("\n",$o)));
+    }
+
+    /**
+     * @param string $tpl
+     * @param array $placeholders
+     * @return string
+     */
+    public function getFileChunk($tpl,array $placeholders = array()) {
+        $output = '';
+        $file = $tpl;
+        if (!file_exists($file)) {
+            $file = $this->modx->getOption('manager_path').'templates/'.$this->modx->getOption('manager_theme',null,'default').'/'.$tpl;
+        }
+        if (!file_exists($file)) {
+            $file = $this->modx->getOption('manager_path').'templates/default/'.$tpl;
+        }
+        if (file_exists($file)) {
+            /** @var modChunk $chunk */
+            $chunk = $this->modx->newObject('modChunk');
+            $chunk->setCacheable(false);
+            $tplContent = file_get_contents($file);
+            $chunk->setContent($tplContent);
+            $output = $chunk->process($placeholders);
+        }
+        return $output;
+    }
+}
+
+return 'modDashboardWidgetFeedProcessor';

--- a/core/model/modx/processors/system/dashboard/widget/feed.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/feed.class.php
@@ -37,8 +37,7 @@ class modDashboardWidgetFeedProcessor extends modProcessor
 
     public function loadFeed($url)
     {
-        $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
-        $this->rss = new modRSSParser($this->modx);
+        $this->rss = $this->modx->getService('rss', 'xmlrss.modRSSParser');
 
         $o = array();
         $rss = $this->rss->parse($url);

--- a/core/model/modx/processors/system/dashboard/widget/feed.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/feed.class.php
@@ -20,7 +20,6 @@ class modDashboardWidgetFeedProcessor extends modProcessor
             return $this->failure('Invalid feed type');
         }
 
-        sleep(5);
         $enabled = $this->modx->getOption('feed_modx_' . $feed . '_enabled', null, true);
         if (!$enabled) {
             return $this->failure();

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -33,7 +33,40 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel,{
         if (this.config.dashboard && this.config.dashboard.hide_trees) {
             Ext.getCmp('modx-layout').hideLeftbar(false);
         }
+        var newsContainer = Ext.get('modx-news-feed-container');
+        if (newsContainer) {
+            this.loadFeed(newsContainer, 'news');
+        }
+        var securityContainer = Ext.get('modx-security-feed-container');
+        if (securityContainer) {
+            this.loadFeed(securityContainer, 'security');
+        }
         MODx.fireEvent('ready');
+    },
+
+    loadFeed: function(container, feed) {
+        MODx.Ajax.request({
+                url: MODx.config.connector_url + '?action=system/dashboard/widget/feed&feed=' + feed
+                ,listeners: {
+                    success: {
+                        fn: function(response) {
+                            if (response.success) {
+                                container.update(response.object.html);
+                            }
+                            else if (response.message.length > 0) {
+                                container.update('<p class="error">' + response.message + '</p>');
+                            }
+                        }, scope: this
+                    }
+                    ,failure: {
+                        fn: function(response) {
+                            var message = response.message.length > 0 ? response.message : _('error_loading_feed');
+                            container.update('<p class="error">' + message + '</p>');
+                        }, scope: this
+                    }
+                }
+            }
+        );
     }
 });
 Ext.reg('modx-panel-welcome', MODx.panel.Welcome);

--- a/manager/controllers/default/dashboard/widget.modx-news.php
+++ b/manager/controllers/default/dashboard/widget.modx-news.php
@@ -9,35 +9,15 @@
  */
 class modDashboardWidgetNewsFeed extends modDashboardWidgetInterface {
     /**
-     * @var modRSSParser $rss
-     */
-    public $rss;
-
-    /**
      * @return string
      */
     public function render() {
-        $url = $this->modx->getOption('feed_modx_news');
-        $feedHost = parse_url($url, PHP_URL_HOST);
-        if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
+        $enabled = $this->modx->getOption('feed_modx_news_enabled',null,true);
+        if (!$enabled) {
             return '';
         }
-        $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
-        $this->rss = new modRSSParser($this->modx);
 
-        $o = array();
-        $newsEnabled = $this->modx->getOption('feed_modx_news_enabled',null,true);
-        if (!empty($url) && !empty($newsEnabled)) {
-            $rss = $this->rss->parse($url);
-            if (is_object($rss)) {
-                foreach (array_keys($rss->items) as $key) {
-                    $item= &$rss->items[$key];
-                    $item['pubdate'] = strftime('%c',$item['date_timestamp']);
-                    $o[] = $this->getFileChunk('dashboard/rssitem.tpl',$item);
-                }
-            }
-        }
-        return implode("\n",$o);
+        return '<div id="modx-news-feed-container" class="feed-loading" data-feed="news"><i class="icon icon-refresh icon-spin" aria-hidden="true"></i> ' . $this->modx->lexicon('loading') . '</div>';
     }
 }
 return 'modDashboardWidgetNewsFeed';

--- a/manager/controllers/default/dashboard/widget.modx-security.php
+++ b/manager/controllers/default/dashboard/widget.modx-security.php
@@ -8,33 +8,13 @@
  * @subpackage dashboard
  */
 class modDashboardWidgetSecurityFeed extends modDashboardWidgetInterface {
-    /**
-     * @var modRSSParser $rss
-     */
-    public $rss;
-
     public function render() {
-        $url = $this->modx->getOption('feed_modx_security');
-        $feedHost = parse_url($url, PHP_URL_HOST);
-        if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
+        $enabled = $this->modx->getOption('feed_modx_security_enabled',null,true);
+        if (!$enabled) {
             return '';
         }
-        $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
-        $this->rss = new modRSSParser($this->modx);
 
-        $o = array();
-        $newsEnabled = $this->modx->getOption('feed_modx_security_enabled',null,true);
-        if (!empty($url) && !empty($newsEnabled)) {
-            $rss = $this->rss->parse($url);
-            if (is_object($rss)) {
-                foreach (array_keys($rss->items) as $key) {
-                    $item= &$rss->items[$key];
-                    $item['pubdate'] = strftime('%c',$item['date_timestamp']);
-                    $o[] = $this->getFileChunk('dashboard/rssitem.tpl',$item);
-                }
-            }
-        }
-        return implode("\n",$o);
+        return '<div id="modx-security-feed-container" class="feed-loading" data-feed="news"><i class="icon icon-refresh icon-spin" aria-hidden="true"></i> ' . $this->modx->lexicon('loading') . '</div>';
     }
 }
 return 'modDashboardWidgetSecurityFeed';


### PR DESCRIPTION
### What does it do?
This changes the way the news and security feeds on the dashboard are rendered. Previously, this happened during rendering of the manager (i.e. before the manager HTML is sent to the browser). Now, it happens asynchronously when the manager page has been rendered by ExtJS.

### Why is it needed?
The RSS feeds can be quite slow, especially in remote places. They also depend on an internet connection to work, which isn't always available. When the feeds are slow to load, the entire dashboard is slow to load, which is bad.

There are also other issues with the current RSS reader implementation, for example, #13209 where the entire manager is blank if the underlying RSS class can't find OpenSSL. By moving it into a separate PHP process, such issues will no longer break the entire manager just like that. I've not changed how that implementation works for now, other than putting the calls into a different place so it's more resilient. 

### Related issue(s)/PR(s)
I can't find a specific issue requesting this to be loaded this over AJAX, but #13209 and #2797 are somewhat related. 