### PR TITLE
Some improvements regarding passwords

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1208,7 +1208,7 @@ $settings['proxy_username']->fromArray(array (
 $settings['password_generated_length']= $xpdo->newObject('modSystemSetting');
 $settings['password_generated_length']->fromArray(array (
   'key' => 'password_generated_length',
-  'value' => '8',
+  'value' => '10',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'authentication',

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -101,7 +101,7 @@ class modUserTest extends MODxTestCase {
     public function providerGeneratePassword() {
         return array(
             array(10),
-            array(1),
+            array(8),
         );
     }
 

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -122,6 +122,20 @@ class modUserTest extends MODxTestCase {
         $this->assertEquals(10, strlen($yetAnotherPassword));
     }
 
+    public function testGeneratePasswordMinLength()
+    {
+        $defaultPasswordMinLength = $this->modx->getOption('password_min_length', 8);
+        $password = $this->user->generatePassword();
+        $this->assertGreaterThanOrEqual($defaultPasswordMinLength, strlen($password));
+
+        $passwordGeneratedLength = 10;
+        $passwordMinLength = 12;
+        $this->modx->setOption('password_generated_length', $passwordGeneratedLength);
+        $this->modx->setOption('password_min_length', $passwordMinLength);
+        $anotherPassword = $this->user->generatePassword();
+        $this->assertGreaterThanOrEqual($passwordMinLength, strlen($anotherPassword));
+    }
+
     /**
      * Ensure passwordMatches works
      * @return void

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -791,6 +791,10 @@ class modUser extends modPrincipal {
         if ($length === null) {
             $length = $this->xpdo->getOption('password_generated_length', null, 10, true);
         }
+        $passwordMinimumLength = $this->xpdo->getOption('password_min_length', null, 8, true);
+        if ($length < $passwordMinimumLength) {
+            $length = $passwordMinimumLength;
+        }
         $options = array_merge(array(
             'allowable_characters' => 'abcdefghjkmnpqrstuvxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789',
             'srand_seed_multiplier' => 1000000,

--- a/core/model/modx/processors/security/user/_validation.php
+++ b/core/model/modx/processors/security/user/_validation.php
@@ -74,7 +74,7 @@ class modUserValidation {
                     $this->processor->addFieldError('specifiedpassword',$this->modx->lexicon('user_err_not_specified_password'));
                 } elseif ($specifiedPassword != $confirmPassword) {
                     $this->processor->addFieldError('confirmpassword',$this->modx->lexicon('user_err_password_no_match'));
-                } elseif (strlen($specifiedPassword) < $this->modx->getOption('password_min_length',null,6)) {
+                } elseif (strlen($specifiedPassword) < $this->modx->getOption('password_min_length', null, 8, true)) {
                     $this->processor->addFieldError('specifiedpassword',$this->modx->lexicon('user_err_password_too_short'));
                 } elseif (!preg_match('/^[^\'\x3c\x3e\(\);\x22\x7b\x7d\x2f\x5c]+$/', $specifiedPassword)) {
                     $this->processor->addFieldError('specifiedpassword', $this->modx->lexicon('user_err_password_invalid'));

--- a/setup/controllers/database.php
+++ b/setup/controllers/database.php
@@ -49,7 +49,7 @@ if (!empty($_POST['proceed'])) {
         if (empty ($_POST['cmspassword'])) {
             $errors['cmspassword'] = $install->lexicon('password_err_ns');
         } else {
-            if (strlen($_POST['cmspassword']) < 6) {
+            if (strlen($_POST['cmspassword']) < 8) {
                 $errors['cmspassword'] = $install->lexicon('password_err_short');
             }
 


### PR DESCRIPTION
### What does it do?

- Increase the default value for the length of a generated password
- Makes sure generated passwords are equal or larger then the minimum password length
- Adds a Unit Test.
- Checks if the password of the admin during installation is also 8 characters long (the default value).

### Important to know
The lexicon "password_err_short" for the installer should be updated since the value of the length is hardcoded (@opengeek).

### Why is it needed?
System settings should be adhered to and it improves consistency.

### Related issue(s)/PR(s)
Fixes #13919 and fixes #13920 