### PR TITLE
Added unique index for template variable values

### DIFF
--- a/core/model/modx/mysql/modtemplatevarresource.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevarresource.map.inc.php
@@ -79,7 +79,7 @@ $xpdo_meta_map['modTemplateVarResource']= array (
     array (
       'alias' => 'tv_cnt',
       'primary' => false,
-      'unique' => false,
+      'unique' => true,
       'type' => 'BTREE',
       'columns' => 
       array (

--- a/core/model/modx/sqlsrv/modtemplatevarresource.map.inc.php
+++ b/core/model/modx/sqlsrv/modtemplatevarresource.map.inc.php
@@ -78,7 +78,7 @@ $xpdo_meta_map['modTemplateVarResource']= array (
     array (
       'alias' => 'tv_cnt',
       'primary' => false,
-      'unique' => false,
+      'unique' => true,
       'type' => 'BTREE',
       'columns' => 
       array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1204,7 +1204,7 @@
         <index alias="contentid" name="contentid" primary="false" unique="false" type="BTREE">
             <column key="contentid" length="" collation="A" null="false" />
         </index>
-        <index alias="tv_cnt" name="tv_cnt" primary="false" unique="false" type="BTREE">
+        <index alias="tv_cnt" name="tv_cnt" primary="false" unique="true" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />
             <column key="contentid" length="" collation="A" null="false" />
         </index>

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -1148,7 +1148,7 @@
         <index alias="contentid" name="contentid" primary="false" unique="false" type="BTREE">
             <column key="contentid" length="" collation="A" null="false" />
         </index>
-        <index alias="tv_cnt" name="tv_cnt" primary="false" unique="false" type="BTREE">
+        <index alias="tv_cnt" name="tv_cnt" primary="false" unique="true" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />
             <column key="contentid" length="" collation="A" null="false" />
         </index>


### PR DESCRIPTION
### What does it do?
It adds unique key to index for modTemplateVarResource object

### Why is it needed?
It needs to prevent duplication of values in `*_site_tmplvar_contentvalues` table for avoiding data issues in cases when by bad script other reason in this tables can exist different data for one template and one tv.

### Related issue(s)/PR(s)
#9918
#modxbughunt