### PR TITLE
Also remove second nocompress checkbox from the setup (re #12857)

### DIFF
--- a/setup/templates/options.tpl
+++ b/setup/templates/options.tpl
@@ -97,17 +97,6 @@
 {/if}
 <table class="options">
 <tbody>
-{if $installmode NE 0}
-<tr>
-    <th>
-        <label>
-            <input type="checkbox" name="nocompress" id="nocompress" value="1" />
-            {$_lang.options_nocompress}
-        </label>
-    </th>
-    <td>{$_lang.options_nocompress_note}</td>
-</tr>
-{/if}
 <tr>
     <th style="padding-top: 2em;">
         <label>


### PR DESCRIPTION
### What does it do?
After merging #12857, I noticed there was another checkbox for it left. 

### Why is it needed?
Nocompress is no longer needed since the manager no longer uses dynamic compression (v2.5). This option should be removed from 3.0.

### Related issue(s)/PR(s)
#12857 and further issues mentioned there.