### PR TITLE
Fixing complete step during setup would always be in EN language

### DIFF
--- a/setup/controllers/complete.php
+++ b/setup/controllers/complete.php
@@ -5,7 +5,6 @@
  * @var modInstallRequest $this
  * @package setup
  */
-$lang = $install->settings->get('language');
 
 if (!empty($_POST['proceed'])) {
     $install->settings->store($_POST);
@@ -26,8 +25,5 @@ if (!empty ($errors)) {
 if (!defined('MODX_SETUP_KEY')) { define('MODX_SETUP_KEY','@git@'); }
 $distro = trim(MODX_SETUP_KEY,'@');
 $parser->set('cleanup',$distro != 'git' ? true : false);
-
-/* Set language after cleanup to display page in current language. */
-$install->settings->set('language', $lang);
 
 return $parser->render('complete.tpl');

--- a/setup/controllers/complete.php
+++ b/setup/controllers/complete.php
@@ -5,6 +5,8 @@
  * @var modInstallRequest $this
  * @package setup
  */
+$lang = $install->settings->get('language');
+
 if (!empty($_POST['proceed'])) {
     $install->settings->store($_POST);
     $this->proceed('login');
@@ -24,5 +26,8 @@ if (!empty ($errors)) {
 if (!defined('MODX_SETUP_KEY')) { define('MODX_SETUP_KEY','@git@'); }
 $distro = trim(MODX_SETUP_KEY,'@');
 $parser->set('cleanup',$distro != 'git' ? true : false);
+
+/* Set language after cleanup to display page in current language. */
+$install->settings->set('language', $lang);
 
 return $parser->render('complete.tpl');

--- a/setup/controllers/language.php
+++ b/setup/controllers/language.php
@@ -14,6 +14,7 @@ if (!empty($_POST['proceed'])) {
         $language = $_REQUEST['language'];
     }
 
+    $cookiePath = preg_replace('#[/\\\\]$#', '', dirname(dirname($_SERVER['REQUEST_URI'])));
     setcookie('modx_setup_language', $language, 0, $cookiePath . '/');
 
     unset($_POST['proceed']);

--- a/setup/controllers/language.php
+++ b/setup/controllers/language.php
@@ -7,12 +7,15 @@
  */
 /* parse language selection */
 if (!empty($_POST['proceed'])) {
-    $language= 'en';
-    $cookiePath = preg_replace('#[/\\\\]$#', '', dirname(dirname($_SERVER['REQUEST_URI'])));
-    if (isset($_REQUEST['language']) && is_dir($cookiePath . '/' . $_REQUEST['language'])) {
-        $language= $_REQUEST['language'];
+    $language = 'en';
+
+    $langPath = preg_replace('#[/\\\\]$#', '', dirname(__DIR__) . '/lang/');
+    if (isset($_REQUEST['language']) && is_dir($langPath . '/' . $_REQUEST['language'])) {
+        $language = $_REQUEST['language'];
     }
+
     setcookie('modx_setup_language', $language, 0, $cookiePath . '/');
+
     unset($_POST['proceed']);
     $settings = $install->request->getConfig();
     $settings = array_merge($settings,$_POST);


### PR DESCRIPTION
### What does it do?
It sets the language setting again after clear installation setting so the complete step is shown in correct language.

### Why is it needed?
During complete step in setup the settings are cleared, which would also clear the language setting. Thats why the complete step would always be shown in English.

### Related issue(s)/PR(s)
Issue #13611
