### PR TITLE
Fix messages being sent to wrong or nonexistent users when sending to a user group

### DIFF
--- a/core/model/modx/processors/security/message/create.class.php
+++ b/core/model/modx/processors/security/message/create.class.php
@@ -131,7 +131,7 @@ class modMessageCreateProcessor extends modObjectProcessor {
             if ($user->get($primaryKey) == $this->modx->user->get('id')) {
                 continue;
             }
-            $recipients[] = $user->get('id');
+            $recipients[] = $user->get($primaryKey);
         }
         return $recipients;
     }


### PR DESCRIPTION
Fixes bug with Message Create processor using the wrong recipient ID when processing usergroup messages.

### What does it do?
Modified the method to get the 'member' field of the modUserGroupMember object rather than the 'id' field.

### Why is it needed?
Messages to user groups are sent to wrong or non-existent users.

### Related issue(s)/PR(s)
Issue #13795
