### PR TITLE
Fixed date format for created filed of package in package provider

### DIFF
--- a/core/model/modx/transport/modtransportprovider.class.php
+++ b/core/model/modx/transport/modtransportprovider.class.php
@@ -222,7 +222,7 @@ class modTransportProvider extends xPDOSimpleObject {
             $package->set('signature', $signature);
             $package->set('state', 1);
             $package->set('workspace', 1);
-            $package->set('created', date('Y-m-d h:i:s'));
+            $package->set('created', strftime('%Y-%m-%d %H:%M:%S'));
             $package->set('provider', $this->get('id'));
             $package->set('metadata', $metadata);
             $package->set('package_name', $metadata['name']);


### PR DESCRIPTION
### What does it do?
It changes the date format to correct when somebody downloads package from package provider.

### Why is it needed?
Before in format string was defined `h` for hours, that means 12-hour format of hours and this value was parsed incorrectly. When time was 13:45 actually it was parsed to 01:45 am. Now it replaced by strftime as in other places where package management manipulates of dates.

### Related issue(s)/PR(s)
#12077
#modxbughunt 