### PR TITLE
Improves the isBinary check

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -151,13 +151,8 @@ class modFileHandler {
 
         if (class_exists('\finfo')) {
             $finfo = new \finfo(FILEINFO_MIME);
-            $fileMimeType = $finfo->file($file);
 
-            if (substr($fileMimeType, 0, 4) !== 'text') {
-                return true;
-            }
-
-            return false;
+            return substr($finfo->file($file), 0, 4) !== 'text';
         }
 
         $fh = @fopen($file, 'r');

--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -145,15 +145,26 @@ class modFileHandler {
      * @return boolean True if a binary file.
      */
     public function isBinary($file) {
-        if (file_exists($file)) {
-            if (!is_file($file)) return false;
-            $fh = @fopen($file, 'r');
-            $blk = @fread($fh, 512);
-            @fclose($fh);
-            @clearstatcache();
-            return (substr_count($blk, "^ -~" /*. "^\r\n"*/) / 512 > 0.3) || (substr_count($blk, "\x00") > 0) ? false : true;
+        if (!file_exists($file) || !is_file($file)) {
+            return false;
         }
-        return false;
+
+        if (class_exists('\finfo')) {
+            $finfo = new \finfo(FILEINFO_MIME);
+            $fileMimeType = $finfo->file($file);
+
+            if (substr($fileMimeType, 0, 4) !== 'text') {
+                return true;
+            }
+
+            return false;
+        }
+
+        $fh = @fopen($file, 'r');
+        $blk = @fread($fh, 512);
+        @fclose($fh);
+        @clearstatcache();
+        return (substr_count($blk, "^ -~" /*. "^\r\n"*/) / 512 > 0.3) || (substr_count($blk, "\x00") > 0);
     }
 }
 

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -201,7 +201,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'type' => 'file',
                     'leaf' => true,
                     // 'qtip' => in_array($ext,$imagesExts) ? '<img src="'.$fromManagerUrl.'" alt="'.$fileName.'" />' : '',
-                    'page' => $this->fileHandler->isBinary($filePathName) ? $page : null,
+                    'page' => $this->fileHandler->isBinary($filePathName) ? null : $page,
                     'perms' => $octalPerms,
                     'path' => $bases['pathAbsoluteWithPath'].$fileName,
                     'pathRelative' => $bases['pathRelative'].$fileName,
@@ -1167,7 +1167,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'disabled' => false,
                     'perms' => $octalPerms,
                     'leaf' => true,
-                    'page' => $this->fileHandler->isBinary($filePathName) ? $page : null,
+                    'page' => $this->fileHandler->isBinary($filePathName) ? null : $page,
                     'size' => $filesize,
                     'menu' => array(),
                 );


### PR DESCRIPTION
### What does it do?
It improves the isBinary check by checking the mime type of the file using the "finfo" class. 

### Why is it needed?
In most cases the mime type of a file is a good indicator if it's a binary file or not.

### Related issue(s)/PR(s)
Fixes issue #14013 