### PR TITLE
Extends fix for displaying SVG in media browser

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -65,6 +65,7 @@
       width: auto;
       max-width: 100%;
       height: auto;
+      max-height: 100%;
     }
   .modx-browser-thumb-wrap span {
     display: block;

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -60,6 +60,7 @@
   }
     .modx-browser-thumb img {
       vertical-align: middle;
+      max-height: 80px;
     }
   .modx-browser-thumb-wrap span {
     display: block;

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -60,7 +60,11 @@
   }
     .modx-browser-thumb img {
       vertical-align: middle;
-      max-height: 80px;
+    }
+    .modx-browser-thumb img[src$=".svg"] {
+      width: auto;
+      max-width: 100%;
+      height: auto;
     }
   .modx-browser-thumb-wrap span {
     display: block;

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -60,6 +60,8 @@
   }
     .modx-browser-thumb img {
       vertical-align: middle;
+      background-color: #ccc;
+      background-image: url($imgPath + 'modx-theme/transparency-pattern.png');
     }
   .modx-browser-thumb-wrap span {
     display: block;
@@ -202,6 +204,8 @@
     width: 100%;
     max-width: 100%;
     height: auto;
+    background-color: #ccc;
+    background-image: url($imgPath + 'modx-theme/transparency-pattern.png');
   }
 }
 
@@ -232,5 +236,7 @@
     width: 100%;
     max-width: 100%;
     height: auto;
+    background-color: #ccc;
+    background-image: url($imgPath + 'modx-theme/transparency-pattern.png');
   }
 }

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -61,12 +61,6 @@
     .modx-browser-thumb img {
       vertical-align: middle;
     }
-    .modx-browser-thumb img[src$=".svg"] {
-      width: auto;
-      max-width: 100%;
-      height: auto;
-      max-height: 100%;
-    }
   .modx-browser-thumb-wrap span {
     display: block;
     overflow: hidden;
@@ -205,7 +199,9 @@
   img {
     display: block;
     margin: 0 auto;
+    width: 100%;
     max-width: 100%;
+    height: auto;
   }
 }
 
@@ -233,6 +229,8 @@
   img {
     display: block;
     margin: 0 auto;
+    width: 100%;
     max-width: 100%;
+    height: auto;
   }
 }

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -570,8 +570,9 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 }
 .x-tip img {
   display: block;
-  min-width:240px;
+  width:100%;
   max-width:100%;
+  height:auto;
   background-color: #ccc;
   background-image: url($imgPath + 'modx-theme/transparency-pattern.png');
 }

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -1037,7 +1037,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     $thumbWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $thumbHeight = $this->ctx->getOption('filemanager_thumb_height', 80);
 
-                    $size = array();
+                    $size = array($imageWidth, $imageHeight);
 
                     if ($fileExtension == 'svg') {
                         $svgString = @file_get_contents($filePathName);
@@ -1053,48 +1053,44 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                             $size[0] = round($svgWidth[2]);
                             $size[1] = round($svgHeight[2]);
                         }
-                        if (!empty(array_filter($size))) {
-                            // proportional scaling of image and thumb
-                            if ($size[0] > $size[1]) {
-                                // landscape
-                                $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                                $imageHeight = round($size[1] * ($imageWidth / $size[0]));
-                                $thumbWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
-                                $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
-                            } else {
-                                // portrait or square
-                                $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                                $imageWidth = round($size[0] * ($imageHeight / $size[1]));
-                                $thumbHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
-                                $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
-                            }
+                        // proportional scaling of image and thumb
+                        if ($size[0] > $size[1]) {
+                            // landscape
+                            $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                            $imageHeight = round($size[1] * ($imageWidth / $size[0]));
+                            $thumbWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                            $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
+                        } else {
+                            // portrait or square
+                            $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                            $imageWidth = round($size[0] * ($imageHeight / $size[1]));
+                            $thumbHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                            $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
                         }
                         $image = $thumb = $bases['urlAbsolute'].urldecode($url);
                     } else {
                         $size = @getimagesize($filePathName);
-                        if (!empty(array_filter($size))) {
-                            // proportional scaling of image and thumb
-                            if ($size[0] > $size[1]) {
-                                // landscape
-                                $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                                $imageQueryHeight = 0;
-                                $imageWidth = $imageQueryWidth;
-                                $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
-                                $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
-                                $thumbQueryHeight = 0;
-                                $thumbWidth = $thumbQueryWidth;
-                                $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
-                            } else {
-                                // portrait or square
-                                $imageQueryWidth = 0;
-                                $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                                $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
-                                $imageHeight = $imageQueryHeight;
-                                $thumbQueryWidth = 0;
-                                $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
-                                $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
-                                $thumbHeight = $thumbQueryHeight;
-                            }
+                        // proportional scaling of image and thumb
+                        if ($size[0] > $size[1]) {
+                            // landscape
+                            $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                            $imageQueryHeight = 0;
+                            $imageWidth = $imageQueryWidth;
+                            $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                            $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                            $thumbQueryHeight = 0;
+                            $thumbWidth = $thumbQueryWidth;
+                            $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                        } else {
+                            // portrait or square
+                            $imageQueryWidth = 0;
+                            $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                            $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                            $imageHeight = $imageQueryHeight;
+                            $thumbQueryWidth = 0;
+                            $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                            $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
+                            $thumbHeight = $thumbQueryHeight;
                         }
                         $imageQuery = http_build_query(array(
                             'src' => $url,

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -252,7 +252,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                             'source' => $this->get('id'),
                         ));
 
-                        $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                        if ($ext == 'svg') {
+                            $image = $bases['urlAbsolute'] . urldecode($url);
+                        } else {
+                            $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                        }
 
                         $files[$fileName]['qtip'] = '<img src="'.$image.'" alt="'.$fileName.'" />';
 
@@ -961,7 +965,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
         /* get default settings */
-        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $use_multibyte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
@@ -1050,8 +1054,13 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         'wctx' => $this->ctx->get('key'),
                         'source' => $this->get('id'),
                     ));
-                    $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
-                    $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                    // Display thumbnail for SVGs
+                    if ($fileExtension == 'svg') {
+                        $thumb = $image = $bases['urlAbsolute'] . urldecode($url);
+                    } else {
+                        $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                        $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                    }
                 } else {
                     $preview = 0;
                     $size = null;
@@ -1170,7 +1179,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 'name' => 'imageExtensions',
                 'desc' => 'prop_file.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif',
+                'value' => 'jpg,jpeg,png,gif,svg',
                 'lexicon' => 'core:source',
             ),
             'thumbnailType' => array(

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -98,7 +98,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
         $editAction = $this->getEditActionId();
 
-        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imagesExts = explode(',',$imagesExts);
         $skipFiles = $this->getOption('skipFiles',$properties,'.svn,.git,_notes,nbproject,.idea,.DS_Store');
         $skipFiles = explode(',',$skipFiles);
@@ -227,38 +227,53 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
                         $thumbnailQuality = $this->getOption('thumbnailQuality', $properties, 90);
 
-                        // get original image size for proportions
-                        $size = @getimagesize($bases['pathAbsoluteWithPath'].$fileName);
-                        if (is_array($size)) {
-                            if ($size[0] > $size[1]) {
-                                // landscape
-                                $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                                $imageHeight = 0;
-                            } else {
-                                // portrait or square
-                                $imageWidth = 0;
-                                $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                            }
-                        }
-
-                        $imageQuery = http_build_query(array(
-                            'src' => $bases['urlRelative'].$fileName,
-                            'w' => $imageWidth,
-                            'h' => $imageHeight,
-                            'HTTP_MODAUTH' => $modAuth,
-                            'f' => $thumbnailType,
-                            'q' => $thumbnailQuality,
-                            'wctx' => $this->ctx->get('key'),
-                            'source' => $this->get('id'),
-                        ));
-
                         if ($ext == 'svg') {
+                            $svgString = @file_get_contents($bases['pathAbsoluteWithPath'].$fileName);
+                            preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                            preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                            preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                            if (!empty($svgViewbox)) {
+                                // get width and height from viewbox attribute
+                                $imageWidth = round($svgViewbox[3]);
+                                $imageHeight = round($svgViewbox[4]);
+                            } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                                // get width and height from width and height attributes
+                                $imageWidth = round($svgWidth[2]);
+                                $imageHeight = round($svgHeight[2]);
+                            }
                             $image = $bases['urlAbsolute'] . urldecode($url);
                         } else {
+                            $size = @getimagesize($bases['pathAbsoluteWithPath'].$fileName);
+                            if (is_array($size)) {
+                                // get original image size for proportional scaling
+                                if ($size[0] > $size[1]) {
+                                    // landscape
+                                    $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                    $imageQueryHeight = 0;
+                                    $imageWidth = $imageQueryWidth;
+                                    $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                                } else {
+                                    // portrait or square
+                                    $imageQueryWidth = 0;
+                                    $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                    $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                                    $imageHeight = $imageQueryHeight;
+                                }
+                            }
+                            $imageQuery = http_build_query(array(
+                                'src' => $bases['urlRelative'].$fileName,
+                                'w' => $imageQueryWidth,
+                                'h' => $imageQueryHeight,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
                             $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                         }
 
-                        $files[$fileName]['qtip'] = '<img src="'.$image.'" alt="'.$fileName.'" />';
+                        $files[$fileName]['qtip'] = '<img src="'.$image.'" width="'.$imageWidth.'" height="'.$imageHeight.'" alt="'.$fileName.'" />';
 
                     }
 
@@ -630,7 +645,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         if (!$file->isReadable()) {
             $this->addError('file',$this->xpdo->lexicon('file_err_perms'));
         }
-        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $fileExtension = pathinfo($objectPath,PATHINFO_EXTENSION);
 
@@ -1017,49 +1032,92 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 /* get thumbnail */
                 if (in_array($fileExtension,$imageExtensions)) {
                     $preview = 1;
-                    $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
-                    $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
+                    $imageWidth = $this->ctx->getOption('filemanager_image_width', 800);
+                    $imageHeight = $this->ctx->getOption('filemanager_image_height', 600);
                     $thumbWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $thumbHeight = $this->ctx->getOption('filemanager_thumb_height', 80);
 
-                    $size = @getimagesize($filePathName);
-                    if (is_array($size)) {
-                        $imageWidth = $size[0] > 800 ? 800 : $size[0];
-                        $imageHeight = $size[1] > 600 ? 600 : $size[1];
-                    }
+                    $size = array();
 
-                    /* ensure max h/w */
-                    if ($thumbWidth > $imageWidth) $thumbWidth = $imageWidth;
-                    if ($thumbHeight > $imageHeight) $thumbHeight = $imageHeight;
-
-                    /* generate thumb/image URLs */
-                    $thumbQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $thumbWidth,
-                        'h' => $thumbHeight,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'far' => '1',
-                        'HTTP_MODAUTH' => $modAuth,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    $imageQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $imageWidth,
-                        'h' => $imageHeight,
-                        'HTTP_MODAUTH' => $modAuth,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    // Display thumbnail for SVGs
                     if ($fileExtension == 'svg') {
-                        $thumb = $image = $bases['urlAbsolute'] . urldecode($url);
+                        $svgString = @file_get_contents($filePathName);
+                        preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                        preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                        preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                        if (!empty($svgViewbox)) {
+                            // get width and height from viewbox attribute
+                            $size[0] = round($svgViewbox[3]);
+                            $size[1] = round($svgViewbox[4]);
+                        } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                            // get width and height from width and height attributes
+                            $size[0] = round($svgWidth[2]);
+                            $size[1] = round($svgHeight[2]);
+                        }
+                        if (!empty(array_filter($size))) {
+                            // proportional scaling of image and thumb
+                            if ($size[0] > $size[1]) {
+                                // landscape
+                                $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                $imageHeight = round($size[1] * ($imageWidth / $size[0]));
+                                $thumbWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                                $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
+                            } else {
+                                // portrait or square
+                                $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                $imageWidth = round($size[0] * ($imageHeight / $size[1]));
+                                $thumbHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                                $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
+                            }
+                        }
+                        $image = $thumb = $bases['urlAbsolute'].urldecode($url);
                     } else {
-                        $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                        $size = @getimagesize($filePathName);
+                        if (!empty(array_filter($size))) {
+                            // proportional scaling of image and thumb
+                            if ($size[0] > $size[1]) {
+                                // landscape
+                                $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                $imageQueryHeight = 0;
+                                $imageWidth = $imageQueryWidth;
+                                $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                                $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                                $thumbQueryHeight = 0;
+                                $thumbWidth = $thumbQueryWidth;
+                                $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                            } else {
+                                // portrait or square
+                                $imageQueryWidth = 0;
+                                $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                                $imageHeight = $imageQueryHeight;
+                                $thumbQueryWidth = 0;
+                                $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                                $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
+                                $thumbHeight = $thumbQueryHeight;
+                            }
+                        }
+                        $imageQuery = http_build_query(array(
+                            'src' => $url,
+                            'w' => $imageQueryWidth,
+                            'h' => $imageQueryHeight,
+                            'HTTP_MODAUTH' => $modAuth,
+                            'f' => $thumbnailType,
+                            'q' => $thumbnailQuality,
+                            'wctx' => $this->ctx->get('key'),
+                            'source' => $this->get('id'),
+                        ));
                         $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                        $thumbQuery = http_build_query(array(
+                            'src' => $url,
+                            'w' => $thumbQueryWidth,
+                            'h' => $thumbQueryHeight,
+                            'HTTP_MODAUTH' => $modAuth,
+                            'f' => $thumbnailType,
+                            'q' => $thumbnailQuality,
+                            'wctx' => $this->ctx->get('key'),
+                            'source' => $this->get('id'),
+                        ));
+                        $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                     }
                 } else {
                     $preview = 0;
@@ -1075,9 +1133,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'id' => $bases['urlAbsoluteWithPath'].$fileName,
                     'name' => $fileName,
                     'cls' => 'icon-'.$fileExtension,
+                    'file_width' => $size[0],
+                    'file_height' => $size[1],
                     'image' => $image,
-                    'image_width' => is_array($size) ? $size[0] : $imageWidth,
-                    'image_height' => is_array($size) ? $size[1] : $imageHeight,
+                    'image_width' => $imageWidth,
+                    'image_height' => $imageHeight,
                     'thumb' => $thumb,
                     'thumb_width' => $thumbWidth,
                     'thumb_height' => $thumbHeight,

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -426,17 +426,6 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 $page = '?a='.$editAction.'&file='.$currentPath.'&wctx='.$this->ctx->get('key').'&source='.$this->get('id');
                 // $isBinary = $this->isBinary(rtrim($properties['url'],'/').'/'.$currentPath);
 
-                // get filesize from S3
-                $filesize = 0;
-                $ch = curl_init($url);
-                curl_setopt($ch, CURLOPT_NOBODY, 1);
-                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 0);
-                curl_setopt($ch, CURLOPT_HEADER, 0);
-                if (curl_exec($ch) !== false) {
-                    $filesize = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
-                }
-                curl_close($ch);
-
                 $filenames[] = strtoupper($fileName);
                 $fileArray = array(
                     'id' => $currentPath,
@@ -446,7 +435,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                     'fullRelativeUrl' => $url,
                     'pathname' => $url,
                     'pathRelative' => $currentPath,
-                    'size' => $filesize,
+                    'size' => 0,
                     'page' => $this->isBinary($url) ? $page : null,
                     'leaf' => true,
                     // 'menu' => array(

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -426,6 +426,17 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 $page = '?a='.$editAction.'&file='.$currentPath.'&wctx='.$this->ctx->get('key').'&source='.$this->get('id');
                 // $isBinary = $this->isBinary(rtrim($properties['url'],'/').'/'.$currentPath);
 
+                // get filesize from S3
+                $filesize = 0;
+                $ch = curl_init($url);
+                curl_setopt($ch, CURLOPT_NOBODY, 1);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 0);
+                curl_setopt($ch, CURLOPT_HEADER, 0);
+                if (curl_exec($ch) !== false) {
+                    $filesize = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
+                }
+                curl_close($ch);
+
                 $filenames[] = strtoupper($fileName);
                 $fileArray = array(
                     'id' => $currentPath,
@@ -435,7 +446,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                     'fullRelativeUrl' => $url,
                     'pathname' => $url,
                     'pathRelative' => $currentPath,
-                    'size' => 0,
+                    'size' => $filesize,
                     'page' => $this->isBinary($url) ? $page : null,
                     'leaf' => true,
                     // 'menu' => array(

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -151,7 +151,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $useMultiByte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
 
-        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif');
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
         $imagesExts = explode(',',$imagesExts);
 
         $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
@@ -223,7 +223,68 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 $files[$currentPath]['menu'] = array('items' => $this->getListContextMenu($currentPath,$isDir,$files[$currentPath]));
 
                 if (!$hideTooltips) {
-                    $files[$currentPath]['qtip'] = in_array($ext,$imagesExts) ? '<img src="'.$url.'" alt="'.$fileName.'" />' : '';
+                    
+                    $files[$currentPath]['qtip'] = '';
+
+                    if (in_array($ext, $imagesExts)) {
+
+                        $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
+
+                        $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
+                        $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
+                        $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
+                        $thumbnailQuality = $this->getOption('thumbnailQuality', $properties, 90);
+
+                        if ($ext == 'svg') {
+                            $svgString = @file_get_contents($bases['pathAbsoluteWithPath'].$url);
+                            preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                            preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                            preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                            if (!empty($svgViewbox)) {
+                                // get width and height from viewbox attribute
+                                $imageWidth = round($svgViewbox[3]);
+                                $imageHeight = round($svgViewbox[4]);
+                            } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                                // get width and height from width and height attributes
+                                $imageWidth = round($svgWidth[2]);
+                                $imageHeight = round($svgHeight[2]);
+                            }
+                            $image = $bases['urlAbsolute'] . urldecode($url);
+                        } else {
+                            $size = @getimagesize($url);
+                            if (is_array($size)) {
+                                // get original image size for proportional scaling
+                                if ($size[0] > $size[1]) {
+                                    // landscape
+                                    $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                    $imageQueryHeight = 0;
+                                    $imageWidth = $imageQueryWidth;
+                                    $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                                } else {
+                                    // portrait or square
+                                    $imageQueryWidth = 0;
+                                    $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                    $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                                    $imageHeight = $imageQueryHeight;
+                                }
+                            }
+                            $imageQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $imageQueryWidth,
+                                'h' => $imageQueryHeight,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                        }
+
+                        $files[$currentPath]['qtip'] = '<img src="'.$image.'" width="'.$imageWidth.'" height="'.$imageHeight.'" alt="'.$fileName.'" />';
+
+                    }
+
                 }
             }
         }
@@ -390,54 +451,102 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
                 /* get thumbnail */
                 if (in_array($fileArray['ext'],$imageExtensions)) {
-                    $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
-                    $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
+                    $imageWidth = $this->ctx->getOption('filemanager_image_width', 800);
+                    $imageHeight = $this->ctx->getOption('filemanager_image_height', 600);
                     $thumbWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $thumbHeight = $this->ctx->getOption('filemanager_thumb_height', 80);
 
-                    $size = @getimagesize($url);
-                    if (is_array($size)) {
-                        $imageWidth = $size[0] > 800 ? 800 : $size[0];
-                        $imageHeight = $size[1] > 600 ? 600 : $size[1];
-                    }
+                    $size = array();
 
-                    /* ensure max h/w */
-                    if ($thumbWidth > $imageWidth) $thumbWidth = $imageWidth;
-                    if ($thumbHeight > $imageHeight) $thumbHeight = $imageHeight;
-
-                    /* generate thumb/image URLs */
-                    $thumbQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $thumbWidth,
-                        'h' => $thumbHeight,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'HTTP_MODAUTH' => $modAuth,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    $imageQuery = http_build_query(array(
-                        'src' => $url,
-                        'w' => $imageWidth,
-                        'h' => $imageHeight,
-                        'HTTP_MODAUTH' => $modAuth,
-                        'f' => $thumbnailType,
-                        'q' => $thumbnailQuality,
-                        'wctx' => $this->ctx->get('key'),
-                        'source' => $this->get('id'),
-                    ));
-                    // Display thumbnail for SVGs
                     if ($fileArray['ext'] == 'svg') {
-                        $fileArray['thumb'] = $fileArray['image'] = $bases['urlAbsolute'] . urldecode($url);
+                        $svgString = @file_get_contents($url);
+                        preg_match('/(<svg[^>]*\swidth=")([\d\.]+)([a-z]*)"/si', $svgString, $svgWidth);
+                        preg_match('/(<svg[^>]*\sheight=")([\d\.]+)([a-z]*)"/si', $svgString, $svgHeight);
+                        preg_match('/(<svg[^>]*\sviewBox=")([\d\.]+(?:,|\s)[\d\.]+(?:,|\s)([\d\.]+)(?:,|\s)([\d\.]+))"/si', $svgString, $svgViewbox);
+                        if (!empty($svgViewbox)) {
+                            // get width and height from viewbox attribute
+                            $size[0] = round($svgViewbox[3]);
+                            $size[1] = round($svgViewbox[4]);
+                        } elseif (!empty($svgWidth) && !empty($svgHeight)) {
+                            // get width and height from width and height attributes
+                            $size[0] = round($svgWidth[2]);
+                            $size[1] = round($svgHeight[2]);
+                        }
+                        if (!empty(array_filter($size))) {
+                            // proportional scaling of image and thumb
+                            if ($size[0] > $size[1]) {
+                                // landscape
+                                $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                $imageHeight = round($size[1] * ($imageWidth / $size[0]));
+                                $thumbWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                                $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
+                            } else {
+                                // portrait or square
+                                $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                $imageWidth = round($size[0] * ($imageHeight / $size[1]));
+                                $thumbHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                                $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
+                            }
+                        }
+                        $fileArray['image'] = $fileArray['thumb'] = $url;
                     } else {
-                        $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                        $size = @getimagesize($url);
+                        if (!empty(array_filter($size))) {
+                            // proportional scaling of image and thumb
+                            if ($size[0] > $size[1]) {
+                                // landscape
+                                $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                $imageQueryHeight = 0;
+                                $imageWidth = $imageQueryWidth;
+                                $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                                $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                                $thumbQueryHeight = 0;
+                                $thumbWidth = $thumbQueryWidth;
+                                $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                            } else {
+                                // portrait or square
+                                $imageQueryWidth = 0;
+                                $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                                $imageHeight = $imageQueryHeight;
+                                $thumbQueryWidth = 0;
+                                $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                                $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
+                                $thumbHeight = $thumbQueryHeight;
+                            }
+                        }
+                        $imageQuery = http_build_query(array(
+                            'src' => $url,
+                            'w' => $imageQueryWidth,
+                            'h' => $imageQueryHeight,
+                            'HTTP_MODAUTH' => $modAuth,
+                            'f' => $thumbnailType,
+                            'q' => $thumbnailQuality,
+                            'wctx' => $this->ctx->get('key'),
+                            'source' => $this->get('id'),
+                        ));
                         $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                        $thumbQuery = http_build_query(array(
+                            'src' => $url,
+                            'w' => $thumbQueryWidth,
+                            'h' => $thumbQueryHeight,
+                            'HTTP_MODAUTH' => $modAuth,
+                            'f' => $thumbnailType,
+                            'q' => $thumbnailQuality,
+                            'wctx' => $this->ctx->get('key'),
+                            'source' => $this->get('id'),
+                        ));
+                        $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                     }
+
+                    $fileArray['file_width'] = $size[0];
+                    $fileArray['file_height'] = $size[1];
                     $fileArray['thumb_width'] = $thumbWidth;
                     $fileArray['thumb_height'] = $thumbHeight;
-                    $fileArray['image_width'] = is_array($size) ? $size[0] : $imageWidth;
-                    $fileArray['image_height'] = is_array($size) ? $size[1] : $imageHeight;
+                    $fileArray['image_width'] = $imageWidth;
+                    $fileArray['image_height'] = $imageHeight;
                     $fileArray['preview'] = 1;
+
                 } else {
                     $fileArray['thumb'] = $fileArray['image'] = $this->ctx->getOption('manager_url', MODX_MANAGER_URL).'templates/default/images/restyle/nopreview.jpg';
                     $fileArray['thumb_width'] = $fileArray['image_width'] = $this->ctx->getOption('filemanager_thumb_width', 100);
@@ -1024,7 +1133,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 'name' => 'imageExtensions',
                 'desc' => 'prop_s3.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif',
+                'value' => 'jpg,jpeg,png,gif,svg',
                 'lexicon' => 'core:source',
             ),
             'thumbnailType' => array(
@@ -1140,7 +1249,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $objectUrl = $properties['url'].$objectPath;
         $contents = @file_get_contents($objectUrl);
 
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $fileExtension = pathinfo($objectPath,PATHINFO_EXTENSION);
 

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -342,7 +342,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $bucketUrl = rtrim($properties['url'],'/').'/';
         $allowedFileTypes = $this->getOption('allowedFileTypes',$this->properties,'');
         $allowedFileTypes = !empty($allowedFileTypes) && is_string($allowedFileTypes) ? explode(',',$allowedFileTypes) : $allowedFileTypes;
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg');
         $imageExtensions = explode(',',$imageExtensions);
         $thumbnailType = $this->getOption('thumbnailType',$this->properties,'png');
         $thumbnailQuality = $this->getOption('thumbnailQuality',$this->properties,90);
@@ -426,10 +426,15 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                         'wctx' => $this->ctx->get('key'),
                         'source' => $this->get('id'),
                     ));
-                    $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                    // Display thumbnail for SVGs
+                    if ($fileArray['ext'] == 'svg') {
+                        $fileArray['thumb'] = $fileArray['image'] = $bases['urlAbsolute'] . urldecode($url);
+                    } else {
+                        $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                        $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                    }
                     $fileArray['thumb_width'] = $thumbWidth;
                     $fileArray['thumb_height'] = $thumbHeight;
-                    $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                     $fileArray['image_width'] = is_array($size) ? $size[0] : $imageWidth;
                     $fileArray['image_height'] = is_array($size) ? $size[1] : $imageHeight;
                     $fileArray['preview'] = 1;

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -456,7 +456,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                     $thumbWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $thumbHeight = $this->ctx->getOption('filemanager_thumb_height', 80);
 
-                    $size = array();
+                    $size = array($imageWidth, $imageHeight);
 
                     if ($fileArray['ext'] == 'svg') {
                         $svgString = @file_get_contents($url);
@@ -472,48 +472,44 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                             $size[0] = round($svgWidth[2]);
                             $size[1] = round($svgHeight[2]);
                         }
-                        if (!empty(array_filter($size))) {
-                            // proportional scaling of image and thumb
-                            if ($size[0] > $size[1]) {
-                                // landscape
-                                $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                                $imageHeight = round($size[1] * ($imageWidth / $size[0]));
-                                $thumbWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
-                                $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
-                            } else {
-                                // portrait or square
-                                $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                                $imageWidth = round($size[0] * ($imageHeight / $size[1]));
-                                $thumbHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
-                                $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
-                            }
+                        // proportional scaling of image and thumb
+                        if ($size[0] > $size[1]) {
+                            // landscape
+                            $imageWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                            $imageHeight = round($size[1] * ($imageWidth / $size[0]));
+                            $thumbWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                            $thumbHeight = round($size[1] * ($thumbWidth / $size[0]));
+                        } else {
+                            // portrait or square
+                            $imageHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                            $imageWidth = round($size[0] * ($imageHeight / $size[1]));
+                            $thumbHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                            $thumbWidth = round($size[0] * ($thumbHeight / $size[1]));
                         }
                         $fileArray['image'] = $fileArray['thumb'] = $url;
                     } else {
                         $size = @getimagesize($url);
-                        if (!empty(array_filter($size))) {
-                            // proportional scaling of image and thumb
-                            if ($size[0] > $size[1]) {
-                                // landscape
-                                $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                                $imageQueryHeight = 0;
-                                $imageWidth = $imageQueryWidth;
-                                $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
-                                $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
-                                $thumbQueryHeight = 0;
-                                $thumbWidth = $thumbQueryWidth;
-                                $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
-                            } else {
-                                // portrait or square
-                                $imageQueryWidth = 0;
-                                $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                                $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
-                                $imageHeight = $imageQueryHeight;
-                                $thumbQueryWidth = 0;
-                                $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
-                                $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
-                                $thumbHeight = $thumbQueryHeight;
-                            }
+                        // proportional scaling of image and thumb
+                        if ($size[0] > $size[1]) {
+                            // landscape
+                            $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                            $imageQueryHeight = 0;
+                            $imageWidth = $imageQueryWidth;
+                            $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                            $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                            $thumbQueryHeight = 0;
+                            $thumbWidth = $thumbQueryWidth;
+                            $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                        } else {
+                            // portrait or square
+                            $imageQueryWidth = 0;
+                            $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                            $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                            $imageHeight = $imageQueryHeight;
+                            $thumbQueryWidth = 0;
+                            $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                            $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
+                            $thumbHeight = $thumbQueryHeight;
                         }
                         $imageQuery = http_build_query(array(
                             'src' => $url,

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -41,7 +41,7 @@ MODx.browser.View = function(config) {
         ,id: this.ident
         ,fields: [
             {name: 'name', sortType: Ext.data.SortTypes.asUCString}
-            ,'cls','url','relativeUrl','fullRelativeUrl','image','image_width','image_height','thumb','thumb_width','thumb_height','pathname','pathRelative','ext','disabled','preview'
+            ,'cls','url','relativeUrl','fullRelativeUrl','file_width','file_height','image','image_width','image_height','thumb','thumb_width','thumb_height','pathname','pathRelative','ext','disabled','preview'
             ,{name: 'size', type: 'float'}
             ,{name: 'lastmod', type: 'date', dateFormat: 'timestamp'}
             ,'menu'
@@ -285,7 +285,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         this.fvWin.setSize(w,h);
         this.fvWin.center();
         this.fvWin.setTitle(data.name);
-        Ext.get(this.ident+'modx-view-item-full').update('<img src="'+data.image+'" alt="" class="modx-browser-fullview-img" onclick="Ext.getCmp(\''+ident+'\').fvWin.hide();" />');
+        Ext.get(this.ident+'modx-view-item-full').update('<img src="'+data.image+'" width="'+data.image_width+'" height="'+data.image_height+'" alt="'+data.name+'" title="'+data.name+'" class="modx-browser-fullview-img" onclick="Ext.getCmp(\''+ident+'\').fvWin.hide();" />');
     }
 
     ,formatData: function(data) {
@@ -298,7 +298,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         };
         data.shortName = Ext.util.Format.ellipsis(data.name,18);
         data.sizeString = data.size != 0 ? formatSize(data.size) : 0;
-        data.imageSizeString = data.preview != 0 ? data.image_width + "x" + data.image_height + "px": 0;
+        data.imageSizeString = data.preview != 0 ? data.file_width + "x" + data.file_height + "px": 0;
         data.imageSizeString = data.imageSizeString === "xpx" ? 0 : data.imageSizeString;
         data.dateString = !Ext.isEmpty(data.lastmod) ? new Date(data.lastmod).format(MODx.config.manager_date_format + " " + MODx.config.manager_time_format) : 0;
         this.lookup[data.name] = data;
@@ -309,7 +309,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             '<tpl for=".">'
                 ,'<div class="modx-browser-thumb-wrap" id="{name}" title="{name}">'
                 ,'  <div class="modx-browser-thumb">'
-                ,'      <img src="{thumb}" title="{name}" />'
+                ,'      <img src="{thumb}" width="{thumb_width}" height="{thumb_height}" alt="{name}" title="{name}" />'
                 ,'  </div>'
                 ,'  <span>{shortName}</span>'
                 ,'</div>'
@@ -339,7 +339,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             ,'  <tpl for=".">'
             ,'  <tpl if="preview === 1">'
             ,'      <div class="modx-browser-detail-thumb preview" onclick="Ext.getCmp(\''+this.ident+'\').showFullView(\'{name}\',\''+this.ident+'\'); return false;">'
-            ,'          <img src="{image}" alt="" />'
+            ,'          <img src="{image}" width="{image_width}" height="{image_height}" alt="{name}" title="{name}" />'
             ,'      </div>'
             ,'  </tpl>'
             ,'  <tpl if="preview === 0">'


### PR DESCRIPTION
### What does it do?
This extends the PR made by @marcjenkins with these features:
- SVG previews for the Files Tree
- SVG support for IE 9+ and Edge (by adding width and height attributes to the img tags for all previews and some CSS)
- image previews are now created proportionally to the original image respecting the options "filemanager_image/thumb_width" and "filemanager_image/thumb_height" as max width and max height
- checked background for transparent images in the MODX Browser
- previews of S3 images are now processed with phpthumb
- file size info for S3

Tested in IE 9+, latest Chrome, Firefox and Safari.

### Related issue(s)/PR(s)
#12459
#13517

### Before
<img width="1392" alt="bildschirmfoto 2017-07-12 um 22 26 18" src="https://user-images.githubusercontent.com/1913250/28138532-63756502-6751-11e7-8c9b-e9f789a42dee.png">

### After
<img width="1392" alt="bildschirmfoto 2017-07-12 um 22 25 11" src="https://user-images.githubusercontent.com/1913250/28138541-6f7dd514-6751-11e7-94c6-2d6fdeb80b8c.png">

### Tree
<img width="1551" alt="bildschirmfoto 2017-07-17 um 20 39 14" src="https://user-images.githubusercontent.com/1913250/28284053-0bf4a670-6b30-11e7-8896-1f01169ff974.png">
