### PR TITLE
Fix files tree and media browser phpthumb bug

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -222,6 +222,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
+                        $preview = 1;
                         $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
                         $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
                         $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
@@ -244,7 +245,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                             $image = $bases['urlAbsolute'] . urldecode($url);
                         } else {
                             $size = @getimagesize($bases['pathAbsoluteWithPath'].$fileName);
-                            if (is_array($size)) {
+                            if (is_array($size) && $size[0] > 0 && $size[1] > 0) {
                                 // get original image size for proportional scaling
                                 if ($size[0] > $size[1]) {
                                     // landscape
@@ -259,21 +260,25 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                     $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
                                     $imageHeight = $imageQueryHeight;
                                 }
+                                $imageQuery = http_build_query(array(
+                                    'src' => $bases['urlRelative'].$fileName,
+                                    'w' => $imageQueryWidth,
+                                    'h' => $imageQueryHeight,
+                                    'HTTP_MODAUTH' => $modAuth,
+                                    'f' => $thumbnailType,
+                                    'q' => $thumbnailQuality,
+                                    'wctx' => $this->ctx->get('key'),
+                                    'source' => $this->get('id'),
+                                ));
+                                $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                            } else {
+                                $preview = 0;
                             }
-                            $imageQuery = http_build_query(array(
-                                'src' => $bases['urlRelative'].$fileName,
-                                'w' => $imageQueryWidth,
-                                'h' => $imageQueryHeight,
-                                'HTTP_MODAUTH' => $modAuth,
-                                'f' => $thumbnailType,
-                                'q' => $thumbnailQuality,
-                                'wctx' => $this->ctx->get('key'),
-                                'source' => $this->get('id'),
-                            ));
-                            $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                         }
 
-                        $files[$fileName]['qtip'] = '<img src="'.$image.'" width="'.$imageWidth.'" height="'.$imageHeight.'" alt="'.$fileName.'" />';
+                        if ($preview) {
+                            $files[$fileName]['qtip'] = '<img src="'.$image.'" width="'.$imageWidth.'" height="'.$imageHeight.'" alt="'.$fileName.'" />';
+                        }
 
                     }
 
@@ -1035,6 +1040,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 $page = !empty($editAction) ? '?a='.$editAction.'&file='.$bases['urlRelative'].$fileName.'&wctx='.$this->ctx->get('key').'&source='.$this->get('id') : null;
 
                 /* get thumbnail */
+                $preview = 0;
+
                 if (in_array($fileExtension,$imageExtensions)) {
                     $preview = 1;
                     $imageWidth = $this->ctx->getOption('filemanager_image_width', 800);
@@ -1075,53 +1082,57 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         $image = $thumb = $bases['urlAbsolute'].urldecode($url);
                     } else {
                         $size = @getimagesize($filePathName);
-                        // proportional scaling of image and thumb
-                        if ($size[0] > $size[1]) {
-                            // landscape
-                            $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                            $imageQueryHeight = 0;
-                            $imageWidth = $imageQueryWidth;
-                            $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
-                            $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
-                            $thumbQueryHeight = 0;
-                            $thumbWidth = $thumbQueryWidth;
-                            $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                        if (is_array($size) && $size[0] > 0 && $size[1] > 0) {
+                            // proportional scaling of image and thumb
+                            if ($size[0] > $size[1]) {
+                                // landscape
+                                $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                $imageQueryHeight = 0;
+                                $imageWidth = $imageQueryWidth;
+                                $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                                $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                                $thumbQueryHeight = 0;
+                                $thumbWidth = $thumbQueryWidth;
+                                $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                            } else {
+                                // portrait or square
+                                $imageQueryWidth = 0;
+                                $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                                $imageHeight = $imageQueryHeight;
+                                $thumbQueryWidth = 0;
+                                $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                                $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
+                                $thumbHeight = $thumbQueryHeight;
+                            }
+                            $imageQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $imageQueryWidth,
+                                'h' => $imageQueryHeight,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                            $thumbQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $thumbQueryWidth,
+                                'h' => $thumbQueryHeight,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                         } else {
-                            // portrait or square
-                            $imageQueryWidth = 0;
-                            $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                            $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
-                            $imageHeight = $imageQueryHeight;
-                            $thumbQueryWidth = 0;
-                            $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
-                            $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
-                            $thumbHeight = $thumbQueryHeight;
+                            $preview = 0;
                         }
-                        $imageQuery = http_build_query(array(
-                            'src' => $url,
-                            'w' => $imageQueryWidth,
-                            'h' => $imageQueryHeight,
-                            'HTTP_MODAUTH' => $modAuth,
-                            'f' => $thumbnailType,
-                            'q' => $thumbnailQuality,
-                            'wctx' => $this->ctx->get('key'),
-                            'source' => $this->get('id'),
-                        ));
-                        $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
-                        $thumbQuery = http_build_query(array(
-                            'src' => $url,
-                            'w' => $thumbQueryWidth,
-                            'h' => $thumbQueryHeight,
-                            'HTTP_MODAUTH' => $modAuth,
-                            'f' => $thumbnailType,
-                            'q' => $thumbnailQuality,
-                            'wctx' => $this->ctx->get('key'),
-                            'source' => $this->get('id'),
-                        ));
-                        $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                     }
-                } else {
-                    $preview = 0;
+                }
+                if (!$preview) {
                     $size = null;
                     $thumb = $image = $this->ctx->getOption('manager_url', MODX_MANAGER_URL).'templates/default/images/restyle/nopreview.jpg';
                     $thumbWidth = $imageWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
@@ -1135,8 +1146,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'name' => $fileName,
                     'cls' => 'icon-'.$fileExtension,
                     'image' => $image,
-                    'image_width' => is_array($size) ? $size[0] : $imageWidth,
-                    'image_height' => is_array($size) ? $size[1] : $imageHeight,
+                    'image_width' => is_array($size) && $size[0] > 0 ? $size[0] : $imageWidth,
+                    'image_height' => is_array($size) && $size[1] > 0 ? $size[1] : $imageHeight,
                     'thumb' => $thumb,
                     'thumb_width' => $thumbWidth,
                     'thumb_height' => $thumbHeight,

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -1134,7 +1134,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                         }
                     }
                 }
-                if (!$preview) {
+                if ($preview == 0) {
                     $size = null;
                     $thumb = $image = $this->ctx->getOption('manager_url', MODX_MANAGER_URL).'templates/default/images/restyle/nopreview.jpg';
                     $thumbWidth = $imageWidth = $this->ctx->getOption('filemanager_thumb_width', 100);

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -273,6 +273,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                 $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                             } else {
                                 $preview = 0;
+                                $this->xpdo->log(modX::LOG_LEVEL_ERROR,'Thumbnail could not be created for file: '.$bases['pathAbsoluteWithPath'].$fileName);
                             }
                         }
 
@@ -1128,6 +1129,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                             ));
                             $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                         } else {
+                            $this->xpdo->log(modX::LOG_LEVEL_ERROR,'Thumbnail could not be created for file: '.$filePathName);
                             $preview = 0;
                         }
                     }

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -222,7 +222,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
-                        $preview = 1;
+                        $preview = true;
                         $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
                         $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
                         $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
@@ -272,7 +272,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                 ));
                                 $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                             } else {
-                                $preview = 0;
+                                $preview = false;
                                 $this->xpdo->log(modX::LOG_LEVEL_ERROR,'Thumbnail could not be created for file: '.$bases['pathAbsoluteWithPath'].$fileName);
                             }
                         }

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -230,6 +230,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
                         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
+                        $preview = 1;
                         $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
                         $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
                         $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
@@ -252,7 +253,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                             $image = $bases['urlAbsolute'] . urldecode($url);
                         } else {
                             $size = @getimagesize($url);
-                            if (is_array($size)) {
+                            if (is_array($size) && $size[0] > 0 && $size[1] > 0) {
                                 // get original image size for proportional scaling
                                 if ($size[0] > $size[1]) {
                                     // landscape
@@ -267,21 +268,25 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                                     $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
                                     $imageHeight = $imageQueryHeight;
                                 }
+                                $imageQuery = http_build_query(array(
+                                    'src' => $url,
+                                    'w' => $imageQueryWidth,
+                                    'h' => $imageQueryHeight,
+                                    'HTTP_MODAUTH' => $modAuth,
+                                    'f' => $thumbnailType,
+                                    'q' => $thumbnailQuality,
+                                    'wctx' => $this->ctx->get('key'),
+                                    'source' => $this->get('id'),
+                                ));
+                                $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                            } else {
+                                $preview = 0;
                             }
-                            $imageQuery = http_build_query(array(
-                                'src' => $url,
-                                'w' => $imageQueryWidth,
-                                'h' => $imageQueryHeight,
-                                'HTTP_MODAUTH' => $modAuth,
-                                'f' => $thumbnailType,
-                                'q' => $thumbnailQuality,
-                                'wctx' => $this->ctx->get('key'),
-                                'source' => $this->get('id'),
-                            ));
-                            $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                         }
 
-                        $files[$currentPath]['qtip'] = '<img src="'.$image.'" width="'.$imageWidth.'" height="'.$imageHeight.'" alt="'.$fileName.'" />';
+                        if ($preview) {
+                            $files[$currentPath]['qtip'] = '<img src="'.$image.'" width="'.$imageWidth.'" height="'.$imageHeight.'" alt="'.$fileName.'" />';
+                        }
 
                     }
 
@@ -461,7 +466,10 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 if (!empty($allowedFileTypes) && !in_array($fileArray['ext'],$allowedFileTypes)) continue;
 
                 /* get thumbnail */
+                $preview = 0;
+
                 if (in_array($fileArray['ext'],$imageExtensions)) {
+                    $preview = 1;
                     $imageWidth = $this->ctx->getOption('filemanager_image_width', 800);
                     $imageHeight = $this->ctx->getOption('filemanager_image_height', 600);
                     $thumbWidth = $this->ctx->getOption('filemanager_thumb_width', 100);
@@ -500,59 +508,64 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                         $fileArray['image'] = $fileArray['thumb'] = $url;
                     } else {
                         $size = @getimagesize($url);
-                        // proportional scaling of image and thumb
-                        if ($size[0] > $size[1]) {
-                            // landscape
-                            $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
-                            $imageQueryHeight = 0;
-                            $imageWidth = $imageQueryWidth;
-                            $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
-                            $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
-                            $thumbQueryHeight = 0;
-                            $thumbWidth = $thumbQueryWidth;
-                            $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                        if (is_array($size) && $size[0] > 0 && $size[1] > 0) {
+                            // proportional scaling of image and thumb
+                            if ($size[0] > $size[1]) {
+                                // landscape
+                                $imageQueryWidth = $size[0] >= $imageWidth ? $imageWidth : $size[0];
+                                $imageQueryHeight = 0;
+                                $imageWidth = $imageQueryWidth;
+                                $imageHeight = round($size[1] * ($imageQueryWidth / $size[0]));
+                                $thumbQueryWidth = $size[0] >= $thumbWidth ? $thumbWidth : $size[0];
+                                $thumbQueryHeight = 0;
+                                $thumbWidth = $thumbQueryWidth;
+                                $thumbHeight = round($size[1] * ($thumbQueryWidth / $size[0]));
+                            } else {
+                                // portrait or square
+                                $imageQueryWidth = 0;
+                                $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
+                                $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
+                                $imageHeight = $imageQueryHeight;
+                                $thumbQueryWidth = 0;
+                                $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
+                                $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
+                                $thumbHeight = $thumbQueryHeight;
+                            }
+                            $imageQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $imageQueryWidth,
+                                'h' => $imageQueryHeight,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
+                            $thumbQuery = http_build_query(array(
+                                'src' => $url,
+                                'w' => $thumbQueryWidth,
+                                'h' => $thumbQueryHeight,
+                                'HTTP_MODAUTH' => $modAuth,
+                                'f' => $thumbnailType,
+                                'q' => $thumbnailQuality,
+                                'wctx' => $this->ctx->get('key'),
+                                'source' => $this->get('id'),
+                            ));
+                            $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                         } else {
-                            // portrait or square
-                            $imageQueryWidth = 0;
-                            $imageQueryHeight = $size[1] >= $imageHeight ? $imageHeight : $size[1];
-                            $imageWidth = round($size[0] * ($imageQueryHeight / $size[1]));
-                            $imageHeight = $imageQueryHeight;
-                            $thumbQueryWidth = 0;
-                            $thumbQueryHeight = $size[1] >= $thumbHeight ? $thumbHeight : $size[1];
-                            $thumbWidth = round($size[0] * ($thumbQueryHeight / $size[1]));
-                            $thumbHeight = $thumbQueryHeight;
+                            $preview = 0;
                         }
-                        $imageQuery = http_build_query(array(
-                            'src' => $url,
-                            'w' => $imageQueryWidth,
-                            'h' => $imageQueryHeight,
-                            'HTTP_MODAUTH' => $modAuth,
-                            'f' => $thumbnailType,
-                            'q' => $thumbnailQuality,
-                            'wctx' => $this->ctx->get('key'),
-                            'source' => $this->get('id'),
-                        ));
-                        $fileArray['image'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
-                        $thumbQuery = http_build_query(array(
-                            'src' => $url,
-                            'w' => $thumbQueryWidth,
-                            'h' => $thumbQueryHeight,
-                            'HTTP_MODAUTH' => $modAuth,
-                            'f' => $thumbnailType,
-                            'q' => $thumbnailQuality,
-                            'wctx' => $this->ctx->get('key'),
-                            'source' => $this->get('id'),
-                        ));
-                        $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
+                    }
+                    if ($preview) {
+                        $fileArray['thumb_width'] = $thumbWidth;
+                        $fileArray['thumb_height'] = $thumbHeight;
+                        $fileArray['image_width'] = is_array($size) && $size[0] > 0 ? $size[0] : $imageWidth;
+                        $fileArray['image_height'] = is_array($size) && $size[1] > 0 ? $size[1] : $imageHeight;
                     }
 
-                    $fileArray['thumb_width'] = $thumbWidth;
-                    $fileArray['thumb_height'] = $thumbHeight;
-                    $fileArray['image_width'] = is_array($size) ? $size[0] : $imageWidth;
-                    $fileArray['image_height'] = is_array($size) ? $size[1] : $imageHeight;
-                    $fileArray['preview'] = 1;
-
-                } else {
+                }
+                if (!$preview) {
                     $fileArray['thumb'] = $fileArray['image'] = $this->ctx->getOption('manager_url', MODX_MANAGER_URL).'templates/default/images/restyle/nopreview.jpg';
                     $fileArray['thumb_width'] = $fileArray['image_width'] = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $fileArray['thumb_height'] = $fileArray['image_height'] = $this->ctx->getOption('filemanager_thumb_height', 80);

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -281,6 +281,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                                 $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                             } else {
                                 $preview = 0;
+                                $this->xpdo->log(modX::LOG_LEVEL_ERROR,'Thumbnail could not be created for file: '.$url);
                             }
                         }
 
@@ -554,6 +555,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                             ));
                             $fileArray['thumb'] = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                         } else {
+                            $this->xpdo->log(modX::LOG_LEVEL_ERROR,'Thumbnail could not be created for file: '.$url);
                             $preview = 0;
                         }
                     }

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -230,7 +230,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
                         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
-                        $preview = 1;
+                        $preview = true;
                         $imageWidth = $this->ctx->getOption('filemanager_image_width', 400);
                         $imageHeight = $this->ctx->getOption('filemanager_image_height', 300);
                         $thumbnailType = $this->getOption('thumbnailType', $properties, 'png');
@@ -280,7 +280,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                                 ));
                                 $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                             } else {
-                                $preview = 0;
+                                $preview = false;
                                 $this->xpdo->log(modX::LOG_LEVEL_ERROR,'Thumbnail could not be created for file: '.$url);
                             }
                         }

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -567,7 +567,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                     }
 
                 }
-                if (!$preview) {
+                if ($preview == 0) {
                     $fileArray['thumb'] = $fileArray['image'] = $this->ctx->getOption('manager_url', MODX_MANAGER_URL).'templates/default/images/restyle/nopreview.jpg';
                     $fileArray['thumb_width'] = $fileArray['image_width'] = $this->ctx->getOption('filemanager_thumb_width', 100);
                     $fileArray['thumb_height'] = $fileArray['image_height'] = $this->ctx->getOption('filemanager_thumb_height', 80);


### PR DESCRIPTION
### What does it do?
The main fix is to handle "Division by zero" errors when getimagesize() fails.

This PR fixes issues with the files tree and media browser **related to image files** where
- the media browser's grid would only show the message "No files match the specified filter." although there are files in the selected directory.
- hovering an image file in the files tree would show an empty preview.
- choosing a different directory in the media browser would show the results of a previous chosen directory in the grid.
- ...

Additionally it logs an error in the MODX error log when this problem occurs:
```
[2017-11-22 20:02:45] (ERROR @ /core/model/modx/sources/modfilemediasource.class.php : 1132) Thumbnail could not be created for file: /absolute/path/to/assets/uploads/images/broken.jpg
```
### Step to reproduce
- When a directory includes an image that's not an image (rename test.txt to text.jpg).
- When a directory includes a broken/corrupt image (server crash, incomplete file transfer).
- When the media source's setting "imageExtensions" includes an extension that can't be thumbnailed.

### Why is it needed?
- Show the default "No preview available" in the grid for "images" that can't be thumbnailed.
- No preview in the files tree for "images" that can't be thumbnailed.