### PR TITLE
Fixed blocketuntil and blockedafter field if unset blocked checkbox

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -417,6 +417,16 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,description: _('user_block_desc')
                     ,xtype: 'xcheckbox'
                     ,inputValue: 1
+                    ,listeners: {
+                        check: {
+                            fn: function (obj, value) {
+                                if (!value) {
+                                    Ext.getCmp('modx-user-blockeduntil').setValue();
+                                    Ext.getCmp('modx-user-blockedafter').setValue();
+                                }
+                            }
+                        }
+                    }
                 },{
                     id: 'modx-user-blockeduntil'
                     ,name: 'blockeduntil'


### PR DESCRIPTION
### What does it do?
Clear blocketuntil and blockedafter field if unset blocked checkbox in user update grid

### Why is it needed?
When I remove the lock from the user, it still remains blocked due to blocketuntil and blockedafter fields

### Related issue(s)/PR(s)
none known
