### PR TITLE
If the copy to clipboard flash file is missing it's a good thing and …

### DIFF
--- a/setup/includes/upgrades/common/3.0.0-remove-copy-to-clipboard.php
+++ b/setup/includes/upgrades/common/3.0.0-remove-copy-to-clipboard.php
@@ -17,5 +17,5 @@ if (file_exists($fileToRemove) === true) {
         $this->runner->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">'.$this->install->lexicon('clipboard_flash_file_unlink_failed').'</p>');
     }
 } else {
-    $this->runner->addResult(modInstallRunner::RESULT_WARNING,'<p class="warning">'.$this->install->lexicon('clipboard_flash_file_missing').'</p>');
+        $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">'.$this->install->lexicon('clipboard_flash_file_missing').'</p>');
 }

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -46,6 +46,6 @@ $_lang['legacy_cleanup_complete'] = 'Legacy file clean up complete.';
 $_lang['legacy_cleanup_count'] = 'Removed [[+files]] file(s) and [[+folders]] folder(s).';
 $_lang['clipboard_flash_file_unlink_success'] = 'Successfully removed the copy to clipboard flash file.';
 $_lang['clipboard_flash_file_unlink_failed'] = 'Error removing the copy to clipboard flash file.';
-$_lang['clipboard_flash_file_missing'] = 'The copy to clipboard flash file does not exist.';
+$_lang['clipboard_flash_file_missing'] = 'The copy to clipboard flash file has already been removed.';
 $_lang['system_setting_cleanup_success'] = 'System Setting `[[+key]]` removed.';
 $_lang['system_setting_cleanup_failed'] = 'System Setting `[[+key]]` could not be removed.';


### PR DESCRIPTION
…we should inform the user with a success message telling that the file has already been removed.

### What does it do?
Changed the result from type "warning" to type "success" and changed the message for the install summary.

### Why is it needed?
That the flash file isn't there is a good thing, shouldn't be styled as warning. 

### Related issue(s)/PR(s)
Issue #13890 