### PR TITLE
Fixing issue #13442 ignoring hide_children_in_tree value

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -365,7 +365,8 @@ class modResourceGetNodesProcessor extends modProcessor {
         $nodeFieldFallback = $this->getProperty('nodeFieldFallback');
         $noHref = $this->getProperty('noHref',false);
 
-        $hasChildren = $resource->get('childrenCount') > 0;
+        $hasChildren  = $resource->get('childrenCount') > 0;
+        $showChildren = $hasChildren && !$resource->get('hide_children_in_tree');
 
         $class = array();
         if (!$resource->isfolder) {
@@ -493,20 +494,20 @@ class modResourceGetNodesProcessor extends modProcessor {
             'selected' => $active,
             'classKey' => $resource->class_key,
             'ctx' => $resource->context_key,
+            'childCount' => $resource->get('childrenCount'),
+            'hasChildren' => $hasChildren,
             'hide_children_in_tree' => $resource->hide_children_in_tree,
             'qtip' => $qtip,
             'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), $sessionEnabled, 'full', array('xhtml_urls' => false)) : '',
             'page' => empty($noHref) ? '?a='.(!empty($this->permissions['edit_document']) ? 'resource/update' : 'resource/data').'&id='.$resource->id : '',
             'allowDrop' => true,
         );
-        if (!$hasChildren) {
-            $itemArray['hasChildren'] = false;
+
+        if (!$showChildren) {
             $itemArray['children'] = array();
             $itemArray['expanded'] = true;
-        } else {
-            $itemArray['hasChildren'] = true;
-            $itemArray['childCount']  = $resource->get('childrenCount');
         }
+
         $itemArray = $resource->prepareTreeNode($itemArray);
         return $itemArray;
     }


### PR DESCRIPTION
### What does it do?
Added a variable to check for the child count and the hide_children_in_tree value.

### Why is it needed?
The hide_children_in_tree value wasn't being respected anymore so child resources would be shown in the resource tree even if hide_children_in_tree was set to 1.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13442