### PR TITLE
Fix "whos online" widget on MySQL 5.7

### DIFF
--- a/core/model/modx/processors/security/user/getonline.class.php
+++ b/core/model/modx/processors/security/user/getonline.class.php
@@ -21,10 +21,11 @@ class modUserWhoIsOnlineProcessor extends modObjectGetListProcessor {
 
     $query->where(array('occurred:>' => $timetocheck));
     $query->sortby('occurred','DESC');
-    $query->groupby('user');
-    $query->select($this->modx->getSelectColumns('modManagerLog','modManagerLog'));
-    $query->select($this->modx->getSelectColumns('modUser','User','',array('username')));
     $query->innerJoin('modUser','User');
+    $columns = $this->modx->getSelectColumns('modUser','User','',array('username'));
+    $columns .= ', ' . $this->modx->getSelectColumns('modManagerLog','modManagerLog');
+    $query->select($columns);
+    $query->groupby($columns);
 
     return $query;
   }


### PR DESCRIPTION
### What does it do?
This PR will fix "Who`s online" on servers with MySQL 5.7 with enabled "sql_mode=only_full_group_by"

### Why is it needed?
Because this widget produces error in manager log and not working.

### Related issue(s)/PR(s)
#13730 