### PR TITLE
Update default.inc.php

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -490,7 +490,7 @@ $_lang['tv'] = 'TV';
 $_lang['tv_default'] = 'Default Value';
 $_lang['tv_default_desc'] = 'The default value will be stored if the user does not specify a value.';
 $_lang['tv_elements'] = 'Input Option Values';
-$_lang['tv_elements_desc'] = 'Option values for TVs with multiple selectable items, such as dropdown or tag (separate options with ||, e.g. Cat||Dog or White==#000000||Black==#ffffff).';
+$_lang['tv_elements_desc'] = 'Option values for TVs with multiple selectable items, such as dropdown or tag (separate options with ||, e.g. Cat||Dog or White==#ffffff||Black==#000000).';
 $_lang['tv_type'] = 'Input Type';
 $_lang['tv_value_inherited'] = 'Value Inherited';
 $_lang['type'] = 'Type';


### PR DESCRIPTION
Update default.inc.php to fix typo in $_lang['tv_elements_desc']

### What does it do?
Fixes minor typo on on Label found in Template Variable > Input Options

### Why is it needed?
Makes the world a neater place.

### Related issue(s)/PR(s)
Fixes issue #13776
