### PR TITLE
Update phpThumb to 1.7.15-201806071234

### DIFF
--- a/core/model/phpthumb/phpthumb.bmp.php
+++ b/core/model/phpthumb/phpthumb.bmp.php
@@ -20,7 +20,7 @@
 
 class phpthumb_bmp {
 
-	function phpthumb_bmp2gd(&$BMPdata, $truecolor=true) {
+	public function phpthumb_bmp2gd(&$BMPdata, $truecolor=true) {
 		$ThisFileInfo = array();
 		if ($this->getid3_bmp($BMPdata, $ThisFileInfo, true, true)) {
 			$gd = $this->PlotPixelsGD($ThisFileInfo['bmp'], $truecolor);
@@ -29,7 +29,7 @@ class phpthumb_bmp {
 		return false;
 	}
 
-	function phpthumb_bmpfile2gd($filename, $truecolor=true) {
+	public function phpthumb_bmpfile2gd($filename, $truecolor=true) {
 		if ($fp = @fopen($filename, 'rb')) {
 			$BMPdata = fread($fp, filesize($filename));
 			fclose($fp);
@@ -38,7 +38,7 @@ class phpthumb_bmp {
 		return false;
 	}
 
-	function GD2BMPstring(&$gd_image) {
+	public function GD2BMPstring(&$gd_image) {
 		$imageX = imagesx($gd_image);
 		$imageY = imagesy($gd_image);
 
@@ -79,7 +79,7 @@ class phpthumb_bmp {
 		return $BITMAPFILEHEADER.$BITMAPINFOHEADER.$BMP;
 	}
 
-	function getid3_bmp(&$BMPdata, &$ThisFileInfo, $ExtractPalette=false, $ExtractData=false) {
+	public function getid3_bmp(&$BMPdata, &$ThisFileInfo, $ExtractPalette=false, $ExtractData=false) {
 
 		// shortcuts
 		$ThisFileInfo['bmp']['header']['raw'] = array();
@@ -104,7 +104,7 @@ class phpthumb_bmp {
 		$offset += 2;
 
 		if ($thisfile_bmp_header_raw['identifier'] != 'BM') {
-			$ThisFileInfo['error'][] = 'Expecting "BM" at offset '.intval(@$ThisFileInfo['avdataoffset']).', found "'.$thisfile_bmp_header_raw['identifier'].'"';
+			$ThisFileInfo['error'][] = 'Expecting "BM" at offset '. (int) (@$ThisFileInfo[ 'avdataoffset']) .', found "'. $thisfile_bmp_header_raw[ 'identifier'].'"';
 			unset($ThisFileInfo['fileformat']);
 			unset($ThisFileInfo['bmp']);
 			return false;
@@ -364,9 +364,9 @@ class phpthumb_bmp {
 					// BYTE    rgbGreen;
 					// BYTE    rgbRed;
 					// BYTE    rgbReserved;
-					$blue  = $this->LittleEndian2Int(substr($BMPpalette, $paletteoffset++, 1));
-					$green = $this->LittleEndian2Int(substr($BMPpalette, $paletteoffset++, 1));
-					$red   = $this->LittleEndian2Int(substr($BMPpalette, $paletteoffset++, 1));
+					$blue  = $this->LittleEndian2Int($BMPpalette[ $paletteoffset++ ]);
+					$green = $this->LittleEndian2Int($BMPpalette[ $paletteoffset++ ]);
+					$red   = $this->LittleEndian2Int($BMPpalette[ $paletteoffset++ ]);
 					if (($thisfile_bmp['type_os'] == 'OS/2') && ($thisfile_bmp['type_version'] == 1)) {
 						// no padding byte
 					} else {
@@ -378,7 +378,7 @@ class phpthumb_bmp {
 		}
 
 		if ($ExtractData) {
-			$RowByteLength = ceil(($thisfile_bmp_header_raw['width'] * ($thisfile_bmp_header_raw['bits_per_pixel'] / 8)) / 4) * 4; // round up to nearest DWORD boundry
+			$RowByteLength = ceil(($thisfile_bmp_header_raw['width'] * ($thisfile_bmp_header_raw['bits_per_pixel'] / 8)) / 4) * 4; // round up to nearest DWORD boundary
 
 			$BMPpixelData = substr($BMPdata, $thisfile_bmp_header_raw['data_offset'], $thisfile_bmp_header_raw['height'] * $RowByteLength);
 			$overalloffset = $thisfile_bmp_header_raw['data_offset'] + ($thisfile_bmp_header_raw['height'] * $RowByteLength);
@@ -477,8 +477,8 @@ class phpthumb_bmp {
 						case 8:
 							$pixelcounter = 0;
 							while ($pixeldataoffset < strlen($BMPpixelData)) {
-								$firstbyte  = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
-								$secondbyte = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
+								$firstbyte  = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
+								$secondbyte = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
 								if ($firstbyte == 0) {
 
 									// escaped/absolute mode - the first byte of the pair can be set to zero to
@@ -499,8 +499,8 @@ class phpthumb_bmp {
 											// delta - The 2 bytes following the escape contain unsigned values
 											// indicating the horizontal and vertical offsets of the next pixel
 											// from the current position.
-											$colincrement = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
-											$rowincrement = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
+											$colincrement = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
+											$rowincrement = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
 											$col = ($pixelcounter % $thisfile_bmp_header_raw['width']) + $colincrement;
 											$row = ($thisfile_bmp_header_raw['height'] - 1 - (($pixelcounter - $col) / $thisfile_bmp_header_raw['width'])) - $rowincrement;
 											$pixelcounter = ($row * $thisfile_bmp_header_raw['width']) + $col;
@@ -512,7 +512,7 @@ class phpthumb_bmp {
 											// number of bytes that follow, each of which contains the color index
 											// of a single pixel. Each run must be aligned on a word boundary.
 											for ($i = 0; $i < $secondbyte; $i++) {
-												$paletteindex = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
+												$paletteindex = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
 												$col = $pixelcounter % $thisfile_bmp_header_raw['width'];
 												$row = $thisfile_bmp_header_raw['height'] - 1 - (($pixelcounter - $col) / $thisfile_bmp_header_raw['width']);
 												$thisfile_bmp['data'][$row][$col] = $thisfile_bmp['palette'][$paletteindex];
@@ -553,8 +553,8 @@ class phpthumb_bmp {
 						case 4:
 							$pixelcounter = 0;
 							while ($pixeldataoffset < strlen($BMPpixelData)) {
-								$firstbyte  = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
-								$secondbyte = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
+								$firstbyte  = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
+								$secondbyte = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
 								if ($firstbyte == 0) {
 
 									// escaped/absolute mode - the first byte of the pair can be set to zero to
@@ -575,8 +575,8 @@ class phpthumb_bmp {
 											// delta - The 2 bytes following the escape contain unsigned values
 											// indicating the horizontal and vertical offsets of the next pixel
 											// from the current position.
-											$colincrement = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
-											$rowincrement = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
+											$colincrement = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
+											$rowincrement = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
 											$col = ($pixelcounter % $thisfile_bmp_header_raw['width']) + $colincrement;
 											$row = ($thisfile_bmp_header_raw['height'] - 1 - (($pixelcounter - $col) / $thisfile_bmp_header_raw['width'])) - $rowincrement;
 											$pixelcounter = ($row * $thisfile_bmp_header_raw['width']) + $col;
@@ -588,8 +588,8 @@ class phpthumb_bmp {
 											// high- and low-order 4 bits, one color index for each pixel. In absolute mode,
 											// each run must be aligned on a word boundary.
 											$paletteindexes = array();
-											for ($i = 0; $i < ceil($secondbyte / 2); $i++) {
-												$paletteindexbyte = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset++, 1));
+											for ($i = 0, $iMax = ceil($secondbyte / 2); $i < $iMax; $i++) {
+												$paletteindexbyte = $this->LittleEndian2Int($BMPpixelData[ $pixeldataoffset++ ]);
 												$paletteindexes[] = ($paletteindexbyte & 0xF0) >> 4;
 												$paletteindexes[] = ($paletteindexbyte & 0x0F);
 											}
@@ -661,9 +661,9 @@ class phpthumb_bmp {
 									$pixelvalue = $this->LittleEndian2Int(substr($BMPpixelData, $pixeldataoffset, $thisfile_bmp_header_raw['bits_per_pixel'] / 8));
 									$pixeldataoffset += $thisfile_bmp_header_raw['bits_per_pixel'] / 8;
 
-									$red   = intval(round(((($pixelvalue & $thisfile_bmp_header_raw['red_mask'])   >> $redshift)   / ($thisfile_bmp_header_raw['red_mask']   >> $redshift))   * 255));
-									$green = intval(round(((($pixelvalue & $thisfile_bmp_header_raw['green_mask']) >> $greenshift) / ($thisfile_bmp_header_raw['green_mask'] >> $greenshift)) * 255));
-									$blue  = intval(round(((($pixelvalue & $thisfile_bmp_header_raw['blue_mask'])  >> $blueshift)  / ($thisfile_bmp_header_raw['blue_mask']  >> $blueshift))  * 255));
+									$red   = (int) round(((($pixelvalue & $thisfile_bmp_header_raw[ 'red_mask'])   >> $redshift)   / ($thisfile_bmp_header_raw[ 'red_mask']   >> $redshift))   * 255);
+									$green = (int) round(((($pixelvalue & $thisfile_bmp_header_raw[ 'green_mask']) >> $greenshift) / ($thisfile_bmp_header_raw[ 'green_mask'] >> $greenshift)) * 255);
+									$blue  = (int) round(((($pixelvalue & $thisfile_bmp_header_raw[ 'blue_mask'])  >> $blueshift)  / ($thisfile_bmp_header_raw[ 'blue_mask']  >> $blueshift))  * 255);
 									$thisfile_bmp['data'][$row][$col] = (($red << 16) | ($green << 8) | ($blue));
 								}
 								while (($pixeldataoffset % 4) != 0) {
@@ -689,14 +689,14 @@ class phpthumb_bmp {
 		return true;
 	}
 
-	function IntColor2RGB($color) {
+	public function IntColor2RGB($color) {
 		$red   = ($color & 0x00FF0000) >> 16;
 		$green = ($color & 0x0000FF00) >> 8;
 		$blue  = ($color & 0x000000FF);
 		return array($red, $green, $blue);
 	}
 
-	function PlotPixelsGD(&$BMPdata, $truecolor=true) {
+	public function PlotPixelsGD(&$BMPdata, $truecolor=true) {
 		$imagewidth  = $BMPdata['header']['raw']['width'];
 		$imageheight = $BMPdata['header']['raw']['height'];
 
@@ -746,14 +746,14 @@ class phpthumb_bmp {
 		return $gd;
 	}
 
-	function PlotBMP(&$BMPinfo) {
+	public function PlotBMP(&$BMPinfo) {
 		$starttime = time();
 		if (!isset($BMPinfo['bmp']['data']) || !is_array($BMPinfo['bmp']['data'])) {
 			echo 'ERROR: no pixel data<BR>';
 			return false;
 		}
 		if (!phpthumb_functions::FunctionIsDisabled('set_time_limit')) {
-			set_time_limit(intval(round($BMPinfo['resolution_x'] * $BMPinfo['resolution_y'] / 10000)));
+			set_time_limit((int) round($BMPinfo[ 'resolution_x'] * $BMPinfo[ 'resolution_y'] / 10000));
 		}
 		$im = $this->PlotPixelsGD($BMPinfo['bmp']);
 		if (headers_sent()) {
@@ -767,7 +767,7 @@ class phpthumb_bmp {
 		return true;
 	}
 
-	function BMPcompressionWindowsLookup($compressionid) {
+	public function BMPcompressionWindowsLookup($compressionid) {
 		static $BMPcompressionWindowsLookup = array(
 			0 => 'BI_RGB',
 			1 => 'BI_RLE8',
@@ -779,7 +779,7 @@ class phpthumb_bmp {
 		return (isset($BMPcompressionWindowsLookup[$compressionid]) ? $BMPcompressionWindowsLookup[$compressionid] : 'invalid');
 	}
 
-	function BMPcompressionOS2Lookup($compressionid) {
+	public function BMPcompressionOS2Lookup($compressionid) {
 		static $BMPcompressionOS2Lookup = array(
 			0 => 'BI_RGB',
 			1 => 'BI_RLE8',
@@ -793,7 +793,7 @@ class phpthumb_bmp {
 
 	// from getid3.lib.php
 
-	function trunc($floatnumber) {
+	public function trunc($floatnumber) {
 		// truncates a floating-point number at the decimal point
 		// returns int (if possible, otherwise float)
 		if ($floatnumber >= 1) {
@@ -809,7 +809,7 @@ class phpthumb_bmp {
 		return $truncatednumber;
 	}
 
-	function LittleEndian2Int($byteword) {
+	public function LittleEndian2Int($byteword) {
 		$intvalue = 0;
 		$byteword = strrev($byteword);
 		$bytewordlen = strlen($byteword);
@@ -819,11 +819,11 @@ class phpthumb_bmp {
 		return $intvalue;
 	}
 
-	function BigEndian2Int($byteword) {
+	public function BigEndian2Int($byteword) {
 		return $this->LittleEndian2Int(strrev($byteword));
 	}
 
-	function BigEndian2Bin($byteword) {
+	public function BigEndian2Bin($byteword) {
 		$binvalue = '';
 		$bytewordlen = strlen($byteword);
 		for ($i = 0; $i < $bytewordlen; $i++) {
@@ -832,12 +832,12 @@ class phpthumb_bmp {
 		return $binvalue;
 	}
 
-	function FixedPoint2_30($rawdata) {
+	public function FixedPoint2_30($rawdata) {
 		$binarystring = $this->BigEndian2Bin($rawdata);
 		return $this->Bin2Dec(substr($binarystring, 0, 2)) + (float) ($this->Bin2Dec(substr($binarystring, 2, 30)) / 1073741824);
 	}
 
-	function Bin2Dec($binstring, $signed=false) {
+	public function Bin2Dec($binstring, $signed=false) {
 		$signmult = 1;
 		if ($signed) {
 			if ($binstring{0} == '1') {
@@ -846,13 +846,13 @@ class phpthumb_bmp {
 			$binstring = substr($binstring, 1);
 		}
 		$decvalue = 0;
-		for ($i = 0; $i < strlen($binstring); $i++) {
-			$decvalue += ((int) substr($binstring, strlen($binstring) - $i - 1, 1)) * pow(2, $i);
+		for ($i = 0, $iMax = strlen($binstring); $i < $iMax; $i++) {
+			$decvalue += ((int) $binstring[ strlen($binstring) - $i - 1 ]) * pow(2, $i);
 		}
 		return $this->CastAsInt($decvalue * $signmult);
 	}
 
-	function CastAsInt($floatnum) {
+	public function CastAsInt($floatnum) {
 		// convert to float if not already
 		$floatnum = (float) $floatnum;
 

--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -10,9 +10,9 @@
 //////////////////////////////////////////////////////////////
 
 ob_start();
-if (!include_once(dirname(__FILE__).'/phpthumb.functions.php')) {
+if (!include_once( __DIR__ .'/phpthumb.functions.php')) {
 	ob_end_flush();
-	die('failed to include_once("'.dirname(__FILE__).'/phpthumb.functions.php")');
+	die('failed to include_once("'. __DIR__ .'/phpthumb.functions.php")');
 }
 ob_end_clean();
 
@@ -21,44 +21,44 @@ class phpthumb {
 	// public:
 	// START PARAMETERS (for object mode and phpThumb.php)
 	// See phpthumb.readme.txt for descriptions of what each of these values are
-	var $src  = null;     // SouRCe filename
-	var $new  = null;     // NEW image (phpThumb.php only)
-	var $w    = null;     // Width
-	var $h    = null;     // Height
-	var $wp   = null;     // Width  (Portrait Images Only)
-	var $hp   = null;     // Height (Portrait Images Only)
-	var $wl   = null;     // Width  (Landscape Images Only)
-	var $hl   = null;     // Height (Landscape Images Only)
-	var $ws   = null;     // Width  (Square Images Only)
-	var $hs   = null;     // Height (Square Images Only)
-	var $f    = null;     // output image Format
-	var $q    = 75;       // jpeg output Quality
-	var $sx   = null;     // Source crop top-left X position
-	var $sy   = null;     // Source crop top-left Y position
-	var $sw   = null;     // Source crop Width
-	var $sh   = null;     // Source crop Height
-	var $zc   = null;     // Zoom Crop
-	var $bc   = null;     // Border Color
-	var $bg   = null;     // BackGround color
-	var $fltr = array();  // FiLTeRs
-	var $goto = null;     // GO TO url after processing
-	var $err  = null;     // default ERRor image filename
-	var $xto  = null;     // extract eXif Thumbnail Only
-	var $ra   = null;     // Rotate by Angle
-	var $ar   = null;     // Auto Rotate
-	var $aoe  = null;     // Allow Output Enlargement
-	var $far  = null;     // Fixed Aspect Ratio
-	var $iar  = null;     // Ignore Aspect Ratio
-	var $maxb = null;     // MAXimum Bytes
-	var $down = null;     // DOWNload thumbnail filename
-	var $md5s = null;     // MD5 hash of Source image
-	var $sfn  = 0;        // Source Frame Number
-	var $dpi  = 150;      // Dots Per Inch for vector source formats
-	var $sia  = null;     // Save Image As filename
+	public $src  = null;     // SouRCe filename
+	public $new  = null;     // NEW image (phpThumb.php only)
+	public $w    = null;     // Width
+	public $h    = null;     // Height
+	public $wp   = null;     // Width  (Portrait Images Only)
+	public $hp   = null;     // Height (Portrait Images Only)
+	public $wl   = null;     // Width  (Landscape Images Only)
+	public $hl   = null;     // Height (Landscape Images Only)
+	public $ws   = null;     // Width  (Square Images Only)
+	public $hs   = null;     // Height (Square Images Only)
+	public $f    = null;     // output image Format
+	public $q    = 75;       // jpeg output Quality
+	public $sx   = null;     // Source crop top-left X position
+	public $sy   = null;     // Source crop top-left Y position
+	public $sw   = null;     // Source crop Width
+	public $sh   = null;     // Source crop Height
+	public $zc   = null;     // Zoom Crop
+	public $bc   = null;     // Border Color
+	public $bg   = null;     // BackGround color
+	public $fltr = array();  // FiLTeRs
+	public $goto = null;     // GO TO url after processing
+	public $err  = null;     // default ERRor image filename
+	public $xto  = null;     // extract eXif Thumbnail Only
+	public $ra   = null;     // Rotate by Angle
+	public $ar   = null;     // Auto Rotate
+	public $aoe  = null;     // Allow Output Enlargement
+	public $far  = null;     // Fixed Aspect Ratio
+	public $iar  = null;     // Ignore Aspect Ratio
+	public $maxb = null;     // MAXimum Bytes
+	public $down = null;     // DOWNload thumbnail filename
+	public $md5s = null;     // MD5 hash of Source image
+	public $sfn  = 0;        // Source Frame Number
+	public $dpi  = 150;      // Dots Per Inch for vector source formats
+	public $sia  = null;     // Save Image As filename
 
-	var $file = null;     // >>>deprecated, DO NOT USE, will be removed in future versions<<<
+	public $file = null;     // >>>deprecated, DO NOT USE, will be removed in future versions<<<
 
-	var $phpThumbDebug = null;
+	public $phpThumbDebug = null;
 	// END PARAMETERS
 
 
@@ -67,173 +67,173 @@ class phpthumb {
 	// See phpThumb.config.php for descriptions of what each of these settings do
 
 	// * Directory Configuration
-	var $config_cache_directory                      = null;
-	var $config_cache_directory_depth                = 0;
-	var $config_cache_disable_warning                = true;
-	var $config_cache_source_enabled                 = false;
-	var $config_cache_source_directory               = null;
-	var $config_temp_directory                       = null;
-	var $config_document_root                        = null;
+	public $config_cache_directory                      = null;
+	public $config_cache_directory_depth                = 0;
+	public $config_cache_disable_warning                = true;
+	public $config_cache_source_enabled                 = false;
+	public $config_cache_source_directory               = null;
+	public $config_temp_directory                       = null;
+	public $config_document_root                        = null;
 
 	// * Default output configuration:
-	var $config_output_format                        = 'jpeg';
-	var $config_output_maxwidth                      = 0;
-	var $config_output_maxheight                     = 0;
-	var $config_output_interlace                     = true;
+	public $config_output_format                        = 'jpeg';
+	public $config_output_maxwidth                      = 0;
+	public $config_output_maxheight                     = 0;
+	public $config_output_interlace                     = true;
 
 	// * Error message configuration
-	var $config_error_image_width                    = 400;
-	var $config_error_image_height                   = 100;
-	var $config_error_message_image_default          = '';
-	var $config_error_bgcolor                        = 'CCCCFF';
-	var $config_error_textcolor                      = 'FF0000';
-	var $config_error_fontsize                       = 1;
-	var $config_error_die_on_error                   = false;
-	var $config_error_silent_die_on_error            = false;
-	var $config_error_die_on_source_failure          = true;
+	public $config_error_image_width                    = 400;
+	public $config_error_image_height                   = 100;
+	public $config_error_message_image_default          = '';
+	public $config_error_bgcolor                        = 'CCCCFF';
+	public $config_error_textcolor                      = 'FF0000';
+	public $config_error_fontsize                       = 1;
+	public $config_error_die_on_error                   = false;
+	public $config_error_silent_die_on_error            = false;
+	public $config_error_die_on_source_failure          = true;
 
 	// * Anti-Hotlink Configuration:
-	var $config_nohotlink_enabled                    = true;
-	var $config_nohotlink_valid_domains              = array();
-	var $config_nohotlink_erase_image                = true;
-	var $config_nohotlink_text_message               = 'Off-server thumbnailing is not allowed';
+	public $config_nohotlink_enabled                    = true;
+	public $config_nohotlink_valid_domains              = array();
+	public $config_nohotlink_erase_image                = true;
+	public $config_nohotlink_text_message               = 'Off-server thumbnailing is not allowed';
 	// * Off-server Linking Configuration:
-	var $config_nooffsitelink_enabled                = false;
-	var $config_nooffsitelink_valid_domains          = array();
-	var $config_nooffsitelink_require_refer          = false;
-	var $config_nooffsitelink_erase_image            = true;
-	var $config_nooffsitelink_watermark_src          = '';
-	var $config_nooffsitelink_text_message           = 'Off-server linking is not allowed';
+	public $config_nooffsitelink_enabled                = false;
+	public $config_nooffsitelink_valid_domains          = array();
+	public $config_nooffsitelink_require_refer          = false;
+	public $config_nooffsitelink_erase_image            = true;
+	public $config_nooffsitelink_watermark_src          = '';
+	public $config_nooffsitelink_text_message           = 'Off-server linking is not allowed';
 
 	// * Border & Background default colors
-	var $config_border_hexcolor                      = '000000';
-	var $config_background_hexcolor                  = 'FFFFFF';
+	public $config_border_hexcolor                      = '000000';
+	public $config_background_hexcolor                  = 'FFFFFF';
 
 	// * TrueType Fonts
-	var $config_ttf_directory                        = './fonts';
+	public $config_ttf_directory                        = './fonts';
 
-	var $config_max_source_pixels                    = null;
-	var $config_use_exif_thumbnail_for_speed         = false;
-	var $allow_local_http_src                        = false;
+	public $config_max_source_pixels                    = null;
+	public $config_use_exif_thumbnail_for_speed         = false;
+	public $config_allow_local_http_src                 = false;
 
-	var $config_imagemagick_path                     = null;
-	var $config_prefer_imagemagick                   = true;
-	var $config_imagemagick_use_thumbnail            = true;
+	public $config_imagemagick_path                     = null;
+	public $config_prefer_imagemagick                   = true;
+	public $config_imagemagick_use_thumbnail            = true;
 
-	var $config_cache_maxage                         = null;
-	var $config_cache_maxsize                        = null;
-	var $config_cache_maxfiles                       = null;
-	var $config_cache_source_filemtime_ignore_local  = false;
-	var $config_cache_source_filemtime_ignore_remote = true;
-	var $config_cache_default_only_suffix            = false;
-	var $config_cache_force_passthru                 = true;
-	var $config_cache_prefix                         = '';    // default value set in the constructor below
+	public $config_cache_maxage                         = null;
+	public $config_cache_maxsize                        = null;
+	public $config_cache_maxfiles                       = null;
+	public $config_cache_source_filemtime_ignore_local  = false;
+	public $config_cache_source_filemtime_ignore_remote = true;
+	public $config_cache_default_only_suffix            = false;
+	public $config_cache_force_passthru                 = true;
+	public $config_cache_prefix                         = '';    // default value set in the constructor below
 
 	// * MySQL
-	var $config_mysql_extension                      = null;
-	var $config_mysql_query                          = null;
-	var $config_mysql_hostname                       = null;
-	var $config_mysql_username                       = null;
-	var $config_mysql_password                       = null;
-	var $config_mysql_database                       = null;
+	public $config_mysql_extension                      = null;
+	public $config_mysql_query                          = null;
+	public $config_mysql_hostname                       = null;
+	public $config_mysql_username                       = null;
+	public $config_mysql_password                       = null;
+	public $config_mysql_database                       = null;
 
 	// * Security
-	var $config_high_security_enabled                = true;
-	var $config_high_security_password               = null;
-	var $config_high_security_url_separator          = '&';
-	var $config_disable_debug                        = true;
-	var $config_allow_src_above_docroot              = false;
-	var $config_allow_src_above_phpthumb             = true;
-	var $config_auto_allow_symlinks                  = true;    // allow symlink target directories without explicitly whitelisting them
-	var $config_additional_allowed_dirs              = array(); // additional directories to allow source images to be read from
-	var $config_file_create_mask                     = 0755;
-	var $config_dir_create_mask                      = 0755;
+	public $config_high_security_enabled                = true;
+	public $config_high_security_password               = null;
+	public $config_high_security_url_separator          = '&';
+	public $config_disable_debug                        = true;
+	public $config_allow_src_above_docroot              = false;
+	public $config_allow_src_above_phpthumb             = true;
+	public $config_auto_allow_symlinks                  = true;    // allow symlink target directories without explicitly whitelisting them
+	public $config_additional_allowed_dirs              = array(); // additional directories to allow source images to be read from
+	public $config_file_create_mask                     = 0755;
+	public $config_dir_create_mask                      = 0755;
 
 	// * HTTP fopen
-	var $config_http_fopen_timeout                   = 10;
-	var $config_http_follow_redirect                 = true;
+	public $config_http_fopen_timeout                   = 10;
+	public $config_http_follow_redirect                 = true;
 
 	// * Compatability
-	var $config_disable_pathinfo_parsing             = false;
-	var $config_disable_imagecopyresampled           = false;
-	var $config_disable_onlycreateable_passthru      = false;
-	var $config_disable_realpath                     = false;
+	public $config_disable_pathinfo_parsing             = false;
+	public $config_disable_imagecopyresampled           = false;
+	public $config_disable_onlycreateable_passthru      = false;
+	public $config_disable_realpath                     = false;
 
-	var $config_http_user_agent                      = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7.12) Gecko/20050915 Firefox/1.0.7';
+	public $config_http_user_agent                      = 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.7.12) Gecko/20050915 Firefox/1.0.7';
 
 	// END CONFIGURATION OPTIONS
 
 
 	// public: error messages (read-only; persistant)
-	var $debugmessages = array();
-	var $debugtiming   = array();
-	var $fatalerror    = null;
+	public $debugmessages = array();
+	public $debugtiming   = array();
+	public $fatalerror    = null;
 
 
 	// private: (should not be modified directly)
-	var $thumbnailQuality = 75;
-	var $thumbnailFormat  = null;
+	public $thumbnailQuality = 75;
+	public $thumbnailFormat  = null;
 
-	var $sourceFilename   = null;
-	var $rawImageData     = null;
-	var $IMresizedData    = null;
-	var $outputImageData  = null;
+	public $sourceFilename   = null;
+	public $rawImageData     = null;
+	public $IMresizedData    = null;
+	public $outputImageData  = null;
 
-	var $useRawIMoutput   = false;
+	public $useRawIMoutput   = false;
 
-	var $gdimg_output     = null;
-	var $gdimg_source     = null;
+	public $gdimg_output     = null;
+	public $gdimg_source     = null;
 
-	var $getimagesizeinfo = null;
+	public $getimagesizeinfo = null;
 
-	var $source_width  = null;
-	var $source_height = null;
+	public $source_width  = null;
+	public $source_height = null;
 
-	var $thumbnailCropX = null;
-	var $thumbnailCropY = null;
-	var $thumbnailCropW = null;
-	var $thumbnailCropH = null;
+	public $thumbnailCropX = null;
+	public $thumbnailCropY = null;
+	public $thumbnailCropW = null;
+	public $thumbnailCropH = null;
 
-	var $exif_thumbnail_width  = null;
-	var $exif_thumbnail_height = null;
-	var $exif_thumbnail_type   = null;
-	var $exif_thumbnail_data   = null;
-	var $exif_raw_data         = null;
+	public $exif_thumbnail_width  = null;
+	public $exif_thumbnail_height = null;
+	public $exif_thumbnail_type   = null;
+	public $exif_thumbnail_data   = null;
+	public $exif_raw_data         = null;
 
-	var $thumbnail_width        = null;
-	var $thumbnail_height       = null;
-	var $thumbnail_image_width  = null;
-	var $thumbnail_image_height = null;
+	public $thumbnail_width        = null;
+	public $thumbnail_height       = null;
+	public $thumbnail_image_width  = null;
+	public $thumbnail_image_height = null;
 
-	var $tempFilesToDelete = array();
-	var $cache_filename    = null;
+	public $tempFilesToDelete = array();
+	public $cache_filename    = null;
 
-	var $AlphaCapableFormats = array('png', 'ico', 'gif');
-	var $is_alpha = false;
+	public $AlphaCapableFormats = array( 'png', 'ico', 'gif');
+	public $is_alpha = false;
 
-	var $iswindows        = null;
-	var $issafemode       = null;
-	var $php_memory_limit = null;
+	public $iswindows        = null;
+	public $issafemode       = null;
+	public $php_memory_limit = null;
 
-	var $phpthumb_version = '1.7.14-201608101311';
+	public $phpthumb_version = '1.7.15-201806071234';
 
 	//////////////////////////////////////////////////////////////////////
 
 	// public: constructor
-	function __construct() {
+	public function __construct() {
 		$this->phpThumb();
 	}
 
-	function phpThumb() {
+	public function phpThumb() {
 		$this->DebugTimingMessage('phpThumb() constructor', __FILE__, __LINE__);
 		$this->DebugMessage('phpThumb() v'.$this->phpthumb_version, __FILE__, __LINE__);
 
 		foreach (array(ini_get('memory_limit'), get_cfg_var('memory_limit')) as $php_config_memory_limit) {
-			if (strlen($php_config_memory_limit)) {
-				if (substr($php_config_memory_limit, -1, 1) == 'G') { // PHP memory limit expressed in Gigabytes
-					$php_config_memory_limit = intval(substr($php_config_memory_limit, 0, -1)) * 1073741824;
-				} elseif (substr($php_config_memory_limit, -1, 1) == 'M') { // PHP memory limit expressed in Megabytes
-					$php_config_memory_limit = intval(substr($php_config_memory_limit, 0, -1)) * 1048576;
+			if ('' !== $php_config_memory_limit) {
+				if (strtoupper($php_config_memory_limit[ strlen($php_config_memory_limit) - 1 ]) == 'G') { // PHP memory limit expressed in Gigabytes
+					$php_config_memory_limit = (int) substr($php_config_memory_limit, 0, -1) * 1073741824;
+				} elseif (strtoupper($php_config_memory_limit[ strlen($php_config_memory_limit) - 1 ]) == 'M') { // PHP memory limit expressed in Megabytes
+					$php_config_memory_limit = (int) substr($php_config_memory_limit, 0, -1) * 1048576;
 				}
 				$this->php_memory_limit = max($this->php_memory_limit, $php_config_memory_limit);
 			}
@@ -249,23 +249,23 @@ class phpthumb {
 
 		$this->purgeTempFiles(); // purge existing temp files if re-initializing object
 
-		$php_sapi_name = strtolower(function_exists('php_sapi_name') ? php_sapi_name() : '');
+		$php_sapi_name = strtolower(function_exists('php_sapi_name') ? PHP_SAPI : '');
 		if ($php_sapi_name == 'cli') {
 			$this->config_allow_src_above_docroot = true;
 		}
 
 		if (!$this->config_disable_debug) {
 			// if debug mode is enabled, force phpThumbDebug output, do not allow normal thumbnails to be generated
-			$this->phpThumbDebug = (is_null($this->phpThumbDebug) ? 9 : max(1, intval($this->phpThumbDebug)));
+			$this->phpThumbDebug = (null === $this->phpThumbDebug ? 9 : max(1, (int) $this->phpThumbDebug));
 		}
 	}
 
-	function __destruct() {
+	public function __destruct() {
 		$this->purgeTempFiles();
 	}
 
 	// public:
-	function purgeTempFiles() {
+	public function purgeTempFiles() {
 		foreach ($this->tempFilesToDelete as $tempFileToDelete) {
 			if (file_exists($tempFileToDelete)) {
 				$this->DebugMessage('Deleting temp file "'.$tempFileToDelete.'"', __FILE__, __LINE__);
@@ -277,12 +277,12 @@ class phpthumb {
 	}
 
 	// public:
-	function setSourceFilename($sourceFilename) {
+	public function setSourceFilename($sourceFilename) {
 		//$this->resetObject();
 		//$this->rawImageData   = null;
 		$this->sourceFilename = $sourceFilename;
 		$this->src            = $sourceFilename;
-		if (is_null($this->config_output_format)) {
+		if (null === $this->config_output_format) {
 			$sourceFileExtension = strtolower(substr(strrchr($sourceFilename, '.'), 1));
 			if (preg_match('#^[a-z]{3,4}$#', $sourceFileExtension)) {
 				$this->config_output_format = $sourceFileExtension;
@@ -296,7 +296,7 @@ class phpthumb {
 	}
 
 	// public:
-	function setSourceData($rawImageData, $sourceFilename='') {
+	public function setSourceData($rawImageData, $sourceFilename='') {
 		//$this->resetObject();
 		//$this->sourceFilename = null;
 		$this->rawImageData   = $rawImageData;
@@ -320,14 +320,14 @@ class phpthumb {
 	}
 
 	// public:
-	function setSourceImageResource($gdimg) {
+	public function setSourceImageResource($gdimg) {
 		//$this->resetObject();
 		$this->gdimg_source = $gdimg;
 		return true;
 	}
 
 	// public:
-	function setParameter($param, $value) {
+	public function setParameter($param, $value) {
 		if ($param == 'src') {
 			$this->setSourceFilename($this->ResolveFilenameToAbsolute($value));
 		} elseif (@is_array($this->$param)) {
@@ -345,7 +345,7 @@ class phpthumb {
 	}
 
 	// public:
-	function getParameter($param) {
+	public function getParameter($param) {
 		//if (property_exists('phpThumb', $param)) {
 			return $this->$param;
 		//}
@@ -355,7 +355,7 @@ class phpthumb {
 
 
 	// public:
-	function GenerateThumbnail() {
+	public function GenerateThumbnail() {
 
 		$this->setOutputFormat();
 			$this->phpThumbDebug('8a');
@@ -443,7 +443,7 @@ class phpthumb {
 
 
 	// public:
-	function RenderOutput() {
+	public function RenderOutput() {
 		if (!$this->useRawIMoutput && !is_resource($this->gdimg_output)) {
 			$this->DebugMessage('RenderOutput() failed because !is_resource($this->gdimg_output)', __FILE__, __LINE__);
 			return false;
@@ -467,8 +467,8 @@ class phpthumb {
 			$builtin_formats['png']  = (bool) ($imagetypes & IMG_PNG);
 		}
 
-		$this->DebugMessage('imageinterlace($this->gdimg_output, '.intval($this->config_output_interlace).')', __FILE__, __LINE__);
-		imageinterlace($this->gdimg_output, intval($this->config_output_interlace));
+		$this->DebugMessage('imageinterlace($this->gdimg_output, '. (int) $this->config_output_interlace .')', __FILE__, __LINE__);
+		imageinterlace($this->gdimg_output, (int) $this->config_output_interlace);
 
 		$this->DebugMessage('RenderOutput() attempting image'.strtolower(@$this->thumbnailFormat).'($this->gdimg_output)', __FILE__, __LINE__);
 		ob_start();
@@ -500,7 +500,7 @@ class phpthumb {
 					ob_end_clean();
 					return false;
 				}
-				if (phpthumb_functions::version_compare_replacement(phpversion(), '5.1.2', '>=')) {
+				if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.1.2', '>=')) {
 					// https://github.com/JamesHeinrich/phpThumb/issues/24
 
 					/* http://php.net/manual/en/function.imagepng.php:
@@ -535,8 +535,8 @@ class phpthumb {
 				break;
 
 			case 'bmp':
-				if (!@include_once(dirname(__FILE__).'/phpthumb.bmp.php')) {
-					$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.bmp.php" which is required for BMP format output', __FILE__, __LINE__);
+				if (!@include_once( __DIR__ .'/phpthumb.bmp.php')) {
+					$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.bmp.php" which is required for BMP format output', __FILE__, __LINE__);
 					ob_end_clean();
 					return false;
 				}
@@ -546,8 +546,8 @@ class phpthumb {
 				break;
 
 			case 'ico':
-				if (!@include_once(dirname(__FILE__).'/phpthumb.ico.php')) {
-					$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.ico.php" which is required for ICO format output', __FILE__, __LINE__);
+				if (!@include_once( __DIR__ .'/phpthumb.ico.php')) {
+					$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.ico.php" which is required for ICO format output', __FILE__, __LINE__);
 					ob_end_clean();
 					return false;
 				}
@@ -574,7 +574,7 @@ class phpthumb {
 
 
 	// public:
-	function RenderToFile($filename) {
+	public function RenderToFile($filename) {
 		if (preg_match('#^[a-z0-9]+://#i', $filename)) {
 			$this->DebugMessage('RenderToFile() failed because $filename ('.$filename.') is a URL', __FILE__, __LINE__);
 			return false;
@@ -611,7 +611,7 @@ class phpthumb {
 
 
 	// public:
-	function OutputThumbnail() {
+	public function OutputThumbnail() {
 		$this->purgeTempFiles();
 
 		if (!$this->useRawIMoutput && !is_resource($this->gdimg_output)) {
@@ -637,8 +637,8 @@ class phpthumb {
 
 		} else {
 
-			$this->DebugMessage('imageinterlace($this->gdimg_output, '.intval($this->config_output_interlace).')', __FILE__, __LINE__);
-			imageinterlace($this->gdimg_output, intval($this->config_output_interlace));
+			$this->DebugMessage('imageinterlace($this->gdimg_output, '. (int) $this->config_output_interlace .')', __FILE__, __LINE__);
+			imageinterlace($this->gdimg_output, (int) $this->config_output_interlace);
 			switch ($this->thumbnailFormat) {
 				case 'jpeg':
 					header('Content-Type: '.phpthumb_functions::ImageTypeToMIMEtype($this->thumbnailFormat));
@@ -654,8 +654,8 @@ class phpthumb {
 					break;
 
 				case 'bmp':
-					if (!@include_once(dirname(__FILE__).'/phpthumb.bmp.php')) {
-						$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.bmp.php" which is required for BMP format output', __FILE__, __LINE__);
+					if (!@include_once( __DIR__ .'/phpthumb.bmp.php')) {
+						$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.bmp.php" which is required for BMP format output', __FILE__, __LINE__);
 						return false;
 					}
 					$phpthumb_bmp = new phpthumb_bmp();
@@ -675,8 +675,8 @@ class phpthumb {
 					break;
 
 				case 'ico':
-					if (!@include_once(dirname(__FILE__).'/phpthumb.ico.php')) {
-						$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.ico.php" which is required for ICO format output', __FILE__, __LINE__);
+					if (!@include_once( __DIR__ .'/phpthumb.ico.php')) {
+						$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.ico.php" which is required for ICO format output', __FILE__, __LINE__);
 						return false;
 					}
 					$phpthumb_ico = new phpthumb_ico();
@@ -708,8 +708,8 @@ class phpthumb {
 
 
 	// public:
-	function CleanUpCacheDirectory() {
-		$this->DebugMessage('CleanUpCacheDirectory() set to purge ('.(is_null($this->config_cache_maxage) ? 'NULL' : number_format($this->config_cache_maxage / 86400, 1)).' days; '.(is_null($this->config_cache_maxsize) ? 'NULL' : number_format($this->config_cache_maxsize / 1048576, 2)).' MB; '.(is_null($this->config_cache_maxfiles) ? 'NULL' : number_format($this->config_cache_maxfiles)).' files)', __FILE__, __LINE__);
+	public function CleanUpCacheDirectory() {
+		$this->DebugMessage('CleanUpCacheDirectory() set to purge ('.(null === $this->config_cache_maxage ? 'NULL' : number_format($this->config_cache_maxage / 86400, 1)).' days; '.(null === $this->config_cache_maxsize ? 'NULL' : number_format($this->config_cache_maxsize / 1048576, 2)).' MB; '.(null === $this->config_cache_maxfiles ? 'NULL' : number_format($this->config_cache_maxfiles)).' files)', __FILE__, __LINE__);
 
 		if (!is_writable($this->config_cache_directory)) {
 			$this->DebugMessage('CleanUpCacheDirectory() skipped because "'.$this->config_cache_directory.'" is not writable', __FILE__, __LINE__);
@@ -865,7 +865,7 @@ class phpthumb {
 	//////////////////////////////////////////////////////////////////////
 
 	// private: re-initializator (call between rendering multiple images with one object)
-	function resetObject() {
+	public function resetObject() {
 		$class_vars = get_class_vars(get_class($this));
 		foreach ($class_vars as $key => $value) {
 			// do not clobber debug or config info
@@ -879,7 +879,7 @@ class phpthumb {
 
 	//////////////////////////////////////////////////////////////////////
 
-	function ResolveSource() {
+	public function ResolveSource() {
 		if (is_resource($this->gdimg_source)) {
 			$this->DebugMessage('ResolveSource() exiting because is_resource($this->gdimg_source)', __FILE__, __LINE__);
 			return true;
@@ -918,7 +918,7 @@ class phpthumb {
 	}
 
 
-	function setOutputFormat() {
+	public function setOutputFormat() {
 		static $alreadyCalled = false;
 		if ($this->thumbnailFormat && $alreadyCalled) {
 			return true;
@@ -927,10 +927,10 @@ class phpthumb {
 
 		$AvailableImageOutputFormats = array();
 		$AvailableImageOutputFormats[] = 'text';
-		if (@is_readable(dirname(__FILE__).'/phpthumb.ico.php')) {
+		if (@is_readable( __DIR__ .'/phpthumb.ico.php')) {
 			$AvailableImageOutputFormats[] = 'ico';
 		}
-		if (@is_readable(dirname(__FILE__).'/phpthumb.bmp.php')) {
+		if (@is_readable( __DIR__ .'/phpthumb.bmp.php')) {
 			$AvailableImageOutputFormats[] = 'bmp';
 		}
 
@@ -993,17 +993,17 @@ class phpthumb {
 		// for JPEG images, quality 1 (worst) to 99 (best)
 		// quality < 25 is nasty, with not much size savings - not recommended
 		// problems with 100 - invalid JPEG?
-		$this->thumbnailQuality = max(1, min(99, ($this->q ? intval($this->q) : 75)));
+		$this->thumbnailQuality = max(1, min(99, ($this->q ? (int) $this->q : 75)));
 		$this->DebugMessage('$this->thumbnailQuality set to "'.$this->thumbnailQuality.'"', __FILE__, __LINE__);
 
 		return true;
 	}
 
 
-	function setCacheDirectory() {
+	public function setCacheDirectory() {
 		// resolve cache directory to absolute pathname
 		$this->DebugMessage('setCacheDirectory() starting with config_cache_directory = "'.$this->config_cache_directory.'"', __FILE__, __LINE__);
-		if (substr($this->config_cache_directory, 0, 1) == '.') {
+		if ($this->config_cache_directory[ 0 ] == '.') {
 			if (preg_match('#^(f|ht)tps?\://#i', $this->src)) {
 				if (!$this->config_cache_disable_warning) {
 					$this->ErrorImage('$this->config_cache_directory ('.$this->config_cache_directory.') cannot be used for remote images. Adjust "cache_directory" or "cache_disable_warning" in phpThumb.config.php');
@@ -1055,17 +1055,17 @@ class phpthumb {
 	/* Takes the array of path segments up to now, and the next segment (maybe a modifier: empty, . or ..)
 	   Applies it, adding or removing from $segments as a result. Returns nothing. */
 	// http://support.silisoftware.com/phpBB3/viewtopic.php?t=961
-	function applyPathSegment(&$segments, $segment) {
+	public function applyPathSegment(&$segments, $segment) {
 		if ($segment == '.') {
 			return; // always remove
 		}
 		if ($segment == '') {
 			$test = array_pop($segments);
-			if (is_null($test)) {
+			if (null === $test) {
 				$segments[] = $segment; // keep the first empty block
 			} elseif ($test == '') {
 				$test = array_pop($segments);
-				if (is_null($test)) {
+				if (null === $test) {
 					$segments[] = $test;
 					$segments[] = $segment; // keep the second one too
 				} else { // put both back and ignore segment
@@ -1078,7 +1078,7 @@ class phpthumb {
 		} else {
 			if ($segment == '..') {
 				$test = array_pop($segments);
-				if (is_null($test)) {
+				if (null === $test) {
 					$segments[] = $segment;
 				} elseif ($test == '..') {
 					$segments[] = $test;
@@ -1096,7 +1096,7 @@ class phpthumb {
 
 	/* Takes array of path components, normalizes it: removes empty slots and '.', collapses '..' and folder names.  Returns array. */
 	// http://support.silisoftware.com/phpBB3/viewtopic.php?t=961
-	function normalizePath($segments) {
+	public function normalizePath($segments) {
 		$parts = array();
 		foreach ($segments as $segment) {
 			$this->applyPathSegment($parts, $segment);
@@ -1106,7 +1106,7 @@ class phpthumb {
 
 	/* True if the provided path points (without resolving symbolic links) into one of the allowed directories. */
 	// http://support.silisoftware.com/phpBB3/viewtopic.php?t=961
-	function matchPath($path, $allowed_dirs) {
+	public function matchPath($path, $allowed_dirs) {
 		if (!empty($allowed_dirs)) {
 			foreach ($allowed_dirs as $one_dir) {
 				if (preg_match('#^'.preg_quote(str_replace(DIRECTORY_SEPARATOR, '/', $this->realPathSafe($one_dir))).'#', $path)) {
@@ -1119,9 +1119,9 @@ class phpthumb {
 
 	/* True if the provided path points inside one of open_basedirs (or if open_basedirs are disabled) */
 	// http://support.silisoftware.com/phpBB3/viewtopic.php?t=961
-	function isInOpenBasedir($path) {
+	public function isInOpenBasedir($path) {
 		static $open_basedirs = null;
-		if (is_null($open_basedirs)) {
+		if (null === $open_basedirs) {
 			$ini_text = ini_get('open_basedir');
 			$this->DebugMessage('open_basedir: "'.$ini_text.'"', __FILE__, __LINE__);
 			$open_basedirs = array();
@@ -1136,7 +1136,7 @@ class phpthumb {
 
 	/* Resolves all symlinks in $path, checking that each continuous part ends in an allowed zone. Returns null, if any component leads outside of allowed zone. */
 	// http://support.silisoftware.com/phpBB3/viewtopic.php?t=961
-	function resolvePath($path, $allowed_dirs) {
+	public function resolvePath($path, $allowed_dirs) {
 		$this->DebugMessage('resolvePath: '.$path.' (allowed_dirs: '.print_r($allowed_dirs, true).')', __FILE__, __LINE__);
 
 		// add base path to the top of the list
@@ -1144,7 +1144,7 @@ class phpthumb {
 			array_unshift($allowed_dirs, $this->realPathSafe($this->config_document_root));
 		} else {
 			if (!$this->config_allow_src_above_phpthumb) {
-				array_unshift($allowed_dirs, $this->realPathSafe(dirname(__FILE__)));
+				array_unshift($allowed_dirs, $this->realPathSafe( __DIR__ ));
 			} else {
 				// no checks are needed, offload the work to realpath and forget about it
 				$this->DebugMessage('resolvePath: checks disabled, returning '.$this->realPathSafe($path), __FILE__, __LINE__);
@@ -1162,7 +1162,7 @@ class phpthumb {
 			// do not use "cleaner" foreach version of this loop as later code relies on both $segments and $i
 			// http://support.silisoftware.com/phpBB3/viewtopic.php?t=964
 			$segments = explode(DIRECTORY_SEPARATOR, $path);
-			for ($i = 0; $i < count($segments); $i++) {
+			for ($i = 0, $iMax = count($segments); $i < $iMax; $i++) {
 				$this->applyPathSegment($parts, $segments[$i]);
 				$thispart = implode(DIRECTORY_SEPARATOR, $parts);
 				if ($this->isInOpenBasedir($thispart)) {
@@ -1207,7 +1207,7 @@ class phpthumb {
 	}
 
 
-	function realPathSafe($filename) {
+	public function realPathSafe($filename) {
 		// http://php.net/manual/en/function.realpath.php -- "Note: The running script must have executable permissions on all directories in the hierarchy, otherwise realpath() will return FALSE"
 		// realPathSafe() provides a reasonable facsimile of realpath() but does not resolve symbolic links, nor does it check that the file/path actually exists
 		if (!$this->config_disable_realpath) {
@@ -1217,7 +1217,7 @@ class phpthumb {
 		// http://stackoverflow.com/questions/21421569
 		$newfilename = preg_replace('#[\\/]+#', DIRECTORY_SEPARATOR, $filename);
 		if (!preg_match('#^'.DIRECTORY_SEPARATOR.'#', $newfilename)) {
-			$newfilename = dirname(__FILE__).DIRECTORY_SEPARATOR.$newfilename;
+			$newfilename =  __DIR__ .DIRECTORY_SEPARATOR.$newfilename;
 		}
 		do {
 			$beforeloop = $newfilename;
@@ -1245,7 +1245,7 @@ class phpthumb {
 	}
 
 
-	function ResolveFilenameToAbsolute($filename) {
+	public function ResolveFilenameToAbsolute($filename) {
 		if (empty($filename)) {
 			return false;
 		}
@@ -1307,7 +1307,7 @@ class phpthumb {
 		} else {
 
 			// relative to current directory (any OS)
-			$AbsoluteFilename = dirname(__FILE__).DIRECTORY_SEPARATOR.preg_replace('#[/\\\\]#', DIRECTORY_SEPARATOR, $filename);
+			$AbsoluteFilename =  __DIR__ .DIRECTORY_SEPARATOR.preg_replace('#[/\\\\]#', DIRECTORY_SEPARATOR, $filename);
 
 			if (substr(dirname(@$_SERVER['PHP_SELF']), 0, 2) == '/~') {
 				if ($ApacheLookupURIarray = phpthumb_functions::ApacheLookupURIarray(dirname(@$_SERVER['PHP_SELF']))) {
@@ -1339,24 +1339,24 @@ class phpthumb {
 			$AbsoluteFilename = preg_replace('#^'.preg_quote($this->realPathSafe($this->config_document_root)).'#i', str_replace('\\', '\\\\', $this->realPathSafe($this->config_document_root)), $AbsoluteFilename);
 			$AbsoluteFilename = str_replace(DIRECTORY_SEPARATOR, '/', $AbsoluteFilename);
 		}
-		$AbsoluteFilename = $this->resolvePath($AbsoluteFilename, $this->config_additional_allowed_dirs);
-		if (!$this->config_allow_src_above_docroot && !preg_match('#^'.preg_quote(str_replace(DIRECTORY_SEPARATOR, '/', $this->realPathSafe($this->config_document_root))).'#', $AbsoluteFilename)) {
+		$resolvedAbsoluteFilename = $this->resolvePath($AbsoluteFilename, $this->config_additional_allowed_dirs);
+		if (!$this->config_allow_src_above_docroot && !preg_match('#^'.preg_quote(str_replace(DIRECTORY_SEPARATOR, '/', $this->realPathSafe($this->config_document_root))).'#', $resolvedAbsoluteFilename)) {
 			$this->DebugMessage('!$this->config_allow_src_above_docroot therefore setting "'.$AbsoluteFilename.'" (outside "'.$this->realPathSafe($this->config_document_root).'") to null', __FILE__, __LINE__);
 			return false;
 		}
-		if (!$this->config_allow_src_above_phpthumb && !preg_match('#^'.preg_quote(str_replace(DIRECTORY_SEPARATOR, '/', dirname(__FILE__))).'#', $AbsoluteFilename)) {
-			$this->DebugMessage('!$this->config_allow_src_above_phpthumb therefore setting "'.$AbsoluteFilename.'" (outside "'.dirname(__FILE__).'") to null', __FILE__, __LINE__);
+		if (!$this->config_allow_src_above_phpthumb && !preg_match('#^'.preg_quote(str_replace(DIRECTORY_SEPARATOR, '/',  __DIR__ )).'#', $resolvedAbsoluteFilename)) {
+			$this->DebugMessage('!$this->config_allow_src_above_phpthumb therefore setting "'.$AbsoluteFilename.'" (outside "'. __DIR__ .'") to null', __FILE__, __LINE__);
 			return false;
 		}
-		return $AbsoluteFilename;
+		return $resolvedAbsoluteFilename;
 	}
 
 
-	function file_exists_ignoreopenbasedir($filename, $cached=true) {
+	public function file_exists_ignoreopenbasedir($filename, $cached=true) {
 		static $open_basedirs = null;
 		static $file_exists_cache = array();
 		if (!$cached || !isset($file_exists_cache[$filename])) {
-			if (is_null($open_basedirs)) {
+			if (null === $open_basedirs) {
 				$open_basedirs = preg_split('#[;:]#', ini_get('open_basedir'));
 			}
 			if (empty($open_basedirs) || in_array(dirname($filename), $open_basedirs)) {
@@ -1373,9 +1373,9 @@ class phpthumb {
 	}
 
 
-	function ImageMagickWhichConvert() {
+	public function ImageMagickWhichConvert() {
 		static $WhichConvert = null;
-		if (is_null($WhichConvert)) {
+		if (null === $WhichConvert) {
 			if ($this->iswindows) {
 				$WhichConvert = false;
 			} else {
@@ -1393,9 +1393,9 @@ class phpthumb {
 	}
 
 
-	function ImageMagickCommandlineBase() {
+	public function ImageMagickCommandlineBase() {
 		static $commandline = null;
-		if (is_null($commandline)) {
+		if (null === $commandline) {
 			if ($this->issafemode) {
 				$commandline = '';
 				return $commandline;
@@ -1406,7 +1406,7 @@ class phpthumb {
 				return $commandline;
 			}
 
-			$commandline = (!is_null($this->config_imagemagick_path) ? $this->config_imagemagick_path : '');
+			$commandline = (null !== $this->config_imagemagick_path ? $this->config_imagemagick_path : '');
 
 			if ($this->config_imagemagick_path && ($this->config_imagemagick_path != $this->realPathSafe($this->config_imagemagick_path))) {
 				if (@is_executable($this->realPathSafe($this->config_imagemagick_path))) {
@@ -1416,10 +1416,10 @@ class phpthumb {
 					$this->DebugMessage('Leaving $this->config_imagemagick_path as ('.$this->config_imagemagick_path.') because !is_execuatable($this->realPathSafe($this->config_imagemagick_path)) ('.$this->realPathSafe($this->config_imagemagick_path).')', __FILE__, __LINE__);
 				}
 			}
-			$this->DebugMessage('                  file_exists('.$this->config_imagemagick_path.') = '.intval(                        @file_exists($this->config_imagemagick_path)), __FILE__, __LINE__);
-			$this->DebugMessage('file_exists_ignoreopenbasedir('.$this->config_imagemagick_path.') = '.intval($this->file_exists_ignoreopenbasedir($this->config_imagemagick_path)), __FILE__, __LINE__);
-			$this->DebugMessage('                      is_file('.$this->config_imagemagick_path.') = '.intval(                            @is_file($this->config_imagemagick_path)), __FILE__, __LINE__);
-			$this->DebugMessage('                is_executable('.$this->config_imagemagick_path.') = '.intval(                      @is_executable($this->config_imagemagick_path)), __FILE__, __LINE__);
+			$this->DebugMessage('                  file_exists('.$this->config_imagemagick_path.') = '. (int) (@file_exists($this->config_imagemagick_path)), __FILE__, __LINE__);
+			$this->DebugMessage('file_exists_ignoreopenbasedir('.$this->config_imagemagick_path.') = '. (int) $this->file_exists_ignoreopenbasedir($this->config_imagemagick_path), __FILE__, __LINE__);
+			$this->DebugMessage('                      is_file('.$this->config_imagemagick_path.') = '. (int) (@is_file($this->config_imagemagick_path)), __FILE__, __LINE__);
+			$this->DebugMessage('                is_executable('.$this->config_imagemagick_path.') = '. (int) (@is_executable($this->config_imagemagick_path)), __FILE__, __LINE__);
 
 			if ($this->file_exists_ignoreopenbasedir($this->config_imagemagick_path)) {
 
@@ -1464,9 +1464,9 @@ class phpthumb {
 	}
 
 
-	function ImageMagickVersion($returnRAW=false) {
+	public function ImageMagickVersion($returnRAW=false) {
 		static $versionstring = null;
-		if (is_null($versionstring)) {
+		if (null === $versionstring) {
 			$versionstring = array(0=>false, 1=>false);
 
 			$IMversionCacheFilename = $this->config_cache_directory.DIRECTORY_SEPARATOR.'phpThumbCacheIMversion.txt';
@@ -1479,7 +1479,7 @@ class phpthumb {
 			} else {
 
 				$commandline = $this->ImageMagickCommandlineBase();
-				$commandline = (!is_null($commandline) ? $commandline : '');
+				$commandline = (null !== $commandline ? $commandline : '');
 				if ($commandline) {
 					$commandline .= ' --version';
 					$this->DebugMessage('ImageMagick version checked with "'.$commandline.'"', __FILE__, __LINE__);
@@ -1498,16 +1498,16 @@ class phpthumb {
 
 			}
 		}
-		return $versionstring[intval($returnRAW)];
+		return $versionstring[ (int) $returnRAW ];
 	}
 
 
-	function ImageMagickSwitchAvailable($switchname) {
+	public function ImageMagickSwitchAvailable($switchname) {
 		static $IMoptions = null;
-		if (is_null($IMoptions)) {
+		if (null === $IMoptions) {
 			$IMoptions = array();
 			$commandline = $this->ImageMagickCommandlineBase();
-			if (!is_null($commandline)) {
+			if (null !== $commandline) {
 				$commandline .= ' -help';
 				$IMhelp_lines = explode("\n", phpthumb_functions::SafeExec($commandline));
 				foreach ($IMhelp_lines as $line) {
@@ -1525,21 +1525,21 @@ class phpthumb {
 					break;
 				}
 			}
-			$this->DebugMessage('ImageMagickSwitchAvailable('.implode(';', $switchname).') = '.intval($allOK).'', __FILE__, __LINE__);
+			$this->DebugMessage('ImageMagickSwitchAvailable('.implode(';', $switchname).') = '. (int) $allOK .'', __FILE__, __LINE__);
 		} else {
 			$allOK = isset($IMoptions[$switchname]);
-			$this->DebugMessage('ImageMagickSwitchAvailable('.$switchname.') = '.intval($allOK).'', __FILE__, __LINE__);
+			$this->DebugMessage('ImageMagickSwitchAvailable('.$switchname.') = '. (int) $allOK .'', __FILE__, __LINE__);
 		}
 		return $allOK;
 	}
 
 
-	function ImageMagickFormatsList() {
+	public function ImageMagickFormatsList() {
 		static $IMformatsList = null;
-		if (is_null($IMformatsList)) {
+		if (null === $IMformatsList) {
 			$IMformatsList = '';
 			$commandline = $this->ImageMagickCommandlineBase();
-			if (!is_null($commandline)) {
+			if (null !== $commandline) {
 				$commandline = dirname($commandline).DIRECTORY_SEPARATOR.str_replace('convert', 'identify', basename($commandline));
 				$commandline .= ' -list format';
 				$IMformatsList = phpthumb_functions::SafeExec($commandline);
@@ -1549,7 +1549,7 @@ class phpthumb {
 	}
 
 
-	function SourceDataToTempFile() {
+	public function SourceDataToTempFile() {
 		if ($IMtempSourceFilename = $this->phpThumb_tempnam()) {
 			$IMtempSourceFilename = $this->realPathSafe($IMtempSourceFilename);
 			ob_start();
@@ -1573,7 +1573,7 @@ class phpthumb {
 	}
 
 
-	function ImageMagickThumbnailToGD() {
+	public function ImageMagickThumbnailToGD() {
 		// http://www.imagemagick.org/script/command-line-options.php
 
 		$this->useRawIMoutput = true;
@@ -1655,6 +1655,7 @@ class phpthumb {
 
 		$commandline = $this->ImageMagickCommandlineBase();
 		if ($commandline) {
+			$commandline .= ' '.phpthumb_functions::escapeshellarg_replacement(preg_replace('#[/\\\\]#', DIRECTORY_SEPARATOR, $this->sourceFilename).(($outputFormat == 'gif') ? '' : '['. (int) $this->sfn .']')); // [0] means first frame of (GIF) animation, can be ignored
 			if ($IMtempfilename = $this->phpThumb_tempnam()) {
 				$IMtempfilename = $this->realPathSafe($IMtempfilename);
 
@@ -1668,7 +1669,7 @@ class phpthumb {
 					$commandline_test = $this->ImageMagickCommandlineBase().' logo: -resize 1x '.phpthumb_functions::escapeshellarg_replacement($IMtempfilename).' 2>&1';
 					$IMresult_test = phpthumb_functions::SafeExec($commandline_test);
 					$IMuseExplicitImageOutputDimensions = preg_match('#image dimensions are zero#i', $IMresult_test);
-					$this->DebugMessage('IMuseExplicitImageOutputDimensions = '.intval($IMuseExplicitImageOutputDimensions), __FILE__, __LINE__);
+					$this->DebugMessage('IMuseExplicitImageOutputDimensions = '. (int) $IMuseExplicitImageOutputDimensions, __FILE__, __LINE__);
 					if ($fp_im_temp = @fopen($IMtempfilename, 'wb')) {
 						// erase temp image so ImageMagick logo doesn't get output if other processing fails
 						fclose($fp_im_temp);
@@ -1677,11 +1678,6 @@ class phpthumb {
 				}
 
 
-				if (!is_null($this->dpi) && $this->ImageMagickSwitchAvailable('density')) {
-					// for vector source formats only (WMF, PDF, etc)
-					$commandline .= ' -flatten';
-					$commandline .= ' -density '.phpthumb_functions::escapeshellarg_replacement($this->dpi);
-				}
 				ob_start();
 				$getimagesize = getimagesize($this->sourceFilename);
 				$GetImageSizeError = ob_get_contents();
@@ -1690,6 +1686,16 @@ class phpthumb {
 					$this->DebugMessage('getimagesize('.$this->sourceFilename.') SUCCEEDED: '.print_r($getimagesize, true), __FILE__, __LINE__);
 				} else {
 					$this->DebugMessage('getimagesize('.$this->sourceFilename.') FAILED with error "'.$GetImageSizeError.'"', __FILE__, __LINE__);
+				}
+				if (null !== $this->dpi && $this->ImageMagickSwitchAvailable('density')) {
+					// for vector source formats only (WMF, PDF, etc)
+					if (is_array($getimagesize) && isset($getimagesize[2]) && ($getimagesize[2] == IMAGETYPE_PNG)) {
+						// explicitly exclude PNG from "-flatten" to make sure transparency is preserved
+						// https://github.com/JamesHeinrich/phpThumb/issues/65
+					} else {
+						$commandline .= ' -flatten';
+						$commandline .= ' -density '.phpthumb_functions::escapeshellarg_replacement($this->dpi);
+					}
 				}
 				if (is_array($getimagesize)) {
 					$this->DebugMessage('getimagesize('.$this->sourceFilename.') returned [w='.$getimagesize[0].';h='.$getimagesize[1].';f='.$getimagesize[2].']', __FILE__, __LINE__);
@@ -1703,6 +1709,10 @@ class phpthumb {
 						$commandline .= ' -background '.phpthumb_functions::escapeshellarg_replacement('#'.($this->bg ? $this->bg : 'FFFFFF'));
 						if ($getimagesize[2] == IMAGETYPE_GIF) {
 							$commandline .= ' -flatten';
+						}
+					} else {
+						if ($getimagesize[2] == IMAGETYPE_PNG && !$this->bg) {
+							$commandline .= ' -background none';
 						}
 					}
 					if ($getimagesize[2] == IMAGETYPE_GIF) {
@@ -1720,8 +1730,8 @@ class phpthumb {
 									}
 								}
 							}
-							$wAll = intval(max($this->w, $this->wp, $this->wl, $this->ws)) - (2 * $borderThickness);
-							$hAll = intval(max($this->h, $this->hp, $this->hl, $this->hs)) - (2 * $borderThickness);
+							$wAll = (int) max($this->w, $this->wp, $this->wl, $this->ws) - (2 * $borderThickness);
+							$hAll = (int) max($this->h, $this->hp, $this->hl, $this->hs) - (2 * $borderThickness);
 							$imAR = $this->source_width / $this->source_height;
 							$zcAR = (($wAll && $hAll) ? $wAll / $hAll : 1);
 							$side  = phpthumb_functions::nonempty_min($this->source_width, $this->source_height, max($wAll, $hAll));
@@ -1729,7 +1739,11 @@ class phpthumb {
 							$sideY = phpthumb_functions::nonempty_min(                     $this->source_height, $hAll, round($wAll / $zcAR));
 
 							$thumbnailH = round(max($sideY, ($sideY * $zcAR) / $imAR));
-							$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement(($IMuseExplicitImageOutputDimensions ? $thumbnailH : '').'x'.$thumbnailH);
+							if ($this->aoe == 1) {
+								$commandline .= ' -'.$IMresizeParameter.' "'.$wAll.'x'.$hAll.'^"';
+							} else {
+								$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement(($IMuseExplicitImageOutputDimensions ? $thumbnailH : '').'x'.$thumbnailH);
+							}
 
 							switch (strtoupper($this->zc)) {
 								case 'T':
@@ -1809,14 +1823,24 @@ if (false) {
 
 						} else {
 
-							if ($this->iar && (intval($this->w) > 0) && (intval($this->h) > 0)) {
+							if ($this->iar && ((int) $this->w > 0) && ((int) $this->h > 0)) {
+
 								list($nw, $nh) = phpthumb_functions::TranslateWHbyAngle($this->w, $this->h, $this->ra);
 								$nw = ((round($nw) != 0) ? round($nw) : '');
 								$nh = ((round($nh) != 0) ? round($nh) : '');
 								$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement($nw.'x'.$nh.'!');
+
+							} elseif ($this->far && ((int) $this->w > 0) && ((int) $this->h > 0)) {
+
+								$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement(phpthumb_functions::nonempty_min($this->w, $getimagesize[0]).'x'.phpthumb_functions::nonempty_min($this->h, $getimagesize[1]));
+								$commandline .= ' -gravity center';
+								$commandline .= ' -background '.phpthumb_functions::escapeshellarg_replacement('#'.$this->bg);
+								$commandline .= ' -extent '.phpthumb_functions::escapeshellarg_replacement($this->w.'x'.$this->h);
+
 							} else {
-								$this->w = ((($this->aoe || $this->far) && $this->w) ? $this->w : ($this->w ? phpthumb_functions::nonempty_min($this->w, $getimagesize[0]) : ''));
-								$this->h = ((($this->aoe || $this->far) && $this->h) ? $this->h : ($this->h ? phpthumb_functions::nonempty_min($this->h, $getimagesize[1]) : ''));
+
+								$this->w = (($this->aoe && $this->w) ? $this->w : ($this->w ? phpthumb_functions::nonempty_min($this->w, $getimagesize[0]) : ''));
+								$this->h = (($this->aoe && $this->h) ? $this->h : ($this->h ? phpthumb_functions::nonempty_min($this->h, $getimagesize[1]) : ''));
 								if ($this->w || $this->h) {
 									if ($IMuseExplicitImageOutputDimensions) {
 										if ($this->w && !$this->h) {
@@ -1830,6 +1854,7 @@ if (false) {
 									$nh = ((round($nh) != 0) ? round($nh) : '');
 									$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement($nw.'x'.$nh);
 								}
+
 							}
 						}
 					}
@@ -1838,7 +1863,7 @@ if (false) {
 
 					$this->DebugMessage('getimagesize('.$this->sourceFilename.') failed', __FILE__, __LINE__);
 					if ($this->w || $this->h) {
-						$exactDimensionsBang = (($this->iar && (intval($this->w) > 0) && (intval($this->h) > 0)) ? '!' : '');
+						$exactDimensionsBang = (($this->iar && ((int) $this->w > 0) && ((int) $this->h > 0)) ? '!' : '');
 						if ($IMuseExplicitImageOutputDimensions) {
 							// unknown source aspect ratio, just put large number and hope IM figures it out
 							$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement(($this->w ? $this->w : '9999').'x'.($this->h ? $this->h : '9999').$exactDimensionsBang);
@@ -1850,7 +1875,7 @@ if (false) {
 				}
 
 				if ($this->ra) {
-					$this->ra = intval($this->ra);
+					$this->ra = (int) $this->ra;
 					if ($this->ImageMagickSwitchAvailable('rotate')) {
 						if (!preg_match('#('.implode('|', $this->AlphaCapableFormats).')#i', $outputFormat) || phpthumb_functions::version_compare_replacement($this->ImageMagickVersion(), '6.3.7', '>=')) {
 							$this->DebugMessage('Using ImageMagick rotate', __FILE__, __LINE__);
@@ -1878,14 +1903,14 @@ if (false) {
 					switch ($command) {
 						case 'brit':
 							if ($this->ImageMagickSwitchAvailable('modulate')) {
-								$commandline .= ' -modulate '.phpthumb_functions::escapeshellarg_replacement((100 + intval($parameter)).',100,100');
+								$commandline .= ' -modulate '.phpthumb_functions::escapeshellarg_replacement((100 + (int) $parameter).',100,100');
 								$successfullyProcessedFilters[] = $filterkey;
 							}
 							break;
 
 						case 'cont':
 							if ($this->ImageMagickSwitchAvailable('contrast')) {
-								$contDiv10 = round(intval($parameter) / 10);
+								$contDiv10 = round((int) $parameter / 10);
 								if ($contDiv10 > 0) {
 									$contDiv10 = min($contDiv10, 100);
 									for ($i = 0; $i < $contDiv10; $i++) {
@@ -1909,7 +1934,7 @@ if (false) {
 									$commandline .= ' -colorspace GRAY';
 									$commandline .= ' -modulate 100,0,100';
 								} else {
-									$commandline .= ' -modulate '.phpthumb_functions::escapeshellarg_replacement('100,'.(100 - intval($parameter)).',100');
+									$commandline .= ' -modulate '.phpthumb_functions::escapeshellarg_replacement('100,'.(100 - (int) $parameter).',100');
 								}
 								$successfullyProcessedFilters[] = $filterkey;
 							}
@@ -1921,7 +1946,7 @@ if (false) {
 									$commandline .= ' -colorspace GRAY';
 									$commandline .= ' -modulate 100,0,100';
 								} else {
-									$commandline .= ' -modulate '.phpthumb_functions::escapeshellarg_replacement('100,'.(100 + intval($parameter)).',100');
+									$commandline .= ' -modulate '.phpthumb_functions::escapeshellarg_replacement('100,'.(100 + (int) $parameter).',100');
 								}
 								$successfullyProcessedFilters[] = $filterkey;
 							}
@@ -1939,7 +1964,7 @@ if (false) {
 							if ($this->ImageMagickSwitchAvailable(array('fill', 'colorize'))) {
 								@list($amount, $color) = explode('|', $parameter);
 								$commandline .= ' -fill '.phpthumb_functions::escapeshellarg_replacement('#'.preg_replace('#[^0-9A-F]#i', '', $color));
-								$commandline .= ' -colorize '.phpthumb_functions::escapeshellarg_replacement(min(max(intval($amount), 0), 100));
+								$commandline .= ' -colorize '.phpthumb_functions::escapeshellarg_replacement(min(max((int) $amount, 0), 100));
 							}
 							break;
 
@@ -1948,7 +1973,7 @@ if (false) {
 								@list($amount, $color) = explode('|', $parameter);
 								$amount = ($amount ? $amount : 80);
 								if (!$color) {
-									$commandline .= ' -sepia-tone '.phpthumb_functions::escapeshellarg_replacement(min(max(intval($amount), 0), 100).'%');
+									$commandline .= ' -sepia-tone '.phpthumb_functions::escapeshellarg_replacement(min(max((int) $amount, 0), 100).'%');
 									$successfullyProcessedFilters[] = $filterkey;
 								}
 							}
@@ -1956,7 +1981,7 @@ if (false) {
 
 						case 'gam':
 							@list($amount) = explode('|', $parameter);
-							$amount = min(max(floatval($amount), 0.001), 10);
+							$amount = min(max((float) $amount, 0.001), 10);
 							if (number_format($amount, 3) != '1.000') {
 								if ($this->ImageMagickSwitchAvailable('gamma')) {
 									$commandline .= ' -gamma '.phpthumb_functions::escapeshellarg_replacement($amount);
@@ -1975,7 +2000,7 @@ if (false) {
 						case 'th':
 							@list($amount) = explode('|', $parameter);
 							if ($this->ImageMagickSwitchAvailable(array('threshold', 'dither', 'monochrome'))) {
-								$commandline .= ' -threshold '.phpthumb_functions::escapeshellarg_replacement(round(min(max(intval($amount), 0), 255) / 2.55).'%');
+								$commandline .= ' -threshold '.phpthumb_functions::escapeshellarg_replacement(round(min(max((int) $amount, 0), 255) / 2.55).'%');
 								$commandline .= ' -dither';
 								$commandline .= ' -monochrome';
 								$successfullyProcessedFilters[] = $filterkey;
@@ -2008,7 +2033,7 @@ if (false) {
 						case 'edge':
 							if ($this->ImageMagickSwitchAvailable('edge')) {
 								$parameter = (!empty($parameter) ? $parameter : 2);
-								$commandline .= ' -edge '.phpthumb_functions::escapeshellarg_replacement(!empty($parameter) ? intval($parameter) : 1);
+								$commandline .= ' -edge '.phpthumb_functions::escapeshellarg_replacement(!empty($parameter) ? (int) $parameter : 1);
 								$successfullyProcessedFilters[] = $filterkey;
 							}
 							break;
@@ -2016,7 +2041,7 @@ if (false) {
 						case 'emb':
 							if ($this->ImageMagickSwitchAvailable(array('emboss', 'negate'))) {
 								$parameter = (!empty($parameter) ? $parameter : 2);
-								$commandline .= ' -emboss '.phpthumb_functions::escapeshellarg_replacement(intval($parameter));
+								$commandline .= ' -emboss '.phpthumb_functions::escapeshellarg_replacement((int) $parameter);
 								if ($parameter < 2) {
 									$commandline .= ' -negate'; // ImageMagick negates the image for some reason with '-emboss 1';
 								}
@@ -2027,8 +2052,8 @@ if (false) {
 						case 'lvl':
 							@list($band, $method, $threshold) = explode('|', $parameter);
 							$band      = ($band ? preg_replace('#[^RGBA\\*]#', '', strtoupper($band))       : '*');
-							$method    = ((strlen($method) > 0)    ? intval($method)                        :   2);
-							$threshold = ((strlen($threshold) > 0) ? min(max(floatval($threshold), 0), 100) : 0.1);
+							$method    = ((strlen($method) > 0)    ? (int) $method :   2);
+							$threshold = ((strlen($threshold) > 0) ? min(max((float) $threshold, 0), 100) : 0.1);
 
 							$band = preg_replace('#[^RGBA\\*]#', '', strtoupper($band));
 
@@ -2089,7 +2114,7 @@ if (false) {
 						case 'wb':
 							if ($this->ImageMagickSwitchAvailable(array('channel', 'contrast-stretch'))) {
 								@list($threshold) = explode('|', $parameter);
-								$threshold = (!empty($threshold) ? min(max(floatval($threshold), 0), 100) : 0.1);
+								$threshold = (!empty($threshold) ? min(max((float) $threshold, 0), 100) : 0.1);
 								$threshold = preg_replace('#[^0-9\\.]#', '', $threshold); // should be unneccesary, but just to be double-sure
 								//$commandline .= ' -channel R -contrast-stretch '.phpthumb_functions::escapeshellarg_replacement($threshold.'%'); // doesn't work on Windows because most versions of PHP do not properly
 								//$commandline .= ' -channel G -contrast-stretch '.phpthumb_functions::escapeshellarg_replacement($threshold.'%'); // escape special characters (such as %) and just replace them with spaces
@@ -2105,7 +2130,7 @@ if (false) {
 						case 'blur':
 							if ($this->ImageMagickSwitchAvailable('blur')) {
 								@list($radius) = explode('|', $parameter);
-								$radius = (!empty($radius) ? min(max(intval($radius), 0), 25) : 1);
+								$radius = (!empty($radius) ? min(max((int) $radius, 0), 25) : 1);
 								$commandline .= ' -blur '.phpthumb_functions::escapeshellarg_replacement($radius);
 								$successfullyProcessedFilters[] = $filterkey;
 							}
@@ -2113,7 +2138,7 @@ if (false) {
 
 						case 'gblr':
 							@list($radius) = explode('|', $parameter);
-							$radius = (!empty($radius) ? min(max(intval($radius), 0), 25) : 1);
+							$radius = (!empty($radius) ? min(max((int) $radius, 0), 25) : 1);
 							// "-gaussian" changed to "-gaussian-blur" sometime around 2009
 							if ($this->ImageMagickSwitchAvailable('gaussian-blur')) {
 								$commandline .= ' -gaussian-blur '.phpthumb_functions::escapeshellarg_replacement($radius);
@@ -2127,9 +2152,9 @@ if (false) {
 						case 'usm':
 							if ($this->ImageMagickSwitchAvailable('unsharp')) {
 								@list($amount, $radius, $threshold) = explode('|', $parameter);
-								$amount    = ($amount            ? min(max(intval($radius), 0), 255) : 80);
-								$radius    = ($radius            ? min(max(intval($radius), 0), 10)  : 0.5);
-								$threshold = (strlen($threshold) ? min(max(intval($radius), 0), 50)  : 3);
+								$amount    = ($amount            ? min(max((int) $amount,    0), 255) : 80);
+								$radius    = ($radius            ? min(max((int) $radius,    0),  10) : 0.5);
+								$threshold = (strlen($threshold) ? min(max((int) $threshold, 0),  50) : 3);
 								$commandline .= ' -unsharp '.phpthumb_functions::escapeshellarg_replacement(number_format(($radius * 2) - 1, 2, '.', '').'x1+'.number_format($amount / 100, 2, '.', '').'+'.number_format($threshold / 100, 2, '.', ''));
 								$successfullyProcessedFilters[] = $filterkey;
 							}
@@ -2139,14 +2164,14 @@ if (false) {
 							if ($this->ImageMagickSwitchAvailable(array('border', 'bordercolor', 'thumbnail', 'crop'))) {
 								if (!$this->zc) {
 									@list($width, $rX, $rY, $color) = explode('|', $parameter);
-									$width = intval($width);
-									$rX    = intval($rX);
-									$rY    = intval($rY);
+									$width = (int) $width;
+									$rX    = (int) $rX;
+									$rY    = (int) $rY;
 									if ($width && !$rX && !$rY) {
 										if (!phpthumb_functions::IsHexColor($color)) {
 											$color = ((!empty($this->bc) && phpthumb_functions::IsHexColor($this->bc)) ? $this->bc : '000000');
 										}
-										$commandline .= ' -border '.phpthumb_functions::escapeshellarg_replacement(intval($width));
+										$commandline .= ' -border '.phpthumb_functions::escapeshellarg_replacement((int) $width);
 										$commandline .= ' -bordercolor '.phpthumb_functions::escapeshellarg_replacement('#'.$color);
 
 										if (preg_match('# \\-crop "([0-9]+)x([0-9]+)\\+0\\+0" #', $commandline, $matches)) {
@@ -2233,7 +2258,6 @@ if (false) {
 						}
 					}
 				}
-				$commandline .= ' '.phpthumb_functions::escapeshellarg_replacement(preg_replace('#[/\\\\]#', DIRECTORY_SEPARATOR, $this->sourceFilename).(($outputFormat == 'gif') ? '' : '['.intval($this->sfn).']')); // [0] means first frame of (GIF) animation, can be ignored
 				$commandline .= ' '.$outputFormat.':'.phpthumb_functions::escapeshellarg_replacement($IMtempfilename);
 				if (!$this->iswindows) {
 					$commandline .= ' 2>&1';
@@ -2297,14 +2321,14 @@ if (false) {
 	}
 
 
-	function Rotate() {
+	public function Rotate() {
 		if ($this->ra || $this->ar) {
 			if (!function_exists('imagerotate')) {
 				$this->DebugMessage('!function_exists(imagerotate)', __FILE__, __LINE__);
 				return false;
 			}
-			if (!include_once(dirname(__FILE__).'/phpthumb.filters.php')) {
-				$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.filters.php" which is required for applying filters ('.implode(';', $this->fltr).')', __FILE__, __LINE__);
+			if (!include_once( __DIR__ .'/phpthumb.filters.php')) {
+				$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.filters.php" which is required for applying filters ('.implode(';', $this->fltr).')', __FILE__, __LINE__);
 				return false;
 			}
 
@@ -2316,12 +2340,12 @@ if (false) {
 			$rotate_angle = 0;
 			if ($this->ra) {
 
-				$rotate_angle = floatval($this->ra);
+				$rotate_angle = (float) $this->ra;
 
 			} else {
 
 				if ($this->ar == 'x') {
-					if (phpthumb_functions::version_compare_replacement(phpversion(), '4.2.0', '>=')) {
+					if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '4.2.0', '>=')) {
 						if ($this->sourceFilename) {
 							if (function_exists('exif_read_data')) {
 								if ($exif_data = @exif_read_data($this->sourceFilename, 'IFD0')) {
@@ -2359,7 +2383,7 @@ if (false) {
 							return false;
 						}
 					} else {
-						$this->DebugMessage('Cannot auto-rotate from EXIF data because PHP is less than v4.2.0 ('.phpversion().')', __FILE__, __LINE__);
+						$this->DebugMessage('Cannot auto-rotate from EXIF data because PHP is less than v4.2.0 ('. PHP_VERSION .')', __FILE__, __LINE__);
 						return false;
 					}
 				} elseif (($this->ar == 'l') && ($this->source_height > $this->source_width)) {
@@ -2384,7 +2408,7 @@ if (false) {
 	}
 
 
-	function FixedAspectRatio() {
+	public function FixedAspectRatio() {
 		// optional fixed-dimension images (regardless of aspect ratio)
 
 		if (!$this->far) {
@@ -2424,7 +2448,7 @@ if (false) {
 	}
 
 
-	function OffsiteDomainIsAllowed($hostname, $allowed_domains) {
+	public function OffsiteDomainIsAllowed($hostname, $allowed_domains) {
 		static $domain_is_allowed = array();
 		$hostname = strtolower($hostname);
 		if (!isset($domain_is_allowed[$hostname])) {
@@ -2449,7 +2473,7 @@ if (false) {
 	}
 
 
-	function AntiOffsiteLinking() {
+	public function AntiOffsiteLinking() {
 		// Optional anti-offsite hijacking of the thumbnail script
 		$allow   = true;
 		if ($allow && $this->config_nooffsitelink_enabled && (@$_SERVER['HTTP_REFERER'] || $this->config_nooffsitelink_require_refer)) {
@@ -2501,8 +2525,8 @@ if (false) {
 			$this->config_nooffsitelink_watermark_src = $this->ResolveFilenameToAbsolute($this->config_nooffsitelink_watermark_src);
 			if (is_file($this->config_nooffsitelink_watermark_src)) {
 
-				if (!include_once(dirname(__FILE__).'/phpthumb.filters.php')) {
-					$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.filters.php" which is required for applying watermark', __FILE__, __LINE__);
+				if (!include_once( __DIR__ .'/phpthumb.filters.php')) {
+					$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.filters.php" which is required for applying watermark', __FILE__, __LINE__);
 					return false;
 				}
 				$watermark_img = $this->ImageCreateFromStringReplacement(file_get_contents($this->config_nooffsitelink_watermark_src));
@@ -2535,7 +2559,7 @@ if (false) {
 	}
 
 
-	function AlphaChannelFlatten() {
+	public function AlphaChannelFlatten() {
 		if (!$this->is_alpha) {
 			// image doesn't have alpha transparency, no need to flatten
 			$this->DebugMessage('skipping AlphaChannelFlatten() because !$this->is_alpha', __FILE__, __LINE__);
@@ -2638,10 +2662,10 @@ if (false) {
 	}
 
 
-	function ApplyFilters() {
+	public function ApplyFilters() {
 		if ($this->fltr && is_array($this->fltr)) {
-			if (!include_once(dirname(__FILE__).'/phpthumb.filters.php')) {
-				$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.filters.php" which is required for applying filters ('.implode(';', $this->fltr).')', __FILE__, __LINE__);
+			if (!include_once( __DIR__ .'/phpthumb.filters.php')) {
+				$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.filters.php" which is required for applying filters ('.implode(';', $this->fltr).')', __FILE__, __LINE__);
 				return false;
 			}
 			$phpthumbFilters = new phpthumb_filters();
@@ -2731,8 +2755,8 @@ if (false) {
 					case 'lvl': // autoLevels
 						@list($band, $method, $threshold) = explode('|', $parameter, 3);
 						$band      = ($band ? preg_replace('#[^RGBA\\*]#', '', strtoupper($band)) : '*');
-						$method    = ((strlen($method) > 0)    ? intval($method)                  :   2);
-						$threshold = ((strlen($threshold) > 0) ? floatval($threshold)             : 0.1);
+						$method    = ((strlen($method) > 0)    ? (int) $method :   2);
+						$threshold = ((strlen($threshold) > 0) ? (float) $threshold : 0.1);
 
 						$phpthumbFilters->HistogramStretch($this->gdimg_output, $band, $method, $threshold);
 						break;
@@ -2788,7 +2812,7 @@ if (false) {
 							} while (strlen($buffer) > 0);
 							fclose($fp_mask);
 							if ($gdimg_mask = $this->ImageCreateFromStringReplacement($MaskImageData)) {
-								if ($invert && phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+								if ($invert && phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 									imagefilter($gdimg_mask, IMG_FILTER_NEGATE);
 								}
 								$this->is_alpha = true;
@@ -2911,8 +2935,8 @@ if (false) {
 						@list($filename, $alignment, $opacity, $margin['x'], $margin['y'], $rotate_angle) = explode('|', $parameter, 6);
 						// $margin can be pixel margin or percent margin if $alignment is text, or max width/height if $alignment is position like "50x75"
 						$alignment    = ($alignment            ? $alignment            : 'BR');
-						$opacity      = (strlen($opacity)      ? intval($opacity)      : 50);
-						$rotate_angle = (strlen($rotate_angle) ? intval($rotate_angle) : 0);
+						$opacity      = (strlen($opacity)      ? (int) $opacity : 50);
+						$rotate_angle = (strlen($rotate_angle) ? (int) $rotate_angle : 0);
 						if (!preg_match('#^([0-9\\.\\-]*)x([0-9\\.\\-]*)$#i', $alignment, $matches)) {
 							$margins = array('x', 'y');
 							foreach ($margins as $xy) {
@@ -2932,8 +2956,8 @@ if (false) {
 									$phpthumbFilters->ImprovedImageRotate($img_watermark, $rotate_angle, 'FFFFFF', null, $this);
 								}
 								if (preg_match('#^([0-9\\.\\-]*)x([0-9\\.\\-]*)$#i', $alignment, $matches)) {
-									$watermark_max_width  = intval($margin['x'] ? $margin['x'] : imagesx($img_watermark));
-									$watermark_max_height = intval($margin['y'] ? $margin['y'] : imagesy($img_watermark));
+									$watermark_max_width  = (int) ($margin[ 'x'] ? $margin[ 'x'] : imagesx($img_watermark));
+									$watermark_max_height = (int) ($margin[ 'y'] ? $margin[ 'y'] : imagesy($img_watermark));
 									$scale = phpthumb_functions::ScaleToFitInBox(imagesx($img_watermark), imagesy($img_watermark), $watermark_max_width, $watermark_max_height, true, true);
 									$this->DebugMessage('Scaling watermark by a factor of '.number_format($scale, 4), __FILE__, __LINE__);
 									if (($scale > 1) || ($scale < 1)) {
@@ -2964,7 +2988,7 @@ if (false) {
 						break;
 
 					case 'wmt': // WaterMarkText
-						@list($text, $size, $alignment, $hex_color, $ttffont, $opacity, $margin, $angle, $bg_color, $bg_opacity, $fillextend) = explode('|', $parameter, 11);
+						@list($text, $size, $alignment, $hex_color, $ttffont, $opacity, $margin, $angle, $bg_color, $bg_opacity, $fillextend, $lineheight) = explode('|', $parameter, 12);
 						$text       = ($text            ? $text       : '');
 						$size       = ($size            ? $size       : 3);
 						$alignment  = ($alignment       ? $alignment  : 'BR');
@@ -2976,13 +3000,14 @@ if (false) {
 						$bg_color   = ($bg_color        ? $bg_color   : false);
 						$bg_opacity = ($bg_opacity      ? $bg_opacity : 0);
 						$fillextend = ($fillextend      ? $fillextend : '');
+						$lineheight = ($lineheight      ? $lineheight : 1.0);
 
 						if (basename($ttffont) == $ttffont) {
 							$ttffont = $this->realPathSafe($this->config_ttf_directory.DIRECTORY_SEPARATOR.$ttffont);
 						} else {
 							$ttffont = $this->ResolveFilenameToAbsolute($ttffont);
 						}
-						$phpthumbFilters->WatermarkText($this->gdimg_output, $text, $size, $alignment, $hex_color, $ttffont, $opacity, $margin, $angle, $bg_color, $bg_opacity, $fillextend);
+						$phpthumbFilters->WatermarkText($this->gdimg_output, $text, $size, $alignment, $hex_color, $ttffont, $opacity, $margin, $angle, $bg_color, $bg_opacity, $fillextend, $lineheight);
 						break;
 
 					case 'blur': // Blur
@@ -3018,12 +3043,12 @@ if (false) {
 						$threshold = (strlen($threshold) ? $threshold : 3);
 						if (phpthumb_functions::gd_version() >= 2.0) {
 							ob_start();
-							if (!@include_once(dirname(__FILE__).'/phpthumb.unsharp.php')) {
+							if (!@include_once( __DIR__ .'/phpthumb.unsharp.php')) {
 								$include_error = ob_get_contents();
 								if ($include_error) {
-									$this->DebugMessage('include_once("'.dirname(__FILE__).'/phpthumb.unsharp.php") generated message: "'.$include_error.'"', __FILE__, __LINE__);
+									$this->DebugMessage('include_once("'. __DIR__ .'/phpthumb.unsharp.php") generated message: "'.$include_error.'"', __FILE__, __LINE__);
 								}
-								$this->DebugMessage('Error including "'.dirname(__FILE__).'/phpthumb.unsharp.php" which is required for unsharp masking', __FILE__, __LINE__);
+								$this->DebugMessage('Error including "'. __DIR__ .'/phpthumb.unsharp.php" which is required for unsharp masking', __FILE__, __LINE__);
 								ob_end_clean();
 								return false;
 							}
@@ -3094,7 +3119,7 @@ if (false) {
 	}
 
 
-	function MaxFileSize() {
+	public function MaxFileSize() {
 		if (phpthumb_functions::gd_version() < 2) {
 			$this->DebugMessage('Skipping MaxFileSize() because gd_version is "'.phpthumb_functions::gd_version().'"', __FILE__, __LINE__);
 			return false;
@@ -3161,7 +3186,7 @@ if (false) {
 	}
 
 
-	function CalculateThumbnailDimensions() {
+	public function CalculateThumbnailDimensions() {
 		$this->DebugMessage('CalculateThumbnailDimensions() starting with [W,H,sx,sy,sw,sh] initially set to ['.$this->source_width.','.$this->source_height.','.$this->sx.','.$this->sy.','.$this->sw.','.$this->sh.']', __FILE__, __LINE__);
 //echo $this->source_width.'x'.$this->source_height.'<hr>';
 		$this->thumbnailCropX = ($this->sx ? (($this->sx >= 2) ? $this->sx : round($this->sx * $this->source_width))  : 0);
@@ -3256,7 +3281,7 @@ if (false) {
 	}
 
 
-	function CreateGDoutput() {
+	public function CreateGDoutput() {
 		$this->CalculateThumbnailDimensions();
 
 		// create the GD image (either true-color or 256-color, depending on GD version)
@@ -3289,7 +3314,7 @@ if (false) {
 		return true;
 	}
 
-	function SetOrientationDependantWidthHeight() {
+	public function SetOrientationDependantWidthHeight() {
 		$this->DebugMessage('SetOrientationDependantWidthHeight() starting with "'.$this->source_width.'"x"'.$this->source_height.'"', __FILE__, __LINE__);
 		if ($this->source_height > $this->source_width) {
 			// portrait
@@ -3306,17 +3331,17 @@ if (false) {
 		}
 		//$this->w = round($this->w ? $this->w : (($this->h && $this->source_height) ? $this->h * $this->source_width  / $this->source_height : $this->w));
 		//$this->h = round($this->h ? $this->h : (($this->w && $this->source_width)  ? $this->w * $this->source_height / $this->source_width  : $this->h));
-		$this->DebugMessage('SetOrientationDependantWidthHeight() setting w="'.intval($this->w).'", h="'.intval($this->h).'"', __FILE__, __LINE__);
+		$this->DebugMessage('SetOrientationDependantWidthHeight() setting w="'. (int) $this->w .'", h="'. (int) $this->h .'"', __FILE__, __LINE__);
 		return true;
 	}
 
-	function ExtractEXIFgetImageSize() {
+	public function ExtractEXIFgetImageSize() {
 		$this->DebugMessage('starting ExtractEXIFgetImageSize()', __FILE__, __LINE__);
 
 		if (preg_match('#^http:#i', $this->src) && !$this->sourceFilename && $this->rawImageData) {
 			$this->SourceDataToTempFile();
 		}
-		if (is_null($this->getimagesizeinfo)) {
+		if (null === $this->getimagesizeinfo) {
 			if ($this->sourceFilename) {
 				$this->getimagesizeinfo = @getimagesize($this->sourceFilename);
 				$this->source_width  = $this->getimagesizeinfo[0];
@@ -3346,10 +3371,6 @@ if (false) {
 
 		}
 
-		if (is_null($this->getimagesizeinfo)) {
-			$this->getimagesizeinfo = @getimagesize($this->sourceFilename);
-		}
-
 		if (!empty($this->getimagesizeinfo)) {
 			// great
 			$this->getimagesizeinfo['filesize'] = @filesize($this->sourceFilename);
@@ -3369,7 +3390,7 @@ if (false) {
 
 		$this->SetOrientationDependantWidthHeight();
 
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '4.2.0', '>=') && function_exists('exif_read_data')) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '4.2.0', '>=') && function_exists('exif_read_data')) {
 			switch ($this->getimagesizeinfo[2]) {
 				case IMAGETYPE_JPEG:
 				case IMAGETYPE_TIFF_II:
@@ -3386,7 +3407,7 @@ if (false) {
 			$this->exif_thumbnail_type   = '';
 
 			// The parameters width, height and imagetype are available since PHP v4.3.0
-			if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.0', '>=')) {
+			if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '4.3.0', '>=')) {
 
 				$this->exif_thumbnail_data = @exif_thumbnail($this->sourceFilename, $this->exif_thumbnail_width, $this->exif_thumbnail_height, $this->exif_thumbnail_type);
 
@@ -3418,7 +3439,7 @@ if (false) {
 
 		}
 
-		$this->DebugMessage('EXIF thumbnail extraction: (size='.strlen($this->exif_thumbnail_data).'; type="'.$this->exif_thumbnail_type.'"; '.intval($this->exif_thumbnail_width).'x'.intval($this->exif_thumbnail_height).')', __FILE__, __LINE__);
+		$this->DebugMessage('EXIF thumbnail extraction: (size='.strlen($this->exif_thumbnail_data).'; type="'.$this->exif_thumbnail_type.'"; '. (int) $this->exif_thumbnail_width .'x'. (int) $this->exif_thumbnail_height .')', __FILE__, __LINE__);
 
 		// see if EXIF thumbnail can be used directly with no processing
 		if ($this->config_use_exif_thumbnail_for_speed && $this->exif_thumbnail_data) {
@@ -3471,12 +3492,12 @@ if (false) {
 	}
 
 
-	function SetCacheFilename() {
-		if (!is_null($this->cache_filename)) {
+	public function SetCacheFilename() {
+		if (null !== $this->cache_filename) {
 			$this->DebugMessage('$this->cache_filename already set, skipping SetCacheFilename()', __FILE__, __LINE__);
 			return true;
 		}
-		if (is_null($this->config_cache_directory)) {
+		if (null === $this->config_cache_directory) {
 			$this->setCacheDirectory();
 			if (!$this->config_cache_directory) {
 				$this->DebugMessage('SetCacheFilename() failed because $this->config_cache_directory is empty', __FILE__, __LINE__);
@@ -3543,12 +3564,12 @@ if (false) {
 		$FilenameParameters2 = array('h', 'w', 'wl', 'wp', 'ws', 'hp', 'hs', 'xto', 'ra', 'iar', 'aoe', 'maxb', 'sfn', 'dpi');
 		foreach ($FilenameParameters2 as $key) {
 			if ($this->$key) {
-				$ParametersString .= '_'.$key.intval($this->$key);
+				$ParametersString .= '_'.$key. (int) $this->$key;
 			}
 		}
 		if ($this->thumbnailFormat == 'jpeg') {
 			// only JPEG output has variable quality option
-			$ParametersString .= '_q'.intval($this->thumbnailQuality);
+			$ParametersString .= '_q'. (int) $this->thumbnailQuality;
 		}
 		$this->DebugMessage('SetCacheFilename() _par set from md5('.$ParametersString.')', __FILE__, __LINE__);
 		$this->cache_filename .= '_par'.strtolower(md5($ParametersString));
@@ -3558,9 +3579,9 @@ if (false) {
 			// do not source image modification date --
 			// cached image will be used even if file was modified or removed
 		} elseif (!$this->config_cache_source_filemtime_ignore_remote && preg_match('#^(f|ht)tps?\://#i', $this->src)) {
-			$this->cache_filename .= '_dat'.intval(phpthumb_functions::filedate_remote($this->src));
+			$this->cache_filename .= '_dat'. (int) phpthumb_functions::filedate_remote($this->src);
 		} elseif (!$this->config_cache_source_filemtime_ignore_local && $this->src && !$this->rawImageData) {
-			$this->cache_filename .= '_dat'.intval(@filemtime($this->sourceFilename));
+			$this->cache_filename .= '_dat'. (int) (@filemtime($this->sourceFilename));
 		}
 
 		$this->cache_filename .= '.'.strtolower($this->thumbnailFormat);
@@ -3574,7 +3595,7 @@ if (false) {
 	}
 
 
-	function SourceImageIsTooLarge($width, $height) {
+	public function SourceImageIsTooLarge($width, $height) {
 		if (!$this->config_max_source_pixels) {
 			return false;
 		}
@@ -3585,7 +3606,7 @@ if (false) {
 		return (bool) (($width * $height) > $this->config_max_source_pixels);
 	}
 
-	function ImageCreateFromFilename($filename) {
+	public function ImageCreateFromFilename($filename) {
 		// try to create GD image source directly via GD, if possible,
 		// rather than buffering to memory and creating with imagecreatefromstring
 		$ImageCreateWasAttempted = false;
@@ -3669,7 +3690,7 @@ if (false) {
 		return $gd_image;
 	}
 
-	function SourceImageToGD() {
+	public function SourceImageToGD() {
 		if (is_resource($this->gdimg_source)) {
 			$this->source_width  = imagesx($this->gdimg_source);
 			$this->source_height = imagesy($this->gdimg_source);
@@ -3862,9 +3883,9 @@ if (false) {
 			switch (@$this->getimagesizeinfo[2]) {
 				case 6:
 					ob_start();
-					if (!@include_once(dirname(__FILE__).'/phpthumb.bmp.php')) {
+					if (!@include_once( __DIR__ .'/phpthumb.bmp.php')) {
 						ob_end_clean();
-						return $this->ErrorImage('include_once('.dirname(__FILE__).'/phpthumb.bmp.php) failed');
+						return $this->ErrorImage('include_once('. __DIR__ .'/phpthumb.bmp.php) failed');
 					}
 					ob_end_clean();
 					if ($fp = @fopen($this->sourceFilename, 'rb')) {
@@ -3945,8 +3966,8 @@ if (false) {
 	}
 
 
-	function phpThumbDebugVarDump($var) {
-		if (is_null($var)) {
+	public function phpThumbDebugVarDump($var) {
+		if (null === $var) {
 			return 'NULL';
 		} elseif (is_bool($var)) {
 			return ($var ? 'TRUE' : 'FALSE');
@@ -3966,7 +3987,7 @@ if (false) {
 		return gettype($var);
 	}
 
-	function phpThumbDebug($level='') {
+	public function phpThumbDebug($level='') {
 		if ($level && ($this->phpThumbDebug !== $level)) {
 			return true;
 		}
@@ -3981,7 +4002,7 @@ if (false) {
 
 		$DebugOutput = array();
 		$DebugOutput[] = 'phpThumb() version          = '.$this->phpthumb_version;
-		$DebugOutput[] = 'phpversion()                = '.@phpversion();
+		$DebugOutput[] = 'phpversion()                = '.@PHP_VERSION;
 		$DebugOutput[] = 'PHP_OS                      = '.PHP_OS;
 		$DebugOutput[] = '$_SERVER[SERVER_SOFTWARE]   = '.@$_SERVER['SERVER_SOFTWARE'];
 		$DebugOutput[] = '__FILE__                    = '.__FILE__;
@@ -4109,14 +4130,14 @@ if (false) {
 		return $this->ErrorImage(implode("\n", $DebugOutput), 700, 500, true);
 	}
 
-	function FatalError($text) {
-		if (is_null($this->fatalerror)) {
+	public function FatalError($text) {
+		if (null === $this->fatalerror) {
 			$this->fatalerror = $text;
 		}
 		return true;
 	}
 
-	function ErrorImage($text, $width=0, $height=0, $forcedisplay=false) {
+	public function ErrorImage($text, $width=0, $height=0, $forcedisplay=false) {
 		$width  = ($width  ? $width  : $this->config_error_image_width);
 		$height = ($height ? $height : $this->config_error_image_height);
 
@@ -4167,7 +4188,7 @@ if (false) {
 
 		$headers_file = '';
 		$headers_line = '';
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.0', '>=') && headers_sent($headers_file, $headers_line)) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '4.3.0', '>=') && headers_sent($headers_file, $headers_line)) {
 
 			echo "\n".'**Headers already sent in file "'.$headers_file.'" on line "'.$headers_line.'", dumping error message as text:**<br><pre>'."\n\n".$text."\n".'</pre>';
 
@@ -4210,7 +4231,7 @@ if (false) {
 		exit;
 	}
 
-	function ImageCreateFromStringReplacement(&$RawImageData, $DieOnErrors=false) {
+	public function ImageCreateFromStringReplacement(&$RawImageData, $DieOnErrors=false) {
 		// there are serious bugs in the non-bundled versions of GD which may cause
 		// PHP to segfault when calling imagecreatefromstring() - avoid if at all possible
 		// when not using a bundled version of GD2
@@ -4264,8 +4285,8 @@ if (false) {
 
 					// Need to create from GIF file, but imagecreatefromgif does not exist
 					ob_start();
-					if (!@include_once(dirname(__FILE__).'/phpthumb.gif.php')) {
-						$ErrorMessage = 'Failed to include required file "'.dirname(__FILE__).'/phpthumb.gif.php" in '.__FILE__.' on line '.__LINE__;
+					if (!@include_once( __DIR__ .'/phpthumb.gif.php')) {
+						$ErrorMessage = 'Failed to include required file "'. __DIR__ .'/phpthumb.gif.php" in '.__FILE__.' on line '.__LINE__;
 						$this->DebugMessage($ErrorMessage, __FILE__, __LINE__);
 					}
 					ob_end_clean();
@@ -4326,7 +4347,7 @@ if (false) {
 		return false;
 	}
 
-	function ImageResizeFunction(&$dst_im, &$src_im, $dstX, $dstY, $srcX, $srcY, $dstW, $dstH, $srcW, $srcH) {
+	public function ImageResizeFunction(&$dst_im, &$src_im, $dstX, $dstY, $srcX, $srcY, $dstW, $dstH, $srcW, $srcH) {
 		$this->DebugMessage('ImageResizeFunction($o, $s, '.$dstX.', '.$dstY.', '.$srcX.', '.$srcY.', '.$dstW.', '.$dstH.', '.$srcW.', '.$srcH.')', __FILE__, __LINE__);
 		if (($dstW == $srcW) && ($dstH == $srcH)) {
 			return imagecopy($dst_im, $src_im, $dstX, $dstY, $srcX, $srcY, $srcW, $srcH);
@@ -4340,7 +4361,7 @@ if (false) {
 		return imagecopyresized($dst_im, $src_im, $dstX, $dstY, $srcX, $srcY, $dstW, $dstH, $srcW, $srcH);
 	}
 
-	function InitializeTempDirSetting() {
+	public function InitializeTempDirSetting() {
 		$this->config_temp_directory = ($this->config_temp_directory ? $this->config_temp_directory : $this->realPathSafe((function_exists('sys_get_temp_dir') ? sys_get_temp_dir() : ''))); // sys_get_temp_dir added in PHP v5.2.1
 		$this->config_temp_directory = ($this->config_temp_directory ? $this->config_temp_directory : $this->realPathSafe(ini_get('upload_tmp_dir')));
 		$this->config_temp_directory = ($this->config_temp_directory ? $this->config_temp_directory : $this->realPathSafe(getenv('TMPDIR')));
@@ -4348,7 +4369,7 @@ if (false) {
 		return true;
 	}
 
-	function phpThumb_tempnam() {
+	public function phpThumb_tempnam() {
 		$this->InitializeTempDirSetting();
 		$tempnam = $this->realPathSafe(tempnam($this->config_temp_directory, 'pThumb'));
 		$this->tempFilesToDelete[$tempnam] = $tempnam;
@@ -4356,12 +4377,12 @@ if (false) {
 		return $tempnam;
 	}
 
-	function DebugMessage($message, $file='', $line='') {
+	public function DebugMessage($message, $file='', $line='') {
 		$this->debugmessages[] = $message.($file ? ' in file "'.(basename($file) ? basename($file) : $file).'"' : '').($line ? ' on line '.$line : '');
 		return true;
 	}
 
-	function DebugTimingMessage($message, $file='', $line='', $timestamp=0) {
+	public function DebugTimingMessage($message, $file='', $line='', $timestamp=0) {
 		if (!$timestamp) {
 			$timestamp = array_sum(explode(' ', microtime()));
 		}

--- a/core/model/phpthumb/phpthumb.filters.php
+++ b/core/model/phpthumb/phpthumb.filters.php
@@ -15,10 +15,10 @@ class phpthumb_filters {
 	* @var phpthumb
 	*/
 
-	var $phpThumbObject = null;
+	public $phpThumbObject = null;
 
 
-	function DebugMessage($message, $file='', $line='') {
+	public function DebugMessage($message, $file='', $line='') {
 		if (is_object($this->phpThumbObject)) {
 			return $this->phpThumbObject->DebugMessage($message, $file, $line);
 		}
@@ -31,7 +31,7 @@ class phpthumb_filters {
 			$this->DebugMessage('Skipping ApplyMask() because gd_version is "'.phpthumb_functions::gd_version().'"', __FILE__, __LINE__);
 			return false;
 		}
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.2', '>=')) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '4.3.2', '>=')) {
 
 			$this->DebugMessage('Using alpha ApplyMask() technique', __FILE__, __LINE__);
 			if ($gdimg_mask_resized = phpthumb_functions::ImageCreateFunction(imagesx($gdimg_image), imagesy($gdimg_image))) {
@@ -43,8 +43,8 @@ class phpthumb_filters {
 					imagefilledrectangle($gdimg_mask_blendtemp, 0, 0, imagesx($gdimg_mask_blendtemp), imagesy($gdimg_mask_blendtemp), $color_background);
 					imagealphablending($gdimg_mask_blendtemp, false);
 					imagesavealpha($gdimg_mask_blendtemp, true);
-					for ($x = 0; $x < imagesx($gdimg_image); $x++) {
-						for ($y = 0; $y < imagesy($gdimg_image); $y++) {
+					for ($x = 0, $xMax = imagesx($gdimg_image); $x < $xMax; $x++) {
+						for ($y = 0, $yMax = imagesy($gdimg_image); $y < $yMax; $y++) {
 							//$RealPixel = phpthumb_functions::GetPixelColor($gdimg_mask_blendtemp, $x, $y);
 							$RealPixel = phpthumb_functions::GetPixelColor($gdimg_image, $x, $y);
 							$MaskPixel = phpthumb_functions::GrayscalePixel(phpthumb_functions::GetPixelColor($gdimg_mask_resized, $x, $y));
@@ -69,13 +69,13 @@ class phpthumb_filters {
 
 		} else {
 			// alpha merging requires PHP v4.3.2+
-			$this->DebugMessage('Skipping ApplyMask() technique because PHP is v"'.phpversion().'"', __FILE__, __LINE__);
+			$this->DebugMessage('Skipping ApplyMask() technique because PHP is v"'. PHP_VERSION .'"', __FILE__, __LINE__);
 		}
 		return true;
 	}
 
 
-    function Bevel(&$gdimg, $width, $hexcolor1, $hexcolor2) {
+    public function Bevel(&$gdimg, $width, $hexcolor1, $hexcolor2) {
         $width     = ($width     ? $width     : 5);
         $hexcolor1 = ($hexcolor1 ? $hexcolor1 : 'FFFFFF');
         $hexcolor2 = ($hexcolor2 ? $hexcolor2 : '000000');
@@ -132,7 +132,7 @@ class phpthumb_filters {
 
 
 	public function BlurGaussian(&$gdimg) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_GAUSSIAN_BLUR)) {
 				return true;
 			}
@@ -140,12 +140,12 @@ class phpthumb_filters {
 			// fall through and try it the hard way
 		}
 		$this->DebugMessage('FAILED: phpthumb_filters::BlurGaussian($gdimg) [using phpthumb_filters::Blur() instead]', __FILE__, __LINE__);
-		return phpthumb_filters::Blur($gdimg, 0.5);
+		return self::Blur($gdimg, 0.5);
 	}
 
 
 	public function BlurSelective(&$gdimg) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_SELECTIVE_BLUR)) {
 				return true;
 			}
@@ -164,7 +164,7 @@ class phpthumb_filters {
 		}
 		$amount = max(-255, min(255, $amount));
 
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_BRIGHTNESS, $amount)) {
 				return true;
 			}
@@ -174,8 +174,8 @@ class phpthumb_filters {
 
 		$scaling = (255 - abs($amount)) / 255;
 		$baseamount = (($amount > 0) ? $amount : 0);
-		for ($x = 0; $x < imagesx($gdimg); $x++) {
-			for ($y = 0; $y < imagesy($gdimg); $y++) {
+		for ($x = 0, $xMax = imagesx($gdimg); $x < $xMax; $x++) {
+			for ($y = 0, $yMax = imagesy($gdimg); $y < $yMax; $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				$NewPixel = array();
 				foreach ($OriginalPixel as $key => $value) {
@@ -195,7 +195,7 @@ class phpthumb_filters {
 		}
 		$amount = max(-255, min(255, $amount));
 
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			// imagefilter(IMG_FILTER_CONTRAST) has range +100 to -100 (positive numbers make it darker!)
 			$amount = ($amount / 255) * -100;
 			if (imagefilter($gdimg, IMG_FILTER_CONTRAST, $amount)) {
@@ -210,8 +210,8 @@ class phpthumb_filters {
 		} else {
 			$scaling = (255 - abs($amount)) / 255;
 		}
-		for ($x = 0; $x < imagesx($gdimg); $x++) {
-			for ($y = 0; $y < imagesy($gdimg); $y++) {
+		for ($x = 0, $xMax = imagesx($gdimg); $x < $xMax; $x++) {
+			for ($y = 0, $yMax = imagesy($gdimg); $y < $yMax; $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				$NewPixel = array();
 				foreach ($OriginalPixel as $key => $value) {
@@ -234,7 +234,7 @@ class phpthumb_filters {
 			return true;
 		}
 
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if ($targetColor == 'gray') {
 				$targetColor = '808080';
 			}
@@ -256,8 +256,8 @@ class phpthumb_filters {
 			$TargetPixel['blue']  = hexdec(substr($targetColor, 4, 2));
 		}
 
-		for ($x = 0; $x < imagesx($gdimg); $x++) {
-			for ($y = 0; $y < imagesy($gdimg); $y++) {
+		for ($x = 0, $xMax = imagesx($gdimg); $x < $xMax; $x++) {
+			for ($y = 0, $yMax = imagesy($gdimg); $y < $yMax; $y++) {
 				$OriginalPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				if ($targetColor == 'gray') {
 					$TargetPixel = phpthumb_functions::GrayscalePixel($OriginalPixel);
@@ -307,7 +307,7 @@ class phpthumb_filters {
 		if ($amount == 0) {
 			return true;
 		}
-		return phpthumb_filters::Colorize($gdimg, $amount, (phpthumb_functions::IsHexColor($color) ? $color : 'gray'));
+		return self::Colorize($gdimg, $amount, (phpthumb_functions::IsHexColor($color) ? $color : 'gray'));
 	}
 
 
@@ -352,8 +352,8 @@ class phpthumb_filters {
 			imagefill($gdimg_dropshadow_temp, 0, 0, $transparent1);
 
 			$PixelMap = array();
-			for ($x = 0; $x < imagesx($gdimg); $x++) {
-				for ($y = 0; $y < imagesy($gdimg); $y++) {
+			for ($x = 0, $xMax = imagesx($gdimg); $x < $xMax; $x++) {
+				for ($y = 0, $yMax = imagesy($gdimg); $y < $yMax; $y++) {
 					$PixelMap[$x][$y] = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				}
 			}
@@ -372,8 +372,8 @@ class phpthumb_filters {
 			}
 
 			imagealphablending($gdimg_dropshadow_temp, true);
-			for ($x = 0; $x < imagesx($gdimg); $x++) {
-				for ($y = 0; $y < imagesy($gdimg); $y++) {
+			for ($x = 0, $xMax = imagesx($gdimg); $x < $xMax; $x++) {
+				for ($y = 0, $yMax = imagesy($gdimg); $y < $yMax; $y++) {
 					if ($PixelMap[$x][$y]['alpha'] < 127) {
 						$thisColor = phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg_dropshadow_temp, $PixelMap[$x][$y]['red'], $PixelMap[$x][$y]['green'], $PixelMap[$x][$y]['blue'], $PixelMap[$x][$y]['alpha']);
 						imagesetpixel($gdimg_dropshadow_temp, $x, $y, $thisColor);
@@ -395,7 +395,7 @@ class phpthumb_filters {
 
 
 	public function EdgeDetect(&$gdimg) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_EDGEDETECT)) {
 				return true;
 			}
@@ -420,7 +420,7 @@ class phpthumb_filters {
 				imagefilledellipse($gdimg_ellipsemask_double, imagesx($gdimg), imagesy($gdimg), (imagesx($gdimg) - 1) * 2, (imagesy($gdimg) - 1) * 2, $color_transparent);
 				imagecopyresampled($gdimg_ellipsemask, $gdimg_ellipsemask_double, 0, 0, 0, 0, imagesx($gdimg), imagesy($gdimg), imagesx($gdimg) * 2, imagesy($gdimg) * 2);
 
-				phpthumb_filters::ApplyMask($gdimg_ellipsemask, $gdimg);
+				self::ApplyMask($gdimg_ellipsemask, $gdimg);
 				imagedestroy($gdimg_ellipsemask);
 				return true;
 
@@ -436,7 +436,7 @@ class phpthumb_filters {
 
 
 	public function Emboss(&$gdimg) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_EMBOSS)) {
 				return true;
 			}
@@ -456,13 +456,13 @@ class phpthumb_filters {
 		if ($tempImage = phpthumb_functions::ImageCreateFunction(imagesx($gdimg), imagesy($gdimg))) {
 			if ($x) {
 				imagecopy($tempImage, $gdimg, 0, 0, 0, 0, imagesx($gdimg), imagesy($gdimg));
-				for ($x = 0; $x < imagesx($gdimg); $x++) {
+				for ($x = 0, $xMax = imagesx($gdimg); $x < $xMax; $x++) {
 					imagecopy($gdimg, $tempImage, imagesx($gdimg) - 1 - $x, 0, $x, 0, 1, imagesy($gdimg));
 				}
 			}
 			if ($y) {
 				imagecopy($tempImage, $gdimg, 0, 0, 0, 0, imagesx($gdimg), imagesy($gdimg));
-				for ($y = 0; $y < imagesy($gdimg); $y++) {
+				for ($y = 0, $yMax = imagesy($gdimg); $y < $yMax; $y++) {
 					imagecopy($gdimg, $tempImage, 0, imagesy($gdimg) - 1 - $y, 0, $y, imagesx($gdimg), 1);
 				}
 			}
@@ -513,14 +513,14 @@ class phpthumb_filters {
 
 
 	public function Grayscale(&$gdimg) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_GRAYSCALE)) {
 				return true;
 			}
 			$this->DebugMessage('FAILED: imagefilter($gdimg, IMG_FILTER_GRAYSCALE)', __FILE__, __LINE__);
 			// fall through and try it the hard way
 		}
-		return phpthumb_filters::Colorize($gdimg, 100, 'gray');
+		return self::Colorize($gdimg, 100, 'gray');
 	}
 
 
@@ -556,9 +556,9 @@ class phpthumb_filters {
 		// equivalent of "Auto Contrast" in Adobe Photoshop
 		// method 0 stretches according to RGB colors. Gives a more conservative stretch.
 		// method 1 band stretches according to grayscale which is color-biased (59% green, 30% red, 11% blue). May give a punchier / more aggressive stretch, possibly appearing over-saturated
-		$Analysis = phpthumb_filters::HistogramAnalysis($gdimg, true);
+		$Analysis = self::HistogramAnalysis($gdimg, true);
 		$keys = array('r'=>'red', 'g'=>'green', 'b'=>'blue', 'a'=>'alpha', '*'=>(($method == 0) ? 'all' : 'gray'));
-		$band = substr($band, 0, 1);
+		$band = $band[ 0 ];
 		if (!isset($keys[$band])) {
 			return false;
 		}
@@ -568,7 +568,7 @@ class phpthumb_filters {
 		// pixel in the image could throw off the whole system. Instead, count up/down
 		// from the limit and allow <threshold> (default = 0.1%) of brightest/darkest
 		// pixels to be clipped to min/max
-		$threshold = floatval($threshold) / 100;
+		$threshold = (float) $threshold / 100;
 		$clip_threshold = imagesx($gdimg) * imagesx($gdimg) * $threshold;
 
 		$countsum  = 0;
@@ -603,7 +603,7 @@ class phpthumb_filters {
 
 		$range_scale = (($range_max == $range_min) ? 1 : (255 / ($range_max - $range_min)));
 		if (($range_min == 0) && ($range_max == 255)) {
-			// no adjustment neccesary - don't waste CPU time!
+			// no adjustment necessary - don't waste CPU time!
 			return true;
 		}
 
@@ -631,9 +631,9 @@ class phpthumb_filters {
 
 
 	public function HistogramOverlay(&$gdimg, $bands='*', $colors='', $width=0.25, $height=0.25, $alignment='BR', $opacity=50, $margin_x=5, $margin_y=null) {
-		$margin_y = (is_null($margin_y) ? $margin_x : $margin_y);
+		$margin_y = (null === $margin_y ? $margin_x : $margin_y);
 
-		$Analysis = phpthumb_filters::HistogramAnalysis($gdimg, true);
+		$Analysis = self::HistogramAnalysis($gdimg, true);
 		$histW = round(($width > 1) ? min($width, imagesx($gdimg)) : imagesx($gdimg) * $width);
 		$histH = round(($width > 1) ? min($width, imagesx($gdimg)) : imagesx($gdimg) * $width);
 		if ($gdHist = imagecreatetruecolor($histW, $histH)) {
@@ -672,7 +672,7 @@ class phpthumb_filters {
 				return false;
 			}
 
-			phpthumb_filters::WatermarkOverlay($gdimg, $gdHist, $alignment, $opacity, $margin_x, $margin_y);
+			self::WatermarkOverlay($gdimg, $gdHist, $alignment, $opacity, $margin_x, $margin_y);
 			imagedestroy($gdHist);
 			return true;
 		}
@@ -756,7 +756,7 @@ class phpthumb_filters {
 		while ($rotate_angle < 0) {
 			$rotate_angle += 360;
 		}
-		$rotate_angle = $rotate_angle % 360;
+		$rotate_angle %= 360;
 		if ($rotate_angle != 0) {
 
 			$background_color = phpthumb_functions::ImageHexColorAllocate($gdimg_source, $config_background_hexcolor);
@@ -785,7 +785,7 @@ class phpthumb_filters {
 					imagealphablending($gdimg_source, false);
 					imagesavealpha($gdimg_source, true);
 					//$this->is_alpha = true;
-					$phpThumbFilters = new phpthumb_filters();
+					$phpThumbFilters = new self();
 					//$phpThumbFilters->phpThumbObject = $this;
 					$phpThumbFilters->phpThumbObject = $phpThumbObject;
 					$phpThumbFilters->ApplyMask($gdimg_rotate_mask, $gdimg_source);
@@ -850,7 +850,7 @@ class phpthumb_filters {
 
 
 	public function MeanRemoval(&$gdimg) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_MEAN_REMOVAL)) {
 				return true;
 			}
@@ -864,7 +864,7 @@ class phpthumb_filters {
 
 
 	public function Negative(&$gdimg) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_NEGATE)) {
 				return true;
 			}
@@ -901,7 +901,7 @@ class phpthumb_filters {
 				imagecopyresampled($gdimg_cornermask, $gdimg_cornermask_triple, imagesx($gdimg) - $radius_x, imagesy($gdimg) - $radius_y, $radius_x * 3, $radius_y * 3, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
 				imagecopyresampled($gdimg_cornermask, $gdimg_cornermask_triple, imagesx($gdimg) - $radius_x,                           0, $radius_x * 3,     $radius_y, $radius_x, $radius_y, $radius_x * 2, $radius_y * 2);
 
-				phpthumb_filters::ApplyMask($gdimg_cornermask, $gdimg);
+				self::ApplyMask($gdimg_cornermask, $gdimg);
 				imagedestroy($gdimg_cornermask);
 				$this->DebugMessage('RoundedImageCorners('.$radius_x.', '.$radius_y.') succeeded', __FILE__, __LINE__);
 				return true;
@@ -926,7 +926,7 @@ class phpthumb_filters {
 		} else {
 			$amount = abs($amount);
 		}
-		return phpthumb_filters::Desaturate($gdimg, $amount, $color);
+		return self::Desaturate($gdimg, $amount, $color);
 	}
 
 
@@ -939,7 +939,7 @@ class phpthumb_filters {
 			return true;
 		}
 
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_GRAYSCALE)) {
 
 				$r = round($amountPct * hexdec(substr($targetColor, 0, 2)));
@@ -992,7 +992,7 @@ class phpthumb_filters {
 		if ($amount == 0) {
 			return true;
 		}
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
+		if (phpthumb_functions::version_compare_replacement(PHP_VERSION, '5.0.0', '>=') && phpthumb_functions::gd_is_bundled()) {
 			if (imagefilter($gdimg, IMG_FILTER_SMOOTH, $amount)) {
 				return true;
 			}
@@ -1067,7 +1067,7 @@ class phpthumb_filters {
 		$colors = max(min($colors, 256), 2);
 		// imagetruecolortopalette usually makes ugly colors, the replacement is a bit better
 		//imagetruecolortopalette($gdimg, $dither, $colors);
-		phpthumb_filters::ImageTrueColorToPalette2($gdimg, $dither, $colors);
+		self::ImageTrueColorToPalette2($gdimg, $dither, $colors);
 		return true;
 	}
 
@@ -1080,7 +1080,7 @@ class phpthumb_filters {
 				'blue'  => hexdec(substr($targetColor, 4, 2))
 			);
 		} else {
-			$Analysis = phpthumb_filters::HistogramAnalysis($gdimg, false);
+			$Analysis = self::HistogramAnalysis($gdimg, false);
 			$targetPixel = array(
 				'red'   => max(array_keys($Analysis['red'])),
 				'green' => max(array_keys($Analysis['green'])),
@@ -1092,8 +1092,8 @@ class phpthumb_filters {
 		$scaleG = $grayValue / $targetPixel['green'];
 		$scaleB = $grayValue / $targetPixel['blue'];
 
-		for ($x = 0; $x < imagesx($gdimg); $x++) {
-			for ($y = 0; $y < imagesy($gdimg); $y++) {
+		for ($x = 0, $xMax = imagesx($gdimg); $x < $xMax; $x++) {
+			for ($y = 0, $yMax = imagesy($gdimg); $y < $yMax; $y++) {
 				$currentPixel = phpthumb_functions::GetPixelColor($gdimg, $x, $y);
 				$newColor = phpthumb_functions::ImageColorAllocateAlphaSafe(
 					$gdimg,
@@ -1109,7 +1109,7 @@ class phpthumb_filters {
 	}
 
 
-	public function WatermarkText(&$gdimg, $text, $size, $alignment, $hex_color='000000', $ttffont='', $opacity=100, $margin=5, $angle=0, $bg_color=false, $bg_opacity=0, $fillextend='') {
+	public function WatermarkText(&$gdimg, $text, $size, $alignment, $hex_color='000000', $ttffont='', $opacity=100, $margin=5, $angle=0, $bg_color=false, $bg_opacity=0, $fillextend='', $lineheight=1.0) {
 		// text watermark requested
 		if (!$text) {
 			return false;
@@ -1117,14 +1117,15 @@ class phpthumb_filters {
 		imagealphablending($gdimg, true);
 
 		if (preg_match('#^([0-9\\.\\-]*)x([0-9\\.\\-]*)(@[LCR])?$#i', $alignment, $matches)) {
-			$originOffsetX = intval($matches[1]);
-			$originOffsetY = intval($matches[2]);
+			$originOffsetX = (int) $matches[ 1];
+			$originOffsetY = (int) $matches[ 2];
 			$alignment = (@$matches[4] ? $matches[4] : 'L');
 			$margin = 0;
 		} else {
 			$originOffsetX = 0;
 			$originOffsetY = 0;
 		}
+		$lineheight = min(100.0, max(0.01, (float) $lineheight));
 
 		$metaTextArray = array(
 			'^Fb' =>       $this->phpThumbObject->getimagesizeinfo['filesize'],
@@ -1138,14 +1139,16 @@ class phpthumb_filters {
 		);
 		$text = strtr($text, $metaTextArray);
 
-		$text = str_replace("\r\n", "\n", $text);
-		$text = str_replace("\r",   "\n", $text);
+		$text = str_replace(array(
+			"\r\n",
+			"\r"
+		), "\n", $text);
 		$textlines = explode("\n", $text);
 		$this->DebugMessage('Processing '.count($textlines).' lines of text', __FILE__, __LINE__);
 
 		if (@is_readable($ttffont) && is_file($ttffont)) {
 
-			$opacity = 100 - intval(max(min($opacity, 100), 0));
+			$opacity = 100 - (int) max(min($opacity, 100), 0);
 			$letter_color_text = phpthumb_functions::ImageHexColorAllocate($gdimg, $hex_color, false, $opacity * 1.27);
 
 			$this->DebugMessage('Using TTF font "'.$ttffont.'"', __FILE__, __LINE__);
@@ -1176,7 +1179,7 @@ class phpthumb_filters {
 						imagettftext($gdimg, $size, $angle, $text_origin_x, $text_origin_y, $letter_color_text, $ttffont, $text);
 						$text_origin_x += ($text_width + $margin);
 					}
-					$text_origin_y += ($text_height + $margin);
+					$text_origin_y += ($text_height + $margin) * $lineheight;
 				}
 
 			} else {
@@ -1247,10 +1250,10 @@ class phpthumb_filters {
 				$y1 = $text_origin_y + $TTFbox[1];
 				$x2 = $text_origin_x + $min_x + $text_width;
 				$y2 = $text_origin_y + $TTFbox[1] - $text_height;
-				$x_TL = preg_match('#x#i', $fillextend) ?               0 : min($x1, $x2);
-				$y_TL = preg_match('#y#i', $fillextend) ?               0 : min($y1, $y2);
-				$x_BR = preg_match('#x#i', $fillextend) ? imagesx($gdimg) : max($x1, $x2);
-				$y_BR = preg_match('#y#i', $fillextend) ? imagesy($gdimg) : max($y1, $y2);
+				$x_TL = false !== stripos($fillextend, "x") ?               0 : min($x1, $x2);
+				$y_TL = false !== stripos($fillextend, "y") ?               0 : min($y1, $y2);
+				$x_BR = false !== stripos($fillextend, "x") ? imagesx($gdimg) : max($x1, $x2);
+				$y_BR = false !== stripos($fillextend, "y") ? imagesy($gdimg) : max($y1, $y2);
 				$this->DebugMessage('WatermarkText() calling imagefilledrectangle($gdimg, '.$x_TL.', '.$y_TL.', '.$x_BR.', '.$y_BR.', $text_color_background)', __FILE__, __LINE__);
 				imagefilledrectangle($gdimg, $x_TL, $y_TL, $x_BR, $y_BR, $text_color_background);
 
@@ -1271,7 +1274,7 @@ class phpthumb_filters {
 						case 'L':
 						case 'TL':
 						case 'BL':
-							// no change neccesary
+							// no change necessary
 							break;
 
 						case 'C':
@@ -1291,7 +1294,7 @@ class phpthumb_filters {
 					$this->DebugMessage('WatermarkText() calling imagettftext($gdimg, '.$size.', '.$angle.', '.$text_origin_x.', '.($text_origin_y + $y_offset).', $letter_color_text, '.$ttffont.', '.$line.')', __FILE__, __LINE__);
 					imagettftext($gdimg, $size, $angle, $text_origin_x, $text_origin_y + $y_offset, $letter_color_text, $ttffont, $line);
 
-					$y_offset += $char_height;
+					$y_offset += $char_height * $lineheight;
 				}
 
 			}
@@ -1398,18 +1401,18 @@ class phpthumb_filters {
 					$this->DebugMessage('WatermarkText() calling imagestring($img_watermark, '.$size.', '.$x_offset.', '.($key * imagefontheight($size)).', '.$line.', $text_color_watermark)', __FILE__, __LINE__);
 					imagestring($img_watermark, $size, $x_offset, $key * imagefontheight($size), $line, $text_color_watermark);
 					if ($angle && $img_watermark_mask) {
-						$this->DebugMessage('WatermarkText() calling imagestring($img_watermark_mask, '.$size.', '.$x_offset.', '.($key * imagefontheight($size)).', '.$text.', $mask_color_watermark)', __FILE__, __LINE__);
-						imagestring($img_watermark_mask, $size, $x_offset, $key * imagefontheight($size), $text, $mask_color_watermark);
+						$this->DebugMessage('WatermarkText() calling imagestring($img_watermark_mask, '.$size.', '.$x_offset.', '.($key * imagefontheight($size) * $lineheight).', '.$text.', $mask_color_watermark)', __FILE__, __LINE__);
+						imagestring($img_watermark_mask, $size, $x_offset, $key * imagefontheight($size) * $lineheight, $text, $mask_color_watermark);
 					}
 				}
 				if ($angle && $img_watermark_mask) {
 					$img_watermark      = imagerotate($img_watermark,      $angle, $text_color_background);
 					$img_watermark_mask = imagerotate($img_watermark_mask, $angle, $mask_color_background);
-					phpthumb_filters::ApplyMask($img_watermark_mask, $img_watermark);
+					self::ApplyMask($img_watermark_mask, $img_watermark);
 				}
 				//phpthumb_filters::WatermarkOverlay($gdimg, $img_watermark, $alignment, $opacity, $margin);
 				$this->DebugMessage('WatermarkText() calling phpthumb_filters::WatermarkOverlay($gdimg, $img_watermark, '.($originOffsetX.'x'.$originOffsetY).', '.$opacity.', 0)', __FILE__, __LINE__);
-				phpthumb_filters::WatermarkOverlay($gdimg, $img_watermark, $originOffsetX.'x'.$originOffsetY, $opacity, 0);
+				self::WatermarkOverlay($gdimg, $img_watermark, $originOffsetX.'x'.$originOffsetY, $opacity, 0);
 				imagedestroy($img_watermark);
 				return true;
 			}
@@ -1427,14 +1430,14 @@ class phpthumb_filters {
 			$watermark_source_width    = imagesx($img_watermark);
 			$watermark_source_height   = imagesy($img_watermark);
 			$watermark_opacity_percent = max(0, min(100, $opacity));
-			$margin_y = (is_null($margin_y) ? $margin_x : $margin_y);
+			$margin_y = (null === $margin_y ? $margin_x : $margin_y);
 			$watermark_margin_x = ((($margin_x > 0) && ($margin_x < 1)) ? round((1 - $margin_x) * $img_source_width)  : $margin_x);
 			$watermark_margin_y = ((($margin_y > 0) && ($margin_y < 1)) ? round((1 - $margin_y) * $img_source_height) : $margin_y);
 			$watermark_destination_x = 0;
 			$watermark_destination_y = 0;
 			if (preg_match('#^([0-9\\.\\-]*)x([0-9\\.\\-]*)$#i', $alignment, $matches)) {
-				$watermark_destination_x = intval($matches[1]);
-				$watermark_destination_y = intval($matches[2]);
+				$watermark_destination_x = (int) $matches[ 1];
+				$watermark_destination_y = (int) $matches[ 2];
 			} else {
 				switch ($alignment) {
 					case '*':

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -11,7 +11,7 @@
 
 class phpthumb_functions {
 
-	static function user_function_exists($functionname) {
+	public static function user_function_exists($functionname) {
 		if (function_exists('get_defined_functions')) {
 			static $get_defined_functions = array();
 			if (empty($get_defined_functions)) {
@@ -23,7 +23,7 @@ class phpthumb_functions {
 	}
 
 
-	static function builtin_function_exists($functionname) {
+	public static function builtin_function_exists($functionname) {
 		if (function_exists('get_defined_functions')) {
 			static $get_defined_functions = array();
 			if (empty($get_defined_functions)) {
@@ -35,7 +35,7 @@ class phpthumb_functions {
 	}
 
 
-	static function version_compare_replacement_sub($version1, $version2, $operator='') {
+	public static function version_compare_replacement_sub($version1, $version2, $operator='') {
 		// If you specify the third optional operator argument, you can test for a particular relationship.
 		// The possible operators are: <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne respectively.
 		// Using this argument, the function will return 1 if the relationship is the one specified by the operator, 0 otherwise.
@@ -61,29 +61,29 @@ class phpthumb_functions {
 		switch ($operator) {
 			case '<':
 			case 'lt':
-				return intval($version1 < $version2);
+				return (int) ($version1 < $version2);
 				break;
 			case '<=':
 			case 'le':
-				return intval($version1 <= $version2);
+				return (int) ($version1 <= $version2);
 				break;
 			case '>':
 			case 'gt':
-				return intval($version1 > $version2);
+				return (int) ($version1 > $version2);
 				break;
 			case '>=':
 			case 'ge':
-				return intval($version1 >= $version2);
+				return (int) ($version1 >= $version2);
 				break;
 			case '==':
 			case '=':
 			case 'eq':
-				return intval($version1 == $version2);
+				return (int) ($version1 == $version2);
 				break;
 			case '!=':
 			case '<>':
 			case 'ne':
-				return intval($version1 != $version2);
+				return (int) ($version1 != $version2);
 				break;
 		}
 		if ($version1 == $version2) {
@@ -95,7 +95,7 @@ class phpthumb_functions {
 	}
 
 
-	static function version_compare_replacement($version1, $version2, $operator='') {
+	public static function version_compare_replacement($version1, $version2, $operator='') {
 		if (function_exists('version_compare')) {
 			// built into PHP v4.1.0+
 			return version_compare($version1, $version2, $operator);
@@ -114,7 +114,7 @@ class phpthumb_functions {
 		$parts2 = explode('.', $version1);
 		$parts_count = max(count($parts1), count($parts2));
 		for ($i = 0; $i < $parts_count; $i++) {
-			$comparison = phpthumb_functions::version_compare_replacement_sub($version1, $version2, $operator);
+			$comparison = self::version_compare_replacement_sub($version1, $version2, $operator);
 			if ($comparison != 0) {
 				return $comparison;
 			}
@@ -122,14 +122,14 @@ class phpthumb_functions {
 		return 0;
 	}
 
-	static function escapeshellarg_replacement($arg) {
-		if (function_exists('escapeshellarg') && !phpthumb_functions::FunctionIsDisabled('escapeshellarg')) {
+	public static function escapeshellarg_replacement($arg) {
+		if (function_exists('escapeshellarg') && !self::FunctionIsDisabled('escapeshellarg')) {
 			return escapeshellarg($arg);
 		}
 		return '\''.str_replace('\'', '\\\'', $arg).'\'';
 	}
 
-	static function phpinfo_array() {
+	public static function phpinfo_array() {
 		static $phpinfo_array = array();
 		if (empty($phpinfo_array)) {
 			ob_start();
@@ -142,7 +142,7 @@ class phpthumb_functions {
 	}
 
 
-	static function exif_info() {
+	public static function exif_info() {
 		static $exif_info = array();
 		if (empty($exif_info)) {
 			// based on code by johnschaefer at gmx dot de
@@ -153,7 +153,7 @@ class phpthumb_functions {
 				'Supported EXIF Version' => '',
 				'Supported filetypes'    => ''
 			);
-			$phpinfo_array = phpthumb_functions::phpinfo_array();
+			$phpinfo_array = self::phpinfo_array();
 			foreach ($phpinfo_array as $line) {
 				$line = trim(strip_tags($line));
 				foreach ($exif_info as $key => $value) {
@@ -168,7 +168,7 @@ class phpthumb_functions {
 	}
 
 
-	static function ImageTypeToMIMEtype($imagetype) {
+	public static function ImageTypeToMIMEtype($imagetype) {
 		if (function_exists('image_type_to_mime_type') && ($imagetype >= 1) && ($imagetype <= 16)) {
 			// PHP v4.3.0+
 			return image_type_to_mime_type($imagetype);
@@ -203,7 +203,7 @@ class phpthumb_functions {
 	}
 
 
-	static function TranslateWHbyAngle($width, $height, $angle) {
+	public static function TranslateWHbyAngle($width, $height, $angle) {
 		if (($angle % 180) == 0) {
 			return array($width, $height);
 		}
@@ -212,7 +212,7 @@ class phpthumb_functions {
 		return array($newwidth, $newheight);
 	}
 
-	static function HexCharDisplay($string) {
+	public static function HexCharDisplay($string) {
 		$len = strlen($string);
 		$output = '';
 		for ($i = 0; $i < $len; $i++) {
@@ -222,28 +222,28 @@ class phpthumb_functions {
 	}
 
 
-	static function IsHexColor($HexColorString) {
+	public static function IsHexColor($HexColorString) {
 		return preg_match('#^[0-9A-F]{6}$#i', $HexColorString);
 	}
 
 
-	static function ImageColorAllocateAlphaSafe(&$gdimg_hexcolorallocate, $R, $G, $B, $alpha=false) {
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.2', '>=') && ($alpha !== false)) {
-			return imagecolorallocatealpha($gdimg_hexcolorallocate, $R, $G, $B, intval($alpha));
+	public static function ImageColorAllocateAlphaSafe(&$gdimg_hexcolorallocate, $R, $G, $B, $alpha=false) {
+		if (self::version_compare_replacement(PHP_VERSION, '4.3.2', '>=') && ($alpha !== false)) {
+			return imagecolorallocatealpha($gdimg_hexcolorallocate, $R, $G, $B, (int) $alpha);
 		} else {
 			return imagecolorallocate($gdimg_hexcolorallocate, $R, $G, $B);
 		}
 	}
 
-	static function ImageHexColorAllocate(&$gdimg_hexcolorallocate, $HexColorString, $dieOnInvalid=false, $alpha=false) {
+	public static function ImageHexColorAllocate(&$gdimg_hexcolorallocate, $HexColorString, $dieOnInvalid=false, $alpha=false) {
 		if (!is_resource($gdimg_hexcolorallocate)) {
 			die('$gdimg_hexcolorallocate is not a GD resource in ImageHexColorAllocate()');
 		}
-		if (phpthumb_functions::IsHexColor($HexColorString)) {
+		if (self::IsHexColor($HexColorString)) {
 			$R = hexdec(substr($HexColorString, 0, 2));
 			$G = hexdec(substr($HexColorString, 2, 2));
 			$B = hexdec(substr($HexColorString, 4, 2));
-			return phpthumb_functions::ImageColorAllocateAlphaSafe($gdimg_hexcolorallocate, $R, $G, $B, $alpha);
+			return self::ImageColorAllocateAlphaSafe($gdimg_hexcolorallocate, $R, $G, $B, $alpha);
 		}
 		if ($dieOnInvalid) {
 			die('Invalid hex color string: "'.$HexColorString.'"');
@@ -252,12 +252,12 @@ class phpthumb_functions {
 	}
 
 
-	static function HexColorXOR($hexcolor) {
+	public static function HexColorXOR($hexcolor) {
 		return strtoupper(str_pad(dechex(~hexdec($hexcolor) & 0xFFFFFF), 6, '0', STR_PAD_LEFT));
 	}
 
 
-	static function GetPixelColor(&$img, $x, $y) {
+	public static function GetPixelColor(&$img, $x, $y) {
 		if (!is_resource($img)) {
 			return false;
 		}
@@ -265,7 +265,7 @@ class phpthumb_functions {
 	}
 
 
-	static function PixelColorDifferencePercent($currentPixel, $targetPixel) {
+	public static function PixelColorDifferencePercent($currentPixel, $targetPixel) {
 		$diff = 0;
 		foreach ($targetPixel as $channel => $currentvalue) {
 			$diff = max($diff, (max($currentPixel[$channel], $targetPixel[$channel]) - min($currentPixel[$channel], $targetPixel[$channel])) / 255);
@@ -273,18 +273,18 @@ class phpthumb_functions {
 		return $diff * 100;
 	}
 
-	static function GrayscaleValue($r, $g, $b) {
+	public static function GrayscaleValue($r, $g, $b) {
 		return round(($r * 0.30) + ($g * 0.59) + ($b * 0.11));
 	}
 
 
-	static function GrayscalePixel($OriginalPixel) {
-		$gray = phpthumb_functions::GrayscaleValue($OriginalPixel['red'], $OriginalPixel['green'], $OriginalPixel['blue']);
+	public static function GrayscalePixel($OriginalPixel) {
+		$gray = self::GrayscaleValue($OriginalPixel[ 'red'], $OriginalPixel[ 'green'], $OriginalPixel[ 'blue']);
 		return array('red'=>$gray, 'green'=>$gray, 'blue'=>$gray);
 	}
 
 
-	static function GrayscalePixelRGB($rgb) {
+	public static function GrayscalePixelRGB($rgb) {
 		$r = ($rgb >> 16) & 0xFF;
 		$g = ($rgb >>  8) & 0xFF;
 		$b =  $rgb        & 0xFF;
@@ -292,9 +292,9 @@ class phpthumb_functions {
 	}
 
 
-	static function ScaleToFitInBox($width, $height, $maxwidth=null, $maxheight=null, $allow_enlarge=true, $allow_reduce=true) {
-		$maxwidth  = (is_null($maxwidth)  ? $width  : $maxwidth);
-		$maxheight = (is_null($maxheight) ? $height : $maxheight);
+	public static function ScaleToFitInBox($width, $height, $maxwidth=null, $maxheight=null, $allow_enlarge=true, $allow_reduce=true) {
+		$maxwidth  = (null === $maxwidth  ? $width  : $maxwidth);
+		$maxheight = (null === $maxheight ? $height : $maxheight);
 		$scale_x = 1;
 		$scale_y = 1;
 		if (($width > $maxwidth) || ($width < $maxwidth)) {
@@ -313,7 +313,7 @@ class phpthumb_functions {
 		return $scale;
 	}
 
-	static function ImageCopyResampleBicubic($dst_img, $src_img, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {
+	public static function ImageCopyResampleBicubic($dst_img, $src_img, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {
 		// ron at korving dot demon dot nl
 		// http://www.php.net/imagecopyresampled
 
@@ -365,9 +365,9 @@ class phpthumb_functions {
 	}
 
 
-	static function ImageCreateFunction($x_size, $y_size) {
+	public static function ImageCreateFunction($x_size, $y_size) {
 		$ImageCreateFunction = 'imagecreate';
-		if (phpthumb_functions::gd_version() >= 2.0) {
+		if (self::gd_version() >= 2.0) {
 			$ImageCreateFunction = 'imagecreatetruecolor';
 		}
 		if (!function_exists($ImageCreateFunction)) {
@@ -380,16 +380,16 @@ class phpthumb_functions {
 	}
 
 
-	static function ImageCopyRespectAlpha(&$dst_im, &$src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $opacity_pct=100) {
+	public static function ImageCopyRespectAlpha(&$dst_im, &$src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $opacity_pct=100) {
 		$opacipct = $opacity_pct / 100;
 		for ($x = $src_x; $x < $src_w; $x++) {
 			for ($y = $src_y; $y < $src_h; $y++) {
-				$RealPixel    = phpthumb_functions::GetPixelColor($dst_im, $dst_x + $x, $dst_y + $y);
-				$OverlayPixel = phpthumb_functions::GetPixelColor($src_im, $x, $y);
+				$RealPixel    = self::GetPixelColor($dst_im, $dst_x + $x, $dst_y + $y);
+				$OverlayPixel = self::GetPixelColor($src_im, $x, $y);
 				$alphapct = $OverlayPixel['alpha'] / 127;
 				$overlaypct = (1 - $alphapct) * $opacipct;
 
-				$newcolor = phpthumb_functions::ImageColorAllocateAlphaSafe(
+				$newcolor = self::ImageColorAllocateAlphaSafe(
 					$dst_im,
 					round($RealPixel['red']   * (1 - $overlaypct)) + ($OverlayPixel['red']   * $overlaypct),
 					round($RealPixel['green'] * (1 - $overlaypct)) + ($OverlayPixel['green'] * $overlaypct),
@@ -404,7 +404,7 @@ class phpthumb_functions {
 	}
 
 
-	static function ProportionalResize($old_width, $old_height, $new_width=false, $new_height=false) {
+	public static function ProportionalResize($old_width, $old_height, $new_width=false, $new_height=false) {
 		$old_aspect_ratio = $old_width / $old_height;
 		if (($new_width === false) && ($new_height === false)) {
 			return false;
@@ -423,13 +423,16 @@ class phpthumb_functions {
 			// limited by height
 			$new_width = $new_height * $old_aspect_ratio;
 		}
-		return array(intval(round($new_width)), intval(round($new_height)));
+		return array(
+			(int) round($new_width),
+			(int) round($new_height)
+		);
 	}
 
 
-	static function FunctionIsDisabled($function) {
+	public static function FunctionIsDisabled($function) {
 		static $DisabledFunctions = null;
-		if (is_null($DisabledFunctions)) {
+		if (null === $DisabledFunctions) {
 			$disable_functions_local  = explode(',',     strtolower(@ini_get('disable_functions')));
 			$disable_functions_global = explode(',', strtolower(@get_cfg_var('disable_functions')));
 			foreach ($disable_functions_local as $key => $value) {
@@ -447,12 +450,12 @@ class phpthumb_functions {
 	}
 
 
-	static function SafeExec($command) {
+	public static function SafeExec($command) {
 		static $AllowedExecFunctions = array();
 		if (empty($AllowedExecFunctions)) {
 			$AllowedExecFunctions = array('shell_exec'=>true, 'passthru'=>true, 'system'=>true, 'exec'=>true);
 			foreach ($AllowedExecFunctions as $key => $value) {
-				$AllowedExecFunctions[$key] = !phpthumb_functions::FunctionIsDisabled($key);
+				$AllowedExecFunctions[$key] = !self::FunctionIsDisabled($key);
 			}
 		}
 		$command .= ' 2>&1'; // force redirect stderr to stdout
@@ -488,9 +491,9 @@ class phpthumb_functions {
 	}
 
 
-	static function ApacheLookupURIarray($filename) {
+	public static function ApacheLookupURIarray($filename) {
 		// apache_lookup_uri() only works when PHP is installed as an Apache module.
-		if (php_sapi_name() == 'apache') {
+		if (PHP_SAPI == 'apache') {
 			//$property_exists_exists = function_exists('property_exists');
 			$keys = array('status', 'the_request', 'status_line', 'method', 'content_type', 'handler', 'uri', 'filename', 'path_info', 'args', 'boundary', 'no_cache', 'no_local_copy', 'allowed', 'send_bodyct', 'bytes_sent', 'byterange', 'clength', 'unparsed_uri', 'mtime', 'request_time');
 			if ($apacheLookupURIobject = @apache_lookup_uri($filename)) {
@@ -505,9 +508,9 @@ class phpthumb_functions {
 	}
 
 
-	static function gd_is_bundled() {
+	public static function gd_is_bundled() {
 		static $isbundled = null;
-		if (is_null($isbundled)) {
+		if (null === $isbundled) {
 			$gd_info = gd_info();
 			$isbundled = (strpos($gd_info['GD Version'], 'bundled') !== false);
 		}
@@ -515,7 +518,7 @@ class phpthumb_functions {
 	}
 
 
-	static function gd_version($fullstring=false) {
+	public static function gd_version($fullstring=false) {
 		static $cache_gd_version = array();
 		if (empty($cache_gd_version)) {
 			$gd_info = gd_info();
@@ -527,22 +530,22 @@ class phpthumb_functions {
 				$cache_gd_version[0] = (float) substr($gd_info['GD Version'], 0, 3); // e.g. "1.6" (not "1.6.2 or higher")
 			}
 		}
-		return $cache_gd_version[intval($fullstring)];
+		return $cache_gd_version[ (int) $fullstring ];
 	}
 
 
-	static function filesize_remote($remotefile, $timeout=10) {
+	public static function filesize_remote($remotefile, $timeout=10) {
 		$size = false;
-		$url = phpthumb_functions::ParseURLbetter($remotefile);
-		if ($fp = @fsockopen($url['host'], ($url['port'] ? $url['port'] : 80), $errno, $errstr, $timeout)) {
-			fwrite($fp, 'HEAD '.@$url['path'].@$url['query'].' HTTP/1.0'."\r\n".'Host: '.@$url['host']."\r\n\r\n");
-			if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.0', '>=')) {
+		$parsed_url = self::ParseURLbetter($remotefile);
+		if ($fp = @fsockopen($parsed_url['host'], $parsed_url['port'], $errno, $errstr, $timeout)) {
+			fwrite($fp, 'HEAD '.$parsed_url['path'].$parsed_url['query'].' HTTP/1.0'."\r\n".'Host: '.$parsed_url['host']."\r\n\r\n");
+			if (self::version_compare_replacement(PHP_VERSION, '4.3.0', '>=')) {
 				stream_set_timeout($fp, $timeout);
 			}
 			while (!feof($fp)) {
 				$headerline = fgets($fp, 4096);
 				if (preg_match('#^Content-Length: (.*)#i', $headerline, $matches)) {
-					$size = intval($matches[1]);
+					$size = (int) $matches[ 1];
 					break;
 				}
 			}
@@ -552,12 +555,12 @@ class phpthumb_functions {
 	}
 
 
-	static function filedate_remote($remotefile, $timeout=10) {
+	public static function filedate_remote($remotefile, $timeout=10) {
 		$date = false;
-		$url = phpthumb_functions::ParseURLbetter($remotefile);
-		if ($fp = @fsockopen($url['host'], ($url['port'] ? $url['port'] : 80), $errno, $errstr, $timeout)) {
-			fwrite($fp, 'HEAD '.@$url['path'].@$url['query'].' HTTP/1.0'."\r\n".'Host: '.@$url['host']."\r\n\r\n");
-			if (phpthumb_functions::version_compare_replacement(phpversion(), '4.3.0', '>=')) {
+		$parsed_url = self::ParseURLbetter($remotefile);
+		if ($fp = @fsockopen($parsed_url['host'], $parsed_url['port'], $errno, $errstr, $timeout)) {
+			fwrite($fp, 'HEAD '.$parsed_url['path'].$parsed_url['query'].' HTTP/1.0'."\r\n".'Host: '.$parsed_url['host']."\r\n\r\n");
+			if (self::version_compare_replacement(PHP_VERSION, '4.3.0', '>=')) {
 				stream_set_timeout($fp, $timeout);
 			}
 			while (!feof($fp)) {
@@ -573,7 +576,7 @@ class phpthumb_functions {
 	}
 
 
-	static function md5_file_safe($filename) {
+	public static function md5_file_safe($filename) {
 		// md5_file() doesn't exist in PHP < 4.2.0
 		if (function_exists('md5_file')) {
 			return md5_file($filename);
@@ -591,7 +594,7 @@ class phpthumb_functions {
 	}
 
 
-	static function nonempty_min() {
+	public static function nonempty_min() {
 		$arg_list = func_get_args();
 		$acceptable = array();
 		foreach ($arg_list as $arg) {
@@ -603,16 +606,16 @@ class phpthumb_functions {
 	}
 
 
-	static function LittleEndian2String($number, $minbytes=1) {
+	public static function LittleEndian2String($number, $minbytes=1) {
 		$intstring = '';
 		while ($number > 0) {
-			$intstring = $intstring.chr($number & 255);
-			$number >>= 8;
+			$intstring .= chr($number & 255);
+			$number    >>= 8;
 		}
 		return str_pad($intstring, $minbytes, "\x00", STR_PAD_RIGHT);
 	}
 
-	static function OneOfThese() {
+	public static function OneOfThese() {
 		// return the first useful (non-empty/non-zero/non-false) value from those passed
 		$arg_list = func_get_args();
 		foreach ($arg_list as $key => $value) {
@@ -623,7 +626,7 @@ class phpthumb_functions {
 		return false;
 	}
 
-	static function CaseInsensitiveInArray($needle, $haystack) {
+	public static function CaseInsensitiveInArray($needle, $haystack) {
 		$needle = strtolower($needle);
 		foreach ($haystack as $key => $value) {
 			if (is_array($value)) {
@@ -635,11 +638,12 @@ class phpthumb_functions {
 		return false;
 	}
 
-	static function URLreadFsock($host, $file, &$errstr, $successonly=true, $port=80, $timeout=10) {
-		if (!function_exists('fsockopen') || phpthumb_functions::FunctionIsDisabled('fsockopen')) {
-			$errstr = 'fsockopen() unavailable';
+	public static function URLreadFsock($host, $file, &$errstr, $successonly=true, $port=-1, $timeout=10) {
+		if (!function_exists('fsockopen') || self::FunctionIsDisabled('fsockopen')) {
+			$errstr = 'URLreadFsock says: function fsockopen() unavailable';
 			return false;
 		}
+		$port = (int) ($port ? $port : -1); // passing anything as the $port parameter (even empty values like null, false, 0, "") will override the default -1. fsockopen uses -1 as the default port value.
 		//if ($fp = @fsockopen($host, $port, $errno, $errstr, $timeout)) {
 		if ($fp = @fsockopen((($port == 443) ? 'ssl://' : '').$host, $port, $errno, $errstr, $timeout)) { // https://github.com/JamesHeinrich/phpThumb/issues/39
 			$out  = 'GET '.$file.' HTTP/1.0'."\r\n";
@@ -648,19 +652,19 @@ class phpthumb_functions {
 			fwrite($fp, $out);
 
 			$isHeader = true;
-			$Data_header = '';
-			$Data_body   = '';
+			$data_header = '';
+			$data_body   = '';
 			$header_newlocation = '';
 			while (!feof($fp)) {
 				$line = fgets($fp, 1024);
 				if ($isHeader) {
-					$Data_header .= $line;
+					$data_header .= $line;
 				} else {
-					$Data_body .= $line;
+					$data_body .= $line;
 				}
 				if (preg_match('#^HTTP/[\\.0-9]+ ([0-9]+) (.+)$#i', rtrim($line), $matches)) {
 					list( , $errno, $errstr) = $matches;
-					$errno = intval($errno);
+					$errno = (int) $errno;
 				} elseif (preg_match('#^Location: (.*)$#i', rtrim($line), $matches)) {
 					$header_newlocation = $matches[1];
 				}
@@ -682,17 +686,17 @@ class phpthumb_functions {
 				}
 			}
 			fclose($fp);
-			return $Data_body;
+			return $data_body;
 		}
 		return null;
 	}
 
-	static function CleanUpURLencoding($url, $queryseperator='&') {
+	public static function CleanUpURLencoding($url, $queryseperator='&') {
 		if (!preg_match('#^http#i', $url)) {
 			return $url;
 		}
-		$parse_url = phpthumb_functions::ParseURLbetter($url);
-		$pathelements = explode('/', $parse_url['path']);
+		$parsed_url = self::ParseURLbetter($url);
+		$pathelements = explode('/', $parsed_url['path']);
 		$CleanPathElements = array();
 		$TranslationMatrix = array(' '=>'%20');
 		foreach ($pathelements as $key => $pathelement) {
@@ -704,7 +708,7 @@ class phpthumb_functions {
 			}
 		}
 
-		$queries = explode($queryseperator, (isset($parse_url['query']) ? $parse_url['query'] : ''));
+		$queries = explode($queryseperator, $parsed_url['query']);
 		$CleanQueries = array();
 		foreach ($queries as $key => $query) {
 			@list($param, $value) = explode('=', $query);
@@ -716,44 +720,46 @@ class phpthumb_functions {
 			}
 		}
 
-		$cleaned_url  = $parse_url['scheme'].'://';
-		$cleaned_url .= (@$parse_url['username'] ? $parse_url['host'].(@$parse_url['password'] ? ':'.$parse_url['password'] : '').'@' : '');
-		$cleaned_url .= $parse_url['host'];
-		$cleaned_url .= ((!empty($parse_url['port']) && ($parse_url['port'] != 80)) ? ':'.$parse_url['port'] : '');
+		$cleaned_url  = $parsed_url['scheme'].'://';
+		$cleaned_url .= ($parsed_url['username'] ? $parsed_url['username'].($parsed_url['password'] ? ':'.$parsed_url['password'] : '').'@' : '');
+		$cleaned_url .= $parsed_url['host'];
+		$cleaned_url .= (($parsed_url['port'] && ($parsed_url['port'] != URLschemeDefaultPort($parsed_url['scheme']))) ? ':'.$parsed_url['port'] : '');
 		$cleaned_url .= '/'.implode('/', $CleanPathElements);
-		$cleaned_url .= (@$CleanQueries ? '?'.implode($queryseperator, $CleanQueries) : '');
+		$cleaned_url .= (!empty($CleanQueries) ? '?'.implode($queryseperator, $CleanQueries) : '');
 		return $cleaned_url;
 	}
 
-	static function ParseURLbetter($url) {
+	public static function URLschemeDefaultPort($scheme) {
+		static $schemePort = array(
+			'ftp'   => 21,
+			'http'  => 80,
+			'https' => 443,
+		);
+		return (isset($schemePort[strtolower($scheme)]) ? $schemePort[strtolower($scheme)] : null);
+	}
+
+	public static function ParseURLbetter($url) {
 		$parsedURL = @parse_url($url);
-		if (!@$parsedURL['port']) {
-			switch (strtolower(@$parsedURL['scheme'])) {
-				case 'ftp':
-					$parsedURL['port'] = 21;
-					break;
-				case 'https':
-					$parsedURL['port'] = 443;
-					break;
-				case 'http':
-					$parsedURL['port'] = 80;
-					break;
+		foreach (array('scheme', 'host', 'port', 'user', 'pass', 'path', 'query', 'fragment') as $key) { // ensure all possible array keys are always returned
+			if (!array_key_exists($key, $parsedURL)) {
+				$parsedURL[$key] = null;
 			}
 		}
+		$parsedURL['port'] = ($parsedURL['port'] ? $parsedURL['port'] : URLschemeDefaultPort($scheme));
 		return $parsedURL;
 	}
 
-	static function SafeURLread($url, &$error, $timeout=10, $followredirects=true) {
+	public static function SafeURLread($url, &$error, $timeout=10, $followredirects=true) {
 		$error   = '';
 		$errstr  = '';
 		$rawData = '';
 
-		$parsed_url = phpthumb_functions::ParseURLbetter($url);
+		$parsed_url = self::ParseURLbetter($url);
 		$alreadyLookedAtURLs[trim($url)] = true;
 
 		while (true) {
 			$tryagain = false;
-			$rawData = phpthumb_functions::URLreadFsock(@$parsed_url['host'], @$parsed_url['path'].'?'.@$parsed_url['query'], $errstr, true, (@$parsed_url['port'] ? @$parsed_url['port'] : 80), $timeout);
+			$rawData = self::URLreadFsock($parsed_url['host'], $parsed_url['path'].'?'.$parsed_url['query'], $errstr, true, $parsed_url['port'], $timeout);
 			if ($followredirects && preg_match('#302 [a-z ]+; Location\\: (http.*)#i', $errstr, $matches)) {
 				$matches[1] = trim(@$matches[1]);
 				if (!@$alreadyLookedAtURLs[$matches[1]]) {
@@ -762,7 +768,7 @@ class phpthumb_functions {
 
 					$tryagain = true;
 					$alreadyLookedAtURLs[$matches[1]] = true;
-					$parsed_url = phpthumb_functions::ParseURLbetter($matches[1]);
+					$parsed_url = self::ParseURLbetter($matches[ 1]);
 				}
 			}
 			if (!$tryagain) {
@@ -780,7 +786,7 @@ class phpthumb_functions {
 			return $rawData;
 		}
 
-		if (function_exists('curl_version') && !phpthumb_functions::FunctionIsDisabled('curl_exec')) {
+		if (function_exists('curl_version') && !self::FunctionIsDisabled('curl_exec')) {
 			$ch = curl_init();
 			curl_setopt($ch, CURLOPT_URL, $url);
 			curl_setopt($ch, CURLOPT_HEADER, false);
@@ -802,8 +808,8 @@ class phpthumb_functions {
 		}
 
 		$BrokenURLfopenPHPversions = array('4.4.2');
-		if (in_array(phpversion(), $BrokenURLfopenPHPversions)) {
-			$error .= 'fopen(URL) broken in PHP v'.phpversion().'; ';
+		if (in_array(PHP_VERSION, $BrokenURLfopenPHPversions)) {
+			$error .= 'fopen(URL) broken in PHP v'. PHP_VERSION .'; ';
 		} elseif (@ini_get('allow_url_fopen')) {
 			$rawData = '';
 			$error_fopen = '';
@@ -831,13 +837,13 @@ class phpthumb_functions {
 		return false;
 	}
 
-	static function EnsureDirectoryExists($dirname, $mask = 0755) {
+	public static function EnsureDirectoryExists($dirname, $mask = 0755) {
 		$directory_elements = explode(DIRECTORY_SEPARATOR, $dirname);
 		$startoffset = (!$directory_elements[0] ? 2 : 1);  // unix with leading "/" then start with 2nd element; Windows with leading "c:\" then start with 1st element
 		$open_basedirs = preg_split('#[;:]#', ini_get('open_basedir'));
 		foreach ($open_basedirs as $key => $open_basedir) {
 			if (preg_match('#^'.preg_quote($open_basedir).'#', $dirname) && (strlen($dirname) > strlen($open_basedir))) {
-				$startoffset = count(explode(DIRECTORY_SEPARATOR, $open_basedir));
+				$startoffset = substr_count($open_basedir, DIRECTORY_SEPARATOR) + 1;
 				break;
 			}
 		}
@@ -855,7 +861,7 @@ class phpthumb_functions {
 				}
 				@mkdir($test_directory, $mask);
 				@chmod($test_directory, $mask);
-				if (!@is_dir($test_directory) || !@is_writeable($test_directory)) {
+				if (!@is_dir($test_directory) || !@is_writable($test_directory)) {
 					return false;
 				}
 			}
@@ -864,7 +870,7 @@ class phpthumb_functions {
 	}
 
 
-	static function GetAllFilesInSubfolders($dirname) {
+	public static function GetAllFilesInSubfolders($dirname) {
 		$AllFiles = array();
 		$dirname = rtrim(realpath($dirname), '/\\');
 		if ($dirhandle = @opendir($dirname)) {
@@ -880,7 +886,7 @@ class phpthumb_functions {
 
 						default:
 							$AllFiles[] = $fullfilename;
-							$subfiles = phpthumb_functions::GetAllFilesInSubfolders($fullfilename);
+							$subfiles = self::GetAllFilesInSubfolders($fullfilename);
 							foreach ($subfiles as $filename) {
 								$AllFiles[] = $filename;
 							}
@@ -897,15 +903,15 @@ class phpthumb_functions {
 	}
 
 
-	static function SanitizeFilename($filename) {
+	public static function SanitizeFilename($filename) {
 		$filename = preg_replace('/[^'.preg_quote(' !#$%^()+,-.;<>=@[]_{}').'a-zA-Z0-9]/', '_', $filename);
-		if (phpthumb_functions::version_compare_replacement(phpversion(), '4.1.0', '>=')) {
+		if (self::version_compare_replacement(PHP_VERSION, '4.1.0', '>=')) {
 			$filename = trim($filename, '.');
 		}
 		return $filename;
 	}
 
-	static function PasswordStrength($password) {
+	public static function PasswordStrength($password) {
 		$strength = 0;
 		$strength += strlen(preg_replace('#[^a-z]#',       '', $password)) * 0.5; // lowercase characters are weak
 		$strength += strlen(preg_replace('#[^A-Z]#',       '', $password)) * 0.8; // uppercase characters are somewhat better
@@ -1008,7 +1014,7 @@ if (!function_exists('preg_quote')) {
 		static $preg_quote_array = array();
 		if (empty($preg_quote_array)) {
 			$escapeables = '.\\+*?[^]$(){}=!<>|:';
-			for ($i = 0; $i < strlen($escapeables); $i++) {
+			for ($i = 0, $iMax = strlen($escapeables); $i < $iMax; $i++) {
 				$strtr_preg_quote[$escapeables{$i}] = $delimiter.$escapeables{$i};
 			}
 		}

--- a/core/model/phpthumb/phpthumb.gif.php
+++ b/core/model/phpthumb/phpthumb.gif.php
@@ -163,14 +163,14 @@ function gif_getSize($gif, &$width, &$height)
 
 class CGIFLZW
 {
-	var $MAX_LZW_BITS;
-	var $Fresh, $CodeSize, $SetCodeSize, $MaxCode, $MaxCodeSize, $FirstCode, $OldCode;
-	var $ClearCode, $EndCode, $Next, $Vals, $Stack, $sp, $Buf, $CurBit, $LastBit, $Done, $LastByte;
+	public $MAX_LZW_BITS;
+	public $Fresh, $CodeSize, $SetCodeSize, $MaxCode, $MaxCodeSize, $FirstCode, $OldCode;
+	public $ClearCode, $EndCode, $Next, $Vals, $Stack, $sp, $Buf, $CurBit, $LastBit, $Done, $LastByte;
 
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function __construct()
+	public function __construct()
 	{
 		$this->MAX_LZW_BITS = 12;
 		unSet($this->Next);
@@ -186,7 +186,7 @@ class CGIFLZW
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function deCompress($data, &$datLen)
+	public function deCompress($data, &$datLen)
 	{
 		$stLen  = strlen($data);
 		$datLen = 0;
@@ -210,7 +210,7 @@ class CGIFLZW
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function LZWCommand(&$data, $bInit)
+	public function LZWCommand(&$data, $bInit)
 	{
 		if ($bInit) {
 			$this->SetCodeSize = ord($data{0});
@@ -325,7 +325,7 @@ class CGIFLZW
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function GetCode(&$data, $bInit)
+	public function GetCode(&$data, $bInit)
 	{
 		if ($bInit) {
 			$this->CurBit   = 0;
@@ -366,7 +366,7 @@ class CGIFLZW
 
 		$iRet = 0;
 		for ($i = $this->CurBit, $j = 0; $j < $this->CodeSize; $i++, $j++) {
-			$iRet |= (($this->Buf[intval($i / 8)] & (1 << ($i % 8))) != 0) << $j;
+			$iRet |= (($this->Buf[ (int) ($i / 8) ] & (1 << ($i % 8))) != 0) << $j;
 		}
 
 		$this->CurBit += $this->CodeSize;
@@ -378,13 +378,13 @@ class CGIFLZW
 
 class CGIFCOLORTABLE
 {
-	var $m_nColors;
-	var $m_arColors;
+	public $m_nColors;
+	public $m_arColors;
 
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function __construct()
+	public function __construct()
 	{
 		unSet($this->m_nColors);
 		unSet($this->m_arColors);
@@ -392,7 +392,7 @@ class CGIFCOLORTABLE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function load($lpData, $num)
+	public function load($lpData, $num)
 	{
 		$this->m_nColors  = 0;
 		$this->m_arColors = array();
@@ -412,7 +412,7 @@ class CGIFCOLORTABLE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function toString()
+	public function toString()
 	{
 		$ret = '';
 
@@ -428,7 +428,7 @@ class CGIFCOLORTABLE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function toRGBQuad()
+	public function toRGBQuad()
 	{
 		$ret = '';
 
@@ -445,9 +445,9 @@ class CGIFCOLORTABLE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function colorIndex($rgb)
+	public function colorIndex($rgb)
 	{
-		$rgb = intval($rgb) & 0xFFFFFF;
+		$rgb = (int) $rgb & 0xFFFFFF;
 		$r1  = ($rgb & 0x0000FF);
 		$g1  = ($rgb & 0x00FF00) >>  8;
 		$b1  = ($rgb & 0xFF0000) >> 16;
@@ -474,21 +474,21 @@ class CGIFCOLORTABLE
 
 class CGIFFILEHEADER
 {
-	var $m_lpVer;
-	var $m_nWidth;
-	var $m_nHeight;
-	var $m_bGlobalClr;
-	var $m_nColorRes;
-	var $m_bSorted;
-	var $m_nTableSize;
-	var $m_nBgColor;
-	var $m_nPixelRatio;
-	var $m_colorTable;
+	public $m_lpVer;
+	public $m_nWidth;
+	public $m_nHeight;
+	public $m_bGlobalClr;
+	public $m_nColorRes;
+	public $m_bSorted;
+	public $m_nTableSize;
+	public $m_nBgColor;
+	public $m_nPixelRatio;
+	public $m_colorTable;
 
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function __construct()
+	public function __construct()
 	{
 		unSet($this->m_lpVer);
 		unSet($this->m_nWidth);
@@ -504,7 +504,7 @@ class CGIFFILEHEADER
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function load($lpData, &$hdrLen)
+	public function load($lpData, &$hdrLen)
 	{
 		$hdrLen = 0;
 
@@ -519,13 +519,13 @@ class CGIFFILEHEADER
 			return false;
 		}
 
-		$b = ord(substr($lpData, 10, 1));
+		$b = ord($lpData[ 10 ]);
 		$this->m_bGlobalClr  = ($b & 0x80) ? true : false;
 		$this->m_nColorRes   = ($b & 0x70) >> 4;
 		$this->m_bSorted     = ($b & 0x08) ? true : false;
 		$this->m_nTableSize  = 2 << ($b & 0x07);
-		$this->m_nBgColor    = ord(substr($lpData, 11, 1));
-		$this->m_nPixelRatio = ord(substr($lpData, 12, 1));
+		$this->m_nBgColor    = ord($lpData[ 11 ]);
+		$this->m_nPixelRatio = ord($lpData[ 12 ]);
 		$hdrLen = 13;
 
 		if ($this->m_bGlobalClr) {
@@ -541,9 +541,9 @@ class CGIFFILEHEADER
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function w2i($str)
+	public function w2i($str)
 	{
-		return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+		return ord($str[ 0 ]) + (ord($str[ 1 ]) << 8);
 	}
 }
 
@@ -551,20 +551,20 @@ class CGIFFILEHEADER
 
 class CGIFIMAGEHEADER
 {
-	var $m_nLeft;
-	var $m_nTop;
-	var $m_nWidth;
-	var $m_nHeight;
-	var $m_bLocalClr;
-	var $m_bInterlace;
-	var $m_bSorted;
-	var $m_nTableSize;
-	var $m_colorTable;
+	public $m_nLeft;
+	public $m_nTop;
+	public $m_nWidth;
+	public $m_nHeight;
+	public $m_bLocalClr;
+	public $m_bInterlace;
+	public $m_bSorted;
+	public $m_nTableSize;
+	public $m_colorTable;
 
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function __construct()
+	public function __construct()
 	{
 		unSet($this->m_nLeft);
 		unSet($this->m_nTop);
@@ -579,7 +579,7 @@ class CGIFIMAGEHEADER
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function load($lpData, &$hdrLen)
+	public function load($lpData, &$hdrLen)
 	{
 		$hdrLen = 0;
 
@@ -612,9 +612,9 @@ class CGIFIMAGEHEADER
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function w2i($str)
+	public function w2i($str)
 	{
-		return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+		return ord($str[ 0 ]) + (ord($str[ 1 ]) << 8);
 	}
 }
 
@@ -622,19 +622,19 @@ class CGIFIMAGEHEADER
 
 class CGIFIMAGE
 {
-	var $m_disp;
-	var $m_bUser;
-	var $m_bTrans;
-	var $m_nDelay;
-	var $m_nTrans;
-	var $m_lpComm;
-	var $m_gih;
-	var $m_data;
-	var $m_lzw;
+	public $m_disp;
+	public $m_bUser;
+	public $m_bTrans;
+	public $m_nDelay;
+	public $m_nTrans;
+	public $m_lpComm;
+	public $m_gih;
+	public $m_data;
+	public $m_lzw;
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function __construct()
+	public function __construct()
 	{
 		unSet($this->m_disp);
 		unSet($this->m_bUser);
@@ -649,7 +649,7 @@ class CGIFIMAGE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function load($data, &$datLen)
+	public function load($data, &$datLen)
 	{
 		$datLen = 0;
 
@@ -696,7 +696,7 @@ class CGIFIMAGE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function skipExt(&$data, &$extLen)
+	public function skipExt(&$data, &$extLen)
 	{
 		$extLen = 0;
 
@@ -741,14 +741,14 @@ class CGIFIMAGE
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function w2i($str)
+	public function w2i($str)
 	{
-		return ord(substr($str, 0, 1)) + (ord(substr($str, 1, 1)) << 8);
+		return ord($str[ 0 ]) + (ord($str[ 1 ]) << 8);
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function deInterlace()
+	public function deInterlace()
 	{
 		$data = $this->m_data;
 		$s = 0;
@@ -796,15 +796,15 @@ class CGIFIMAGE
 
 class CGIF
 {
-	var $m_gfh;
-	var $m_lpData;
-	var $m_img;
-	var $m_bLoaded;
+	public $m_gfh;
+	public $m_lpData;
+	public $m_img;
+	public $m_bLoaded;
 
 	///////////////////////////////////////////////////////////////////////////
 
 	// CONSTRUCTOR
-	function __construct()
+	public function __construct()
 	{
 		$this->m_gfh     = new CGIFFILEHEADER();
 		$this->m_img     = new CGIFIMAGE();
@@ -814,7 +814,7 @@ class CGIF
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function loadFile($lpszFileName, $iIndex)
+	public function loadFile($lpszFileName, $iIndex)
 	{
 		if ($iIndex < 0) {
 			return false;
@@ -847,7 +847,7 @@ class CGIF
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function getSize($lpszFileName, &$width, &$height)
+	public function getSize($lpszFileName, &$width, &$height)
 	{
 		if (!($fh = @fopen($lpszFileName, 'rb'))) {
 			return false;
@@ -867,7 +867,7 @@ class CGIF
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function getBmp($bgColor)
+	public function getBmp($bgColor)
 	{
 		$out = '';
 
@@ -967,7 +967,7 @@ class CGIF
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function getPng($bgColor)
+	public function getPng($bgColor)
 	{
 		$out = '';
 
@@ -1072,7 +1072,7 @@ class CGIF
 
 	// Takes raw image data and plots it pixel-by-pixel on a new GD image and returns that
 	// It's extremely slow, but the only solution when imagecreatefromstring() fails
-	function getGD_PixelPlotterVersion()
+	public function getGD_PixelPlotterVersion()
 	{
 		if (!$this->m_bLoaded) {
 			return false;
@@ -1131,44 +1131,44 @@ class CGIF
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function dword($val)
+	public function dword($val)
 	{
-		$val = intval($val);
+		$val = (int) $val;
 		return chr($val & 0xFF).chr(($val & 0xFF00) >> 8).chr(($val & 0xFF0000) >> 16).chr(($val & 0xFF000000) >> 24);
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function ndword($val)
+	public function ndword($val)
 	{
-		$val = intval($val);
+		$val = (int) $val;
 		return chr(($val & 0xFF000000) >> 24).chr(($val & 0xFF0000) >> 16).chr(($val & 0xFF00) >> 8).chr($val & 0xFF);
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function width()
+	public function width()
 	{
 		return $this->m_gfh->m_nWidth;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function height()
+	public function height()
 	{
 		return $this->m_gfh->m_nHeight;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function comment()
+	public function comment()
 	{
 		return $this->m_img->m_lpComm;
 	}
 
 	///////////////////////////////////////////////////////////////////////////
 
-	function loaded()
+	public function loaded()
 	{
 		return $this->m_bLoaded;
 	}

--- a/core/model/phpthumb/phpthumb.ico.php
+++ b/core/model/phpthumb/phpthumb.ico.php
@@ -12,7 +12,7 @@
 
 class phpthumb_ico {
 
-	function GD2ICOstring(&$gd_image_array) {
+	public function GD2ICOstring(&$gd_image_array) {
 		$ImageWidths  = array();
 		$ImageHeights = array();
 		$bpp          = array();
@@ -55,7 +55,7 @@ class phpthumb_ico {
 			}
 			$icAND[$key] = '';
 			foreach ($icANDmask[$key] as $y => $scanlinemaskbits) {
-				for ($i = 0; $i < strlen($scanlinemaskbits); $i += 8) {
+				for ($i = 0, $iMax = strlen($scanlinemaskbits); $i < $iMax; $i += 8) {
 					$icAND[$key] .= chr(bindec(str_pad(substr($scanlinemaskbits, $i, 8), 8, '0', STR_PAD_LEFT)));
 				}
 			}

--- a/core/model/phpthumb/phpthumb.unsharp.php
+++ b/core/model/phpthumb/phpthumb.unsharp.php
@@ -37,13 +37,13 @@ difference in colour values that is allowed between the original and the mask. I
 this means that low-contrast areas of the picture are left unrendered whereas edges
 are treated normally. This is good for pictures of e.g. skin or blue skies.
 
-Any suggenstions for improvement of the algorithm, expecially regarding the speed
+Any suggenstions for improvement of the algorithm, especially regarding the speed
 and the roundoff errors in the Gaussian blur process, are welcome.
 */
 
 class phpUnsharpMask {
 
-	static function applyUnsharpMask(&$img, $amount, $radius, $threshold) {
+	public static function applyUnsharpMask(&$img, $amount, $radius, $threshold) {
 
 		// $img is an image that is already created within php using
 		// imgcreatetruecolor. No url! $img must be a truecolor image.


### PR DESCRIPTION
### What does it do?
Update phpThumb to 1.7.15-201806071234

### Why is it needed?
Fix some issues (i.e. transparency in PNG files). See: phpThumb#65

All the patches on that class should be compatible to PHP 5.3.3+ (checked by PhpStorm)

### Related issue(s)/PR(s)
None known.
