### PR TITLE
[3.x] [ReUp] added active/selected row colour for resource tree and media browser

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -532,6 +532,9 @@
 .x-tree-node .x-tree-node-over {
   background-color: $brandHover;
 }
+.x-tree-node .x-tree-selected {
+  background-color: $brandSelectedBg;
+}
 .x-tree-node .x-tree-expanded {
   color: $brandSelectedColor;
   background-color: $brandHover;


### PR DESCRIPTION
### What does it do?
This PR adds a missing CSS style for an active/selected row state for the Resources, Elements, and File Tree. It also adds an active/selected row state to the Media Browser, so you can see what folder you've clicked on.

![screen shot 2018-07-16 at 13 58 38](https://user-images.githubusercontent.com/2373940/42757470-885f14ea-8900-11e8-888f-09a37051a8bc.png)

### Why is it needed?
For usability; for visually identifying what you've clicked on when you have many items in view.

### Related issue(s)/PR(s)
This should fix the following issues:
https://github.com/modxcms/revolution/issues/13960
https://github.com/modxcms/revolution/issues/13956
