### PR TITLE
Make manager search search by id for all objects

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -198,6 +198,7 @@ class modSearchProcessor extends modProcessor
         $c->where(array(
             'name:LIKE' => '%' . $this->query . '%',
             'OR:description:LIKE' => '%' . $this->query .'%',
+            'OR:id:=' => $this->query,
         ));
 
         $c->limit($this->maxResults);
@@ -223,6 +224,7 @@ class modSearchProcessor extends modProcessor
         $c->where(array(
             'name:LIKE' => '%' . $this->query . '%',
             'OR:description:LIKE' => '%' . $this->query .'%',
+            'OR:id:=' => $this->query,
         ));
 
         $c->limit($this->maxResults);
@@ -248,6 +250,7 @@ class modSearchProcessor extends modProcessor
         $c->where(array(
             'templatename:LIKE' => '%' . $this->query . '%',
             'OR:description:LIKE' => '%' . $this->query .'%',
+            'OR:id:=' => $this->query,
         ));
 
         $c->limit($this->maxResults);
@@ -273,6 +276,7 @@ class modSearchProcessor extends modProcessor
         $c->where(array(
             'name:LIKE' => '%' . $this->query . '%',
             'OR:description:LIKE' => '%' . $this->query .'%',
+            'OR:id:=' => $this->query,
         ));
 
         $c->limit($this->maxResults);
@@ -298,6 +302,7 @@ class modSearchProcessor extends modProcessor
         $c->where(array(
             'name:LIKE' => '%' . $this->query . '%',
             'OR:caption:LIKE' => '%' . $this->query .'%',
+            'OR:id:=' => $this->query,
         ));
 
         $c->limit($this->maxResults);
@@ -329,6 +334,7 @@ class modSearchProcessor extends modProcessor
             'username:LIKE' => '%' . $this->query . '%',
             'OR:Profile.fullname:LIKE' => '%' . $this->query .'%',
             'OR:Profile.email:LIKE' => '%' . $this->query .'%',
+            'OR:id:=' => $this->query,
         ));
 
         $c->limit($this->maxResults);


### PR DESCRIPTION
Error messages identify snippets and plugins by ID, not by name, and on a large site they can be very difficult to find. Occasionally, there is a need to search  for other objects by ID as well and the cost of adding that search criterion is small.

### What does it do?
Add id to fields to be searched.
`'OR:id:=' => $this->query,`

### Why is it needed?
see #13803

### Related issue(s)/PR(s)
#13803