### PR TITLE
CLI install script to use after composer create-project

### DIFF
--- a/setup/cli-install.php
+++ b/setup/cli-install.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * CLI install script for MODX
+ *
+ * Run and answer the questions. Also you can pre-define values:
+ * php www/setup/install.php --database=my_db --database_user=db_user_12 --language=ru
+ */
+
+if (PHP_SAPI != 'cli') {
+    exit('This file should be run through the command line interface!');
+}
+$path = dirname(__FILE__) . '/';
+$config = $path . 'config.xml';
+$mode = 'new';
+
+$variables = [
+    'database_type' => 'mysql',
+    'database_server' => [
+        'prompt' => 'Database server',
+        'default' => '127.0.0.1',
+    ],
+    'database' => [
+        'prompt' => 'Database',
+        'default' => '',
+    ],
+    'database_user' => [
+        'prompt' => 'Database user',
+        'default' => '',
+    ],
+    'database_password' => [
+        'prompt' => 'Database password',
+        'default' => '',
+    ],
+    'database_connection_charset' => 'utf8',
+    'database_charset' => 'utf8',
+    'database_collation' => 'utf8_general_ci',
+    'table_prefix' => [
+        'prompt' => 'Table prefix',
+        'default' => 'modx_',
+    ],
+    'https_port' => 443,
+    'http_host' => [
+        'prompt' => 'Http host',
+        'default' => '',
+    ],
+    'cache_disabled' => 0,
+    'inplace' => 0,
+    'unpacked' => 0,
+    'language' => [
+        'prompt' => 'Language',
+        'default' => 'en',
+    ],
+    'cmsadmin' => [
+        'prompt' => 'Admin login',
+        'default' => 'admin',
+    ],
+    'cmspassword' => [
+        'prompt' => 'Admin password',
+        'default' => '',
+    ],
+    'cmsadminemail' => [
+        'prompt' => 'Admin email',
+        'default' => '',
+    ],
+    'core_path' => [
+        'prompt' => 'Path to core',
+        'default' => dirname($path) . '/core/',
+    ],
+    'context_mgr_path' => [
+        'prompt' => 'Path to manager',
+        'default' => dirname($path) . '/manager/',
+    ],
+    'context_mgr_url' => [
+        'prompt' => 'Manager url',
+        'default' => '/manager/',
+    ],
+    'context_connectors_path' => [
+        'prompt' => 'Path to connectors',
+        'default' => dirname($path) . '/connectors/',
+    ],
+    'context_connectors_url' => [
+        'prompt' => 'Url to connectors',
+        'default' => '/connectors/',
+    ],
+    'context_web_path' => dirname($path) . '/',
+    'context_web_url' => '/',
+    'remove_setup_directory' => 1,
+];
+
+// Parse CLI arguments
+$args = array_slice($argv, 1);
+$cli_variables = [];
+foreach ($args as $arg) {
+    $tmp = array_map('trim', explode('=', $arg));
+    if (count($tmp) === 2) {
+        $k = ltrim($tmp[0], '-');
+        if (isset($variables[$k])) {
+            $cli_variables[$k] = $tmp[1];
+        } elseif ($k == 'mode' && in_array($tmp[1], ['new', 'upgrade', 'advanced'])) {
+            $mode = $tmp[1];
+        }
+    }
+}
+
+// If it is upgrade - parse old variables
+$old_variables = [];
+if (file_exists($config)) {
+    $use = ($mode == 'upgrade')
+        ? 'Y'
+        : readline("There is an old config found at {$config}. Do you want to load this values? (Y): ");
+    if (empty($use) || strtolower($use) == 'y') {
+        $tmp = simplexml_load_file($config);
+        $tmp = @json_decode(json_encode($tmp), true);
+        if (is_array($tmp)) {
+            $old_variables = $tmp;
+        }
+    }
+}
+
+// Merge everything
+$variables = array_merge($variables, $old_variables, $cli_variables);
+
+// Process config
+$data = [];
+foreach ($variables as $key => $params) {
+    if (!is_array($params)) {
+        $data[$key] = $params;
+    } elseif (!empty($params['prompt'])) {
+        $prompt = $params['prompt'];
+        $res = '';
+        if (!empty($params['default'])) {
+            $prompt .= " ({$params['default']})";
+            if (!$res = readline($prompt . ': ')) {
+                $res = $params['default'];
+            }
+        } else {
+            while (!$res = readline($prompt . ': ')) {
+                echo $prompt . " is required!\n";
+            }
+            readline_add_history(trim($res));
+        }
+        $data[$key] = trim($res);
+    }
+    if (strpos($key, '_path') !== false || strpos($key, '_url') !== false) {
+        $data[$key] = preg_replace('#/+#', '/', ('/' . trim($data[$key], '/') . '/'));
+    }
+}
+
+// Check directories
+$dirs = [
+    'core_path' => '/core/',
+    'context_mgr_path' => '/manager/',
+    'context_connectors_path' => '/connectors/',
+];
+foreach ($dirs as $key => $value) {
+    $target = dirname($path) . $value;
+    if (file_exists($target) && $data[$key] != $target) {
+        shell_exec("rm -rf {$data[$key]}");
+        shell_exec("mv {$target} {$data[$key]}");
+    }
+}
+
+// Generate config file
+$xml = new SimpleXMLElement('<modx/>');
+foreach ($data as $key => $value) {
+    $xml->addChild($key, $value);
+}
+file_put_contents($config, $xml->asXML());
+
+// Run install!
+echo shell_exec("php {$path}index.php --installmode={$mode} --core_path={$data['core_path']} --config={$config}");

--- a/setup/cli-install.php
+++ b/setup/cli-install.php
@@ -13,78 +13,73 @@ if (PHP_SAPI != 'cli') {
 $path = dirname(__FILE__) . '/';
 $config = $path . 'config.xml';
 $mode = 'new';
+$languages = array_slice(scandir($path . 'lang/'), 2);
 
 $variables = [
     'database_type' => 'mysql',
     'database_server' => [
-        'prompt' => 'Database server',
-        'default' => '127.0.0.1',
+        'prompt' => 'connection_database_host',
+        'default' => 'localhost',
     ],
     'database' => [
-        'prompt' => 'Database',
+        'prompt' => 'connection_database_name',
         'default' => '',
     ],
     'database_user' => [
-        'prompt' => 'Database user',
+        'prompt' => 'connection_database_login',
         'default' => '',
     ],
     'database_password' => [
-        'prompt' => 'Database password',
+        'prompt' => 'connection_database_pass',
         'default' => '',
     ],
     'database_connection_charset' => 'utf8',
     'database_charset' => 'utf8',
     'database_collation' => 'utf8_general_ci',
     'table_prefix' => [
-        'prompt' => 'Table prefix',
+        'prompt' => 'connection_table_prefix',
         'default' => 'modx_',
     ],
     'https_port' => 443,
-    'http_host' => [
-        'prompt' => 'Http host',
-        'default' => '',
-    ],
+    'http_host' => 'localhost',
     'cache_disabled' => 0,
     'inplace' => 0,
     'unpacked' => 0,
     'language' => [
-        'prompt' => 'Language',
+        'prompt' => 'choose_language',
         'default' => 'en',
     ],
     'cmsadmin' => [
-        'prompt' => 'Admin login',
+        'prompt' => 'connection_default_admin_login',
         'default' => 'admin',
     ],
     'cmspassword' => [
-        'prompt' => 'Admin password',
+        'prompt' => 'connection_default_admin_password',
         'default' => '',
     ],
     'cmsadminemail' => [
-        'prompt' => 'Admin email',
+        'prompt' => 'connection_default_admin_email',
         'default' => '',
-    ],
-    'core_path' => [
-        'prompt' => 'Path to core',
-        'default' => dirname($path) . '/core/',
-    ],
-    'context_mgr_path' => [
-        'prompt' => 'Path to manager',
-        'default' => dirname($path) . '/manager/',
-    ],
-    'context_mgr_url' => [
-        'prompt' => 'Manager url',
-        'default' => '/manager/',
-    ],
-    'context_connectors_path' => [
-        'prompt' => 'Path to connectors',
-        'default' => dirname($path) . '/connectors/',
-    ],
-    'context_connectors_url' => [
-        'prompt' => 'Url to connectors',
-        'default' => '/connectors/',
     ],
     'context_web_path' => dirname($path) . '/',
     'context_web_url' => '/',
+    'core_path' => dirname($path) . '/core/',
+    'context_mgr_path' => [
+        'prompt' => 'context_manager_path',
+        'default' => dirname($path) . '/manager/',
+    ],
+    'context_mgr_url' => [
+        'prompt' => 'context_manager_url',
+        'default' => '/manager/',
+    ],
+    'context_connectors_path' => [
+        'prompt' => 'context_connector_path',
+        'default' => dirname($path) . '/connectors/',
+    ],
+    'context_connectors_url' => [
+        'prompt' => 'context_connector_url',
+        'default' => '/connectors/',
+    ],
     'remove_setup_directory' => 1,
 ];
 
@@ -103,12 +98,18 @@ foreach ($args as $arg) {
     }
 }
 
+$lang = !empty($cli_variables['language']) && in_array($cli_variables['language'], $languages)
+    ? $cli_variables['language']
+    : 'en';
+/** @var array $_lang */
+require($path . 'lang/' . $lang . '/default.inc.php');
+
 // If it is upgrade - parse old variables
 $old_variables = [];
 if (file_exists($config)) {
     $use = ($mode == 'upgrade')
         ? 'Y'
-        : readline("There is an old config found at {$config}. Do you want to load this values? (Y): ");
+        : readline("There is an existing config file found at {$config}. Do you want to load this values? (Y): ");
     if (empty($use) || strtolower($use) == 'y') {
         $tmp = simplexml_load_file($config);
         $tmp = @json_decode(json_encode($tmp), true);
@@ -127,16 +128,19 @@ foreach ($variables as $key => $params) {
     if (!is_array($params)) {
         $data[$key] = $params;
     } elseif (!empty($params['prompt'])) {
-        $prompt = $params['prompt'];
+        $prompt = rtrim($_lang[$params['prompt']], ':');
         $res = '';
         if (!empty($params['default'])) {
+            if ($key == 'language') {
+                $prompt .= ' (' . implode('|', $languages) . ') ';
+            }
             $prompt .= " ({$params['default']})";
             if (!$res = readline($prompt . ': ')) {
                 $res = $params['default'];
             }
         } else {
             while (!$res = readline($prompt . ': ')) {
-                echo $prompt . " is required!\n";
+                // pass
             }
             readline_add_history(trim($res));
         }
@@ -148,6 +152,13 @@ foreach ($variables as $key => $params) {
 }
 
 // Check directories
+$rmdir = function ($dir) use (&$rmdir) {
+    $files = array_diff(scandir($dir), ['.', '..']);
+    foreach ($files as $file) {
+        is_dir("$dir/$file") ? $rmdir("$dir/$file") : unlink("$dir/$file");
+    }
+    rmdir($dir);
+};
 $dirs = [
     'core_path' => '/core/',
     'context_mgr_path' => '/manager/',
@@ -155,11 +166,12 @@ $dirs = [
 ];
 foreach ($dirs as $key => $value) {
     $target = dirname($path) . $value;
-    if (file_exists($target) && $data[$key] != $target) {
-        shell_exec("rm -rf {$data[$key]}");
-        shell_exec("mv {$target} {$data[$key]}");
+    if (file_exists($target) && $data[$key] != $target && strpos($data[$key], dirname($path)) === 0) {
+        $rmdir(rtrim($data[$key], DIRECTORY_SEPARATOR));
+        rename($target, $data[$key]);
     }
 }
+unset($rmdir);
 
 // Generate config file
 $xml = new SimpleXMLElement('<modx/>');
@@ -169,4 +181,11 @@ foreach ($data as $key => $value) {
 file_put_contents($config, $xml->asXML());
 
 // Run install!
-echo shell_exec("php {$path}index.php --installmode={$mode} --core_path={$data['core_path']} --config={$config}");
+echo "\n\033[32m{$_lang['thank_installing']}MODX!\n\n\033[0m";
+$argv = [
+    $path . 'index.php',
+    '--installmode=' . $mode,
+    '--core_path=' . $data['core_path'],
+    '--config=' . $config,
+];
+require($path . 'index.php');


### PR DESCRIPTION
### What does it do?
Add ability to install MODX from CLI with interactive dialog, instead of edit `config.xml`. If there is already `config.xml` exists, script will suggest to load values from it.

Also you can always override any value by CLI arguments to file. This script will generate `config.xml` and start default MODX CLI install.

#### Examples:
default run with interactive questions
```
php www/setup/cli-install.php
```
specify some values with arguments
```
php www/setup/cli-install.php --database=s12973 --database_user=s12973
```
specify mode
```
php www/setup/cli-install.php --mode=upgrade --language=ru --remove_setup_directory=0
```

### Why is it needed?
It allows to install MODX in interactive mode without opening web browser.
Also you can make installation fully automatically along with `composer`. For example:
```
composer create-project modx/revolution ./www 2.x-dev --keep-vcs &&
rm -rf ./www/.git && 
php ./www/setup/cli-install.php --database_server=127.0.0.1 --database=s12973 --database_user=s12973 --database_password=o0D9VRNdulnJ --table_prefix=modx_ --http_host=s12973.h2.modhost.pro --language=en --cmsadmin=admin --cmspassword=adminpass --cmsadminemail=admin@s12973.h2.modhost.pro --core_path=/home/s12973/www/core/ --context_mgr_path=/home/s12973/www/manager/ --context_mgr_url=/manager/ --context_connectors_path=/home/s12973/www/connectors/ --context_connectors_url=/connectors/ --context_web_path=/home/s12973/www/
```

### Related issue(s)/PR(s)
#13784 