### PR TITLE
Fix the incorrect sorting in Dashboard widgets, when empty widget is …

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -25,6 +25,9 @@
   }
   .dashboard-block {
     margin: 1% 0 0 1%;
+    &.hidden{
+    display:none;
+    }
     &:not(.headless) {
       background-color: $white;
       border-radius: $borderRadius;

--- a/core/model/modx/moddashboardwidget.class.php
+++ b/core/model/modx/moddashboardwidget.class.php
@@ -3,9 +3,6 @@
  * @package modx
  * @subpackage mysql
  */
-use xPDO\Om\xPDOSimpleObject;
-use xPDO\xPDO;
-
 /**
  * Abstraction of a Dashboard Widget, which can be placed on Dashboards for welcome screen customization.
  *
@@ -254,6 +251,11 @@ abstract class modDashboardWidgetInterface {
             $output = $this->getFileChunk('dashboard/block.tpl',$widgetArray);
             $output = preg_replace('@\[\[(.[^\[\[]*?)\]\]@si','',$output);
             $output = preg_replace('@\[\[(.[^\[\[]*?)\]\]@si','',$output);
+        }else{
+            $widgetArray = $this->widget->toArray();
+            $widgetArray['size'] = '';
+            $widgetArray['class'] = 'hidden';
+            $output = $this->getFileChunk('dashboard/block.tpl',$widgetArray);
         }
         return $output;
     }
@@ -311,26 +313,14 @@ abstract class modDashboardWidgetInterface {
      * Render the widget content as if it were a Snippet
      *
      * @param string $content
-     *
      * @return string
      */
-    public function renderAsSnippet($content = '')
-    {
-        if (empty($content)) {
-            $content = $this->widget->get('content');
-        }
-        $content = str_replace(['<?php', '?>'], '', $content);
-        $closure = function ($scriptProperties) use ($content) {
-            global $modx;
-            if (is_array($scriptProperties)) {
-                extract($scriptProperties, EXTR_SKIP);
-            }
-
-            return eval($content);
-        };
-
-        return $closure([
+    public function renderAsSnippet($content = '') {
+        if (empty($content)) $content = $this->widget->get('content');
+        $content = str_replace(array('<?php','?>'),'',$content);
+        $closure = create_function('$scriptProperties','global $modx;if (is_array($scriptProperties)) {extract($scriptProperties, EXTR_SKIP);}'.$content);
+        return $closure(array(
             'controller' => $this->controller,
-        ]);
+        ));
     }
 }


### PR DESCRIPTION
### What does it do?
Show empty widget as empty hidden div, when output of widget is empty

### Why is it needed?
Because current sorting od widgets work incorrect, because of div position != widget rank

### Related issue(s)/PR(s)
[#13844](https://github.com/modxcms/revolution/pull/13844)