### PR TITLE
Require minimal PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,8 @@
     "prefer-stable": true,
     "require-dev": {
         "phpunit/phpunit": "~5.7|~6.5"
+    },
+    "require": {
+        "php": ">=5.3.3"
     }
 }


### PR DESCRIPTION
### What does it do?
Set the minimal PHP version in composer.json

### Why is it needed?
PHPStorm uses this information to set the automatic code check

### Related issue(s)/PR(s)
None known
