### PR TITLE
Fix package update window not working if update button was pressed twice

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -361,6 +361,9 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 
 	/* Search for a package update - only for installed package */
     ,update: function(btn,e) {
+        if (this.windows['modx-window-package-update']) {
+            this.windows['modx-window-package-update'].destroy();
+        }
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
@@ -373,6 +376,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
                         xtype: 'modx-window-package-update'
                         ,packages: r.object
                         ,record: this.menu.record
+                        ,force: true
                         ,listeners: {
                             'success': {fn: function(o) {
                                 this.refresh();

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -373,7 +373,6 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
                         xtype: 'modx-window-package-update'
                         ,packages: r.object
                         ,record: this.menu.record
-                        ,force: true
                         ,listeners: {
                             'success': {fn: function(o) {
                                 this.refresh();


### PR DESCRIPTION
### What does it do?
Don't force the package update window to open to prevent issues when the update button has been clicked multiple times.

### Why is it needed?
It's a fix for issue #13982 

### Related issue(s)/PR(s)
issue #13982 