### PR TITLE
Do not give TVs with output type as HTML an ID if no ID is sat

### DIFF
--- a/core/model/modx/processors/element/tv/renders/web/output/htmltag.class.php
+++ b/core/model/modx/processors/element/tv/renders/web/output/htmltag.class.php
@@ -16,7 +16,7 @@ class modTemplateVarOutputRenderHtmlTag extends modTemplateVarOutputRender {
             $tagvalue = is_array($value[$i]) ? implode(' ', $value[$i]) : $value[$i];
             if (!$tagvalue) continue;
 
-            $domId = $tagid ? $tagid : $id;
+            $domId = $tagid ? $tagid : '';
             $domId .= count($value) > 1 ? $i : '';
 
             $attributes = '';


### PR DESCRIPTION
### What does it do?
If a template variable has their output type sat to HTML, and not ID is specified for that output type, it should not produce an ID in the rendered markup. The old behavior was to use the template variable name.

### Why is it needed?
It is inconherent and wrong behavior. 

### Related issue(s)/PR(s)
Fixes #10012
