### PR TITLE
Issue #13729

### DIFF
--- a/core/model/modx/modscript.class.php
+++ b/core/model/modx/modscript.class.php
@@ -159,7 +159,7 @@ class modScript extends modElement {
                 if ($folderMode) $options['new_folder_permissions'] = $folderMode;
                 $fileMode = $this->xpdo->getOption('new_cache_file_permissions', null, false);
                 if ($fileMode) $options['new_file_permissions'] = $fileMode;
-                $result = $this->xpdo->cacheManager->writeFile($includeFilename, "<?php\n" . $script, 'wb' , $options);
+                $result = $this->xpdo->cacheManager->writeFile($includeFilename, "<?php\n" . $script, 'w' , $options);
             }
         }
         if ($result !== false) {


### PR DESCRIPTION
### What does it do?
Changes xpdo::cacheManager::writeFile  fopen mode 

### Why is it needed?
Sometimes when cache manager trying to write file twice at the same time script content appends creating exception <?php ...code... <?php ...code... (not closed "<?php" tag but opened twice)

xpdo::cacheManager::writeFile has hardcoded "A" file open mode when using flag "B" or "T" on call
`$fmode = (strlen($mode) > 1 && in_array($mode[1], array('b', 't'))) ? "a{$mode[1]}" : 'a';`

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13729
