### PR TITLE
Adding system setting "automatic_template_assignment" to fix #5980

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -114,6 +114,15 @@ $settings['automatic_alias']->fromArray(array (
   'area' => 'furls',
   'editedon' => null,
 ), '', true, true);
+$settings['automatic_template_assignment']= $xpdo->newObject('modSystemSetting');
+$settings['automatic_template_assignment']->fromArray(array (
+    'key' => 'automatic_template_assignment',
+    'value' => 'parent',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'site',
+    'editedon' => null,
+), '', true, true);
 $settings['base_help_url']= $xpdo->newObject('modSystemSetting');
 $settings['base_help_url']->fromArray(array (
   'key' => 'base_help_url',
@@ -808,15 +817,6 @@ $settings['hidemenu_default']->fromArray(array (
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
-$settings['inherit_parent_template']= $xpdo->newObject('modSystemSetting');
-$settings['inherit_parent_template']->fromArray(array (
-    'key' => 'inherit_parent_template',
-    'value' => 1,
-    'xtype' => 'combo-boolean',
-    'namespace' => 'core',
-    'area' => 'site',
-    'editedon' => null,
 ), '', true, true);
 $settings['inline_help']= $xpdo->newObject('modSystemSetting');
 $settings['inline_help']->fromArray(array (

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -809,6 +809,15 @@ $settings['hidemenu_default']->fromArray(array (
   'area' => 'site',
   'editedon' => null,
 ), '', true, true);
+$settings['inherit_parent_template']= $xpdo->newObject('modSystemSetting');
+$settings['inherit_parent_template']->fromArray(array (
+    'key' => 'inherit_parent_template',
+    'value' => 1,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'site',
+    'editedon' => null,
+), '', true, true);
 $settings['inline_help']= $xpdo->newObject('modSystemSetting');
 $settings['inline_help']->fromArray(array (
   'key' => 'inline_help',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -119,6 +119,9 @@ $_lang['setting_allow_multiple_emails_desc'] = 'If enabled, Users may share the 
 $_lang['setting_automatic_alias'] = 'Automatically generate alias';
 $_lang['setting_automatic_alias_desc'] = 'Select \'Yes\' to have the system automatically generate an alias based on the Resource\'s page title when saving.';
 
+$_lang['setting_automatic_template_assignment'] = 'Automatic Template Assignment';
+$_lang['setting_automatic_template_assignment'] = 'Choose how templates are assigned to new Resources on creation. Options include: system (default template from system settings), parent (inherits the parent template), or sibling (inherits the most used sibling template)';
+
 $_lang['setting_base_help_url'] = 'Base Help URL';
 $_lang['setting_base_help_url_desc'] = 'The base URL by which to build the Help links in the top right of pages in the manager.';
 

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -191,8 +191,32 @@ class ResourceCreateManagerController extends ResourceManagerController {
         $defaultTemplate = $this->context->getOption('default_template', 0, $this->modx->_userConfig);
         if (isset($this->scriptProperties['template'])) {
             $defaultTemplate = $this->scriptProperties['template'];
-        } elseif (!empty($this->parent->id) && $this->context->getOption('inherit_parent_template', true, $this->modx->_userConfig)) {
-            $defaultTemplate =  $this->parent->get('template');
+        } else {
+            switch ($this->context->getOption('automatic_template_assignment', 'parent', $this->modx->_userConfig)) {
+                case 'parent':
+                    if (!empty($this->parent->id))
+                        $defaultTemplate = $this->parent->get('template');
+                    break;
+                case 'sibling':
+                    if (!empty($this->parent->id)) {
+                        $c = $this->modx->newQuery('modResource');
+                        $c->select('COUNT(*) as count, modResource.*');
+                        $c->where(array('parent'=>$this->parent->id));
+                        $c->groupby('template');
+                        $c->sortby('count', 'DESC');
+                        $c->limit(1);
+                        $siblings = $this->modx->getCollection('modResource', $c);
+                        if (!empty($siblings)) {
+                            foreach ($siblings as $sibling){
+                                $defaultTemplate = $sibling->get('template');
+                            }
+                        }
+                    }
+                    break;
+                case 'system':
+                    /* already established */
+                    break;
+            }
         }
         $userGroups = $this->modx->user->getUserGroups();
         $c = $this->modx->newQuery('modActionDom');

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -200,16 +200,17 @@ class ResourceCreateManagerController extends ResourceManagerController {
                 case 'sibling':
                     if (!empty($this->parent->id)) {
                         $c = $this->modx->newQuery('modResource');
-                        $c->select('COUNT(*) as count, modResource.*');
-                        $c->where(array('parent'=>$this->parent->id));
-                        $c->groupby('template');
-                        $c->sortby('count', 'DESC');
+                        $c->where(array('parent'=>$this->parent->id, 'context_key'=>$this->ctx));
+                        $c->sortby('id', 'DESC');
                         $c->limit(1);
                         $siblings = $this->modx->getCollection('modResource', $c);
                         if (!empty($siblings)) {
                             foreach ($siblings as $sibling){
                                 $defaultTemplate = $sibling->get('template');
                             }
+                        }else{
+                            if (!empty($this->parent->id))
+                                $defaultTemplate = $this->parent->get('template');
                         }
                     }
                     break;

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -188,7 +188,12 @@ class ResourceCreateManagerController extends ResourceManagerController {
      * @return int
      */
     public function getDefaultTemplate() {
-        $defaultTemplate = (isset($this->scriptProperties['template']) ? $this->scriptProperties['template'] : (!empty($this->parent->id) ? $this->parent->get('template') : $this->context->getOption('default_template', 0, $this->modx->_userConfig)));
+        $defaultTemplate = $this->context->getOption('default_template', 0, $this->modx->_userConfig);
+        if (isset($this->scriptProperties['template'])) {
+            $defaultTemplate = $this->scriptProperties['template'];
+        } elseif (!empty($this->parent->id) && $this->context->getOption('inherit_parent_template', true, $this->modx->_userConfig)) {
+            $defaultTemplate =  $this->parent->get('template');
+        }
         $userGroups = $this->modx->user->getUserGroups();
         $c = $this->modx->newQuery('modActionDom');
         $c->innerJoin('modFormCustomizationSet','FCSet');


### PR DESCRIPTION
### What does it do?
I've reworked my previous pull #12705, by sanitizing the default template function, and added a system setting to disable the behavior of inheriting parent template. 

### Why is it needed?
Sometimes you need a special template for a parent page, but want all the siblings to have a standard template.  Without being able to disable inheriting the parent template, every time you create a child it will pick the parent's template instead of the default template. 

### Related issue(s)/PR(s)
Reworking pull request #12705 and closes issue #5980, which was accidentally closed as the pull request was never merged. 

### UPDATE:
I've reworked this to work like Evo and changed it to "automatic_template_assignment" with three options: system, parent, sibling