### PR TITLE
Fix for "Invalid relative media source path shows root path contents"

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -47,7 +47,10 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $bases['path'] = $properties['basePath']['value'];
         $bases['pathIsRelative'] = false;
         if (!empty($properties['basePathRelative']['value'])) {
-            $bases['pathAbsolute'] = realpath("{$this->ctx->getOption('base_path',MODX_BASE_PATH)}{$bases['path']}"). '/';
+            $realpath = realpath("{$this->ctx->getOption('base_path',MODX_BASE_PATH)}{$bases['path']}");
+            if ($realpath !== false) {
+                $bases['pathAbsolute'] = $realpath. '/';
+            }
             $bases['pathIsRelative'] = true;
         } else {
             $bases['pathAbsolute'] = $bases['path'];

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -47,10 +47,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $bases['path'] = $properties['basePath']['value'];
         $bases['pathIsRelative'] = false;
         if (!empty($properties['basePathRelative']['value'])) {
-            $realpath = realpath("{$this->ctx->getOption('base_path',MODX_BASE_PATH)}{$bases['path']}");
-            if ($realpath !== false) {
-                $bases['pathAbsolute'] = $realpath. '/';
-            }
+            $realpath = realpath($this->ctx->getOption('base_path', MODX_BASE_PATH) . $bases['path']);
+            $bases['pathAbsolute'] = ($realpath !== false) ? $realpath. '/' : '';
             $bases['pathIsRelative'] = true;
         } else {
             $bases['pathAbsolute'] = $bases['path'];


### PR DESCRIPTION
### What does it do?
An invalid relative media source path would result in '/' being set as path.
With this PR there is a check if realpath returns an actual path instead of false.

### Why is it needed?
Quick solution for issue #14024 

### Related issue(s)/PR(s)
#14024 

This also needs to be fixed in 3.x 