### PR TITLE
Add ID number to manager pages (resources and elements)

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -66,7 +66,13 @@ MODx.panel.Chunk = function(config) {
                         ,value: config.record.name
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
-                                Ext.getCmp('modx-chunk-header').getEl().update(_('chunk')+': '+f.getValue());
+                                var title = Ext.util.Format.stripTags(f.getValue());
+                                title = _('chunk')+': '+Ext.util.Format.htmlEncode(title);
+                                if (MODx.request.a !== 'element/chunk/create') {
+                                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                                }
+
+                                Ext.getCmp('modx-chunk-header').getEl().update(title);
                             }}
                         }
                     },{
@@ -250,7 +256,7 @@ Ext.extend(MODx.panel.Chunk,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-chunk-header').getEl().update(_('chunk')+': '+this.config.record.name);
+            Ext.getCmp('modx-chunk-header').getEl().update(_('chunk')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -68,8 +68,8 @@ MODx.panel.Chunk = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('chunk')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/chunk/create') {
-                                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                                if (MODx.request.a !== 'element/chunk/create' && MODx.perm.tree_show_element_ids === 1) {
+                                    title += ' <small>('+this.config.record.id+')</small>';
                                 }
 
                                 Ext.getCmp('modx-chunk-header').getEl().update(title);
@@ -256,7 +256,11 @@ Ext.extend(MODx.panel.Chunk,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-chunk-header').getEl().update(_('chunk')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
+            var title = _('chunk')+': '+this.config.record.name;
+            if (MODx.perm.tree_show_element_ids === 1) {
+                title = title+ ' <small>('+this.config.record.id+')</small>';
+            }
+            Ext.getCmp('modx-chunk-header').getEl().update(title);
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -70,7 +70,7 @@ MODx.panel.Plugin = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('plugin')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/plugin/create') {
+                                if (MODx.request.a !== 'element/plugin/create' && MODx.perm.tree_show_element_ids === 1) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -284,7 +284,11 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-plugin-header').getEl().update(_('plugin')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
+            var title = _('plugin')+': '+this.config.record.name;
+            if (MODx.perm.tree_show_element_ids === 1) {
+                title = title+ ' <small>('+this.config.record.id+')</small>';
+            }
+            Ext.getCmp('modx-plugin-header').getEl().update(title);
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -68,7 +68,13 @@ MODx.panel.Plugin = function(config) {
                         ,value: config.record.name
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
-                                Ext.getCmp('modx-plugin-header').getEl().update(_('plugin')+': '+f.getValue());
+                                var title = Ext.util.Format.stripTags(f.getValue());
+                                title = _('plugin')+': '+Ext.util.Format.htmlEncode(title);
+                                if (MODx.request.a !== 'element/plugin/create') {
+                                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                                }
+
+                                Ext.getCmp('modx-plugin-header').getEl().update(title);
                             }}
                         }
                     },{
@@ -278,7 +284,7 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-plugin-header').getEl().update(_('plugin')+': '+this.config.record.name);
+            Ext.getCmp('modx-plugin-header').getEl().update(_('plugin')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -69,7 +69,7 @@ MODx.panel.Snippet = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('snippet')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/snippet/create') {
+                                if (MODx.request.a !== 'element/snippet/create' && MODx.perm.tree_show_element_ids === 1) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -256,7 +256,11 @@ Ext.extend(MODx.panel.Snippet,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-snippet-header').getEl().update(_('snippet')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
+            var title = _('snippet')+': '+this.config.record.name;
+            if (MODx.perm.tree_show_element_ids === 1) {
+                title = title+ ' <small>('+this.config.record.id+')</small>';
+            }
+            Ext.getCmp('modx-snippet-header').getEl().update(title);
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -67,7 +67,13 @@ MODx.panel.Snippet = function(config) {
                         ,value: config.record.name
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
-                                Ext.getCmp('modx-snippet-header').getEl().update(_('snippet')+': '+f.getValue());
+                                var title = Ext.util.Format.stripTags(f.getValue());
+                                title = _('snippet')+': '+Ext.util.Format.htmlEncode(title);
+                                if (MODx.request.a !== 'element/snippet/create') {
+                                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                                }
+
+                                Ext.getCmp('modx-snippet-header').getEl().update(title);
                             }}
                         }
                     },{
@@ -250,7 +256,7 @@ Ext.extend(MODx.panel.Snippet,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-snippet-header').getEl().update(_('snippet')+': '+this.config.record.name);
+            Ext.getCmp('modx-snippet-header').getEl().update(_('snippet')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -70,7 +70,13 @@ MODx.panel.Template = function(config) {
                         ,value: config.record.templatename
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
-                                Ext.getCmp('modx-template-header').getEl().update(_('template')+': '+f.getValue());
+                                var title = Ext.util.Format.stripTags(f.getValue());
+                                title = _('template')+': '+Ext.util.Format.htmlEncode(title);
+                                if (MODx.request.a !== 'element/template/create') {
+                                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                                }
+
+                                Ext.getCmp('modx-template-header').getEl().update(title);
                             }}
                         }
                     },{
@@ -290,7 +296,7 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.templatename)) {
-            Ext.getCmp('modx-template-header').getEl().update(_('template')+': '+this.config.record.templatename);
+            Ext.getCmp('modx-template-header').getEl().update(_('template')+': '+this.config.record.templatename+ ' <small>('+this.config.record.id+')</small>');
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -296,7 +296,7 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.templatename)) {
-            var title = _('template')+': '+this.config.record.name;
+            var title = _('template')+': '+this.config.record.templatename;
             if (MODx.perm.tree_show_element_ids === 1) {
                 title = title+ ' <small>('+this.config.record.id+')</small>';
             }

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -72,7 +72,7 @@ MODx.panel.Template = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('template')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/template/create') {
+                                if (MODx.request.a !== 'element/template/create' && MODx.perm.tree_show_element_ids === 1) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -296,7 +296,11 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.templatename)) {
-            Ext.getCmp('modx-template-header').getEl().update(_('template')+': '+this.config.record.templatename+ ' <small>('+this.config.record.id+')</small>');
+            var title = _('template')+': '+this.config.record.name;
+            if (MODx.perm.tree_show_element_ids === 1) {
+                title = title+ ' <small>('+this.config.record.id+')</small>';
+            }
+            Ext.getCmp('modx-template-header').getEl().update(title);
         }
         if (!Ext.isEmpty(this.config.record.properties)) {
             var d = this.config.record.properties;

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -70,7 +70,13 @@ MODx.panel.TV = function(config) {
                         ,value: config.record.name
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
-                                Ext.getCmp('modx-tv-header').getEl().update(_('tv')+': '+f.getValue());
+                                var title = Ext.util.Format.stripTags(f.getValue());
+                                title = _('tv')+': '+Ext.util.Format.htmlEncode(title);
+                                if (MODx.request.a !== 'element/tv/create') {
+                                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                                }
+
+                                Ext.getCmp('modx-tv-header').getEl().update(title);
                             }}
                         }
                     },{
@@ -337,7 +343,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-tv-header').getEl().update(_('tv')+': '+this.config.record.name);
+            Ext.getCmp('modx-tv-header').getEl().update(_('tv')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
         }
         var d;
         if (!Ext.isEmpty(this.config.record.properties)) {

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -72,7 +72,7 @@ MODx.panel.TV = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('tv')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/tv/create') {
+                                if (MODx.request.a !== 'element/tv/create' && MODx.perm.tree_show_element_ids === 1) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -343,7 +343,11 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.getCmp('modx-tv-header').getEl().update(_('tv')+': '+this.config.record.name+ ' <small>('+this.config.record.id+')</small>');
+            var title = _('tv')+': '+this.config.record.name;
+            if (MODx.perm.tree_show_element_ids === 1) {
+                title = title+ ' <small>('+this.config.record.id+')</small>';
+            }
+            Ext.getCmp('modx-tv-header').getEl().update(title);
         }
         var d;
         if (!Ext.isEmpty(this.config.record.properties)) {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -54,7 +54,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             if (!Ext.isEmpty(this.config.record.pagetitle)) {
                 var title = Ext.util.Format.stripTags(this.config.record.pagetitle);
                 title = Ext.util.Format.htmlEncode(title);
-                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
+                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+' <small>('+this.config.record.id+')</small></h2>');
             }
             // initial check to enable realtime alias
             if (Ext.isEmpty(this.config.record.alias)) {
@@ -547,6 +547,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     var titlePrefix = MODx.request.a == 'resource/create' ? _('new_document') : _('document');
                     var title = Ext.util.Format.stripTags(f.getValue());
                     title = Ext.util.Format.htmlEncode(title);
+                    if (MODx.request.a !== 'resource/create') {
+                        title = title+ '<small>('+this.config.record.id+')</small>';
+                    }
                     Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
 
                     // check some system settings before doing real time alias transliteration

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -548,7 +548,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     var title = Ext.util.Format.stripTags(f.getValue());
                     title = Ext.util.Format.htmlEncode(title);
                     if (MODx.request.a !== 'resource/create') {
-                        title = title+ '<small>('+this.config.record.id+')</small>';
+                        title = title+ ' <small>('+this.config.record.id+')</small>';
                     }
                     Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
 

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -54,7 +54,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             if (!Ext.isEmpty(this.config.record.pagetitle)) {
                 var title = Ext.util.Format.stripTags(this.config.record.pagetitle);
                 title = Ext.util.Format.htmlEncode(title);
-                if (MODx.perm.tree_show_element_ids === 1) {
+                if (MODx.perm.tree_show_resource_ids === 1) {
                     title = title+ ' <small>('+this.config.record.id+')</small>';
                 }
                 Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
@@ -550,7 +550,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     var titlePrefix = MODx.request.a == 'resource/create' ? _('new_document') : _('document');
                     var title = Ext.util.Format.stripTags(f.getValue());
                     title = Ext.util.Format.htmlEncode(title);
-                    if (MODx.request.a !== 'resource/create' && MODx.perm.tree_show_element_ids === 1) {
+                    if (MODx.request.a !== 'resource/create' && MODx.perm.tree_show_resource_ids === 1) {
                         title = title+ ' <small>('+this.config.record.id+')</small>';
                     }
                     Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -54,7 +54,10 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             if (!Ext.isEmpty(this.config.record.pagetitle)) {
                 var title = Ext.util.Format.stripTags(this.config.record.pagetitle);
                 title = Ext.util.Format.htmlEncode(title);
-                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+' <small>('+this.config.record.id+')</small></h2>');
+                if (MODx.perm.tree_show_element_ids === 1) {
+                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                }
+                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
             }
             // initial check to enable realtime alias
             if (Ext.isEmpty(this.config.record.alias)) {
@@ -547,7 +550,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     var titlePrefix = MODx.request.a == 'resource/create' ? _('new_document') : _('document');
                     var title = Ext.util.Format.stripTags(f.getValue());
                     title = Ext.util.Format.htmlEncode(title);
-                    if (MODx.request.a !== 'resource/create') {
+                    if (MODx.request.a !== 'resource/create' && MODx.perm.tree_show_element_ids === 1) {
                         title = title+ ' <small>('+this.config.record.id+')</small>';
                     }
                     Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');

--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -43,6 +43,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
             });
         });
         MODx.onChunkFormRender = "'.$this->onChunkFormRender.'";
+        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
         MODx.perm.unlock_element_properties = '.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).';
         // ]]>
         </script>');

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -47,6 +47,7 @@ class ElementPluginUpdateManagerController extends modManagerController {
             });
         });
         MODx.onPluginFormRender = "'.$this->onPluginFormRender.'";
+        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
         MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         // ]]>
         </script>');

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -39,6 +39,7 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         <script type="text/javascript">
         // <![CDATA[
         MODx.onSnipFormRender = "'.$this->onSnipFormRender.'";
+        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
         MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -47,6 +47,7 @@ class ElementTemplateUpdateManagerController extends modManagerController {
             });
         });
         MODx.onTempFormRender = "'.$this->onTempFormRender.'";
+        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
         MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         // ]]>
         </script>');

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -41,6 +41,7 @@ class ElementTVUpdateManagerController extends modManagerController {
         <script type="text/javascript">
         // <![CDATA[
         MODx.onTVFormRender = "'.$this->onTVFormRender.'";
+        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
         MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -57,6 +57,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
                 ,mode: "update"
             });
         });
+        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
         // ]]>
         </script>');
         /* load RTE */

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -57,7 +57,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
                 ,mode: "update"
             });
         });
-        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
+        MODx.perm.tree_show_resource_ids = '.($this->modx->hasPermission('tree_show_resource_ids') ? 1 : 0).';
         // ]]>
         </script>');
         /* load RTE */


### PR DESCRIPTION
### What does it do?
It makes the ID of the object on various manager pages visible after the title/name.
This improves usability of the current manager design.

### Why is it needed?
It makes it easier to find the ID of a certain object (like the ID of a page). More discussion about this can be found in issue #11096.

MODX 3 is right around the corner, but it would still be very helpful to have this in a 2.* release. 

### Related issue(s)/PR(s)
Fixes #11096