### PR TITLE
Preventing deleting any file in registry by mistake and filtering paths in topics

### DIFF
--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -108,7 +108,7 @@ if (file_exists($packageDirectory . 'core') && is_dir($packageDirectory . 'core'
     $cacheManager->deleteTree($packageDirectory . 'core',array(
         'deleteTop' => true,
         'skipDirs' => false,
-        'extensions' => '*',
+        'extensions' => array(),
     ));
 }
 if (!file_exists($packageDirectory . 'core') && !file_exists($packageDirectory . 'core.transport.zip')) {

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -632,7 +632,7 @@ class modDirectory extends modFileSystemResource {
         $options = array_merge(array(
             'deleteTop' => true,
             'skipDirs' => false,
-            'extensions' => '',
+            'extensions' => array(),
         ), $options);
 
         $this->fileHandler->modx->getCacheManager();

--- a/core/model/modx/registry/modfileregister.class.php
+++ b/core/model/modx/registry/modfileregister.class.php
@@ -64,7 +64,10 @@ class modFileRegister extends modRegister {
      */
     public function clear($topic)
     {
-        $topicDirectory = $this->directory . ltrim(basename($topic), '/');
+        /** @var modFileHandler $fileHandler */
+        $fileHandler = $this->modx->getService('fileHandler', 'modFileHandler');
+
+        $topicDirectory = $this->directory . ltrim($fileHandler->sanitizePath($topic), '/');
 
         return $this->modx->cacheManager->deleteTree(
             realpath($topicDirectory),

--- a/core/model/modx/registry/modfileregister.class.php
+++ b/core/model/modx/registry/modfileregister.class.php
@@ -27,16 +27,21 @@ class modFileRegister extends modRegister {
     /**
      * Construct a new modFileRegister instance.
      *
-     * {@inheritdoc}
+     * @param modX &$modx A reference to a modX instance.
+     * @param string $key A valid PHP variable which will be set on the modRegistry instance.
+     * @param array $options Optional array of registry options.
      */
-    function __construct(& $modx, $key, $options = array()) {
-        parent :: __construct($modx, $key, $options);
+    function __construct(& $modx, $key, $options = array())
+    {
+        parent::__construct($modx, $key, $options);
+
         $modx->getCacheManager();
         $this->directory = $modx->getCachePath() . 'registry/';
         $this->directory .= isset($options['directory'])
-                ? $options['directory']
-                : $key;
-        if ($this->directory[strlen($this->directory)-1] != '/') $this->directory .= '/';
+            ? $options['directory']
+            : $key;
+
+        $this->directory = rtrim($this->directory, '/') . '/';
     }
 
     /**
@@ -57,12 +62,16 @@ class modFileRegister extends modRegister {
      *
      * {@inheritdoc}
      */
-    public function clear($topic) {
-        $topicDirectory = $this->directory;
-        $topicDirectory.= $topic[0] == '/' ? substr($topic, 1) : $topic ;
-        return $this->modx->cacheManager->deleteTree($topicDirectory, array(
-            'extensions' => '.msg.php'
-        ));
+    public function clear($topic)
+    {
+        $topicDirectory = $this->directory . ltrim(basename($topic), '/');
+
+        return $this->modx->cacheManager->deleteTree(
+            realpath($topicDirectory),
+            array(
+                'extensions' => array('.msg.php')
+            )
+        );
     }
 
     /**

--- a/core/model/modx/registry/modfileregister.class.php
+++ b/core/model/modx/registry/modfileregister.class.php
@@ -64,10 +64,7 @@ class modFileRegister extends modRegister {
      */
     public function clear($topic)
     {
-        /** @var modFileHandler $fileHandler */
-        $fileHandler = $this->modx->getService('fileHandler', 'modFileHandler');
-
-        $topicDirectory = $this->directory . ltrim($fileHandler->sanitizePath($topic), '/');
+        $topicDirectory = $this->directory . ltrim($this->sanitizePath($topic), '/');
 
         return $this->modx->cacheManager->deleteTree(
             realpath($topicDirectory),
@@ -274,5 +271,15 @@ class modFileRegister extends modRegister {
 
     public function close() {
         return true;
+    }
+
+    /**
+     * Sanitize the specified path
+     *
+     * @param string $path The path to clean
+     * @return string The sanitized path
+     */
+    protected function sanitizePath($path) {
+        return preg_replace(array("/\.*[\/|\\\]/i", "/[\/|\\\]+/i"), array('/', '/'), $path);
     }
 }


### PR DESCRIPTION
### What does it do?
It fixes some issues with path traversal in the cache manager and determining file extensions for deleting.

### Why is it needed?
It is a security fix, let's discuss details personally in Slack.

### Related issue(s)/PR(s)
none