### PR TITLE
Removing null-byte character check #13289

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -280,7 +280,6 @@ class modX extends xPDO {
      * @static
      */
     public static function protect() {
-        if (isset ($_SERVER['QUERY_STRING']) && strpos(urldecode($_SERVER['QUERY_STRING']), chr(0)) !== false) die();
         if (@ ini_get('register_globals') && isset ($_REQUEST)) {
             while (list($key, $value)= each($_REQUEST)) {
                 $GLOBALS[$key] = null;


### PR DESCRIPTION
### What does it do?
Removed null-byte character check.

### Why is it needed?
When calling URL with null-byte character no response body was returned and was immediately terminated. This check is not needed anymore since null byte injection has been fixed in PHP 5.3.4 (https://security.stackexchange.com/questions/48187/null-byte-injection-on-php/74660#74660) and MODX 2.6 will possibly have a PHP minimum version of 5.4.x.

### Related issue(s)/PR(s)
Issue https://github.com/modxcms/revolution/issues/13289

### Requirements
Minimum PHP 5.3.4
