### PR TITLE
Add wildcard support to form customization actions (i.e., support resource/create and resource/update in single set)

### DIFF
--- a/core/lexicon/en/formcustomization.inc.php
+++ b/core/lexicon/en/formcustomization.inc.php
@@ -22,6 +22,7 @@ $_lang['default_value'] = 'Default Value';
 $_lang['export'] = 'Export';
 $_lang['fc.action_create'] = 'Create Resource';
 $_lang['fc.action_update'] = 'Update Resource';
+$_lang['fc.action_resource_wildcard'] = 'Create & Update Resource';
 $_lang['field'] = 'Field';
 $_lang['field_desc'] = 'This is the field to affect. This may also be a tab, or TV. If it is a TV, please specify in this format: "tv#", where # is the ID of the TV.';
 $_lang['field_default'] = 'Field Default Value';

--- a/core/model/modx/modformcustomizationset.class.php
+++ b/core/model/modx/modformcustomizationset.class.php
@@ -28,6 +28,12 @@ class modFormCustomizationSet extends xPDOSimpleObject {
     public function getData() {
         $setArray = array();
 
+        // If the action ends in /* (wildcard rule), we assume the update action to be the "base" action
+        $baseAction = $this->get('action');
+        if (substr($baseAction, -2) === '/*') {
+            $baseAction = str_replace('/*', '/update', $baseAction);
+        }
+
         /* get fields */
         $c = $this->xpdo->newQuery('modActionField');
         $c->innerJoin('modActionField','Tab','Tab.name = modActionField.tab');
@@ -36,7 +42,7 @@ class modFormCustomizationSet extends xPDOSimpleObject {
             'tab_rank' => 'Tab.rank',
         ));
         $c->where(array(
-            'action' => $this->get('action'),
+            'action' => $baseAction,
             'type' => 'field',
         ));
         $c->sortby('Tab.rank','ASC');
@@ -151,7 +157,7 @@ class modFormCustomizationSet extends xPDOSimpleObject {
         /* get tabs */
         $c = $this->xpdo->newQuery('modActionField');
         $c->where(array(
-            'action' => $this->get('action'),
+            'action' => $baseAction,
             'type' => 'tab',
         ));
         $c->sortby('rank','ASC');

--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -760,10 +760,10 @@ HTML;
      * Checks Form Customization rules for an object.
      *
      * @param xPDOObject $obj If passed, will validate against for rules with constraints.
-     * @param bool $forParent
+     * @param bool $forParent No longer used - filtering only happens by controller
      * @return array
      */
-    public function checkFormCustomizationRules(&$obj = null,$forParent = false) {
+    public function checkFormCustomizationRules(&$obj = null, $forParent = false) {
         $overridden = array();
 
         if ($this->modx->getOption('form_customization_use_all_groups',null,false)) {
@@ -779,9 +779,24 @@ HTML;
         $c->innerJoin('modFormCustomizationProfile','Profile','FCSet.profile = Profile.id');
         $c->leftJoin('modFormCustomizationProfileUserGroup','ProfileUserGroup','Profile.id = ProfileUserGroup.profile');
         $c->leftJoin('modFormCustomizationProfile','UGProfile','UGProfile.id = ProfileUserGroup.profile');
+
+        // Filter on the controller (action).
+        $controller = array_key_exists('controller', $this->config) ? $this->config['controller'] : '';
+        if (strpos($controller, '/') !== false) {
+            // For multi-level controllers (e.g. resource/create), we get the last part
+            // of the controller name to also search for a wildcard (e.g. resource/*)
+            $wildController = substr($controller, 0, strrpos($controller, '/')) . '/*';
+            $c->where(array(
+                'modActionDom.action:IN' => array($controller, $wildController),
+            ));
+        }
+        else {
+            $c->where(array(
+                'modActionDom.action' => array_key_exists('controller',$this->config) ? $this->config['controller'] : '',
+            ));
+        }
+
         $c->where(array(
-            'modActionDom.action' => array_key_exists('controller',$this->config) ? $this->config['controller'] : '',
-            'modActionDom.for_parent' => $forParent,
             'FCSet.active' => true,
             'Profile.active' => true,
         ));

--- a/core/model/modx/processors/security/forms/set/update.class.php
+++ b/core/model/modx/processors/security/forms/set/update.class.php
@@ -134,10 +134,16 @@ class modFormCustomizationSetUpdateProcessor extends modObjectUpdateProcessor {
         $tabs = $this->getProperty('tabs',null);
         if ($tabs == null) return;
         $tabs = is_array($tabs) ? $tabs : $this->modx->fromJSON($tabs);
+        $action = $this->object->get('action');
+
+        // If the action ends in /* (wildcard rule), we assume tabs that exist for an update action
+        if (substr($action, -2) === '/*') {
+            $action = str_replace('/*', '/update', $action);
+        }
 
         foreach ($tabs as $tab) {
             $tabField = $this->modx->getObject('modActionField',array(
-                'action' => $this->object->get('action'),
+                'action' => $action,
                 'name' => $tab['name'],
                 'type' => 'tab',
             ));

--- a/manager/assets/modext/widgets/fc/modx.fc.common.js
+++ b/manager/assets/modext/widgets/fc/modx.fc.common.js
@@ -7,6 +7,7 @@ MODx.combo.FCAction = function(config) {
             ,data: [
                 [_('fc.action_create'),'resource/create']
                 ,[_('fc.action_update'),'resource/update']
+                ,[_('fc.action_resource_wildcard'),'resource/*']
             ]
         })
         ,displayField: 'd'

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -22,8 +22,12 @@ MODx.grid.FCSet = function(config) {
             header: _('action')
             ,dataIndex: 'action'
             ,width: 200
-            ,editable: true
+            ,editable: false
             ,sortable: true
+            ,editor: {
+                xtype: 'modx-combo-fc-action',
+                renderer: true
+            }
         },{
             header: _('description')
             ,dataIndex: 'description'

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -127,7 +127,7 @@ class ResourceCreateManagerController extends ResourceManagerController {
             $this->getResourceGroups();
 
             /* check FC rules */
-            $overridden = $this->checkFormCustomizationRules($this->parent,true);
+            $overridden = $this->checkFormCustomizationRules($this->resource);
         } else {
             $this->resourceArray = array_merge($this->resourceArray, $reloadData);
             $this->resourceArray['resourceGroups'] = array();
@@ -150,7 +150,7 @@ class ResourceCreateManagerController extends ResourceManagerController {
             $this->resource->fromArray($reloadData); // We should have in Reload Data everything needed to do form customization checkings
 
             /* check FC rules */
-            $overridden = $this->checkFormCustomizationRules($this->resource,true); // This "forParent" doesn't seems logical for me, but it seems that all "resource/create" rules require this (see /core/model/modx/processors/security/forms/set/import.php for example)
+            $overridden = $this->checkFormCustomizationRules($this->resource);
         }
 
         /* apply FC rules */


### PR DESCRIPTION
### What does it do?
Changes form customization to support actions like `resource/*`, which will then apply to any controller that starts with resource/.  Primarily this will be used by people to manage FC rules that apply to create and update, instead of just one of those.

FC was architected to be useful for a lot more than just resources, so this method does not hardcode the resource bits anywhere, instead opting for a bit more flexible wildcard approach. 

When editing a wildcard action, FC will look at the update action to determine the default fields/tabs/etc. This could have also been the create, but it is assumed that update actions may have more fields than create in certain (hypothetical) situations, so update seemed like the better idea. 

### Why is it needed?
To make it easier to manage rules that affect both create and update.

### Related issue(s)/PR(s)
#3772 