### PR TITLE
Remove non-functional cache_disabled system setting

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -222,15 +222,6 @@ $settings['cache_default']->fromArray(array (
   'area' => 'caching',
   'editedon' => null,
 ), '', true, true);
-$settings['cache_disabled']= $xpdo->newObject('modSystemSetting');
-$settings['cache_disabled']->fromArray(array (
-  'key' => 'cache_disabled',
-  'value' => '0',
-  'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'caching',
-  'editedon' => null,
-), '', true, true);
 $settings['cache_expires']= $xpdo->newObject('modSystemSetting');
 $settings['cache_expires']->fromArray(array (
   'key' => 'cache_expires',

--- a/_build/test/revo_install.sample.xml
+++ b/_build/test/revo_install.sample.xml
@@ -10,7 +10,6 @@
     <table_prefix>modx_</table_prefix>
     <https_port>443</https_port>
     <http_host>{$host}</http_host>
-    <cache_disabled>0</cache_disabled>
     <inplace>1</inplace>
     <unpacked>0</unpacked>
     <language>{$language}</language>

--- a/core/docs/config.inc.tpl
+++ b/core/docs/config.inc.tpl
@@ -85,7 +85,3 @@ if (!defined('MODX_LOG_LEVEL_FATAL')) {
     define('MODX_LOG_LEVEL_INFO', 3);
     define('MODX_LOG_LEVEL_DEBUG', 4);
 }
-if (!defined('MODX_CACHE_DISABLED')) {
-    $modx_cache_disabled= {cache_disabled};
-    define('MODX_CACHE_DISABLED', $modx_cache_disabled);
-}

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -156,10 +156,6 @@ $_lang['setting_cache_default'] = 'Cacheable default';
 $_lang['setting_cache_default_desc'] = 'Select \'Yes\' to make all new Resources cacheable by default.';
 $_lang['setting_cache_default_err'] = 'Please state whether or not you want documents to be cached by default.';
 
-$_lang['setting_cache_disabled'] = 'Disable Global Cache Options';
-$_lang['setting_cache_disabled_desc'] = 'Select \'Yes\' to disable all MODX caching features. MODX does not recommend disabling caching.';
-$_lang['setting_cache_disabled_err'] = 'Please state whether or not you want the cache enabled.';
-
 $_lang['setting_cache_expires'] = 'Expiration Time for Default Cache';
 $_lang['setting_cache_expires_desc'] = 'This value (in seconds) sets the amount of time cache files last for default caching.';
 

--- a/index.php
+++ b/index.php
@@ -16,9 +16,6 @@ if (!defined('MODX_API_MODE')) {
     define('MODX_API_MODE', false);
 }
 
-/* this can be used to disable caching in MODX absolutely */
-$modx_cache_disabled= false;
-
 /* include custom core config and define core path */
 @include(dirname(__FILE__) . '/config.core.php');
 if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__FILE__) . '/core/');

--- a/setup/cli-install.php
+++ b/setup/cli-install.php
@@ -42,7 +42,6 @@ $variables = [
     ],
     'https_port' => 443,
     'http_host' => 'localhost',
-    'cache_disabled' => 0,
     'inplace' => 0,
     'unpacked' => 0,
     'language' => [

--- a/setup/config.dist.new.xml
+++ b/setup/config.dist.new.xml
@@ -1,8 +1,8 @@
 <!--
  This file is part of MODX Revolution.
- 
+
  Copyright (c) MODX, LLC. All Rights Reserved.
- 
+
  For the full copyright and license information, please view the LICENSE
  file that was distributed with this source code.
 -->
@@ -18,12 +18,11 @@
     <table_prefix>modx_</table_prefix>
     <https_port>443</https_port>
     <http_host>localhost</http_host>
-    <cache_disabled>0</cache_disabled>
 
     <!-- Set this to 1 if you are using MODX from Git or extracted it from the full MODX package to the server prior
          to installation. -->
     <inplace>0</inplace>
-    
+
     <!-- Set this to 1 if you have manually extracted the core package from the file core/packages/core.transport.zip.
          This will reduce the time it takes for the installation process on systems that do not allow the PHP time_limit
          and Apache script execution time settings to be altered. -->

--- a/setup/config.dist.upgrade-advanced.xml
+++ b/setup/config.dist.upgrade-advanced.xml
@@ -18,7 +18,6 @@
     <table_prefix>modx_</table_prefix>
     <https_port>443</https_port>
     <http_host>localhost</http_host>
-    <cache_disabled>0</cache_disabled>
 
     <!-- Set this to 1 if you are using MODX from Git or extracted it from the full MODX package to the server prior
          to installation. -->

--- a/setup/includes/config/modconfigreader.class.php
+++ b/setup/includes/config/modconfigreader.class.php
@@ -52,7 +52,6 @@ abstract class modConfigReader {
             'database_password' => isset ($_POST['databaseloginpassword']) ? $_POST['databaseloginpassword'] : '',
             'table_prefix' => isset ($_POST['tableprefix']) ? $_POST['tableprefix'] : 'modx_',
             'site_sessionname' => 'SN' . uniqid(''),
-            'cache_disabled' => !empty($_POST['cache_disabled']) ? 'true' : 'false',
             'inplace' => isset ($_POST['inplace']) ? 1 : 0,
             'unpacked' => isset ($_POST['unpacked']) ? 1 : 0,
             'config_options' => array(),

--- a/setup/includes/config/modevolutionconfigreader.class.php
+++ b/setup/includes/config/modevolutionconfigreader.class.php
@@ -42,7 +42,6 @@ class modEvolutionConfigReader extends modConfigReader {
                 'https_port' => isset ($https_port) ? $https_port : '443',
                 'http_host' => defined('MODX_HTTP_HOST') ? MODX_HTTP_HOST : $this->config['http_host'],
                 'site_sessionname' => isset ($site_sessionname) ? $site_sessionname : 'SN' . uniqid(''),
-                'cache_disabled' => isset ($cache_disabled) && $cache_disabled ? 'true' : 'false',
                 'inplace' => isset ($_POST['inplace']) ? 1 : 0,
                 'unpacked' => isset ($_POST['unpacked']) ? 1 : 0,
                 'config_options' => $config_options,

--- a/setup/includes/config/modrevolutionconfigreader.class.php
+++ b/setup/includes/config/modrevolutionconfigreader.class.php
@@ -61,7 +61,6 @@ class modRevolutionConfigReader extends modConfigReader {
                 'https_port' => isset ($https_port) ? $https_port : '443',
                 'http_host' => defined('MODX_HTTP_HOST') ? MODX_HTTP_HOST : $this->config['http_host'],
                 'site_sessionname' => isset ($site_sessionname) ? $site_sessionname : 'SN' . uniqid(''),
-                'cache_disabled' => isset ($cache_disabled) && $cache_disabled ? 'true' : 'false',
                 'inplace' => isset ($_POST['inplace']) ? 1 : 0,
                 'unpacked' => isset ($_POST['unpacked']) ? 1 : 0,
                 'config_options' => $config_options,

--- a/setup/includes/upgrades/common/2.7-remove-cache-disabled.php
+++ b/setup/includes/upgrades/common/2.7-remove-cache-disabled.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Common upgrade script for removing cache_disabled System Setting
+ *
+ * @var modX $modx
+ * @package setup
+ */
+$modx->removeObject('modSystemSetting', array('key' => 'cache_disabled'));

--- a/setup/includes/upgrades/mysql/2.7.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.7.0-pl.php
@@ -11,3 +11,4 @@
 include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-description-text.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-browser-tree-hide-files.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-remove-cache-disabled.php';

--- a/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.7.0-pl.php
@@ -11,3 +11,4 @@
 include dirname(dirname(__FILE__)) . '/common/2.7-alias-visible.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-description-text.php';
 include dirname(dirname(__FILE__)) . '/common/2.7-browser-tree-hide-files.php';
+include dirname(dirname(__FILE__)) . '/common/2.7-remove-cache-disabled.php';


### PR DESCRIPTION
Also removes MODX_CACHE_DISABLED constant

### What does it do?
Removes cache_disabled system setting and MODX_CACHE_DISABLED constant in the config file.

### Why is it needed?
These settings have not been functional since 2.0.0-beta-1.

### Related issue(s)/PR(s)
#12938 
#10121
#13937 