### PR TITLE
[WIP/PoC] YAML config file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
         "phpmailer/phpmailer": "^6.0",
         "smarty/smarty": "^3.1",
         "james-heinrich/phpthumb": "^1.7",
-        "pelago/emogrifier": "^2.0"
+        "pelago/emogrifier": "^2.0",
+        "symfony/yaml": "^4.0"
     },
     "autoload": {
         "classmap": ["core/xpdo/"]

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -8,6 +8,9 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Yaml\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
 /**
  * This is the main file to include in your scripts to use MODX.
  *
@@ -460,6 +463,10 @@ class modX extends xPDO {
         }
     }
 
+    private static function configFileExists($configPath, $suffix) {
+        return file_exists($configPath . MODX_CONFIG_KEY . '.' . $suffix);
+    }
+
     /**
      * Load the modX configuration when creating an instance of modX.
      *
@@ -467,58 +474,256 @@ class modX extends xPDO {
      * @param array $data Data provided to initialize the instance with, overriding config file entries.
      * @param null $driverOptions Driver options for the primary connection.
      * @return array The merged config data ready for use by the modX::__construct() method.
+     * @throws xPDOException Throw exception if we are unable to load the config file
      */
     protected function loadConfig($configPath = '', $data = array(), $driverOptions = null) {
-        if (!is_array($data)) $data = array();
+        if (!is_array($data)) {
+            $data = array();
+        }
+
         modX :: protect();
+
         if (!defined('MODX_CONFIG_KEY')) {
             define('MODX_CONFIG_KEY', 'config');
         }
         if (empty ($configPath)) {
             $configPath= MODX_CORE_PATH . 'config/';
         }
-        global $database_dsn, $database_user, $database_password, $config_options, $driver_options, $table_prefix, $site_id, $uuid;
-        if (file_exists($configPath . MODX_CONFIG_KEY . '.inc.php') && include ($configPath . MODX_CONFIG_KEY . '.inc.php')) {
-            $cachePath= MODX_CORE_PATH . 'cache/';
-            if (MODX_CONFIG_KEY !== 'config') $cachePath .= MODX_CONFIG_KEY . '/';
-            if (!is_array($config_options)) $config_options = array();
-            if (!is_array($driver_options)) $driver_options = array();
-            $data = array_merge(
-                array (
-                    xPDO::OPT_CACHE_KEY => 'default',
-                    xPDO::OPT_CACHE_HANDLER => 'xPDO\Cache\xPDOFileCache',
-                    xPDO::OPT_CACHE_PATH => $cachePath,
-                    xPDO::OPT_TABLE_PREFIX => $table_prefix,
-                    xPDO::OPT_HYDRATE_FIELDS => true,
-                    xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
-                    xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
-                    xPDO::OPT_VALIDATOR_CLASS => 'validation.modValidator',
-                    xPDO::OPT_VALIDATE_ON_SAVE => true,
-                    'cache_system_settings' => true,
-                    'cache_system_settings_key' => 'system_settings'
-                ),
-                $config_options,
-                $data
-            );
-            $primaryConnection = array(
-                'dsn' => $database_dsn,
-                'username' => $database_user,
-                'password' => $database_password,
-                'options' => array(
-                    xPDO::OPT_CONN_MUTABLE => isset($data[xPDO::OPT_CONN_MUTABLE]) ? (boolean) $data[xPDO::OPT_CONN_MUTABLE] : true,
-                ),
-                'driverOptions' => $driver_options
-            );
-            if (!array_key_exists(xPDO::OPT_CONNECTIONS, $data) || !is_array($data[xPDO::OPT_CONNECTIONS])) {
-                $data[xPDO::OPT_CONNECTIONS] = array();
-            }
-            array_unshift($data[xPDO::OPT_CONNECTIONS], $primaryConnection);
-            if (!empty($site_id)) $this->site_id = $site_id;
-            if (!empty($uuid)) $this->uuid = $uuid;
-        } else {
+
+        if (!static::configFileExists($configPath, 'inc.php') and !static::configFileExists($configPath, 'yaml.php')) {
             throw new xPDOException("Could not load MODX config file.");
         }
+
+        if (static::configFileExists($configPath, '.inc.php')) {
+            // Use legacy (old) modx config files
+            return $this->loadLegacyConfig($configPath, $data, $driverOptions);
+        }
+
+        return $this->loadYAMLConfig($configPath, $data, $driverOptions);
+    }
+
+    protected function loadLegacyConfig($configPath, $data, $driverOptions) {
+        global $database_dsn, $database_user, $database_password, $config_options, $driver_options, $table_prefix, $site_id, $uuid;
+
+        if (!@include($configPath . MODX_CONFIG_KEY . '.inc.php')) {
+            throw new xPDOException("Could not load MODX config file.");
+        }
+
+        $cachePath= MODX_CORE_PATH . 'cache/';
+        if (MODX_CONFIG_KEY !== 'config') $cachePath .= MODX_CONFIG_KEY . '/';
+        if (!is_array($config_options)) $config_options = array();
+        if (!is_array($driver_options)) $driver_options = array();
+        $data = array_merge(
+            array (
+                xPDO::OPT_CACHE_KEY => 'default',
+                xPDO::OPT_CACHE_HANDLER => 'xPDO\Cache\xPDOFileCache',
+                xPDO::OPT_CACHE_PATH => $cachePath,
+                xPDO::OPT_TABLE_PREFIX => $table_prefix,
+                xPDO::OPT_HYDRATE_FIELDS => true,
+                xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
+                xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
+                xPDO::OPT_VALIDATOR_CLASS => 'validation.modValidator',
+                xPDO::OPT_VALIDATE_ON_SAVE => true,
+                'cache_system_settings' => true,
+                'cache_system_settings_key' => 'system_settings'
+            ),
+            $config_options,
+            $data
+        );
+        $primaryConnection = array(
+            'dsn' => $database_dsn,
+            'username' => $database_user,
+            'password' => $database_password,
+            'options' => array(
+                xPDO::OPT_CONN_MUTABLE => isset($data[xPDO::OPT_CONN_MUTABLE]) ? (boolean) $data[xPDO::OPT_CONN_MUTABLE] : true,
+            ),
+            'driverOptions' => $driver_options
+        );
+
+        if (!array_key_exists(xPDO::OPT_CONNECTIONS, $data) || !is_array($data[xPDO::OPT_CONNECTIONS])) {
+            $data[xPDO::OPT_CONNECTIONS] = array();
+        }
+
+        array_unshift($data[xPDO::OPT_CONNECTIONS], $primaryConnection);
+
+        if (!empty($site_id)) {
+            $this->site_id = $site_id;
+        }
+
+        if (!empty($uuid)) {
+            $this->uuid = $uuid;
+        }
+
         return $data;
+    }
+
+    protected function loadYAMLConfig($configPath, $data, $driverOptions) {
+        try {
+            $config = Yaml::parseFile($configPath . MODX_CONFIG_KEY . '.yaml.php');
+            return $this->processYAMLConfig($config, $data, $driverOptions);
+        }
+        catch (ParseException $e) {
+            throw new xPDOException("Could not load MODX config file.");
+        }
+    }
+
+    private function processYAMLConfig($config, $data, $driverOptions) {
+        if (!is_array($config['modx']) or !is_array($config['modx']['db'])) {
+            return [];
+        }
+
+        $this->processYAMLConfigPaths($config);
+        $this->processYAMLConfigURLs($config);
+        $this->processYAMLConfigLogLevels($config);
+
+        $this->resolveYAMLConfigRequestSettings($config);
+
+        if (!empty($config['modx']['id'])) {
+            $this->site_id = $config['modx']['id'];
+        }
+        if (!empty($config['modx']['uuid'])) {
+            $this->uuid = $config['modx']['uuid'];
+        }
+
+        if (!defined('MODX_CACHE_DISABLED')) {
+            // TODO fallback to false
+            define('MODX_CACHE_DISABLED', $config['modx']['disable_cache']);
+        }
+
+        $cachePath= MODX_CORE_PATH . 'cache/';
+        if (MODX_CONFIG_KEY !== 'config') {
+            $cachePath .= MODX_CONFIG_KEY . '/';
+        }
+
+        if (!is_array($config['modx']['db']['config_options'])) {
+            $config['modx']['db']['config_options'] = array();
+        }
+        if (!is_array($config['modx']['db']['driver_options'])) {
+            $config['modx']['db']['driver_options'] = array();
+        }
+
+        $data = array_merge(
+            array (
+                xPDO::OPT_CACHE_KEY => 'default',
+                xPDO::OPT_CACHE_HANDLER => 'xPDO\Cache\xPDOFileCache',
+                xPDO::OPT_CACHE_PATH => $cachePath,
+                xPDO::OPT_TABLE_PREFIX => $config['modx']['db']['table_prefix'],
+                xPDO::OPT_HYDRATE_FIELDS => true,
+                xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
+                xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
+                xPDO::OPT_VALIDATOR_CLASS => 'validation.modValidator',
+                xPDO::OPT_VALIDATE_ON_SAVE => true,
+                'cache_system_settings' => true,
+                'cache_system_settings_key' => 'system_settings'
+            ),
+            $config['modx']['db']['config_options'],
+            $data
+        );
+        $primaryConnection = array(
+            'dsn' => $config['modx']['db']['dns'],
+            'username' => $config['modx']['db']['user'],
+            'password' => $config['modx']['db']['password'],
+            'options' => array(
+                xPDO::OPT_CONN_MUTABLE => isset($data[xPDO::OPT_CONN_MUTABLE]) ? (boolean) $data[xPDO::OPT_CONN_MUTABLE] : true,
+            ),
+            'driverOptions' => $config['modx']['db']['driver_options']
+        );
+
+        if (!array_key_exists(xPDO::OPT_CONNECTIONS, $data) || !is_array($data[xPDO::OPT_CONNECTIONS])) {
+            $data[xPDO::OPT_CONNECTIONS] = array();
+        }
+
+        array_unshift($data[xPDO::OPT_CONNECTIONS], $primaryConnection);
+
+        return $data;
+    }
+
+    private function processYAMLConfigPaths($config) {
+        if (!isset($config['modx']['paths'])) {
+            return null;
+        }
+
+        if (!defined('MODX_CORE_PATH')) {
+            define('MODX_CORE_PATH', $config['modx']['paths']['core']);
+        }
+        if (!defined('MODX_PROCESSORS_PATH')) {
+            define('MODX_PROCESSORS_PATH', $config['modx']['paths']['processors']);
+        }
+        if (!defined('MODX_CONNECTORS_PATH')) {
+            define('MODX_CONNECTORS_PATH', $config['modx']['paths']['connectors']);
+        }
+        if (!defined('MODX_MANAGER_PATH')) {
+            define('MODX_MANAGER_PATH', $config['modx']['paths']['manager']);
+        }
+        if (!defined('MODX_BASE_PATH')) {
+            define('MODX_BASE_PATH', $config['modx']['paths']['base']);
+        }
+        if (!defined('MODX_ASSETS_PATH')) {
+            define('MODX_ASSETS_PATH', $config['modx']['paths']['assets']);
+        }
+    }
+
+    private function processYAMLConfigURLs($config) {
+        if (!isset($config['modx']['urls'])) {
+            return null;
+        }
+
+        if (!defined('MODX_CONNECTORS_URL')) {
+            define('MODX_CONNECTORS_URL', $config['modx']['urls']['connectors']);
+        }
+        if (!defined('MODX_MANAGER_URL')) {
+            define('MODX_MANAGER_URL', $config['modx']['urls']['manager']);
+        }
+        if (!defined('MODX_BASE_URL')) {
+            define('MODX_BASE_URL', $config['modx']['urls']['base']);
+        }
+        if (!defined('MODX_ASSETS_URL')) {
+            define('MODX_ASSETS_URL', $config['modx']['urls']['assets']);
+        }
+    }
+
+    private function processYAMLConfigLogLevels($config) {
+        if (!isset($config['modx']['log_levels'])) {
+            return null;
+        }
+
+        if (!defined('MODX_LOG_LEVEL_FATAL')) {
+            define('MODX_LOG_LEVEL_FATAL', $config['modx']['log_levels']['fatal']);
+            define('MODX_LOG_LEVEL_ERROR', $config['modx']['log_levels']['error']);
+            define('MODX_LOG_LEVEL_WARN', $config['modx']['log_levels']['warn']);
+            define('MODX_LOG_LEVEL_INFO', $config['modx']['log_levels']['info']);
+            define('MODX_LOG_LEVEL_DEBUG', $config['modx']['log_levels']['debug']);
+        }
+    }
+
+    private function resolveYAMLConfigRequestSettings($config) {
+        if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
+            $isSecureRequest = false;
+        } else {
+            $isSecureRequest = ((isset ($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') || $_SERVER['SERVER_PORT'] == $config['modx']['https_port']);
+        }
+        if (!defined('MODX_URL_SCHEME')) {
+            $url_scheme=  $isSecureRequest ? 'https://' : 'http://';
+            define('MODX_URL_SCHEME', $url_scheme);
+        }
+        if (!defined('MODX_HTTP_HOST')) {
+            if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
+                $http_host='192.168.99.100:8000';
+                define('MODX_HTTP_HOST', $http_host);
+            } else {
+                $http_host= array_key_exists('HTTP_HOST', $_SERVER) ? htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES) : '192.168.99.100:8000';
+                if ($_SERVER['SERVER_PORT'] != 80) {
+                    $http_host= str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
+                }
+                $http_host .= ($_SERVER['SERVER_PORT'] == 80 || $isSecureRequest) ? '' : ':' . $_SERVER['SERVER_PORT'];
+                define('MODX_HTTP_HOST', $http_host);
+            }
+        }
+        if (!defined('MODX_SITE_URL')) {
+            // TODO
+            $site_url= $url_scheme . $http_host . MODX_BASE_URL;
+            define('MODX_SITE_URL', $site_url);
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do?
This work-in-progress Proof of Concept uses a YAML config file, instead of the regular _config.inc.php_ file. 

We use the _symphony/yaml_ library for parsing the file. Note that the file type is `.yaml.php`. This was ment to make the file unreadable from the internet, but I realize now that that will not work because we have no opening `<?php`  tag in the file. Not sure how to handle this.

An example of a working config file looks like this:

```
modx:
  db:
    type: mysql
    server: db
    user: revolution
    password: revolution
    connection_charset: utf8
    database: revolution
    table_prefix: modx_
    dns: mysql:host=db;dbname=revolution;charset=utf8
    config_options:
    driver_options:
  last_install_time: 1511612195
  id: modx5a195f23229026.07399157
  https_port: 443
  uuid: 55e54c57-9018-44cd-ba9a-5bfcc0b3bec0
  url_scheme: automatic
  http_host: 192.168.99.100:8000
  disable_cache: false
  paths:
    base: /var/www/html/
    core: /var/www/html/core/
    processors: /var/www/html/core/model/modx/processors/
    connectors: /var/www/html/connectors/
    manager: /var/www/html/manager/
    assets: /var/www/html/assets/
  urls:
    base: /
    connectors: /connectors/
    manager: /manager/
    assets: /assets/
  log_levels:
    fatal: 0
    error: 1
    warn: 2
    info: 3
    debug: 4
```

Note that there is still a lot work that needs to be done on this (installation, upgrade, migration from 2.x etc). I am also considering moving the YAML logic out of the MODX class to avoid bloating it even more.

This PR works if you install the composer depdency and place the config content above in the file `core/config/config.yaml.php` (on traditional installations).

Also note that this PoC is backwards compatible with the old `config.inc.php` type config files.

### Why is it needed?
The benefit of using a YAML config file is that we can avoid some global variables that can cause problems with other systems (we experienced this with phpBB). YAML files are also more readable and easier to edit. This leads to less chance of bugs or problems. We can also mitigate away from having logic in the config files. This should be placed in the actual MODX code, not resolved in the config itself. There is still some work left to do here. The plan is to slim the config down, meaning remove redundant settings.