### PR TITLE
Added phpunit/phpunit ^5 as development requirement.

### DIFF
--- a/_build/test/MODxTestCase.php
+++ b/_build/test/MODxTestCase.php
@@ -26,7 +26,7 @@
  *
  * @package modx-test
  */
-abstract class MODxTestCase extends PHPUnit_Framework_TestCase {
+abstract class MODxTestCase extends \PHPUnit\Framework\TestCase {
     /**
      * @var modX $modx
      */

--- a/_build/test/Tests/modXSetupTest.php
+++ b/_build/test/Tests/modXSetupTest.php
@@ -28,7 +28,7 @@
  * @package modx-test
  * @subpackage modx
  */
-class modXSetupTest extends PHPUnit_Framework_TestCase {
+class modXSetupTest extends \PHPUnit\Framework\TestCase {
     /**
      * Test that the PDO extension is available and loaded.
      */

--- a/_build/test/Tests/modXTeardownTest.php
+++ b/_build/test/Tests/modXTeardownTest.php
@@ -28,7 +28,7 @@
  * @package modx-test
  * @subpackage modx
  */
-class MODxTeardownTest extends PHPUnit_Framework_TestCase {
+class MODxTeardownTest extends \PHPUnit\Framework\TestCase {
     public function testTearDown() {
         $this->assertTrue(true);
     }

--- a/composer.json
+++ b/composer.json
@@ -46,5 +46,8 @@
         ]
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "phpunit/phpunit": "^5"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^5"
+        "phpunit/phpunit": "~5.7|~6.5"
     }
 }


### PR DESCRIPTION
### What does it do?
It marks phpunit/phpunit ^5 as development requirement in composer.json

### Why is it needed?
To help new contributors set up a development environment it would be helpful if the development packages were included in composer.json. 
In this case it's only phpunit.

### Related issue(s)/PR(s)
#13910 