### PR TITLE
Fix modParser so we can output brackets around parsed elements

### DIFF
--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -72,7 +72,8 @@ class modParserTest extends MODxTestCase {
         return array(
             array("", '[[', ']]', array(), 0),
             array("[[tag]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
-            array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag]]", "tag"), array("[[tag2]]", "tag2")), 2),
+            array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[*field:is=`0`:then=`Tag`:else=`Tag`]]", "*field:is=`0`:then=`Tag`:else=`Tag`")), 1),
+            array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag2]]", "tag"), array("[[tag2]]", "tag2")), 2),
             array("[[tag[[tag2]]]]", '[[', ']]', array(array("[[tag[[tag2]]]]", "tag[[tag2]]")), 1),
             array("[[tag[[tag2[[tag3]]]]]]", '[[', ']]', array(array("[[tag[[tag2[[tag3]]]]]]", "tag[[tag2[[tag3]]]]")), 1),
             array("[[tag\n?food=`beer`\n[[tag2]]]]", '[[', ']]', array(array("[[tag\n?food=`beer`\n[[tag2]]]]", "tag\n?food=`beer`\n[[tag2]]")), 1),

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -72,7 +72,7 @@ class modParserTest extends MODxTestCase {
         return array(
             array("", '[[', ']]', array(), 0),
             array("[[tag]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
-            array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[*field:is=`0`:then=`Tag`:else=`Tag`]]", "*field:is=`0`:then=`Tag`:else=`Tag`")), 1),
+            array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", "[[*field:is=`0`:then=`Tag`:else=`Tag`]]")), 1),
             array("items[[[tag]]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
             array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag]]", "tag"), array("[[tag2]]", "tag2")), 2),
             array("[[tag[[tag2]]]]", '[[', ']]', array(array("[[tag[[tag2]]]]", "tag[[tag2]]")), 1),

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -74,6 +74,16 @@ class modParserTest extends MODxTestCase {
             array("[[tag]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
             array("<title>[[*pagetitle]] - [[++site_name]]</title><body>[something]</body>", '[[', ']]', array(array("[[*pagetitle]]", "*pagetitle"), array("[[++site_name]]", "++site_name")), 2),
             array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", "[[*field:is=`0`:then=`Tag`:else=`Tag`]]")), 1),
+            array("[[!+fi.successMessage:empty=`
+    test[]
+	[[~[[*id]]]]
+`]]", '[[', ']]', array(array("[[!+fi.successMessage:empty=`
+    test[]
+	[[~[[*id]]]]
+`]]", "!+fi.successMessage:empty=`
+    test[]
+	[[~[[*id]]]]
+`")), 1),
             array("items[[[tag]]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
             array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag]]", "tag"), array("[[tag2]]", "tag2")), 2),
             array("[[tag[[tag2]]]]", '[[', ']]', array(array("[[tag[[tag2]]]]", "tag[[tag2]]")), 1),

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -74,7 +74,7 @@ class modParserTest extends MODxTestCase {
             array("[[tag]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
             array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[*field:is=`0`:then=`Tag`:else=`Tag`]]", "*field:is=`0`:then=`Tag`:else=`Tag`")), 1),
             array("items[[[tag]]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
-            array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag2]]", "tag"), array("[[tag2]]", "tag2")), 2),
+            array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag]]", "tag"), array("[[tag2]]", "tag2")), 2),
             array("[[tag[[tag2]]]]", '[[', ']]', array(array("[[tag[[tag2]]]]", "tag[[tag2]]")), 1),
             array("[[tag[[tag2[[tag3]]]]]]", '[[', ']]', array(array("[[tag[[tag2[[tag3]]]]]]", "tag[[tag2[[tag3]]]]")), 1),
             array("[[tag\n?food=`beer`\n[[tag2]]]]", '[[', ']]', array(array("[[tag\n?food=`beer`\n[[tag2]]]]", "tag\n?food=`beer`\n[[tag2]]")), 1),

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -73,6 +73,7 @@ class modParserTest extends MODxTestCase {
             array("", '[[', ']]', array(), 0),
             array("[[tag]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
             array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[*field:is=`0`:then=`Tag`:else=`Tag`]]", "*field:is=`0`:then=`Tag`:else=`Tag`")), 1),
+            array("items[[[tag]]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
             array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag2]]", "tag"), array("[[tag2]]", "tag2")), 2),
             array("[[tag[[tag2]]]]", '[[', ']]', array(array("[[tag[[tag2]]]]", "tag[[tag2]]")), 1),
             array("[[tag[[tag2[[tag3]]]]]]", '[[', ']]', array(array("[[tag[[tag2[[tag3]]]]]]", "tag[[tag2[[tag3]]]]")), 1),

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -72,6 +72,7 @@ class modParserTest extends MODxTestCase {
         return array(
             array("", '[[', ']]', array(), 0),
             array("[[tag]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
+            array("<title>[[*pagetitle]] - [[++site_name]]</title><body>[something]</body>", '[[', ']]', array(array("[[*pagetitle]]", "*pagetitle"), array("[[++site_name]]", "++site_name")), 2),
             array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", "[[*field:is=`0`:then=`Tag`:else=`Tag`]]")), 1),
             array("items[[[tag]]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
             array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag]]", "tag"), array("[[tag2]]", "tag2")), 2),

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -135,8 +135,19 @@ class modParser {
             if (($stopPos= strrpos($origContent, $suffix)) === false) {
                 return $matchCount;
             }
+            // We want to have a string containing all unique characters the prefix consists of. In most cases this will
+            // be 1. Unless someone doesn't use the default MODX prefix and suffix.
             $uniqueCharacters = count_chars($prefix, 3);
+            // We count the amount of unique characters. If it's 1 we know it can break the parser in some cases. See
+            // issue #13903 https://github.com/modxcms/revolution/issues/13903
             if (strlen($uniqueCharacters) === 1) {
+                // Now we check how many times the character occurs. If the result is odd we have to move the $startPos
+                // by one so it will use the correct $prefix.
+                // This is because the parser will start looking from the left to find the $prefix.
+                // Example element in a chunk: <input type="text" name="items[[[*id]]][foo]" value="something">
+                // Without moving the $startPos by one it would find match see the first two ['s. Then it sees [*
+                // and then it would parse it as a snippet throwing an error:
+                // ERROR @ core/model/modx/modparser.class.php : 540) Could not find snippet with name [*id.
                 if (substr_count($origContent, $uniqueCharacters) % 2 === 1) {
                     $startPos += 1;
                 }

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -123,12 +123,12 @@ class modParser {
      */
     public function collectElementTags($origContent, array &$matches, $prefix= '[[', $suffix= ']]') {
         $matchCount= 0;
-        if (!empty ($origContent) && is_string($origContent) && strpos($origContent, $prefix) !== false) {
+        if (!empty ($origContent) && is_string($origContent) && strrpos($origContent, $prefix) !== false) {
             $openCount= 0;
             $offset= 0;
             $openPos= 0;
             $closePos= 0;
-            if (($startPos= strpos($origContent, $prefix)) === false) {
+            if (($startPos= strrpos($origContent, $prefix)) === false) {
                 return $matchCount;
             }
             $offset= $startPos +strlen($prefix);

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -125,14 +125,14 @@ class modParser {
         $subPrefix = $prefix;
         $subSuffix = $suffix;
 
-        if ($prefix % 2 === 0) {
+        if (strlen($prefix) % 2 === 0) {
             $uniqueCharactersPrefix = count_chars($prefix, 3);
 
             if (strlen($uniqueCharactersPrefix) === 1) {
                 $subPrefix = substr($prefix, 0, 1);
             }
         }
-        if ($suffix % 2 === 0) {
+        if (strlen($suffix) % 2 === 0) {
             $uniqueCharactersSuffix = count_chars($suffix, 3);
 
             if (strlen($uniqueCharactersSuffix) === 1) {

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -123,17 +123,23 @@ class modParser {
      */
     public function collectElementTags($origContent, array &$matches, $prefix= '[[', $suffix= ']]') {
         $matchCount= 0;
-        if (!empty ($origContent) && is_string($origContent) && strrpos($origContent, $prefix) !== false) {
+        if (!empty ($origContent) && is_string($origContent) && strpos($origContent, $prefix) !== false) {
             $openCount= 0;
             $offset= 0;
             $openPos= 0;
             $closePos= 0;
-            if (($startPos= strrpos($origContent, $prefix)) === false) {
+            if (($startPos= strpos($origContent, $prefix)) === false) {
                 return $matchCount;
             }
             $offset= $startPos +strlen($prefix);
             if (($stopPos= strrpos($origContent, $suffix)) === false) {
                 return $matchCount;
+            }
+            $uniqueCharacters = count_chars($prefix, 3);
+            if (strlen($uniqueCharacters) === 1) {
+                if (substr_count($origContent, $uniqueCharacters) % 2 === 1) {
+                    $startPos += 1;
+                }
             }
             $stopPos= $stopPos + strlen($suffix);
             $length= $stopPos - $startPos;

--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -122,7 +122,25 @@ class modParser {
      * @return integer The number of tags collected from the content.
      */
     public function collectElementTags($origContent, array &$matches, $prefix= '[[', $suffix= ']]') {
-        $pattern = '/'.preg_quote($prefix).'((?>[^'.preg_quote($prefix).preg_quote($suffix).']+|(?R))*)'.preg_quote($suffix).'/';
+        $subPrefix = $prefix;
+        $subSuffix = $suffix;
+
+        if ($prefix % 2 === 0) {
+            $uniqueCharactersPrefix = count_chars($prefix, 3);
+
+            if (strlen($uniqueCharactersPrefix) === 1) {
+                $subPrefix = substr($prefix, 0, 1);
+            }
+        }
+        if ($suffix % 2 === 0) {
+            $uniqueCharactersSuffix = count_chars($suffix, 3);
+
+            if (strlen($uniqueCharactersSuffix) === 1) {
+                $subSuffix = substr($suffix, 0, 1);
+            }
+        }
+
+        $pattern = '/\Q'.$prefix.'\E((?:(?:[^'.$subSuffix.$subPrefix.'][\s\S]*?|(?R))*?))\Q'.$suffix.'\E/x';
         preg_match_all($pattern, $origContent, $matches, PREG_SET_ORDER);
 
         $matchCount = count($matches);


### PR DESCRIPTION
### What does it do?
Find the position of the last occurrence of prefix in the original content so we can output brackets around parsed elements.

### Why is it needed?
This way we can for example use the output as array key in a form input name.

### Related issue(s)/PR(s)
#13903 