### PR TITLE
Restore core/cache/.gitignore after accidentally removing it in earlier merge

### DIFF
--- a/core/cache/.gitignore
+++ b/core/cache/.gitignore
@@ -1,0 +1,4 @@
+# ignore everything
+*
+# except .gitignore
+!.gitignore


### PR DESCRIPTION
### What does it do?
Restores the core/cache/.gitignore file, which acts as a gitkeep of sorts, and also makes sure cache files don't accidentally get committed.

### Why is it needed?
Accidentally removed this in merge commit 5a385693c76c69e9ac9fdc2623740a9dd1b2dbe3 from #13786 

### Related issue(s)/PR(s)
#13786