### PR TITLE
Adds a RewriteRule to the example htaccess

### DIFF
--- a/ht.access
+++ b/ht.access
@@ -13,6 +13,11 @@ RewriteBase /
 
 
 
+# Prevent dot directories (hidden directories like .git) to be exposed to the public
+# Except for the .well-known directory used by LetsEncrypt a.o
+RewriteRule "/\.|^\.(?!well-known/)" - [F]
+
+
 # Rewrite www.domain.com -> domain.com -- used with SEO Strict URLs plugin
 #RewriteCond %{HTTP_HOST} .
 #RewriteCond %{HTTP_HOST} ^www.(.*)$ [NC]


### PR DESCRIPTION
### What does it do?
Adds a RewriteRule to hide dot directories from the public.

### Why is it needed?
To make things a bit more secure.

### Related issue(s)/PR(s)
Fixes #13925 
