### PR TITLE
Fix incorrect description and validation for aliases/URIs per #13815

### DIFF
--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -315,7 +315,7 @@ $_lang['setting_friendly_alias_lowercase_only'] = 'FURL Lowercase Aliases';
 $_lang['setting_friendly_alias_lowercase_only_desc'] = 'Determines whether to allow only lowercase characters in a Resource alias.';
 
 $_lang['setting_friendly_alias_max_length'] = 'FURL Alias Maximum Length';
-$_lang['setting_friendly_alias_max_length_desc'] = 'If greater than zero, the maximum number of characters to allow in a Resource alias. Zero equals unlimited.';
+$_lang['setting_friendly_alias_max_length_desc'] = 'If greater than zero, the maximum number of characters to allow in a Resource alias. When set to zero, the length of the alias per resource is not specifically limited, however a maximum of 191 characters for URI is still in effect.';
 
 $_lang['setting_friendly_alias_realtime'] = 'FURL Alias Real-Time';
 $_lang['setting_friendly_alias_realtime_desc'] = 'Determines whether a resource alias should be created on the fly when typing the pagetitle or if this should happen when the resource is saved (automatic_alias needs to be enabled for this to have an effect).';

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -850,7 +850,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,description: '<b>[[*uri]]</b><br />'+_('resource_uri_help')
             ,name: 'uri'
             ,id: 'modx-resource-uri'
-            ,maxLength: 255
+            ,maxLength: 191
             ,anchor: '70%'
             ,value: config.record.uri || ''
             ,hidden: !config.record.uri_override


### PR DESCRIPTION
### What does it do?
Updates the lexicon description to indicate the limit on aliases isn't technically unlimited, but maximum 191 characters. Also updates validation on the uri field to properly use the same length.

### Why is it needed?
Inconsisten behaviour/error messages as discussed in #13815.

### Related issue(s)/PR(s)
#13815 
