### PR TITLE
New 'Who's Online' dashboard widget

### DIFF
--- a/core/model/modx/processors/security/user/getonline.class.php
+++ b/core/model/modx/processors/security/user/getonline.class.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Gets a list of all users who are online
+ *
+ * @package modx
+ * @subpackage processors.security.user
+ */
+
+class modUserWhoIsOnlineProcessor extends modObjectGetListProcessor {
+  public $classKey = 'modManagerLog';
+  public $defaultSortField = 'occurred';
+
+  public function prepareQueryBeforeCount(xPDOQuery $query) {
+
+    $date_timezone = !empty($this->modx->getOption('date_timezone')) ? $this->modx->getOption('date_timezone') : date_default_timezone_get();
+    $datetime = new DateTime($date_timezone);
+    $interval = new DateInterval("PT20M");
+    $interval->invert = 1;
+    $datetime->add($interval);
+    $timetocheck = $datetime->format('Y-m-d H:i:s');
+
+    $query->where(array('occurred:>' => $timetocheck));
+    $query->sortby('occurred','DESC');
+    $query->groupby('user');
+    $query->select($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
+    $query->select($this->modx->getSelectColumns('modUser','User','',array('username')));
+    $query->innerJoin('modUser','User');
+
+    return $query;
+  }
+  public function process() {
+    $beforeQuery = $this->beforeQuery();
+    if ($beforeQuery !== true) {
+      return $this->failure($beforeQuery);
+    }
+    $data = $this->getData();
+    $list = $this->iterate($data);
+
+    if ($list) {
+      $dateformat = $this->modx->getOption('manager_date_format') . " " . $this->modx->getOption('manager_time_format');
+      $namecheck = $this->modx->getOption('manager_use_fullname');
+
+      foreach($list as $row) {
+        $datetime = new DateTime($row['occurred']);
+        $row['occurred'] = $datetime->format($dateformat);
+
+        if ($namecheck == 1) {
+          $profile = $this->modx->getObject('modUserProfile', array('internalKey' => $row['user']));
+          $row['username'] = $profile->get('fullname');
+        }
+
+        $list[] = $row;
+      }
+    }
+
+    return $this->outputArray($list,$data['total']);
+  }
+}
+
+return 'modUserWhoIsOnlineProcessor';

--- a/manager/assets/modext/widgets/security/modx.grid.user.online.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.online.js
@@ -1,0 +1,62 @@
+/**
+ * Loads a grid of all users who are online.
+ *
+ * @class MODx.grid.WhoIsOnline
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of options.
+ * @xtype modx-grid-user-online
+ */
+MODx.grid.WhoIsOnline = function(config) {
+  config = config || {};
+  Ext.applyIf(config,{
+    title: _('onlineusers_title')
+    ,url: MODx.config.connector_url
+    ,baseParams: {
+      action: 'security/user/getonline'
+    }
+    ,autosave: false
+    ,save_action: ''
+    ,pageSize: 10
+    ,fields: ['user','username','occurred','action']
+    ,columns: [{
+      header: _('onlineusers_userid')
+      ,dataIndex: 'user'
+      ,width: 80
+      ,fixed: true
+    },{
+      header: _('onlineusers_user')
+      ,dataIndex: 'username'
+    },{
+      header: _('onlineusers_lasthit')
+      ,dataIndex: 'occurred'
+    },{
+      header: _('onlineusers_action')
+      ,dataIndex: 'action'
+    }]
+    ,paging: true
+    ,listeners: {
+      afterrender: this.onAfterRender
+      ,scope: this
+    }
+  });
+  MODx.grid.WhoIsOnline.superclass.constructor.call(this,config);
+};
+Ext.extend(MODx.grid.WhoIsOnline,MODx.grid.Grid,{
+  // Workaround to resize the grid when in a dashboard widget
+  onAfterRender: function() {
+    var cnt = Ext.getCmp('modx-content')
+    // Dashboard widget "parent" (renderTo)
+    ,parent = Ext.get('modx-grid-user-online');
+
+    if (cnt && parent) {
+      cnt.on('afterlayout', function(elem, layout) {
+        var width = parent.getWidth();
+        // Only resize when more than 500px (else let's use/enable the horizontal scrolling)
+        if (width > 500) {
+          this.setWidth(width);
+        }
+      }, this);
+    }
+  }
+});
+Ext.reg('modx-grid-user-online',MODx.grid.WhoIsOnline);

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -7,52 +7,30 @@
  * @package modx
  * @subpackage dashboard
  */
+
 class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
-    public function render() {
-        $timetocheck = (time()-(60*20));
 
-        $c = $this->modx->newQuery('modManagerLog');
-        $c->setClassAlias('lastlog');
-        $c->innerJoin('modManagerLog', 'modManagerLog', array('`lastlog`.`id` = `modManagerLog`.`id`'));
-        $c->leftJoin('modUser', 'User');
-            $tmp = $this->modx->newQuery('modManagerLog');
-            $tmp->setClassAlias('tmp');
-            $tmp->select(array('MAX(`id`) AS `id`', '`user`'));
-            $tmp->where(array('tmp.occurred:>' => strftime('%Y-%m-%d, %H:%M:%S', $timetocheck)));
-            $tmp->groupby('user');
-            $tmp->prepare();
-            $c->query['from']['tables'][0]['table'] = '('.$tmp->toSQL().')';
-        $c->select($this->modx->getSelectColumns('modManagerLog', 'modManagerLog'));
-        $c->select($this->modx->getSelectColumns('modUser', 'User', '', array('username')));
-        $c->sortby('occurred', 'DESC');
-        $ausers = $this->modx->getIterator('modManagerLog', $c);
+  public function render() {
+    $date_timezone = $this->modx->getOption('date_timezone');
+    $timezone = !empty($date_timezone) ? $date_timezone : date_default_timezone_get();
+    $timeformat = $this->modx->getOption('manager_time_format');
+    $datetime = new DateTime($timezone);
+    $curtime = $datetime->format($timeformat);
+    $this->modx->setPlaceholder('curtime',$curtime);
 
-        $users = array();
+    $this->controller->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/security/modx.grid.user.online.js');
+    $this->controller->addHtml('
+    <script type="text/javascript">
+      Ext.applyIf(MODx.lang, '. $this->modx->toJSON($this->modx->lexicon->loadCache('core', 'dashboard')) .');
+      Ext.onReady(function() {
+        MODx.load({
+          xtype: "modx-grid-user-online"
+          ,renderTo: "modx-grid-user-online"
+        });
+      });
+    </script>');
 
-        /** @var modActiveUser $user */
-        $alt = false;
-        foreach ($ausers as $user) {
-            $userArray = $user->toArray();
-            $userArray['currentAction'] = $user->get('action');
-            $userArray['occurred'] = date(
-                    $this->modx->getOption('manager_date_format') .' - '. $this->modx->getOption('manager_time_format'),
-                    strtotime($user->get('occurred')) + floatval($this->modx->getOption('server_offset_time', null, 0)) * 3600
-            );
-            $userArray['class'] = $alt ? 'alt' : '';
-            if (!$userArray['username']) {
-                $userArray['username'] = 'anonymous';
-            }
-            $users[] = $this->getFileChunk('dashboard/onlineusers.row.tpl', $userArray);
-        }
-
-        $output = $this->getFileChunk('dashboard/onlineusers.tpl', array(
-            'users' => implode("\n", $users),
-            'curtime' => strftime(
-                '%I:%M %p',
-                time() + floatval($this->modx->getOption('server_offset_time', null, 0)) * 3600
-            ),
-        ));
-        return $output;
-    }
+    return $this->getFileChunk('dashboard/onlineusers.tpl');
+  }
 }
 return 'modDashboardWidgetWhoIsOnline';

--- a/manager/templates/default/dashboard/onlineusers.tpl
+++ b/manager/templates/default/dashboard/onlineusers.tpl
@@ -1,19 +1,3 @@
-[[%onlineusers_message? &curtime=`[[+curtime]]`]]
-<br /><br />
-
-<table class="classy" style="width: 100%;">
-<thead>
-<tr>
-    <th>[[%onlineusers_user]]</th>
-    <th>[[%onlineusers_userid]]</th>
-    <th>[[%onlineusers_lasthit]]</th>
-    <th>[[%onlineusers_action]]</th>
-</tr>
-</thead>
-<tbody>
-[[+users:is=``:then=`
-<tr>
-    <th colspan="5">[[%active_users_none]]</th>
-</tr>`:else=`[[+users]]`]]
-</tbody>
-</table>
+<p>[[%onlineusers_message? &curtime=`[[+curtime]]`]]</p>
+<br />
+<div id="modx-grid-user-online"></div>


### PR DESCRIPTION
### What does it do?
- Changed from unstyled table layout to a modx grid
- New processor to return online users
- Improved accuracy of 20min window
- Add 'manager_use_fullname' setting support

### Why is it needed?
Improves design consistency and fixes users showing in list when last activity was +20mins. Also address a security concern where administrators user names are revealed as 'manager_use_fullname' setting is ignored.

### Related issue(s)/PR(s)
#11518 
