### PR TITLE
Remove hardcoded class name from sql queries from user processors

### DIFF
--- a/core/model/modx/processors/security/group/user/getlist.class.php
+++ b/core/model/modx/processors/security/group/user/getlist.class.php
@@ -39,14 +39,14 @@ class modUserGroupUserGetListProcessor extends modObjectGetListProcessor {
         $username = $this->getProperty('username','');
         if (!empty($username)) {
             $c->where(array(
-                'modUser.username:LIKE' => '%'.$username.'%',
+                $this->classKey . '.username:LIKE' => '%'.$username.'%',
             ));
         }
         return $c;
     }
 
     public function prepareQueryAfterCount(xPDOQuery $c) {
-        $c->select($this->modx->getSelectColumns('modUser','modUser'));
+        $c->select($this->modx->getSelectColumns($this->classKey,$this->classKey));
         $c->select(array(
             'usergroup' => 'UserGroup.id',
             'usergroup_name' => 'UserGroup.name',

--- a/core/model/modx/processors/security/user/getlist.class.php
+++ b/core/model/modx/processors/security/user/getlist.class.php
@@ -25,8 +25,12 @@ class modUserGetListProcessor extends modObjectGetListProcessor {
             'usergroup' => false,
             'query' => '',
         ));
-        if ($this->getProperty('sort') == 'username_link') $this->setProperty('sort','username');
-        if ($this->getProperty('sort') == 'id') $this->setProperty('sort','modUser.id');
+        if ($this->getProperty('sort') == 'username_link') {
+            $this->setProperty('sort', 'username');
+        }
+        if ($this->getProperty('sort') == 'id') {
+            $this->setProperty('sort',$this->classKey . '.id');
+        }
         return $initialized;
     }
 
@@ -36,7 +40,7 @@ class modUserGetListProcessor extends modObjectGetListProcessor {
         $query = $this->getProperty('query','');
         if (!empty($query)) {
             $c->where(array(
-                'modUser.username:LIKE' => '%'.$query.'%',
+                $this->classKey . '.username:LIKE' => '%'.$query.'%',
                 'OR:Profile.fullname:LIKE' => '%'.$query.'%',
                 'OR:Profile.email:LIKE' => '%'.$query.'%',
             ));


### PR DESCRIPTION
### What does it do?
It replaces hardcoded modUser class name from query builders for having the ability to extends base processor classes and use with custom use them with custom user classes.

### Why is it needed?
It solves the issue with a wrong class name in case processor extended and used custom user class.

### Related issue(s)/PR(s)
#9906
#modxbughunt