### PR TITLE
Sort TVs that have been assigned to a template

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -12,7 +12,7 @@ MODx.grid.TemplateTV = function(config) {
         header: _('access')
         ,dataIndex: 'access'
         ,width: 70
-        ,sortable: false
+        ,sortable: true
     });
     Ext.applyIf(config,{
         title: _('template_assignedtv_tab')


### PR DESCRIPTION
### What does it do?
Enables sorting on the access column in tpl > tv's grid.

### Why is it needed?
Allows you to easily show which tv's are assigned to a template. Very useful on large sites with 100s of tv's.

### Related issue(s)/PR(s)
Addresses: #9685
