### PR TITLE
Fix #7580. Do not add duplicate prefix for the children. #modxbughunt

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -1075,11 +1075,12 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                     $child->duplicate(array(
                         'duplicateChildren' => true,
                         'parent' => $newResource->get('id'),
-                        'prefixDuplicate' => $prefixDuplicate,
+                        'prefixDuplicate' => false,
                         'overrides' => !empty($options['overrides']) ? $options['overrides'] : false,
                         'publishedMode' => $publishedMode,
                         'preserve_alias' => $preserve_alias,
-                        'preserve_menuindex' => $preserve_menuindex
+                        'preserve_menuindex' => $preserve_menuindex,
+                        'preserve_pagetitle' => true
                     ));
                 }
             }


### PR DESCRIPTION
### What does it do?
Does not add the "Duplicate of" prefix to duplicated child resources.

### Why is it needed?
Without all child resources pagetitles are changed, which then might have to get manually changed back. Can be horrible e.g. if you duplicated a big collection.

### Related issue(s)/PR(s)
Fixes #7580.