### PR TITLE
Fix Regex validation for TV's of the input type "Text" 

### DIFF
--- a/manager/templates/default/element/tv/renders/input/textbox.tpl
+++ b/manager/templates/default/element/tv/renders/input/textbox.tpl
@@ -19,7 +19,7 @@ Ext.onReady(function() {
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         {if $params.minLength|default},minLength: {$params.minLength|default}{/if}
         {if $params.maxLength|default},maxLength: {$params.maxLength|default}{/if}
-        {if $params.regex|default},regex: new RegExp('{$params.regex|default}'){/if}
+        {if $params.regex|default},regex: new RegExp(/{$params.regex|default}/){/if}
         {if $params.regexText|default},regexText: '{$params.regexText|default}'{/if}
     {literal}
         ,listeners: { 'keydown': { fn:MODx.fireResourceFormChange, scope:this}}


### PR DESCRIPTION
### What does it do?
Create the RegExp object using the literal notation since our regular expression will remain constant. 

### Why is it needed?
This solves an issue with the Regular Expression Validator used for "Text" Template Variables.
When creating the RegExp object using the constructor function, the normal string escape rules (preceding special characters with \ when included in a string) are necessary. This might be unclear to users. 

More info about creating RegExp objects using literal notation or constructor can be found at the [MDN documentation on RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) 

### Related issue(s)/PR(s)
#13899 