### PR TITLE
Add system setting to limit number of search results

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2095,4 +2095,13 @@ $settings['log_snippet_not_found']->fromArray(array (
     'area' => 'site',
     'editedon' => null,
 ), '', true, true);
+$settings['max_search_results']= $xpdo->newObject('modSystemSetting');
+$settings['max_search_results']->fromArray(array (
+    'key' => 'max_search_results',
+    'value' => 5,
+    'xtype' => 'numberfield',
+    'namespace' => 'core',
+    'area' => 'manager',
+    'editedon' => null,
+), '', true, true);
 return $settings;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -4,19 +4,19 @@
 #modx-leftbar {
   /* the main container + bg behind the tabs */
   @include media($mobile) {
-    position:relative !important;		
+    position:relative !important;
 	top:auto !important;
 	left:auto !important;
 	width:100% !important;
 	height:auto !important;
   }
-  
+
   .x-plain-body {
 	  @include media($mobile) {
 		  height:auto !important;
 	  }
   }
-  
+
   & .x-tab-panel-noborder {
     margin: 26px 10px 26px 26px;
   }
@@ -143,7 +143,7 @@
 				left:0 !important;
 				right:0 !important;
 			}
-			
+
 		}
 	}
 }
@@ -152,7 +152,7 @@
 	.x-layout-mini {
 		@include media($mobile) {
 			left:0 !important;
-			&:after { 
+			&:after {
 				border:none;
 				@include awesome-font();
 				line-height:42px;
@@ -242,19 +242,19 @@
   @extend %pseudo-font;
   content:$fa-var-lock;
 }
-.tree-resource:before {
+.tree-resource:before, .icon-resource:before {
   @extend %pseudo-font;
   content:$fa-var-file-o;
 }
-.tree-static-resource:before {
+.tree-static-resource:before, .icon-static-resource:before {
   @extend %pseudo-font;
   content:$fa-var-file-text-o;
 }
-.tree-weblink:before {
+.tree-weblink:before, .icon-weblink:before {
   @extend %pseudo-font;
   content:$fa-var-link;
 }
-.tree-symlink:before {
+.tree-symlink:before, .icon-symlink:before {
   @extend %pseudo-font;
   content:$fa-var-files-o;
 }

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -814,5 +814,8 @@ $_lang['setting_default_username_desc'] = 'Default username for an unauthenticat
 $_lang['setting_manager_use_fullname'] = 'Show fullname in manager header ';
 $_lang['setting_manager_use_fullname_desc'] = 'If set to yes, the content of the "fullname" field will be shown in manager instead of "loginname"';
 
+$_lang['setting_max_search_results'] = 'Maximum searchresults ';
+$_lang['setting_max_search_results_desc'] = 'Adjust the maximum results from searchbar.';
+
 $_lang['log_snippet_not_found'] = 'Log snippets not found';
 $_lang['log_snippet_not_found_desc'] = 'If set to yes, snippets that are called but not found will be logged to the error log.';

--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -21,6 +21,11 @@ class modSearchProcessor extends modProcessor
      */
     public function process()
     {
+        $maxSearchResults = (int) $this->modx->getOption('max_search_results');
+        if ($maxSearchResults > 0) {
+            $this->maxResults = $maxSearchResults;
+        }
+
         $this->query = $this->getProperty('query');
         if (!empty($this->query)) {
             if (strpos($this->query, ':') === 0) {


### PR DESCRIPTION
### What does it do?
Fixed the icon issues and added some extra features like showing the contextkey and make max searchresults adjustable with a contextsetting.

### Why is it needed?
There was no difference between the resource types. The icon was all the same.

### Related issue(s)/PR(s)
Issue reported in #12828. Reimplemented from PR #13332
