### PR TITLE
Adding padding top for new .modx-alert and .modx-confirm classes

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -107,7 +107,7 @@
     .x-window-body {
       padding-top: 0;
     }
-    &.modx-console {
+    &.modx-console, &.modx-alert, &.modx-confirm {
       .x-window-body {
         padding-top: 15px;
       }

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -13,6 +13,7 @@ MODx.window.PackageUninstall = function(config) {
         // ,height: 400
         // ,width: 400
         ,id: 'modx-window-package-uninstall'
+        ,cls: 'modx-confirm'
         ,saveBtnText: _('uninstall')
         ,fields: [{
             html: _('preexisting_mode_select')
@@ -65,6 +66,7 @@ MODx.window.RemovePackage = function(config) {
         ,baseParams: {
             action: 'workspace/packages/uninstall'
         }
+        ,cls: 'modx-confirm'
         ,defaults: { border: false }
         ,fields: [{
             xtype: 'hidden'
@@ -141,6 +143,7 @@ MODx.window.SetupOptions = function(config) {
 		,layout: 'form'
 		,width: 650
 		,autoHeight: true
+        ,cls: 'modx-confirm'
 		,items:[{
 			xtype: 'modx-template-panel'
 			,id: 'modx-setupoptions-panel'

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -143,7 +143,7 @@ MODx.window.SetupOptions = function(config) {
 		,layout: 'form'
 		,width: 650
 		,autoHeight: true
-        ,cls: 'modx-confirm'
+		,cls: 'modx-confirm'
 		,items:[{
 			xtype: 'modx-template-panel'
 			,id: 'modx-setupoptions-panel'


### PR DESCRIPTION
### What does it do?
Add two new css classes for adding padding top to a .modx-window

### Why is it needed?
Since #13038 the padding-top of .modx-window that are starting without a label is too small.

### Related issue(s)/PR(s)
#13038