### PR TITLE
Fix "reference expected" warnings when using PHP 7.1

### DIFF
--- a/core/model/modx/modaccessibleobject.class.php
+++ b/core/model/modx/modaccessibleobject.class.php
@@ -21,13 +21,9 @@ class modAccessibleObject extends xPDOObject {
     /**
      * Custom instance from row loader that respects policy checking
      *
-     * @param xPDO|modX $xpdo A reference to the xPDO/modX object.
-     * @param string $className The name of the class by which to grab the instance from
-     * @param mixed $criteria A criteria to use when grabbing this instance
-     * @param int $row The row to select
-     * @return modAccessibleObject|null An instance of the object
+     * {@inheritdoc}
      */
-    public static function _loadInstance(& $xpdo, $className, $criteria, $row) {
+    public static function _loadInstance($xpdo, $className, $criteria, $row) {
         /** @var modAccessibleObject $instance */
         $instance = xPDOObject :: _loadInstance($xpdo, $className, $criteria, $row);
         if ($instance instanceof modAccessibleObject && !$instance->checkPolicy('load')) {
@@ -46,8 +42,7 @@ class modAccessibleObject extends xPDOObject {
      *
      * {@inheritdoc}
      */
-    public static function _loadCollectionInstance(xPDO & $xpdo, array & $objCollection, $className, $criteria, $row, $fromCache, $cacheFlag=true) {
-        $loaded = false;
+    public static function _loadCollectionInstance(xPDO $xpdo, array $objCollection, $className, $criteria, $row, $fromCache, $cacheFlag=true) {
         if ($obj= modAccessibleObject :: _loadInstance($xpdo, $className, $criteria, $row)) {
             if (($cacheKey= $obj->getPrimaryKey()) && !$obj->isLazy()) {
                 if (is_array($cacheKey)) {
@@ -64,13 +59,12 @@ class modAccessibleObject extends xPDOObject {
                     }
                 }
                 $objCollection[$pkval]= $obj;
-                $loaded = true;
             } else {
                 $objCollection[]= $obj;
-                $loaded = true;
             }
         }
-        return $loaded;
+
+        return $objCollection;
     }
 
     /**
@@ -78,7 +72,7 @@ class modAccessibleObject extends xPDOObject {
      *
      * {@inheritdoc}
      */
-    public static function load(xPDO & $xpdo, $className, $criteria, $cacheFlag= true) {
+    public static function load(xPDO $xpdo, $className, $criteria, $cacheFlag= true) {
         $instance= null;
         $fromCache= false;
         if ($className= $xpdo->loadClass($className)) {
@@ -127,9 +121,8 @@ class modAccessibleObject extends xPDOObject {
      *
      * {@inheritdoc}
      */
-    public static function loadCollection(xPDO & $xpdo, $className, $criteria= null, $cacheFlag= true) {
+    public static function loadCollection(xPDO $xpdo, $className, $criteria= null, $cacheFlag= true) {
         $objCollection= array ();
-        $fromCache = false;
         if (!$className= $xpdo->loadClass($className)) return $objCollection;
         $rows= false;
         $fromCache= false;
@@ -146,12 +139,12 @@ class modAccessibleObject extends xPDOObject {
         }
         if (is_array ($rows)) {
             foreach ($rows as $row) {
-                modAccessibleObject :: _loadCollectionInstance($xpdo, $objCollection, $className, $criteria, $row, $fromCache, $cacheFlag);
+                $objCollection = modAccessibleObject :: _loadCollectionInstance($xpdo, $objCollection, $className, $criteria, $row, $fromCache, $cacheFlag);
             }
         } elseif (is_object($rows)) {
             $cacheRows = array();
             while ($row = $rows->fetch(PDO::FETCH_ASSOC)) {
-                modAccessibleObject :: _loadCollectionInstance($xpdo, $objCollection, $className, $criteria, $row, $fromCache, $cacheFlag);
+                $objCollection = modAccessibleObject :: _loadCollectionInstance($xpdo, $objCollection, $className, $criteria, $row, $fromCache, $cacheFlag);
                 if ($collectionCaching > 0 && $xpdo->_cacheEnabled && $cacheFlag && !$fromCache) $cacheRows[] = $row;
             }
             if ($collectionCaching > 0 && $xpdo->_cacheEnabled && $cacheFlag && !$fromCache) $rows =& $cacheRows;
@@ -168,12 +161,11 @@ class modAccessibleObject extends xPDOObject {
      * {@inheritdoc}
      */
     public function save($cacheFlag = null) {
-        $saved = false;
         if (!$this->checkPolicy('save')) {
             $this->xpdo->error->failure($this->xpdo->lexicon('permission_denied'));
         }
-        $saved = parent :: save($cacheFlag);
-        return $saved;
+
+        return parent :: save($cacheFlag);
     }
 
     /**
@@ -182,12 +174,11 @@ class modAccessibleObject extends xPDOObject {
      * {@inheritdoc}
      */
     public function remove(array $ancestors= array ()) {
-        $removed = false;
         if (!$this->checkPolicy('remove')) {
             $this->xpdo->error->failure($this->xpdo->lexicon('permission_denied'));
         }
-        $removed = parent :: remove($ancestors);
-        return $removed;
+
+        return parent :: remove($ancestors);
     }
 
     /**

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -379,7 +379,7 @@ class modCacheManager extends xPDOCacheManager {
                 if ($action['namespace_name'] != 'core') {
                     $nsPath = $action['namespace_path'];
                     if (!empty($nsPath)) {
-                        $nsPath = $this->modx->call('modNamespace','translatePath',array(&$this->modx,$nsPath));
+                        $nsPath = $this->modx->call('modNamespace','translatePath',array($this->modx,$nsPath));
                         $action['namespace_path'] = $nsPath;
                     }
                 }
@@ -413,8 +413,8 @@ class modCacheManager extends xPDOCacheManager {
                     $namespace['path'] = $this->modx->getOption('manager_path',null,MODX_MANAGER_PATH);
                     $namespace['assets_path'] = $this->modx->getOption('manager_path',null,MODX_MANAGER_PATH).'assets/';
                 } else {
-                    $namespace['path'] = $this->modx->call('modNamespace','translatePath',array(&$this->modx,$namespace['path']));
-                    $namespace['assets_path'] = $this->modx->call('modNamespace','translatePath',array(&$this->modx,$namespace['assets_path']));
+                    $namespace['path'] = $this->modx->call('modNamespace','translatePath',array($this->modx,$namespace['path']));
+                    $namespace['assets_path'] = $this->modx->call('modNamespace','translatePath',array($this->modx,$namespace['assets_path']));
                 }
                 $results[$namespace['name']] = $namespace;
             }
@@ -459,7 +459,7 @@ class modCacheManager extends xPDOCacheManager {
                 ),$extensionPackage['path']);
 
                 if (empty($extensionPackage['path'])) {
-                    $extensionPackage['path'] = $this->modx->call('modNamespace','translatePath',array(&$this->modx,$extensionPackage['namespace_path']));
+                    $extensionPackage['path'] = $this->modx->call('modNamespace','translatePath',array($this->modx,$extensionPackage['namespace_path']));
                 }
                 if (empty($extensionPackage['name'])) {
                     $extensionPackage['name'] = $extensionPackage['namespace'];

--- a/core/model/modx/modcontext.class.php
+++ b/core/model/modx/modcontext.class.php
@@ -56,11 +56,11 @@ class modContext extends modAccessibleObject {
      * Prepare and execute a PDOStatement to retrieve data needed for $aliasMap and $resourceMap.
      *
      * @static
-     * @param modContext &$context A reference to a specific modContext instance.
+     * @param modContext $context A specific modContext instance.
      * @return PDOStatement|bool A PDOStatement, prepared and executed, with the map data, or false
      * if the statement could not be prepared or executed.
      */
-    public static function getResourceCacheMapStmt(&$context) {
+    public static function getResourceCacheMapStmt($context) {
         return false;
     }
 
@@ -68,11 +68,11 @@ class modContext extends modAccessibleObject {
      * Prepare and execute a PDOStatement to retrieve data needed for $webLinkMap.
      *
      * @static
-     * @param modContext &$context A reference to a specific modContext instance.
+     * @param modContext $context A specific modContext instance.
      * @return PDOStatement|bool A PDOStatement, prepared and executed, with the map data, or false
      * if the statement could not be prepared or executed.
      */
-    public static function getWebLinkCacheMapStmt(&$context) {
+    public static function getWebLinkCacheMapStmt($context) {
         return false;
     }
 
@@ -391,7 +391,7 @@ class modContext extends modAccessibleObject {
      * @return PDOStatement|null
      */
     public function getResourceCacheMap() {
-        return $this->xpdo->call('modContext', 'getResourceCacheMapStmt', array(&$this));
+        return $this->xpdo->call('modContext', 'getResourceCacheMapStmt', array($this));
     }
 
     /**
@@ -400,7 +400,7 @@ class modContext extends modAccessibleObject {
      * @return PDOStatement|null
      */
     public function getWebLinkCacheMap() {
-        return $this->xpdo->call('modContext', 'getWebLinkCacheMapStmt', array(&$this));
+        return $this->xpdo->call('modContext', 'getWebLinkCacheMapStmt', array($this));
     }
 
     /**

--- a/core/model/modx/modextensionpackage.class.php
+++ b/core/model/modx/modextensionpackage.class.php
@@ -23,7 +23,7 @@ class modExtensionPackage extends xPDOSimpleObject {
         }
         $saved = parent::save($cacheFlag);
         if ($saved && !$this->getOption(xPDO::OPT_SETUP)) {
-            $this->xpdo->call('modExtensionPackage','clearCache',array(&$this->xpdo));
+            $this->xpdo->call('modExtensionPackage','clearCache',array($this->xpdo));
         }
         return $saved;
     }
@@ -31,7 +31,7 @@ class modExtensionPackage extends xPDOSimpleObject {
     public function remove(array $ancestors = array()) {
         $removed = parent::remove($ancestors);
         if ($removed && !$this->getOption(xPDO::OPT_SETUP)) {
-            $this->xpdo->call('modExtensionPackage','clearCache',array(&$this->xpdo));
+            $this->xpdo->call('modExtensionPackage','clearCache',array($this->xpdo));
         }
         return $removed;
     }
@@ -42,7 +42,7 @@ class modExtensionPackage extends xPDOSimpleObject {
      * @param xPDO|modX $modx
      * @return array|mixed
      */
-    public static function loadCache(xPDO &$modx) {
+    public static function loadCache(xPDO $modx) {
         if (!$modx->getCacheManager()) {
             return array();
         }

--- a/core/model/modx/modmanagerresponse.class.php
+++ b/core/model/modx/modmanagerresponse.class.php
@@ -21,7 +21,7 @@ class modManagerResponse extends modResponse {
 
     protected function _loadNamespaces() {
         $loaded = false;
-        $cache = $this->modx->call('modNamespace','loadCache',array(&$this->modx));
+        $cache = $this->modx->call('modNamespace','loadCache',array($this->modx));
         if ($cache) {
             $this->namespaces = $cache;
             $loaded = true;

--- a/core/model/modx/modnamespace.class.php
+++ b/core/model/modx/modnamespace.class.php
@@ -22,7 +22,7 @@ class modNamespace extends modAccessibleObject {
     public function save($cacheFlag = null) {
         $saved = parent::save();
         if ($saved && !$this->getOption(xPDO::OPT_SETUP)) {
-            $this->xpdo->call('modNamespace','clearCache',array(&$this->xpdo));
+            $this->xpdo->call('modNamespace','clearCache',array($this->xpdo));
         }
         return $saved;
     }
@@ -30,7 +30,7 @@ class modNamespace extends modAccessibleObject {
     public function remove(array $ancestors = array()) {
         $removed = parent::remove($ancestors);
         if ($removed && !$this->getOption(xPDO::OPT_SETUP)) {
-            $this->xpdo->call('modNamespace','clearCache',array(&$this->xpdo));
+            $this->xpdo->call('modNamespace','clearCache',array($this->xpdo));
         }
         return $removed;
     }
@@ -63,15 +63,15 @@ class modNamespace extends modAccessibleObject {
 
     public function getCorePath() {
         $path = $this->get('path');
-        return $this->xpdo->call('modNamespace','translatePath',array(&$this->xpdo,$path));
+        return $this->xpdo->call('modNamespace','translatePath',array($this->xpdo,$path));
     }
 
     public function getAssetsPath() {
         $path = $this->get('assets_path');
-        return $this->xpdo->call('modNamespace','translatePath',array(&$this->xpdo,$path));
+        return $this->xpdo->call('modNamespace','translatePath',array($this->xpdo,$path));
     }
 
-    public static function translatePath(xPDO &$xpdo,$path) {
+    public static function translatePath(xPDO $xpdo,$path) {
         return str_replace(array(
             '{core_path}',
             '{base_path}',

--- a/core/model/modx/modtemplate.class.php
+++ b/core/model/modx/modtemplate.class.php
@@ -26,14 +26,14 @@ class modTemplate extends modElement {
      * This list includes an access field indicating their relationship to a modTemplate.
      *
      * @static
-     * @param modTemplate &$template A modTemplate instance.
+     * @param modTemplate $template A modTemplate instance.
      * @param array $sort An array of criteria for sorting the list.
      * @param int $limit An optional limit to apply to the list.
      * @param array $conditions
      * @param int $offset An optional offset to apply to the list.
      * @return array An array with the list collection and total records in the collection.
      */
-    public static function listTemplateVars(modTemplate &$template, array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
+    public static function listTemplateVars(modTemplate $template, array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
         return array('collection' => array(), 'total' => 0);
     }
 
@@ -187,7 +187,7 @@ class modTemplate extends modElement {
      * @return array An array containing the collection and total.
      */
     public function getTemplateVarList(array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
-        return $this->xpdo->call('modTemplate', 'listTemplateVars', array(&$this, $sort, $limit, $offset,$conditions));
+        return $this->xpdo->call('modTemplate', 'listTemplateVars', array($this, $sort, $limit, $offset,$conditions));
     }
 
     /**

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -172,7 +172,7 @@ class modUser extends modPrincipal {
                 $this->_attributes[$context][$t] = $this->xpdo->call(
                     $t,
                     'loadAttributes',
-                    array(&$this->xpdo, $context, $this->get('id'))
+                    array($this->xpdo, $context, $this->get('id'))
                 );
                 if (!isset($this->_attributes[$context][$t]) || !is_array($this->_attributes[$context][$t])) {
                     $this->_attributes[$context][$t] = array();

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -569,7 +569,7 @@ class modX extends xPDO {
      * extension packages which will be merged with those specified via config.
      */
     protected function _loadExtensionPackages($options = null) {
-        $cache = $this->call('modExtensionPackage','loadCache',array(&$this));
+        $cache = $this->call('modExtensionPackage','loadCache',array($this));
         if (!empty($cache)) {
             foreach ($cache as $package) {
                 $package['table_prefix'] = !empty($package['table_prefix']) ? $package['table_prefix'] : null;
@@ -1013,7 +1013,7 @@ class modX extends xPDO {
      * @return string|null A valid path segment string or null if an error occurs.
      */
     public function filterPathSegment($string, array $options = array()) {
-        return $this->call('modResource', 'filterPathSegment', array(&$this, $string, $options));
+        return $this->call('modResource', 'filterPathSegment', array($this, $string, $options));
     }
 
     public function findResource($uri, $context = '') {

--- a/core/model/modx/mysql/modcontext.class.php
+++ b/core/model/modx/mysql/modcontext.class.php
@@ -11,7 +11,7 @@ include_once (strtr(realpath(dirname(__FILE__)), '\\', '/') . '/../modcontext.cl
  * @subpackage mysql
  */
 class modContext_mysql extends modContext {
-    public static function getResourceCacheMapStmt(&$context) {
+    public static function getResourceCacheMapStmt($context) {
         $stmt = false;
         if ($context instanceof modContext) {
             $time=microtime(true);
@@ -61,7 +61,7 @@ class modContext_mysql extends modContext {
         return $stmt;
     }
 
-    public static function getWebLinkCacheMapStmt(&$context) {
+    public static function getWebLinkCacheMapStmt($context) {
         $stmt = false;
         if ($context instanceof modContext) {
             $time=microtime(true);

--- a/core/model/modx/mysql/modformcustomizationprofile.class.php
+++ b/core/model/modx/mysql/modformcustomizationprofile.class.php
@@ -9,7 +9,7 @@ require_once (dirname(__DIR__) . '/modformcustomizationprofile.class.php');
  * @subpackage mysql
  */
 class modFormCustomizationProfile_mysql extends modFormCustomizationProfile {
-    public static function listProfiles(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+    public static function listProfiles(xPDO $xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
         /* query for profiles */
         $c = $xpdo->newQuery('modFormCustomizationProfile');
         $c->select(array(

--- a/core/model/modx/mysql/modtemplate.class.php
+++ b/core/model/modx/mysql/modtemplate.class.php
@@ -9,7 +9,7 @@ include_once (strtr(realpath(dirname(__FILE__)), '\\', '/') . '/../modtemplate.c
  * @subpackage mysql
  */
 class modTemplate_mysql extends modTemplate {
-    public static function listTemplateVars(modTemplate &$template, array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
+    public static function listTemplateVars(modTemplate $template, array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
         $result = array('collection' => array(), 'total' => 0);
         $c = $template->xpdo->newQuery('modTemplateVar');
         $result['total'] = $template->xpdo->getCount('modTemplateVar',$c);

--- a/core/model/modx/processors/context/setting/create.class.php
+++ b/core/model/modx/processors/context/setting/create.class.php
@@ -106,7 +106,7 @@ class modContextSettingCreateProcessor extends modObjectCreateProcessor {
         }
         if ($refreshURIs) {
             $this->context->config[$key] = $value;
-            $this->modx->call('modResource', 'refreshURIs', array(&$this->modx, 0, array('contexts' => $this->context->get('key'))));
+            $this->modx->call('modResource', 'refreshURIs', array($this->modx, 0, array('contexts' => $this->context->get('key'))));
         }
 
         return true;

--- a/core/model/modx/processors/context/setting/getlist.class.php
+++ b/core/model/modx/processors/context/setting/getlist.class.php
@@ -65,7 +65,7 @@ class modContextSettingGetListProcessor extends modObjectGetListProcessor {
         }
 
         $settingsResult = $this->modx->call('modContextSetting', 'listSettings', array(
-            &$this->modx,
+            $this->modx,
             $criteria,
             array(
                 $this->getProperty('sort') => $this->getProperty('dir'),

--- a/core/model/modx/processors/context/setting/update.class.php
+++ b/core/model/modx/processors/context/setting/update.class.php
@@ -56,7 +56,7 @@ class modContextSettingUpdateProcessor extends modSystemSettingsUpdateProcessor 
     public function refreshURIs() {
         if ($this->refreshURIs) {
             $this->context->config[$this->object->get('key')] = $this->object->get('value');
-            $this->modx->call('modResource', 'refreshURIs', array(&$this->modx, 0, array('contexts' => $this->context->get('key'))));
+            $this->modx->call('modResource', 'refreshURIs', array($this->modx, 0, array('contexts' => $this->context->get('key'))));
         }
         return $this->refreshURIs;
     }

--- a/core/model/modx/processors/element/plugin/event/getlist.class.php
+++ b/core/model/modx/processors/element/plugin/event/getlist.class.php
@@ -57,7 +57,7 @@ class modPluginEventGetListProcessor extends modObjectProcessor {
 
         $this->modx->newQuery('modEvent');
         $eventsResult = $this->modx->call('modEvent', 'listEvents', array(
-            &$this->modx,
+            $this->modx,
             $this->getProperty('plugin'),
             $criteria,
             array($this->getProperty('sort') => $this->getProperty('dir')),

--- a/core/model/modx/processors/element/tv/renders/getinputproperties.class.php
+++ b/core/model/modx/processors/element/tv/renders/getinputproperties.class.php
@@ -118,7 +118,7 @@ class modTvRendersGetPropertiesProcessor extends modProcessor {
      * @return array
      */
     public function loadNamespaceCache() {
-        $cache = $this->modx->call('modNamespace', 'loadCache', array(&$this->modx));
+        $cache = $this->modx->call('modNamespace', 'loadCache', array($this->modx));
         $cachedDirs = array();
         if (!empty($cache) && is_array($cache)) {
             foreach ($cache as $namespace) {

--- a/core/model/modx/processors/element/tv/renders/getinputs.class.php
+++ b/core/model/modx/processors/element/tv/renders/getinputs.class.php
@@ -50,7 +50,7 @@ class modElementTvRendersGetInputsProcessor extends modProcessor {
         }
 
         /* load namespace caches */
-        $cache = $this->modx->call('modNamespace','loadCache',array(&$this->modx));
+        $cache = $this->modx->call('modNamespace','loadCache',array($this->modx));
         if (!empty($cache) && is_array($cache)) {
             foreach ($cache as $namespace) {
                 $inputDir = rtrim($namespace['path'],'/').'/tv/input/';

--- a/core/model/modx/processors/element/tv/renders/getoutputs.class.php
+++ b/core/model/modx/processors/element/tv/renders/getoutputs.class.php
@@ -45,7 +45,7 @@ class modElementTVRendersGetOutputsProcessor extends modProcessor {
      * @return array
      */
     public function loadNamespaceCache() {
-        $cache = $this->modx->call('modNamespace', 'loadCache', array(&$this->modx));
+        $cache = $this->modx->call('modNamespace', 'loadCache', array($this->modx));
         $cachedDirs = array();
         if (!empty($cache) && is_array($cache)) {
             foreach ($cache as $namespace) {

--- a/core/model/modx/processors/resource/translit.class.php
+++ b/core/model/modx/processors/resource/translit.class.php
@@ -17,7 +17,7 @@ class modTranslitProcessor extends modProcessor {
 		$string = $this->getProperty('string');
 		$transliteration = array(
 			'input' => $string,
-			'transliteration' => $this->modx->call('modResource', 'filterPathSegment', array(&$this->modx, $string)),
+			'transliteration' => $this->modx->call('modResource', 'filterPathSegment', array($this->modx, $string)),
 		);
 
 		return $this->success('', $transliteration);

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -675,7 +675,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
      */
     public function checkContextOfChildren() {
         if (is_object($this->oldContext) && $this->oldContext instanceof modContext && $this->oldContext->get('key') !== $this->workingContext->get('key')) {
-            $this->modx->call($this->object->get('class_key'), 'updateContextOfChildren', array(&$this->modx, $this->object));
+            $this->modx->call($this->object->get('class_key'), 'updateContextOfChildren', array($this->modx, $this->object));
         }
     }
 

--- a/core/model/modx/processors/security/forms/profile/getlist.class.php
+++ b/core/model/modx/processors/security/forms/profile/getlist.class.php
@@ -39,7 +39,7 @@ class modFormCustomizationProfileGetListProcessor extends modObjectGetListProces
             );
         }
         $profileResult = $this->modx->call('modFormCustomizationProfile', 'listProfiles', array(
-            &$this->modx,
+            $this->modx,
             $criteria,
             array(
                 $this->getProperty('sort') => $this->getProperty('dir'),

--- a/core/model/modx/processors/system/contenttype/update.class.php
+++ b/core/model/modx/processors/system/contenttype/update.class.php
@@ -48,7 +48,7 @@ class modContentTypeUpdateProcessor extends modObjectUpdateProcessor {
      */
     public function afterSave() {
         if ($this->refreshURIs) {
-            $this->modx->call('modResource', 'refreshURIs', array(&$this->modx));
+            $this->modx->call('modResource', 'refreshURIs', array($this->modx));
         }
         return parent::afterSave();
     }

--- a/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
+++ b/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
@@ -60,7 +60,7 @@ class modContentTypeUpdateFromGridProcessor extends modProcessor {
         $this->modx->logManagerAction('content_type_save','modContentType',$contentType->get('id'));
 
         if (array_search(true, $refresh, true) !== false) {
-            $this->modx->call('modResource', 'refreshURIs', array(&$this->modx));
+            $this->modx->call('modResource', 'refreshURIs', array($this->modx));
         }
         return $this->success();
     }

--- a/core/model/modx/processors/system/refreshuris.class.php
+++ b/core/model/modx/processors/system/refreshuris.class.php
@@ -11,7 +11,7 @@ class modSystemRefreshurisProcessor extends modProcessor {
     }
 
     public function process() {
-        $this->modx->call('modResource', 'refreshURIs', array(&$this->modx));
+        $this->modx->call('modResource', 'refreshURIs', array($this->modx));
         $result = true; // refreshURIs void response
         $output = $this->modx->lexicon('refresh_' . ( $result ? 'success' : 'failure') );
         $this->modx->log(modX::LOG_LEVEL_INFO, $output );

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -73,7 +73,7 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
         }
 
         $settingsResult = $this->modx->call($this->classKey, 'listSettings', array(
-            &$this->modx,
+            $this->modx,
             $criteria,
             array(
                 $this->getProperty('sort') => $this->getProperty('dir'),

--- a/core/model/modx/processors/system/settings/update.class.php
+++ b/core/model/modx/processors/system/settings/update.class.php
@@ -19,7 +19,7 @@ class modSystemSettingsUpdateProcessor extends modObjectUpdateProcessor {
     public $permission = 'settings';
     public $objectType = 'setting';
     public $primaryKeyField = 'key';
-    
+
     /** @var modSystemSetting $object */
     public $object;
     /** @var boolean $refreshURIs */
@@ -69,10 +69,10 @@ class modSystemSettingsUpdateProcessor extends modObjectUpdateProcessor {
         }
         return $value;
     }
-    
+
     /**
      * Check to see if the URIs need to be refreshed
-     * 
+     *
      * @return boolean
      */
     public function checkForRefreshURIs() {
@@ -89,7 +89,7 @@ class modSystemSettingsUpdateProcessor extends modObjectUpdateProcessor {
 
     /**
      * Update lexicon name/description
-     * 
+     *
      * @param array $fields
      * @return void
      */
@@ -114,7 +114,7 @@ class modSystemSettingsUpdateProcessor extends modObjectUpdateProcessor {
     public function refreshURIs() {
         if ($this->refreshURIs) {
             $this->modx->setOption($this->object->get('key'), $this->object->get('value'));
-            $this->modx->call('modResource', 'refreshURIs', array(&$this->modx));
+            $this->modx->call('modResource', 'refreshURIs', array($this->modx));
         }
         return $this->refreshURIs;
     }

--- a/core/model/modx/processors/workspace/packages/getlist.class.php
+++ b/core/model/modx/processors/workspace/packages/getlist.class.php
@@ -51,7 +51,7 @@ class modPackageGetListProcessor extends modObjectGetListProcessor {
         $limit = intval($this->getProperty('limit'));
         $start = intval($this->getProperty('start'));
         $pkgList = $this->modx->call('transport.modTransportPackage', 'listPackages', array(
-            &$this->modx,
+            $this->modx,
             $this->getProperty('workspace',1),
             $limit > 0 ? $limit : 0,
             $start,

--- a/core/model/modx/processors/workspace/packages/version/getlist.class.php
+++ b/core/model/modx/processors/workspace/packages/version/getlist.class.php
@@ -37,7 +37,7 @@ class modPackageVersionGetListProcessor extends modObjectGetListProcessor {
             'package_name' => urldecode($this->getProperty('package_name',$signatureArray[0])),
         );
         $limit = $this->getProperty('limit');
-        $pkgList = $this->modx->call('transport.modTransportPackage', 'listPackageVersions', array(&$this->modx, $criteria, $limit > 0 ? $limit : 0, $this->getProperty('start')));
+        $pkgList = $this->modx->call('transport.modTransportPackage', 'listPackageVersions', array($this->modx, $criteria, $limit > 0 ? $limit : 0, $this->getProperty('start')));
         $data['results'] = $pkgList['collection'];
         $data['total'] = $pkgList['total'];
         return $data;

--- a/core/model/modx/registry/moddbregister.class.php
+++ b/core/model/modx/registry/moddbregister.class.php
@@ -127,7 +127,7 @@ class modDbRegister extends modRegister {
                 $topicMessages = array();
                 $balance = $msgLimit - $msgCount;
                 $args = array(
-                    &$this,
+                    $this,
                     $topic,
                     dirname($topic) . '/',
                     basename($topic),

--- a/core/model/modx/sqlsrv/modcontext.class.php
+++ b/core/model/modx/sqlsrv/modcontext.class.php
@@ -9,7 +9,7 @@ require_once (dirname(__DIR__) . '/modcontext.class.php');
  * @subpackage sqlsrv
  */
 class modContext_sqlsrv extends modContext {
-    public static function getResourceCacheMapStmt(&$context) {
+    public static function getResourceCacheMapStmt($context) {
         $stmt = false;
         if ($context instanceof modContext) {
             $tblResource= $context->xpdo->getTableName('modResource');
@@ -26,7 +26,7 @@ class modContext_sqlsrv extends modContext {
         return $stmt;
     }
 
-    public static function getWebLinkCacheMapStmt(&$context) {
+    public static function getWebLinkCacheMapStmt($context) {
         $stmt = false;
         if ($context instanceof modContext) {
             $tblResource = $context->xpdo->getTableName('modResource');

--- a/core/model/modx/sqlsrv/modformcustomizationprofile.class.php
+++ b/core/model/modx/sqlsrv/modformcustomizationprofile.class.php
@@ -9,7 +9,7 @@ require_once (dirname(__DIR__) . '/modformcustomizationprofile.class.php');
  * @subpackage sqlsrv
  */
 class modFormCustomizationProfile_sqlsrv extends modFormCustomizationProfile {
-    public static function listProfiles(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+    public static function listProfiles(xPDO $xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
         $objCollection= array ();
 
         /* query for profiles */
@@ -31,7 +31,7 @@ class modFormCustomizationProfile_sqlsrv extends modFormCustomizationProfile {
         $rowsArray = $rows->fetchAll(PDO::FETCH_ASSOC);
         $rows->closeCursor();
         foreach($rowsArray as $row) {
-            $objCollection[] = $xpdo->call('modFormCustomizationProfile', '_loadInstance', array(&$xpdo, 'modFormCustomizationProfile', $c, $row));
+            $objCollection[] = $xpdo->call('modFormCustomizationProfile', '_loadInstance', array($xpdo, 'modFormCustomizationProfile', $c, $row));
         }
         unset($row, $rowsArray);
         return array(
@@ -40,7 +40,7 @@ class modFormCustomizationProfile_sqlsrv extends modFormCustomizationProfile {
         );
     }
 
-    public static function _loadInstance(& $xpdo, $className, $criteria, $row) {
+    public static function _loadInstance($xpdo, $className, $criteria, $row) {
         $sql = "SELECT gr.[name]
              FROM {$xpdo->config['table_prefix']}membergroup_names AS gr,
               {$xpdo->config['table_prefix']}fc_profiles_usergroups AS pu,

--- a/core/model/modx/sqlsrv/modtemplate.class.php
+++ b/core/model/modx/sqlsrv/modtemplate.class.php
@@ -9,7 +9,7 @@ require_once (dirname(__DIR__) . '/modtemplate.class.php');
  * @subpackage sqlsrv
  */
 class modTemplate_sqlsrv extends modTemplate {
-    public static function listTemplateVars(modTemplate &$template, array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
+    public static function listTemplateVars(modTemplate $template, array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
         $result = array('collection' => array(), 'total' => 0);
         $c = $template->xpdo->newQuery('modTemplateVar');
         $result['total'] = $template->xpdo->getCount('modTemplateVar',$c);

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -62,12 +62,13 @@ abstract class ResourceManagerController extends modManagerController {
         }
 
         if ($isDerivative) {
+            /** @var modResource $resourceClass */
             $resourceClass = str_replace(array('../','..','/','\\'),'',$resourceClass);
             if (!class_exists($resourceClass) && !$modx->loadClass($resourceClass)) {
                 $resourceClass = 'modDocument';
             }
 
-            $delegateView = $modx->call($resourceClass,'getControllerPath',array(&$modx));
+            $delegateView = $resourceClass::getControllerPath($modx);
             $action = strtolower(str_replace(array('Resource','ManagerController'),'',$className));
             $className = str_replace('mod','',$resourceClass).ucfirst($action).'ManagerController';
             $controllerFile = $delegateView.$action.'.class.php';
@@ -75,7 +76,7 @@ abstract class ResourceManagerController extends modManagerController {
                 // We more than likely are using a custom manager theme without overridden controller, let's try with the default theme
                 $theme = $modx->getOption('manager_theme', null, 'default');
                 $modx->setOption('manager_theme', 'default');
-                $delegateView = $modx->call($resourceClass, 'getControllerPath', array(&$modx));
+                $delegateView = $resourceClass::getControllerPath($modx);
                 $controllerFile = $delegateView.$action.'.class.php';
                 // Restore custom theme (so we don't process/use default theme assets)
                 $modx->setOption('manager_theme', $theme);


### PR DESCRIPTION
### What does it do?
Fixes the reference expected warnings when installing and running 3.x branch on PHP 7.1.

### Why is it needed?
In PHP 7.1, using `call_user_func_array()` with static methods that expect parameters as references trigger warnings. This removes all dependencies on parameters as references in the 3.x branch or avoids the use of `xPDO->call()` when utilizing such methods.

### Related issue(s)/PR(s)
N/A