### PR TITLE
Added missed upgrading script

### DIFF
--- a/setup/includes/upgrades/common/3.0.0-remove-copy-to-clipboard.php
+++ b/setup/includes/upgrades/common/3.0.0-remove-copy-to-clipboard.php
@@ -12,9 +12,9 @@ $fileToRemove = $managerPath.'assets/modext/_clipboard.swf';
 
 if (file_exists($fileToRemove) === true) {
     if (unlink($fileToRemove) === true) {
-        $this->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">'.$this->install->lexicon('clipboard_flash_file_unlink_success').'</p>');
+        $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">'.$this->install->lexicon('clipboard_flash_file_unlink_success').'</p>');
     } else {
-        $this->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">'.$this->install->lexicon('clipboard_flash_file_unlink_failed').'</p>');
+        $this->runner->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">'.$this->install->lexicon('clipboard_flash_file_unlink_failed').'</p>');
     }
 } else {
     $this->runner->addResult(modInstallRunner::RESULT_WARNING,'<p class="warning">'.$this->install->lexicon('clipboard_flash_file_missing').'</p>');

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';


### PR DESCRIPTION
### What does it do?
It is adding the script `3.0.0-remove-copy-to-clipboard.php` to database driver related upgrading scripts.

### Why is it needed?
Now, this script exists in the code but never used. It should be fixed.

### Related issue(s)/PR(s)
#13814