### PR TITLE
No fall back to context key if context name isn't specified. #13739 #modxbughunt

### DIFF
--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -60,6 +60,7 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
     public function prepareRow(xPDOObject $object) {
         $contextArray = $object->toArray();
         $contextArray['perm'] = array();
+        $contextArray['name'] = $object->get('name') != '' ? $object->get('name') : $object->get('key');
         if ($this->canCreate) {
             $contextArray['perm'][] = 'pnew';
         }


### PR DESCRIPTION
### What does it do?
Just a fallback on the key in de getlist processor.

### Why is it needed?
When a context has no name (from updates old MODX to new MODX) an empty row will show in the context combos.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13739
