### PR TITLE
Load all mgr permissions at once to MODx.perm

### DIFF
--- a/core/model/modx/processors/system/config.js.php
+++ b/core/model/modx/processors/system/config.js.php
@@ -101,21 +101,17 @@ $actions = $modx->request->getAllActionIDs();
 $o .= 'MODx.action = ' . $modx->toJSON($actions) . ';';
 
 if ($modx->user) {
-    if ($modx->hasPermission('directory_create')) { $o .= 'MODx.perm.directory_create = true;'; }
-    if ($modx->hasPermission('resource_tree')) { $o .= 'MODx.perm.resource_tree = true;'; }
-    if ($modx->hasPermission('element_tree')) { $o .= 'MODx.perm.element_tree = true;'; }
-    if ($modx->hasPermission('file_tree')) { $o .= 'MODx.perm.file_tree = true;'; }
-    if ($modx->hasPermission('file_upload')) { $o .= 'MODx.perm.file_upload = true;'; }
-    if ($modx->hasPermission('file_create')) { $o .= 'MODx.perm.file_create = true;'; }
-    if ($modx->hasPermission('file_manager')) { $o .= 'MODx.perm.file_manager = true;'; }
-    if ($modx->hasPermission('new_chunk')) { $o .= 'MODx.perm.new_chunk  = true;'; }
-    if ($modx->hasPermission('new_plugin')) { $o .= 'MODx.perm.new_plugin = true;'; }
-    if ($modx->hasPermission('new_snippet')) { $o .= 'MODx.perm.new_snippet = true;'; }
-    if ($modx->hasPermission('new_template')) { $o .= 'MODx.perm.new_template = true;'; }
-    if ($modx->hasPermission('new_tv')) { $o .= 'MODx.perm.new_tv = true;'; }
-    if ($modx->hasPermission('new_category')) { $o .= 'MODx.perm.new_category = true;'; }
-    if ($modx->hasPermission('resourcegroup_resource_edit')) { $o .= 'MODx.perm.resourcegroup_resource_edit = true;'; }
-    if ($modx->hasPermission('resourcegroup_resource_list')) { $o .= 'MODx.perm.resourcegroup_resource_list = true;'; }
+
+    $accessPermissionsQuery = $modx->newQuery('modAccessPermission');
+    $accessPermissionsQuery->select('name');
+    $accessPermissionsQuery->distinct();
+    $permissions = $modx->getIterator('modAccessPermission', $accessPermissionsQuery);
+    $permissionValues = [];
+    foreach ($permissions as $permisson) {
+        $name = $permisson->get('name');
+        $permissionValues[$name] = $modx->hasPermission($name);
+    }
+    $o .= 'MODx.perm = ' . $modx->toJSON($permissionValues) . ';';
 
     $o .= 'MODx.user = {id:"'.$modx->user->get('id').'",username:"'.$modx->user->get('username').'"}';
 }

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -257,7 +257,7 @@ Ext.extend(MODx.panel.Chunk,MODx.FormPanel,{
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
             var title = _('chunk')+': '+this.config.record.name;
-            if (MODx.perm.tree_show_element_ids === 1) {
+            if (MODx.perm.tree_show_element_ids) {
                 title = title+ ' <small>('+this.config.record.id+')</small>';
             }
             Ext.getCmp('modx-chunk-header').getEl().update(title);

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -285,7 +285,7 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
             var title = _('plugin')+': '+this.config.record.name;
-            if (MODx.perm.tree_show_element_ids === 1) {
+            if (MODx.perm.tree_show_element_ids) {
                 title = title+ ' <small>('+this.config.record.id+')</small>';
             }
             Ext.getCmp('modx-plugin-header').getEl().update(title);

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -257,7 +257,7 @@ Ext.extend(MODx.panel.Snippet,MODx.FormPanel,{
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
             var title = _('snippet')+': '+this.config.record.name;
-            if (MODx.perm.tree_show_element_ids === 1) {
+            if (MODx.perm.tree_show_element_ids) {
                 title = title+ ' <small>('+this.config.record.id+')</small>';
             }
             Ext.getCmp('modx-snippet-header').getEl().update(title);

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -297,7 +297,7 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.templatename)) {
             var title = _('template')+': '+this.config.record.templatename;
-            if (MODx.perm.tree_show_element_ids === 1) {
+            if (MODx.perm.tree_show_element_ids) {
                 title = title+ ' <small>('+this.config.record.id+')</small>';
             }
             Ext.getCmp('modx-template-header').getEl().update(title);

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -344,7 +344,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
         this.getForm().setValues(this.config.record);
         if (!Ext.isEmpty(this.config.record.name)) {
             var title = _('tv')+': '+this.config.record.name;
-            if (MODx.perm.tree_show_element_ids === 1) {
+            if (MODx.perm.tree_show_element_ids) {
                 title = title+ ' <small>('+this.config.record.id+')</small>';
             }
             Ext.getCmp('modx-tv-header').getEl().update(title);

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -55,7 +55,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             if (!Ext.isEmpty(this.config.record.pagetitle)) {
                 var title = Ext.util.Format.stripTags(this.config.record.pagetitle);
                 title = Ext.util.Format.htmlEncode(title);
-                if (MODx.perm.tree_show_resource_ids === 1) {
+                if (MODx.perm.tree_show_resource_ids) {
                     title = title+ ' <small>('+this.config.record.id+')</small>';
                 }
                 Ext.getCmp('modx-resource-header').getEl().update(title);
@@ -418,7 +418,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         if (config.show_tvs && MODx.config.tvs_below_content != 1) {
             it.push(this.getTemplateVariablesPanel(config));
         }
-        if (MODx.perm.resourcegroup_resource_list == 1) {
+        if (MODx.perm.resourcegroup_resource_list) {
             it.push(this.getAccessPermissionsTab(config));
         }
         var its = [];

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -41,7 +41,7 @@ MODx.panel.GroupsRoles = function(config) {
         }
     });
 
-    if (MODx.perm.usergroup_user_list == 1) {
+    if (MODx.perm.usergroup_user_list) {
         Ext.getCmp('modx-tree-usergroup').on('click', function(node,e){
             this.getUsers(node);
         }, this);
@@ -52,7 +52,7 @@ MODx.panel.GroupsRoles = function(config) {
 Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
     getPageTabs: function(config) {
         var tbs = [];
-        if (MODx.perm.usergroup_view == 1) {
+        if (MODx.perm.usergroup_view1) {
             tbs.push({
                 title: _('user_groups') + ' & ' + _('users')
                 ,autoHeight: true
@@ -98,7 +98,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                 }]
             });
         }
-        if (MODx.perm.view_role == 1) {
+        if (MODx.perm.view_role) {
             tbs.push({
                 title: _('roles')
                 ,autoHeight: true
@@ -114,7 +114,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                 }]
             });
         }
-        if (MODx.perm.policy_view == 1) {
+        if (MODx.perm.policy_view) {
             tbs.push({
                 title: _('policies')
                 ,id: 'modx-panel-access-policies'

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -52,7 +52,7 @@ MODx.panel.GroupsRoles = function(config) {
 Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
     getPageTabs: function(config) {
         var tbs = [];
-        if (MODx.perm.usergroup_view1) {
+        if (MODx.perm.usergroup_view) {
             tbs.push({
                 title: _('user_groups') + ' & ' + _('users')
                 ,autoHeight: true

--- a/manager/controllers/default/context/update.class.php
+++ b/manager/controllers/default/context/update.class.php
@@ -47,12 +47,10 @@ class ContextUpdateManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
-        $perm = (bool)$this->modx->hasPermission('new_context');
         $this->addHtml("<script>
             // <![CDATA[
             MODx.onContextFormRender = '".$this->onContextFormRender."';
             MODx.ctx = '".$this->contextKey."';
-            MODx.perm.new_context = {$perm};
             Ext.onReady(function() {
                 MODx.add('modx-page-context-update');
             });

--- a/manager/controllers/default/element/chunk/create.class.php
+++ b/manager/controllers/default/element/chunk/create.class.php
@@ -40,7 +40,6 @@ class ElementChunkCreateManagerController extends modManagerController {
             });
         });
         MODx.onChunkFormRender = "'.$this->onChunkFormRender.'";
-        MODx.perm.unlock_element_properties = '.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).';
         // ]]>
         </script>');
     }

--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -43,8 +43,6 @@ class ElementChunkUpdateManagerController extends modManagerController {
             });
         });
         MODx.onChunkFormRender = "'.$this->onChunkFormRender.'";
-        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
-        MODx.perm.unlock_element_properties = '.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).';
         // ]]>
         </script>');
 

--- a/manager/controllers/default/element/plugin/create.class.php
+++ b/manager/controllers/default/element/plugin/create.class.php
@@ -41,7 +41,6 @@ class ElementPluginCreateManagerController extends modManagerController {
             });
         });
         MODx.onPluginFormRender = "'.$this->onPluginFormRender.'";
-        MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         // ]]>
         </script>');
     }

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -47,8 +47,6 @@ class ElementPluginUpdateManagerController extends modManagerController {
             });
         });
         MODx.onPluginFormRender = "'.$this->onPluginFormRender.'";
-        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
-        MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         // ]]>
         </script>');
     }

--- a/manager/controllers/default/element/snippet/create.class.php
+++ b/manager/controllers/default/element/snippet/create.class.php
@@ -32,7 +32,6 @@ class ElementSnippetCreateManagerController extends modManagerController {
         <script type="text/javascript">
         // <![CDATA[
         MODx.onSnipFormRender = "'.$this->onSnipFormRender.'";
-        MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-snippet-create"

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -39,8 +39,6 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         <script type="text/javascript">
         // <![CDATA[
         MODx.onSnipFormRender = "'.$this->onSnipFormRender.'";
-        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
-        MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-snippet-update"

--- a/manager/controllers/default/element/template/create.class.php
+++ b/manager/controllers/default/element/template/create.class.php
@@ -33,7 +33,6 @@ class ElementTemplateCreateManagerController extends modManagerController {
         <script type="text/javascript">
         // <![CDATA[
         MODx.onTempFormRender = "'.$this->onTempFormRender.'";
-        MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-template-create"

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -47,8 +47,6 @@ class ElementTemplateUpdateManagerController extends modManagerController {
             });
         });
         MODx.onTempFormRender = "'.$this->onTempFormRender.'";
-        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
-        MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         // ]]>
         </script>');
     }

--- a/manager/controllers/default/element/tv/create.class.php
+++ b/manager/controllers/default/element/tv/create.class.php
@@ -35,7 +35,6 @@ class ElementTVCreateManagerController extends modManagerController {
 <script type="text/javascript">
 // <![CDATA[
 MODx.onTVFormRender = "'.$this->onTVFormRender.'";
-MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
 Ext.onReady(function() {
     MODx.load({
         xtype: "modx-page-tv-create"

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -41,8 +41,6 @@ class ElementTVUpdateManagerController extends modManagerController {
         <script type="text/javascript">
         // <![CDATA[
         MODx.onTVFormRender = "'.$this->onTVFormRender.'";
-        MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';
-        MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-tv-update"

--- a/manager/controllers/default/security/message.class.php
+++ b/manager/controllers/default/security/message.class.php
@@ -24,9 +24,6 @@ class SecurityMessageManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/message/list.js');
         $this->addHtml('<script>
             Ext.onReady(function() {
-                MODx.perm.view_user = '.($this->modx->hasPermission('view_user') ? 1 : 0).';
-                MODx.perm.view_role = '.($this->modx->hasPermission('view_role') ? 1 : 0).';
-                MODx.perm.view_usergroup = '.($this->modx->hasPermission('usergroup_view') ? 1 : 0).';
                 MODx.load({
                     xtype: "modx-page-messages"
                 });

--- a/manager/controllers/default/security/permission.class.php
+++ b/manager/controllers/default/security/permission.class.php
@@ -27,26 +27,6 @@ class SecurityPermissionManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.tree.user.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.role.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.groups.roles.js');
-        $canListUserGroups = $this->modx->hasPermission('usergroup_view') ? 1 : 0;
-        $canListRoles = $this->modx->hasPermission('view_role') ? 1 : 0;
-        $canListPolicies = $this->modx->hasPermission('policy_view') ? 1 : 0;
-        $canListPolicyTemplates = $this->modx->hasPermission('policy_template_view') ? 1 : 0;
-        $canEditUser = $this->modx->hasPermission('usergroup_user_edit') ? 1 : 0;
-        $canListUser = $this->modx->hasPermission('usergroup_user_list') ? 1 : 0;
-        $canAddUserGroup = $this->modx->hasPermission('usergroup_new') ? 1 : 0;
-        $canEditUserGroup = $this->modx->hasPermission('usergroup_edit') ? 1 : 0;
-        $canDeleteUserGroup = $this->modx->hasPermission('usergroup_delete') ? 1 : 0;
-        $this->addHtml('<script type="text/javascript">'
-                .'MODx.perm.usergroup_view = '.$canListUserGroups.';'
-                .'MODx.perm.view_role = '.$canListRoles.';'
-                .'MODx.perm.policy_view = '.$canListPolicies.';'
-                .'MODx.perm.policy_template_view = '.$canListPolicyTemplates.';'
-                .'MODx.perm.usergroup_user_edit = '.$canEditUser.';'
-                .'MODx.perm.usergroup_user_list = '.$canListUser.';'
-                .'MODx.perm.usergroup_new = '.$canAddUserGroup.';'
-                .'MODx.perm.usergroup_edit = '.$canEditUserGroup.';'
-                .'MODx.perm.usergroup_delete = '.$canDeleteUserGroup.';'
-                .'</script>');
         $this->addHtml("<script>
             Ext.onReady(function() {
                 MODx.add('modx-page-groups-roles');

--- a/manager/controllers/default/security/profile.class.php
+++ b/manager/controllers/default/security/profile.class.php
@@ -31,8 +31,6 @@ class SecurityProfileManagerController extends modManagerController {
                 ,user: "'.$this->modx->user->get('id').'"
             });
         });
-        MODx.perm.change_password = '.(int)$this->modx->hasPermission('change_password').';
-        MODx.perm.view_document = '.(int)$this->modx->hasPermission('view_document').';
         // ]]>
         </script>');
     }

--- a/manager/controllers/default/security/usergroup/update.class.php
+++ b/manager/controllers/default/security/usergroup/update.class.php
@@ -30,12 +30,8 @@ class SecurityUserGroupUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.group.source.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.group.namespace.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.user.group.js');
-        $canEditUsers = $this->modx->hasPermission('usergroup_user_edit') ? 1 : 0;
-        $canListUsers = $this->modx->hasPermission('usergroup_user_list') ? 1 : 0;
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/usergroup/update.js');
         $this->addHtml('<script type="text/javascript">
-        MODx.perm.usergroup_user_edit = '.$canEditUsers.';
-        MODx.perm.usergroup_user_list = '.$canListUsers.';
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-user-group-update"


### PR DESCRIPTION
### What does it do?
Load all mgr permissions at once to MODx.perm and removes related JS code scattered around. 

### Why is it needed?
Manager permissions are concentrated in one place. This means that developers do not have to do this manually every time they want to check for a permission using JavaScript.

### Related issue(s)/PR(s)
Fixes #12211