### PR TITLE
Fix some minor XSS issues reported in security ticket 69

### DIFF
--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -72,7 +72,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         if (!$object->checkPolicy('view')) return array();
 
         $resourceArray = $object->get(array('id','pagetitle','description','published','deleted', 'context_key'));
-        $resourceArray['pagetitle'] = htmlspecialchars($resourceArray['pagetitle'], ENT_QUOTES, 'UTF-8');
+        $resourceArray['pagetitle'] = htmlspecialchars($resourceArray['pagetitle'], ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
         $resourceArray['menu'] = array();
         $resourceArray['menu'][] = array(
             'text' => $this->modx->lexicon('resource_view'),

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -72,6 +72,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         if (!$object->checkPolicy('view')) return array();
 
         $resourceArray = $object->get(array('id','pagetitle','description','published','deleted', 'context_key'));
+        $resourceArray['pagetitle'] = htmlspecialchars($resourceArray['pagetitle'], ENT_QUOTES, 'UTF-8');
         $resourceArray['menu'] = array();
         $resourceArray['menu'][] = array(
             'text' => $this->modx->lexicon('resource_view'),

--- a/core/model/modx/processors/system/menu/getnodes.class.php
+++ b/core/model/modx/processors/system/menu/getnodes.class.php
@@ -60,6 +60,7 @@ class modMenuGetNodesProcessor extends modObjectGetListProcessor {
         }
         $text = $this->modx->lexicon($object->get('text'));
         $desc = $this->modx->lexicon($object->get('description'));
+        $text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
 
         $objectArray = array(
             'text' => $text.($controller != '' ? ' <i>('.$namespace.':'.$controller.')</i>' : ''),

--- a/core/model/modx/processors/system/menu/getnodes.class.php
+++ b/core/model/modx/processors/system/menu/getnodes.class.php
@@ -60,7 +60,7 @@ class modMenuGetNodesProcessor extends modObjectGetListProcessor {
         }
         $text = $this->modx->lexicon($object->get('text'));
         $desc = $this->modx->lexicon($object->get('description'));
-        $text = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+        $text = htmlspecialchars($text, ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
 
         $objectArray = array(
             'text' => $text.($controller != '' ? ' <i>('.$namespace.':'.$controller.')</i>' : ''),

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -126,6 +126,8 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
         } else {
             $settingArray['name'] = $settingArray['name_trans'];
         }
+        $settingArray['key'] = htmlspecialchars($settingArray['key'], ENT_QUOTES, 'UTF-8');
+        $settingArray['name_trans'] = htmlspecialchars($settingArray['name_trans'], ENT_QUOTES, 'UTF-8');
 
         $settingArray['oldkey'] = $settingArray['key'];
 

--- a/core/model/modx/processors/system/settings/getlist.class.php
+++ b/core/model/modx/processors/system/settings/getlist.class.php
@@ -126,8 +126,8 @@ class modSystemSettingsGetListProcessor extends modObjectGetListProcessor {
         } else {
             $settingArray['name'] = $settingArray['name_trans'];
         }
-        $settingArray['key'] = htmlspecialchars($settingArray['key'], ENT_QUOTES, 'UTF-8');
-        $settingArray['name_trans'] = htmlspecialchars($settingArray['name_trans'], ENT_QUOTES, 'UTF-8');
+        $settingArray['key'] = htmlspecialchars($settingArray['key'], ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
+        $settingArray['name_trans'] = htmlspecialchars($settingArray['name_trans'], ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
 
         $settingArray['oldkey'] = $settingArray['key'];
 


### PR DESCRIPTION
### What does it do?
Applies htmlspecialchars to some processors which were exposing 3 stored XSS issues. 

### Why is it needed?
Tighten security a bit. 

None of these XSS issues should have any far-reaching consequences. They all require manager access for starters. Also

- The one in the recently edited dashboard widget would only be useful to XSS yourself, as the resource list only shows resources you personally edited. Perhaps a problem when sharing user accounts. 
- Access to edit the top menu (actions) is needed for number 2. That's an advanced permission that only full admins should have.
- Adding/editing setting permission is needed for number 3. Also, that should already be limited to full admin users.

### Related issue(s)/PR(s)
Security inbox ticket number 69. Reported by Aman Sahey on April 25th.