### PR TITLE
Remove resource template values when context is removed #8069 #modxbughunt

### DIFF
--- a/core/model/modx/processors/context/remove.class.php
+++ b/core/model/modx/processors/context/remove.class.php
@@ -23,9 +23,26 @@ class modContextRemoveProcessor extends modObjectRemoveProcessor {
     }
 
     public function afterRemove() {
+        /* Retrieve all resources from this context. */
+        $resources = $this->modx->getCollection('modResource',array(
+            'context_key' => $this->object->get('key'),
+        ));
+
+        $resourceIds = array();
+        foreach ($resources as $resource) {
+            $resourceIds[] = $resource->get('id');
+        }
+
+        /* Remove content values.*/
+        $this->modx->removeCollection('modTemplateVarResource',array(
+            'contentid:IN' => $resourceIds,
+        ));
+
+        /* Remove resources. */
         $this->modx->removeCollection('modResource',array(
             'context_key' => $this->object->get('key'),
         ));
+
         return true;
     }
 

--- a/core/model/modx/processors/context/remove.class.php
+++ b/core/model/modx/processors/context/remove.class.php
@@ -24,7 +24,7 @@ class modContextRemoveProcessor extends modObjectRemoveProcessor {
 
     public function afterRemove() {
         /* Retrieve all resources from this context. */
-        $resources = $this->modx->getCollection('modResource',array(
+        $resources = $this->modx->getIterator('modResource',array(
             'context_key' => $this->object->get('key'),
         ));
 


### PR DESCRIPTION
### What does it do?
When a context is removed, also remove the resource template values that are linked to this context.

### Why is it needed?
Prevent a lot of overhead in the database.

### Related issue(s)/PR(s)
Related issue #8069
