### PR TITLE
cleanAlias on base of context settings

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -612,10 +612,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      */
     public function cleanAlias($alias, array $options = array()) {
         if ($this->xpdo instanceof modX && $ctx = $this->xpdo->getContext($this->get('context_key'))) {
-            $options = ($ctx->getOption('friendly_alias_translit')) ?
-                array_merge(array(
-                    'friendly_alias_translit' => $ctx->getOption('friendly_alias_translit')
-                ), $options) : $options;
+            $options = array_merge($ctx->config, $options);
         }
         return $this->xpdo->call($this->_class, 'filterPathSegment', array(&$this->xpdo, $alias, $options));
     }

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -611,7 +611,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      * @return string The transformed string.
      */
     public function cleanAlias($alias, array $options = array()) {
-        if ($ctx = $this->xpdo->getContext($this->get('context_key'))) {
+        if ($this->xpdo instanceof modX && $ctx = $this->xpdo->getContext($this->get('context_key'))) {
             $options = ($ctx->getOption('friendly_alias_translit')) ?
                 array_merge(array(
                     'friendly_alias_translit' => $ctx->getOption('friendly_alias_translit')
@@ -753,7 +753,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                 }
             }
         }
-     
+
         return $removed;
     }
 

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -611,6 +611,12 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      * @return string The transformed string.
      */
     public function cleanAlias($alias, array $options = array()) {
+        if ($ctx = $this->xpdo->getContext($this->get('context_key'))) {
+            $options = ($ctx->getOption('friendly_alias_translit')) ?
+                array_merge(array(
+                    'friendly_alias_translit' => $ctx->getOption('friendly_alias_translit')
+                ), $options) : $options;
+        }
         return $this->xpdo->call($this->_class, 'filterPathSegment', array(&$this->xpdo, $alias, $options));
     }
 


### PR DESCRIPTION
### What does it do?
Add the `friendly_alias_translit` context/system setting as option to the filterPathSegment call.

### Why is it needed?
Before this patch, the cleanAlias method called the filterPathSegment method without the `friendly_alias_translit` context/system setting. That way always the system setting was used. 

This patch will add a possible `friendly_alias_translit` context setting to the filterPathSegment method call. Since requesting a context setting will default to the system setting, if no context setting is available and the `friendly_alias_translit` context setting could be overridden by the options of the cleanAlias method, there occurs no BC with the patch.

### Related issue(s)/PR(s)
#13046
