### PR TITLE
Remove cache_system_settings from the installation

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -303,15 +303,6 @@ $settings['cache_scripts']->fromArray(array (
   'area' => 'caching',
   'editedon' => null,
 ), '', true, true);
-$settings['cache_system_settings']= $xpdo->newObject('modSystemSetting');
-$settings['cache_system_settings']->fromArray(array (
-  'key' => 'cache_system_settings',
-  'value' => '1',
-  'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'caching',
-  'editedon' => null,
-), '', true, true);
 $settings['clear_cache_refresh_trees']= $xpdo->newObject('modSystemSetting');
 $settings['clear_cache_refresh_trees']->fromArray(array (
   'key' => 'clear_cache_refresh_trees',


### PR DESCRIPTION
### What does it do?

Remove the `cache_system_settings` setting from the build data. It's not removed on upgrade, but wont be created on new installations.

### Why is it needed?

This option cannot logically work as a system setting. 

When MODX is initialized, it has to first load the settings (which will use the cache), **before** it can determine if the cache should be used according to this setting. Does not compute. 

If people want to disable the system settings cache, which I DO NOT recommend at all, that has to be added to the `$config_options` array in the core/config/config.inc.php file to make sure it is available from the start.

The symptoms of this problem is that changed system settings don't seem to apply. This is described in #13816 with a PR #13817 which uses the wrong hammer for the type of nail. 

### Related issue(s)/PR(s)

#13816, #13817 