### PR TITLE
Fixed issue #5512 #modxbughunt

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -33,6 +33,7 @@ textarea.x-form-field,
   border-radius: $borderRadius;
   border: 1px solid $borderColor;
   position: relative;
+  resize: vertical;
   transition: border-color 0.25s;
 }
 


### PR DESCRIPTION
### What does it do?
It makes it possible to resize the textarea (input type TV) in vertical direction. The css code adds the resize option on the right bottom edge. So you don't have to scroll when you have more than 7 lines.

### Why is it needed?
Currently you have to scroll when you have above 7 lines in a textarea. In that case you may loose the overview.

### Related issue(s)/PR(s)
TV input type "textarea" not high enough (https://github.com/modxcms/revolution/issues/5512)
