### PR TITLE
Fixed the Unit Test for the invalid category. 

### DIFF
--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -107,11 +107,9 @@ class ChunkProcessorsTest extends MODxTestCase {
                 'category' => 1,
             )),
             /* fail: invalid category */
-            /* @TODO: Fix. For some reason this crashes on the $category->checkPolicy('add_children') in the
-             * create processor. (line 33)
             array(false,'UnitTestChunk3',array(
                 'category' => 123,
-            )),*/
+            )),
             /* fail: already exists */
             array(false,'UnitTestChunk'),
             /* fail: no data */

--- a/core/model/modx/processors/element/create.class.php
+++ b/core/model/modx/processors/element/create.class.php
@@ -38,10 +38,10 @@ abstract class modElementCreateProcessor extends modObjectCreateProcessor {
         if (!empty($category)) {
             /** @var modCategory $category */
             $category = $this->modx->getObject('modCategory',array('id' => $category));
-            if (empty($category)) {
+            if ($category === null) {
                 $this->addFieldError('category',$this->modx->lexicon('category_err_nf'));
             }
-            if (!$category->checkPolicy('add_children')) {
+            if ($category !== null && !$category->checkPolicy('add_children')) {
                 $this->addFieldError('category',$this->modx->lexicon('access_denied'));
             }
         }


### PR DESCRIPTION
This solves the todo: "For some reason this crashes on the $category->checkPolicy('add_children') in the create processor. (line 33)"

### What does it do?
Checks if the category is null instead of empty.

### Why is it needed?
It fixes the unit test "ChunkTest" with the data for an "invalid category".

### Related issue(s)/PR(s)
Non that I'm aware of.
