### PR TITLE
Add OPTIONS request method

### DIFF
--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -91,6 +91,10 @@ abstract class modRestController {
     public $deleteRequiredFields = array();
     /** @var string $deleteMethod The method on the object to call for DELETE requests */
     public $deleteMethod = 'remove';
+    /** @var array $allowedMethods An array of allowed request methods */
+    public $allowedMethods = array('GET', 'POST', 'PUT', 'DELETE');
+    /** @var array $allowedMethods An array of allowed request methods */
+    public $allowedHeaders = array('Content-Type');
 
     /**
      * @param modX $modx The modX instance
@@ -750,6 +754,15 @@ abstract class modRestController {
      */
     public function afterDelete(array &$objectArray) {}
 
+    /**
+     * Handle OPTIONS requests
+     * @return array
+     */
+    public function options() {
+        header('Access-Control-Allow-Methods: ' . implode(', ', $this->allowedMethods));
+        header('Access-Control-Allow-Headers: ' . implode(', ', $this->allowedHeaders));
+        $this->responseStatus = 200;
+    }
 
     /**
      * Set object-specific model-layer errors for classes that implement the getErrors/addFieldError methods

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -146,7 +146,7 @@ class modRestService {
 				$controller = $controller->newInstance($this->modx,$this->request,$this->config);
 			    $controller->setProperties($this->request->parameters);
 			    $controller->setHeaders($this->request->headers);
-			    if ($controller->isProtected()) {
+			    if ($controller->isProtected() && $this->request->method != 'options') {
                     if (!$controller->verifyAuthentication()) {
                         throw new Exception('Unauthorized', 401);
                     }


### PR DESCRIPTION
### What does it do?

- Add an options method to the modRestController class.
- An additional class property $allowedMethod is introduced to be filled with an array of allowed request methods.
- Another additional class properties $allowedHeaders could be filled with an array of allowed request headers.

I am not sure about allowing the OPTIONS request method in authentificated controllers, so the part in the modRestService class could be removed and $this->request->method has to be checked in the verifyAuthentication method.

### Why is it needed?
Used in cross-origin HTTP request
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
- http://zacstewart.com/2012/04/14/http-options-method.html

### Related issue(s)/PR(s)
None known.
