### PR TITLE
Make policies in grid sortable by enabled/disabled mark

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.js
@@ -154,7 +154,7 @@ MODx.grid.PolicyPermissions = function(config) {
         header: _('enabled')
         ,dataIndex: 'enabled'
         ,width: 40
-        ,sortable: false
+        ,sortable: true
     });
     Ext.applyIf(config,{
         id: 'modx-grid-policy-permissions'


### PR DESCRIPTION
### What does it do?
It allows sorting access policied by enabled/disabled mark.

### Why is it needed?
It improves user experience during configuring ACLs.

![sorting](https://user-images.githubusercontent.com/303498/42944956-bd71fc76-8b6f-11e8-9e75-1e15ec3f847d.gif)


### Related issue(s)/PR(s)
Fixes #7335