### PR TITLE
Change modResource.description column to text

### DIFF
--- a/core/model/modx/mysql/modresource.map.inc.php
+++ b/core/model/modx/mysql/modresource.map.inc.php
@@ -99,8 +99,7 @@ $xpdo_meta_map['modResource']= array (
     ),
     'description' =>
     array (
-      'dbtype' => 'varchar',
-      'precision' => '191',
+      'dbtype' => 'text',
       'phptype' => 'string',
       'null' => false,
       'default' => '',

--- a/core/model/modx/sqlsrv/modresource.map.inc.php
+++ b/core/model/modx/sqlsrv/modresource.map.inc.php
@@ -96,7 +96,7 @@ $xpdo_meta_map['modResource']= array (
     'description' =>
     array (
       'dbtype' => 'nvarchar',
-      'precision' => '255',
+      'precision' => 'max',
       'phptype' => 'string',
       'null' => false,
       'default' => '',

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -872,7 +872,7 @@
         <field key="contentType" dbtype="varchar" precision="50" phptype="string" null="false" default="text/html" />
         <field key="pagetitle" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="longtitle" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
+        <field key="description" dbtype="text" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="alias" dbtype="varchar" precision="191" phptype="string" null="true" default="" index="index" />
         <field key="link_attributes" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
         <field key="published" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -825,7 +825,7 @@
         <field key="contentType" dbtype="nvarchar" precision="50" phptype="string" null="false" default="text/html" />
         <field key="pagetitle" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="longtitle" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
-        <field key="description" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
+        <field key="description" dbtype="nvarchar" precision="max" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="alias" dbtype="nvarchar" precision="255" phptype="string" null="true" default="" index="index" />
         <field key="link_attributes" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" />
         <field key="published" dbtype="bit" phptype="boolean" null="false" default="0" index="index" />

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -586,7 +586,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,description: '<b>[[*description]]</b><br />'+_('resource_description_help')
             ,name: 'description'
             ,id: 'modx-resource-description'
-            ,maxLength: 255
+            ,grow: true
             ,anchor: '100%'
             ,value: config.record.description || ''
 

--- a/setup/includes/upgrades/common/2.7-description-text.php
+++ b/setup/includes/upgrades/common/2.7-description-text.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Common upgrade script for 2.7 modResource
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+/* modify modResource.description field */
+$class = 'modResource';
+$table = $modx->getTableName($class);
+
+$description = $this->install->lexicon('alter_column',array('column' => 'description','table' => $table));
+$this->processResults($class, $description, array($modx->manager, 'alterField'), array($class, 'description'));

--- a/setup/includes/upgrades/mysql/2.7.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.7.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-description-text.php';

--- a/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Specific upgrades for Revolution 2.6.0-pl
+ * Specific upgrades for Revolution 2.7.0-pl
  *
  * @var modX $modx
  * @package setup
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-description-text.php';

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -7,6 +7,7 @@
  */
 $_lang['add_column'] = 'Added new `[[+column]]` column to `[[+table]]`.';
 $_lang['add_index'] = 'Added new index on `[[+index]]` for table `[[+table]]`.';
+$_lang['alter_column'] = 'Modified column `[[+column]]` in table `[[+table]]`.';
 $_lang['add_moduser_classkey'] = 'Added class_key field to support modUser derivatives.';
 $_lang['added_cachepwd'] = 'Added cachepwd field missing in early Revolution releases.';
 $_lang['added_content_ft_idx'] = 'Added new `content_ft_idx` full-text index on the fields `pagetitle`, `longtitle`, `description`, `introtext`, `content`.';

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -7,7 +7,7 @@
  */
 $_lang['add_column'] = 'Added new `[[+column]]` column to `[[+table]]`.';
 $_lang['add_index'] = 'Added new index on `[[+index]]` for table `[[+table]]`.';
-$_lang['alter_column'] = 'Modified column `[[+column]]` in table `[[+table]]`.';
+$_lang['alter_column'] = 'Modified column `[[+column]]` in table [[+table]].';
 $_lang['add_moduser_classkey'] = 'Added class_key field to support modUser derivatives.';
 $_lang['added_cachepwd'] = 'Added cachepwd field missing in early Revolution releases.';
 $_lang['added_content_ft_idx'] = 'Added new `content_ft_idx` full-text index on the fields `pagetitle`, `longtitle`, `description`, `introtext`, `content`.';


### PR DESCRIPTION
### What does it do?
Changes the type of modResource.description from varchar(255) to text
![screen shot 2018-03-02 at 16 57 43](https://user-images.githubusercontent.com/1257284/36908420-72b34b1e-1e3b-11e8-94cb-3800318f9737.png)

### Why is it needed?
To use more letters in description and work better with crawlers

### Related issue(s)/PR(s)
#13738 
