### PR TITLE
Fixed date format for resource quick update #13526 #modxbughunt

### DIFF
--- a/core/model/modx/processors/resource/get.class.php
+++ b/core/model/modx/processors/resource/get.class.php
@@ -17,7 +17,10 @@ class modResourceGetProcessor extends modObjectGetProcessor {
     public function process() {
         $resourceArray = $this->object->toArray();
         $resourceArray['canpublish'] = $this->modx->hasPermission('publish_document');
-        $this->formatDates($resourceArray);
+        if (!$this->getProperty('skipFormatDates') ||
+            ($this->getProperty('skipFormatDates') && $this->getProperty('skipFormatDates') == 'false')) {
+            $this->formatDates($resourceArray);
+        }
         return $this->success('',$resourceArray);
     }
 

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -123,7 +123,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     ,duplicateResource: function(item,e) {
         var node = this.cm.activeNode;
         var id = node.id.split('_');id = id[1];
-        
+
         var r = {
             resource: id
             ,is_folder: node.getUI().hasClass('folder')
@@ -178,11 +178,11 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,listeners: {
                 'success': {fn:function() {
 	            	var cmp = Ext.getCmp('modx-grid-context');
-	            	
+
 	            	if (cmp) {
 		            	cmp.refresh();
-	            	} 
-	            	
+	            	}
+
 	                this.refresh();
 	            },scope:this}
             }
@@ -471,6 +471,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,params: {
                 action: 'resource/get'
                 ,id: this.cm.activeNode.attributes.pk
+                ,skipFormatDates: true
             }
             ,listeners: {
                 'success': {fn:function(r) {


### PR DESCRIPTION
### What does it do?
Skip date format check when using quick update.

### Why is it needed?
The publish and unpublish dates should be the same as before.

### Related issue(s)/PR(s)
Related issue #13526
