### PR TITLE
Fixing container urls and redirecting index.php to home url #12465

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -58,12 +58,16 @@ class modRequest {
      */
     public function handleRequest() {
         /* Redirect /index.php to site start url. */
-        if (ltrim(explode('?', $_SERVER['REQUEST_URI'], 2)[0], '/') === 'index.php') {
+        $parsedUrl = parse_url($_SERVER['REQUEST_URI']);
+        $path = $parsedUrl['path'];
+        if (ltrim($path, '/') === 'index.php') {
+            $parsedQuery = $parsedUrl['query'];
+            parse_str($parsedQuery, $query);
             $this->modx->sendRedirect(
                 $this->modx->makeUrl(
                     (integer) $this->modx->getOption('site_start', null, 1),
                     null,
-                    $_GET,
+                    $query,
                     'full'
                 )
             );

--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -57,6 +57,19 @@ class modRequest {
      * @return boolean True if a request is handled without interruption.
      */
     public function handleRequest() {
+        /* Redirect /index.php to site start url. */
+        if (ltrim(parse_url($_SERVER['REQUEST_URI'])['path'], '/') === 'index.php') {
+            parse_str(parse_url($_SERVER['REQUEST_URI'])['query'], $query);
+            $this->modx->sendRedirect(
+                $this->modx->makeUrl(
+                    (integer) $this->modx->getOption('site_start', null, 1),
+                    null,
+                    $query,
+                    'full'
+                )
+            );
+        }
+
         $this->loadErrorHandler();
 
         // If enabled, send the X-Powered-By header to identify this site as running MODX, per discussion in #12882
@@ -179,6 +192,7 @@ class modRequest {
         if (!is_numeric($resourceId)) {
             $this->modx->sendErrorPage();
         }
+
         $isForward = array_key_exists('forward', $options) && !empty($options['forward']);
         $fromCache = false;
         $cacheKey = $this->modx->context->get('key') . "/resources/{$resourceId}";
@@ -323,6 +337,11 @@ class modRequest {
                 } else {
                     $identifier = "{$identifier}{$containerSuffix}";
                     $found = $this->modx->findResource("{$identifier}{$containerSuffix}");
+
+                    if (!$found) {
+                        $identifier = "{$identifier}";
+                        $found = $this->modx->findResource("{$identifier}");
+                    }
                 }
                 if ($found) {
                     $parameters = $this->getParameters();

--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -58,13 +58,12 @@ class modRequest {
      */
     public function handleRequest() {
         /* Redirect /index.php to site start url. */
-        if (ltrim(parse_url($_SERVER['REQUEST_URI'])['path'], '/') === 'index.php') {
-            parse_str(parse_url($_SERVER['REQUEST_URI'])['query'], $query);
+        if (ltrim(explode('?', $_SERVER['REQUEST_URI'], 2)[0], '/') === 'index.php') {
             $this->modx->sendRedirect(
                 $this->modx->makeUrl(
                     (integer) $this->modx->getOption('site_start', null, 1),
                     null,
-                    $query,
+                    $_GET,
                     'full'
                 )
             );


### PR DESCRIPTION
### What does it do?
Redirects /index.php to site start URL and container resources URL's without trailing slash are now being redirected to container resource URL with trailing slash.

For example:
- https://www.example.com/index.php will be redirected to: https://www.example.com/
- When visiting https://www.example.com/container the URL will become https://www.example.com/container/

### Why is it needed?
Container resources could be visited on both url's, for example:
- https://www.example.com/container
- https://www.example.com/container/

And a user was able to visit the homepage with following URL, where it would be nicer if the user was redirected to the site start url instead of visiting the page as index.php:
- https://www.example.com/index.php

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/12465
