### PR TITLE
fixes issue #13505

### DIFF
--- a/_build/data/transport.core.accesspolicies.php
+++ b/_build/data/transport.core.accesspolicies.php
@@ -80,7 +80,7 @@ $policies['7']->fromArray(array (
   'description' => 'Context administration policy with limited, content-editing related Permissions, but no publishing.',
   'parent' => 0,
   'class' => '',
-  'data' => '{"change_profile":true,"class_map":true,"countries":true,"edit_document":true,"frames":true,"help":true,"home":true,"load":true,"list":true,"logout":true,"menu_reports":true,"menu_site":true,"menu_support":true,"menu_tools":true,"menu_user":true,"resource_duplicate":true,"resource_tree":true,"save_document":true,"source_view":true,"tree_show_resource_ids":true,"view":true,"view_document":true,"new_document":true,"delete_document":true}',
+  'data' => '{"change_profile":true,"class_map":true,"countries":true,"edit_document":true,"frames":true,"help":true,"home":true,"load":true,"list":true,"logout":true,"menu_reports":true,"menu_site":true,"menu_support":true,"menu_tools":true,"menu_user":true,"resource_duplicate":true,"resource_tree":true,"save_document":true,"source_view":true,"tree_show_resource_ids":true,"view":true,"view_document":true,"view_template":true,"new_document":true,"delete_document":true}',
   'lexicon' => 'permissions',
 ), '', true, true);
 


### PR DESCRIPTION
### What does it do ?
Added setting `"view_template":true` for the "Content Editor" access policy in the file data/transport.core.accesspolicies.php

### Why is it needed?
Prevents the "Permission denied"-message when opening a resource or changing the template as a user with the default "Content Editor" access policy.

### Related issue(s)/PR(s)
#13505 
#modxbughunt 
