### PR TITLE
Check if contentEl exists before using it

### DIFF
--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -96,7 +96,7 @@ Ext.onReady(function() {
         }
         ,listeners: {
             beforeadd: function (tabpanel, comp) {
-                if (Ext.get(comp.contentEl).child('.modx-tv') === null) {
+                if (comp.contentEl && (Ext.get(comp.contentEl).child('.modx-tv') === null)) {
                     return false;
                 }
             }


### PR DESCRIPTION
### What does it do?
Check if contentEl exists before using it

### Why is it needed?
Without it it triggers an error in console and stops other JS causing other extras to not work properly

### Related issue(s)/PR(s)
Fixes #13682
