### PR TITLE
Fix for displaying SVG in media browser

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -65,6 +65,7 @@
       width: auto;
       max-width: 100%;
       height: auto;
+      max-height: 100%;
     }
   .modx-browser-thumb-wrap span {
     display: block;

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -60,6 +60,7 @@
   }
     .modx-browser-thumb img {
       vertical-align: middle;
+      max-height: 80px;
     }
   .modx-browser-thumb-wrap span {
     display: block;

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -60,7 +60,11 @@
   }
     .modx-browser-thumb img {
       vertical-align: middle;
-      max-height: 80px;
+    }
+    .modx-browser-thumb img[src$=".svg"] {
+      width: auto;
+      max-width: 100%;
+      height: auto;
     }
   .modx-browser-thumb-wrap span {
     display: block;

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -252,7 +252,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                             'source' => $this->get('id'),
                         ));
 
-                        $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                        if ($ext == 'svg') {
+                            $image = $bases['urlAbsolute'] . urldecode($url);
+                        } else {
+                            $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                        }
 
                         $files[$fileName]['qtip'] = '<img src="'.$image.'" alt="'.$fileName.'" />';
 
@@ -961,7 +965,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
         /* get default settings */
-        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $use_multibyte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
@@ -1050,8 +1054,13 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         'wctx' => $this->ctx->get('key'),
                         'source' => $this->get('id'),
                     ));
-                    $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
-                    $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                    // Display thumbnail for SVGs
+                    if ($fileExtension == 'svg') {
+                        $thumb = $image = $bases['urlAbsolute'] . urldecode($url);
+                    } else {
+                        $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                        $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                    }
                 } else {
                     $preview = 0;
                     $size = null;
@@ -1170,7 +1179,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 'name' => 'imageExtensions',
                 'desc' => 'prop_file.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif',
+                'value' => 'jpg,jpeg,png,gif,svg',
                 'lexicon' => 'core:source',
             ),
             'thumbnailType' => array(

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -342,7 +342,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $bucketUrl = rtrim($properties['url'],'/').'/';
         $allowedFileTypes = $this->getOption('allowedFileTypes',$this->properties,'');
         $allowedFileTypes = !empty($allowedFileTypes) && is_string($allowedFileTypes) ? explode(',',$allowedFileTypes) : $allowedFileTypes;
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $thumbnailType = $this->getOption('thumbnailType',$this->properties,'png');
         $thumbnailQuality = $this->getOption('thumbnailQuality',$this->properties,90);
@@ -426,10 +426,15 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                         'wctx' => $this->ctx->get('key'),
                         'source' => $this->get('id'),
                     ));
-                    $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                    // Display thumbnail for SVGs
+                    if ($fileArray['ext'] == 'svg') {
+                        $fileArray['thumb'] = $fileArray['image'] = $bases['urlAbsolute'] . urldecode($url);
+                    } else {
+                        $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                        $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                    }
                     $fileArray['thumb_width'] = $thumbWidth;
                     $fileArray['thumb_height'] = $thumbHeight;
-                    $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                     $fileArray['image_width'] = is_array($size) ? $size[0] : $imageWidth;
                     $fileArray['image_height'] = is_array($size) ? $size[1] : $imageHeight;
                     $fileArray['preview'] = 1;


### PR DESCRIPTION
### What does it do?
Displays SVGs in the media browser.

### Why is it needed?
SVG's weren't being displayed as they were being processed by PHPThumb.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/12459
