### PR TITLE
Invoke event when resource cache is updated + add event to build file

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -480,6 +480,12 @@ $events['OnResourceAddToResourceGroup']->fromArray(array (
     'service' => 1,
     'groupname' => 'Resources',
 ), '', true, true);
+$events['OnResourceCacheUpdate']= $xpdo->newObject('modEvent');
+$events['OnResourceCacheUpdate']->fromArray(array (
+    'name' => 'OnResourceCacheUpdate',
+    'service' => 1,
+    'groupname' => 'Resources',
+), '', true, true);
 
 
 /* Richtext Editor */

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -747,7 +747,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                 }
             }
         }
-     
+
         return $removed;
     }
 
@@ -1142,7 +1142,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         } else {
             $resourceGroup =& $resourceGroupPk;
         }
-        
+
         if (!$this->isMember($resourceGroup->get('name'))) {
             $this->xpdo->log(modX::LOG_LEVEL_ERROR, __METHOD__ . ' - Resource ' . $this->get('id') . ' is not in resource group: ' . (is_object($resourceGroupPk) ? $resourceGroupPk->get('name') : $resourceGroupPk));
             return false;
@@ -1176,9 +1176,9 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      */
     public function getResourceGroupNames() {
         $resourceGroupNames= array();
-        
+
         $resourceGroups = $this->xpdo->getCollectionGraph('modResourceGroup', '{"ResourceGroupResources":{}}', array('ResourceGroupResources.document' => $this->get('id')));
-        
+
         if ($resourceGroups) {
             /** @var modResourceGroup $resourceGroup */
             foreach ($resourceGroups as $resourceGroup) {
@@ -1205,7 +1205,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     public function isMember($groups, $matchAll = false) {
         $isMember = false;
         $resourceGroupNames = $this->getResourceGroupNames();
-        
+
         if ($resourceGroupNames) {
             if (is_array($groups)) {
                 if ($matchAll) {
@@ -1341,5 +1341,8 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $key = $this->getCacheKey($context);
         $cache->delete($key, array('deleteTop' => true));
         $cache->delete($key);
+        $this->modx->invokeEvent('OnResourceCacheUpdate', array(
+            'id' => $this->get('id')
+        ));
     }
 }


### PR DESCRIPTION
### What does it do?
Invokes a new event when a resource get its cache updated.

### Why is it needed?
According the to original PR it is need in other to get [StatCache](https://github.com/modxcms/revolution/pull/12833) working, although I am not sure if this is correct. However, I would see it as a benefit having this functionality.

### Related issue(s)/PR(s)
Finished work from PR #12833
