### PR TITLE
Make the resource class a little closer to SOLID principles

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -432,6 +432,19 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     }
 
     /**
+     * Prepare the resource for output.
+     */
+    public function prepare()
+    {
+        # 1. Parse cacheable elements if exist.
+        $this->process();
+        # 2. Copy registered scripts added by the cacheable elements.
+        $this->syncScripts();
+        # 3. Parse uncacheable elements.
+        $this->parseContent();
+    }
+    
+    /**
      * Process a resource, transforming source content to output.
      *
      * @return string The processed cacheable content of a resource.
@@ -457,6 +470,42 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         return $this->_content;
     }
 
+    /**
+     * @param array $data Data for placeholders
+     * @return string
+     */
+    public function parseContent($data = array())
+    {
+        $this->xpdo->getParser();
+        $maxIterations = intval($this->xpdo->getOption('parser_max_iterations', null, 10));
+        $oldResource = $this->xpdo->resource;
+        $this->xpdo->resource = $this;
+        if (!empty($data)) {
+            $scope = $this->xpdo->toPlaceholders($data, '', '.', true);
+        }
+        if (!$this->_processed) {
+            $this->_content = $this->getContent();
+            $this->xpdo->parser->processElementTags('', $this->_content, false, false, '[[', ']]', array(), $maxIterations);
+            $this->_processed = true;
+        }
+        $this->_output = $this->_content;
+        $this->xpdo->parser->processElementTags('', $this->_output, true, false, '[[', ']]', array(), $maxIterations);
+        $this->xpdo->parser->processElementTags('', $this->_output, true, true, '[[', ']]', array(), $maxIterations);
+        $this->xpdo->resource = $oldResource;
+        if (isset($scope['keys'])) $this->xpdo->unsetPlaceholders($scope['keys']);
+        if (isset($scope['restore'])) $this->xpdo->toPlaceholders($scope['restore']);
+        return $this->_output;
+    }
+
+    /**
+     * Store scripts registered by cached elements.
+     */
+    public function syncScripts()
+    {
+        $this->_jscripts       = $this->xpdo->jscripts;
+        $this->_sjscripts      = $this->xpdo->sjscripts;
+        $this->_loadedjscripts = $this->xpdo->loadedjscripts;
+    }    
     /**
      * Gets the raw, unprocessed source content for a resource.
      *

--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -72,16 +72,7 @@ class modResponse {
         }
 
         if (!$this->contentType->get('binary')) {
-            $this->modx->resource->_output= $this->modx->resource->process();
-            $this->modx->resource->_jscripts= $this->modx->jscripts;
-            $this->modx->resource->_sjscripts= $this->modx->sjscripts;
-            $this->modx->resource->_loadedjscripts= $this->modx->loadedjscripts;
-
-            /* collect any uncached element tags in the content and process them */
-            $this->modx->getParser();
-            $maxIterations= intval($this->modx->getOption('parser_max_iterations', $options, 10));
-            $this->modx->parser->processElementTags('', $this->modx->resource->_output, true, false, '[[', ']]', array(), $maxIterations);
-            $this->modx->parser->processElementTags('', $this->modx->resource->_output, true, true, '[[', ']]', array(), $maxIterations);
+            $this->modx->resource->prepare();
 
             /*FIXME: only do this for HTML content ?*/
             if (strpos($this->contentType->get('mime_type'), 'text/html') !== false) {


### PR DESCRIPTION
### What does it do?
Move resource parsing functionality from the modResponse class to the modResource class. 

### Why is it needed?
1. A little closer to SOLID principles. Response class does not need to know about how the resource class must be parsed. Derivatives of the resource class can have their own implementation of parsing.
2. Also it can be useful for ajax request:
```
$resource = $modx->getObject('modResource', $id);
$content = $resource->parseContent();
```

