### PR TITLE
Proper processing uncached elements inside cached [#13250]

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -449,6 +449,10 @@ class modParser {
             $cacheable= false;
             $tokenOffset++;
             $token= substr($tagName, $tokenOffset, 1);
+        } elseif (!$processUncacheable && strpos($tagPropString, '[[!') !== false) {
+            $this->modx->log(xPDO::LOG_LEVEL_ERROR, "You should not call uncached elements inside cached!\nOuter tag: {$tag[0]}\nInner tag {$innerTag}");
+            $this->_processingTag = false;
+            return $outerTag;
         }
         if ($cacheable && $token !== '+') {
             $elementOutput= $this->loadFromCache($outerTag);


### PR DESCRIPTION
### What does it do?
It fixes weird parser behaviour when uncached tags called inside cached.

### Why is it needed?
When parser will see uncached element inside cached it will leave cached tag until processing of all uncached elements. So such cached element will be uncached in real.

People should not call uncached elements inside cached, so this fix will warn them about it in system log.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13250
