### PR TITLE
htmlspecialchars pagetitle for delete resource dialog UI

### DIFF
--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -42,7 +42,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
             MODx.load({
                 xtype: "modx-page-resource-update"
                 ,resource: "'.$this->resource->get('id').'"
-                ,pagetitle: "'.$this->modx->toJSON($this->resource->get('pagetitle')).'"
+                ,pagetitle: "'.htmlspecialchars($this->resource->get('pagetitle')).'"
                 ,record: '.$this->modx->toJSON($this->resourceArray).'
                 ,publish_document: "'.$this->canPublish.'"
                 ,preview_url: "'.$this->previewUrl.'"

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -42,7 +42,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
             MODx.load({
                 xtype: "modx-page-resource-update"
                 ,resource: "'.$this->resource->get('id').'"
-                ,pagetitle: "'.$this->resource->get('pagetitle').'"
+                ,pagetitle: "'.$this->modx->toJSON($this->resource->get('pagetitle')).'"
                 ,record: '.$this->modx->toJSON($this->resourceArray).'
                 ,publish_document: "'.$this->canPublish.'"
                 ,preview_url: "'.$this->previewUrl.'"


### PR DESCRIPTION
### What does it do?
htmlspecialchars ~~JSON encodes~~ the pagetitle for delete resource dialog UI.

### Why is it needed?
2.6 introduced an advanced delete resource dialog that shows the pagetitle of the resource to be deleted. When the pagetitle contains quotes, the update resource manager page would not load due to a js syntax error.

### Related issue(s)/PR(s)
#13664 
#13497
