### PR TITLE
Fix modx.class.php's sendError() always has "503 Error" as the headline

### DIFF
--- a/core/error/unavailable.include.php
+++ b/core/error/unavailable.include.php
@@ -1,5 +1,7 @@
 <?php
-header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
+if (isset($errorHeader) === false) {
+    header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
+}
 ?>
 <html>
 <head>

--- a/core/error/unavailable.include.php
+++ b/core/error/unavailable.include.php
@@ -1,5 +1,5 @@
 <?php
-if (isset($errorHeader) === false) {
+if (!isset($errorHeader)) {
     header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
 }
 ?>

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1073,10 +1073,11 @@ class modX extends xPDO {
         if (!XPDO_CLI_MODE) {
             $errorPageTitle = $this->getOption('error_pagetitle', $options, 'Error 503: Service temporarily unavailable');
             $errorMessage = $this->getOption('error_message', $options, '<p>Site temporarily unavailable.</p>');
+            $errorHeader = $this->getOption('error_header', $options, $_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
             if (file_exists(MODX_CORE_PATH . "error/{$type}.include.php")) {
                 @include(MODX_CORE_PATH . "error/{$type}.include.php");
             }
-            header($this->getOption('error_header', $options, $_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable'));
+            header($errorHeader);
             echo "<html><head><title>{$errorPageTitle}</title></head><body>{$errorMessage}</body></html>";
             @session_write_close();
         } else {


### PR DESCRIPTION
### What does it do?
When the $options['error_header'] value is set for $modx->sendError() the page "core/error/unavailable.include.php" should not override this header.

### Why is it needed?
To fix a 3 year old issue.

### Related issue(s)/PR(s)
Fixes #12379