### PR TITLE
Save resource given from controller to proper render of TVs

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -332,6 +332,9 @@ class modTemplateVar extends modElement {
             $resource = $this->xpdo->resource;
         }
         $resourceId = $resource ? $resource->get('id') : 0;
+        if ($resource) {
+            $this->xpdo->resource = $resource;
+        }
 
         if (is_string($options) && !empty($options)) {
             // fall back to deprecated $style setting


### PR DESCRIPTION
### What does it do?
If modElement::renderInput() method will get resource object, it should be loaded as current resource so any TVs can check it properties and act correctly

### Why is it needed?
It fixes weird issues when you create a new resource in another context but TVs uses context "web".

### Related issue(s)/PR(s)
#13609
