### PR TITLE
Loading event log via ajax only

### DIFF
--- a/manager/assets/modext/sections/system/error.log.js
+++ b/manager/assets/modext/sections/system/error.log.js
@@ -33,6 +33,7 @@ MODx.page.ErrorLog = function(config) {
         }]
     });
     MODx.page.ErrorLog.superclass.constructor.call(this,config);
+    this.refreshLog();
 };
 Ext.extend(MODx.page.ErrorLog,MODx.Component,{
     clear: function() {

--- a/manager/controllers/default/system/event.class.php
+++ b/manager/controllers/default/system/event.class.php
@@ -39,16 +39,15 @@ class SystemEventManagerController extends modManagerController {
      * @return mixed
      */
     public function process(array $scriptProperties = array()) {
-        $f = $this->modx->getOption(xPDO::OPT_CACHE_PATH).'logs/error.log';
+        $f = $this->modx->getOption(xPDO::OPT_CACHE_PATH) . 'logs/error.log';
         $this->logArray['name'] = $f;
         if (file_exists($f)) {
-            $this->logArray['size'] = round(@filesize($f) / 1000 / 1000,2);
+            $this->logArray['size'] = round(@filesize($f) / 1000 / 1000, 2);
+            $this->logArray['log'] = '';
             if ($this->logArray['size'] > 1) {
-                $this->logArray['log'] = '';
                 $this->logArray['tooLarge'] = true;
                 $this->logArray['size'] .= ' MiB';
             } else {
-                $this->logArray['log'] = @file_get_contents($f);
                 $this->logArray['tooLarge'] = false;
             }
         }


### PR DESCRIPTION
### What does it do?
This PR will force errors log to load data only with ajax.

### Why is it needed?
Because sometimes we can get a blank screen due to characters collide. Just put this string into your `core/cache/logs/error.log`:
```
<!--]<script>
```
And it will break both error log and edit page for this file because browser can`t parse it correctly

![screen](https://user-images.githubusercontent.com/1257284/28563468-c294f6a6-712e-11e7-8fd6-be9087c3474d.png)
You can see on this screenshot, that tags highlight is broken.

We can use htmlspecialchars function, but it will change html tags in log. But in the other hand we already have the function to load log via ajax. Why don`t use it for initial load?