### PR TITLE
[Enhancement] Speedup the Feed-Dashboards

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -549,7 +549,7 @@ $settings['feed_modx_news']->fromArray(array (
 $settings['feed_modx_news_enabled']= $xpdo->newObject('modSystemSetting');
 $settings['feed_modx_news_enabled']->fromArray(array (
   'key' => 'feed_modx_news_enabled',
-  'value' => '1',
+  'value' => '0',
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
@@ -567,7 +567,7 @@ $settings['feed_modx_security']->fromArray(array (
 $settings['feed_modx_security_enabled']= $xpdo->newObject('modSystemSetting');
 $settings['feed_modx_security_enabled']->fromArray(array (
   'key' => 'feed_modx_security_enabled',
-  'value' => '1',
+  'value' => '0',
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',

--- a/manager/controllers/default/dashboard/widget.modx-news.php
+++ b/manager/controllers/default/dashboard/widget.modx-news.php
@@ -17,17 +17,17 @@ class modDashboardWidgetNewsFeed extends modDashboardWidgetInterface {
      * @return string
      */
     public function render() {
-        $url = $this->modx->getOption('feed_modx_news');
-        $feedHost = parse_url($url, PHP_URL_HOST);
-        if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
-            return '';
-        }
-        $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
-        $this->rss = new modRSSParser($this->modx);
-
         $o = array();
+        $url = $this->modx->getOption('feed_modx_news');
         $newsEnabled = $this->modx->getOption('feed_modx_news_enabled',null,true);
         if (!empty($url) && !empty($newsEnabled)) {
+            $feedHost = parse_url($url, PHP_URL_HOST);
+            if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
+                return '';
+            }
+            $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
+            $this->rss = new modRSSParser($this->modx);
+
             $rss = $this->rss->parse($url);
             if (is_object($rss)) {
                 foreach (array_keys($rss->items) as $key) {

--- a/manager/controllers/default/dashboard/widget.modx-security.php
+++ b/manager/controllers/default/dashboard/widget.modx-security.php
@@ -14,17 +14,17 @@ class modDashboardWidgetSecurityFeed extends modDashboardWidgetInterface {
     public $rss;
 
     public function render() {
-        $url = $this->modx->getOption('feed_modx_security');
-        $feedHost = parse_url($url, PHP_URL_HOST);
-        if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
-            return '';
-        }
-        $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
-        $this->rss = new modRSSParser($this->modx);
-
         $o = array();
+        $url = $this->modx->getOption('feed_modx_security');
         $newsEnabled = $this->modx->getOption('feed_modx_security_enabled',null,true);
         if (!empty($url) && !empty($newsEnabled)) {
+            $feedHost = parse_url($url, PHP_URL_HOST);
+            if ($feedHost && function_exists('checkdnsrr') && !checkdnsrr($feedHost, 'A')) {
+                return '';
+            }
+            $this->modx->loadClass('xmlrss.modRSSParser','',false,true);
+            $this->rss = new modRSSParser($this->modx);
+
             $rss = $this->rss->parse($url);
             if (is_object($rss)) {
                 foreach (array_keys($rss->items) as $key) {


### PR DESCRIPTION
### What does it do?
Speeds up the dashboard widgets for the rss feeds

### Why is it needed?
More speed and less overhead work if the feeds are turned off anyway.

### Related issue(s)/PR(s)
none
