### PR TITLE
Text javascript

### DIFF
--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -774,7 +774,7 @@ goes here'),
         $this->tag->set('name','utp:jsToHead=`'.($plainText ? 1 : 0).'`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script type="text/javascript" src="'.$value.'"></script>';
+            $value = '<script src="'.$value.'"></script>';
         }
         $this->assertContains($value,$this->modx->sjscripts);
         unset($this->modx->sjscripts[$value]);
@@ -785,7 +785,7 @@ goes here'),
     public function providerJsToHead() {
         return array(
             array('assets/js/hscript.js',true,false),
-            array('<script type="text/javascript" src="assets/js/hscript2.js"></script>',false,false),
+            array('<script src="assets/js/hscript2.js"></script>',false,false),
             array('assets/js/hscript3.js',false,true),
         );
     }

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -745,7 +745,7 @@ goes here'),
         $this->tag->set('name','utp:jsToBottom=`'.($plainText ? 1 : 0).'`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script type="text/javascript" src="'.$value.'"></script>';
+            $value = '<script src="'.$value.'"></script>';
         }
         $this->assertContains($value,$this->modx->jscripts);
         unset($this->modx->jscripts[$value]);
@@ -756,7 +756,7 @@ goes here'),
     public function providerJsToBottom() {
         return array(
             array('assets/js/script.js',true,false),
-            array('<script type="text/javascript" src="assets/js/script2.js"></script>',false,false),
+            array('<script src="assets/js/script2.js"></script>',false,false),
             array('assets/js/script3.js',false,true),
         );
     }

--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -142,7 +142,7 @@ abstract class modManagerController {
         $this->setCssURLPlaceholders();
         /* help url */
         $helpUrl = $this->getHelpUrl();
-        $this->addHtml('<script type="text/javascript">MODx.helpUrl = "'.($helpUrl).'"</script>');
+        $this->addHtml('<script>MODx.helpUrl = "'.($helpUrl).'"</script>');
 
         $this->modx->invokeEvent('OnManagerPageBeforeRender',array('controller' => &$this));
 
@@ -549,7 +549,7 @@ abstract class modManagerController {
             $o = '';
             // Add script tags for the required javascript
             foreach ($externals as $js) {
-                $o .= '<script type="text/javascript" src="'.$js.'"></script>'."\n";
+                $o .= '<script src="'.$js.'"></script>'."\n";
             }
 
             // Get the state and user token for adding to the init script
@@ -565,7 +565,7 @@ abstract class modManagerController {
                 $layout = 'MODx.load({xtype: "modx-layout",accordionPanels: MODx.accordionPanels || [],auth: "'.$siteId.'"});';
             }
             $o .= <<<HTML
-<script type="text/javascript">
+<script>
 Ext.onReady(function() {
     {$state}
     {$layout}
@@ -668,7 +668,7 @@ HTML;
         $cssjs = array();
         if (!empty($jsToCompress)) {
             foreach ($jsToCompress as $scr) {
-                $cssjs[] = '<script src="'.$scr.'" type="text/javascript"></script>';
+                $cssjs[] = '<script src="'.$scr.'"></script>';
             }
         }
 
@@ -698,7 +698,7 @@ HTML;
         }
         if (!empty($lastjs)) {
             foreach ($lastjs as $scr) {
-                $cssjs[] = '<script src="'.$scr.'" type="text/javascript"></script>';
+                $cssjs[] = '<script src="'.$scr.'"></script>';
             }
         }
 
@@ -837,7 +837,7 @@ HTML;
             if (!empty($r)) $rules[] = $r;
         }
         if (!empty($rules)) {
-            $this->ruleOutput[] = '<script type="text/javascript">Ext.onReady(function() {'.implode("\n",$rules).'});</script>';
+            $this->ruleOutput[] = '<script>Ext.onReady(function() {'.implode("\n",$rules).'});</script>';
         }
         return $overridden;
     }

--- a/core/model/modx/modmanagercontrollerdeprecated.class.php
+++ b/core/model/modx/modmanagercontrollerdeprecated.class.php
@@ -207,7 +207,7 @@ class modManagerControllerDeprecated extends modManagerController {
 
                 $path = str_replace(array(
                     $this->modx->getOption('manager_url').'assets/modext/',
-                    '<script type="text/javascript" src="',
+                    '<script src="',
                     '"></script>',
                 ),'',$newUrl);
 

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1501,7 +1501,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1524,7 +1524,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
         }
     }
 

--- a/core/model/smarty/debug.tpl
+++ b/core/model/smarty/debug.tpl
@@ -151,7 +151,7 @@
     </body>
     </html>
 {/capture}
-<script type="text/javascript">
+<script>
     {$id = '__Smarty__'}
     {if $display_mode}{$id = "$offset$template_name"|md5}{/if}
     _smarty_console = window.open("", "console{$id}", "width=1024,height=600,left={$offset},top={$offset},resizable,scrollbars=yes");

--- a/core/model/smarty/plugins/function.mailto.php
+++ b/core/model/smarty/plugins/function.mailto.php
@@ -111,7 +111,7 @@ function smarty_function_mailto($params)
             $js_encode .= '%' . bin2hex($string[ $x ]);
         }
 
-        return '<script type="text/javascript">eval(unescape(\'' . $js_encode . '\'))</script>';
+        return '<script>eval(unescape(\'' . $js_encode . '\'))</script>';
     } elseif ($encode == 'javascript_charcode') {
         $string = '<a href="mailto:' . $address . '" ' . $extra . '>' . $text . '</a>';
 


### PR DESCRIPTION
### What does it do?
Remove an obsolete type="text/javascript" attribute from script tags.

### Why is it needed?
The attribute is not needed anymore in HTML5. See the [answers](https://stackoverflow.com/questions/5265202/do-you-need-text-javascript-specified-in-your-script-tags) on StackOverflow. It should be safe with modern browsers and IE7+.

### Related issue(s)/PR(s)
#13846