### PR TITLE
Use the correct ISO 3166 code‎ for Sint Maarten

### DIFF
--- a/core/lexicon/country/ar.inc.php
+++ b/core/lexicon/country/ar.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'سورينام'; // Suriname
 $_country_lang["ss"] = 'جنوب السودان'; // South Sudan
 $_country_lang["st"] = 'ساو تومي وبرينسيبي'; // Sao Tome and Principe
 $_country_lang["sv"] = 'السلفادور'; // El Salvador
-$_country_lang["sc"] = 'سانت مارتن (الجزء الهولندي)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'سانت مارتن (الجزء الهولندي)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'الجمهورية العربية السورية'; // Syrian Arab Republic
 $_country_lang["sz"] = 'سويسرا'; // Swaziland
 

--- a/core/lexicon/country/be.inc.php
+++ b/core/lexicon/country/be.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Сурынам'; // Suriname
 $_country_lang["ss"] = 'Паўднёвы Судан'; // South Sudan
 $_country_lang["st"] = 'Сан-Томе і Прынсэп'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Сальвадор'; // El Salvador
-$_country_lang["sc"] = 'Сінт-Маартен (Галандская частка)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Сінт-Маартен (Галандская частка)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Сірыя'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Свазіленд'; // Swaziland
 

--- a/core/lexicon/country/bg.inc.php
+++ b/core/lexicon/country/bg.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Суринам'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'Сао Томе и Принсипи'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Салвадор'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Сирия '; // Syrian Arab Republic
 $_country_lang["sz"] = 'Свазиленд'; // Swaziland
 

--- a/core/lexicon/country/cs.inc.php
+++ b/core/lexicon/country/cs.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Surinam'; // Suriname
 $_country_lang["ss"] = 'Jižní Súdán'; // South Sudan
 $_country_lang["st"] = 'Svatý Tomáš a Princův ostrov'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Salvador'; // El Salvador
-$_country_lang["sc"] = 'Saint Maarten (nizozemská část)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Saint Maarten (nizozemská část)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Sjednocená arabská republika'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Svazijsko'; // Swaziland
 

--- a/core/lexicon/country/da.inc.php
+++ b/core/lexicon/country/da.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Surinam'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'Sao Tome og Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syrien'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swaziland'; // Swaziland
 

--- a/core/lexicon/country/de.inc.php
+++ b/core/lexicon/country/de.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'Südsudan'; // South Sudan
 $_country_lang["st"] = 'São Tomé und Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (niederländischer Teil)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (niederländischer Teil)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syrien'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swasiland'; // Swaziland
 

--- a/core/lexicon/country/el.inc.php
+++ b/core/lexicon/country/el.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Σουρινάμ'; // Suriname
 $_country_lang["ss"] = 'Νότιο Σουδάν'; // South Sudan
 $_country_lang["st"] = 'Σάο Τομέ και Πρίνσιπε'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Ελ Σαλβαδόρ'; // El Salvador
-$_country_lang["sc"] = 'Άγιος Μαρτίνος (Ολλανδικό τμήμα)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Άγιος Μαρτίνος (Ολλανδικό τμήμα)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Αραβική Δημοκρατία της Συρίας'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Σουαζιλάνδη'; // Swaziland
 

--- a/core/lexicon/country/en.inc.php
+++ b/core/lexicon/country/en.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'Sao Tome and Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syrian Arab Republic'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swaziland'; // Swaziland
 

--- a/core/lexicon/country/es.inc.php
+++ b/core/lexicon/country/es.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Surinam'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'Santo Tomé y Príncipe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Siria'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Suazilandia'; // Swaziland
 

--- a/core/lexicon/country/et.inc.php
+++ b/core/lexicon/country/et.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'São Tomé ja Príncipe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Süüria Araabia Vabariik'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Svaasimaa'; // Swaziland
 

--- a/core/lexicon/country/fa.inc.php
+++ b/core/lexicon/country/fa.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'سورینام'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'سائو تومه و پرنسیپ'; // Sao Tome and Principe
 $_country_lang["sv"] = 'السالوادور'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'سوریه'; // Syrian Arab Republic
 $_country_lang["sz"] = 'سوازیلند'; // Swaziland
 

--- a/core/lexicon/country/fi.inc.php
+++ b/core/lexicon/country/fi.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'Salomonsaaret'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syyria'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swazimaa'; // Swaziland
 

--- a/core/lexicon/country/fr.inc.php
+++ b/core/lexicon/country/fr.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Surinam'; // Suriname
 $_country_lang["ss"] = 'Sud-Soudan'; // South Sudan
 $_country_lang["st"] = 'Sao Tome et Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Salvador'; // El Salvador
-$_country_lang["sc"] = 'Saint-Martin (partie néerlandaise)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Saint-Martin (partie néerlandaise)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syrie'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swaziland'; // Swaziland
 

--- a/core/lexicon/country/he.inc.php
+++ b/core/lexicon/country/he.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'סורינאם'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'סאו טומה ופרינסיפה'; // Sao Tome and Principe
 $_country_lang["sv"] = 'אל סלבדור'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'הרפובליקה הערבית הסורית'; // Syrian Arab Republic
 $_country_lang["sz"] = 'סווזילנד'; // Swaziland
 

--- a/core/lexicon/country/hi.inc.php
+++ b/core/lexicon/country/hi.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'सूरीनाम'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'साओ टोम और प्रिंसिपे'; // Sao Tome and Principe
 $_country_lang["sv"] = 'अल साल्वाडोर'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'सीरियाई अरब गणराज्य'; // Syrian Arab Republic
 $_country_lang["sz"] = 'स्वाज़ीलैंड'; // Swaziland
 

--- a/core/lexicon/country/hu.inc.php
+++ b/core/lexicon/country/hu.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'Dél-szudáni Köztársaság'; // South Sudan
 $_country_lang["st"] = 'São Tomé és Príncipe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Szíria'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Szváziföld'; // Swaziland
 

--- a/core/lexicon/country/id.inc.php
+++ b/core/lexicon/country/id.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'Sudan Selatan'; // South Sudan
 $_country_lang["st"] = 'Sao Tome dan Principe, Republik'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Saint Maarten (Wilayah Belanda)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Saint Maarten (Wilayah Belanda)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syria'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swazilandia'; // Swaziland
 

--- a/core/lexicon/country/it.inc.php
+++ b/core/lexicon/country/it.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'Sudan del Sud'; // South Sudan
 $_country_lang["st"] = 'Sao Tome e Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Saint Maarten (parte Olandese)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Saint Maarten (parte Olandese)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Siria'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swaziland'; // Swaziland
 

--- a/core/lexicon/country/ja.inc.php
+++ b/core/lexicon/country/ja.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'スリナム'; // Suriname
 $_country_lang["ss"] = '南スーダン'; // South Sudan
 $_country_lang["st"] = 'サントメ・プリンシペ'; // Sao Tome and Principe
 $_country_lang["sv"] = 'エルサルバドル'; // El Salvador
-$_country_lang["sc"] = 'シント ・ マールテン島 (オランダの一部)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'シント ・ マールテン島 (オランダの一部)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'シリア'; // Syrian Arab Republic
 $_country_lang["sz"] = 'スワジランド'; // Swaziland
 

--- a/core/lexicon/country/nl.inc.php
+++ b/core/lexicon/country/nl.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'Zuid-Soedan'; // South Sudan
 $_country_lang["st"] = 'Sao Tomé en Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Nederlands deel)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Nederlands deel)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syrië'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swaziland'; // Swaziland
 

--- a/core/lexicon/country/pl.inc.php
+++ b/core/lexicon/country/pl.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Surinam'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'Wyspy Świętego Tomasza i Książęca'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Salwador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syryjska Republika Arabska'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Suazi'; // Swaziland
 

--- a/core/lexicon/country/pt-br.inc.php
+++ b/core/lexicon/country/pt-br.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'Sudão do Sul'; // South Sudan
 $_country_lang["st"] = 'São Tomé e Príncipe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'São Martim (Parte Holandesa)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'São Martim (Parte Holandesa)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Síria'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swuzilândia'; // Swaziland
 

--- a/core/lexicon/country/ro.inc.php
+++ b/core/lexicon/country/ro.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Suriname'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'S&#227;o Tom&#233; și Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Siria'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swaziland'; // Swaziland
 

--- a/core/lexicon/country/ru.inc.php
+++ b/core/lexicon/country/ru.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Суринам'; // Suriname
 $_country_lang["ss"] = 'Южный Судан'; // South Sudan
 $_country_lang["st"] = 'Сан-Томе и Принсипи'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Сальвадор'; // El Salvador
-$_country_lang["sc"] = 'Синт-Мартен (владение Нидерландов)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Синт-Мартен (владение Нидерландов)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Сирийская Арабская Республика'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Свазиленд'; // Swaziland
 

--- a/core/lexicon/country/sv.inc.php
+++ b/core/lexicon/country/sv.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Surinam'; // Suriname
 $_country_lang["ss"] = 'Sydsudan'; // South Sudan
 $_country_lang["st"] = 'Sao Tome och Principe'; // Sao Tome and Principe
 $_country_lang["sv"] = 'El Salvador'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (nederländska delen)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (nederländska delen)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Syrien'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Swaziland'; // Swaziland
 

--- a/core/lexicon/country/th.inc.php
+++ b/core/lexicon/country/th.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'สาธารณรัฐซูรินาเม'; //
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'สาธารณรัฐประชาธิปไตยเซาตูเมและปรินซิปี'; // Sao Tome and Principe
 $_country_lang["sv"] = 'สาธารณรัฐเอลซัลวาดอร์'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'สาธารณรัฐอาหรับซีเรีย'; // Syrian Arab Republic
 $_country_lang["sz"] = 'ราชอาณาจักรสวาซิแลนด์'; // Swaziland
 

--- a/core/lexicon/country/uk.inc.php
+++ b/core/lexicon/country/uk.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = 'Суринам'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = 'Сан-Томе і Прінсіпі'; // Sao Tome and Principe
 $_country_lang["sv"] = 'Сальвадор'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = 'Сирія'; // Syrian Arab Republic
 $_country_lang["sz"] = 'Свазіленд'; // Swaziland
 

--- a/core/lexicon/country/zh.inc.php
+++ b/core/lexicon/country/zh.inc.php
@@ -237,7 +237,7 @@ $_country_lang["sr"] = '苏里南'; // Suriname
 $_country_lang["ss"] = 'South Sudan'; // South Sudan
 $_country_lang["st"] = '圣多美和普林西比'; // Sao Tome and Principe
 $_country_lang["sv"] = '萨尔瓦多'; // El Salvador
-$_country_lang["sc"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
+$_country_lang["sx"] = 'Sint Maarten (Dutch part)'; // Sint Maarten (Dutch part)
 $_country_lang["sy"] = '叙利亚'; // Syrian Arab Republic
 $_country_lang["sz"] = '斯威士兰'; // Swaziland
 


### PR DESCRIPTION
### What does it do?
Renamed the array key for the Sint Maarten $_country_lang entry.

### Why is it needed?
The name of the key was wrong and also being used for another country. 

### Related issue(s)/PR(s)
#13822 
