### PR TITLE
Add context filter in tree resource

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -130,9 +130,9 @@ class modResourceGetNodesProcessor extends modProcessor {
         $this->itemClass= 'modContext';
         $c= $this->modx->newQuery($this->itemClass, array('key:!=' => 'mgr'));
         if (!empty($this->getProperty('contextFilter'))) {
-            $c->where([
+            $c->where(array(
                 'name:LIKE' => "%{$this->getProperty('contextFilter', '')}%",
-            ]);
+            ));
         }
         if (!empty($this->defaultRootId)) {
             $c->where(array(

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -128,7 +128,7 @@ class modResourceGetNodesProcessor extends modProcessor {
      */
     public function getContextQuery() {
         $this->itemClass= 'modContext';
-        $c= $this->modx->newQuery($this->itemClass, array('key:!=' => 'mgr'));
+        $c= $this->modx->newQuery($this->itemClass, array('key:!=' => 'mgr', 'name:LIKE' => "%{$this->getProperty('contextFilter', '')}%"));
         if (!empty($this->defaultRootId)) {
             $c->where(array(
                 "(SELECT COUNT(*) FROM {$this->modx->getTableName('modResource')} WHERE context_key = modContext.{$this->modx->escape('key')} AND id IN ({$this->defaultRootId})) > 0",

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -128,7 +128,12 @@ class modResourceGetNodesProcessor extends modProcessor {
      */
     public function getContextQuery() {
         $this->itemClass= 'modContext';
-        $c= $this->modx->newQuery($this->itemClass, array('key:!=' => 'mgr', 'name:LIKE' => "%{$this->getProperty('contextFilter', '')}%"));
+        $c= $this->modx->newQuery($this->itemClass, array('key:!=' => 'mgr'));
+        if (!empty($this->getProperty('contextFilter'))) {
+            $c->where([
+                'name:LIKE' => "%{$this->getProperty('contextFilter', '')}%",
+            ]);
+        }
         if (!empty($this->defaultRootId)) {
             $c->where(array(
                 "(SELECT COUNT(*) FROM {$this->modx->getTableName('modResource')} WHERE context_key = modContext.{$this->modx->escape('key')} AND id IN ({$this->defaultRootId})) > 0",

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -63,6 +63,43 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 this.expandPath(treeState[i]);
             }
         }
+
+        this.addContextFilter();
+    }
+
+    ,addContextFilter: function() {
+        this.contextFilter = new Ext.form.TextField({
+            id: 'contextFilter'
+            , name: 'contextFilter'
+            , emptyText: _('search_ellipsis')
+            , width: this.getWidth() - 12
+            , listeners: {
+                render: {
+                    fn: function (object) {
+                        object.getEl().on('keyup', function () {
+                            this.filterBy(object);
+                        }, this);
+                    }, scope: this
+                }
+            }
+        });
+
+        this.filterBar = new Ext.Toolbar({
+            renderTo: this.tbar
+            , id: 'modx-resource-filterbar'
+            , items: [this.contextFilter]
+        });
+
+        this.on('resize', function(){
+            this.contextFilter.setWidth(this.getWidth() - 12);
+        }, this);
+    }
+
+    , filterBy: function (object) {
+        if (this.baseParams[object.name] != object.getValue()) {
+            this.baseParams[object.name] = object.getValue();
+            this.refresh();
+        }
     }
 
     /*,addSearchToolbar: function() {


### PR DESCRIPTION
### What does it do?
Adds context filter in the resource tree
![1](https://user-images.githubusercontent.com/22609593/32286085-025bf1aa-bf35-11e7-858b-0eac2329345f.png)


### Why is it needed?
When I have a lot of contexts on my site, I spend a lot of time searching for the right context. It is not confortable

### Related issue(s)/PR(s)
No