### PR TITLE
Fix too much data being sent along to the package install request

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -94,17 +94,16 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
 		var topic = '/workspace/package/install/'+r.signature+'/';
         g.loadConsole(Ext.getBody(),topic);
 
-		va = va || {};
-        Ext.apply(va,{
+        var params = {
             action: 'workspace/packages/install'
             ,signature: r.signature
             ,register: 'mgr'
             ,topic: topic
-        });
+        };
 
         MODx.Ajax.request({
             url: MODx.config.connector_url
-            ,params: va
+            ,params: params
             ,listeners: {
                 'success': {fn:function() {
                     var bc = Ext.getCmp('packages-breadcrumbs');


### PR DESCRIPTION
### What does it do?

In the (ExtJS) package install handler, the `va` variable is the event being fed into the install method. This is a click event on the "Continue" button. This data was then being added on with the signature and registry information for the console for the actual installation to be done server-side. 

All the data in `va` is unnecessary for the installation. It contains raw javascript code (the handler code on the button) and all sorts of other event data. I've removed the va variable from being used here.   

### Why is it needed?

Aside from sending way too much data, some of this data is likely to trigger firewalls/mod_security type WAFs. This would prevent people from installing packages in such environments.

### How to test?

Keep the browser dev tools open when starting a package installation/reinstallation/update. Note the first request to connector.php at this point. Prior to the patch, it sends lots of javascript data in the request parameters. After the patch, only the information needed to do the install is sent.

### Related issue(s)/PR(s)

modmore support ticket 16334, related forum thread https://forums.modx.com/thread/103572/extras-fail-to-update-install#dis-post-557258
