### PR TITLE
Display context name and key in Context dropdown

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -333,7 +333,7 @@ MODx.combo.Context = function(config) {
     Ext.applyIf(config,{
         name: 'context'
         ,hiddenName: 'context'
-        ,displayField: 'name'
+        ,displayField: 'key'
         ,valueField: 'key'
         ,fields: ['key', 'name']
         ,pageSize: 20
@@ -341,6 +341,7 @@ MODx.combo.Context = function(config) {
         ,baseParams: {
             action: 'context/getlist'
         }
+        ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{name:htmlEncode}</span> <span style="font-style: italic; font-size: small;">({key:htmlEncode})</span></div></tpl>')
     });
     MODx.combo.Context.superclass.constructor.call(this,config);
 };


### PR DESCRIPTION
*NOTE: this pull request requires a `grunt build` to be run to update minified js*

### What does it do?
Changed the `context/getlist` processor to add a display_name attribute comprised of the name and the key of the context which is then used in `MODx.combo.Context` to clarify the list of contexts presented to a user in various places in the manager UI.

### Why is it needed?
This is to make it clearer when working with areas where the context key is being displayed in a grid, as in when editing context ACLs, and to provide a fallback for contexts where no name is provided.

### Related issue(s)/PR(s)
Addresses #13739
Alternative to #13765 