### PR TITLE
Make sure an invalid ctx parameter (array instead of string) doesn't throw errors

### DIFF
--- a/connectors/index.php
+++ b/connectors/index.php
@@ -42,7 +42,7 @@ if (!include_once(MODX_CORE_PATH . 'model/modx/modx.class.php')) {
 $modx = new modX('', array(xPDO::OPT_CONN_INIT => array(xPDO::OPT_CONN_MUTABLE => true)));
 
 /* initialize the proper context */
-$ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';
+$ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) && is_string($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';
 $modx->initialize($ctx);
 
 /* check for anonymous access or for a context access policy - return error on failure */


### PR DESCRIPTION
### What does it do?

Ensures the `ctx` parameter when sent to the connector is ignored if it isn't a string.  

### Why is it needed?

If a different type, say array, is passed along into `modX->initialize()`, the connector will log and/or show notices and warnings in the response depending on the server configuration. When the server is set to show errors, this may expose core paths to attackers.

This [came up in Slack (05:45:29)](https://logs.modx.org/%23general/2017-10-05.log) as a result of an ancient attack (fixed in 2.2.13/2.3.0: #11180) where the ctx parameter was vulnerable for sql injection. After investigating it a bit I found that the exploit can no longer be exploited (thanks to both the fix in #11180 and improvements to xPDO's sql injection detection in 2.5.x), but that it could still throw errors.

In my test environment, these errors were shown when providing an array `ctx` like in the exploit:

-  ( ! ) Notice: Array to string conversion in core/model/modx/modx.class.php on line 2325 (_initContext method)
- ( ! ) Warning: preg_match() expects parameter 2 to be string, array given in core/xpdo/validation/xpdovalidator.class.php on line 82
- ( ! ) Warning: Illegal offset type in isset or empty in core/model/modx/modx.class.php on line 2319

In addition, the following got written to the error log:

````
[2017-10-05 12:11:34] (ERROR @ core/model/modx/modx.class.php : 2102) Culture not initialized; cannot use lexicon.
[2017-10-05 12:11:34] (ERROR @ core/model/modx/modx.class.php : 2325) No valid context specified: Array
[2017-10-05 12:11:34] (ERROR @ connectors/index.php : 51) PHP warning: Cannot modify header information - headers already sent by (output started at core/model/modx/modx.class.php:2319)
[2017-10-05 12:11:34] (ERROR @ connectors/index.php : 52) PHP warning: Cannot modify header information - headers already sent by (output started at core/model/modx/modx.class.php:2319)
````

With this fix applied, both the output and the error log remain quiet. 

As context keys can only be strings, I see no potential harm in ignoring the provided ctx value. Users that have no access to the mgr context will get an unauthorized error like normal. 

### Related issue(s)/PR(s)

Somewhat related to #11180, but just to clarify, this is not a regression or exploitable vulnerability. 