### PR TITLE
Added plugins and snippets to array to strip php tags from

### DIFF
--- a/core/model/modx/modscript.class.php
+++ b/core/model/modx/modscript.class.php
@@ -37,7 +37,7 @@ class modScript extends modElement {
      * {@inheritdoc}
      */
     public function set($k, $v= null, $vType= '') {
-        if (in_array($k, array('content'))) {
+        if (in_array($k, array('snippet', 'plugincode', 'content'))) {
             $v= trim($v);
             if (strncmp($v, '<?', 2) == 0) {
                 $v= substr($v, 2);


### PR DESCRIPTION
### What does it do?
Readded plugincode and snippet to the array in modscript which handles the removal of php start and end tags to prevent 500 errors on the frontend caused by duplicate PHP tags in the code.

### Why is it needed?
These types where removed from this array in merge https://github.com/modxcms/revolution/pull/13523 and was causing 500 errors in the frontend as described in issue https://github.com/modxcms/revolution/issues/13573

### Related issue(s)/PR(s)
Related issue: https://github.com/modxcms/revolution/issues/13573
Related PR: https://github.com/modxcms/revolution/pull/13523
