### PR TITLE
Fetch Lexicon languages and topics from DB as well as file system

### DIFF
--- a/core/model/modx/modlexicon.class.php
+++ b/core/model/modx/modlexicon.class.php
@@ -336,6 +336,23 @@ class modLexicon {
                 }
             }
         }
+
+        $c = $this->modx->newQuery('modLexiconEntry');
+        $c->where(array(
+            'namespace' => $namespace,
+            'topic:NOT IN' => $topics,
+        ));
+        $c->select(array('topic'));
+        $c->query['distinct'] = 'DISTINCT';
+        if ($c->prepare() && $c->stmt->execute()) {
+            $entries = $c->stmt->fetchAll(\PDO::FETCH_ASSOC);
+            if (is_array($entries) and count($entries) > 0) {
+                foreach ($entries as $v) {
+                    $topics[] = $v['topic'];
+                }
+            }
+        }
+
         sort($topics);
         return $topics;
     }
@@ -362,6 +379,23 @@ class modLexicon {
                 $languages[] = $language->getFilename();
             }
         }
+
+        $c = $this->modx->newQuery('modLexiconEntry');
+        $c->where(array(
+            'namespace' => $namespace,
+            'language:NOT IN' => $languages,
+        ));
+        $c->select(array('language'));
+        $c->query['distinct'] = 'DISTINCT';
+        if ($c->prepare() && $c->stmt->execute()) {
+            $entries = $c->stmt->fetchAll(\PDO::FETCH_ASSOC);
+            if (is_array($entries) and count($entries) > 0) {
+                foreach ($entries as $v) {
+                    $languages[] = $v['language'];
+                }
+            }
+        }
+
         sort($languages);
         return $languages;
     }

--- a/core/model/modx/processors/system/language/getlist.class.php
+++ b/core/model/modx/processors/system/language/getlist.class.php
@@ -27,7 +27,7 @@ class modSystemLanguageGetListProcessor extends modProcessor {
     public function process() {
         $data = $this->getData();
         if (empty($data)) return $this->failure();
-        
+
         /* loop through */
         $list = array();
         foreach ($data['results'] as $language) {
@@ -61,7 +61,7 @@ class modSystemLanguageGetListProcessor extends modProcessor {
         if ($limit > 0) {
             $data['results'] = array_slice($data['results'],$this->getProperty('start'),$limit,true);
         }
-        
+
         return $data;
     }
 }


### PR DESCRIPTION
### What does it do?
Implement two additional queries. These attempts to fetch topics and languages for lexicon that are not present in the file system. This means that the lexicon entries are added with the manager interface.

### Why is it needed?
Solves problems that people have when they add lexicon entries for extras (or the core) with namespaces and/or languages that are not present in the lexicon files.

### Test case

Download Simplesearch and install the extra. Go to the manager interface. Add a new Lexicon entry:

- Name: foo
- Namespace: sisea
- Topic: context
- Language: zh
- Value: lorem

Update the page. If you select namespace sisea in the dropdown at the top of the grid, then the context topic will not be present. Similar, if click the dropdown for language, then zh will not be present. This PR fixes that.

Note that the system correctly fetches the actual entries for topics and languages that are only stored in the database, it is only the dropdowns that are not populated correctly.

### Related issue(s)/PR(s)
#13457
