### PR TITLE
[3.x] [ReUp] Sidebar Improvements

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -21,6 +21,7 @@
   min-width: $navbarWidth;
   position: absolute;
   z-index: 2;
+  height: 100%;
 }
 
 #modx-navbar {

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -48,7 +48,7 @@
     cursor: pointer;
     color: $navbarText;
     display: block;
-    line-height: 50px;
+    line-height: 12px;
     font-size: 10px;
     text-decoration: none;
   }
@@ -57,6 +57,12 @@
       opacity: .7;
     }
   }
+  #modx-manager-search-icon a,
+  #modx-leftbar-trigger a,
+  #modx-user-menu a {
+      padding: 12px 0;
+  }
+
   #modx-topnav {
     @extend %outer-container;
     list-style: none;
@@ -69,20 +75,22 @@
       > a {
         display: block;
         position: relative;
-        padding-top: 22px;
-        &:after {
+        padding: 12px 0;
+        &:before {
           @include absolute-corners;
           @include awesome-font;
           text-align: center;
-          line-height: 50px;
           font-size: 22px;
+          margin-bottom: 6px;
+          width: 100%;
+          position: static;
         }
       }
     }
-    #limenu-site > a:after { content: $fa-var-file-text-o; }
-    #limenu-media > a:after { content: $fa-var-picture-o; }
-    #limenu-components > a:after { content: $fa-var-cube; }
-    #limenu-manage > a:after { content: $fa-var-sliders; }
+    #limenu-site > a:before { content: $fa-var-file-text-o; }
+    #limenu-media > a:before { content: $fa-var-picture-o; }
+    #limenu-components > a:before { content: $fa-var-cube; }
+    #limenu-manage > a:before { content: $fa-var-sliders; }
   }
   #modx-user-menu {
     margin-top: auto;


### PR DESCRIPTION
### What does it do?
Added a default CSS height to `#modx-header` to make the sidebar feel less jumpy on page load whilst the javascript loads. It gives the impression the manager is loading faster than it actually is (#13953)

![42212742-4ad8a274-7eb7-11e8-9cfa-41f4374d7d39](https://user-images.githubusercontent.com/2373940/42762014-72ecb644-890f-11e8-80d7-1e2f70737ac9.png)

Tweaked the sidebar styles so if a menu title falls onto 2 lines or more it doesn't look broken (#13983)

![42446168-9ab22244-8375-11e8-8d12-14ca6daa1d94](https://user-images.githubusercontent.com/2373940/42762002-6aa0fc66-890f-11e8-8a82-c13359f5d749.png)

### Why is it needed?
Better User Experience.

### Related issue(s)/PR(s)
Fixes https://github.com/modxcms/revolution/issues/13953
Fixes https://github.com/modxcms/revolution/issues/13983
