### PR TITLE
Fixed services default value to null for proper initialization contai…

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -98,7 +98,7 @@ class modX extends xPDO {
     /**
      * @var array An array of supplemental service classes for this modX instance.
      */
-    public $services= array ();
+    public $services= null;
     /**
      * @var array A listing of site Resources and Context-specific meta data.
      */


### PR DESCRIPTION
…ner of services

### What does it do?
It set up initial value of property `services` of class ModX to null instead array().

### Why is it needed?
It is needed for preventing errors when the method cannot be found in the array. It happens because by default in MODX this value is array and checks in xPDO ignore this fact waiting null value as it defined in the parent class (xPDO).

### Related issue(s)/PR(s)
n/a, but branch without this fix unworking.