### PR TITLE
Hide user group tree panel splitbar if center panel is hidden [#13511]

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -99,10 +99,6 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                     ]
                 }]
             });
-
-
-
-
         }
         if (MODx.perm.view_role == 1) {
             tbs.push({

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -27,10 +27,21 @@ MODx.panel.GroupsRoles = function(config) {
         })]
     });
     MODx.panel.GroupsRoles.superclass.constructor.call(this,config);
-    
-    Ext.getCmp('modx-tree-usergroup').on('expandnode', this.fixPanelHeight);
-    Ext.getCmp('modx-tree-usergroup').on('collapsenode', this.fixPanelHeight);
-    
+
+    var west, usergroupTree = Ext.getCmp('modx-tree-usergroup');
+
+    usergroupTree.on('expandnode', this.fixPanelHeight);
+    usergroupTree.on('collapsenode', this.fixPanelHeight);
+
+    usergroupTree.addListener({
+        resize : function(cmp) {
+            var centre = Ext.getCmp('modx-usergroup-users');
+            if (centre.hidden){
+                cmp.ownerCt.ownerCt.layout.west.getSplitBar().el.hide();
+            }
+        }
+    });
+
     if (MODx.perm.usergroup_user_list == 1) {
         Ext.getCmp('modx-tree-usergroup').on('click', function(node,e){
             this.getUsers(node);
@@ -69,6 +80,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                             ,useSplitTips: true
                             ,monitorResize: true
                             ,width: 270
+                            ,minWidth: 270
                             ,minSize: 270
                             ,maxSize: 400
                             ,layout: 'fit'
@@ -87,6 +99,10 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                     ]
                 }]
             });
+
+
+
+
         }
         if (MODx.perm.view_role == 1) {
             tbs.push({
@@ -146,11 +162,14 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
         var usergroup = id.replace('n_ug_', '') - 0; // typecasting
         
         var userGrid = Ext.getCmp('modx-usergroup-users');
+        var westPanel = Ext.getCmp('modx-tree-usergroup').ownerCt.ownerCt.layout.west;
+
         if (usergroup == 0) {
             userGrid.hide();
+            westPanel.getSplitBar().el.hide();
         } else {
             userGrid.show();
-
+            westPanel.getSplitBar().el.show();
             userGrid.usergroup = usergroup;
             userGrid.config.usergroup = usergroup;
             userGrid.store.baseParams.usergroup = usergroup;

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -37,7 +37,7 @@ MODx.panel.GroupsRoles = function(config) {
         resize : function(cmp) {
             var centre = Ext.getCmp('modx-usergroup-users');
             if (centre.hidden){
-                cmp.ownerCt.ownerCt.layout.west.getSplitBar().el.hide();
+                Ext.getCmp('modx-tree-panel-usergroup').layout.west.getSplitBar().el.hide();
             }
         }
     });
@@ -162,7 +162,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
         var usergroup = id.replace('n_ug_', '') - 0; // typecasting
         
         var userGrid = Ext.getCmp('modx-usergroup-users');
-        var westPanel = Ext.getCmp('modx-tree-usergroup').ownerCt.ownerCt.layout.west;
+        var westPanel = Ext.getCmp('modx-tree-panel-usergroup').layout.west;
 
         if (usergroup == 0) {
             userGrid.hide();


### PR DESCRIPTION
### What does it do?
hide the User Group tree panel splitbar when the centre panel is hidden (no group selected or group is empty).

### Why is it needed?
This circumvents a ui bug which incrementally decreased the size of the split panel if the centre region was hidden. Each time the user clicked on the splitbar, it jumped further to the left obscuring the tree and could not be dragged out to the right.

### Related issues/PRs
#13511 