### PR TITLE
Clean the system settings cache after saving system settings

### DIFF
--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -557,7 +557,9 @@ class modCacheManager extends xPDOCacheManager {
                     $results['auto_publish'] = $this->autoPublish($partOptions);
                     break;
                 case 'system_settings':
-                    $results['system_settings'] = ($this->generateConfig($partOptions) ? true : false);
+                    if ($results['system_settings'] = $this->clean($partOptions)) {
+                        $results['system_settings'] = ($this->generateConfig($partOptions) ? true : false);
+                    }
                     break;
                 case 'context_settings':
                     if (array_key_exists('contexts', $partOptions)) {


### PR DESCRIPTION
### What does it do?
It makes sure we clean the system settings cache after saving them. 

### Why is it needed?
It solves an issue where the cache has to be deleted manually when turning on/off cache_system_settings. 

### Related issue(s)/PR(s)
#13816 