### PR TITLE
Fix incorrect view_url after changing the resource alias #13740

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -726,6 +726,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         }
         $returnArray['class_key'] = $this->object->get('class_key');
         $this->workingContext->prepare(false);
+        $this->modx->reloadContext($this->workingContext->key);
         $returnArray['preview_url'] = '';
         if (!$this->object->get('deleted')) {
             $returnArray['preview_url'] = $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');


### PR DESCRIPTION
### What does it do?
makeUrl() was loading the cached aliasMap. It reloads the Content after saving the resource to receive the updated aliasMap with the new set alias.

### Why is it needed?
After changing the alias and saving the resource, the "publish button" showed/opened the old URL (preview_url).

### Related issue(s)/PR(s)
#13740
