### PR TITLE
Replace all hardcoded http versions by $_SERVER['SERVER_PROTOCOL'] va…

### DIFF
--- a/connectors/index.php
+++ b/connectors/index.php
@@ -30,7 +30,7 @@ if (!defined('MODX_CORE_PATH')) {
 /* include modX class - return error on failure */
 if (!include_once(MODX_CORE_PATH . 'model/modx/modx.class.php')) {
     header("Content-Type: application/json; charset=UTF-8");
-    header('HTTP/1.1 404 Not Found');
+    header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
     echo json_encode(array(
         'success' => false,
         'code' => 404,
@@ -49,7 +49,7 @@ $modx->initialize($ctx);
 if (defined('MODX_REQP') && MODX_REQP === false) {
 } else if (!is_object($modx->context) || !$modx->context->checkPolicy('load')) {
     header("Content-Type: application/json; charset=UTF-8");
-    header('HTTP/1.1 401 Not Authorized');
+    header($_SERVER['SERVER_PROTOCOL'] . ' 401 Not Authorized');
     echo json_encode(array(
         'success' => false,
         'code' => 401,

--- a/connectors/lang.js.php
+++ b/connectors/lang.js.php
@@ -53,7 +53,7 @@ if ($modx->getOption('cache_lang_js',null,false)) {
 
     /* if Browser sent ID, check if they match */
     if (isset($headers['If-None-Match']) && @preg_match($hash, $headers['If-None-Match'])) {
-        header('HTTP/1.1 304 Not Modified');
+        header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
     } else {
         header("ETag: \"{$hash}\"");
         header('Accept-Ranges: bytes');

--- a/core/error/fatal.include.php
+++ b/core/error/fatal.include.php
@@ -1,5 +1,5 @@
 <?php
-header('HTTP/1.1 500 Internal Server Error');
+header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error');
 ?>
 <html>
 <head>

--- a/core/error/unavailable.include.php
+++ b/core/error/unavailable.include.php
@@ -1,5 +1,5 @@
 <?php
-header('HTTP/1.1 503 Service Unavailable');
+header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
 ?>
 <html>
 <head>

--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -157,7 +157,7 @@ class modConnectorResponse extends modResponse {
                 $message = $this->_responseCodes[$this->responseCode];
             }
             header('Status: '.$this->responseCode.' '.$message);
-            header('Version: HTTP/1.1');
+            header('Version: ' . $_SERVER['SERVER_PROTOCOL']);
         }
         if (is_array($this->header)) {
             foreach ($this->header as $header) header($header);

--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -68,7 +68,7 @@ class modRequest {
         $this->sanitizeRequest();
         $this->modx->invokeEvent('OnHandleRequest');
         if (!$this->modx->checkSiteStatus()) {
-            header('HTTP/1.1 503 Service Unavailable');
+            header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
             if (!$this->modx->getOption('site_unavailable_page',null,1)) {
                 $this->modx->resource = $this->modx->newObject('modDocument');
                 $this->modx->resource->template = 0;
@@ -89,7 +89,7 @@ class modRequest {
                     } else {
                         $url = $this->modx->getOption('site_url', null, MODX_SITE_URL) . $uri;
                     }
-                    $this->modx->sendRedirect($url, array('responseCode' => 'HTTP/1.1 301 Moved Permanently'));
+                    $this->modx->sendRedirect($url, array('responseCode' => $_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently'));
                 }
             }
         }
@@ -306,7 +306,7 @@ class modRequest {
     public function _cleanResourceIdentifier($identifier) {
         if (empty ($identifier)) {
             if ($this->modx->getOption('base_url', null, MODX_BASE_URL) !== strtok($_SERVER["REQUEST_URI"],'?')) {
-                $this->modx->sendRedirect($this->modx->getOption('site_url', null, MODX_SITE_URL), array('responseCode' => 'HTTP/1.1 301 Moved Permanently'));
+                $this->modx->sendRedirect($this->modx->getOption('site_url', null, MODX_SITE_URL), array('responseCode' => $_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently'));
             }
             $identifier = $this->modx->getOption('site_start', null, 1);
             $this->modx->resourceMethod = 'id';
@@ -328,14 +328,14 @@ class modRequest {
                     $parameters = $this->getParameters();
                     unset($parameters[$this->modx->getOption('request_param_alias')]);
                     $url = $this->modx->makeUrl($found, $this->modx->context->get('key'), $parameters, 'full');
-                    $this->modx->sendRedirect($url, array('responseCode' => 'HTTP/1.1 301 Moved Permanently'));
+                    $this->modx->sendRedirect($url, array('responseCode' => $_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently'));
                 }
                 $this->modx->resourceMethod = 'alias';
             } elseif ((integer) $this->modx->getOption('site_start', null, 1) === $found) {
                 $parameters = $this->getParameters();
                 unset($parameters[$this->modx->getOption('request_param_alias')]);
                 $url = $this->modx->makeUrl($this->modx->getOption('site_start', null, 1), $this->modx->context->get('key'), $parameters, 'full');
-                $this->modx->sendRedirect($url, array('responseCode' => 'HTTP/1.1 301 Moved Permanently'));
+                $this->modx->sendRedirect($url, array('responseCode' => $_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently'));
             } else {
                 if ($this->modx->getOption('friendly_urls_strict', null, false)) {
                     $requestUri = $_SERVER['REQUEST_URI'];
@@ -347,7 +347,7 @@ class modRequest {
                         $parameters = $this->getParameters();
                         unset($parameters[$this->modx->getOption('request_param_alias')]);
                         $url = $this->modx->makeUrl($found, $this->modx->context->get('key'), $parameters, 'full');
-                        $this->modx->sendRedirect($url, array('responseCode' => 'HTTP/1.1 301 Moved Permanently'));
+                        $this->modx->sendRedirect($url, array('responseCode' => $_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently'));
                     }
                 }
                 $this->modx->resourceMethod = 'alias';

--- a/core/model/modx/modweblink.class.php
+++ b/core/model/modx/modweblink.class.php
@@ -39,7 +39,7 @@ class modWebLink extends modResource implements modResourceInterface {
         } else {
             $this->_output= $this->_content;
         }
-        $this->xpdo->sendRedirect($this->_output, array('responseCode' => $this->getProperty('responseCode', 'core', 'HTTP/1.1 301 Moved Permanently')));
+        $this->xpdo->sendRedirect($this->_output, array('responseCode' => $this->getProperty('responseCode', 'core', $_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently')));
     }
 
     /**

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1050,7 +1050,7 @@ class modX extends xPDO {
             if (file_exists(MODX_CORE_PATH . "error/{$type}.include.php")) {
                 @include(MODX_CORE_PATH . "error/{$type}.include.php");
             }
-            header($this->getOption('error_header', $options, 'HTTP/1.1 503 Service Unavailable'));
+            header($this->getOption('error_header', $options, $_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable'));
             echo "<html><head><title>{$errorPageTitle}</title></head><body>{$errorMessage}</body></html>";
             @session_write_close();
         } else {
@@ -1151,7 +1151,7 @@ class modX extends xPDO {
             $options= array_merge(
                 array(
                     'error_type' => '404'
-                    ,'error_header' => $this->getOption('error_page_header', $options,'HTTP/1.1 404 Not Found')
+                    ,'error_header' => $this->getOption('error_page_header', $options,$_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found')
                     ,'error_pagetitle' => $this->getOption('error_page_pagetitle', $options,'Error 404: Page not found')
                     ,'error_message' => $this->getOption('error_page_message', $options,'<h1>Page not found</h1><p>The page you requested was not found.</p>')
                 ),
@@ -1173,9 +1173,9 @@ class modX extends xPDO {
         if (!is_array($options)) $options = array();
         $options= array_merge(
             array(
-                'response_code' => $this->getOption('error_page_header', $options, 'HTTP/1.1 404 Not Found')
+                'response_code' => $this->getOption('error_page_header', $options, $_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found')
                 ,'error_type' => '404'
-                ,'error_header' => $this->getOption('error_page_header', $options, 'HTTP/1.1 404 Not Found')
+                ,'error_header' => $this->getOption('error_page_header', $options, $_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found')
                 ,'error_pagetitle' => $this->getOption('error_page_pagetitle', $options, 'Error 404: Page not found')
                 ,'error_message' => $this->getOption('error_page_message', $options, '<h1>Page not found</h1><p>The page you requested was not found.</p>')
             ),
@@ -1197,9 +1197,9 @@ class modX extends xPDO {
         if (!is_array($options)) $options = array();
         $options= array_merge(
             array(
-                'response_code' => $this->getOption('unauthorized_page_header' ,$options ,'HTTP/1.1 401 Unauthorized')
+                'response_code' => $this->getOption('unauthorized_page_header' ,$options ,$_SERVER['SERVER_PROTOCOL'] . ' 401 Unauthorized')
                 ,'error_type' => '401'
-                ,'error_header' => $this->getOption('unauthorized_page_header', $options,'HTTP/1.1 401 Unauthorized')
+                ,'error_header' => $this->getOption('unauthorized_page_header', $options,$_SERVER['SERVER_PROTOCOL'] . ' 401 Unauthorized')
                 ,'error_pagetitle' => $this->getOption('unauthorized_page_pagetitle',$options, 'Error 401: Unauthorized')
                 ,'error_message' => $this->getOption('unauthorized_page_message', $options,'<h1>Unauthorized</h1><p>You are not authorized to view the requested content.</p>')
             ),

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -243,13 +243,13 @@ class modRestService {
     public function iterateDirectories($pattern, $flags = 0) {
         $files = glob($pattern, $flags);
         $dirs = glob(dirname($pattern) . '/*', GLOB_ONLYDIR|GLOB_NOSORT);
-        
+
         if ($dirs) {
             foreach ($dirs as $dir) {
                 $files = array_merge($files, $this->iterateDirectories($dir . '/' . basename($pattern), $flags));
             }
         }
-        
+
         return $files;
     }
 
@@ -261,7 +261,7 @@ class modRestService {
         if (!$exit) {
             $this->modx->sendUnauthorizedPage();
         } else {
-            header('HTTP/1.1 401 Unauthorized');
+            header($_SERVER['SERVER_PROTOCOL'] . ' 401 Unauthorized');
             @session_write_close();
             exit(0);
         }
@@ -642,7 +642,7 @@ class modRestServiceResponse {
         $status = !empty($this->payload['status']) ? $this->payload['status'] : 200;
         $body = empty($this->payload['body']) ? '' : $this->payload['body'];
 
-		$headers = 'HTTP/1.1 ' . $status . ' ' . $this->getResponseCodeMessage($status);
+		$headers = $_SERVER['SERVER_PROTOCOL'] . ' ' . $status . ' ' . $this->getResponseCodeMessage($status);
 		header($headers);
 		header('Content-Type: ' . $contentType);
 		echo $body;

--- a/core/model/modx/rest/modrestsockclient.class.php
+++ b/core/model/modx/rest/modrestsockclient.class.php
@@ -43,7 +43,7 @@ class modRestSockClient extends modRestClient {
         $ip = $this->modx->request->getClientIp();
         $ip = $ip['ip'];
 
-        $out = $method." ".$purl['path']."/$path HTTP/1.1\r\n"
+        $out = $method." ".$purl['path']."/$path ".$_SERVER['SERVER_PROTOCOL']."\r\n"
                 ."Host: $host\r\n"
                 ."User-Agent: ".$this->config[modRestClient::OPT_USERAGENT]."\r\n"
                 ."Content-type: text/xml; charset=UTF-8\r\n"
@@ -73,11 +73,11 @@ class modRestSockClient extends modRestClient {
 
         list($header,$response) = explode('<?xml',$response);
         $response = '<?xml'.$response;
-        
+
         /* strip junk at end of string */
         $response = strrev($response);
         $response = strrev(substr($response,strpos($response,'>')));
-        
+
         /* commented out for debugging */
         //echo '<textarea cols="180" rows="50">'.$response.'</textarea>'; die();
         //echo '<pre>'.htmlentities($xml->asXml()).'</pre>'; die();

--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -671,7 +671,7 @@ class modTransportPackage extends xPDOObject {
         if( !$fp ) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,'Could not retrieve from '.$url);
         } else {
-            fwrite($fp, "GET $path HTTP/1.0\r\n" .
+            fwrite($fp, "GET $path ".$_SERVER['SERVER_PROTOCOL']."\r\n" .
                 "Host: $host\r\n" .
                 "User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.0.3) Gecko/20060426 Firefox/1.5.0.3\r\n" .
                 "Accept: */*\r\n" .

--- a/core/model/modx/xmlrpc/xmlrpc.inc
+++ b/core/model/modx/xmlrpc/xmlrpc.inc
@@ -1334,7 +1334,7 @@
 				$cookieheader = 'Cookie:' . $version . substr($cookieheader, 0, -1) . "\r\n";
 			}
 
-			$op= 'POST ' . $uri. " HTTP/1.0\r\n" .
+			$op= 'POST ' . $uri. " ".$_SERVER['SERVER_PROTOCOL']."\r\n" .
 				'User-Agent: ' . $GLOBALS['xmlrpcName'] . ' ' . $GLOBALS['xmlrpcVersion'] . "\r\n" .
 				'Host: '. $server . ':' . $port . "\r\n" .
 				$credentials .

--- a/core/model/modx/xmlrss/extlib/snoopy.class.php
+++ b/core/model/modx/xmlrss/extlib/snoopy.class.php
@@ -857,7 +857,7 @@ class Snoopy
                 if (isset($this->capath))
                     $context_opts['ssl']['capath'] = $this->capath;
             }
-                    
+
             $host = 'ssl://' . $host;
         }
 

--- a/core/model/smarty/plugins/function.fetch.php
+++ b/core/model/smarty/plugins/function.fetch.php
@@ -163,9 +163,9 @@ function smarty_function_fetch($params, $template)
                 return;
             } else {
                 if ($_is_proxy) {
-                    fputs($fp, 'GET ' . $params['file'] . " HTTP/1.0\r\n");
+                    fputs($fp, 'GET ' . $params['file'] . " ".$_SERVER['SERVER_PROTOCOL']."\r\n");
                 } else {
-                    fputs($fp, "GET $uri HTTP/1.0\r\n");
+                    fputs($fp, "GET $uri ".$_SERVER['SERVER_PROTOCOL']."\r\n");
                 }
                 if (!empty($host)) {
                     fputs($fp, "Host: $host\r\n");

--- a/index.php
+++ b/index.php
@@ -27,7 +27,7 @@ if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__FILE__) . '/c
 if (!@include_once (MODX_CORE_PATH . "model/modx/modx.class.php")) {
     $errorMessage = 'Site temporarily unavailable';
     @include(MODX_CORE_PATH . 'error/unavailable.include.php');
-    header('HTTP/1.1 503 Service Unavailable');
+    header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
     echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
     exit();
 }
@@ -41,7 +41,7 @@ if (!is_object($modx) || !($modx instanceof modX)) {
     ob_get_level() && @ob_end_flush();
     $errorMessage = '<a href="setup/">MODX not installed. Install now?</a>';
     @include(MODX_CORE_PATH . 'error/unavailable.include.php');
-    header('HTTP/1.1 503 Service Unavailable');
+    header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
     echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
     exit();
 }

--- a/manager/controllers/default/resource/weblink/create.class.php
+++ b/manager/controllers/default/resource/weblink/create.class.php
@@ -37,7 +37,7 @@ Ext.onReady(function() {
         /* load RTE */
         $this->loadRichTextEditor();
     }
-    
+
     /**
      * Return the location of the template file
      * @return string
@@ -48,7 +48,7 @@ Ext.onReady(function() {
 
     public function process(array $scriptProperties = array()) {
         $placeholders = parent::process($scriptProperties);
-        $this->resourceArray['responseCode'] = $this->resource->getProperty('responseCode','core','HTTP/1.1 301 Moved Permanently');
+        $this->resourceArray['responseCode'] = $this->resource->getProperty('responseCode','core',$_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently');
         return $placeholders;
     }
 }

--- a/manager/controllers/default/resource/weblink/update.class.php
+++ b/manager/controllers/default/resource/weblink/update.class.php
@@ -46,7 +46,7 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController {
         /* load RTE */
         $this->loadRichTextEditor();
     }
-    
+
     /**
      * Return the location of the template file
      * @return string
@@ -57,7 +57,7 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController {
 
     public function process(array $scriptProperties = array()) {
         $placeholders = parent::process($scriptProperties);
-        $this->resourceArray['responseCode'] = $this->resource->getProperty('responseCode','core','HTTP/1.1 301 Moved Permanently');
+        $this->resourceArray['responseCode'] = $this->resource->getProperty('responseCode','core',$_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently');
         return $placeholders;
     }
 }

--- a/manager/index.php
+++ b/manager/index.php
@@ -44,7 +44,7 @@ $modx= new modX('', array(xPDO::OPT_CONN_INIT => array(xPDO::OPT_CONN_MUTABLE =>
 if (!is_object($modx) || !($modx instanceof modX)) {
     $errorMessage = '<a href="../setup/">MODX not installed. Install now?</a>';
     include MODX_CORE_PATH . 'error/unavailable.include.php';
-    header('HTTP/1.1 503 Service Unavailable');
+    header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
     echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
     exit();
 }

--- a/manager/min/index.php
+++ b/manager/min/index.php
@@ -23,7 +23,7 @@ $modx= new modX('', array(xPDO::OPT_CONN_INIT => array(xPDO::OPT_CONN_MUTABLE =>
 if (!is_object($modx) || !($modx instanceof modX)) {
     $errorMessage = 'MODX not installed!';
     include MODX_CORE_PATH . 'error/unavailable.include.php';
-    header('HTTP/1.1 503 Service Unavailable');
+    header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
     echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
     exit();
 }
@@ -130,7 +130,7 @@ if (isset($_GET['g'])) {
     $min_serveOptions['minApp']['groups'] = (require MINIFY_MIN_DIR . '/groupsConfig.php');
 }
 if (isset($_GET['f']) || isset($_GET['g'])) {
-    // serve!   
+    // serve!
     if (! isset($min_serveController)) {
         require 'Minify/Controller/MinApp.php';
         $min_serveController = new Minify_Controller_MinApp();

--- a/manager/min/lib/HTTP/ConditionalGet.php
+++ b/manager/min/lib/HTTP/ConditionalGet.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class HTTP_ConditionalGet  
+ * Class HTTP_ConditionalGet
  * @package Minify
  * @subpackage HTTP
  */
@@ -21,7 +21,7 @@
  * }
  * echo $content;
  * </code>
- * 
+ *
  * E.g. Shortcut for the above
  * <code>
  * HTTP_ConditionalGet::check($updateTime, true); // exits if client has cache
@@ -40,7 +40,7 @@
  * }
  * echo $content;
  * </code>
- * 
+ *
  * E.g. Static content with some static includes:
  * <code>
  * // before content
@@ -64,7 +64,7 @@ class HTTP_ConditionalGet {
 
     /**
      * Does the client have a valid copy of the requested resource?
-     * 
+     *
      * You'll want to check this after instantiating the object. If true, do
      * not send content, just call sendHeaders() if you haven't already.
      *
@@ -74,36 +74,36 @@ class HTTP_ConditionalGet {
 
     /**
      * @param array $spec options
-     * 
+     *
      * 'isPublic': (bool) if false, the Cache-Control header will contain
      * "private", allowing only browser caching. (default false)
-     * 
+     *
      * 'lastModifiedTime': (int) if given, both ETag AND Last-Modified headers
      * will be sent with content. This is recommended.
      *
      * 'encoding': (string) if set, the header "Vary: Accept-Encoding" will
      * always be sent and a truncated version of the encoding will be appended
-     * to the ETag. E.g. "pub123456;gz". This will also trigger a more lenient 
+     * to the ETag. E.g. "pub123456;gz". This will also trigger a more lenient
      * checking of the client's If-None-Match header, as the encoding portion of
      * the ETag will be stripped before comparison.
-     * 
+     *
      * 'contentHash': (string) if given, only the ETag header can be sent with
-     * content (only HTTP1.1 clients can conditionally GET). The given string 
-     * should be short with no quote characters and always change when the 
-     * resource changes (recommend md5()). This is not needed/used if 
+     * content (only HTTP1.1 clients can conditionally GET). The given string
+     * should be short with no quote characters and always change when the
+     * resource changes (recommend md5()). This is not needed/used if
      * lastModifiedTime is given.
-     * 
+     *
      * 'eTag': (string) if given, this will be used as the ETag header rather
      * than values based on lastModifiedTime or contentHash. Also the encoding
      * string will not be appended to the given value as described above.
-     * 
+     *
      * 'invalidate': (bool) if true, the client cache will be considered invalid
-     * without testing. Effectively this disables conditional GET. 
+     * without testing. Effectively this disables conditional GET.
      * (default false)
-     * 
-     * 'maxAge': (int) if given, this will set the Cache-Control max-age in 
-     * seconds, and also set the Expires header to the equivalent GMT date. 
-     * After the max-age period has passed, the browser will again send a 
+     *
+     * 'maxAge': (int) if given, this will set the Cache-Control max-age in
+     * seconds, and also set the Expires header to the equivalent GMT date.
+     * After the max-age period has passed, the browser will again send a
      * conditional GET to revalidate its cache.
      */
     public function __construct($spec)
@@ -113,7 +113,7 @@ class HTTP_ConditionalGet {
             : 'private';
         $maxAge = 0;
         // backwards compatibility (can be removed later)
-        if (isset($spec['setExpires']) 
+        if (isset($spec['setExpires'])
             && is_numeric($spec['setExpires'])
             && ! isset($spec['maxAge'])) {
             $spec['maxAge'] = $spec['setExpires'] - $_SERVER['REQUEST_TIME'];
@@ -121,7 +121,7 @@ class HTTP_ConditionalGet {
         if (isset($spec['maxAge'])) {
             $maxAge = $spec['maxAge'];
             $this->_headers['Expires'] = self::gmtDate(
-                $_SERVER['REQUEST_TIME'] + $spec['maxAge'] 
+                $_SERVER['REQUEST_TIME'] + $spec['maxAge']
             );
         }
         $etagAppend = '';
@@ -156,14 +156,14 @@ class HTTP_ConditionalGet {
             ? false
             : $this->_isCacheValid();
     }
-    
+
     /**
      * Get array of output headers to be sent
-     * 
+     *
      * In the case of 304 responses, this array will only contain the response
      * code header: array('_responseCode' => 'HTTP/1.0 304 Not Modified')
-     * 
-     * Otherwise something like: 
+     *
+     * Otherwise something like:
      * <code>
      * array(
      *     'Cache-Control' => 'max-age=0, public'
@@ -171,7 +171,7 @@ class HTTP_ConditionalGet {
      * )
      * </code>
      *
-     * @return array 
+     * @return array
      */
     public function getHeaders()
     {
@@ -180,13 +180,13 @@ class HTTP_ConditionalGet {
 
     /**
      * Set the Content-Length header in bytes
-     * 
+     *
      * With most PHP configs, as long as you don't flush() output, this method
-     * is not needed and PHP will buffer all output and set Content-Length for 
+     * is not needed and PHP will buffer all output and set Content-Length for
      * you. Otherwise you'll want to call this to let the client know up front.
-     * 
+     *
      * @param int $bytes
-     * 
+     *
      * @return int copy of input $bytes
      */
     public function setContentLength($bytes)
@@ -196,9 +196,9 @@ class HTTP_ConditionalGet {
 
     /**
      * Send headers
-     * 
+     *
      * @see getHeaders()
-     * 
+     *
      * Note this doesn't "clear" the headers. Calling sendHeaders() will
      * call header() again (but probably have not effect) and getHeaders() will
      * still return the headers.
@@ -218,7 +218,7 @@ class HTTP_ConditionalGet {
             header($name . ': ' . $val);
         }
     }
-    
+
     /**
      * Exit if the client's cache is valid for this resource
      *
@@ -227,8 +227,8 @@ class HTTP_ConditionalGet {
      * @param int $lastModifiedTime if given, both ETag AND Last-Modified headers
      * will be sent with content. This is recommended.
      *
-     * @param bool $isPublic (default false) if true, the Cache-Control header 
-     * will contain "public", allowing proxies to cache the content. Otherwise 
+     * @param bool $isPublic (default false) if true, the Cache-Control header
+     * will contain "public", allowing proxies to cache the content. Otherwise
      * "private" will be sent, allowing only browser caching.
      *
      * @param array $options (default empty) additional options for constructor
@@ -245,24 +245,24 @@ class HTTP_ConditionalGet {
             exit();
         }
     }
-    
-    
+
+
     /**
      * Get a GMT formatted date for use in HTTP headers
-     * 
+     *
      * <code>
      * header('Expires: ' . HTTP_ConditionalGet::gmtdate($time));
-     * </code>  
+     * </code>
      *
      * @param int $time unix timestamp
-     * 
+     *
      * @return string
      */
     public static function gmtDate($time)
     {
         return gmdate('D, d M Y H:i:s \G\M\T', $time);
     }
-    
+
     protected $_headers = array();
     protected $_lmTime = null;
     protected $_etag = null;
@@ -297,13 +297,13 @@ class HTTP_ConditionalGet {
     {
         if (null === $this->_etag) {
             // lmTime is copied to ETag, so this condition implies that the
-            // server sent neither ETag nor Last-Modified, so the client can't 
+            // server sent neither ETag nor Last-Modified, so the client can't
             // possibly has a valid cache.
             return false;
         }
         $isValid = ($this->resourceMatchedEtag() || $this->resourceNotModified());
         if ($isValid) {
-            $this->_headers['_responseCode'] = 'HTTP/1.0 304 Not Modified';
+            $this->_headers['_responseCode'] = $_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified';
         }
         return $isValid;
     }
@@ -320,7 +320,7 @@ class HTTP_ConditionalGet {
             ? stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])
             : $_SERVER['HTTP_IF_NONE_MATCH'];
         $clientEtags = explode(',', $clientEtagList);
-        
+
         $compareTo = $this->normalizeEtag($this->_etag);
         foreach ($clientEtags as $clientEtag) {
             if ($this->normalizeEtag($clientEtag) === $compareTo) {
@@ -356,7 +356,7 @@ class HTTP_ConditionalGet {
         // strip off IE's extra data (semicolon)
         list($ifModifiedSince) = explode(';', $_SERVER['HTTP_IF_MODIFIED_SINCE'], 2);
         if (strtotime($ifModifiedSince) >= $this->_lmTime) {
-            // Apache 2.2's behavior. If there was no ETag match, send the 
+            // Apache 2.2's behavior. If there was no ETag match, send the
             // non-encoded version of the ETag value.
             $this->_headers['ETag'] = $this->normalizeEtag($this->_etag);
             return true;

--- a/manager/min/lib/Minify/Controller/Base.php
+++ b/manager/min/lib/Minify/Controller/Base.php
@@ -1,39 +1,39 @@
 <?php
 /**
- * Class Minify_Controller_Base  
+ * Class Minify_Controller_Base
  * @package Minify
  */
 
 /**
  * Base class for Minify controller
- * 
+ *
  * The controller class validates a request and uses it to create sources
  * for minification and set options like contentType. It's also responsible
  * for loading minifier code upon request.
- * 
+ *
  * @package Minify
  * @author Stephen Clay <steve@mrclay.org>
  */
 abstract class Minify_Controller_Base {
-    
+
     /**
      * Setup controller sources and set an needed options for Minify::source
-     * 
-     * You must override this method in your subclass controller to set 
-     * $this->sources. If the request is NOT valid, make sure $this->sources 
-     * is left an empty array. Then strip any controller-specific options from 
+     *
+     * You must override this method in your subclass controller to set
+     * $this->sources. If the request is NOT valid, make sure $this->sources
+     * is left an empty array. Then strip any controller-specific options from
      * $options and return it. To serve files, $this->sources must be an array of
      * Minify_Source objects.
-     * 
+     *
      * @param array $options controller and Minify options
-     * 
+     *
      * @return array $options Minify::serve options
      */
     abstract public function setupSources($options);
-    
+
     /**
      * Get default Minify options for this controller.
-     * 
+     *
      * Override in subclass to change defaults
      *
      * @return array options for Minify
@@ -51,22 +51,22 @@ abstract class Minify_Controller_Base {
             ,'bubbleCssImports' => false
             ,'quiet' => false // serve() will send headers and output
             ,'debug' => false
-            
+
             // if you override these, the response codes MUST be directly after
             // the first space.
-            ,'badRequestHeader' => 'HTTP/1.0 400 Bad Request'
-            ,'errorHeader'      => 'HTTP/1.0 500 Internal Server Error'
-            
+            ,'badRequestHeader' => $_SERVER['SERVER_PROTOCOL'] . ' 400 Bad Request'
+            ,'errorHeader'      => $_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error'
+
             // callback function to see/modify content of all sources
             ,'postprocessor' => null
             // file to require to load preprocessor
             ,'postprocessorRequire' => null
         );
-    }  
+    }
 
     /**
      * Get default minifiers for this controller.
-     * 
+     *
      * Override in subclass to change defaults
      *
      * @return array minifier callbacks for common types
@@ -77,22 +77,22 @@ abstract class Minify_Controller_Base {
         $ret[Minify::TYPE_HTML] = array('Minify_HTML', 'minify');
         return $ret;
     }
-    
+
     /**
      * Load any code necessary to execute the given minifier callback.
-     * 
+     *
      * The controller is responsible for loading minification code on demand
      * via this method. This built-in function will only load classes for
      * static method callbacks where the class isn't already defined. It uses
-     * the PEAR convention, so, given array('Jimmy_Minifier', 'minCss'), this 
+     * the PEAR convention, so, given array('Jimmy_Minifier', 'minCss'), this
      * function will include 'Jimmy/Minifier.php'.
-     * 
+     *
      * If you need code loaded on demand and this doesn't suit you, you'll need
-     * to override this function in your subclass. 
+     * to override this function in your subclass.
      * @see Minify_Controller_Page::loadMinifier()
-     * 
+     *
      * @param callback $minifierCallback callback of minifier function
-     * 
+     *
      * @return null
      */
     public function loadMinifier($minifierCallback)
@@ -100,23 +100,23 @@ abstract class Minify_Controller_Base {
         if (is_array($minifierCallback)
             && is_string($minifierCallback[0])
             && !class_exists($minifierCallback[0], false)) {
-            
+
             require str_replace('_', '/', $minifierCallback[0]) . '.php';
         }
     }
-    
+
     /**
      * Is a user-given file within an allowable directory, existing,
      * and having an extension js/css/html/txt ?
-     * 
+     *
      * This is a convenience function for controllers that have to accept
      * user-given paths
      *
      * @param string $file full file path (already processed by realpath())
-     * 
+     *
      * @param array $safeDirs directories where files are safe to serve. Files can also
      * be in subdirectories of these directories.
-     * 
+     *
      * @return bool file is safe
      *
      * @deprecated use checkAllowDirs, checkNotHidden instead
@@ -173,27 +173,27 @@ abstract class Minify_Controller_Base {
      * instances of Minify_Source, which provide content and any individual minification needs.
      *
      * @var array
-     * 
+     *
      * @see Minify_Source
      */
     public $sources = array();
-    
+
     /**
      * Short name to place inside cache id
      *
      * The setupSources() method may choose to set this, making it easier to
      * recognize a particular set of sources/settings in the cache folder. It
      * will be filtered and truncated to make the final cache id <= 250 bytes.
-     * 
+     *
      * @var string
      */
     public $selectionId = '';
 
     /**
      * Mix in default controller options with user-given options
-     * 
+     *
      * @param array $options user options
-     * 
+     *
      * @return array mixed options
      */
     public final function mixInDefaultOptions($options)
@@ -209,16 +209,16 @@ abstract class Minify_Controller_Base {
         );
         return $ret;
     }
-    
+
     /**
-     * Analyze sources (if there are any) and set $options 'contentType' 
+     * Analyze sources (if there are any) and set $options 'contentType'
      * and 'lastModifiedTime' if they already aren't.
-     * 
+     *
      * @param array $options options for Minify
-     * 
+     *
      * @return array options for Minify
      */
-    public final function analyzeSources($options = array()) 
+    public final function analyzeSources($options = array())
     {
         if ($this->sources) {
             if (! isset($options['contentType'])) {
@@ -231,7 +231,7 @@ abstract class Minify_Controller_Base {
                     $max = max($source->lastModified, $max);
                 }
                 $options['lastModifiedTime'] = $max;
-            }    
+            }
         }
         return $options;
     }

--- a/manager/min/lib/Minify/Controller/Version1.php
+++ b/manager/min/lib/Minify/Controller/Version1.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Minify_Controller_Version1  
+ * Class Minify_Controller_Version1
  * @package Minify
  */
 
@@ -8,22 +8,22 @@ require_once 'Minify/Controller/Base.php';
 
 /**
  * Controller class for emulating version 1 of minify.php (mostly a proof-of-concept)
- * 
+ *
  * <code>
  * Minify::serve('Version1');
  * </code>
- * 
+ *
  * @package Minify
  * @author Stephen Clay <steve@mrclay.org>
  */
 class Minify_Controller_Version1 extends Minify_Controller_Base {
-    
+
     /**
      * Set up groups of files as sources
-     * 
+     *
      * @param array $options controller and Minify options
      * @return array Minify options
-     * 
+     *
      */
     public function setupSources($options) {
         self::_setupDefines();
@@ -33,13 +33,13 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
                 : '';
             Minify::setCache($cacheDir);
         }
-        $options['badRequestHeader'] = 'HTTP/1.0 404 Not Found';
+        $options['badRequestHeader'] = $_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found';
         $options['contentTypeCharset'] = MINIFY_ENCODING;
 
         // The following restrictions are to limit the URLs that minify will
         // respond to. Ideally there should be only one way to reference a file.
         if (! isset($_GET['files'])
-            // verify at least one file, files are single comma separated, 
+            // verify at least one file, files are single comma separated,
             // and are all same extension
             || ! preg_match('/^[^,]+\\.(css|js)(,[^,]+\\.\\1)*$/', $_GET['files'], $m)
             // no "//" (makes URL rewriting easier)
@@ -52,33 +52,33 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
             return $options;
         }
         $extension = $m[1];
-        
+
         $files = explode(',', $_GET['files']);
         if (count($files) > MINIFY_MAX_FILES) {
             return $options;
         }
-        
+
         // strings for prepending to relative/absolute paths
         $prependRelPaths = dirname($_SERVER['SCRIPT_FILENAME'])
             . DIRECTORY_SEPARATOR;
         $prependAbsPaths = $_SERVER['DOCUMENT_ROOT'];
-        
+
         $sources = array();
         $goodFiles = array();
         $hasBadSource = false;
-        
+
         $allowDirs = isset($options['allowDirs'])
             ? $options['allowDirs']
             : MINIFY_BASE_DIR;
-        
+
         foreach ($files as $file) {
             // prepend appropriate string for abs/rel paths
             $file = ($file[0] === '/' ? $prependAbsPaths : $prependRelPaths) . $file;
             // make sure a real file!
             $file = realpath($file);
             // don't allow unsafe or duplicate files
-            if (parent::_fileIsSafe($file, $allowDirs) 
-                && !in_array($file, $goodFiles)) 
+            if (parent::_fileIsSafe($file, $allowDirs)
+                && !in_array($file, $goodFiles))
             {
                 $goodFiles[] = $file;
                 $srcOptions = array(
@@ -98,7 +98,7 @@ class Minify_Controller_Version1 extends Minify_Controller_Base {
         }
         return $options;
     }
-    
+
     private static function _setupDefines()
     {
         $defaults = array(


### PR DESCRIPTION
### What does it do?
It changes all headers and replaces hardcoded HTTP protocol versions to an actual version that comes from the webserver. 

### Why is it needed?
Webserver can request pages using different http protocol version (1.0, 1.1, 2.0) and backend (MODX) should answer with the same protocol version.

### Related issue(s)/PR(s)
#9751
#modxbughunt