### PR TITLE
modUser - generatePasssword improvements.

### DIFF
--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -105,6 +105,19 @@ class modUserTest extends MODxTestCase {
         );
     }
 
+    public function testGeneratePasswordWithPasswordLengthOption()
+    {
+        $password = $this->user->generatePassword();
+        $this->assertNotEmpty($password);
+        $this->assertNotEquals(12, strlen($password));
+
+        $this->modx->setOption('password_generated_length',12);
+        $anotherPassword = $this->user->generatePassword();
+
+        $this->assertNotEmpty($anotherPassword);
+        $this->assertEquals(12, strlen($anotherPassword));
+    }
+
     /**
      * Ensure passwordMatches works
      * @return void

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -113,9 +113,13 @@ class modUserTest extends MODxTestCase {
 
         $this->modx->setOption('password_generated_length',12);
         $anotherPassword = $this->user->generatePassword();
-
         $this->assertNotEmpty($anotherPassword);
         $this->assertEquals(12, strlen($anotherPassword));
+
+        $this->modx->setOption('password_generated_length','');
+        $yetAnotherPassword = $this->user->generatePassword();
+        $this->assertNotEmpty($yetAnotherPassword);
+        $this->assertEquals(10, strlen($yetAnotherPassword));
     }
 
     /**

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -788,11 +788,8 @@ class modUser extends modPrincipal {
      * @return string The newly generated password
      */
     public function generatePassword($length = null,array $options = array()) {
-        if ($length === null || $length === '') {
-            $length = $this->getOption('password_generated_length',null,10);
-            if ($length === '') {
-                $length = 10;
-            }
+        if ($length === null) {
+            $length = $this->xpdo->getOption('password_generated_length', null, 10, true);
         }
         $options = array_merge(array(
             'allowable_characters' => 'abcdefghjkmnpqrstuvxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789',

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -788,8 +788,11 @@ class modUser extends modPrincipal {
      * @return string The newly generated password
      */
     public function generatePassword($length = null,array $options = array()) {
-        if ($length === null) {
+        if ($length === null || $length === '') {
             $length = $this->getOption('password_generated_length',null,10);
+            if ($length === '') {
+                $length = 10;
+            }
         }
         $options = array_merge(array(
             'allowable_characters' => 'abcdefghjkmnpqrstuvxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789',

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -787,7 +787,10 @@ class modUser extends modPrincipal {
      * @param array $options
      * @return string The newly generated password
      */
-    public function generatePassword($length = 10,array $options = array()) {
+    public function generatePassword($length = null,array $options = array()) {
+        if ($length === null) {
+            $length = $this->getOption('password_generated_length',null,10);
+        }
         $options = array_merge(array(
             'allowable_characters' => 'abcdefghjkmnpqrstuvxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789',
             'srand_seed_multiplier' => 1000000,

--- a/core/model/modx/processors/security/user/_validation.php
+++ b/core/model/modx/processors/security/user/_validation.php
@@ -64,8 +64,7 @@ class modUserValidation {
             }
             $passwordGenerationMethod = $this->processor->getProperty('passwordgenmethod','g');
             if ($passwordGenerationMethod == 'g') {
-                $len = $this->modx->getOption('password_generated_length',null,8);
-                $autoPassword = $this->generatePassword($len);
+                $autoPassword = $this->user->generatePassword();
                 $this->user->set('password', $autoPassword);
                 $this->processor->newPassword= $autoPassword;
             } else {
@@ -170,17 +169,6 @@ class modUserValidation {
             $this->processor->setProperty('blockedafter',$blockedAfter);
             $this->profile->set('blockedafter',$blockedAfter);
         }
-    }
-
-    public function generatePassword($length = 10) {
-        $allowable_characters = 'abcdefghjkmnpqrstuvxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789';
-        $ps_len = strlen($allowable_characters);
-        srand((double) microtime() * 1000000);
-        $pass = '';
-        for ($i = 0; $i < $length; $i++) {
-                $pass .= $allowable_characters[mt_rand(0, $ps_len -1)];
-        }
-        return $pass;
     }
 
 }


### PR DESCRIPTION
### What does it do?
Removed a duplicate generatePassword and make it use "password_generated_length"

### Why is it needed?
Duplicate code can cause problems down the road.
This also solves an issue where the system setting "password_generated_length" didn't work properly in all cases.

### Related issue(s)/PR(s)
It solves issue #12996
