### PR TITLE
Make error.log location customizable #13752

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2110,7 +2110,7 @@ $settings['error_log_filename']->fromArray(array (
     'value' => 'error.log',
     'xtype' => 'textfield',
     'namespace' => 'core',
-    'area' => 'site',
+    'area' => 'system',
     'editedon' => null,
 ), '', true, true);
 $settings['error_log_path']= $xpdo->newObject('modSystemSetting');
@@ -2119,7 +2119,7 @@ $settings['error_log_path']->fromArray(array (
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',
-    'area' => 'site',
+    'area' => 'system',
     'editedon' => null,
 ), '', true, true);
 return $settings;

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2104,4 +2104,22 @@ $settings['log_snippet_not_found']->fromArray(array (
     'area' => 'site',
     'editedon' => null,
 ), '', true, true);
+$settings['error_log_filename']= $xpdo->newObject('modSystemSetting');
+$settings['error_log_filename']->fromArray(array (
+    'key' => 'error_log_filename',
+    'value' => 'error.log',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'site',
+    'editedon' => null,
+), '', true, true);
+$settings['error_log_path']= $xpdo->newObject('modSystemSetting');
+$settings['error_log_path']->fromArray(array (
+    'key' => 'error_log_path',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'site',
+    'editedon' => null,
+), '', true, true);
 return $settings;

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2113,9 +2113,9 @@ $settings['error_log_filename']->fromArray(array (
     'area' => 'system',
     'editedon' => null,
 ), '', true, true);
-$settings['error_log_path']= $xpdo->newObject('modSystemSetting');
-$settings['error_log_path']->fromArray(array (
-    'key' => 'error_log_path',
+$settings['error_log_filepath']= $xpdo->newObject('modSystemSetting');
+$settings['error_log_filepath']->fromArray(array (
+    'key' => 'error_log_filepath',
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -819,3 +819,9 @@ $_lang['setting_manager_use_fullname_desc'] = 'If set to yes, the content of the
 
 $_lang['log_snippet_not_found'] = 'Log snippets not found';
 $_lang['log_snippet_not_found_desc'] = 'If set to yes, snippets that are called but not found will be logged to the error log.';
+
+$_lang['setting_error_log_filename'] = 'Error log filename';
+$_lang['setting_error_log_filename_desc'] = 'Customize the filename of the MODX error log file (includes file existension).';
+
+$_lang['setting_error_log_path'] = 'Error log path';
+$_lang['setting_error_log_path_desc'] = 'Optionally set a absolute path the a custom error log location. You might use placehodlers like {cache_path}.';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -821,7 +821,7 @@ $_lang['log_snippet_not_found'] = 'Log snippets not found';
 $_lang['log_snippet_not_found_desc'] = 'If set to yes, snippets that are called but not found will be logged to the error log.';
 
 $_lang['setting_error_log_filename'] = 'Error log filename';
-$_lang['setting_error_log_filename_desc'] = 'Customize the filename of the MODX error log file (includes file existension).';
+$_lang['setting_error_log_filename_desc'] = 'Customize the filename of the MODX error log file (includes file extension).';
 
-$_lang['setting_error_log_path'] = 'Error log path';
-$_lang['setting_error_log_path_desc'] = 'Optionally set a absolute path the a custom error log location. You might use placehodlers like {cache_path}.';
+$_lang['setting_error_log_filepath'] = 'Error log path';
+$_lang['setting_error_log_filepath_desc'] = 'Optionally set a absolute path the a custom error log location. You might use placehodlers like {cache_path}.';

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -524,6 +524,18 @@ class modX extends xPDO {
             $this->getCacheManager();
             $this->getConfig();
             $this->_initContext($contextKey, false, $options);
+            $logTarget = $this->getLogTarget();
+            if ($logTarget === 'FILE') {
+                $options = array();
+                $filename = $this->getOption('error_log_filename', $options, '');
+                if (!empty($filename)) $options['filename'] = $filename;
+                $filepath = $this->getOption('error_log_filepath', $options, '');
+                if (!empty($filepath)) $options['filepath'] = $filepath;
+                $this->setLogTarget(array(
+                    'target' => 'FILE',
+                    'options' => $options
+                ));
+            }
             $this->_loadExtensionPackages($options);
             $this->_initSession($options);
             $this->_initErrorHandler($options);

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -530,7 +530,7 @@ class modX extends xPDO {
                 $filename = $this->getOption('error_log_filename', $options, '');
                 if (!empty($filename)) $options['filename'] = $filename;
                 $filepath = $this->getOption('error_log_filepath', $options, '');
-                if (!empty($filepath)) $options['filepath'] = $filepath;
+                if (!empty($filepath)) $options['filepath'] = rtrim($filepath, '/') . '/';
                 $this->setLogTarget(array(
                     'target' => 'FILE',
                     'options' => $options

--- a/core/model/modx/processors/system/errorlog/clear.class.php
+++ b/core/model/modx/processors/system/errorlog/clear.class.php
@@ -10,7 +10,9 @@ class modSystemErrorLogClearProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_erase');
     }
     public function process() {
-        $file = $this->modx->getOption(xPDO::OPT_CACHE_PATH).'logs/error.log';
+        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
+        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $file = $filepath.$filename;
         $content = '';
         $tooLarge = false;
         if (file_exists($file)) {

--- a/core/model/modx/processors/system/errorlog/clear.class.php
+++ b/core/model/modx/processors/system/errorlog/clear.class.php
@@ -10,8 +10,12 @@ class modSystemErrorLogClearProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_erase');
     }
     public function process() {
-        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
-        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
+        $logTarget = $this->modx->getLogTarget();
+        if (!is_array($logTarget)) {
+            $logTarget = array('options' => array());
+        }
+        $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
+        $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $file = $filepath.$filename;
         $content = '';
         $tooLarge = false;

--- a/core/model/modx/processors/system/errorlog/clear.class.php
+++ b/core/model/modx/processors/system/errorlog/clear.class.php
@@ -16,7 +16,7 @@ class modSystemErrorLogClearProcessor extends modProcessor {
         }
         $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
         $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
-        $file = $filepath.$filename;
+        $file = rtrim($filepath, '/').'/'.$filename;
         $content = '';
         $tooLarge = false;
         if (file_exists($file)) {

--- a/core/model/modx/processors/system/errorlog/clear.class.php
+++ b/core/model/modx/processors/system/errorlog/clear.class.php
@@ -10,8 +10,8 @@ class modSystemErrorLogClearProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_erase');
     }
     public function process() {
-        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
-        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
+        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $file = $filepath.$filename;
         $content = '';
         $tooLarge = false;

--- a/core/model/modx/processors/system/errorlog/download.class.php
+++ b/core/model/modx/processors/system/errorlog/download.class.php
@@ -10,8 +10,12 @@ class modSystemErrorLogDownloadProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_view');
     }
     public function process() {
-        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
-        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
+        $logTarget = $this->modx->getLogTarget();
+        if (!is_array($logTarget)) {
+            $logTarget = array('options' => array());
+        }
+        $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
+        $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $f = $filepath.$filename;
         if (!file_exists($f)) {
             return $this->failure();

--- a/core/model/modx/processors/system/errorlog/download.class.php
+++ b/core/model/modx/processors/system/errorlog/download.class.php
@@ -16,7 +16,7 @@ class modSystemErrorLogDownloadProcessor extends modProcessor {
         }
         $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
         $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
-        $f = $filepath.$filename;
+        $f = rtrim($filepath, '/').'/'.$filename;
         if (!file_exists($f)) {
             return $this->failure();
         }

--- a/core/model/modx/processors/system/errorlog/download.class.php
+++ b/core/model/modx/processors/system/errorlog/download.class.php
@@ -10,7 +10,9 @@ class modSystemErrorLogDownloadProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_view');
     }
     public function process() {
-        $f = $this->modx->getOption(xPDO::OPT_CACHE_PATH).'logs/error.log';
+        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
+        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $f = $filepath.$filename;
         if (!file_exists($f)) {
             return $this->failure();
         }

--- a/core/model/modx/processors/system/errorlog/download.class.php
+++ b/core/model/modx/processors/system/errorlog/download.class.php
@@ -10,8 +10,8 @@ class modSystemErrorLogDownloadProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_view');
     }
     public function process() {
-        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
-        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
+        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $f = $filepath.$filename;
         if (!file_exists($f)) {
             return $this->failure();

--- a/core/model/modx/processors/system/errorlog/download.class.php
+++ b/core/model/modx/processors/system/errorlog/download.class.php
@@ -16,15 +16,15 @@ class modSystemErrorLogDownloadProcessor extends modProcessor {
         }
         $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
         $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
-        $f = rtrim($filepath, '/').'/'.$filename;
-        if (!file_exists($f)) {
+        $file = rtrim($filepath, '/').'/'.$filename;
+        if (!file_exists($file)) {
             return $this->failure();
         }
         header('Content-Type: application/force-download');
-        header('Content-Length: ' . filesize($f));
+        header('Content-Length: ' . filesize($file));
         header('Content-Disposition: attachment; filename="error.'.time().'.log');
         ob_get_level() && @ob_end_flush();
-        readfile($f);
+        readfile($file);
         die();
     }
 }

--- a/core/model/modx/processors/system/errorlog/get.class.php
+++ b/core/model/modx/processors/system/errorlog/get.class.php
@@ -10,7 +10,9 @@ class modSystemErrorLogGetProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_view');
     }
     public function process() {
-        $f = $this->modx->getOption(xPDO::OPT_CACHE_PATH).'logs/error.log';
+        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
+        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $f = $filepath.$filename;
         $content = '';
         $tooLarge = false;
         if (file_exists($f)) {

--- a/core/model/modx/processors/system/errorlog/get.class.php
+++ b/core/model/modx/processors/system/errorlog/get.class.php
@@ -10,8 +10,8 @@ class modSystemErrorLogGetProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_view');
     }
     public function process() {
-        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
-        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
+        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $f = $filepath.$filename;
         $content = '';
         $tooLarge = false;

--- a/core/model/modx/processors/system/errorlog/get.class.php
+++ b/core/model/modx/processors/system/errorlog/get.class.php
@@ -16,19 +16,19 @@ class modSystemErrorLogGetProcessor extends modProcessor {
         }
         $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
         $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
-        $f = rtrim($filepath, '/').'/'.$filename;
+        $file = rtrim($filepath, '/').'/'.$filename;
         $content = '';
         $tooLarge = false;
-        if (file_exists($f)) {
-            $size = round(@filesize($f) / 1000 / 1000,2);
+        if (file_exists($file)) {
+            $size = round(@filesize($file) / 1000 / 1000,2);
             if ($size > 1) {
                 $tooLarge = true;
             } else {
-                $content = @file_get_contents($f);
+                $content = @file_get_contents($file);
             }
         }
         $la = array(
-            'name' => $f,
+            'name' => $file,
             'log' => $content,
             'tooLarge' => $tooLarge,
         );

--- a/core/model/modx/processors/system/errorlog/get.class.php
+++ b/core/model/modx/processors/system/errorlog/get.class.php
@@ -16,7 +16,7 @@ class modSystemErrorLogGetProcessor extends modProcessor {
         }
         $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
         $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
-        $f = $filepath.$filename;
+        $f = rtrim($filepath, '/').'/'.$filename;
         $content = '';
         $tooLarge = false;
         if (file_exists($f)) {

--- a/core/model/modx/processors/system/errorlog/get.class.php
+++ b/core/model/modx/processors/system/errorlog/get.class.php
@@ -10,8 +10,12 @@ class modSystemErrorLogGetProcessor extends modProcessor {
         return $this->modx->hasPermission('error_log_view');
     }
     public function process() {
-        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
-        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
+        $logTarget = $this->modx->getLogTarget();
+        if (!is_array($logTarget)) {
+            $logTarget = array('options' => array());
+        }
+        $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
+        $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $f = $filepath.$filename;
         $content = '';
         $tooLarge = false;

--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -2076,10 +2076,8 @@ class xPDO {
         $content= @ob_get_contents();
         @ob_end_clean();
         if ($target=='FILE' && $this->getCacheManager()) {
-            $defaultFilename = !empty($this->getOption('error_log_filename')) ? $this->getOption('error_log_filename') : 'error.log';
-            $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : $defaultFilename;
-            $defaultFilepath = !empty($this->getOption('error_log_path')) ? $this->getOption('error_log_path') : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
-            $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $defaultFilepath;
+            $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
+            $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
             $this->cacheManager->writeFile($filepath . $filename, $content, 'a');
         } elseif ($target=='ARRAY' && isset($targetOptions['var']) && is_array($targetOptions['var'])) {
             $targetOptions['var'][] = $content;

--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -2076,8 +2076,10 @@ class xPDO {
         $content= @ob_get_contents();
         @ob_end_clean();
         if ($target=='FILE' && $this->getCacheManager()) {
-            $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
-            $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
+            $defaultFilename = !empty($this->getOption('error_log_filename')) ? $this->getOption('error_log_filename') : 'error.log';
+            $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : $defaultFilename;
+            $defaultFilepath = !empty($this->getOption('error_log_path')) ? $this->getOption('error_log_path') : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
+            $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $defaultFilepath;
             $this->cacheManager->writeFile($filepath . $filename, $content, 'a');
         } elseif ($target=='ARRAY' && isset($targetOptions['var']) && is_array($targetOptions['var'])) {
             $targetOptions['var'][] = $content;

--- a/manager/controllers/default/system/event.class.php
+++ b/manager/controllers/default/system/event.class.php
@@ -39,8 +39,8 @@ class SystemEventManagerController extends modManagerController {
      * @return mixed
      */
     public function process(array $scriptProperties = array()) {
-        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
-        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
+        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $f = $filepath.$filename;
         $this->logArray['name'] = $f;
         if (file_exists($f)) {

--- a/manager/controllers/default/system/event.class.php
+++ b/manager/controllers/default/system/event.class.php
@@ -39,8 +39,12 @@ class SystemEventManagerController extends modManagerController {
      * @return mixed
      */
     public function process(array $scriptProperties = array()) {
-        $filename = $this->modx->getOption('error_log_filename', null, 'error.log', true);
-        $filepath = $this->modx->getOption('error_log_path', null, $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
+        $logTarget = $this->modx->getLogTarget();
+        if (!is_array($logTarget)) {
+            $logTarget = array('options' => array());
+        }
+        $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
+        $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
         $f = $filepath.$filename;
         $this->logArray['name'] = $f;
         if (file_exists($f)) {

--- a/manager/controllers/default/system/event.class.php
+++ b/manager/controllers/default/system/event.class.php
@@ -39,7 +39,9 @@ class SystemEventManagerController extends modManagerController {
      * @return mixed
      */
     public function process(array $scriptProperties = array()) {
-        $f = $this->modx->getOption(xPDO::OPT_CACHE_PATH) . 'logs/error.log';
+        $filename = !empty($this->modx->getOption('error_log_filename')) ? $this->modx->getOption('error_log_filename') : 'error.log';
+        $filepath = !empty($this->modx->getOption('error_log_path')) ? $this->modx->getOption('error_log_path') : $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $f = $filepath.$filename;
         $this->logArray['name'] = $f;
         if (file_exists($f)) {
             $this->logArray['size'] = round(@filesize($f) / 1000 / 1000, 2);


### PR DESCRIPTION
### What does it do?
Adds 2 new system settings for the MODX error log to specify the filename (`error_log_filename`) and filepath (`error_log_filepath`).

Note: Changing the error log filename or path was already possible with `setLogTarget`, however this is not really convenient, so we added those system settings. The system settings internally updated the log target.

The manager error log processors are updated to also finally support the log target and show the correct log when the target has been customized.

### Why is it needed?
This makes it possible to fully customize the location of the MODX error log. Now one could move the error log outside of the MODX directory and name it modx.log easily with the system settings. Also the error log view in the manager now works correctly with custom locations.

### Related issue(s)/PR(s)
Issue: #13752
Failed PRs: #12352 by gerrit1986 and #13751 by IamNeo1
