### PR TITLE
[3.x] [ReUp] Changed status message appearance and position

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -22,6 +22,12 @@ $red: #BE0000;
 $green: #6CB24A;
 $blue: #3697cd; /* default theme $colorSplash */
 
+/* Status Message */
+$statusMessageBg: #6CB24A;
+$statusMessageText: #fff;
+$statusMessageIconBg: #fff;
+$statusMessageIconText: #6CB24A;
+
 /* Brand colors */
 $brandBg: #FFF;
 $brandHover: #e8f0f8;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1028,14 +1028,13 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
   padding-left: 24px !important;
 }
 
-
 /* status messages */
 .modx-status-msg {
-  background: $green;
+  background: $statusMessageBg;
   border-radius: $borderRadius;
   box-sizing: border-box;
   bottom: 20px;
-  color: $white;
+  color: $statusMessageText;
   padding: 15px 15px 15px 65px;
   position: fixed;
   right: 15px;
@@ -1045,9 +1044,9 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
       position: relative;
   }
   &:after {
-      background: $white;
+      background: $statusMessageIconBg;
       border-radius: 50%;
-      color: $green;
+      color: $statusMessageIconText;
       content: "\f00c";
       display: inline-block;
       font-family: FontAwesome;
@@ -1067,7 +1066,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
       font-size: 14px;
   }
   h3 {
-     color: $white;
+     color: $statusMessageText;
      margin: 0;
   }
 

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1030,6 +1030,9 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
 
 /* status messages */
 .modx-status-msg {
+    @include media($mobile) {
+        max-width: 100%;
+    }
   background: $statusMessageBg;
   border-radius: $borderRadius;
   box-sizing: border-box;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1035,6 +1035,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
   box-sizing: border-box;
   bottom: 20px;
   color: $statusMessageText;
+  max-width: 360px;
   padding: 15px 15px 15px 65px;
   position: fixed;
   right: 15px;

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1028,20 +1028,92 @@ a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
   padding-left: 24px !important;
 }
 
+
 /* status messages */
 .modx-status-msg {
-  background: #f4f4f4;
-  border-radius: 5px;
-  left: 70%;
-  /*filter: alpha(opacity=80);*/
-  margin: 0;
-  opacity: 0.8;
-  filter: alpha(opacity=80); /* for IE <= 8 */
-  padding: 5px;
+  background: $green;
+  border-radius: $borderRadius;
+  box-sizing: border-box;
+  bottom: 20px;
+  color: $white;
+  padding: 15px 15px 15px 65px;
   position: fixed;
-  top: 10px;
+  right: 15px;
   width: 25%;
   z-index: 20000;
+  &:before {
+      position: relative;
+  }
+  &:after {
+      background: $white;
+      border-radius: 50%;
+      color: $green;
+      content: "\f00c";
+      display: inline-block;
+      font-family: FontAwesome;
+      font-size: 16px;
+      height: 38px;
+      left: 15px;
+      line-height: 36px;
+      margin-right: 13px;
+      position: absolute;
+      text-align: center;
+      top: 15px;
+      vertical-align: middle;
+      width: 38px;
+  }
+  h3,
+  span {
+      font-size: 14px;
+  }
+  h3 {
+     color: $white;
+     margin: 0;
+  }
+
+}
+
+// position the success message in the center of the screen
+.modx-status-msg.has-position-center-center {
+    bottom: auto;
+    left: 0;
+    margin-left: auto;
+    margin-right: auto;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+// position the success message center top of the screen
+.modx-status-msg.has-position-center-top {
+    bottom: auto;
+    left: 0;
+    margin-left: auto;
+    margin-right: auto;
+    right: 0;
+    top: 15px;
+}
+
+.modx-status-msg.has-position-right-top {
+    bottom: auto;
+    left: auto;
+    right: 15px;
+    top: 15px;
+}
+
+/* status messages mobile view */
+.modx-status-msg,
+.modx-status-msg.has-position-center-center,
+.modx-status-msg.has-position-center-top,
+.modx-status-msg.has-position-right-top {
+    @include media($mobile) {
+        border-radius: 0;
+        top: auto;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+    }
 }
 
 iframe[classname="x-hidden"] {


### PR DESCRIPTION
### What does it do?
This PR changes the default appearance and position of the status notification (the one you receive after saving a resource).

![modx3_message_save2](https://user-images.githubusercontent.com/2373940/42943719-dcccb1d0-8b63-11e8-9158-6abddea8f52c.gif)

![screen shot 2018-07-19 at 14 32 47](https://user-images.githubusercontent.com/2373940/42943740-e850c604-8b63-11e8-808a-09f8b83cc582.png)

Based on feedback from Slack, this PR also adds some css utility styles so you can position the status message in different positions on the screen. These are `.modx-status-msg.has-position-center-center`, `.modx-status-msg.has-position-center-top`, and `.modx-status-msg.has-position-right-top`. 

If one day, somebody decides to create a system setting for the position, they can hook into these css utility classes.

**Screen shot of `.modx-status-msg.has-position-right-top`**
![screen shot 2018-07-19 at 14 26 41](https://user-images.githubusercontent.com/2373940/42943755-f1292f3c-8b63-11e8-8621-256e9504b448.png)
**Screen shot of `.modx-status-msg.has-position-center-top`**
![screen shot 2018-07-19 at 14 26 16](https://user-images.githubusercontent.com/2373940/42943756-f1405a36-8b63-11e8-9870-60f24920b4de.png)
**Screen shot of `.modx-status-msg.has-position-center-center`**
![screen shot 2018-07-19 at 14 25 35](https://user-images.githubusercontent.com/2373940/42943757-f156dc0c-8b63-11e8-82be-a3990133fd80.png)

### Why is it needed?
In 2.x the status message was almost invisible. In MODX 3 we have lots of new styles - styling up the status message makes the product feel more consistent. 

It also moves the status message away from the action buttons at the top, which are unusable whilst the message is in display.

### Related issue(s)/PR(s)
Mentioned in #13988, #13942
