### PR TITLE
Fix non-sudo users being unable of updating user group settings [#12566]

### DIFF
--- a/core/model/modx/processors/security/group/setting/update.class.php
+++ b/core/model/modx/processors/security/group/setting/update.class.php
@@ -13,7 +13,7 @@ include_once MODX_CORE_PATH . 'model/modx/processors/system/settings/update.clas
 class modUserGroupSettingUpdateProcessor extends modSystemSettingsUpdateProcessor {
     public $classKey = 'modUserGroupSetting';
     public $languageTopics = array('setting', 'user');
-    public $permission = array('save_group' => true, 'settings' => true);
+    public $permission = array('usergroup_save' => true, 'settings' => true);
 
     public function initialize() {
         $group = (int)$this->getProperty('fk', 0);


### PR DESCRIPTION
### What does it do?
Changes the required permission from a non-existent to actually available setting. 

### Why is it needed?
As described in https://github.com/modxcms/revolution/issues/12566#issuecomment-132931163, non-sudo users were unable of saving user group setting values. They could create, but not update. 

This was due to the wrong permission being checked. Sudo users have all permissions, including non-existent ones, so they could still use the functionality.

### Related issue(s)/PR(s)
#12566