### PR TITLE
Allow callback if nothing is selected

### DIFF
--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -1485,8 +1485,8 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
         var callback = this.config.onSelect || this.onSelectHandler;
         var lookup = this.view.lookup;
         var scope = this.config.scope;
-        if(selNode && callback) {
-            data = lookup[selNode.id];
+        if(callback) {
+            data = (selNode) ? lookup[selNode.id] : null;
             Ext.callback(callback,scope || this,[data]);
             this.fireEvent('select',data);
             if (window.top.opener) {
@@ -1497,6 +1497,10 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
     }
 
     ,onCancel: function() {
+        var callback = this.config.onSelect || this.onSelectHandler;
+        var scope = this.config.scope;
+        Ext.callback(callback,scope || this,[null]);
+        this.fireEvent('select',null);
         if (window.top.opener) {
             window.top.close();
             window.top.opener.focus();


### PR DESCRIPTION
Would not fire browser callback if cancel hit or nothing was selected. Fixes TinyMCE RTE Issue 10 https://github.com/modxcms/tinymce-rte/issues/10

### What does it do?
Adds callback support to the Cancel button and the OK button when nothing is selected.

### Why is it needed?
If browser is iframed, there is no way to close it.

### Related issue(s)/PR(s)
https://github.com/modxcms/tinymce-rte/issues/10
