### PR TITLE
Fix site_status issue when a session is not available

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2152,7 +2152,7 @@ class modX extends xPDO {
      */
     public function checkSiteStatus() {
         $status = false;
-        if ($this->config['site_status'] == '1' || $this->hasPermission('view_offline')) {
+        if ($this->config['site_status'] == '1' || ($this->getSessionState() === modX::SESSION_STATE_INITIALIZED && $this->hasPermission('view_offline'))) {
             $status = true;
         }
         return $status;


### PR DESCRIPTION
### What does it do?
Fixes an issue which prevents site_status from working when a user session is not available.

### Why is it needed?
When sessions were disabled for a context or for anonymous users in a context, site_status was being ignored.

### Related issue(s)/PR(s)
#13630