### PR TITLE
Log setlocale errors

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2383,7 +2383,10 @@ class modX extends xPDO {
 
         if ($this->getOption('setlocale', $options, true)) {
             $locale = setlocale(LC_ALL, null);
-            setlocale(LC_ALL, $this->getOption('locale', null, $locale));
+            $result = setlocale(LC_ALL, $this->getOption('locale', null, $locale));
+            if ($result === false) {
+                $this->log(modX::LOG_LEVEL_ERROR, 'Could not set the locale. Please check if the locale ' . $this->getOption('locale', null, $locale) . ' exists on your system');
+            }
         }
 
         $this->getService('lexicon', $this->getOption('lexicon_class', $options, 'modLexicon'), '', is_array($options) ? $options : array());


### PR DESCRIPTION
### What does it do?
An error is logged, when the locale functionality is not implemented or the specified locale does not exist on the system.

### Why is it needed?
Avoid issues like in #13854

### Related issue(s)/PR(s)
#13854
