### PR TITLE
Get only unique template paths

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -384,6 +384,7 @@ abstract class modManagerController {
         $managerPath = $this->modx->getOption('manager_path',null,MODX_MANAGER_PATH);
         $paths[] = $managerPath . 'templates/'.$this->theme.'/';
         $paths[] = $managerPath . 'templates/default/';
+        $paths = array_unique($paths);
         return $paths;
     }
 


### PR DESCRIPTION
### What does it do?
Call array_unique on $paths.

### Why is it needed?
If `$this->theme` contains `default`, it is included twice and the folders are maybe searched twice afterwards.

### Related issue(s)/PR(s)
None known.
