### PR TITLE
Fix for #13609

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -330,6 +330,8 @@ class modTemplateVar extends modElement {
         }
         if (empty($resource)) {
             $resource = $this->xpdo->resource;
+        } else {
+            $this->xpdo->resource = $resource;
         }
         $resourceId = $resource ? $resource->get('id') : 0;
 


### PR DESCRIPTION
### What does it do?
If modElement::renderInput() method will get resource object, it should be loaded as current resource so any TVs can check it properties and act correctly

### Why is it needed?
It fixes weird issues when you create a new resource in another context but TVs uses context "web".

### Related issue(s)/PR(s)
#13609

_Recreated this PR because of wrong target branch_