### PR TITLE
Array based config file

### DIFF
--- a/core/docs/config.inc.tpl
+++ b/core/docs/config.inc.tpl
@@ -2,90 +2,45 @@
 /**
  *  MODX Configuration file
  */
-$database_type = '{database_type}';
-$database_server = '{database_server}';
-$database_user = '{database_user}';
-$database_password = '{database_password}';
-$database_connection_charset = '{database_connection_charset}';
-$dbase = '{dbase}';
-$table_prefix = '{table_prefix}';
-$database_dsn = '{database_dsn}';
-$config_options = {config_options};
-$driver_options = {driver_options};
 
-$lastInstallTime = {last_install_time};
-
-$site_id = '{site_id}';
-$site_sessionname = '{site_sessionname}';
-$https_port = '{https_port}';
-$uuid = '{uuid}';
-
-if (!defined('MODX_CORE_PATH')) {
-    $modx_core_path= '{core_path}';
-    define('MODX_CORE_PATH', $modx_core_path);
-}
-if (!defined('MODX_PROCESSORS_PATH')) {
-    $modx_processors_path= '{processors_path}';
-    define('MODX_PROCESSORS_PATH', $modx_processors_path);
-}
-if (!defined('MODX_CONNECTORS_PATH')) {
-    $modx_connectors_path= '{connectors_path}';
-    $modx_connectors_url= '{connectors_url}';
-    define('MODX_CONNECTORS_PATH', $modx_connectors_path);
-    define('MODX_CONNECTORS_URL', $modx_connectors_url);
-}
-if (!defined('MODX_MANAGER_PATH')) {
-    $modx_manager_path= '{mgr_path}';
-    $modx_manager_url= '{mgr_url}';
-    define('MODX_MANAGER_PATH', $modx_manager_path);
-    define('MODX_MANAGER_URL', $modx_manager_url);
-}
-if (!defined('MODX_BASE_PATH')) {
-    $modx_base_path= '{web_path}';
-    $modx_base_url= '{web_url}';
-    define('MODX_BASE_PATH', $modx_base_path);
-    define('MODX_BASE_URL', $modx_base_url);
-}
-if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
-    $isSecureRequest = false;
-} else {
-    $isSecureRequest = ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') || $_SERVER['SERVER_PORT'] == $https_port);
-}
-if (!defined('MODX_URL_SCHEME')) {
-    $url_scheme=  $isSecureRequest ? 'https://' : 'http://';
-    define('MODX_URL_SCHEME', $url_scheme);
-}
-if (!defined('MODX_HTTP_HOST')) {
-    if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
-        $http_host='{http_host}';
-        define('MODX_HTTP_HOST', $http_host);
-    } else {
-        $http_host= array_key_exists('HTTP_HOST', $_SERVER) ? htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES) : '{http_host}';
-        if ($_SERVER['SERVER_PORT'] != 80) {
-            $http_host= str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
-        }
-        $http_host .= ($_SERVER['SERVER_PORT'] == 80 || $isSecureRequest) ? '' : ':' . $_SERVER['SERVER_PORT'];
-        define('MODX_HTTP_HOST', $http_host);
-    }
-}
-if (!defined('MODX_SITE_URL')) {
-    $site_url= $url_scheme . $http_host . MODX_BASE_URL;
-    define('MODX_SITE_URL', $site_url);
-}
-if (!defined('MODX_ASSETS_PATH')) {
-    $modx_assets_path= '{assets_path}';
-    $modx_assets_url= '{assets_url}';
-    define('MODX_ASSETS_PATH', $modx_assets_path);
-    define('MODX_ASSETS_URL', $modx_assets_url);
-}
-if (!defined('MODX_LOG_LEVEL_FATAL')) {
-    define('MODX_LOG_LEVEL_FATAL', 0);
-    define('MODX_LOG_LEVEL_ERROR', 1);
-    define('MODX_LOG_LEVEL_WARN', 2);
-    define('MODX_LOG_LEVEL_INFO', 3);
-    define('MODX_LOG_LEVEL_DEBUG', 4);
-}
-if (!defined('MODX_CACHE_DISABLED')) {
-    $modx_cache_disabled= {cache_disabled};
-    define('MODX_CACHE_DISABLED', $modx_cache_disabled);
-}
+return [
+    'last_install_time' => {last_install_time},
+    'id' => '{site_id}',
+    'https_port' => '{https_port}',
+    'uuid' => '{uuid}',
+    'http_host' => '{http_host}',
+    'disable_cache' => {cache_disabled},
+    'db' => [
+        'type' => '{database_type}',
+        'server' => '{database_server}',
+        'user' => '{database_user}',
+        'password' => '{database_password}',
+        'connection_charset' => '{database_connection_charset}',
+        'database' => '{dbase}',
+        'table_prefix' => '{table_prefix}',
+        'dns' => '{database_dsn}',
+        'config_options' => {config_options},
+        'driver_options' => {driver_options},
+    ],
+    'paths' => [
+        'base' => '{web_path}',
+        'core' => '{core_path}',
+        'processors' => '{processors_path}',
+        'connectors' => '{connectors_path}',
+        'manager' => '{mgr_path}',
+        'assets' => '{assets_path}',
+    ],
+    'urls' => [
+        'base' => '{web_url}',
+        'connectors' => '{connectors_url}',
+        'manager' => '{mgr_url}',
+        'assets' => '{assets_url}',
+    ],
+    'log_levels' => [
+        'fatal' => 0,
+        'error' => 1,
+        'warn' => 2,
+        'info' => 3,
+        'debug' => 4,
+    ]
+];


### PR DESCRIPTION
### What does it do?
The spiritual successor of PR #13834.

This PR provides a new, cleaner, and easier-to-work-with config file for MODX Revolution. 

I have always thought that the current config file is far too complex. It contains both constants, and a lot of logic. It is difficult to find what you are looking for, and it is easy to make mistakes. Some variables derived from the setup process is even defined twice. With this PR, we instead return the complete config array, and define the constants in the modx class, which I think makes much more sense.

Example of a working config file, produced from the setup process:

```php
<?php
/**
 *  MODX Configuration file
 */

return [
    'last_install_time' => 1533854383,
    'id' => 'modx5b6cc2af7f1be3.27746164',
    'https_port' => '443',
    'uuid' => '157b9732-ea87-47f8-b447-8c4ee24893fb',
    'url_scheme' => 'automatic',
    'http_host' => '192.168.99.100:8000',
    'disable_cache' => false,
    'db' => [
        'type' => 'mysql',
        'server' => 'db',
        'user' => 'revolution',
        'password' => 'revolution',
        'connection_charset' => 'utf8',
        'database' => 'revolution',
        'table_prefix' => 'modx99_',
        'dns' => 'mysql:host=db;dbname=revolution;charset=utf8',
        'config_options' => array (
),
        'driver_options' => array (
),
    ],
    'paths' => [
        'base' => '/var/www/html/',
        'core' => '/var/www/html/core/',
        'processors' => '/var/www/html/core/model/modx/processors/',
        'connectors' => '/var/www/html/connectors/',
        'manager' => '/var/www/html/manager/',
        'assets' => '/var/www/html/assets/',
    ],
    'urls' => [
        'base' => '/',
        'connectors' => '/connectors/',
        'manager' => '/manager/',
        'assets' => '/assets/',
    ],
    'log_levels' => [
        'fatal' => 0,
        'error' => 1,
        'warn' => 2,
        'info' => 3,
        'debug' => 4,
    ]
];
```

No additional changes has been made, other than changing the format of the config template file, as well as reimplementing the logic that was earlier found there.

Note that this needs testing, but I have successfully used the code in this PR on a test site, and it seem to function as it should.
