### PR TITLE
Fix Issue #13640: New "Delete" button for chunks/snippet/tv/plugin redirects wrong

### DIFF
--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -80,7 +80,7 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             ,listeners: {
                 success: {
                     fn: function(r) {
-                        MODx.loadPage(MODx.config.manager_url);
+                        MODx.loadPage('?');
                     },scope:this}
             }
         });

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -80,7 +80,7 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             ,listeners: {
                 success: {
                     fn: function(r) {
-                        MODx.loadPage(MODx.config.manager_url);
+                        MODx.loadPage('?');
                     },scope:this}
             }
         });

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -80,7 +80,7 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             ,listeners: {
                 success: {
                     fn: function(r) {
-                        MODx.loadPage(MODx.config.manager_url);
+                        MODx.loadPage('?');
                     },scope:this}
             }
         });

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -80,7 +80,7 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             ,listeners: {
                 success: {
                     fn: function(r) {
-                        MODx.loadPage(MODx.config.manager_url);
+                        MODx.loadPage('?');
                     },scope:this}
             }
         });

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -81,7 +81,7 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             ,listeners: {
                 success: {
                     fn: function(r) {
-                        MODx.loadPage(MODx.config.manager_url);
+                        MODx.loadPage('?');
                     },scope:this}
             }
         });

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -19,7 +19,7 @@ MODx.panel.Chunk = function(config) {
         ,items: [{
             html: _('chunk_new')
             ,id: 'modx-chunk-header'
-            ,xtype: 'modx-description'
+            ,xtype: 'modx-header'
         },MODx.getPageStructure([{
             title: _('chunk_title')
             ,defaults: { border: false ,msgTarget: 'side' }


### PR DESCRIPTION
### What does it do?
Fix the redirect after deleting a chunk/snippet/tv/template/plugin by clicking on the new "delete" button

### Related issue(s)/PR(s)
#13640 
Was already discussed here: https://github.com/modxcms/revolution/pull/13245/files/c43a25483b0e39a0a6e8fa700f7f96ecc33475d1#r95083093
