### PR TITLE
Fixed correct field attaching of duplication error message

### DIFF
--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -947,6 +947,10 @@ class modObjectDuplicateProcessor extends modObjectProcessor {
     /** @var xPDOObject $newObject The newly duplicated object */
     public $newObject;
     public $nameField = 'name';
+    /** @var string $newNameField The name of field that used for filling new name of object.
+     * If defined, duplication error will be attached to field with this name
+     */
+    public $newNameField;
 
     /**
      * {@inheritDoc}
@@ -983,7 +987,10 @@ class modObjectDuplicateProcessor extends modObjectProcessor {
         $this->setNewName($name);
 
         if ($this->alreadyExists($name)) {
-            $this->addFieldError($this->nameField,$this->modx->lexicon($this->objectType.'_err_ae',array('name' => $name)));
+            $this->addFieldError(
+                $this->newNameField ? $this->newNameField : $this->nameField,
+                $this->modx->lexicon($this->objectType.'_err_ae',array('name' => $name))
+            );
         }
 
         $canSave = $this->beforeSave();

--- a/core/model/modx/processors/context/duplicate.class.php
+++ b/core/model/modx/processors/context/duplicate.class.php
@@ -15,6 +15,7 @@ class modContextDuplicateProcessor extends modObjectDuplicateProcessor {
     public $objectType = 'context';
     public $primaryKeyField = 'key';
     public $nameField = 'key';
+    public $newNameField = 'newkey';
 
     public function afterSave() {
         $this->duplicateSettings();
@@ -29,21 +30,21 @@ class modContextDuplicateProcessor extends modObjectDuplicateProcessor {
      * @return boolean
      */
     public function beforeSave() {
-        $newKey = $this->getProperty('newkey');
+        $newKey = $this->getProperty($this->newNameField);
         /* make sure the new key is a valid PHP identifier with no underscore characters */
         if (empty($newKey) || !preg_match('/^[a-zA-Z\x7f-\xff][a-zA-Z0-9\x2d-\x2f\x7f-\xff]*$/', $newKey)) {
-            $this->addFieldError('newkey',$this->modx->lexicon('context_err_ns_key'));
+            $this->addFieldError($this->newNameField,$this->modx->lexicon('context_err_ns_key'));
         }
 
         return parent::beforeSave();
     }
-    
+
     /**
      * Get the new name for the duplicate
      * @return string
      */
     public function getNewName() {
-        $name = $this->getProperty('newkey');
+        $name = $this->getProperty($this->newNameField);
         $newName = !empty($name) ? $name : $this->modx->lexicon('duplicate_of',array('name' => $this->object->get($this->nameField)));
         return $newName;
     }


### PR DESCRIPTION
### What does it do?
It changes allow to declare the name of the field with a new value of an object in duplication windows that allows attaching error messages to correct fields. 

### Why is it needed?
It fixes wrong error message attaching during the context duplication.

### Related issue(s)/PR(s)
#13403
#modxbughunt 