### PR TITLE
Fixed issue with covered button New User Group on Russian

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -4,19 +4,19 @@
 #modx-leftbar {
   /* the main container + bg behind the tabs */
   @include media($mobile) {
-    position:relative !important;		
+    position:relative !important;
 	top:auto !important;
 	left:auto !important;
 	width:100% !important;
 	height:auto !important;
   }
-  
+
   .x-plain-body {
 	  @include media($mobile) {
 		  height:auto !important;
 	  }
   }
-  
+
   & .x-tab-panel-noborder {
     margin: 26px 10px 26px 26px;
   }
@@ -46,6 +46,11 @@
       background-color: $white;
     }
   }
+}
+
+#modx-tree-usergroup .x-toolbar-left-row {
+    display: flex;
+    flex-wrap: wrap;
 }
 
 #modx-resource-tree-tbar .x-toolbar-left .x-btn.tree-new-resource,
@@ -143,7 +148,7 @@
 				left:0 !important;
 				right:0 !important;
 			}
-			
+
 		}
 	}
 }
@@ -152,7 +157,7 @@
 	.x-layout-mini {
 		@include media($mobile) {
 			left:0 !important;
-			&:after { 
+			&:after {
 				border:none;
 				@include awesome-font();
 				line-height:42px;

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -79,9 +79,9 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                             ,split: true
                             ,useSplitTips: true
                             ,monitorResize: true
-                            ,width: 270
-                            ,minWidth: 270
-                            ,minSize: 270
+                            ,width: 280
+                            ,minWidth: 280
+                            ,minSize: 280
                             ,maxSize: 400
                             ,layout: 'fit'
                             ,items: [{
@@ -156,7 +156,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
         center.removeAll();
         var id = node.attributes.id;
         var usergroup = id.replace('n_ug_', '') - 0; // typecasting
-        
+
         var userGrid = Ext.getCmp('modx-usergroup-users');
         var westPanel = Ext.getCmp('modx-tree-panel-usergroup').layout.west;
 
@@ -171,7 +171,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
             userGrid.store.baseParams.usergroup = usergroup;
             userGrid.clearFilter();
         }
-        
+
     }
     ,fixPanelHeight: function() {
         // fixing border layout's height regarding to tree panel's


### PR DESCRIPTION
### What does it do?
It changes styles of toolbar in user group tree for avoiding covered button "New User Group" in cases when translation to another language too long.

### Why is it needed?
More clear screen view of user group tree component without visual bugs.

Before:
<img width="759" alt="screenshot 2017-07-17 23 40 53" src="https://user-images.githubusercontent.com/303498/28288924-81e7b476-6b49-11e7-8a69-0425351e2368.png">
<img width="767" alt="screenshot 2017-07-17 23 42 07" src="https://user-images.githubusercontent.com/303498/28288943-93bf7706-6b49-11e7-856c-4b2836b7bff3.png">


After (see animation):
![pull-13555](https://user-images.githubusercontent.com/303498/28289238-8c008b8a-6b4a-11e7-82e6-4743795030fb.gif)


### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13511
https://github.com/modxcms/revolution/pull/13520