### PR TITLE
Media manager optimizations

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1100,7 +1100,7 @@ $settings['manager_week_start']->fromArray(array (
 $settings['modx_browser_tree_hide_files']= $xpdo->newObject('modSystemSetting');
 $settings['modx_browser_tree_hide_files']->fromArray(array (
   'key' => 'modx_browser_tree_hide_files',
-  'value' => false,
+  'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',

--- a/connectors/system/phpthumb.php
+++ b/connectors/system/phpthumb.php
@@ -3,6 +3,8 @@
  * @var modX $modx
  * @package modx
  */
+
+session_cache_limiter('public');
 define('MODX_CONNECTOR_INCLUDED', 1);
 require_once dirname(__DIR__).'/index.php';
 $_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -472,7 +472,7 @@ $_lang['setting_modRequest.class'] = 'Request Handler Class';
 $_lang['setting_modRequest.class_desc'] = '';
 
 $_lang['setting_modx_browser_tree_hide_files'] = 'Media Browser Tree Hide Files';
-$_lang['setting_modx_browser_tree_hide_files_desc'] = 'If true the files inside folders are not displayed in the Media Browser source tree. Defaults to false.';
+$_lang['setting_modx_browser_tree_hide_files_desc'] = 'If true the files inside folders are not displayed in the Media Browser source tree.';
 
 $_lang['setting_modx_browser_tree_hide_tooltips'] = 'Media Browser Tree Hide Tooltips';
 $_lang['setting_modx_browser_tree_hide_tooltips_desc'] = 'If true, no image preview tooltips are shown when hovering over a file in the Media Browser tree. Defaults to true.';

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -269,6 +269,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                     'q' => $thumbnailQuality,
                                     'wctx' => $this->ctx->get('key'),
                                     'source' => $this->get('id'),
+                                    't' => $file->getMTime(),
                                 ));
                                 $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                             } else {
@@ -1115,6 +1116,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                 'q' => $thumbnailQuality,
                                 'wctx' => $this->ctx->get('key'),
                                 'source' => $this->get('id'),
+                                't' => $file->getMTime(),
                             ));
                             $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($imageQuery);
                             $thumbQuery = http_build_query(array(
@@ -1126,6 +1128,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                 'q' => $thumbnailQuality,
                                 'wctx' => $this->ctx->get('key'),
                                 'source' => $this->get('id'),
+                                't' => $file->getMTime(),
                             ));
                             $thumb = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL).'system/phpthumb.php?'.urldecode($thumbQuery);
                         } else {

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -58,10 +58,40 @@ MODx.browser.View = function(config) {
         }
         ,tpl: MODx.config.modx_browser_default_viewmode === 'list' ? this.templates.list : this.templates.thumb
         ,itemSelector: MODx.config.modx_browser_default_viewmode === 'list' ? 'div.modx-browser-list-item' : 'div.modx-browser-thumb-wrap'
+        ,thumbnails: []
+        ,lazyLoad: function() {
+            var height = this.getEl().parent().getHeight() + 100;
+            for (var i = 0; i < this.thumbnails.length; i++) {
+                var image = this.thumbnails[i];
+                if (image !== undefined) {
+                    var rect = image.getBoundingClientRect();
+                    if (rect.top >= 0 && rect.left >= 0 && rect.top <= height) {
+                        var src = image.getAttribute('data-src');
+                        if (src !== null && src !== undefined) {
+                            image.src = src;
+                            image.removeAttribute('data-src');
+                            delete(this.thumbnails[i]);
+                        }
+                    }
+                }
+            }
+        }
+        ,refresh: function() {
+            MODx.DataView.prototype.refresh.call(this);
+            this.thumbnails = Array.prototype.slice.call(document.querySelectorAll('img[data-src]'));
+            this.lazyLoad();
+        }
         ,listeners: {
             'selectionchange': {fn:this.showDetails, scope:this, buffer:100}
             ,'dblclick': config.onSelect || {fn:Ext.emptyFn,scope:this}
             ,'render': {fn:this.sortStore, scope:this}
+            ,'afterrender': {
+                fn: function() {
+                    this.getEl().parent().on('scroll', function() {
+                        this.lazyLoad();
+                    }, this);
+                }, scope:this
+            }
         }
         ,prepareData: this.formatData.createDelegate(this)
     });
@@ -309,7 +339,8 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             '<tpl for=".">'
                 ,'<div class="modx-browser-thumb-wrap" id="{name}" title="{name}">'
                 ,'  <div class="modx-browser-thumb">'
-                ,'      <img src="{thumb}" width="{thumb_width}" height="{thumb_height}" alt="{name}" title="{name}" />'
+                ,'      <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" ' +
+                            'data-src="{thumb}" width="{thumb_width}" height="{thumb_height}" alt="{name}" title="{name}" />'
                 ,'  </div>'
                 ,'  <span>{shortName}</span>'
                 ,'</div>'

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -66,12 +66,8 @@ MODx.browser.View = function(config) {
                 if (image !== undefined) {
                     var rect = image.getBoundingClientRect();
                     if (rect.top >= 0 && rect.left >= 0 && rect.top <= height) {
-                        var src = image.getAttribute('data-src');
-                        if (src !== null && src !== undefined) {
-                            image.src = src;
-                            image.removeAttribute('data-src');
-                            delete(this.thumbnails[i]);
-                        }
+                        image.src = image.getAttribute('data-src');
+                        delete(this.thumbnails[i]);
                     }
                 }
             }

--- a/setup/includes/upgrades/common/2.7-browser-tree-hide-files.php
+++ b/setup/includes/upgrades/common/2.7-browser-tree-hide-files.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Common upgrade script for enabling modx_browser_tree_hide_files System Setting
+ *
+ * @var modX $modx
+ * @package setup
+ */
+if ($object = $modx->getObject('modSystemSetting', array('key' => 'modx_browser_tree_hide_files', 'value' => 0), false)) {
+    $object->set('value', 1);
+    $object->save();
+}

--- a/setup/includes/upgrades/mysql/2.7.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.7.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-browser-tree-hide-files.php';

--- a/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-browser-tree-hide-files.php';


### PR DESCRIPTION
### What does it do?
Enabled modx_browser_tree_hide_files system setting by default
Enabled caching of images from phpthumb connector by browser
Lazy load of images in media browser

### Why is it needed?
To make media manager work faster and make less requests to server. 

Tested on directory with more than 2700 images (click to see gif)
[![](https://file.modx.pro/files/c/0/9/c09336f9fd12106c40d65087cc3491f9s.jpg)](https://file.modx.pro/files/c/0/9/c09336f9fd12106c40d65087cc3491f9.gif)

### Related issue(s)/PR(s)
#13633
