### PR TITLE
Symlink redirect loop

### DIFF
--- a/core/model/modx/modsymlink.class.php
+++ b/core/model/modx/modsymlink.class.php
@@ -29,7 +29,7 @@ class modSymLink extends modResource implements modResourceInterface {
      */
     public function process() {
         $this->_content= $this->get('content');
-        if (empty ($this->_content)) {
+        if (empty ($this->_content) || $this->get('id') == $this->_content) {
             $this->xpdo->sendErrorPage();
         }
         if (is_numeric($this->_content)) {


### PR DESCRIPTION
Prevent an infinite loop when symlink equals the id of the resource.

### What does it do?
Return to error page when symlinking to the same page

### Why is it needed?
Preventing an infinite loop when symlinking to the same page 

### Related issue(s)/PR(s)
None as far as i know
