### PR TITLE
Implement native PHP password hashing

### DIFF
--- a/_build/test/Tests/Model/Hashing/modNativeHashTest.php
+++ b/_build/test/Tests/Model/Hashing/modNativeHashTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * MODX Revolution
+ *
+ * Copyright 2006-2014 by MODX, LLC.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package modx-test
+ */
+/**
+ * Tests related to the modNative class, a derivative of modHash.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group Hashing
+ * @group modHash
+ * @group modHashing
+ */
+class modNativeHashTest extends MODxTestCase {
+    /**
+     * Test the native hasher implementation
+     *
+     * @dataProvider providerHash
+     * @param $string The string to create a hash of.
+     * @param $options The options for the hash process.
+     * @param $expected The expected hash value.
+     */
+    public function testHash($string) {
+        $this->modx->getService('hashing', 'hashing.modHashing');
+        /** @var modNative $hasher */
+        $hasher = $this->modx->hashing->getHash('modNative', 'hashing.modNative');
+
+        $generated = $hasher->hash($string);
+        $this->assertNotEmpty($generated);
+        $this->assertTrue($hasher->verify($string, $generated));
+        $this->assertFalse($hasher->verify($string . 'X', $generated));
+        $this->assertFalse($hasher->verify($string, $generated . '$'));
+    }
+
+    public function providerHash() {
+        return array(
+            array('password123'),
+            array('123456'),
+            array('what do you think of this?'),
+            array('letmein'),
+        );
+    }
+}

--- a/core/model/lib/password.php
+++ b/core/model/lib/password.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * A Compatibility library with PHP 5.5's simplified password hashing API.
+ *
+ * @author Anthony Ferrara <ircmaxell@php.net>
+ * @license http://www.opensource.org/licenses/mit-license.html MIT License
+ * @copyright 2012 The Authors
+ */
+
+namespace {
+
+    if (!defined('PASSWORD_BCRYPT')) {
+        /**
+         * PHPUnit Process isolation caches constants, but not function declarations.
+         * So we need to check if the constants are defined separately from
+         * the functions to enable supporting process isolation in userland
+         * code.
+         */
+        define('PASSWORD_BCRYPT', 1);
+        define('PASSWORD_DEFAULT', PASSWORD_BCRYPT);
+        define('PASSWORD_BCRYPT_DEFAULT_COST', 10);
+    }
+
+    if (!function_exists('password_hash')) {
+
+        /**
+         * Hash the password using the specified algorithm
+         *
+         * @param string $password The password to hash
+         * @param int    $algo     The algorithm to use (Defined by PASSWORD_* constants)
+         * @param array  $options  The options for the algorithm to use
+         *
+         * @return string|false The hashed password, or false on error.
+         */
+        function password_hash($password, $algo, array $options = array()) {
+            if (!function_exists('crypt')) {
+                trigger_error("Crypt must be loaded for password_hash to function", E_USER_WARNING);
+                return null;
+            }
+            if (is_null($password) || is_int($password)) {
+                $password = (string) $password;
+            }
+            if (!is_string($password)) {
+                trigger_error("password_hash(): Password must be a string", E_USER_WARNING);
+                return null;
+            }
+            if (!is_int($algo)) {
+                trigger_error("password_hash() expects parameter 2 to be long, " . gettype($algo) . " given", E_USER_WARNING);
+                return null;
+            }
+            $resultLength = 0;
+            switch ($algo) {
+                case PASSWORD_BCRYPT:
+                    $cost = PASSWORD_BCRYPT_DEFAULT_COST;
+                    if (isset($options['cost'])) {
+                        $cost = (int) $options['cost'];
+                        if ($cost < 4 || $cost > 31) {
+                            trigger_error(sprintf("password_hash(): Invalid bcrypt cost parameter specified: %d", $cost), E_USER_WARNING);
+                            return null;
+                        }
+                    }
+                    // The length of salt to generate
+                    $raw_salt_len = 16;
+                    // The length required in the final serialization
+                    $required_salt_len = 22;
+                    $hash_format = sprintf("$2y$%02d$", $cost);
+                    // The expected length of the final crypt() output
+                    $resultLength = 60;
+                    break;
+                default:
+                    trigger_error(sprintf("password_hash(): Unknown password hashing algorithm: %s", $algo), E_USER_WARNING);
+                    return null;
+            }
+            $salt_req_encoding = false;
+            if (isset($options['salt'])) {
+                switch (gettype($options['salt'])) {
+                    case 'NULL':
+                    case 'boolean':
+                    case 'integer':
+                    case 'double':
+                    case 'string':
+                        $salt = (string) $options['salt'];
+                        break;
+                    case 'object':
+                        if (method_exists($options['salt'], '__tostring')) {
+                            $salt = (string) $options['salt'];
+                            break;
+                        }
+                    case 'array':
+                    case 'resource':
+                    default:
+                        trigger_error('password_hash(): Non-string salt parameter supplied', E_USER_WARNING);
+                        return null;
+                }
+                if (PasswordCompat\binary\_strlen($salt) < $required_salt_len) {
+                    trigger_error(sprintf("password_hash(): Provided salt is too short: %d expecting %d", PasswordCompat\binary\_strlen($salt), $required_salt_len), E_USER_WARNING);
+                    return null;
+                } elseif (0 == preg_match('#^[a-zA-Z0-9./]+$#D', $salt)) {
+                    $salt_req_encoding = true;
+                }
+            } else {
+                $buffer = '';
+                $buffer_valid = false;
+                if (function_exists('mcrypt_create_iv') && !defined('PHALANGER')) {
+                    $buffer = mcrypt_create_iv($raw_salt_len, MCRYPT_DEV_URANDOM);
+                    if ($buffer) {
+                        $buffer_valid = true;
+                    }
+                }
+                if (!$buffer_valid && function_exists('openssl_random_pseudo_bytes')) {
+                    $strong = false;
+                    $buffer = openssl_random_pseudo_bytes($raw_salt_len, $strong);
+                    if ($buffer && $strong) {
+                        $buffer_valid = true;
+                    }
+                }
+                if (!$buffer_valid && @is_readable('/dev/urandom')) {
+                    $file = fopen('/dev/urandom', 'r');
+                    $read = 0;
+                    $local_buffer = '';
+                    while ($read < $raw_salt_len) {
+                        $local_buffer .= fread($file, $raw_salt_len - $read);
+                        $read = PasswordCompat\binary\_strlen($local_buffer);
+                    }
+                    fclose($file);
+                    if ($read >= $raw_salt_len) {
+                        $buffer_valid = true;
+                    }
+                    $buffer = str_pad($buffer, $raw_salt_len, "\0") ^ str_pad($local_buffer, $raw_salt_len, "\0");
+                }
+                if (!$buffer_valid || PasswordCompat\binary\_strlen($buffer) < $raw_salt_len) {
+                    $buffer_length = PasswordCompat\binary\_strlen($buffer);
+                    for ($i = 0; $i < $raw_salt_len; $i++) {
+                        if ($i < $buffer_length) {
+                            $buffer[$i] = $buffer[$i] ^ chr(mt_rand(0, 255));
+                        } else {
+                            $buffer .= chr(mt_rand(0, 255));
+                        }
+                    }
+                }
+                $salt = $buffer;
+                $salt_req_encoding = true;
+            }
+            if ($salt_req_encoding) {
+                // encode string with the Base64 variant used by crypt
+                $base64_digits =
+                    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+                $bcrypt64_digits =
+                    './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+                $base64_string = base64_encode($salt);
+                $salt = strtr(rtrim($base64_string, '='), $base64_digits, $bcrypt64_digits);
+            }
+            $salt = PasswordCompat\binary\_substr($salt, 0, $required_salt_len);
+
+            $hash = $hash_format . $salt;
+
+            $ret = crypt($password, $hash);
+
+            if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != $resultLength) {
+                return false;
+            }
+
+            return $ret;
+        }
+
+        /**
+         * Get information about the password hash. Returns an array of the information
+         * that was used to generate the password hash.
+         *
+         * array(
+         *    'algo' => 1,
+         *    'algoName' => 'bcrypt',
+         *    'options' => array(
+         *        'cost' => PASSWORD_BCRYPT_DEFAULT_COST,
+         *    ),
+         * )
+         *
+         * @param string $hash The password hash to extract info from
+         *
+         * @return array The array of information about the hash.
+         */
+        function password_get_info($hash) {
+            $return = array(
+                'algo' => 0,
+                'algoName' => 'unknown',
+                'options' => array(),
+            );
+            if (PasswordCompat\binary\_substr($hash, 0, 4) == '$2y$' && PasswordCompat\binary\_strlen($hash) == 60) {
+                $return['algo'] = PASSWORD_BCRYPT;
+                $return['algoName'] = 'bcrypt';
+                list($cost) = sscanf($hash, "$2y$%d$");
+                $return['options']['cost'] = $cost;
+            }
+            return $return;
+        }
+
+        /**
+         * Determine if the password hash needs to be rehashed according to the options provided
+         *
+         * If the answer is true, after validating the password using password_verify, rehash it.
+         *
+         * @param string $hash    The hash to test
+         * @param int    $algo    The algorithm used for new password hashes
+         * @param array  $options The options array passed to password_hash
+         *
+         * @return boolean True if the password needs to be rehashed.
+         */
+        function password_needs_rehash($hash, $algo, array $options = array()) {
+            $info = password_get_info($hash);
+            if ($info['algo'] !== (int) $algo) {
+                return true;
+            }
+            switch ($algo) {
+                case PASSWORD_BCRYPT:
+                    $cost = isset($options['cost']) ? (int) $options['cost'] : PASSWORD_BCRYPT_DEFAULT_COST;
+                    if ($cost !== $info['options']['cost']) {
+                        return true;
+                    }
+                    break;
+            }
+            return false;
+        }
+
+        /**
+         * Verify a password against a hash using a timing attack resistant approach
+         *
+         * @param string $password The password to verify
+         * @param string $hash     The hash to verify against
+         *
+         * @return boolean If the password matches the hash
+         */
+        function password_verify($password, $hash) {
+            if (!function_exists('crypt')) {
+                trigger_error("Crypt must be loaded for password_verify to function", E_USER_WARNING);
+                return false;
+            }
+            $ret = crypt($password, $hash);
+            if (!is_string($ret) || PasswordCompat\binary\_strlen($ret) != PasswordCompat\binary\_strlen($hash) || PasswordCompat\binary\_strlen($ret) <= 13) {
+                return false;
+            }
+
+            $status = 0;
+            for ($i = 0; $i < PasswordCompat\binary\_strlen($ret); $i++) {
+                $status |= (ord($ret[$i]) ^ ord($hash[$i]));
+            }
+
+            return $status === 0;
+        }
+    }
+
+}
+
+namespace PasswordCompat\binary {
+
+    if (!function_exists('PasswordCompat\\binary\\_strlen')) {
+
+        /**
+         * Count the number of bytes in a string
+         *
+         * We cannot simply use strlen() for this, because it might be overwritten by the mbstring extension.
+         * In this case, strlen() will count the number of *characters* based on the internal encoding. A
+         * sequence of bytes might be regarded as a single multibyte character.
+         *
+         * @param string $binary_string The input string
+         *
+         * @internal
+         * @return int The number of bytes
+         */
+        function _strlen($binary_string) {
+            if (function_exists('mb_strlen')) {
+                return mb_strlen($binary_string, '8bit');
+            }
+            return strlen($binary_string);
+        }
+
+        /**
+         * Get a substring based on byte limits
+         *
+         * @see _strlen()
+         *
+         * @param string $binary_string The input string
+         * @param int    $start
+         * @param int    $length
+         *
+         * @internal
+         * @return string The substring
+         */
+        function _substr($binary_string, $start, $length) {
+            if (function_exists('mb_substr')) {
+                return mb_substr($binary_string, $start, $length, '8bit');
+            }
+            return substr($binary_string, $start, $length);
+        }
+
+        /**
+         * Check if current PHP version is compatible with the library
+         *
+         * @return boolean the check result
+         */
+        function check() {
+            static $pass = NULL;
+
+            if (is_null($pass)) {
+                if (function_exists('crypt')) {
+                    $hash = '$2y$04$usesomesillystringfore7hnbRJHxXVLeakoG8K30oukPsA.ztMG';
+                    $test = crypt("password", $hash);
+                    $pass = $test == $hash;
+                } else {
+                    $pass = false;
+                }
+            }
+            return $pass;
+        }
+
+    }
+}

--- a/core/model/modx/hashing/modhashing.class.php
+++ b/core/model/modx/hashing/modhashing.class.php
@@ -129,7 +129,7 @@ abstract class modHash {
      * @param array|null $options An optional array of configuration options
      * @return modHash A new derivative instance of the modHash class
      */
-    function __construct(modHashing &$host, $options= array()) {
+    public function __construct(modHashing &$host, $options= array()) {
         $this->host =& $host;
         if (is_array($options)) {
             $this->options = $options;
@@ -165,4 +165,18 @@ abstract class modHash {
      * @return mixed The hash result or false on failure.
      */
     public abstract function hash($string, array $options = array());
+
+    /**
+     * Verifies if $string, when hashed according to this hash implementation, matches the stored hash in $expected.
+     *
+     * @param string $string
+     * @param string $expected
+     * @param array $options Implementation-specific hash options.
+     * @return bool
+     */
+    public function verify($string, $expected, array $options = array())
+    {
+        $hashedPassword = $this->hash($string, $options);
+        return $expected === $hashedPassword;
+    }
 }

--- a/core/model/modx/hashing/modnative.class.php
+++ b/core/model/modx/hashing/modnative.class.php
@@ -5,6 +5,10 @@
  * @subpackage hashing
  */
 
+if (!function_exists('password_hash')) {
+    require MODX_CORE_PATH . 'model/lib/password.php';
+}
+
 /**
  * A PHP native password_hash/password_verify implementation of modHash.
  *

--- a/core/model/modx/hashing/modnative.class.php
+++ b/core/model/modx/hashing/modnative.class.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file contains a modHash implementation of PHP's native password_hash/password_verify handling.
+ * @package modx
+ * @subpackage hashing
+ */
+
+/**
+ * A PHP native password_hash/password_verify implementation of modHash.
+ *
+ * {@inheritdoc}
+ *
+ * @package modx
+ * @subpackage hashing
+ */
+class modNative extends modHash {
+    /**
+     * Generates the hash for the provided string using PHP's password_hash function.
+     *
+     * @param string $string A string to generate a secure hash from.
+     * @param array $options An array of options to be passed to the hash implementation.
+     * @return mixed The hash result or false on failure.
+     */
+    public function hash($string, array $options = array()) {
+
+        return password_hash($string, PASSWORD_DEFAULT);
+    }
+
+    /**
+     * Verifies with PHP's native password_verify function that the provided hash in $expected matches the
+     * raw (unhashed) $string.
+     *
+     * @param string $string
+     * @param string $expected
+     * @param array $options
+     * @return bool
+     */
+    public function verify($string, $expected, array $options = array())
+    {
+        return password_verify($string, $expected);
+    }
+}

--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -245,8 +245,9 @@ class modUser extends modPrincipal {
         $match = false;
         if ($this->xpdo->getService('hashing', 'hashing.modHashing')) {
             $options = array_merge(array('salt' => $this->get('salt')), $options);
-            $hashedPassword = $this->xpdo->hashing->getHash('', $this->get('hash_class'))->hash($password, $options);
-            $match = ($this->get('password') === $hashedPassword);
+
+            $hasher = $this->xpdo->hashing->getHash('', $this->get('hash_class'));
+            $match = $hasher->verify($password, $this->get('password'), $options);
         }
         return $match;
     }

--- a/core/model/modx/mysql/moduser.map.inc.php
+++ b/core/model/modx/mysql/moduser.map.inc.php
@@ -21,7 +21,7 @@ $xpdo_meta_map['modUser']= array (
     'active' => 1,
     'remote_key' => NULL,
     'remote_data' => NULL,
-    'hash_class' => 'hashing.modPBKDF2',
+    'hash_class' => 'hashing.modNative',
     'salt' => '',
     'primary_group' => 0,
     'session_stale' => NULL,
@@ -42,7 +42,7 @@ $xpdo_meta_map['modUser']= array (
     'password' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '100',
+      'precision' => '255',
       'phptype' => 'string',
       'null' => false,
       'default' => '',
@@ -50,7 +50,7 @@ $xpdo_meta_map['modUser']= array (
     'cachepwd' => 
     array (
       'dbtype' => 'varchar',
-      'precision' => '100',
+      'precision' => '255',
       'phptype' => 'string',
       'null' => false,
       'default' => '',
@@ -93,7 +93,7 @@ $xpdo_meta_map['modUser']= array (
       'precision' => '100',
       'phptype' => 'string',
       'null' => false,
-      'default' => 'hashing.modPBKDF2',
+      'default' => 'hashing.modNative',
     ),
     'salt' => 
     array (

--- a/core/model/modx/sqlsrv/moduser.map.inc.php
+++ b/core/model/modx/sqlsrv/moduser.map.inc.php
@@ -17,7 +17,7 @@ $xpdo_meta_map['modUser']= array (
     'active' => 1,
     'remote_key' => NULL,
     'remote_data' => NULL,
-    'hash_class' => 'hashing.modPBKDF2',
+    'hash_class' => 'hashing.modNative',
     'salt' => '',
     'primary_group' => 0,
     'session_stale' => NULL,
@@ -38,7 +38,7 @@ $xpdo_meta_map['modUser']= array (
     'password' => 
     array (
       'dbtype' => 'nvarchar',
-      'precision' => '100',
+      'precision' => '255',
       'phptype' => 'string',
       'null' => false,
       'default' => '',
@@ -46,7 +46,7 @@ $xpdo_meta_map['modUser']= array (
     'cachepwd' => 
     array (
       'dbtype' => 'nvarchar',
-      'precision' => '100',
+      'precision' => '255',
       'phptype' => 'string',
       'null' => false,
       'default' => '',
@@ -88,7 +88,7 @@ $xpdo_meta_map['modUser']= array (
       'precision' => '100',
       'phptype' => 'string',
       'null' => false,
-      'default' => 'hashing.modPBKDF2',
+      'default' => 'hashing.modNative',
     ),
     'salt' => 
     array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1231,13 +1231,13 @@
 
     <object class="modUser" table="users" extends="modPrincipal">
         <field key="username" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="unique" />
-        <field key="password" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
-        <field key="cachepwd" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="password" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="cachepwd" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="class_key" dbtype="varchar" precision="100" phptype="string" null="false" default="modUser" index="index" />
         <field key="active" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="false" default="1" />
         <field key="remote_key" dbtype="varchar" precision="191" phptype="string" null="true" index="index" />
         <field key="remote_data" dbtype="text" phptype="json" null="true" />
-        <field key="hash_class" dbtype="varchar" precision="100" phptype="string" null="false" default="hashing.modPBKDF2" />
+        <field key="hash_class" dbtype="varchar" precision="100" phptype="string" null="false" default="hashing.modNative" />
         <field key="salt" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="primary_group" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="index" />
         <field key="session_stale" dbtype="text" phptype="array" null="true" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -1170,13 +1170,13 @@
 
     <object class="modUser" table="users" extends="modPrincipal">
         <field key="username" dbtype="nvarchar" precision="100" phptype="string" null="false" default="" index="unique" />
-        <field key="password" dbtype="nvarchar" precision="100" phptype="string" null="false" default="" />
-        <field key="cachepwd" dbtype="nvarchar" precision="100" phptype="string" null="false" default="" />
+        <field key="password" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" />
+        <field key="cachepwd" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" />
         <field key="class_key" dbtype="nvarchar" precision="100" phptype="string" null="false" default="modUser" index="index" />
         <field key="active" dbtype="bit" phptype="boolean" null="false" default="1" />
         <field key="remote_key" dbtype="nvarchar" precision="255" phptype="string" null="true" index="index" />
         <field key="remote_data" dbtype="nvarchar" precision="max" phptype="json" null="true" />
-        <field key="hash_class" dbtype="nvarchar" precision="100" phptype="string" null="false" default="hashing.modPBKDF2" />
+        <field key="hash_class" dbtype="nvarchar" precision="100" phptype="string" null="false" default="hashing.modNative" />
         <field key="salt" dbtype="nvarchar" precision="100" phptype="string" null="false" default="" />
         <field key="primary_group" dbtype="int" phptype="integer" null="false" default="0" index="index" />
         <field key="session_stale" dbtype="nvarchar" precision="max" phptype="array" null="true" />

--- a/setup/includes/upgrades/common/2.7-native-password-hash.php
+++ b/setup/includes/upgrades/common/2.7-native-password-hash.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Common upgrade script to update modUser fields for native password hashing feature.
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$class = 'modUser';
+$table = $modx->getTableName($class);
+
+/* modify modUser.password field */
+$password = $this->install->lexicon('alter_column',array('column' => 'password','table' => $table));
+$this->processResults($class, $password, array($modx->manager, 'alterField'), array($class, 'password'));
+
+/* modify modUser.cachepwd field */
+$cachepwd = $this->install->lexicon('alter_column',array('column' => 'cachepwd','table' => $table));
+$this->processResults($class, $cachepwd, array($modx->manager, 'alterField'), array($class, 'cachepwd'));
+
+/* modify modUser.hash_class field */
+$hash_class = $this->install->lexicon('alter_column',array('column' => 'hash_class','table' => $table));
+$this->processResults($class, $hash_class, array($modx->manager, 'alterField'), array($class, 'hash_class'));

--- a/setup/includes/upgrades/mysql/2.7.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.7.0-pl.php
@@ -12,3 +12,4 @@ include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-description-text.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-browser-tree-hide-files.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-remove-cache-disabled.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-native-password-hash.php';

--- a/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
@@ -12,3 +12,4 @@ include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-description-text.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-browser-tree-hide-files.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-remove-cache-disabled.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-native-password-hash.php';


### PR DESCRIPTION
### What does it do?

Adds a new modHash instance called modNative that implements native password hashing using password_hash and password_verify. These functions were introduced in PHP 5.5 as a way to make strong password hashing easy, and adaptable for the future.

Full information about the rationale behind those functions can be found in the RFC at https://wiki.php.net/rfc/password_hash

This change also introduces a new method on modHash called verify, and updates the modUser->passwordMatches method to delegate responsibility of the actual verification to the modHash implementation. This is to prevent against time-based attacks when comparing hashes, also detailed in the linked RFC. The current MD5 and modPBKDF2 hash implementations use the verify() method of modHash to preserve existing behaviour there.

The modNative hasher does not use salts the same way modMD5/modPBKDF2 do, as the hash itself includes a salt (automatically and securely generated by password_hash) which is present in the returned hash for database persistence.

### Why is it needed?

We're currently relying on modPBKDF2 for password hashing. While to the best of my knowledge that is still considered safe (and it also uses salts), we need to keep up with crypto to remain secure. 

These native functions are future proof as we rely on the PHP default algorithm, which can be changed in future versions. Currently that's bcrypt, but [Argon2i was added in PHP 7.2](http://php.net/manual/en/function.password-hash.php) so that may be switched out in the future.

### Next steps

- To make the core actually uses this new hasher, we need to make modNative the default hash_class for users, per #13927. 
- We also need to think about a migration path for existing user accounts. See the request for comments in #13928.
- As password_hash may return longer hashes in the future, PHP recommends expecting hashes of up to 255 characters even though it will only return hashes of 60 characters in the forseeable future. See #13929. 