### PR TITLE
Force setting the original value of the resource template to prevent false warning when using "empty" template

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -40,6 +40,10 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     ,setup: function() {
         if (!this.initialized) {
             this.getForm().setValues(this.config.record);
+            var tpl = this.getForm().findField('modx-resource-template');
+            if (tpl) {
+                tpl.originalValue = this.config.record.template;
+            }
             var pcmb = this.getForm().findField('parent-cmb');
             if (pcmb && Ext.isEmpty(this.config.record.parent_pagetitle)) {
                 pcmb.setValue('');


### PR DESCRIPTION
### What does it do?

Make sure the original value for the template is set

### Why is it needed?

Prevent false warnings when closing the panel & using the "empty" template

### Related issue(s)/PR(s)

Closes #13483
