### PR TITLE
[3.x] [ReUp] Resource/Media Browser CSS Improvements

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -36,6 +36,7 @@
   overflow: hidden;
   padding: 4px;
   cursor: pointer;
+  user-select: none;
 }
 .modx-browser-thumb-wrap.x-view-over {
   border: 1px solid $brandSelectedColor;
@@ -198,7 +199,7 @@
       opacity: 0.6;
       filter: alpha(opacity=60); /* for IE <= 8 */
     }
-  } 
+  }
 
   img {
     display: block;

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -678,7 +678,7 @@ input::-moz-focus-inner {
         }
         &:after {
           left: .1em;
-          top: 50%;
+          top: 0.8em;
           margin-top: -.65em;
           height: 1.3em;
           width: 1.3em;
@@ -690,7 +690,8 @@ input::-moz-focus-inner {
       &:checked {
         & + .x-form-cb-label, & + .x-fieldset-header-text {
           &:after {
-            left: 1.6em;
+            left: 0.1em;
+            top: 0.8em;
           }
           &:before {
             background-color: $green;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -432,12 +432,12 @@ hr {
   #modx-resource-tabs & {
     display: flex;
     color: $darkGray;
-    align-items: center;
     margin-bottom: 5px;
     border-bottom: 1px solid $borderColor;
     .x-panel-header-text {
       order: 0;
       font-size: 14px;
+      flex: 1;
     }
     .x-tool.x-tool-toggle {
       order: 1;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -447,7 +447,7 @@ hr {
   #modx-resource-main-left & {
     border-bottom: 0;
     padding-top: 15px !important;
-    width: calc(100% - 30px);
+    right: 15px;
     position: absolute;
     z-index: 20;
     .x-panel-header-text { display: none; }
@@ -458,6 +458,7 @@ hr {
     position: relative;
     padding-top: 15px !important;
     width: 100%;
+    right: 0;
     .x-panel-header-text { display: block; }
   }
 }


### PR DESCRIPTION
### What does it do?

1. Fixes display error on toggle/switch on smaller screens (https://github.com/modxcms/revolution/issues/13947)
2. Fixes open/close buttons on publishing, template and menu panels when a long custom title is used (that falls onto 2 or 3 lines) (https://github.com/modxcms/revolution/issues/13971)
3. Fixes overlapping element preventing title and resource alias labels from being clicked on a resource page (un-reported)
4. Adds `user-select: none;` to `.modx-browser-thumb-wrap` to prevent text highlighting getting in the way when you select multiple files in the media browser (https://github.com/modxcms/revolution/issues/13963)

### Why is it needed?
Better User Experience 

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13947
https://github.com/modxcms/revolution/issues/13971
https://github.com/modxcms/revolution/issues/13963
