### PR TITLE
Only save properties modified from the default for an element

### DIFF
--- a/core/model/modx/processors/element/propertyset/updatefromelement.class.php
+++ b/core/model/modx/processors/element/propertyset/updatefromelement.class.php
@@ -1,5 +1,6 @@
 <?php
-include_once dirname(__FILE__) . '/update.class.php';
+include_once dirname(__FILE__).'/update.class.php';
+
 /**
  * Saves a property set
  *
@@ -13,32 +14,41 @@ class modPropertySetUpdateFromElementProcessor extends modPropertySetUpdateProce
     /** @var modPropertySet|null */
     public $object;
 
+    /** @var modElement|null  */
+    public $element = null;
+
+    /**
+     * Get element, if necessary
+     * @return null|modElement
+     */
+    public function getElement() {
+        $elementId = (int)$this->getProperty('elementId', 0);
+        $elementClass = $this->getProperty('elementType', '');
+        if ($elementId && !empty($elementClass)) {
+            return $this->modx->getObject($elementClass, $elementId);
+        }
+
+        return null;
+    }
+
     /**
      * {@inheritdoc}
      * @return bool|null|string
      */
     public function initialize() {
-        
-        /*
-             Determine whether the transferred parameter set ID.
-             If so, then the class of the current object left without changes modPropertySet
-             If not, change the class of the class of the updated element.
-             That is the current element $this->object as the case may be, or modPropertySet or modTemplate | modSnippet etc.
-        */
+        $this->element = $this->getElement();
 
-        $id = (int)$this->getProperty($this->primaryKeyField);
-        if(!$id){
-            $elementType = $this->getProperty('elementType');
-            if(!$elementType){
-                return $this->modx->lexicon('propertysets_err_item_class_ns');
-            }
-            
-            $this->classKey = $elementType;
-            $id = (int)$this->getProperty('elementId');
+        $primaryKey = $this->getProperty($this->primaryKeyField, false);
+        if ($primaryKey == 'Default') {
+            $primaryKey = 0;
+            $this->setProperty($this->primaryKeyField, 0);
         }
-        
-        $this->setProperty($this->primaryKeyField, $id);
-        
+
+        if (!$primaryKey) {
+            if (!$this->element) return $this->modx->lexicon('element_err_ns');
+            return true;
+        }
+
         return parent::initialize();
     }
 
@@ -50,32 +60,55 @@ class modPropertySetUpdateFromElementProcessor extends modPropertySetUpdateProce
         return $this->modx->fromJSON($this->getProperty('data'));
     }
 
-    public function beforeSet() {
-        
-        /*
-            It is necessary to set these values as their parent processor frays,
-            if they were not transferred to the parameters
-        */
-        
-        $this->setDefaultProperties(array(
-            'name'  => $this->object->get('name'),
-            'category'  => $this->object->get('category'),
-        ));
-        
-        return parent::beforeSet();
-    }
-    
     /**
      * Convert JSON data to array and unset default properties
      * @return bool
      */
     public function beforeSave() {
-        
-        $this->object->setProperties($this->getData());
-        
+        $data = $this->getData();
+
+        if ($this->element) {
+            $default = $this->element->getProperties();
+            foreach ($data as $k => $prop) {
+                if (array_key_exists($prop['name'],$default)) {
+                    if ($prop['value'] == $default[$prop['name']]) {
+                        unset($data[$k]);
+                    }
+                }
+            }
+        }
+
+        $this->setProperty('data', $data);
+
         return parent::beforeSave();
     }
-    
+
+    /**
+     * {@inheritDoc}
+     * @return mixed
+     */
+    public function process() {
+        if (!$this->object) {
+            $this->element->setProperties($this->getData());
+            $this->element->save();
+        } else {
+            /* Run the beforeSave method and allow stoppage */
+            $canSave = $this->beforeSave();
+            if ($canSave !== true) {
+                return $this->failure($canSave);
+            }
+
+            $this->object->setProperties($this->getProperty('data'));
+
+            if ($this->saveObject() == false) {
+                return $this->failure($this->modx->lexicon($this->objectType.'_err_save'));
+            }
+        }
+
+        $this->logManagerAction();
+        return $this->success();
+    }
+
     /**
      * Log the property set update from element manager action
      * @return void
@@ -84,10 +117,6 @@ class modPropertySetUpdateFromElementProcessor extends modPropertySetUpdateProce
         $key = $this->object ? $this->object->get($this->primaryKeyField) :
             $this->getProperty('elementType') . ' ' . $this->getProperty('elementId') .  ' Default';
         $this->modx->logManagerAction($this->objectType.'_update_from_element', $this->classKey, $key);
-    }
-    
-    public function cleanup(){
-        return $this->success('');
     }
 }
 


### PR DESCRIPTION
In the Property Set UI, a "bug fix" incorporated in 2.4.2 broke property sets causing them to save all properties from an element to the set, instead of only those modified from the Default property values for an element. This should restore that behavior but still prevent the reported bug which lead to this change.

This reverts commit bd61e77bfba648563f7bf0faeaab6efb2cc599dc introduced via PR #12614 intended to address a bug reported in #12580.

### What does it do?
Reverted the changes which prevented comparing default properties to the values being sent to the processor.

### Why is it needed?
Restoring intended behavior to property sets (i.e. saving only properties to the set with values modified from the default specified for the element they originated from).

### Related issue(s)/PR(s)
#12580
#12614
#12695
