### PR TITLE
Fixed bug 11269 with wrong parsing if at-sign inside output filter #modxbughunt

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -1065,7 +1065,7 @@ abstract class modTag {
         $name = $this->get('name');
         if (strpos($name, '@') !== false) {
 
-            $tagChars = '[\w\d\-\.\/\x{a1}-\x{2af}]+';
+            $tagChars = '[\s\w\d\-\.\/\x{a1}-\x{2af}]+';
             $psChars = $tagChars;   // there might be different rules for ps names?
             preg_match('/(?<tag>'.$tagChars.')(@(?<psName>'.$psChars.'))?(\:(?<rest>.*))?/',$name, $split);
 

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -1064,10 +1064,12 @@ abstract class modTag {
         $propertySet= null;
         $name = $this->get('name');
         if (strpos($name, '@') !== false) {
+
+            $tagChars = '[\w\d\-\.\/\x{a1}-\x{2af}]+';
+            $psChars = $tagChars;   // there might be different rules for ps names?
+            preg_match('/(?<tag>'.$tagChars.')(@(?<psName>'.$psChars.'))?(\:(?<rest>.*))?/',$name, $split);
+
             $psName= '';
-
-            preg_match('/(?<tag>[\w]*)(@(?<psName>\w*))?(\:(?<rest>.*))?/',$name, $split);
-
             if (isset($split['psName'])) {
                 $name = $split['tag'];
                 $psName = $split['psName'];

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -1063,29 +1063,17 @@ abstract class modTag {
     public function getPropertySet($setName = null) {
         $propertySet= null;
         $name = $this->get('name');
-
-        if (strpos($name, '@') !== false) { // <!-- this is useless as it triggers even if an @ is inside `content`. But should be quicker and reduces unneccessary preg matches...
+        if (strpos($name, '@') !== false) {
             $psName= '';
-
-            // the escSplit seems to fail, it steps down into `@bla` parts, according to the
-            // xpdo docs it should not! so this is a bug in XPDO.
-            // nevertheless, we don't need the (slow?) escSplit here, we can work with regexes,
-            // as we are only interested in the property set!
-            $split= xPDO :: escSplit('@', $name);
 
             preg_match('/(?<tag>[\w]*)(@(?<psName>\w*))?(\:(?<rest>.*))?/',$name, $split);
 
-            // we only need to process further if we have found a property set for the tag
             if (isset($split['psName'])) {
                 $name = $split['tag'];
                 $psName = $split['psName'];
-
-                // we already have the rest, no need to further split anything
                 if (isset($split['rest'])) {
-                    // build the new name without the property set
                     $name.= ':' . $split['rest'];
                 }
-
                 $this->set('name', $name);
             }
             if (!empty($psName)) {


### PR DESCRIPTION
### What does it do?
Fixes the wrong parser behaviour if an @ is used inside output filter.

### Why is it needed?
Issues #11269 and (closed) #12159. Parsers xpdo call to escSplit works not as proposed, the string is split inside escaped parts, which causes the bug.

The split of the string to find the property set is now managed by a preg_match regex call. The benefit is, that this also replaces the second split there, which only splits PropertySet:outputFilters. Might be even quicker at all.

### Remarks
Besides the fact, that the regex imho is the more elegant solution, this seems to be a bug in the xpdo->escSplit method. The method is intended _not_ to go into escaped content, but it does here. Therefore, additionally further tests with xpdo might have to be done. 
