### PR TITLE
Bug parser returning unattended message on comments

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -421,7 +421,6 @@ class modParser {
 
         $outerTag= $tag[0];
         $innerTag= $tag[1];
-
         /* Avoid all processing for comment tags, e.g. [[- comments here]] */
         if (substr($innerTag, 0, 1) === '-') {
             return "";
@@ -464,6 +463,9 @@ class modParser {
         }
         if ($elementOutput === null) {
             switch ($token) {
+                case '-':
+                    $elementOutput = '';
+                    break;
                 case '+':
                     $tagName= substr($tagName, 1 + $tokenOffset);
                     $element= new modPlaceholderTag($this->modx);
@@ -533,7 +535,7 @@ class modParser {
                         $element->setCacheable($cacheable);
                         $elementOutput= $element->process($tagPropString);
                     }
-                    else {
+                    elseif(!empty($tagName)) {
                         if ($this->modx->getOption('log_snippet_not_found', null, false)) {
                             $this->modx->log(xPDO::LOG_LEVEL_ERROR, "Could not find snippet with name {$tagName}.");
                         }


### PR DESCRIPTION
### What does it do?
Modified parser in order to properly proccess placeholder with conditional output modifier returning a - sign to be treated as a comment

### Why is it needed?
```
[[[[+majcache:gt=`0`:then=`AC_SupprCache`:else=`-`]]]]
```
generate a messages in the log file like
```
(ERROR @ /var/www/vhosts/yourdomain.tlds/core/model/modx/modparser.class.php : 540) Could not find snippet with name .
(ERROR @ /var/www/vhosts/yourdomain.tld/core/model/modx/modparser.class.php : 540) Could not find snippet with name -.
```

### Related issue(s)/PR(s)
Issue discussed with MarkH during the bughunt#3
