### PR TITLE
Fixing 'Flush Your Permissions' in topmenu

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -255,7 +255,8 @@ $children[3]->fromArray(array (
         action: \'security/access/flush\'
     }
     ,listeners: {
-        \'success\': {fn:function() { location.href = \'./\'; },scope:this}
+        \'success\': {fn:function() { location.href = \'./\'; },scope:this},
+        \'failure\': {fn:function(response) { Ext.MessageBox.alert(\'failure\', response.responseText); },scope:this},
     }
 });',
 ), '', true, true);

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -769,7 +769,7 @@ class modCacheManager extends xPDOCacheManager {
             $contexts = $ctxQuery->stmt->fetchAll(PDO::FETCH_COLUMN);
             if ($contexts) {
                 $serialized = serialize($contexts);
-                if ($this->modx->exec("UPDATE {$this->modx->getTableName('modUser')} SET {$this->modx->escape('session_stale')} = {$this->modx->quote($serialized)}")) {
+                if ($this->modx->exec("UPDATE {$this->modx->getTableName('modUser')} SET {$this->modx->escape('session_stale')} = {$this->modx->quote($serialized)}") !== false) {
                     return true;
                 }
             }

--- a/core/model/modx/processors/security/access/flush.class.php
+++ b/core/model/modx/processors/security/access/flush.class.php
@@ -6,12 +6,19 @@
  * @subpackage processors.security.access
  */
 class modFlushPermissionsProcessor extends modProcessor {
+    public function getLanguageTopics() {
+        return array('topmenu');
+    }
+
     public function checkPermissions() {
         return $this->modx->hasPermission('access_permissions');
     }
 
     public function process() {
-        $this->modx->cacheManager->flushPermissions();
+        if (!$this->modx->cacheManager->flushPermissions()) {
+            return $this->failure($this->modx->lexicon('flush_sessions_err'));
+        }
+        return $this->success();
     }
 }
 return 'modFlushPermissionsProcessor';


### PR DESCRIPTION
### What does it do?

- Fix the result of the cacheManager->flushPermissions() method result (0 is not false).
- Return the success/failure of $modx->cacheManager->flushPermissions() in the processor response with an error message on failure.
- Display an ExtJS error message on failure.

### Why is it needed?

After #13311 a manager reload was not triggered and the cacheManager->flushPermissions() method returned a false failure result, if no line was changed in the database call.

### Related issue(s)/PR(s)

#13311, #13687
