### PR TITLE
Fix javascript issue on resources containing a quote sign

### DIFF
--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -70,7 +70,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
 
     ,deleteResource: function(btn,e) {
         MODx.msg.confirm({
-            title: this.config.pagetitle ? _('resource_delete') + ' ' + this.config.pagetitle + ' (' + this.config.resource + ')' : _('resource_delete')
+            title: this.config.record.pagetitle ? _('resource_delete') + ' ' + this.config.record.pagetitle + ' (' + this.config.resource + ')' : _('resource_delete')
             ,text: _('resource_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -42,7 +42,6 @@ class ResourceUpdateManagerController extends ResourceManagerController {
             MODx.load({
                 xtype: "modx-page-resource-update"
                 ,resource: "'.$this->resource->get('id').'"
-                ,pagetitle: "'.$this->resource->get('pagetitle').'"
                 ,record: '.$this->modx->toJSON($this->resourceArray).'
                 ,publish_document: "'.$this->canPublish.'"
                 ,preview_url: "'.$this->previewUrl.'"


### PR DESCRIPTION
### What does it do?
Use the already existing config.record.pagetitle instead of creating a not escaped config.pagetitle

### Why is it needed?
Resources containing a quote sign can't be updated in the manager.

### Related issue(s)/PR(s)
Introduced in #13497 
Reported in #13664