### PR TITLE
Fixed bug with adding a plugin to the eventMap

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1951,7 +1951,7 @@ class modX extends xPDO {
             if (!isset($this->eventMap[$event]) || empty ($this->eventMap[$event])) {
                 $this->eventMap[$event]= array();
             }
-            $this->eventMap[$event][]= $pluginId;
+            $this->eventMap[$event][$pluginId]= $pluginId;
             $added= true;
         }
         return $added;


### PR DESCRIPTION
### What does it do?
Fixed bug with adding a plugin to the eventMap.

### Why is it needed?
Plugins added by the addEventListener method will never run.

### Related issue(s)/PR(s)
[PR #13124](https://github.com/modxcms/revolution/pull/13124) but without changing the signature of the addEventListener method.