### PR TITLE
Prevent line-wrap in error log

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -34,6 +34,7 @@ MODx.panel.ErrorLog = function(config) {
                     ,grow: true
                     ,anchor: '100%'
                     ,hidden: config.record.tooLarge ? true : false
+                    ,style: 'white-space: nowrap; overflow: auto;'
                 },{
                     html: '<p>'+_('error_log_too_large',{
                         name: config.record.name


### PR DESCRIPTION
Makes for easier scanning in the log file.

### What does it do?
Added CSS style to error log textarea

### Why is it needed?
Quickly scanning through the error log in the manager is cumbersome because of line-wraping

