### PR TITLE
Fix installation of transport packages with setup options

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -81,26 +81,41 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
         Ext.each(this.buttons, function(btn){ Ext.getCmp(btn.id).hide(); });
     }
 
-	,install: function(va){
+    /**
+	 *
+     * @param va ExtJS instance of the button that was clicked
+     * @param event The Ext.EventObjectImpl from clicking the button
+     * @param options Object containing the setup options if available, or undefined.
+     * @returns {boolean}
+     */
+	,install: function(va, event, options){
+    	options = options || {};
         var r;
         var g = Ext.getCmp('modx-package-grid');
         if (!g) return false;
 
+        // Set the signature from the button config (set in MODx.panel.PackageBeforeInstall.updatePanel)
         if (va.signature != undefined && va.signature != '') {
             r = {signature: va.signature};
         } else {
             r = g.menu.record.data ? g.menu.record.data : g.menu.record;
         }
+
+        // Load up the installation console
 		var topic = '/workspace/package/install/'+r.signature+'/';
         g.loadConsole(Ext.getBody(),topic);
 
+        // Grab the params to send to the install processor
         var params = {
             action: 'workspace/packages/install'
             ,signature: r.signature
             ,register: 'mgr'
             ,topic: topic
         };
+        // Include the setup options that were provided from MODx.window.SetupOptions.install
+        Ext.apply(params, options);
 
+        // Trigger the actual installation
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: params

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -179,7 +179,7 @@ Ext.extend(MODx.window.SetupOptions,MODx.Window,{
 		this.hide();
 		var options = Ext.getCmp('modx-setupoptions-form').getForm().getValues();
         options.signature = this.signature;
-		Ext.getCmp('modx-panel-packages').install( options );
+		Ext.getCmp('modx-panel-packages').install(btn, ev, options);
 	}
 });
 Ext.reg('modx-package-setupoptions', MODx.window.SetupOptions);


### PR DESCRIPTION
### What does it do?

Make sure setup options are sent to the processor when installing a package.

### Why is it needed?

In #13813 I removed the `va` variable from being sent to the processor as that contained an extjs config object which was tripping over mod_security rules. But I failed to notice that setup options from a package were also being sent in this variable, so in 2.6.2 setup options were no longer being sent to the server, breaking installation (or preventing easy set-up) of some packages.

To remove the ambiguity of the `va` variable I've updated the setup options install method to send the same variables to install, with the `options` as a new third parameter instead. That way it can be treated properly. I've also added extensive comments for the next poor sap to explore into the depths of the package installation process.

### Related issue(s)/PR(s)

#13813 
