### PR TITLE
Fix headers being overwritten in modRest (#12500)

### DIFF
--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -314,7 +314,7 @@ class RestClientRequest {
      */
     protected function prepareHeaders() {
         if (!empty($this->headers)) {
-            $this->requestOptions[CURLOPT_HTTPHEADER] = array();
+            if (empty($this->requestOptions[CURLOPT_HTTPHEADER])) $this->requestOptions[CURLOPT_HTTPHEADER] = array();
             foreach ($this->headers as $key => $value) {
                 $this->requestOptions[CURLOPT_HTTPHEADER][] = sprintf("%s: %s", $key, $value);
             }

--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -314,7 +314,9 @@ class RestClientRequest {
      */
     protected function prepareHeaders() {
         if (!empty($this->headers)) {
-            if (empty($this->requestOptions[CURLOPT_HTTPHEADER])) $this->requestOptions[CURLOPT_HTTPHEADER] = array();
+            if (empty($this->requestOptions[CURLOPT_HTTPHEADER])) {
+                $this->requestOptions[CURLOPT_HTTPHEADER] = array();
+            }
             foreach ($this->headers as $key => $value) {
                 $this->requestOptions[CURLOPT_HTTPHEADER][] = sprintf("%s: %s", $key, $value);
             }


### PR DESCRIPTION
### What does it do?
Prevents the existing headers from being overwritten when preparing the headers.

### Related issue(s)/PR(s)
Bug #12500