### PR TITLE
Lowered the log level for cases when uncached elements called in cached

### DIFF
--- a/core/model/modx/modparser.class.php
+++ b/core/model/modx/modparser.class.php
@@ -449,7 +449,7 @@ class modParser {
             $tokenOffset++;
             $token= substr($tagName, $tokenOffset, 1);
         } elseif (!$processUncacheable && strpos($tagPropString, '[[!') !== false) {
-            $this->modx->log(xPDO::LOG_LEVEL_ERROR, "You should not call uncached elements inside cached!\nOuter tag: {$tag[0]}\nInner tag {$innerTag}");
+            $this->modx->log(xPDO::LOG_LEVEL_WARN, "You should not call uncached elements inside cached!\nOuter tag: {$tag[0]}\nInner tag {$innerTag}");
             $this->_processingTag = false;
             return $outerTag;
         }


### PR DESCRIPTION
### What does it do?
It set log level of the message to the warning against the error.

### Why is it needed?
Uncached elements shouldn't be called inside cached, it's true, but some old websites already can use old behavior and after upgrading they will have tons errors in the logs when it is actually not a fatal error when the application crashed, just a wrong usage. So it makes sense show it as a warning message and keep production sites logs clear and readable for real urgent alerts.

### Related issue(s)/PR(s)
#14011 
#13530 