### PR TITLE
[WIP] Fix svg preview in file manager #12459 + 2 additions

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -57,10 +57,21 @@
     padding: 5px;
     text-align: center;
     width: 100px;
-  }
-    .modx-browser-thumb img {
+    .modx-browser-thumb-figure {
+      position: relative;
+      display: inline-block;
+      margin: 0 auto;
       vertical-align: middle;
+      background: url($imgPath + 'modx-theme/transparency-pattern.png') repeat left top #ccc;
+      img {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+      }
     }
+  }
   .modx-browser-thumb-wrap span {
     display: block;
     overflow: hidden;
@@ -171,9 +182,26 @@
   cursor: default;
   padding: 5px;
   position: relative;
+  text-align: center;
 
   &.preview {
     cursor: pointer;
+
+    margin: 0 auto;
+    max-width: 600px;
+
+    .modx-browser-detail-thumb-figure {
+      height: 0;
+      position: relative;
+      background: url($imgPath + 'modx-theme/transparency-pattern.png') repeat left top #ccc;
+      img {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+      }
+    }
 
     &:before {
       @extend %pseudo-font;
@@ -183,7 +211,10 @@
       margin-top: -28px; /* half of the height to center vertically with top 50% */
       opacity: 0;
       filter: alpha(opacity=0); /* for IE <= 8 */
-      position: absolute; top: 50%; left: 0;
+      position: absolute;
+      z-index: 10;
+      top: 50%;
+      left: 0;
       text-align: center;
       width: 100%;
       text-shadow: 0 0 10px rgba(0,0,0,0.2);
@@ -194,13 +225,8 @@
       opacity: 0.6;
       filter: alpha(opacity=60); /* for IE <= 8 */
     }
-  } 
-
-  img {
-    display: block;
-    margin: 0 auto;
-    max-width: 100%;
   }
+
 }
 
 .modx-browser-details-info {
@@ -221,12 +247,15 @@
   }
 }
 
-.modx-browser-fullview {
-  text-align: center;
-
+.modx-browser-fullview-figure {
+  height: 0;
+  position: relative;
+  background: url($imgPath + 'modx-theme/transparency-pattern.png') repeat left top #ccc;
   img {
-    display: block;
-    margin: 0 auto;
-    max-width: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
   }
 }

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -568,12 +568,19 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
   font: $fontMedium;
   width: auto !important; /* override ExtJS inline width */
 }
-.x-tip img {
-  display: block;
-  min-width:240px;
-  max-width:100%;
-  background-color: #ccc;
-  background-image: url($imgPath + 'modx-theme/transparency-pattern.png');
+.x-tip .x-tip-figure {
+  position: relative;
+  height: 0;
+  min-width: 240px;
+  max-width: 100%;
+  background: url($imgPath + 'modx-theme/transparency-pattern.png') repeat left top #ccc;
+  img {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+  }
 }
 .x-form-invalid-tip .x-tip-tc, .x-form-invalid-tip .x-tip-tl, .x-form-invalid-tip .x-tip-tr, .x-form-invalid-tip .x-tip-bc,
 .x-form-invalid-tip .x-tip-bl, .x-form-invalid-tip .x-tip-br, .x-form-invalid-tip .x-tip-ml, .x-form-invalid-tip .x-tip-mr {

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -227,34 +227,51 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
                         $thumbnailQuality = $this->getOption('thumbnailQuality', $properties, 90);
 
-                        // get original image size for proportions
-                        $size = @getimagesize($bases['pathAbsoluteWithPath'].$fileName);
-                        if (is_array($size)) {
-                            if ($size[0] > $size[1]) {
-                                // landscape
-                                $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                                $imageHeight = 0;
-                            } else {
-                                // portrait or square
-                                $imageWidth = 0;
-                                $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                            }
+                        $size = array($imageWidth, $imageHeight);
+                        switch ($ext) {
+                            case 'svg':
+                                $svgString = @file_get_contents($bases['pathAbsoluteWithPath'].$fileName);
+                                preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                                preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                                preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                                if (!empty($svgViewbox)) {
+                                    // get width and height from viewbox attribute
+                                    $size[0] = round($svgViewbox[3]);
+                                    $size[1] = round($svgViewbox[4]);
+                                } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                                    // get width and height from width and height attributes
+                                    $size[0] = round($svgWidth[2]);
+                                    $size[1] = round($svgHeight[2]);
+                                }
+                                $image = $bases['urlAbsolute'] . urldecode($url);
+                                break;
+                            default:
+                                $size = @getimagesize($bases['pathAbsoluteWithPath'].$fileName);
+                                if ($size[0] > $size[1]) {
+                                    // landscape
+                                    $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                    $imageHeight = 0;
+                                } else {
+                                    // portrait or square
+                                    $imageWidth = 0;
+                                    $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                }
+                                $imageQuery = http_build_query(array(
+                                    'src' => $bases['urlRelative'].$fileName,
+                                    'w' => $imageWidth,
+                                    'h' => $imageHeight,
+                                    'HTTP_MODAUTH' => $modAuth,
+                                    'f' => $thumbnailType,
+                                    'q' => $thumbnailQuality,
+                                    'wctx' => $this->ctx->get('key'),
+                                    'source' => $this->get('id'),
+                                ));
+                                $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                                break;
                         }
+                        $imageWidthHeightRatio = round($size[1] / $size[0] * 100);
 
-                        $imageQuery = http_build_query(array(
-                            'src' => $bases['urlRelative'].$fileName,
-                            'w' => $imageWidth,
-                            'h' => $imageHeight,
-                            'HTTP_MODAUTH' => $modAuth,
-                            'f' => $thumbnailType,
-                            'q' => $thumbnailQuality,
-                            'wctx' => $this->ctx->get('key'),
-                            'source' => $this->get('id'),
-                        ));
-
-                        $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
-
-                        $files[$fileName]['qtip'] = '<img src="'.$image.'" alt="'.$fileName.'" />';
+                        $files[$fileName]['qtip'] = '<div class="x-tip-figure" style="padding-bottom: '.$imageWidthHeightRatio.'%;""><img src="'.$image.'" alt="'.$fileName.'" /></div>';
 
                     }
 
@@ -961,7 +978,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
         /* get default settings */
-        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $use_multibyte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
@@ -1018,40 +1035,71 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     $thumbWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $thumbHeight = $this->ctx->getOption('filemanager_thumb_height', 80);
 
-                    $size = @getimagesize($filePathName);
-                    if (is_array($size)) {
-                        $imageWidth = $size[0] > 800 ? 800 : $size[0];
-                        $imageHeight = $size[1] > 600 ? 600 : $size[1];
+                    $size = array($imageWidth, $imageHeight);
+                    switch ($fileExtension) {
+                        case 'svg':
+                            $svgString = @file_get_contents($filePathName);
+                            preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                            preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                            preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                            if (!empty($svgViewbox)) {
+                                // get width and height from viewbox attribute
+                                $size[0] = round($svgViewbox[3]);
+                                $size[1] = round($svgViewbox[4]);
+                            } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                                // get width and height from width and height attributes
+                                $size[0] = round($svgWidth[2]);
+                                $size[1] = round($svgHeight[2]);
+                            }
+                            break;
+                        default:
+                            $size = @getimagesize($filePathName);
+                            break;
+                    }
+                    if ($size[0] > $size[1]) {
+                        // landscape
+                        $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                        $imageHeight = 0;
+                        $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
+                    } else {
+                        // portrait or square
+                        $imageWidth = 0;
+                        $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                        $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
+                    }
+                    $imageHeightToWidthRatio = round($size[1] / $size[0] * 100);
+
+                    // generate thumb/image URLs
+                    switch ($fileExtension) {
+                        case 'svg':
+                            $thumb = $image = $bases['urlAbsolute'].urldecode($url);
+                            break;
+                        default:
+                            $thumbQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $thumbWidth,
+                                'h' => $thumbHeight,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                            $imageQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $imageWidth,
+                                'h' => $imageHeight,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                            break;
                     }
 
-                    /* ensure max h/w */
-                    if ($thumbWidth > $imageWidth) $thumbWidth = $imageWidth;
-                    if ($thumbHeight > $imageHeight) $thumbHeight = $imageHeight;
-
-                    /* generate thumb/image URLs */
-                    $thumbQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $thumbWidth,
-                        'h' => $thumbHeight,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'far' => '1',
-                        'HTTP_MODAUTH' => $modAuth,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    $imageQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $imageWidth,
-                        'h' => $imageHeight,
-                        'HTTP_MODAUTH' => $modAuth,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
-                    $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                 } else {
                     $preview = 0;
                     $size = null;
@@ -1067,8 +1115,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'name' => $fileName,
                     'cls' => 'icon-'.$fileExtension,
                     'image' => $image,
-                    'image_width' => is_array($size) ? $size[0] : $imageWidth,
-                    'image_height' => is_array($size) ? $size[1] : $imageHeight,
+                    'image_width' => $size[0],
+                    'image_height' => $size[1],
                     'thumb' => $thumb,
                     'thumb_width' => $thumbWidth,
                     'thumb_height' => $thumbHeight,
@@ -1086,6 +1134,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'page' => $this->fileHandler->isBinary($filePathName) ? $page : null,
                     'size' => $filesize,
                     'menu' => array(),
+                    'imageHeightToWidthRatio' => $imageHeightToWidthRatio
                 );
                 $files[$fileName]['menu'] = $this->getListContextMenu($file, $files[$fileName]);
             }
@@ -1170,7 +1219,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 'name' => 'imageExtensions',
                 'desc' => 'prop_file.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif',
+                'value' => 'jpg,jpeg,png,gif,svg',
                 'lexicon' => 'core:source',
             ),
             'thumbnailType' => array(

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -98,7 +98,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
         $editAction = $this->getEditActionId();
 
-        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imagesExts = explode(',',$imagesExts);
         $skipFiles = $this->getOption('skipFiles',$properties,'.svn,.git,_notes,nbproject,.idea,.DS_Store');
         $skipFiles = explode(',',$skipFiles);
@@ -643,7 +643,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         if (!$file->isReadable()) {
             $this->addError('file',$this->xpdo->lexicon('file_err_perms'));
         }
-        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $fileExtension = pathinfo($objectPath,PATHINFO_EXTENSION);
 

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -269,9 +269,9 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                 $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                                 break;
                         }
-                        $imageWidthHeightRatio = round($size[1] / $size[0] * 100);
+                        $imageHeightToWidthRatio = round($size[1] / $size[0] * 100);
 
-                        $files[$fileName]['qtip'] = '<div class="x-tip-figure" style="padding-bottom: '.$imageWidthHeightRatio.'%;""><img src="'.$image.'" alt="'.$fileName.'" /></div>';
+                        $files[$fileName]['qtip'] = '<div class="x-tip-figure" style="padding-bottom: '.$imageHeightToWidthRatio.'%;""><img src="'.$image.'" alt="'.$fileName.'" /></div>';
 
                     }
 

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -151,7 +151,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $useMultiByte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
 
-        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif.svg');
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imagesExts = explode(',',$imagesExts);
 
         $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
@@ -277,9 +277,9 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                                 $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                                 break;
                         }
-                        $imageWidthHeightRatio = round($size[1] / $size[0] * 100);
+                        $imageHeightToWidthRatio = round($size[1] / $size[0] * 100);
 
-                        $files[$currentPath]['qtip'] = '<div class="x-tip-figure" style="padding-bottom: '.$imageWidthHeightRatio.'%;""><img src="'.$image.'" alt="'.$fileName.'" /></div>';
+                        $files[$currentPath]['qtip'] = '<div class="x-tip-figure" style="padding-bottom: '.$imageHeightToWidthRatio.'%;""><img src="'.$image.'" alt="'.$fileName.'" /></div>';
 
                     }
 

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -401,7 +401,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $bucketUrl = rtrim($properties['url'],'/').'/';
         $allowedFileTypes = $this->getOption('allowedFileTypes',$this->properties,'');
         $allowedFileTypes = !empty($allowedFileTypes) && is_string($allowedFileTypes) ? explode(',',$allowedFileTypes) : $allowedFileTypes;
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif.svg');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $thumbnailType = $this->getOption('thumbnailType',$this->properties,'png');
         $thumbnailQuality = $this->getOption('thumbnailQuality',$this->properties,90);

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -151,7 +151,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $useMultiByte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
 
-        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif.svg');
         $imagesExts = explode(',',$imagesExts);
 
         $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
@@ -223,7 +223,66 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 $files[$currentPath]['menu'] = array('items' => $this->getListContextMenu($currentPath,$isDir,$files[$currentPath]));
 
                 if (!$hideTooltips) {
-                    $files[$currentPath]['qtip'] = in_array($ext,$imagesExts) ? '<img src="'.$url.'" alt="'.$fileName.'" />' : '';
+
+                    $files[$fileName]['qtip'] = '';
+
+                    if (in_array($ext, $imagesExts)) {
+
+                        $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
+
+                        $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
+                        $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
+                        $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
+                        $thumbnailQuality = $this->getOption('thumbnailQuality', $properties, 90);
+
+                        $size = array($imageWidth, $imageHeight);
+                        switch ($ext) {
+                            case 'svg':
+                                $svgString = @file_get_contents($url);
+                                preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                                preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                                preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                                if (!empty($svgViewbox)) {
+                                    // get width and height from viewbox attribute
+                                    $size[0] = round($svgViewbox[3]);
+                                    $size[1] = round($svgViewbox[4]);
+                                } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                                    // get width and height from width and height attributes
+                                    $size[0] = round($svgWidth[2]);
+                                    $size[1] = round($svgHeight[2]);
+                                }
+                                $image = $url;
+                                break;
+                            default:
+                                $size = @getimagesize($url);
+                                if ($size[0] > $size[1]) {
+                                    // landscape
+                                    $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                    $imageHeight = 0;
+                                } else {
+                                    // portrait or square
+                                    $imageWidth = 0;
+                                    $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                }
+                                $imageQuery = http_build_query(array(
+                                    'src' => $url,
+                                    'w' => $imageWidth,
+                                    'h' => $imageHeight,
+                                    'HTTP_MODAUTH' => $modAuth,
+                                    'f' => $thumbnailType,
+                                    'q' => $thumbnailQuality,
+                                    'wctx' => $this->ctx->get('key'),
+                                    'source' => $this->get('id'),
+                                ));
+                                $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                                break;
+                        }
+                        $imageWidthHeightRatio = round($size[1] / $size[0] * 100);
+
+                        $files[$currentPath]['qtip'] = '<div class="x-tip-figure" style="padding-bottom: '.$imageWidthHeightRatio.'%;""><img src="'.$image.'" alt="'.$fileName.'" /></div>';
+
+                    }
+
                 }
             }
         }
@@ -342,7 +401,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $bucketUrl = rtrim($properties['url'],'/').'/';
         $allowedFileTypes = $this->getOption('allowedFileTypes',$this->properties,'');
         $allowedFileTypes = !empty($allowedFileTypes) && is_string($allowedFileTypes) ? explode(',',$allowedFileTypes) : $allowedFileTypes;
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif.svg');
         $imageExtensions = explode(',',$imageExtensions);
         $thumbnailType = $this->getOption('thumbnailType',$this->properties,'png');
         $thumbnailQuality = $this->getOption('thumbnailQuality',$this->properties,90);
@@ -390,54 +449,85 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
                 /* get thumbnail */
                 if (in_array($fileArray['ext'],$imageExtensions)) {
+                    $fileArray['preview'] = 1;
                     $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
                     $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
                     $thumbWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $thumbHeight = $this->ctx->getOption('filemanager_thumb_height', 80);
 
-                    $size = @getimagesize($url);
-                    if (is_array($size)) {
-                        $imageWidth = $size[0] > 800 ? 800 : $size[0];
-                        $imageHeight = $size[1] > 600 ? 600 : $size[1];
+                    $size = array($imageWidth, $imageHeight);
+                    switch ($fileArray['ext']) {
+                        case 'svg':
+                            $svgString = @file_get_contents($url);
+                            preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                            preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                            preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                            if (!empty($svgViewbox)) {
+                                // get width and height from viewbox attribute
+                                $size[0] = round($svgViewbox[3]);
+                                $size[1] = round($svgViewbox[4]);
+                            } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                                // get width and height from width and height attributes
+                                $size[0] = round($svgWidth[2]);
+                                $size[1] = round($svgHeight[2]);
+                            }
+                            break;
+                        default:
+                            $size = @getimagesize($url);
+                            break;
                     }
-
-                    /* ensure max h/w */
-                    if ($thumbWidth > $imageWidth) $thumbWidth = $imageWidth;
-                    if ($thumbHeight > $imageHeight) $thumbHeight = $imageHeight;
-
-                    /* generate thumb/image URLs */
-                    $thumbQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $thumbWidth,
-                        'h' => $thumbHeight,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'HTTP_MODAUTH' => $modAuth,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    $imageQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $imageWidth,
-                        'h' => $imageHeight,
-                        'HTTP_MODAUTH' => $modAuth,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                    if ($size[0] > $size[1]) {
+                        // landscape
+                        $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                        $imageHeight = 0;
+                        $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
+                    } else {
+                        // portrait or square
+                        $imageWidth = 0;
+                        $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                        $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
+                    }
                     $fileArray['thumb_width'] = $thumbWidth;
                     $fileArray['thumb_height'] = $thumbHeight;
-                    $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
-                    $fileArray['image_width'] = is_array($size) ? $size[0] : $imageWidth;
-                    $fileArray['image_height'] = is_array($size) ? $size[1] : $imageHeight;
-                    $fileArray['preview'] = 1;
+                    $fileArray['image_width'] = $size[0];
+                    $fileArray['image_height'] = $size[1];
+                    $fileArray['imageHeightToWidthRatio'] = round($size[1] / $size[0] * 100);
+
+                    // generate thumb/image URLs
+                    switch ($fileArray['ext']) {
+                        case 'svg':
+                            $fileArray['thumb'] = $fileArray['image'] = $url;
+                            break;
+                        default:
+                            $thumbQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $thumbWidth,
+                                'h' => $thumbHeight,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                            $imageQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $imageWidth,
+                                'h' => $imageHeight,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                            break;
+                    }
                 } else {
+                    $fileArray['preview'] = 0;
                     $fileArray['thumb'] = $fileArray['image'] = $this->ctx->getOption('manager_url', MODX_MANAGER_URL).'templates/default/images/restyle/nopreview.jpg';
                     $fileArray['thumb_width'] = $fileArray['image_width'] = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $fileArray['thumb_height'] = $fileArray['image_height'] = $this->ctx->getOption('filemanager_thumb_height', 80);
-                    $fileArray['preview'] = 0;
                 }
                 $files[$fileName] = $fileArray;
                 $files[$fileName]['menu'] = $this->getListContextMenu($file, false, $files[$fileName]);
@@ -1019,7 +1109,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 'name' => 'imageExtensions',
                 'desc' => 'prop_s3.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif',
+                'value' => 'jpg,jpeg,png,gif,svg',
                 'lexicon' => 'core:source',
             ),
             'thumbnailType' => array(
@@ -1135,7 +1225,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $objectUrl = $properties['url'].$objectPath;
         $contents = @file_get_contents($objectUrl);
 
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $fileExtension = pathinfo($objectPath,PATHINFO_EXTENSION);
 

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -41,7 +41,7 @@ MODx.browser.View = function(config) {
         ,id: this.ident
         ,fields: [
             {name: 'name', sortType: Ext.data.SortTypes.asUCString}
-            ,'cls','url','relativeUrl','fullRelativeUrl','image','image_width','image_height','thumb','thumb_width','thumb_height','pathname','pathRelative','ext','disabled','preview'
+            ,'cls','url','relativeUrl','fullRelativeUrl','image','image_width','image_height','thumb','thumb_width','thumb_height','pathname','pathRelative','ext','disabled','preview','imageHeightToWidthRatio'
             ,{name: 'size', type: 'float'}
             ,{name: 'lastmod', type: 'date', dateFormat: 'timestamp'}
             ,'menu'
@@ -285,7 +285,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         this.fvWin.setSize(w,h);
         this.fvWin.center();
         this.fvWin.setTitle(data.name);
-        Ext.get(this.ident+'modx-view-item-full').update('<img src="'+data.image+'" alt="" class="modx-browser-fullview-img" onclick="Ext.getCmp(\''+ident+'\').fvWin.hide();" />');
+        Ext.get(this.ident+'modx-view-item-full').update('<div class="modx-browser-fullview-figure" style="padding-bottom: '+data.imageHeightToWidthRatio+'%;"><img src="'+data.image+'" width="'+data.image_width+'" height="'+data.image_height+'" alt="'+data.name+'" title="'+data.name+'" onclick="Ext.getCmp(\''+ident+'\').fvWin.hide();" /></div>');
     }
 
     ,formatData: function(data) {
@@ -309,7 +309,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             '<tpl for=".">'
                 ,'<div class="modx-browser-thumb-wrap" id="{name}" title="{name}">'
                 ,'  <div class="modx-browser-thumb">'
-                ,'      <img src="{thumb}" title="{name}" />'
+                ,'      <div class="modx-browser-thumb-figure" style="width: {thumb_width}px; height: {thumb_height}px;"><img src="{thumb}" alt="{name}" title="{name}" /></div>'
                 ,'  </div>'
                 ,'  <span>{shortName}</span>'
                 ,'</div>'
@@ -339,12 +339,14 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             ,'  <tpl for=".">'
             ,'  <tpl if="preview === 1">'
             ,'      <div class="modx-browser-detail-thumb preview" onclick="Ext.getCmp(\''+this.ident+'\').showFullView(\'{name}\',\''+this.ident+'\'); return false;">'
-            ,'          <img src="{image}" alt="" />'
+            ,'          <div class="modx-browser-detail-thumb-figure" style="padding-bottom: {imageHeightToWidthRatio}%;">'
+            ,'              <img src="{image}" alt="{name}" title="{name}" />'
+            ,'          </div>'
             ,'      </div>'
             ,'  </tpl>'
             ,'  <tpl if="preview === 0">'
             ,'      <div class="modx-browser-detail-thumb">'
-            ,'          <img src="{image}" alt="" />'
+            ,'          <img src="{image}" alt="{name}" title="{name}" />'
             ,'      </div>'
             ,'  </tpl>'
             ,'  <div class="modx-browser-details-info">'


### PR DESCRIPTION
### What does it do?
- Adds support for Svg to the MODX Browser and the Files Tree.
- Adds checked background to transparent images in the MODX Browser.
- The preview now reflects the real proportions of the original image.

### Related issue(s)/PR(s)
#12459

### Before
<img width="1392" alt="bildschirmfoto 2017-07-12 um 22 26 18" src="https://user-images.githubusercontent.com/1913250/28138532-63756502-6751-11e7-8c9b-e9f789a42dee.png">

### After
<img width="1392" alt="bildschirmfoto 2017-07-12 um 22 25 11" src="https://user-images.githubusercontent.com/1913250/28138541-6f7dd514-6751-11e7-94c6-2d6fdeb80b8c.png">

### Tree
<img width="1551" alt="bildschirmfoto 2017-07-17 um 20 39 14" src="https://user-images.githubusercontent.com/1913250/28284053-0bf4a670-6b30-11e7-8896-1f01169ff974.png">

In short: 1 more div per view. Sorry. And more inline styling. Sorry. See below.

Tested in IE 9+, latest Chrome, Firefox and Safari. Please also test!

Credits go to @marcjenkins for his initial PR #13517 and @sottwell for letting me use her S3 bucket. :)

Because some browsers have problems to display svgs the way they are meant to (due to that the width and height attributes for svgs are optional) the most robust solution I know of and use in every project for this purpose is an outer container (positioned relative) with either fixed width and height or no height and a padding to the bottom that reflects the height to width proportion of the image and then to position the image absolute.

Please, please let me know if you have another solution!