### PR TITLE
Fixed issue introduced by #13506 preventing to download 2 packages in a row

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -217,16 +217,17 @@ Ext.extend(MODx.panel.PackagesBrowser,MODx.Panel,{
 		Ext.getCmp('packages-breadcrumbs').updateDetail(bd);
 	}
 
-	,showWait: function(){
-		if(typeof(this.wait) == "undefined"){
-			this.wait = new MODx.PackageBrowserWaitWindow();
-		}
-		this.wait.show();
-	}
+    ,showWait: function(){
+        if (!this.wait) {
+            this.wait = new MODx.PackageBrowserWaitWindow();
+        }
+        this.wait.show();
+    }
 
     ,hideWait: function() {
         if (this.wait) {
             this.wait.destroy();
+            delete this.wait;
         }
     }
 });


### PR DESCRIPTION
### What does it do?

Removed an object attribute

### Why is it needed?

The attribute was checked (and obviously destroying the window did not make the check successful) and caused error when trying to download 2 packages

Related to #13506 (sorry)