### PR TITLE
Fix weird effects with nested items #13250 #modxbughunt

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -442,10 +442,10 @@ class modParser {
         $tokenOffset= 0;
         $cacheable= true;
         if ($token === '!') {
-            if (!$processUncacheable) {
-                $this->_processingTag = false;
-                return $outerTag;
-            }
+//            if (!$processUncacheable) {
+//                $this->_processingTag = false;
+//                return $outerTag;
+//            }
             $cacheable= false;
             $tokenOffset++;
             $token= substr($tagName, $tokenOffset, 1);


### PR DESCRIPTION
### What does it do?
Continue parsing tags if a nested uncached tag is parsed in a cached tag.

### Why is it needed?
Make sure all tags are processed.

### Related issue(s)/PR(s)
Related issue #13250
