### PR TITLE
Bug 13488

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -368,7 +368,7 @@ class modUser extends modPrincipal {
             }
             $this->sessionContexts[$context]= $this->get('id');
             $_SESSION['modx.user.contextTokens']= $this->sessionContexts;
-            if (!isset($_SESSION["modx.{$context}.user.token"])) {
+            if (!isset($_SESSION["modx.{$context}.user.token"]) || empty($_SESSION["modx.{$context}.user.token"])) {
                 $_SESSION["modx.{$context}.user.token"]= $this->generateToken($context);
             }
         } else {

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -367,7 +367,9 @@ class modUser extends modPrincipal {
                 }
             }
             $this->sessionContexts[$context]= $this->get('id');
+
             $_SESSION['modx.user.contextTokens']= $this->sessionContexts;
+
             if (!isset($_SESSION["modx.{$context}.user.token"]) || empty($_SESSION["modx.{$context}.user.token"])) {
                 $_SESSION["modx.{$context}.user.token"]= $this->generateToken($context);
             }


### PR DESCRIPTION
### What does it do?
This fix checks if the the 'user token session' is set or is empty (empty = 0) during the login process, if the 'user token session' is empty a new token will be set.

### Why is it needed?
Some times you get a message 'session expired' in the manager. After trying to login you get an infinity loop of messages 'Session expired'. My experience is that the 'user token session' some times gets set to 0 and that causes the 'session expired' message. The login function uses modUsers class to login, but before the user can login in the function will check if the 'user token session' is set, if yes no new token will be set. But the 'user token session' is set to 0 so no new token will be set.

Note: This fix only contains a fix the login into the manager again, not a fix why the 'user token session' gets set to 0 (thats a bug in some 3th party extra's/plugins).

### Related issue(s)/PR(s)
13488 (https://github.com/modxcms/revolution/issues/13488)
