### PR TITLE
Prevent adding ./ to filepath when in root of a mediasource [12625]

### DIFF
--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -364,7 +364,8 @@ class modMediaSource extends modAccessibleSimpleObject implements modMediaSource
      * @return string
      */
     public function getOpenTo($value,array $parameters = array()) {
-        return dirname($value).'/';
+        $dirname = dirname($value);
+        return $dirname == '.' ? '' : $dirname . '/';
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Only returns the dirname in getOpenTo, when not in root, otherwise returns an empty string

### Why is it needed?
Solves the issue with prefixed ./ in image or file - TVs, when in Root.
Doesn't happen the first time, but as soon as the Manager - Page is reloaded and a image or file-TV is saved again. Then the openTo was ./ and this was prefixed to the filepath

### Related issue(s)/PR(s)
Related to
https://github.com/modxcms/revolution/issues/12625
and
https://github.com/modxcms/revolution/issues/11830
