### PR TITLE
Add check to make sure the MODX parser is available before calling methods on it

### DIFF
--- a/core/model/modx/modscript.class.php
+++ b/core/model/modx/modscript.class.php
@@ -78,6 +78,12 @@ class modScript extends modElement {
                 if ($this->_output && is_string($this->_output)) {
                     /* collect element tags in the evaluated content and process them */
                     $maxIterations= intval($this->xpdo->getOption('parser_max_iterations',null,10));
+
+                    // Make sure we have the parser available
+                    if ($this->xpdo->parser === null) {
+                        $this->xpdo->getParser();
+                    }
+
                     $this->xpdo->parser->processElementTags(
                         $this->_tag,
                         $this->_output,


### PR DESCRIPTION
### What does it do?
There are calls done to `$this->xpdo->parser->processElementTags()` before we have made sure that the parser is loaded and initialized.  This PR adds a check and loads the parser if it is null (uninitialized). 

### Why is it needed?
Could result in a fatal error, as reported in the original issue.

### Related issue(s)/PR(s)
#13482
