### PR TITLE
Add new output modifier "filterPathSegment"

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -657,6 +657,9 @@ class modOutputFilter {
                             }
                             $output = implode($delimiter, $return_values);
                             break;
+                        case 'filterPathSegment':
+                            $output = $this->modx->filterPathSegment($output);
+                            break;
 
                         /* Default, custom modifier (run snippet with modifier name) */
                         default:
@@ -698,7 +701,7 @@ class modOutputFilter {
         try {
             $m_con = ($conditional !== '') ? @eval("return (" . $conditional . ");") : false;
             $m_con = intval($m_con);
-            
+
             // If negate is true, we want the value of $m_con to be false
             if (!$negate) {
                 if ($m_con) {

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -657,7 +657,7 @@ class modOutputFilter {
                             }
                             $output = implode($delimiter, $return_values);
                             break;
-                        case 'slug':
+                        case 'filterPathSegment':
                             $output = $this->modx->filterPathSegment($output);
                             break;
 

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -657,7 +657,7 @@ class modOutputFilter {
                             }
                             $output = implode($delimiter, $return_values);
                             break;
-                        case 'filterPathSegment':
+                        case 'slug':
                             $output = $this->modx->filterPathSegment($output);
                             break;
 


### PR DESCRIPTION
### What does it do?
This outputs the "slug" or "friendly URL" version of the input. It uses the same function that is used by MODX to build friendly URLs.

```
[[+foo:filterPathSegment]]
```
"Test 1 ? oA u" -> "test-1-oa-u"

As it uses the core functionality, it also takes the translit system settings in account.

E.g. when the extra "translit" is installed with the setting "friendly_alias_translit" set to "german":

"Test 1 ? öÄ ß" -> "test-1-oeae-ss"