### PR TITLE
Login forgotten password improvements

### DIFF
--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -259,11 +259,11 @@ class SecurityLoginManagerController extends modManagerController {
                 $this->modx->log(modX::LOG_LEVEL_ERROR,$err);
                 $this->setPlaceholder('error_message',$err);
             } else {
-                $this->setPlaceholder('error_message',$this->modx->lexicon('login_password_reset_act_sent'));
+                $this->setPlaceholder('success_message',$this->modx->lexicon('login_password_reset_act_sent'));
             }
             $this->modx->mail->reset();
         } else {
-            $this->setPlaceholder('error_message',$this->modx->lexicon('login_user_err_nf_email'));
+            $this->setPlaceholder('success_message',$this->modx->lexicon('login_user_err_nf_email'));
         }
     }
 

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -49,9 +49,11 @@
                     <div class="x-panel-body x-panel-body-noheader">
                         <h2>{$_config.site_name|strip_tags|escape}</h2>
                         <br class="clear" />
-{if $error_message|default}
-                        <p class="error">{$error_message}</p>
-{/if}
+                        {if $error_message}
+                            <p class="error">{$error_message|default}</p>
+                        {elseif $success_message}
+                            <p class="success">{$success_message|default}</p>
+                        {/if}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### What does it do?
If a password reset is done for a non-existing user it also shows the success message. 
The style for is-success is also being added.

### Why is it needed?
It's a fix for issue #13976

### Related issue(s)/PR(s)
#13976
