### PR TITLE
Implement output filter that calls the parser

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -657,7 +657,13 @@ class modOutputFilter {
                             }
                             $output = implode($delimiter, $return_values);
                             break;
-
+                        case 'parse':
+                            if ($this->modx->getParser()) {
+                                $maxIterations = intval($this->modx->getOption('parser_max_iterations', array(), 10));
+                                $this->modx->parser->processElementTags('', $output, true, false, '[[', ']]', array(), $maxIterations);
+                                $this->modx->parser->processElementTags('', $output, true, true, '[[', ']]', array(), $maxIterations);
+                            }
+                            break;
                         /* Default, custom modifier (run snippet with modifier name) */
                         default:
                             /*@todo Possibility to only look for snippet names prefixed with 'filter:' */
@@ -698,7 +704,7 @@ class modOutputFilter {
         try {
             $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
             $m_con = intval($m_con);
-            
+
             // If negate is true, we want the value of $m_con to be false
             if (!$negate) {
                 if ($m_con) {


### PR DESCRIPTION
### What does it do?
Add a new output filter that calls the MODX parser.

### Why is it needed?
It is a special edge case, but in certain scenarios you might want to call the MODX parser before any other output filters are applied, such as the problem reported in the original PR and forum post (see below).

Also see original PR for test case.

### Related issue(s)/PR(s)
First attempted solved in PR #13306.
Issue reported in [forum post](https://forums.modx.com/thread/96866/ellipsis-not-working-as-expected#dis-post-524087).