### PR TITLE
[ReUp] Enhancement for dashboard jumping around on page load

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -146,6 +146,12 @@ hr {
   position: absolute;
 }
 
+/* give #modx-content an initial left value to prevent the panel from
+jumping around */
+#modx-content {
+    left: 310px;
+}
+
 .modx-form p {
   padding-bottom: 10px;
 }


### PR DESCRIPTION
### What does it do?
This PR adds a default CSS `left` value to `#modx-content`. When the javascript value is loaded, this default CSS value is overwritten and ignored. It is also ignored for mobile/tablets.

### Why is it needed?
It stops the dashboard from jumping around on page load, as seen below. It makes the loading experience seem more solid. It makes the perceived loading time feel faster.

![43406496-a25bf8be-941c-11e8-903c-81f8908aebc6](https://user-images.githubusercontent.com/2373940/43406496-a25bf8be-941c-11e8-903c-81f8908aebc6.png)

After the fix has been applied:

![modx_dashboard_glitch](https://user-images.githubusercontent.com/2373940/43898633-bbf48d7a-9bdf-11e8-88f0-a098d8b60cb5.gif)

Having said that, if a user sets the tree wider than the default width and visits the dashboard again, a small amount of jumping will re-appear because the `left` value is set to `310px`.

Up to the integrators to decide if this is a fix, or if this PR creates another problem, or if this issue simply can't be fixed at this moment in time.
 
### Related issue(s)/PR(s)
Fixes #14019
