### PR TITLE
Fixed dragging files more than once [#13351]

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -68,6 +68,7 @@ MODx.tree.Directory = function(config) {
         ,'afterRemove': true
         ,'fileBrowserSelect': true
         ,'changeSource': true
+        ,'afterSort': true
     });
     this.on('click',function(n,e) {
         n.select();
@@ -91,6 +92,7 @@ MODx.tree.Directory = function(config) {
     },this);
     this._init();
     this.on('afterrender', this.showRefresh, this);
+    this.on('afterSort',this._handleAfterDrop,this);
 };
 Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
 
@@ -291,6 +293,26 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         }
         var p = n.getPath('text');
         Ext.state.Manager.set(this.treestate_id, p);
+    }
+
+
+    ,_handleAfterDrop: function(o,r) {
+        var targetNode = o.event.target;
+        var dropNode = o.event.dropNode;
+        if (o.event.point == 'append' && targetNode) {
+            var ui = targetNode.getUI();
+            ui.addClass('haschildren');
+            ui.removeClass('icon-resource');
+        }
+        if((MODx.request.a == MODx.action['resource/update']) && dropNode.attributes.pk == MODx.request.id){
+            var parentFieldCmb = Ext.getCmp('modx-resource-parent');
+            var parentFieldHidden = Ext.getCmp('modx-resource-parent-hidden');
+            if(parentFieldCmb && parentFieldHidden){
+                parentFieldHidden.setValue(dropNode.parentNode.attributes.pk);
+                parentFieldCmb.setValue(dropNode.parentNode.attributes.text.replace(/(<([^>]+)>)/ig,""));
+            }
+        }
+        targetNode.reload(true);
     }
 
     ,_handleDrag: function(dropEvent) {


### PR DESCRIPTION
### What does it do?
Added missing afterSort event listener and _handleAfterDrop method.
Added a reload(true) onto the taergetNode in _handleafterDrop

### Why is it needed?
Filesystem tree would not let you move a file more than once or twice.

### Related issues
#13351 