### PR TITLE
Fixing installing two packages with setup options

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -143,6 +143,8 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
 				id: 'modx-window-setupoptions'
 				,signature: btn.signature || ''
 			});
+		} else {
+			this.win.signature = btn.signature || '';
 		}
 		this.win.show(btn);
 		var opts = Ext.getCmp('modx-package-beforeinstall').getOptions();


### PR DESCRIPTION
### What does it do?
Change the signature property of an existing MODx.window.SetupOptions. Otherwise the previous value will be used.

### Why is it needed?
Can't install/update two packages with 'Setup Options'. The second package is never marked as installed and the first (previous) package is installed again.

### Related issue(s)/PR(s)
#13169
