### PR TITLE
Set default template based on template property childTemplate

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -188,7 +188,23 @@ class ResourceCreateManagerController extends ResourceManagerController {
      * @return int
      */
     public function getDefaultTemplate() {
-        $defaultTemplate = (isset($this->scriptProperties['template']) ? $this->scriptProperties['template'] : (!empty($this->parent->id) ? $this->parent->get('template') : $this->context->getOption('default_template', 0, $this->modx->_userConfig)));
+        $defaultTemplate = $this->context->getOption('default_template', 0, $this->modx->_userConfig);
+        if (isset($this->scriptProperties['template'])) {
+            $defaultTemplate = $this->scriptProperties['template'];
+        } elseif (!empty($this->parent->id)) {
+            $defaultTemplate = $this->parent->get('template');
+
+            $parentTplObj = $this->modx->getObject('modTemplate', $this->parent->get('template'));
+            if ($parentTplObj) {
+                $props = $parentTplObj->getProperties();
+
+                $childTpl = !empty($props) ? $this->modx->fromJSON($props['childTemplate']) : null;
+                if ($childTpl) {
+                    $defaultTemplate = $childTpl;
+                }
+            }
+        }
+
         $userGroups = $this->modx->user->getUserGroups();
         $c = $this->modx->newQuery('modActionDom');
         $c->innerJoin('modFormCustomizationSet','FCSet');


### PR DESCRIPTION
### What does it do?
Rewritten shortif containing multiple shortifs to if statement and added a check if template property childTemplate is set, then the default template is set to this value.

### Why is it needed?
This PR makes it possible to control the default templates that is used for childresources of a resource with a specific template. 

### How to use
Simply add the template property **childTemplate** to a template and set it to the desired child template id. Now you can create a child resource which will automatically have the template set to the configured childTemplate.

### Related issue(s)/PR(s)
Issue #13753
