### PR TITLE
Fixed error log line wrapping problem in Firefox.

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -34,7 +34,7 @@ MODx.panel.ErrorLog = function(config) {
                     ,grow: true
                     ,anchor: '100%'
                     ,hidden: config.record.tooLarge ? true : false
-                    ,style: 'white-space: nowrap; overflow: auto;'
+                    ,style: 'overflow: auto;'
                 },{
                     html: '<p>'+_('error_log_too_large',{
                         name: config.record.name

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -34,7 +34,7 @@ MODx.panel.ErrorLog = function(config) {
                     ,grow: true
                     ,anchor: '100%'
                     ,hidden: config.record.tooLarge ? true : false
-                    ,style: 'overflow: auto;'
+                    ,style: 'white-space:pre;overflow: auto;'
                 },{
                     html: '<p>'+_('error_log_too_large',{
                         name: config.record.name


### PR DESCRIPTION
### What does it do?
In latest 3.x when using Firefox, all errors were appearing on a single line.

### Why is it needed?
Each error should have its own line.

### Related issue(s)/PR(s)
This is related to issue #13946

Please check in at least Firefox and Chrome to confirm it's fixed appropriately.
