### PR TITLE
Make sure Widget exists before calling methods on it

### DIFF
--- a/manager/controllers/default/system/dashboards/update.class.php
+++ b/manager/controllers/default/system/dashboards/update.class.php
@@ -58,6 +58,11 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
         /** @var modDashboardWidgetPlacement $placement */
         foreach ($placements as $placement) {
             $placement->getOne('Widget');
+
+            if (!($placement->Widget instanceof modDashboardWidget)) {
+                continue;
+            }
+
             if ($placement->Widget->get('lexicon') != 'core:dashboards') {
                 $this->modx->lexicon->load($placement->Widget->get('lexicon'));
             }


### PR DESCRIPTION
### What does it do?
Add a "sanity" check that the widget from a placement is not null before running methods on it.

### Why is it needed?
Avoid fatal error.

### Related issue(s)/PR(s)
#12684
