### PR TITLE
Added filtering and search to event list during creting a new plugin

### DIFF
--- a/core/model/modx/processors/element/plugin/event/getlist.class.php
+++ b/core/model/modx/processors/element/plugin/event/getlist.class.php
@@ -44,12 +44,27 @@ class modPluginEventGetListProcessor extends modObjectProcessor {
 
     public function getData() {
         $criteria = array();
-        if (!empty($name)) {
-            $criteria[] = array('name:LIKE' => '%'.$name.'%');
+
+        $query = $this->getProperty('query');
+        if (!empty($query)) {
+            $criteria[] = array('name:LIKE' => '%'.$query.'%');
         }
+
+        $group = $this->getProperty('group');
+        if (!empty($group)) {
+            $criteria[] = array('groupname' => $group);
+        }
+
         $this->modx->newQuery('modEvent');
-        $eventsResult = $this->modx->call('modEvent', 'listEvents', array(&$this->modx, $this->getProperty('plugin'), $criteria, array(
-            $this->getProperty('sort') => $this->getProperty('dir')), $this->getProperty('limit'), $this->getProperty('start')));
+        $eventsResult = $this->modx->call('modEvent', 'listEvents', array(
+            &$this->modx,
+            $this->getProperty('plugin'),
+            $criteria,
+            array($this->getProperty('sort') => $this->getProperty('dir')),
+            $this->getProperty('limit'),
+            $this->getProperty('start')
+        ));
+
         return array(
             'total' => $eventsResult['count'],
             'results' => $eventsResult['collection'],

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -289,6 +289,26 @@ MODx.combo.UserGroupRole = function(config) {
 Ext.extend(MODx.combo.UserGroupRole,MODx.combo.ComboBox);
 Ext.reg('modx-combo-usergrouprole',MODx.combo.UserGroupRole);
 
+MODx.combo.EventGroup = function(config) {
+    config = config || {};
+    Ext.applyIf(config,{
+        name: 'group'
+        ,hiddenName: 'group'
+        ,displayField: 'name'
+        ,valueField: 'name'
+        ,fields: ['name']
+        ,pageSize: 20
+        ,url: MODx.config.connector_url
+        ,baseParams: {
+            action: 'system/event/grouplist'
+        }
+        ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{name:htmlEncode}</span>','</div></tpl>')
+    });
+    MODx.combo.EventGroup.superclass.constructor.call(this,config);
+};
+Ext.extend(MODx.combo.EventGroup,MODx.combo.ComboBox);
+Ext.reg('modx-combo-eventgroup',MODx.combo.EventGroup);
+
 MODx.combo.ResourceGroup = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -640,19 +660,19 @@ MODx.combo.Namespace = function(config) {
 Ext.extend(MODx.combo.Namespace,MODx.combo.ComboBox, {
     preselectFirstValue: function(r) {
         var item;
-        
+
         if (this.config.preselectValue == '') {
             item = r.getAt(0);
         } else {
             var found = r.find('name', this.config.preselectValue);
-            
+
             if (found != -1) {
                 item = r.getAt(found);
             } else {
                 item = r.getAt(0);
             }
         }
-        
+
         if (item) {
             this.setValue(item.data.name);
             this.fireEvent('select', this, item);

--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -129,7 +129,6 @@ Ext.extend(MODx.grid.PluginEvent,MODx.grid.Grid,{
         return true;
     }
     ,filterGroup: function (cb,nv,ov) {
-        console.log(cb,nv,ov);
         this.getStore().baseParams.group = Ext.isEmpty(nv) || Ext.isObject(nv) ? cb.getValue() : nv;
         this.getStore().load();
         return true;

--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -76,20 +76,42 @@ MODx.grid.PluginEvent = function(config) {
             ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,sortable: true
         }]
-        /*,tbar: [{
-            xtype: 'textfield'
-            ,name: 'name_filter'
-            ,id: 'modx-'+this.ident+'-filter-name'
-            ,emptyText: _('filter_by_name')
+        ,tbar: ['->',{
+            xtype: 'modx-combo-eventgroup'
+            ,name: 'group'
+            ,id: 'modx-plugin-event-filter-group'
+            ,itemId: 'group'
+            ,emptyText: _('group')+'...'
+            ,width: 200
             ,listeners: {
-                'change': {fn:this.filterByName,scope:this}
-                ,'render': {fn:function(tf) {
-                    tf.getEl().addKeyListener(Ext.EventObject.ENTER,function() {
-                        tf.fireEvent('change');
-                    },this);
-                }}
+                'select': {fn:this.filterGroup,scope:this}
             }
-        }] */
+        },{
+            xtype: 'textfield'
+            ,name: 'search'
+            ,id: 'modx-plugin-event-search'
+            ,cls: 'x-form-filter'
+            ,emptyText: _('search_ellipsis')
+            ,listeners: {
+                'change': {fn: this.search, scope: this}
+                ,'render': {fn: function(cmp) {
+                    new Ext.KeyMap(cmp.getEl(), {
+                        key: Ext.EventObject.ENTER
+                        ,fn: this.blur
+                        ,scope: cmp
+                    });
+                },scope:this}
+            }
+        },{
+            xtype: 'button'
+            ,id: 'modx-filter-clear'
+            ,cls: 'x-form-filter-clear'
+            ,text: _('filter_clear')
+            ,listeners: {
+                'click': {fn: this.clearFilter, scope: this},
+                'mouseout': {fn: function () {this.removeClass('x-btn-focus')}}
+            }
+        }]
     });
     MODx.grid.PluginEvent.superclass.constructor.call(this,config);
 
@@ -100,23 +122,26 @@ MODx.grid.PluginEvent = function(config) {
     this.addEvents('updateEvent');
 };
 Ext.extend(MODx.grid.PluginEvent,MODx.grid.Grid,{
-    /*filterByName: function(tf,newValue,oldValue) {
-        this.getStore().baseParams = {
-            action: 'getList'
-            ,name: newValue
-            ,id: this.config.plugin
-        };
-        this.getStore().load({
-            params: {
-                start: 0
-                ,limit: 20
-                ,plugin: this.config.plugin
-            }
-            ,scope: this
-            ,callback: this.refresh
-        });
+    search: function(tf,newValue) {
+        var nv = newValue || tf;
+        this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
+        this.getStore().load();
+        return true;
     }
-    ,*/updateEvent: function(btn,e) {
+    ,filterGroup: function (cb,nv,ov) {
+        console.log(cb,nv,ov);
+        this.getStore().baseParams.group = Ext.isEmpty(nv) || Ext.isObject(nv) ? cb.getValue() : nv;
+        this.getStore().load();
+        return true;
+    }
+    ,clearFilter: function() {
+        delete this.getStore().baseParams.query;
+        delete this.getStore().baseParams.group;
+        Ext.getCmp('modx-plugin-event-search').reset();
+        Ext.getCmp('modx-plugin-event-filter-group').reset();
+        this.getStore().load();
+    }
+    ,updateEvent: function(btn,e) {
         var r = this.menu.record;
         if (!this.windows.peu) {
             this.windows.peu = MODx.load({

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -319,7 +319,6 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     ,filterUsergroup: function(cb,nv,ov) {
         this.getStore().baseParams.usergroup = Ext.isEmpty(nv) || Ext.isObject(nv) ? cb.getValue() : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
     ,search: function(tf,newValue,oldValue) {
@@ -335,7 +334,6 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         Ext.getCmp('modx-user-search').reset();
         Ext.getCmp('modx-user-filter-usergroup').reset();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 });
 Ext.reg('modx-grid-user',MODx.grid.User);


### PR DESCRIPTION
### What does it do?
This PR adds filtering by group and search field to top bar of the grid with event on plugin creating/updating page.

### Why is it needed?
List of events very long (180 items) and it useful when a user has the ability to filter or search events by name.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/8294