### PR TITLE
Correct display of permissions in access settings for a group of users

### DIFF
--- a/core/model/modx/processors/security/access/usergroup/category/getlist.class.php
+++ b/core/model/modx/processors/security/access/usergroup/category/getlist.class.php
@@ -88,10 +88,11 @@
         $data = $this->modx->fromJSON($data);
         if (!empty($data)) {
             $permissions = array();
-            foreach ($data as $perm => $v) {
-                $permissions[] = $perm;
+            foreach ($data as $permission => $enabled) {
+                if (!$enabled) { continue; }
+                $permissions[] = $permission;
             }
-            $objectArray['permissions'] = implode(', ',$permissions);
+            $objectArray['permissions'] = implode(', ', $permissions);
         }
 
         $cls = '';

--- a/core/model/modx/processors/security/access/usergroup/context/getlist.class.php
+++ b/core/model/modx/processors/security/access/usergroup/context/getlist.class.php
@@ -86,10 +86,11 @@ class modUserGroupAccessContextGetListProcessor extends modObjectGetListProcesso
         $data = $this->modx->fromJSON($data);
         if (!empty($data)) {
             $permissions = array();
-            foreach ($data as $perm => $v) {
-                $permissions[] = $perm;
+            foreach ($data as $permission => $enabled) {
+                if (!$enabled) { continue; }
+                $permissions[] = $permission;
             }
-            $objectArray['permissions'] = implode(', ',$permissions);
+            $objectArray['permissions'] = implode(', ', $permissions);
         }
 
         $cls = '';

--- a/core/model/modx/processors/security/access/usergroup/namespace/getlist.class.php
+++ b/core/model/modx/processors/security/access/usergroup/namespace/getlist.class.php
@@ -88,10 +88,11 @@
         $data = $this->modx->fromJSON($data);
         if (!empty($data)) {
             $permissions = array();
-            foreach ($data as $perm => $v) {
-                $permissions[] = $perm;
+            foreach ($data as $permission => $enabled) {
+                if (!$enabled) { continue; }
+                $permissions[] = $permission;
             }
-            $objectArray['permissions'] = implode(', ',$permissions);
+            $objectArray['permissions'] = implode(', ', $permissions);
         }
 
 

--- a/core/model/modx/processors/security/access/usergroup/resourcegroup/getlist.class.php
+++ b/core/model/modx/processors/security/access/usergroup/resourcegroup/getlist.class.php
@@ -87,11 +87,11 @@
         unset($objectArray['policy_data']);
         $data = $this->modx->fromJSON($data);
         if (!empty($data)) {
-            $permissions = array();
-            foreach ($data as $perm => $v) {
-                $permissions[] = $perm;
+            foreach ($data as $permission => $enabled) {
+                if (!$enabled) { continue; }
+                $permissions[] = $permission;
             }
-            $objectArray['permissions'] = implode(', ',$permissions);
+            $objectArray['permissions'] = implode(', ', $permissions);
         }
 
         $cls = '';

--- a/core/model/modx/processors/security/access/usergroup/source/getlist.class.php
+++ b/core/model/modx/processors/security/access/usergroup/source/getlist.class.php
@@ -92,10 +92,11 @@
         $data = $this->modx->fromJSON($data);
         if (!empty($data)) {
             $permissions = array();
-            foreach ($data as $perm => $v) {
-                $permissions[] = $perm;
+            foreach ($data as $permission => $enabled) {
+                if (!$enabled) { continue; }
+                $permissions[] = $permission;
             }
-            $objectArray['permissions'] = implode(', ',$permissions);
+            $objectArray['permissions'] = implode(', ', $permissions);
         }
 
         $cls = '';

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
@@ -2,9 +2,9 @@
 MODx.grid.UserGroupCategory = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
-        tpl : new Ext.Template(
-            '<p class="desc">{permissions}</p>'
-        )
+        tpl: new Ext.Template('<p class="desc">{permissions}</p>'),
+        lazyRender: false,
+        enableCaching: false
     });
     Ext.applyIf(config,{
         id: 'modx-grid-user-group-categories'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -2,9 +2,9 @@
 MODx.grid.UserGroupContext = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
-        tpl : new Ext.Template(
-            '<p class="desc">{permissions}</p>'
-        )
+        tpl: new Ext.Template('<p class="desc">{permissions}</p>'),
+        lazyRender: false,
+        enableCaching: false
     });
     Ext.applyIf(config,{
         id: 'modx-grid-user-group-contexts'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
@@ -2,9 +2,9 @@
 MODx.grid.UserGroupNamespace = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
-        tpl : new Ext.Template(
-            '<p class="desc">{permissions}</p>'
-        )
+        tpl: new Ext.Template('<p class="desc">{permissions}</p>'),
+        lazyRender: false,
+        enableCaching: false
     });
     Ext.applyIf(config,{
         id: 'modx-grid-user-group-namespace'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
@@ -2,9 +2,9 @@
 MODx.grid.UserGroupResourceGroup = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
-        tpl : new Ext.Template(
-            '<p class="desc">{permissions}</p>'
-        )
+        tpl: new Ext.Template('<p class="desc">{permissions}</p>'),
+        lazyRender: false,
+        enableCaching: false
     });
     Ext.applyIf(config,{
         id: 'modx-grid-user-group-resource-groups'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
@@ -2,9 +2,9 @@
 MODx.grid.UserGroupSource = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
-        tpl : new Ext.Template(
-            '<p class="desc">{permissions}</p>'
-        )
+        tpl: new Ext.Template('<p class="desc">{permissions}</p>'),
+        lazyRender: false,
+        enableCaching: false
     });
     Ext.applyIf(config,{
         id: 'modx-grid-user-group-sources'


### PR DESCRIPTION
### What does it do?
It fixes some presenting issues on the screen of configuring access for user groups.

### Why is it needed?
It needed for admins who configures access for other users in the system and it should decrease the number of mistakes because before the fix they saw wrong data.

### Related issue(s)/PR(s)
Fixes #7974 
Fixes #7316