### PR TITLE
Resource Action Log

### DIFF
--- a/core/model/modx/processors/system/log/getlist.class.php
+++ b/core/model/modx/processors/system/log/getlist.class.php
@@ -59,7 +59,7 @@ class modSystemLogGetListProcessor extends modProcessor {
      */
     public function getData() {
         $actionType = $this->getProperty('actionType');
-        $classKey = $this->getProperty('classKey');
+        $classKey = $this->explodeAndClean($this->getProperty('classKey'));
         $item = $this->getProperty('item');
         $user = $this->getProperty('user');
         $dateStart = $this->getProperty('dateStart');
@@ -71,7 +71,13 @@ class modSystemLogGetListProcessor extends modProcessor {
         /* check filters */
         $wa = array();
         if (!empty($actionType)) { $wa['action:LIKE'] = '%'.$actionType.'%'; }
-        if (!empty($classKey)) { $wa['classKey:LIKE'] = '%'.$classKey.'%'; }
+        if (!empty($classKey)) {
+            $classQuery = array();
+            foreach($classKey as $c) {
+                $classQuery[] = array('OR:classKey:LIKE' => '%'.$c.'%');
+            }
+            $wa[] = $classQuery;
+        }
         if (!empty($item)) { $wa['item:LIKE'] = '%'.$item.'%'; }
         if (!empty($user)) { $wa['user'] = $user; }
         if (!empty($dateStart)) {
@@ -166,6 +172,28 @@ class modSystemLogGetListProcessor extends modProcessor {
             default: break;
         }
         return $field;
+    }
+
+    /**
+     * Convert comma separated field into array and clean up
+     *
+     * @param string $string field to be processed
+     * @param string $delimiter the value to explode defaults to ','
+     * @param boolean $keepZero remove empty calues from the array
+     * @return array
+     */
+    public function explodeAndClean($string, $delimiter = ',', $keepZero = false) {
+        $array = explode($delimiter, $string);            // Explode fields to array
+        $array = array_map('trim', $array);       // Trim array's values
+        $array = array_keys(array_flip($array));  // Remove duplicate fields
+
+        if ($keepZero === false) {
+            $array = array_filter($array);            // Remove empty values from array
+        } else {
+            $array = array_filter($array, function($value) { return $value !== ''; });
+        }
+
+        return $array;
     }
 }
 return 'modSystemLogGetListProcessor';

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -109,7 +109,7 @@ MODx.panel.ResourceData = function(config) {
                 ,xtype: 'staticboolean'
             },{
                 name: 'isfolder'
-                ,fieldLabel: _('resource_folder')
+                    ,fieldLabel: _('resource_folder')
                 ,description: _('resource_folder_help')
                 ,xtype: 'staticboolean'
             }]
@@ -121,6 +121,7 @@ MODx.panel.ResourceData = function(config) {
             ,autoHeight: true
             ,bodyCssClass: 'main-wrapper'
             ,defaultType: 'statictextfield'
+            ,anchor: '100%'
             ,items: [{
                 name: 'createdon_adjusted'
                 ,fieldLabel: _('resource_createdon')
@@ -139,6 +140,17 @@ MODx.panel.ResourceData = function(config) {
             },{
                 name: 'publishedon_by'
                 ,fieldLabel: _('resource_publishedby')
+            },{
+                xtype: 'modx-grid-manager-log'
+                ,anchor: '100%'
+                ,preventRender: true
+                ,formpanel: 'modx-panel-manager-log'
+                ,baseParams: {
+                    action: 'system/log/getlist'
+                    ,item: MODx.request.id
+                    ,classKey: 'mod%o%u'
+                }
+                ,tbar: []
             }]
         },{
             title: _('cache_output')

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -148,7 +148,7 @@ MODx.panel.ResourceData = function(config) {
                 ,baseParams: {
                     action: 'system/log/getlist'
                     ,item: MODx.request.id
-                    ,classKey: 'mod%o%u'
+                    ,classKey: 'modResource'
                 }
                 ,tbar: []
             }]
@@ -189,6 +189,10 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
             this.fireEvent('ready');
         	return false;
         }
+        var g = Ext.getCmp('modx-grid-manager-log');
+        g.getStore().baseParams.item = this.config.resource;
+        g.getStore().baseParams.classKey = 'modResource,'+this.config.class_key;
+        g.getBottomToolbar().changePage(1);
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -109,7 +109,7 @@ MODx.panel.ResourceData = function(config) {
                 ,xtype: 'staticboolean'
             },{
                 name: 'isfolder'
-                    ,fieldLabel: _('resource_folder')
+                ,fieldLabel: _('resource_folder')
                 ,description: _('resource_folder_help')
                 ,xtype: 'staticboolean'
             }]

--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -26,6 +26,7 @@ class ResourceDataManagerController extends ResourceManagerController {
      */
     public function loadCustomCssJs() {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
+        $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.grid.manager.log.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.data.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/data.js');
         $this->addHtml('


### PR DESCRIPTION
### What does it do?
Adds a resource-specific manager log to the changes tab of the Resource Overview page.

### Why is it needed?
Show more data on the changes tab than just the latest static information. Easier to point blame on a specific resource.

### Related issue(s)/PR(s)
This doesn't close any issues, but it did expose an issue with inconsistent classKey usage on resources #13733.  It works for the majority of pages until that issue is resolved. I could also probably add a class key selector for filtering through data if we feel that is necessary.  Another option would be rewriting the getList class to support multiple class keys.
