### PR TITLE
Make sure we dont store the appended context key in the context name

### DIFF
--- a/core/model/modx/processors/context/updatefromgrid.class.php
+++ b/core/model/modx/processors/context/updatefromgrid.class.php
@@ -8,7 +8,7 @@
 class modContextUpdateFromGridProcessor extends modProcessor {
     /** @var modContext $context */
     public $context;
-    
+
     public function checkPermissions() {
         return $this->modx->hasPermission('edit_context');
     }
@@ -18,7 +18,7 @@ class modContextUpdateFromGridProcessor extends modProcessor {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return mixed
      */
     public function initialize() {
@@ -38,13 +38,15 @@ class modContextUpdateFromGridProcessor extends modProcessor {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @return mixed
      */
     public function process() {
         if (!$this->validate()) {
             return $this->failure();
         }
+
+        $this->cleanContextName();
 
         $this->context->fromArray($this->getProperties());
         if ($this->context->save() == false) {
@@ -73,7 +75,23 @@ class modContextUpdateFromGridProcessor extends modProcessor {
                 $this->addFieldError('key',$this->modx->lexicon('context_err_ae'));
             }
         }
+
         return !$this->hasErrors();
+    }
+
+    /**
+     * Remove the (context-key) endfix from the name. This is added to the name because we edit the context
+     * inline in the grid.
+     *
+     * @return void
+     */
+
+    private function cleanContextName() {
+        $contextName = $this->getProperty('name');
+        $contextEndfix = '(' . $this->getProperty('key') . ')';
+        if (substr($contextName, -strlen($contextEndfix)) === $contextEndfix) {
+            $this->setProperty('name', trim(substr($contextName, 0, strlen($contextName) - strlen($contextEndfix))));
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do?
You can edit the name of contexts in the context grid (manager -> wheel -> contexts). Here you can double click to edit the context name. The context name is rendered on the format: `context name (context key)`. If you change the name and save, it will be saved as `context name (context key) (context key)` because the value of `(context key)` is concatenated to the original context name.

This PR solves this problem by stripping away `(context key)` at the end of the context name string. This is an alternative to @achterbahn solution, which removed the endfix with the context key. His code is available [here](https://github.com/achterbahn/revolution/commit/9e7f57a416b384cbd679914734bc3524c171dfe5#comments), but as far as I can tell was never PR'ed to this repository.

### Why is it needed?
Fixes the issue described above.

### Related issue(s)/PR(s)
#13371
