### PR TITLE
Escaping ORDER BY fields.

### DIFF
--- a/core/xpdo/om/mysql/xpdoquery.class.php
+++ b/core/xpdo/om/mysql/xpdoquery.class.php
@@ -136,11 +136,11 @@ class xPDOQuery_mysql extends xPDOQuery {
         if ($command == 'SELECT' && !empty ($this->query['sortby'])) {
             $sortby= reset($this->query['sortby']);
             $sql.= 'ORDER BY ';
-            $sql.= $sortby['column'];
+            $sql.= $this->xpdo->escape($sortby['column']);
             if ($sortby['direction']) $sql.= ' ' . $sortby['direction'];
             while ($sortby= next($this->query['sortby'])) {
                 $sql.= ', ';
-                $sql.= $sortby['column'];
+                $sql.= $this->xpdo->escape($sortby['column']);
                 if ($sortby['direction']) $sql.= ' ' . $sortby['direction'];
             }
             $sql.= ' ';


### PR DESCRIPTION
since MySQL word RANK (R) added in 8.0.2 (reserved). This field is used in modCategory for sorting ASC in manager.
without that escaping you get false result for query.

### What does it do?
i just make xpdo->escape for field when generating sql order by part.

### Why is it needed?
With Mysql >=8.0.2  core object modCategory have field name "rank" - this is reserved keyword. And in manager on resource TV tab i can'nt see category vertical tabs.
