### PR TITLE
Fix for #13631 endless loop when error log is too big

### DIFF
--- a/manager/assets/modext/sections/system/error.log.js
+++ b/manager/assets/modext/sections/system/error.log.js
@@ -33,7 +33,9 @@ MODx.page.ErrorLog = function(config) {
         }]
     });
     MODx.page.ErrorLog.superclass.constructor.call(this,config);
-    this.refreshLog();
+    if (!config.record.tooLarge) {
+        this.refreshLog();
+    }
 };
 Ext.extend(MODx.page.ErrorLog,MODx.Component,{
     clear: function() {


### PR DESCRIPTION
### What does it do?
It fixes endless loop when error log is too big

### Why is it needed?
To fix endless loop when error log is too big

### Related issue(s)/PR(s)
#13560 #13566 #13631
