### PR TITLE
Fixes #12465: Container resources are available by urls both with and without container suffix

### DIFF
--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -322,7 +322,7 @@ class modRequest {
                     $found = $this->modx->findResource($identifier);
                 } else {
                     $identifier = "{$identifier}{$containerSuffix}";
-                    $found = $this->modx->findResource("{$identifier}{$containerSuffix}");
+                    $found = $this->modx->findResource($identifier);
                 }
                 if ($found) {
                     $parameters = $this->getParameters();


### PR DESCRIPTION
### What does it do?
301 redirect all container URLs without "container_suffix" to URLs with "container_suffix" setting

### Why is it needed?
"container_suffix" had no impact on container URLs

### Related issue(s)/PR(s)
"Container resources are available by urls both with and without container suffix #12465"
