### PR TITLE
Addressed  issue #13637 #modxbughunt

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -141,7 +141,6 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
             ,split: true
             ,width: 310
             ,minSize: 288
-            //,maxSize: 800
             ,autoScroll: true
             ,unstyled: true
             ,collapseMode: 'mini'

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -141,7 +141,7 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
             ,split: true
             ,width: 310
             ,minSize: 288
-            ,maxSize: 800
+            //,maxSize: 800
             ,autoScroll: true
             ,unstyled: true
             ,collapseMode: 'mini'


### PR DESCRIPTION
### What does it do?
Removed the maxSize restriction on the west region allowing the splitbar to be moved further than 800px. As @pepebe says, this will allow the west region to be used for new functionality.

### Why is it needed?
To allow the splitbar to be made wider.

### Related issue(s)/PR(s)
#13637
