### PR TITLE
Unhilite the 'Clear Filter' button on mouseout across the manager [#11954] #modxbughunt

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -73,7 +73,11 @@ MODx.grid.SettingsGrid = function(config) {
         ,cls: 'x-form-filter-clear'
         ,text: _('filter_clear')
         ,listeners: {
-            'click': {fn: this.clearFilter, scope: this}
+            'click': {fn: this.clearFilter, scope: this},
+            'mouseout': { fn: function(evt){
+                   this.removeClass('x-btn-focus');
+                }
+            }
         }
     });
 

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -104,7 +104,11 @@ MODx.grid.TemplateTV = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -75,7 +75,11 @@ MODx.grid.TemplateVarTemplate = function(config) {
             ,id: 'modx-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -124,7 +124,11 @@ MODx.grid.FCProfile = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -98,7 +98,11 @@ MODx.grid.FCSet = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -119,7 +119,11 @@ MODx.grid.AccessPolicy = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -122,7 +122,11 @@ MODx.grid.AccessPolicyTemplate = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/security/modx.grid.message.js
+++ b/manager/assets/modext/widgets/security/modx.grid.message.js
@@ -132,7 +132,11 @@ MODx.grid.Message = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -151,7 +151,11 @@ MODx.grid.User = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -114,7 +114,11 @@ MODx.grid.Sources = function(config) {
             ,id: 'modx-filter-clear'
             ,cls: 'x-form-filter-clear'
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -66,7 +66,11 @@ MODx.grid.Context = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -74,7 +74,11 @@ MODx.grid.DashboardWidgets = function(config) {
             ,id: 'modx-dashboard-widgets-filter-clear'
             ,cls: 'x-form-filter-clear'
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/widgets/system/modx.grid.system.event.js
+++ b/manager/assets/modext/widgets/system/modx.grid.system.event.js
@@ -66,7 +66,11 @@ MODx.grid.SystemEvent = function(config) {
 			,cls: 'x-form-filter-clear'
 			,text: _('filter_clear')
 			,listeners: {
-				'click': {fn: this.clearFilter, scope: this}
+				'click': {fn: this.clearFilter, scope: this},
+				'mouseout': { fn: function(evt){
+					this.removeClass('x-btn-focus');
+				}
+				}
 			}
 		}]
     });

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -132,7 +132,11 @@ MODx.grid.Dashboards = function(config) {
             ,id: 'modx-filter-clear'
             ,cls: 'x-form-filter-clear'
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -120,7 +120,11 @@ MODx.grid.Lexicon = function(config) {
             ,itemId: 'clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                    'mouseout': { fn: function(evt){
+                        this.removeClass('x-btn-focus');
+                    }
+                    }
             }
         }]
         ,pagingItems: [{

--- a/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
+++ b/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
@@ -105,7 +105,11 @@ MODx.grid.Namespace = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                    }
+                }
             }
         }]
     });

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -110,7 +110,11 @@ MODx.grid.Package = function(config) {
             ,cls: 'x-form-filter-clear'
             ,text: _('filter_clear')
             ,listeners: {
-                'click': {fn: this.clearFilter, scope: this}
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': { fn: function(evt){
+                    this.removeClass('x-btn-focus');
+                }
+                }
             }
         }]
     });


### PR DESCRIPTION
### What does it do?
Added a mouseout listener to the 'Clear Filter' buttons across the manager.

### Why is it needed?
When the button is clicked,  Chrome is adding an x-btn-focus class to the dom which was not being removed on mouseout.
Other browsers were not adding this class and thus not displaying the problem.

Overrides can't be used for events so the listener had to be added to each file displaying the issue -> Ugly.

For ease of testing the affected panels are as follows:

Media: Media Sources
Manage:  Users
User: Settings
Logged In User : Messages
System Settings : System Settings
System Settings : System Events
Manager Customisation
Contexts
Dashboards : Dashboards
Dashboards : Widgets
Access Control Lists : Access Policies
Access Control Lists : Policy Templates
Lexicon Management
Namespaces
Elements:
Template : Template Variables
Template Variable : Template Access