### PR TITLE
Add correct modx_media_sources_elements when context is duplicated #12428 #modxbughunt

### DIFF
--- a/core/model/modx/processors/context/duplicate.class.php
+++ b/core/model/modx/processors/context/duplicate.class.php
@@ -20,6 +20,7 @@ class modContextDuplicateProcessor extends modObjectDuplicateProcessor {
         $this->duplicateSettings();
         $this->duplicateAccessControlLists();
         $this->reloadPermissions();
+        $this->duplicateMediaSourceElements();
         $this->duplicateResources();
         return parent::afterSave();
     }
@@ -37,7 +38,7 @@ class modContextDuplicateProcessor extends modObjectDuplicateProcessor {
 
         return parent::beforeSave();
     }
-    
+
     /**
      * Get the new name for the duplicate
      * @return string
@@ -98,6 +99,30 @@ class modContextDuplicateProcessor extends modObjectDuplicateProcessor {
         if ($this->modx->getUser()) {
             $this->modx->user->getAttributes(array(), '', true);
         }
+    }
+
+    /**
+     * Duplicate the MediaSourceElements of the old Context into the new one
+     * @return array
+     */
+    public function duplicateMediaSourceElements() {
+        $duplicatedElements = array();
+        $mediaSourcesElements = $this->modx->getCollection('sources.modMediaSourceElement', array(
+            'context_key'  => $this->object->get('key'),
+        ));
+
+        /** @var modMediaSourceElement $mediaSourcesElement */
+        foreach ($mediaSourcesElements as $mediaSourcesElement) {
+            /** @var modMediaSourceElement $newMediaSourcesElement */
+            $newMediaSourcesElement = $this->modx->newObject('sources.modMediaSourceElement');
+            $newMediaSourcesElement->set('source', $mediaSourcesElement->get('source'));
+            $newMediaSourcesElement->set('object_class', $mediaSourcesElement->get('object_class'));
+            $newMediaSourcesElement->set('object', $mediaSourcesElement->get('object'));
+            $newMediaSourcesElement->set('context_key', $this->newObject->get('key'));
+            $newMediaSourcesElement->save();
+            $duplicatedElements[] = $mediaSourcesElement;
+        }
+        return $duplicatedElements;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Add extra function to add modx_media_sources_elements when a context is duplicated.

### Why is it needed?
TVs are not assigned to the duplicated context and have to be opened and saved again. This PR will fix this.

### Related issue(s)/PR(s)
Related issue #12428
