### PR TITLE
[3.x] Remove @EVAL binding from TVs to prevent arbitrary code execution by admins

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2037,15 +2037,6 @@ $settings['preserve_menuindex']->fromArray(array (
     'area' => 'manager',
     'editedon' => null,
 ), '', true, true);
-$settings['allow_tv_eval']= $xpdo->newObject('modSystemSetting');
-$settings['allow_tv_eval']->fromArray(array (
-    'key' => 'allow_tv_eval',
-    'value' => true,
-    'xtype' => 'combo-boolean',
-    'namespace' => 'core',
-    'area' => 'system',
-    'editedon' => null,
-), '', true, true);
 $settings['log_snippet_not_found']= $xpdo->newObject('modSystemSetting');
 $settings['log_snippet_not_found']->fromArray(array (
     'key' => 'log_snippet_not_found',

--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -43,7 +43,6 @@ class modTemplateVar extends modElement {
         'DOCUMENT',
         'RESOURCE',
         'SELECT',
-        'EVAL',
         'INHERIT',
         'DIRECTORY'
     );
@@ -831,15 +830,6 @@ class modTemplateVar extends modElement {
                         $stmt->closeCursor();
                     }
                     $output = $data;
-                }
-                break;
-
-            case 'EVAL':        /* evaluates text as php codes return the results */
-                if ($preProcess) {
-                    $output = $param;
-                    if ($this->xpdo->getOption('allow_tv_eval', null, true)) {
-                        $output = eval($param);
-                    }
                 }
                 break;
 

--- a/setup/includes/upgrades/common/3.0.0-remove-tv-eval-system-setting.php
+++ b/setup/includes/upgrades/common/3.0.0-remove-tv-eval-system-setting.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Common upgrade script to clean up deprecated system settings for TV eval feature.
+ *
+ * @var modX
+ *
+ * @package setup
+ */
+
+$deprecatedSetting = $modx->getObject('modSystemSetting', array(
+    'key' => 'allow_tv_eval'
+));
+if ($deprecatedSetting instanceof modSystemSetting) {
+    if ($deprecatedSetting->remove()) {
+        $this->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">allow_tv_eval System Setting removed.</p>');
+    } else {
+        $this->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">allow_tv_eval System Setting could not be removed.</p>');
+    }
+} else {
+    $this->runner->addResult(modInstallRunner::RESULT_WARNING,'<p class="warning">allow_tv_eval System Setting was not found.</p>');
+}

--- a/setup/includes/upgrades/common/3.0.0-remove-tv-eval-system-setting.php
+++ b/setup/includes/upgrades/common/3.0.0-remove-tv-eval-system-setting.php
@@ -6,16 +6,22 @@
  *
  * @package setup
  */
+$settings = [
+    'allow_tv_eval'
+];
 
-$deprecatedSetting = $modx->getObject('modSystemSetting', array(
-    'key' => 'allow_tv_eval'
-));
-if ($deprecatedSetting instanceof modSystemSetting) {
-    if ($deprecatedSetting->remove()) {
-        $this->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">allow_tv_eval System Setting removed.</p>');
-    } else {
-        $this->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">allow_tv_eval System Setting could not be removed.</p>');
+$messageTemplate = '<p class="%s">%s</p>';
+
+foreach ($settings as $key) {
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject('modSystemSetting', ['key' => $key]);
+    if ($setting instanceof modSystemSetting) {
+        if ($setting->remove()) {
+            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+                sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])));
+        } else {
+            $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+                sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
+        }
     }
-} else {
-    $this->runner->addResult(modInstallRunner::RESULT_WARNING,'<p class="warning">allow_tv_eval System Setting was not found.</p>');
 }

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -9,3 +9,6 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -9,3 +9,6 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -47,3 +47,5 @@ $_lang['legacy_cleanup_count'] = 'Removed [[+files]] file(s) and [[+folders]] fo
 $_lang['clipboard_flash_file_unlink_success'] = 'Successfully removed the copy to clipboard flash file.';
 $_lang['clipboard_flash_file_unlink_failed'] = 'Error removing the copy to clipboard flash file.';
 $_lang['clipboard_flash_file_missing'] = 'The copy to clipboard flash file does not exist.';
+$_lang['system_setting_cleanup_success'] = 'System Setting `[[+key]]` removed.';
+$_lang['system_setting_cleanup_failed'] = 'System Setting `[[+key]]` could not be removed.';


### PR DESCRIPTION
### What does it do?
Take advantage of major version to remove dangerous feature.

### Why is it needed?
The `@EVAL` binding allows any User with Manager access, that has permissions to CREATE or UPDATE Template Variables, to execute arbitrary php code, yet creating or updating Template Variables is an action that non-admin, non-developer users may commonly need to undertake.

### Related issue(s)/PR(s)
Branch 3.x-tveval
