### PR TITLE
Make less strict https status check

### DIFF
--- a/core/docs/config.inc.tpl
+++ b/core/docs/config.inc.tpl
@@ -49,7 +49,7 @@ if (!defined('MODX_BASE_PATH')) {
 if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
     $isSecureRequest = false;
 } else {
-    $isSecureRequest = ((isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $https_port);
+    $isSecureRequest = ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') || $_SERVER['SERVER_PORT'] == $https_port);
 }
 if (!defined('MODX_URL_SCHEME')) {
     $url_scheme=  $isSecureRequest ? 'https://' : 'http://';

--- a/setup/includes/config/modconfigreader.class.php
+++ b/setup/includes/config/modconfigreader.class.php
@@ -67,7 +67,7 @@ abstract class modConfigReader {
     public function getHttpHost() {
         if (php_sapi_name() != 'cli') {
             $this->config['https_port'] = isset ($_POST['httpsport']) ? $_POST['httpsport'] : '443';
-            $isSecureRequest = ((isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $this->config['https_port']);
+            $isSecureRequest = ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') || $_SERVER['SERVER_PORT'] == $this->config['https_port']);
             $this->config['http_host']= $_SERVER['HTTP_HOST'];
             if ($_SERVER['SERVER_PORT'] != 80) {
                 $this->config['http_host']= str_replace(':' . $_SERVER['SERVER_PORT'], '', $this->config['http_host']); /* remove port from HTTP_HOST */


### PR DESCRIPTION
### What does it do?
It make more flexible check if the script was requested through the HTTPS protocol or not. Due to [PHP documentation](http://php.net/manual/en/reserved.variables.server.php) the $_SERVER['HTTPS'] value can be set to non empty value, not only 'on' value.

### Why is it needed?
I cannot get HTTPS connection on one of the client projects with MODX Revolution 2.6 on-board. When I investigating this problem, i found that hosting's web server set $_SERVER['HTTPS'] variable to 1 and MODX expected 'on' value. That's why HTTPS connection didn't worked.

### Related issue(s)/PR(s)
Not related.