### PR TITLE
Refactor setUserGroups/addUsers methods

### DIFF
--- a/core/model/modx/processors/security/group/update.class.php
+++ b/core/model/modx/processors/security/group/update.class.php
@@ -57,33 +57,84 @@ class modUserGroupUpdateProcessor extends modObjectUpdateProcessor {
 
     /**
      * Add users to the User Group
-     * 
-     * @return array
+     *
+     * @return modUserGroupMember[]
      */
     public function addUsers() {
-        $users = $this->getProperty('users',null);
+        $users = $this->getProperty('users', null);
         $id = $this->getProperty('id');
         $memberships = array();
         $flush = false;
 
         if ($users !== null && !empty($id)) {
-            $oldMemberships = $this->object->getMany('UserGroupMembers');
-            /** @var modUserGroupMember $oldMembership */
-            foreach ($oldMemberships as $oldMembership) {
-                $oldMembership->remove();
+            $users = is_array($users) ? $users : json_decode($users, true);
+
+            $currentUsers = array();
+            $currentUserIds = array();
+            foreach ($users as $user) {
+                $currentUsers[$user['id']] = $user;
+                $currentUserIds[] = $user['id'];
             }
 
-            $users = is_array($users) ? $users : $this->modx->fromJSON($users);
+            $remainingUserIds = array();
+            /** @var modUserGroupMember[] $existingMemberships */
+            $existingMemberships = $this->object->getMany('UserGroupMembers');
+            foreach ($existingMemberships as $existingMembership) {
+                if (!in_array($existingMembership->get('member'), $currentUserIds)) {
+                    $existingMembership->remove();
+                } else {
+                    $existingUser = $currentUsers[$existingMembership->get('member')];
+                    $existingMembership->fromArray(array(
+                        'role' => $existingUser['role']
+                    ));
+                    $remainingUserIds[] = $existingMembership->get('member');
+                }
+            }
+
+            $newUserIds = array_diff($currentUserIds, $remainingUserIds);
+            $newUsers = array();
             foreach ($users as $user) {
+                if (in_array($user['id'], $newUserIds)) {
+                    $newUsers[] = $user;
+                }
+            }
+
+            $idx = 0;
+            foreach ($newUsers as $newUser) {
                 /** @var modUserGroupMember $membership */
                 $membership = $this->modx->newObject('modUserGroupMember');
-                $membership->set('user_group',$this->object->get('id'));
-                $membership->set('member',$user['id']);
-                $membership->set('role',empty($user['role']) ? 0 : $user['role']);
+                $membership->fromArray(array(
+                    'user_group' => $this->object->get('id'),
+                    'role' => empty($newUser['role']) ? 0 : $newUser['role'],
+                    'member' => $newUser['id']
+                ));
+
+                $user = $this->modx->getObject('modUser', $newUser['id']);
+                /* invoke OnUserBeforeAddToGroup event */
+                $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', array(
+                    'user' => &$user,
+                    'usergroup' => &$this->object,
+                    'membership' => &$membership,
+                ));
+                $canSave = $this->processEventResponse($OnUserBeforeAddToGroup);
+                if (!empty($canSave)) {
+                    return $this->failure($canSave);
+                }
 
                 if ($membership->save()) {
                     $memberships[] = $membership;
+                } else {
+                    return $this->failure($this->modx->lexicon('user_group_member_err_save'));
                 }
+
+                /* invoke OnUserAddToGroup event */
+                $this->modx->invokeEvent('OnUserAddToGroup', array(
+                    'user' => &$user,
+                    'usergroup' => &$this->object,
+                    'membership' => &$membership,
+                ));
+
+                $idx++;
             }
             $flush = true;
         }

--- a/core/model/modx/processors/security/user/create.class.php
+++ b/core/model/modx/processors/security/user/create.class.php
@@ -80,35 +80,66 @@ class modUserCreateProcessor extends modObjectCreateProcessor {
 
     /**
      * Add User Group memberships to the User
-     * @return array
+     * @return modUserGroupMember[]
      */
-    public function setUserGroups() {
+    public function setUserGroups()
+    {
         $memberships = array();
-        $groups = $this->getProperty('groups',null);
+        $groups = $this->getProperty('groups', null);
         if ($groups !== null) {
             $primaryGroupId = 0;
-            $groups = is_array($groups) ? $groups : $this->modx->fromJSON($groups);
+            $groups = is_array($groups) ? $groups : json_decode($groups, true);
             $groupsAdded = array();
             $idx = 0;
             foreach ($groups as $group) {
-                if (in_array($group['usergroup'],$groupsAdded)) continue;
+                if (in_array($group['usergroup'], $groupsAdded)) {
+                    continue;
+                }
 
                 /** @var modUserGroupMember $membership */
                 $membership = $this->modx->newObject('modUserGroupMember');
-                $membership->set('user_group',$group['usergroup']);
-                $membership->set('role',$group['role']);
-                $membership->set('member',$this->object->get('id'));
-                $membership->set('rank',isset($group['rank']) ? $group['rank'] : $idx);
+                $membership->fromArray(array(
+                    'user_group' => $group['usergroup'],
+                    'role' => $group['role'],
+                    'member' => $this->object->get('id'),
+                    'rank' => isset($group['rank']) ? $group['rank'] : $idx
+                ));
                 if (empty($group['rank'])) {
                     $primaryGroupId = $group['usergroup'];
                 }
-                //$membership->save();
-                $memberships[] = $membership;
+
+                $usergroup = $this->modx->getObject('modUserGroup', $group['usergroup']);
+                /* invoke OnUserBeforeAddToGroup event */
+                $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', array(
+                    'user' => &$this->object,
+                    'usergroup' => &$usergroup,
+                    'membership' => &$membership,
+                ));
+                $canSave = $this->processEventResponse($OnUserBeforeAddToGroup);
+                if (!empty($canSave)) {
+                    $this->object->save();
+                    return $this->failure($canSave);
+                }
+
+                if ($membership->save()) {
+                    $memberships[] = $membership;
+                } else {
+                    $this->object->save();
+                    return $this->failure($this->modx->lexicon('user_group_member_err_save'));
+                }
+
+                /* invoke OnUserAddToGroup event */
+                $this->modx->invokeEvent('OnUserAddToGroup', array(
+                    'user' => &$this->object,
+                    'usergroup' => &$usergroup,
+                    'membership' => &$membership,
+                ));
+
                 $groupsAdded[] = $group['usergroup'];
                 $idx++;
             }
-            $this->object->addMany($memberships,'UserGroupMembers');
-            $this->object->set('primary_group',$primaryGroupId);
+            $this->object->addMany($memberships, 'UserGroupMembers');
+            $this->object->set('primary_group', $primaryGroupId);
             $this->object->save();
         }
         return $memberships;


### PR DESCRIPTION
### What does it do?
Don't remove the user from all existing groups and add it afterwards to all belonging groups. Just remove the user from old groups and add it to new groups. Invoke 'OnUserBeforeAddToGroup' and 'OnUserAddToGroup'.

### Why is it needed?
The previous code was ineffective and did not allow to have the 'OnUserBeforeAddToGroup' and 'OnUserAddToGroup' events triggered for adding the user only to new groups.

### Related issue(s)/PR(s)
#13160