### PR TITLE
Improve changelog display

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -523,7 +523,7 @@ Ext.extend(MODx.window.PackageUpdate,MODx.Window,{
                                     xtype: 'modx-window'
                                     ,fields: [{
                                         xtype: 'box'
-                                        ,html: pkg.changelog
+                                        ,html: pkg.changelog.replace(/(?:\r\n|\r|\n)/g, '<br>')
                                     }]
                                     ,buttons: [{
                                         text: _('close')

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -521,9 +521,13 @@ Ext.extend(MODx.window.PackageUpdate,MODx.Window,{
                             Ext.get(changelog).on('click', function(elem) {
                                 var win = MODx.load({
                                     xtype: 'modx-window'
+                                    ,title: _('changelog')
+                                    ,cls: 'modx-alert'
+                                    ,width: 520
+                                    ,style: 'white-space: pre'
                                     ,fields: [{
                                         xtype: 'box'
-                                        ,html: pkg.changelog.replace(/(?:\r\n|\r|\n)/g, '<br>')
+                                        ,html: pkg.changelog
                                     }]
                                     ,buttons: [{
                                         text: _('close')

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -524,7 +524,7 @@ Ext.extend(MODx.window.PackageUpdate,MODx.Window,{
                                     ,title: _('changelog')
                                     ,cls: 'modx-alert'
                                     ,width: 520
-                                    ,style: 'white-space: pre'
+                                    ,style: 'white-space: pre-wrap'
                                     ,fields: [{
                                         xtype: 'box'
                                         ,html: pkg.changelog


### PR DESCRIPTION
### What does it do?
~~Replace newlines with br tags in the displayed changelog.~~ Display the changelog with the style `white-space: pre`. Better than adding br tags.

### Why is it needed?
Sometimes the changelog will contain only text and the output in the modx-window expects html. The css change should improve the readability of the changelog output.

### Related issue(s)/PR(s)
#13455