### PR TITLE
Remove obsolete system settings

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -996,15 +996,6 @@ $settings['manager_js_document_root']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
-$settings['manager_js_zlib_output_compression']= $xpdo->newObject('modSystemSetting');
-$settings['manager_js_zlib_output_compression']->fromArray(array (
-  'key' => 'manager_js_zlib_output_compression',
-  'value' => 0,
-  'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'manager',
-  'editedon' => null,
-), '', true, true);
 $settings['manager_time_format']= $xpdo->newObject('modSystemSetting');
 $settings['manager_time_format']->fromArray(array (
   'key' => 'manager_time_format',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -348,15 +348,6 @@ $settings['compress_js']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
-$settings['compress_js_max_files']= $xpdo->newObject('modSystemSetting');
-$settings['compress_js_max_files']->fromArray(array (
-  'key' => 'compress_js_max_files',
-  'value' => 10,
-  'xtype' => 'textfield',
-  'namespace' => 'core',
-  'area' => 'manager',
-  'editedon' => null,
-), '', true, true);
 $settings['confirm_navigation']= $xpdo->newObject('modSystemSetting');
 $settings['confirm_navigation']->fromArray(array (
   'key' => 'confirm_navigation',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -202,9 +202,6 @@ $_lang['setting_compress_js_desc'] = 'When this is enabled, MODX will serve a co
 $_lang['setting_compress_js_groups'] = 'Use Grouping When Compressing JavaScript';
 $_lang['setting_compress_js_groups_desc'] = 'Group the core MODX manager JavaScript using minify\'s groupsConfig. Set to Yes if using suhosin or other limiting factors.';
 
-$_lang['setting_compress_js_max_files'] = 'Maximum JavaScript Files Compression Threshold';
-$_lang['setting_compress_js_max_files_desc'] = 'The maximum number of JavaScript files MODX will attempt to compress at once when compress_js is on. Set to a lower number if you are experiencing issues with Google Minify in the manager.';
-
 $_lang['setting_concat_js'] = 'Use Concatenated Javascript Libraries';
 $_lang['setting_concat_js_desc'] = 'When this is enabled, MODX will use a concatenated version of its common JavaScript libraries in the manager interface. This greatly reduces load and execution time within the manager. Disable only if you are modifying core elements.';
 

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -428,8 +428,6 @@ $_lang['setting_manager_js_cache_max_age'] = 'Manager JS/CSS Compression Cache A
 $_lang['setting_manager_js_cache_max_age_desc'] = 'Maximum age of browser cache of manager CSS/JS compression in seconds. After this period, the browser will send another conditional GET. Use a longer period for lower traffic.';
 $_lang['setting_manager_js_document_root'] = 'Manager JS/CSS Compression Document Root';
 $_lang['setting_manager_js_document_root_desc'] = 'If your server does not handle the DOCUMENT_ROOT server variable, set it explicitly here to enable the manager CSS/JS compression. Do not change this unless you know what you are doing.';
-$_lang['setting_manager_js_zlib_output_compression'] = 'Enable zlib Output Compression for Manager JS/CSS';
-$_lang['setting_manager_js_zlib_output_compression_desc'] = 'Whether or not to enable zlib output compression for compressed CSS/JS in the manager. Do not turn this on unless you are sure the PHP config variable zlib.output_compression can be set to 1. MODX recommends leaving it off.';
 
 $_lang['setting_manager_login_url_alternate'] = 'Alternate Manager Login URL';
 $_lang['setting_manager_login_url_alternate_desc'] = 'An alternate URL to send an unauthenticated user to when they need to login to the manager. The login form there must login the user to the "mgr" context to work.';

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -3,18 +3,21 @@
  * Remove obsolete system settings about compression
  */
 
-/** @var modSystemSetting $compress_js_max_files */
-$compress_js_max_files = $modx->getObject('modSystemSetting', [
-    'key' => 'compress_js_max_files'
-]);
-if ($compress_js_max_files) {
-    $compress_js_max_files->remove();
-}
+$settings = ['compress_js_max_files', 'manager_js_zlib_output_compression'];
 
-/** @var modSystemSetting $manager_js_zlib_output_compression */
-$manager_js_zlib_output_compression = $modx->getObject('modSystemSetting', [
-    'key' => 'manager_js_zlib_output_compression'
-]);
-if ($manager_js_zlib_output_compression) {
-    $manager_js_zlib_output_compression->remove();
+foreach ($settings as $key) {
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject('modSystemSetting', ['key' => $key]);
+    if ($setting instanceof modSystemSetting) {
+        if ($setting->remove()) {
+            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+                '<p class="ok">' . $key . ' System Setting removed.</p>');
+        } else {
+            $this->runner->addResult(modInstallRunner::RESULT_FAILURE,
+                '<p class="notok">' . $key . ' System Setting could not be removed.</p>');
+        }
+    } else {
+        $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+            '<p class="warning">' . $key . ' System Setting was not found.</p>');
+    }
 }

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Remove obsolete system settings about compression
+ */
+
+/** @var modSystemSetting $compress_js_max_files */
+$compress_js_max_files = $modx->getObject('modSystemSetting', [
+    'key' => 'compress_js_max_files'
+]);
+if ($compress_js_max_files) {
+    $compress_js_max_files->remove();
+}
+
+/** @var modSystemSetting $manager_js_zlib_output_compression */
+$manager_js_zlib_output_compression = $modx->getObject('modSystemSetting', [
+    'key' => 'manager_js_zlib_output_compression'
+]);
+if ($manager_js_zlib_output_compression) {
+    $manager_js_zlib_output_compression->remove();
+}

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -18,11 +18,8 @@ foreach ($settings as $key) {
             $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
                 sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])));
         } else {
-            $this->runner->addResult(modInstallRunner::RESULT_FAILURE,
-                sprintf($messageTemplate, 'notok', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
+            $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+                sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
         }
-    } else {
-        $this->runner->addResult(modInstallRunner::RESULT_WARNING,
-            sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_nf', ['key' => $key])));
     }
 }

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -3,7 +3,12 @@
  * Remove obsolete system settings about compression
  */
 
-$settings = ['compress_js_max_files', 'manager_js_zlib_output_compression'];
+$settings = [
+    'compress_js_max_files',
+    'manager_js_zlib_output_compression'
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
 
 foreach ($settings as $key) {
     /** @var modSystemSetting $setting */
@@ -11,13 +16,13 @@ foreach ($settings as $key) {
     if ($setting instanceof modSystemSetting) {
         if ($setting->remove()) {
             $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
-                '<p class="ok">' . $key . ' System Setting removed.</p>');
+                sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])));
         } else {
             $this->runner->addResult(modInstallRunner::RESULT_FAILURE,
-                '<p class="notok">' . $key . ' System Setting could not be removed.</p>');
+                sprintf($messageTemplate, 'notok', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
         }
     } else {
         $this->runner->addResult(modInstallRunner::RESULT_WARNING,
-            '<p class="warning">' . $key . ' System Setting was not found.</p>');
+            sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_nf', ['key' => $key])));
     }
 }

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -47,3 +47,6 @@ $_lang['legacy_cleanup_count'] = 'Removed [[+files]] file(s) and [[+folders]] fo
 $_lang['clipboard_flash_file_unlink_success'] = 'Successfully removed the copy to clipboard flash file.';
 $_lang['clipboard_flash_file_unlink_failed'] = 'Error removing the copy to clipboard flash file.';
 $_lang['clipboard_flash_file_missing'] = 'The copy to clipboard flash file does not exist.';
+$_lang['system_setting_cleanup_success'] = 'System Setting `[[+key]]` removed.';
+$_lang['clipboard_flash_file_unlink_failed'] = 'System Setting `[[+key]]` could not be removed.';
+$_lang['clipboard_flash_file_missing'] = 'System Setting `[[+key]]` was not found.';

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -48,5 +48,4 @@ $_lang['clipboard_flash_file_unlink_success'] = 'Successfully removed the copy t
 $_lang['clipboard_flash_file_unlink_failed'] = 'Error removing the copy to clipboard flash file.';
 $_lang['clipboard_flash_file_missing'] = 'The copy to clipboard flash file does not exist.';
 $_lang['system_setting_cleanup_success'] = 'System Setting `[[+key]]` removed.';
-$_lang['clipboard_flash_file_unlink_failed'] = 'System Setting `[[+key]]` could not be removed.';
-$_lang['clipboard_flash_file_missing'] = 'System Setting `[[+key]]` was not found.';
+$_lang['system_setting_cleanup_failed'] = 'System Setting `[[+key]]` could not be removed.';


### PR DESCRIPTION
### What does it do?
Removes obsolete system settings.

### Why is it needed?
They not used in the system anymore and are messing up the code.

### Related issue(s)/PR(s)
#13858