### PR TITLE
Hide Input Option Values for TV types where this is useless

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -534,6 +534,11 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
         Ext.getCmp('modx-panel-tv').markDirty();
     }
     ,showInputProperties: function(cb,rc,i) {
+        var element = Ext.getCmp('modx-tv-elements');
+        if (element) {
+          element.show();
+        }
+
         this.markPanelDirty();
         var pu = Ext.get('modx-input-props').getUpdater();
         pu.loadScripts = true;

--- a/manager/templates/default/element/tv/renders/inputproperties/date.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/date.tpl
@@ -9,6 +9,12 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/email.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/email.tpl
@@ -9,6 +9,12 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/file.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/file.tpl
@@ -9,6 +9,12 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/image.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/image.tpl
@@ -9,6 +9,12 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/number.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/number.tpl
@@ -9,6 +9,12 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
@@ -9,6 +9,12 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/text.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/text.tpl
@@ -10,6 +10,11 @@ var params = {
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
 
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
@@ -9,6 +9,12 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'


### PR DESCRIPTION
### What does it do?
The box called Input Option Values are displayed for all types of TVs. This makes no sense for a bunch of them, and hiding the box would most likely be a good idea. This PR attempts to do this.

The approach is not very good, but I found no better ways of doing while attempting to solve this. The approach is to hide the box in the renderes, and display it when a new TV type is selected. This way, we do not hide the box for third party or custom TV types.

### Why is it needed?
Reasons stated above.

### Related issue(s)/PR(s)
#7293
