### PR TITLE
Allow users to define the state provider class to use

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -22,9 +22,7 @@ MODx.Layout = function(config){
     MODx.siteId = config.auth;
     MODx.expandHelp = !Ext.isEmpty(MODx.config.inline_help);
 
-    var sp = new MODx.HttpProvider();
-    Ext.state.Manager.setProvider(sp);
-    sp.initState(MODx.defaultState);
+    this.initStateProvider();
 
     config.showTree = false;
 
@@ -52,13 +50,22 @@ MODx.Layout = function(config){
 };
 Ext.extend(MODx.Layout, Ext.Viewport, {
     /**
+     * Initialize the state provider to use
+     */
+    initStateProvider: function() {
+        var provider = MODx.config.stateprovider || MODx.HttpProvider,
+            sp = new provider();
+        Ext.state.Manager.setProvider(sp);
+        sp.initState(MODx.defaultState);
+    }
+    /**
      * Wrapper method to build the layout regions
      *
      * @param {Object} config
      *
      * @returns {Array}
      */
-    buildLayout: function(config) {
+    ,buildLayout: function(config) {
         var items = []
             ,north = this.getNorth(config)
             ,west = this.getWest(config)


### PR DESCRIPTION
### What does it do?

Added a new configuration parameter to define the class to be used as state manager/provider, as well as wrapping the state manager/provider into a dedicated method so i could be overridden in custom layouts.

### Why is it needed?

This would allow customization of the state provider, for example to use localStorage/sessionStorage instead of the current implementation.

### Related issue(s)/PR(s)

Would allow one to ship her own implementation for #13565 

Possibly related to #12786 & #8769
