### PR TITLE
Improve compatibility with extras

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -24,7 +24,7 @@ interface modResourceInterface {
      * @param xPDO $modx A reference to the modX object
      * @return string The absolute path to the controller for this Resource class
      */
-    public static function getControllerPath(&$modx);
+    public static function getControllerPath(xPDO &$modx);
 
     /**
      * Use this in your extended Resource class to display the text for the context menu item, if showInContextMenu is
@@ -1260,7 +1260,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      * @param xPDO $modx A reference to the modX object
      * @return string The absolute path to the controller for this Resource class
      */
-    public static function getControllerPath(&$modx) {
+    public static function getControllerPath(xPDO &$modx) {
         $theme = $modx->getOption('manager_theme',null,'default');
         $controllersPath = $modx->getOption('manager_path',null,MODX_MANAGER_PATH).'controllers/'.$theme.'/';
         return $controllersPath.'resource/';

--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -217,7 +217,7 @@ class modStaticResource extends modResource implements modResourceInterface {
      * @param xPDO $modx A reference to the modX instance
      * @return string
      */
-    public static function getControllerPath(&$modx) {
+    public static function getControllerPath(xPDO &$modx) {
         $path = modResource::getControllerPath($modx);
         return $path.'staticresource/';
     }

--- a/core/model/modx/modsymlink.class.php
+++ b/core/model/modx/modsymlink.class.php
@@ -56,7 +56,7 @@ class modSymLink extends modResource implements modResourceInterface {
      * @param xPDO $modx A reference to the modX instance
      * @return string
      */
-    public static function getControllerPath(&$modx) {
+    public static function getControllerPath(xPDO &$modx) {
         $path = modResource::getControllerPath($modx);
         return $path.'symlink/';
     }

--- a/core/model/modx/modweblink.class.php
+++ b/core/model/modx/modweblink.class.php
@@ -50,7 +50,7 @@ class modWebLink extends modResource implements modResourceInterface {
      * @param xPDO $modx A reference to the modX instance
      * @return string The absolute path to the controller for managing WebLinks
      */
-    public static function getControllerPath(&$modx) {
+    public static function getControllerPath(xPDO &$modx) {
         $path = modResource::getControllerPath($modx);
         return $path.'weblink/';
     }

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -39,6 +39,14 @@ use xPDO\Cache\xPDOCacheManager;
 use xPDO\Om\xPDOObject;
 
 class_alias('xPDO\xPDO', 'xPDO');
+class_alias('\xPDO\Om\xPDOCriteria', 'xPDOCriteria');
+class_alias('\xPDO\Om\xPDOSimpleObject', 'xPDOSimpleObject');
+class_alias('\xPDO\Om\xPDOQuery', 'xPDOQuery');
+class_alias('\xPDO\Om\xPDOObject', 'xPDOObject');
+class_alias('\xPDO\Cache\xPDOCacheManager', 'xPDOCacheManager');
+class_alias('\xPDO\Cache\xPDOFileCache', 'xPDOFileCache');
+class_alias('\xPDO\Transport\xPDOTransport', 'xPDOTransport');
+class_alias('\xPDO\Transport\xPDOObjectVehicle', 'xPDOObjectVehicle');
 
 /**
  * This is the MODX gateway class.

--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -35,7 +35,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     /** @var array $permissions */
     protected $permissions = [];
     /** @var array $errors */
-    protected $errors = [];
+    public $errors = [];
 
     /** @var bool to enable visibility support */
     protected $visibility_dirs = false;
@@ -665,7 +665,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         ]);
         $this->xpdo->logManagerAction('file_create', '', "{$this->get('name')}: $path");
 
-        return rawurlencode($path);
+        return rawurlencode($this->getBases()['pathAbsolute'] . $path);
     }
 
 

--- a/core/model/modx/transport/modpackagebuilder.class.php
+++ b/core/model/modx/transport/modpackagebuilder.class.php
@@ -57,7 +57,6 @@ class modPackageBuilder {
     function __construct(modX &$modx) {
         $this->modx = & $modx;
         $this->modx->loadClass('transport.modTransportVehicle', '', false, true);
-        $this->modx->loadClass('transport.xPDOTransport', XPDO_CORE_PATH, true, true);
 
         if (!$workspace = $this->modx->getObject('modWorkspace', array (
                 'active' => 1

--- a/core/model/modx/transport/modtransportmanager.class.php
+++ b/core/model/modx/transport/modtransportmanager.class.php
@@ -44,7 +44,6 @@ class modTransportManager {
     function __construct(xPDO &$modx) {
         $this->modx = &$modx;
         $this->getActiveWorkspace();
-        $this->modx->loadClass('transport.xPDOTransport', XPDO_CORE_PATH . 'om/', true, true);
     }
 
 	/**

--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -81,11 +81,6 @@ class modTransportPackage extends xPDOObject {
         return array('collection' => array(), 'total' => 0);
     }
 
-    public function __construct(&$xpdo) {
-        parent::__construct($xpdo);
-        $this->xpdo->loadClass('transport.xPDOTransport', XPDO_CORE_PATH, true, true);
-    }
-
     /**
      * Overrides xPDOObject::save to set a default created time if new.
      *

--- a/core/model/modx/transport/modtransportprovider.class.php
+++ b/core/model/modx/transport/modtransportprovider.class.php
@@ -376,7 +376,7 @@ class modTransportProvider extends xPDOSimpleObject {
             'revolution_version' => $this->xpdo->version['code_name'].'-'.$this->xpdo->version['full_version'],
             'supports' => $this->xpdo->version['code_name'].'-'.$this->xpdo->version['full_version'],
             'http_host' => $this->xpdo->getOption('http_host'),
-            'php_version' => XPDO_PHP_VERSION,
+            'php_version' => PHP_VERSION,
             'language' => $this->xpdo->getOption('manager_language', $_SESSION, $this->xpdo->getOption('cultureKey', null, 'en')),
         );
         return array_merge($baseArgs, $args);


### PR DESCRIPTION
### What does it do?
- Fixed "undefined constant XPDO_PHP_VERSION" on extras install
- Fixed "Could not load class: xPDOTransport" on extras install
- Fixed modX::getControllerPath method signature

### Why is it needed?
To improve compatibility with old extras

### Related issue(s)/PR(s)
#13841
