### PR TITLE
Turns MODX into Composer library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,3 @@ _build/templates/default/sass/neat
 _build/templates/default/sass/font-awesome
 *.css.map
 *.js.map
-
-#ignore composer files
-composer.json
-composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "modx/revolution",
+  "description": "Content Management System and Application Framework.",
+  "keywords": [
+    "modx",
+    "cms"
+  ],
+  "type": "package",
+  "homepage": "http://www.modx.com/",
+  "license": "GPLv2",
+  "authors": [
+    {
+      "name": "MODX Team",
+      "homepage": "https://modx.com/get-modx"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/modxcms/revolution/issues",
+    "forum": "https://forums.modx.com",
+    "wiki": "https://docs.modx.com",
+    "slack": "https://modx.org",
+    "source": "https://github.com/modxcms/revolution"
+  },
+  "require": {
+    "php": ">=5.3"
+  }
+}


### PR DESCRIPTION
### What does it do ?
Turns MODX into [Composer](https://getcomposer.org/) library. No autoloading by namespaces, no core split into separate packages - just making MODX available to be installed via Composer, nothing more and nothing less.

### Why is it needed ?
It gives MODX an opportunity to be installed via the most popular dependency manager for PHP. It wont be on [packagist](https://packagist.org) by default but we can at least require MODX with Composer using [repositories](https://getcomposer.org/doc/05-repositories.md). This won't have any disadvantages. 

### Related issue(s)/PR(s)
Issue #13619 