### PR TITLE
Fixes TV > tpl access sorting

### DIFF
--- a/core/model/modx/processors/element/tv/template/getlist.class.php
+++ b/core/model/modx/processors/element/tv/template/getlist.class.php
@@ -69,19 +69,20 @@ class modElementTvTemplateGetList extends modProcessor {
                 'Category.id' => $category
             ));
         }
-        
+
         $data['total'] = $this->modx->getCount('modTemplate',$c);
-        
+
         $c->leftJoin('modTemplateVarTemplate','TemplateVarTemplates',array(
             'modTemplate.id = TemplateVarTemplates.templateid',
             'TemplateVarTemplates.tmplvarid' => $this->getProperty('tv'),
         ));
-        
+
         $c->select($this->modx->getSelectColumns('modTemplate','modTemplate'));
         $c->select(array(
             'category_name' => 'Category.category',
         ));
         $c->select($this->modx->getSelectColumns('modTemplateVarTemplate','TemplateVarTemplates','',array('tmplvarid')));
+        $c->select(array('access' => 'TemplateVarTemplates.tmplvarid'));
         $c->sortby($this->getProperty('sort'),$this->getProperty('dir'));
         if ($isLimit) $c->limit($limit,$this->getProperty('start'));
         $data['results'] = $this->modx->getCollection('modTemplate',$c);
@@ -97,8 +98,6 @@ class modElementTvTemplateGetList extends modProcessor {
      */
     public function prepareRow(modTemplate $template) {
         $templateArray = $template->toArray();
-        $templateArray['access'] = $template->get('tmplvarid');
-        $templateArray['access'] = empty($templateArray['access']) ? false : true;
         $templateArray['category_name']= $template->get('category_name');
         unset($templateArray['content']);
         return $templateArray;


### PR DESCRIPTION
### What does it do?
Fixes v old bug by setting remoteSort to false in the 'TV>Template Access' grid

### Why is it needed?
When sorting by the Access column the processor returns no results and xpdo logs an unknown column error. This because the access value is set manually in the processor after the db query.

### Related issue(s)/PR(s)
Fixes: #12319, #7896 New pr version of #13597

Tested on: MODX 2.6.4-dev, PHP 7.0.27 & 10.1.30-MariaDB