### PR TITLE
Show correct icon in search results for non-document resource types

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -184,6 +184,7 @@ class modSearchProcessor extends modProcessor
                 '_action' => 'resource/update&id=' . $record->get('id'),
                 'description' => $record->get('description'),
                 'type' => $type,
+                'class' => $record->get('class_key'),
                 'type_label' => $typeLabel,
             );
         }

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -54,6 +54,22 @@ MODx.SearchBar = function(config) {
                     if (values.icon) {
                         return values.icon;
                     }
+
+                    if (values.class) {
+                        switch (values.class) {
+                            case 'modDocument':
+                                return 'file';
+                            case 'modSymLink':
+                                return 'files-o';
+                            case 'modWebLink':
+                                return 'link';
+                            case 'modStaticResource':
+                                return 'file-text-o';
+                            default:
+                                break;
+                        }
+                    }
+
                     switch (values.type) {
                         case 'resources':
                             return 'file';
@@ -95,7 +111,7 @@ MODx.SearchBar = function(config) {
             }
             ,root: 'results'
             ,totalProperty: 'total'
-            ,fields: ['name', '_action', 'description', 'type', 'icon', 'label']
+            ,fields: ['name', '_action', 'description', 'type', 'icon', 'label', 'class']
             ,listeners: {
                 beforeload: function(store, options) {
                     if (options.params._action) {


### PR DESCRIPTION
### What does it do?
When you search for a resource in the search bar, the results all have the default "document" icon, even if the resource is a static resource, web link or symlink. This patch fixes this issue by checking the class of the modResource.

#### Illustration

![example_12828](https://user-images.githubusercontent.com/2326278/33230716-1419ac22-d1e9-11e7-9dbe-a231711602ca.png)

### Why is it needed?
The results and their graphical representation is not consistent in the manager interface. This is bad UX.

### Related issue(s)/PR(s)
Reported in #12828 
Attempted fixed in #13329 & #13332 
