### PR TITLE
Improve search in user management

### DIFF
--- a/core/model/modx/processors/security/user/getlist.class.php
+++ b/core/model/modx/processors/security/user/getlist.class.php
@@ -37,13 +37,21 @@ class modUserGetListProcessor extends modObjectGetListProcessor {
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $c->leftJoin('modUserProfile','Profile');
 
-        $query = $this->getProperty('query','');
-        if (!empty($query)) {
-            $c->where(array(
-                $this->classKey . '.username:LIKE' => '%'.$query.'%',
-                'OR:Profile.fullname:LIKE' => '%'.$query.'%',
-                'OR:Profile.email:LIKE' => '%'.$query.'%',
-            ));
+        $queryChunks = explode(':', $this->getProperty('query',''));
+        if (count($queryChunks) == 2) {
+            list($field, $query) = $queryChunks;
+            if (in_array($field, array_keys($this->modx->getFields('modUserProfile')))) {
+                $c->where(array("Profile.$field:LIKE" => '%'.$query.'%'));
+            }
+        } else {
+            $query = current($queryChunks);
+            if (!empty($query)) {
+                $c->where(array(
+                    $this->classKey . '.username:LIKE' => '%'.$query.'%',
+                    'Profile.fullname:LIKE' => '%'.$query.'%',
+                    'Profile.email:LIKE' => '%'.$query.'%'
+                ), xPDOQuery::SQL_OR);
+            }
         }
 
         $userGroup = $this->getProperty('usergroup',0);


### PR DESCRIPTION
### What does it do?
It adds new option to search field - key for search. Query for searching by key should be like that `zip:99` or `phone:45678`. It works similar to search on github (`is:issue is:open sort:updated-asc `). Value after colon additionally wrapped by `LIKE '%%'`, that does search more simple.

### Why is it needed?
Sometimes need to find a user by any meta info that was known about this user. Not only username or email, but maybe phone, or address or any other field. Now search uses only visible fields: username, fullname and email. With the new solution, we can search by any Profile field.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/8265