### PR TITLE
Add created and edited columns to elements

### DIFF
--- a/core/lexicon/en/element.inc.php
+++ b/core/lexicon/en/element.inc.php
@@ -8,6 +8,7 @@
 $_lang['element'] = 'Element';
 $_lang['element_err_nf'] = 'Element not found.';
 $_lang['element_err_ns'] = 'Element not specified.';
+$_lang['element_err_outdated'] = 'A newer version of this element exists and therefore it will not be saved. Please make sure you are not editing the same element in a different tab in your browser.';
 $_lang['element_static_source_immutable'] = 'The static file specified as the element source is not writable! You cannot edit the content of this element in the manager.';
 $_lang['element_static_source_protected_invalid'] = 'You cannot point your Element to the MODX configuration directory; this is a protected, non-accessible directory.';
 $_lang['is_static'] = 'Is Static';

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -406,6 +406,7 @@ class modElement extends modAccessibleSimpleObject {
                 if ($this->_content !== $this->_fields['content']) {
                     $this->setContent($this->_content);
                     if (!$this->isNew()) {
+                        $this->set('editedon', time());
                         $this->save();
                     }
                 }

--- a/core/model/modx/mysql/modelement.map.inc.php
+++ b/core/model/modx/mysql/modelement.map.inc.php
@@ -74,17 +74,65 @@ $xpdo_meta_map['modElement']= array (
       'default' => 0,
     ),
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'editedon' =>
+    'createdby' => 
+    array (
+      'alias' => 'createdby',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'createdby' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'createdon' => 
+    array (
+      'alias' => 'createdon',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'createdon' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'editedby' => 
+    array (
+      'alias' => 'editedby',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'editedby' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'editedon' => 
     array (
       'alias' => 'editedon',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'editedon' =>
+        'editedon' => 
         array (
           'length' => '',
           'collation' => 'A',

--- a/core/model/modx/mysql/modelement.map.inc.php
+++ b/core/model/modx/mysql/modelement.map.inc.php
@@ -14,11 +14,47 @@ $xpdo_meta_map['modElement']= array (
   ),
   'fields' => 
   array (
+    'createdby' => 0,
+    'createdon' => 0,
+    'editedby' => 0,
+    'editedon' => 0,
     'source' => 0,
     'property_preprocess' => 0,
   ),
   'fieldMeta' => 
   array (
+    'createdby' => 
+    array (
+      'dbtype' => 'int',
+      'precision' => '10',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'createdon' => 
+    array (
+      'dbtype' => 'int',
+      'precision' => '20',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
+    'editedby' => 
+    array (
+      'dbtype' => 'int',
+      'precision' => '10',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'editedon' => 
+    array (
+      'dbtype' => 'int',
+      'precision' => '20',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
     'source' => 
     array (
       'dbtype' => 'int',
@@ -36,6 +72,25 @@ $xpdo_meta_map['modElement']= array (
       'phptype' => 'boolean',
       'null' => false,
       'default' => 0,
+    ),
+  ),
+  'indexes' =>
+  array (
+    'editedon' =>
+    array (
+      'alias' => 'editedon',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'editedon' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
     ),
   ),
   'composites' => 

--- a/core/model/modx/processors/element/chunk/update.class.php
+++ b/core/model/modx/processors/element/chunk/update.class.php
@@ -10,7 +10,7 @@ require_once (dirname(__DIR__).'/update.class.php');
  * @param string $snippet The code of the chunk.
  * @param boolean $locked Whether or not the chunk can only be accessed by
  * administrators.
- * @param json $propdata A json array of properties to store.
+ * @param string $propdata A json array of properties to store.
  *
  * @package modx
  * @subpackage processors.element.chunk
@@ -38,7 +38,11 @@ class modChunkUpdateProcessor extends modElementUpdateProcessor {
     }
 
     public function cleanup() {
-        return $this->success('',array_merge($this->object->get(array('id', 'name', 'description', 'locked', 'category', 'snippet')), array('previous_category' => $this->previousCategory)));
+        return $this->success('', array_merge(
+            $this->object->get(['id', 'name', 'description', 'locked', 'category', 'snippet', 'editedon']),
+            ['previous_category' => $this->previousCategory])
+        );
     }
 }
+
 return 'modChunkUpdateProcessor';

--- a/core/model/modx/processors/element/create.class.php
+++ b/core/model/modx/processors/element/create.class.php
@@ -65,6 +65,14 @@ abstract class modElementCreateProcessor extends modObjectCreateProcessor {
             }
         }
 
+        if (!$this->getProperty('createdon')) {
+            $this->object->set('createdon', time());
+        }
+
+        if (!$this->getProperty('createdby')) {
+            $this->object->set('createdby', $this->modx->user->get('id'));
+        }
+
         return !$this->hasErrors();
     }
 

--- a/core/model/modx/processors/element/plugin/update.class.php
+++ b/core/model/modx/processors/element/plugin/update.class.php
@@ -72,9 +72,10 @@ class modPluginUpdateProcessor extends modElementUpdateProcessor {
 
     public function cleanup() {
         return $this->success('', array_merge(
-            $this->object->get(array('id', 'name', 'description', 'locked', 'category', 'disabled', 'plugincode')),
-            array('previous_category' => $this->previousCategory)
+            $this->object->get(['id', 'name', 'description', 'locked', 'category', 'disabled', 'plugincode', 'editedon']),
+            ['previous_category' => $this->previousCategory]
         ));
     }
 }
+
 return 'modPluginUpdateProcessor';

--- a/core/model/modx/processors/element/snippet/update.class.php
+++ b/core/model/modx/processors/element/snippet/update.class.php
@@ -39,7 +39,11 @@ class modSnippetUpdateProcessor extends modElementUpdateProcessor {
     }
 
     public function cleanup() {
-        return $this->success('',array_merge($this->object->get(array('id', 'name', 'description', 'locked', 'category', 'snippet')), array('previous_category' => $this->previousCategory)));
+        return $this->success('', array_merge(
+            $this->object->get(['id', 'name', 'description', 'locked', 'category', 'snippet', 'editedon']),
+            ['previous_category' => $this->previousCategory])
+        );
     }
 }
+
 return 'modSnippetUpdateProcessor';

--- a/core/model/modx/processors/element/tv/update.class.php
+++ b/core/model/modx/processors/element/tv/update.class.php
@@ -205,7 +205,11 @@ class modElementTvUpdateProcessor extends modElementUpdateProcessor {
     }
 
     public function cleanup() {
-        return $this->success('',array_merge($this->object->get(array('id', 'name', 'description', 'locked', 'category', 'default_text')), array('previous_category' => $this->previousCategory)));
+        return $this->success('', array_merge(
+            $this->object->get(['id', 'name', 'description', 'locked', 'category', 'default_text', 'editedon']),
+            ['previous_category' => $this->previousCategory])
+        );
     }
 }
+
 return 'modElementTvUpdateProcessor';

--- a/core/model/modx/processors/element/update.class.php
+++ b/core/model/modx/processors/element/update.class.php
@@ -17,6 +17,19 @@ abstract class modElementUpdateProcessor extends modObjectUpdateProcessor {
             $this->object->set('locked',(boolean)$locked);
         }
 
+        $editedon = $this->getProperty('editedon', 0);
+        if (!is_numeric($editedon)) {
+            $editedon = strtotime($editedon);
+        }
+        if ($this->modx->getCount($this->classKey, ['id' => $this->object->get('id'), 'editedon:>' => $editedon])) {
+            return $this->modx->lexicon('element_err_outdated');
+        }
+        $this->object->set('editedon', time());
+
+        if (!$this->getProperty('editedby')) {
+            $this->object->set('editedby', $this->modx->user->get('id'));
+        }
+
         /* make sure a name was specified */
         $nameField = $this->classKey == 'modTemplate' ? 'templatename' : 'name';
         $name = $this->getProperty($nameField,'');
@@ -74,6 +87,9 @@ abstract class modElementUpdateProcessor extends modObjectUpdateProcessor {
     }
 
     public function cleanup() {
-        return $this->success('',array_merge($this->object->get(array('id', 'name', 'description', 'locked', 'category', 'content')), array('previous_category' => $this->previousCategory)));
+        return $this->success('', array_merge(
+                $this->object->get(['id', 'name', 'description', 'locked', 'category', 'content', 'editedon']),
+                ['previous_category' => $this->previousCategory])
+        );
     }
 }

--- a/core/model/modx/sqlsrv/modelement.map.inc.php
+++ b/core/model/modx/sqlsrv/modelement.map.inc.php
@@ -63,17 +63,65 @@ $xpdo_meta_map['modElement']= array (
       'default' => 0,
     ),
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'editedon' =>
+    'createdby' => 
+    array (
+      'alias' => 'createdby',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'createdby' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'createdon' => 
+    array (
+      'alias' => 'createdon',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'createdon' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'editedby' => 
+    array (
+      'alias' => 'editedby',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'editedby' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'editedon' => 
     array (
       'alias' => 'editedon',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'editedon' =>
+        'editedon' => 
         array (
           'length' => '',
           'collation' => 'A',

--- a/core/model/modx/sqlsrv/modelement.map.inc.php
+++ b/core/model/modx/sqlsrv/modelement.map.inc.php
@@ -10,11 +10,43 @@ $xpdo_meta_map['modElement']= array (
   'extends' => 'modAccessibleSimpleObject',
   'fields' => 
   array (
+    'createdby' => 0,
+    'createdon' => 0,
+    'editedby' => 0,
+    'editedon' => 0,
     'source' => 0,
     'property_preprocess' => 0,
   ),
   'fieldMeta' => 
   array (
+    'createdby' => 
+    array (
+      'dbtype' => 'int',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'createdon' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
+    'editedby' => 
+    array (
+      'dbtype' => 'int',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'editedon' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
     'source' => 
     array (
       'dbtype' => 'int',
@@ -29,6 +61,25 @@ $xpdo_meta_map['modElement']= array (
       'phptype' => 'boolean',
       'null' => false,
       'default' => 0,
+    ),
+  ),
+  'indexes' =>
+  array (
+    'editedon' =>
+    array (
+      'alias' => 'editedon',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'editedon' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
     ),
   ),
   'composites' => 

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -572,8 +572,16 @@
     <object class="modDocument" extends="modResource" />
 
     <object class="modElement" table="site_element" extends="modAccessibleSimpleObject">
+        <field key="createdby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
         <field key="source" dbtype="int" attributes="unsigned" phptype="integer" null="false" default="0" index="fk" />
         <field key="property_preprocess" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+
+        <index alias="editedon" name="editedon" primary="false" unique="false" type="BTREE">
+            <column key="editedon" length="" collation="A" null="false" />
+        </index>
 
         <composite alias="Acls" class="modAccessElement" local="id" foreign="target" owner="local" cardinality="many" />
         <aggregate alias="CategoryAcls" class="modAccessCategory" local="category" foreign="target" owner="local" cardinality="many" />

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -579,6 +579,15 @@
         <field key="source" dbtype="int" attributes="unsigned" phptype="integer" null="false" default="0" index="fk" />
         <field key="property_preprocess" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
 
+        <index alias="createdby" name="createdby" primary="false" unique="false" type="BTREE">
+            <column key="createdby" length="" collation="A" null="false" />
+        </index>
+        <index alias="createdon" name="createdon" primary="false" unique="false" type="BTREE">
+            <column key="createdon" length="" collation="A" null="false" />
+        </index>
+        <index alias="editedby" name="editedby" primary="false" unique="false" type="BTREE">
+            <column key="editedby" length="" collation="A" null="false" />
+        </index>
         <index alias="editedon" name="editedon" primary="false" unique="false" type="BTREE">
             <column key="editedon" length="" collation="A" null="false" />
         </index>

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -498,6 +498,15 @@
         <field key="source" dbtype="int" phptype="integer" null="false" default="0" index="fk" />
         <field key="property_preprocess" dbtype="bit" phptype="boolean" null="false" default="0" />
 
+        <index alias="createdby" name="createdby" primary="false" unique="false" type="BTREE">
+            <column key="createdby" length="" collation="A" null="false" />
+        </index>
+        <index alias="createdon" name="createdon" primary="false" unique="false" type="BTREE">
+            <column key="createdon" length="" collation="A" null="false" />
+        </index>
+        <index alias="editedby" name="editedby" primary="false" unique="false" type="BTREE">
+            <column key="editedby" length="" collation="A" null="false" />
+        </index>
         <index alias="editedon" name="editedon" primary="false" unique="false" type="BTREE">
             <column key="editedon" length="" collation="A" null="false" />
         </index>

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -491,8 +491,16 @@
     <object class="modDocument" extends="modResource" />
 
     <object class="modElement" table="site_element" extends="modAccessibleSimpleObject">
+        <field key="createdby" dbtype="int" phptype="integer" null="false" default="0" />
+        <field key="createdon" dbtype="bigint" phptype="timestamp" null="false" default="0" />
+        <field key="editedby" dbtype="int" phptype="integer" null="false" default="0" />
+        <field key="editedon" dbtype="bigint" phptype="timestamp" null="false" default="0" />
         <field key="source" dbtype="int" phptype="integer" null="false" default="0" index="fk" />
         <field key="property_preprocess" dbtype="bit" phptype="boolean" null="false" default="0" />
+
+        <index alias="editedon" name="editedon" primary="false" unique="false" type="BTREE">
+            <column key="editedon" length="" collation="A" null="false" />
+        </index>
 
         <composite alias="Acls" class="modAccessElement" local="id" foreign="target" owner="local" cardinality="many" />
         <aggregate alias="CategoryAcls" class="modAccessCategory" local="category" foreign="target" owner="local" cardinality="many" />

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -50,6 +50,11 @@ MODx.panel.Chunk = function(config) {
                         ,value: config.record.id || MODx.request.id
                     },{
                         xtype: 'hidden'
+                        ,name: 'editedon'
+                        ,id: 'modx-tv-editedon'
+                        ,value: config.record.editedon || 0
+                    },{
+                        xtype: 'hidden'
                         ,name: 'props'
                         ,id: 'modx-chunk-props'
                         ,value: config.record.props || null

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -52,6 +52,11 @@ MODx.panel.Plugin = function(config) {
                         ,value: config.record.id || 0
                     },{
                         xtype: 'hidden'
+                        ,name: 'editedon'
+                        ,id: 'modx-tv-editedon'
+                        ,value: config.record.editedon || 0
+                    },{
+                        xtype: 'hidden'
                         ,name: 'props'
                         ,id: 'modx-plugin-props'
                         ,value: config.record.props || null

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -51,6 +51,11 @@ MODx.panel.Snippet = function(config) {
                         ,value: config.snippet
                     },{
                         xtype: 'hidden'
+                        ,name: 'editedon'
+                        ,id: 'modx-tv-editedon'
+                        ,value: config.record.editedon || 0
+                    },{
+                        xtype: 'hidden'
                         ,name: 'props'
                         ,id: 'modx-snippet-props'
                         ,value: config.record.props || null

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -54,6 +54,11 @@ MODx.panel.Template = function(config) {
                         ,value: config.template
                     },{
                         xtype: 'hidden'
+                        ,name: 'editedon'
+                        ,id: 'modx-tv-editedon'
+                        ,value: config.record.editedon || 0
+                    },{
+                        xtype: 'hidden'
                         ,name: 'props'
                         ,id: 'modx-template-props'
                         ,value: config.record.props || null

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -54,6 +54,11 @@ MODx.panel.TV = function(config) {
                         ,value: config.record.id || MODx.request.id
                     },{
                         xtype: 'hidden'
+                        ,name: 'editedon'
+                        ,id: 'modx-tv-editedon'
+                        ,value: config.record.editedon || 0
+                    },{
+                        xtype: 'hidden'
                         ,name: 'props'
                         ,id: 'modx-tv-props'
                         ,value: config.record.props || null

--- a/setup/includes/upgrades/common/3.0.0-elements-columns.php
+++ b/setup/includes/upgrades/common/3.0.0-elements-columns.php
@@ -7,7 +7,7 @@
  */
 
 $columns = ['createdby', 'createdon', 'editedby', 'editedon'];
-$classes = $modx->getDescendants('modElement');
+$classes = array_diff($modx->getDescendants('modElement'), ['modScript']);
 foreach ($classes as $class) {
     $table = $modx->getTableName($class);
     foreach ($columns as $column) {

--- a/setup/includes/upgrades/common/3.0.0-elements-columns.php
+++ b/setup/includes/upgrades/common/3.0.0-elements-columns.php
@@ -13,7 +13,8 @@ foreach ($classes as $class) {
     foreach ($columns as $column) {
         $description = $this->install->lexicon('add_column', ['column' => $column, 'table' => $table]);
         $this->processResults($class, $description, [$modx->manager, 'addField'], [$class, $column]);
+
+        $description = $this->install->lexicon('add_index', ['index' => $column, 'table' => $table]);
+        $this->processResults($class, $description, [$modx->manager, 'addIndex'], [$class, $column]);
     }
-    $description = $this->install->lexicon('add_index', ['index' => 'editedon', 'table' => $table]);
-    $this->processResults($class, $description, [$modx->manager, 'addIndex'], [$class, 'editedon']);
 }

--- a/setup/includes/upgrades/common/3.0.0-elements-columns.php
+++ b/setup/includes/upgrades/common/3.0.0-elements-columns.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Common upgrade script for 3.0 for adding new columns to elements tables.
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$columns = ['createdby', 'createdon', 'editedby', 'editedon'];
+$classes = $modx->getDescendants('modElement');
+foreach ($classes as $class) {
+    $table = $modx->getTableName($class);
+    foreach ($columns as $column) {
+        $description = $this->install->lexicon('add_column', ['column' => $column, 'table' => $table]);
+        $this->processResults($class, $description, [$modx->manager, 'addField'], [$class, $column]);
+    }
+    $description = $this->install->lexicon('add_index', ['index' => 'editedon', 'table' => $table]);
+    $this->processResults($class, $description, [$modx->manager, 'addIndex'], [$class, 'editedon']);
+}

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -12,3 +12,4 @@ include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-elements-columns.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -12,3 +12,4 @@ include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-elements-columns.php';


### PR DESCRIPTION
### What does it do?
- Added 4 new columns (createdby, createdon, editedby, editedon) to all modElement descendants: to modChunk, modPlugin, modSnippet, modTemplate, modTemplateVar

- Prevent overwrite of elements by checking createdon value before save

### Why is it needed?
To protect users from overwriting elements. Also now we would be able to get actual creators and editors of elements with MODX API.

### Related issue(s)/PR(s)
#13770 #13626 #13641 #2027

![screen shot 2018-04-10 at 11 15 48](https://user-images.githubusercontent.com/1257284/38547878-8adb6616-3cb0-11e8-950d-9c4ff82bdac5.png)

This PR changes javascript files, so please, don`t forget to disable `compress_js` system setting before testing.