### PR TITLE
Fix wrong width of textarea and text TVs when moved

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -148,10 +148,6 @@ input::-moz-focus-inner {
       line-height: 20px;
       height: auto;
     }
-    .modx-tv input[type="text"] {
-      line-height: 20px;
-      height: auto;
-    }
     .modx-tv .x-superboxselect-input-field {
       min-width: 200px;
     }

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -138,6 +138,25 @@ input::-moz-focus-inner {
     padding: 0 0 0 0px !important;
   }
 
+  #modx-resource-main-columns {
+    .modx-tv textarea {
+      box-sizing: border-box;
+      width: 100%!important;
+      min-width: 200px;
+    }
+    .modx-tv input[type="text"] {
+      line-height: 20px;
+      height: auto;
+    }
+    .modx-tv input[type="text"] {
+      line-height: 20px;
+      height: auto;
+    }
+    .modx-tv .x-superboxselect-input-field {
+      min-width: 200px;
+    }
+  }
+
   /* is outside of the label */
   .modx-tv-inherited {
     color: $darkGray;


### PR DESCRIPTION
### What does it do?
If you are moving textfields and textareas to `modx-resource-main-left` or `modx-resource-main-right`, they are slightly too wide on the right side, breaking the bounderies of their surrounding columns.

Please note that this is untested! I copied the code from @pepebe 's original PR.

### Test case
Please see original issue #13323

### Why is it needed?
Fixes issue with styling.

### Related issue(s)/PR(s)
Issue ##13323
PR #13344
Local PR [pepebe/revolution/#2](https://github.com/pepebe/revolution/pull/2)