### PR TITLE
Fix set height of error log

### DIFF
--- a/manager/assets/modext/sections/system/error.log.js
+++ b/manager/assets/modext/sections/system/error.log.js
@@ -71,6 +71,7 @@ Ext.extend(MODx.page.ErrorLog,MODx.Component,{
                         location.href = location.href;
                     } else {
                         this.getForm().setValues(r.object);
+                        panel.setTextareaHeight();
                     }
                 },scope:panel}
             }

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -34,14 +34,6 @@ MODx.panel.ErrorLog = function(config) {
                     ,grow: true
                     ,anchor: '100%'
                     ,hidden: config.record.tooLarge ? true : false
-                    ,listeners: {
-                        afterrender: {
-                            fn: function(elem) {
-                                this.setTextareaHeight(elem);
-                            }
-                            ,scope: this
-                        }
-                    }
                 },{
                     html: '<p>'+_('error_log_too_large',{
                         name: config.record.name
@@ -78,10 +70,9 @@ Ext.extend(MODx.panel.ErrorLog,MODx.FormPanel,{
     }
     /**
      * Set the textarea height to make use of the maximum "space" the client viewport allows
-     *
-     * @param {Ext.TextArea} elem
      */
-    ,setTextareaHeight: function(elem) {
+    ,setTextareaHeight: function() {
+        var elem = Ext.getCmp('modx-error-log-content');
         // Client viewport visible height
         var clientHeight = document.documentElement.clientHeight || window.innerHeight || document.body.clientHeight
             // Our textarea "top" position


### PR DESCRIPTION
### What does it do?
This PR fixes height of the error log textarea

### Why is it needed?
Because after this fix #13560 textarea was always small. So I removed unnecessary afterrender action and add call of setTextareaHeight() after each successful ajax load.

### Related issue(s)/PR(s)
#13560 #13563 