### PR TITLE
Allow contexts to be duplicated from the contexts grid and update panel [#13276]

### DIFF
--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -20,6 +20,8 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
     public $canEdit = false;
     /** @var boolean $canRemove Determines whether or not the user can remove a Context */
     public $canRemove = false;
+    /** @var boolean $canCreate Determines whether or not the user can create a context (/duplicate one) */
+    public $canCreate = false;
 
     public function initialize() {
         $initialized = parent::initialize();
@@ -27,6 +29,7 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
             'search' => '',
             'exclude' => '',
         ));
+        $this->canCreate = $this->modx->hasPermission('new_context');
         $this->canEdit = $this->modx->hasPermission('edit_context');
         $this->canRemove = $this->modx->hasPermission('delete_context');
         return $initialized;
@@ -61,6 +64,9 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
         }
         $contextArray['name'] .= "({$contextArray['key']})";
         $contextArray['perm'] = array();
+        if ($this->canCreate) {
+            $contextArray['perm'][] = 'pnew';
+        }
         if ($this->canEdit) {
             $contextArray['perm'][] = 'pedit';
         }

--- a/manager/assets/modext/sections/context/update.js
+++ b/manager/assets/modext/sections/context/update.js
@@ -26,6 +26,12 @@ MODx.page.UpdateContext = function(config) {
                 ,ctrl: true
             }]
         },{
+            text: _('duplicate')
+            ,id: 'modx-abtn-duplicate'
+            ,handler: this.duplicateContext
+            ,scope: this
+            ,hidden: !MODx.perm.new_context
+        },{
             process: 'cancel'
             ,text: _('cancel')
             ,id: 'modx-abtn-cancel'
@@ -44,5 +50,25 @@ MODx.page.UpdateContext = function(config) {
     });
     MODx.page.UpdateContext.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.page.UpdateContext,MODx.Component);
+Ext.extend(MODx.page.UpdateContext,MODx.Component, {
+    duplicateContext: function(e) {
+        var r = {
+            key: MODx.request.key
+            ,newkey: ''
+        };
+        var w = MODx.load({
+            xtype: 'modx-window-context-duplicate'
+            ,record: r
+            ,listeners: {
+                'success': {fn:function() {
+                    var tree = Ext.getCmp('modx-resource-tree');
+                    if (tree) {
+                        tree.refresh();
+                    }
+                },scope:this}
+            }
+        });
+        w.show();
+    }
+});
 Ext.reg('modx-page-context-update',MODx.page.UpdateContext);

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -90,6 +90,14 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         var r = this.getSelectionModel().getSelected();
         var p = r.data.perm;
         var m = [];
+        console.log(p);
+        if (p.indexOf('pnew') != -1) {
+            m.push({
+                text: _('context_duplicate')
+                ,handler: this.duplicateContext
+                ,scope: this
+            });
+        }
         if (p.indexOf('pedit') != -1) {
             m.push({
                 text: _('context_update')
@@ -105,6 +113,27 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
             });
         }
         return m;
+    }
+
+    ,duplicateContext: function() {
+        var r = {
+            key: this.menu.record.key
+            ,newkey: ''
+        };
+        var w = MODx.load({
+            xtype: 'modx-window-context-duplicate'
+            ,record: r
+            ,listeners: {
+                'success': {fn:function() {
+                    this.refresh();
+                    var tree = Ext.getCmp('modx-resource-tree');
+                    if (tree) {
+                        tree.refresh();
+                    }
+                },scope:this}
+            }
+        });
+        w.show();
     }
 
     ,search: function(tf,newValue,oldValue) {

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -90,7 +90,6 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         var r = this.getSelectionModel().getSelected();
         var p = r.data.perm;
         var m = [];
-        console.log(p);
         if (p.indexOf('pnew') != -1) {
             m.push({
                 text: _('context_duplicate')

--- a/manager/controllers/default/context/update.class.php
+++ b/manager/controllers/default/context/update.class.php
@@ -47,10 +47,12 @@ class ContextUpdateManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
+        $perm = (bool)$this->modx->hasPermission('new_context');
         $this->addHtml("<script>
             // <![CDATA[
             MODx.onContextFormRender = '".$this->onContextFormRender."';
             MODx.ctx = '".$this->contextKey."';
+            MODx.perm.new_context = {$perm};
             Ext.onReady(function() {
                 MODx.add('modx-page-context-update');
             });


### PR DESCRIPTION
### What does it do?
Adds 2 new ways to duplicate a context. It was already possible to duplicate from the resource tree, but it's now also possible from the contexts grid (under System > Contexts) and when editing a context through the top bar. 

### Why is it needed?
These ways of duplicating a context are more consistent with how other types of items in MODX can be duplicated.  

### Related issue(s)/PR(s)
Requested in #13276