### PR TITLE
Add template icon for resources in search results.

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -188,9 +188,11 @@ class modSearchProcessor extends modProcessor
                 'description' => $record->get('description'),
                 'type' => $type,
                 'type_label' => $typeLabel,
-                'icon' => $record->get('icon')?:false,
+                'icon' => $record->get('icon') ?: false,
             );
-            if($this->results['icon'])$this->results['icon']=str_replace('icon-','',$this->results['icon']);
+            if($this->results['icon']){
+                $this->results['icon']=str_replace('icon-','',$this->results['icon']);
+            }
         }
     }
 

--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -159,20 +159,23 @@ class modSearchProcessor extends modProcessor
         }
 
         $c = $this->modx->newQuery('modResource');
+        $c->leftJoin('modTemplate','modTemplate','modResource.template=modTemplate.id');
+        $c->select($this->modx->getSelectColumns('modResource','modResource'));
+        $c->select("modTemplate.icon as icon");
         $c->where(array(
             array(
-                'pagetitle:LIKE' => '%' . $this->query .'%',
-                'OR:longtitle:LIKE' => '%' . $this->query .'%',
-                'OR:alias:LIKE' => '%' . $this->query .'%',
-                'OR:description:LIKE' => '%' . $this->query .'%',
-                'OR:introtext:LIKE' => '%' . $this->query .'%',
-                'OR:id:=' => $this->query,
+                'modResource.pagetitle:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.longtitle:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.alias:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.description:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.introtext:LIKE' => '%' . $this->query .'%',
+                'OR:modResource.id:=' => $this->query,
             ),
             array(
-                'context_key:IN' => $contextKeys,
+                'modResource.context_key:IN' => $contextKeys,
             )
         ));
-        $c->sortby('createdon', 'DESC');
+        $c->sortby('modResource.createdon', 'DESC');
 
         $c->limit($this->maxResults);
 
@@ -185,7 +188,9 @@ class modSearchProcessor extends modProcessor
                 'description' => $record->get('description'),
                 'type' => $type,
                 'type_label' => $typeLabel,
+                'icon' => $record->get('icon')?:false,
             );
+            if($this->results['icon'])$this->results['icon']=str_replace('icon-','',$this->results['icon']);
         }
     }
 

--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -159,8 +159,8 @@ class modSearchProcessor extends modProcessor
         }
 
         $c = $this->modx->newQuery('modResource');
-        $c->leftJoin('modTemplate','modTemplate','modResource.template=modTemplate.id');
-        $c->select($this->modx->getSelectColumns('modResource','modResource'));
+        $c->leftJoin('modTemplate', 'modTemplate', 'modResource.template = modTemplate.id');
+        $c->select($this->modx->getSelectColumns('modResource', 'modResource'));
         $c->select("modTemplate.icon as icon");
         $c->where(array(
             array(
@@ -188,11 +188,8 @@ class modSearchProcessor extends modProcessor
                 'description' => $record->get('description'),
                 'type' => $type,
                 'type_label' => $typeLabel,
-                'icon' => $record->get('icon') ?: false,
+                'icon' => str_replace('icon-', '', $record->get('icon'))
             );
-            if($this->results['icon']){
-                $this->results['icon']=str_replace('icon-','',$this->results['icon']);
-            }
         }
     }
 


### PR DESCRIPTION
### What does it do?
Add template icon for resources in uberbar search results.

### Why is it needed?
If we have some resources with same names, but different templates, in search results we see its icons to distinguish them.

### Related issue(s)/PR(s)
![result](https://i.imgur.com/nD3y7kk.png "Result")

PR to 2.6.x branch:
#13869 