### PR TITLE
Make buttongroup title visible again

### DIFF
--- a/_build/templates/default/sass/_toolbars.scss
+++ b/_build/templates/default/sass/_toolbars.scss
@@ -29,6 +29,10 @@
   line-height: 0;
 }
 
+.x-toolbar .x-btn-group-header {
+  line-height: 1;
+}
+
 .x-toolbar .x-btn-over em.x-btn-split,
 .x-toolbar .x-btn-click em.x-btn-split,
 .x-toolbar .x-btn-menu-active em.x-btn-split,


### PR DESCRIPTION
### What does it do?
Make buttongroup title visible again

### Why is it needed?
The line height was of the x-toolbar elements were reduced in #13543. That change makes the buttongroup title invisible.

### Related issue(s)/PR(s)
#13612
