### PR TITLE
Fix silent fail on login

### DIFF
--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -374,11 +374,18 @@ class modSecurityLoginProcessor extends modProcessor {
      */
     public function afterLogin() {
         $this->addSessionContexts();
+        if ($this->loginContext == 'mgr') {
+            $this->modx->user = null;
+            $this->modx->getUser('mgr', true);
+            if (!$this->modx->hasPermission('frames')) {
+                return $this->failure($this->modx->lexicon('access_denied'));
+            }
+        }
         $this->fireAfterLoginEvent();
 
         $this->modx->logManagerAction('login','modContext',$this->loginContext, $this->user->get('id'));
 
-        return $this->prepareResponse();
+        return $this->cleanup($this->prepareResponse());
     }
 
     /**
@@ -396,8 +403,7 @@ class modSecurityLoginProcessor extends modProcessor {
             return $this->failure($preventLogin);
         }
 
-        $response = $this->afterLogin();
-        return $this->cleanup($response);
+        return $this->afterLogin();
     }
 
     /** Return the response

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -378,6 +378,7 @@ class modSecurityLoginProcessor extends modProcessor {
             $this->modx->user = null;
             $this->modx->getUser('mgr', true);
             if (!$this->modx->hasPermission('frames')) {
+                $this->modx->runProcessor('security/logout');
                 return $this->failure($this->modx->lexicon('access_denied'));
             }
         }


### PR DESCRIPTION
### What does it do?
Return error if user has no permission for using manager

### Why is it needed?
If user successfully login to manager, but has no permission to use backend, login pagewill  just reload without any errors. That can be very confusing.

### Related issue(s)/PR(s)
#12706 