### PR TITLE
ignore yarn.lock

### DIFF
--- a/_build/templates/default/.gitignore
+++ b/_build/templates/default/.gitignore
@@ -1,1 +1,2 @@
 lib
+yarn.lock


### PR DESCRIPTION
### What does it do?
Ignores `yarn.lock`

### Why is it needed?
We aren't using yarn, sticking with npm. This ensures people don't accidentally submit `yarn.lock` with PRs if they are using yarn.

### Related issue(s)/PR(s)
#13541 
