### PR TITLE
Save manager states in HTML5 sessionStorage for browser tabs

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -782,11 +782,19 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         if (!name) {
             return;
         }
+        // additionally save state in HTML5 sessionStorage for this browser tab
+        if (typeof(Storage) !== 'undefined') {
+            sessionStorage[name] = Ext.encode(value);
+        }
         this.queueChange(name, value);
     }
     ,get : function(name, defaultValue){
-        return typeof this.state[name] == "undefined" ?
-            defaultValue : this.state[name];
+        var output = typeof this.state[name] == "undefined" ? defaultValue : this.state[name];
+        // get state from HTML5 sessionStorage for this browser tab
+        if (typeof(Storage) !== 'undefined' && sessionStorage.getItem(name) !== null) {
+            output = Ext.decode(sessionStorage[name]);
+        }
+        return output;
     }
     ,start: function() {
         this.dt.delay(this.delay);


### PR DESCRIPTION
### What does it do?
**Additionally** save manager states in HTML5 sessionStorage for browser tabs.

### Why is it needed?
This preserves for example the active state of the "Resources/Elements/Files"-tabs when working in multiple browser tabs.

### Notes
This will need testing.