### PR TITLE
Fixed handling $depth variable during recursive calls in getTree method

### DIFF
--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -29,11 +29,71 @@
  * @group Model
  * @group modX
  */
-class modXTest extends MODxTestCase {
+class modXTest extends MODxTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        /*
+         * This map following the next pattern:
+         *  1 Mainpage
+         *  2 Services
+         *  └──3 Group of services
+         *     └──4 Service
+         *        └──5 SubService
+         *  6 Catalog
+         *  └──7 Category
+         *     └──8 SubCategory
+         *        └──9 SubCategory
+         *           └──10 SubCategory
+         *              └──11 SubCategory
+         *                 └──12 SubCategory
+         *                    └──13 SubCategory
+         *                       └──14 SubCategory
+         *                          └──15 SubCategory
+         *                             └──16 SubCategory
+         *                                └──17 SubCategory
+         *                                   └──18 SubCategory
+         *                                      └──19 SubCategory
+         */
+        $this->modx->resourceMap = array(
+            0 => array(1, 2, 6),
+            2 => array(3),
+            3 => array(4),
+            4 => array(5),
+            6 => array(7),
+            7 => array(8),
+            8 => array(9),
+            9 => array(10),
+            10 => array(11),
+            11 => array(12),
+            12 => array(13),
+            13 => array(14),
+            14 => array(15),
+            15 => array(16),
+            16 => array(17),
+            17 => array(18),
+            18 => array(19)
+        );
+
+        $ctx = new stdClass();
+        $ctx->resourceMap = array(
+            21 => array(22),
+            22 => array(23),
+            23 => array(24),
+            24 => array(25)
+        );
+        $this->modx->contexts['custom'] = $ctx;
+    }
+
+
 
     public function tearDown() {
         parent::tearDown();
         $this->modx->placeholders = array();
+        $this->modx->resourceMap = array(array(1));
+        unset($this->modx->contexts['custom']);
     }
     /**
      * Test getting the modCacheManager instance.
@@ -268,6 +328,54 @@ class modXTest extends MODxTestCase {
         return array(
             array(array('test' => 'testing'),array('test'),'test'),
             array(array('test' => 'testing','one' => 1),array('one'),'one'),
+        );
+    }
+
+    /**
+     * @param null $start
+     * @param int $depth
+     * @param array $options
+     * @param array $result
+     * @dataProvider providerGetTree
+     */
+    public function testGetTree($start, $depth, array $options, array $result)
+    {
+        $tree = $this->modx->getTree($start, is_null($depth) ? 10 : $depth, $options ?: array());
+        $this->assertEquals($result, $tree);
+    }
+
+    public function providerGetTree()
+    {
+        return array(
+            array(0, 0, array(), array(1 => 1, 2 => 2, 6 => 6)),
+            array(0, 1, array(), array(1 => 1, 2 => array(3 => 3), 6 => array(7 => 7))),
+            array(7, 5, array(), array(8 => array(9 => array(10 => array(11 => array(12 => array(13 => 13))))))),
+            array(6, null, array(), array(7 => array(8 => array(9 => array(10 => array(11 => array(12 => array(13 => array(14 => array(15 => array(16 => array(17 => 17)))))))))))),
+            array(21, 3, array('context' => 'custom'), array(22 => array(23 => array(24 => array(25 => 25)))))
+        );
+    }
+
+    /**
+     * @param $start
+     * @param $depth
+     * @param array $options
+     * @param array $result
+     * @dataProvider providerGetChildIds
+     */
+    public function testGetChildIds($start, $depth, array $options, array $result)
+    {
+        $ids = $this->modx->getChildIds($start, is_null($depth) ? 10 : $depth, $options ?: $options);
+        $this->assertEquals($ids, $result);
+    }
+
+    public function providerGetChildIds()
+    {
+        return array(
+            array(0, 0, array(), array()),
+            array(0, 1, array(), array(1, 2, 6)),
+            array(6, 5, array(), array(7, 8, 9, 10, 11)),
+            array(6, null, array(), array(7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
+            array(22, 2, array('context' => 'custom'), array(23, 24))
         );
     }
 }

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -759,9 +759,8 @@ class modX extends xPDO {
             if (isset ($resourceMap["{$id}"])) {
                 if ($children= $resourceMap["{$id}"]) {
                     foreach ($children as $child) {
-                        $processDepth = $depth - 1;
-                        if ($c= $this->getChildIds($child,$processDepth,$options)) {
-                            $children= array_merge($children, $c);
+                        if ($c = $this->getChildIds($child, $depth - 1, $options)) {
+                            $children = array_merge($children, $c);
                         }
                     }
                 }
@@ -782,20 +781,17 @@ class modX extends xPDO {
      */
     public function getTree($id= null, $depth= 10, array $options = array()) {
         $tree= array ();
-        $context = '';
         if (!empty($options['context'])) {
             $this->getContext($options['context']);
-            $context = $options['context'];
         }
         if ($id !== null) {
             if (is_array ($id)) {
                 foreach ($id as $k => $v) {
-                    $tree[$v]= $this->getTree($v, $depth, $options);
+                    $tree[$v] = $this->getTree($v, $depth - 1, $options);
                 }
-            }
-            elseif ($branch= $this->getChildIds($id, 1, $options)) {
+            } elseif ($branch= $this->getChildIds($id, 1, $options)) {
                 foreach ($branch as $key => $child) {
-                    if ($depth > 0 && $leaf= $this->getTree($child, $depth--, $options)) {
+                    if ($depth > 0 && $leaf = $this->getTree($child, $depth - 1, $options)) {
                         $tree[$child]= $leaf;
                     } else {
                         $tree[$child]= $child;


### PR DESCRIPTION
### What does it do?
It fixes issues with a recursive call of the `getTree` (and `getChildIds`) method. Before a fix depth doesn't work at all, showing the full list of nested elements and also there was an issue when each next section of elements has less value of depth than previous. 
It happened because was used the wrong way to decrease the value of $depth. $depth-- decreases the value of variable itself and between iterations (in foreach) it becomes less than should be. But for passing into the recursive call we should use decreased value. So `$depth - 1` solves the issue.

See examples below:
Before a fix:
```
// $tree = $modx->getTree(0, 3); print_r($tree)
Array(
    [1] => 1
    [3] => Array(
        [2] => Array(
            [4] => Array(
                [5] => Array(
                    [6] => Array(
                        [7] => Array(
                            [8] => Array(
                                [9] => Array(
                                    [10] => Array(
                                        [11] => Array(
                                            [12] => Array(
                                                [13] => 13
                                            )
                                        )
                                    )
                                )
                            )
                        )
                    )
                )
            )
        )
    )

    [14] => Array(
        [15] => Array(
            [16] => Array(
                [17] => Array(
                    [18] => Array(
                        [19] => Array(
                            [20] => Array(
                                [21] => Array(
                                    [22] => Array(
                                        [23] => Array(
                                            [24] => Array(
                                                [25] => 25
                                            )
                                        )
                                    )
                                )
                            )
                        )
                    )
                )
            )
        )
    )
    [26] => 26
)
```

After fix:
```
// $tree = $modx->getTree(0, 3); print_r($tree)
Array(
    [1] => 1
    [3] => Array(
        [2] => Array(
            [4] => Array(
                [5] => 5
            )
        )
    )
    [14] => Array(
        [15] => Array(
            [16] => Array(
                [17] => 17
            )
        )
    )
    [26] => Array(
        [27] => Array(
            [28] => Array(
                [29] => 29
            )
        )
    )
)
```

### Why is it needed?
It solves an issue when during the `getTree` call user gets not a full list of nested items. 

### Related issue(s)/PR(s)
Fixes #4973
Fixed #8430