### PR TITLE
Fixed hover styles on login and forget password buttons

### DIFF
--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -233,6 +233,20 @@ input[type="checkbox"] {
   }
 }
 
+button#modx-fl-btn {
+  border: 1px solid transparent;
+  &:hover {
+    background-color: $white;
+    color: $primary1;
+    box-shadow: none;
+    border: 1px solid $primary1;
+    transition: color .2s ease-out, background-color .2s ease-out, border .2s ease-out;
+  }
+  &:focus {
+    box-shadow: none;
+  }
+}
+
 .c-password-label {
   display: flex;
   justify-content: space-between;

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -217,34 +217,19 @@ input[type="checkbox"] {
   }
 }
 
-#modx-login-btn {
-  border: 1px solid transparent;
-  &:hover {
-    background-color: $white;
-    color: $primary2;
-    box-shadow: none;
-    border: 1px solid $primary2;
-    transition: color .2s ease-out,
-    background-color .2s ease-out,
-    border .2s ease-out;
-  }
-  &:focus{
-    box-shadow: none;
-  }
-}
-
-button#modx-fl-btn {
-  border: 1px solid transparent;
-  &:hover {
-    background-color: $white;
-    color: $primary1;
-    box-shadow: none;
-    border: 1px solid $primary1;
-    transition: color .2s ease-out, background-color .2s ease-out, border .2s ease-out;
-  }
-  &:focus {
-    box-shadow: none;
-  }
+#modx-login-btn,
+#modx-fl-btn {
+    border: 1px solid transparent;
+    &:hover, &:focus {
+        background-color: $white;
+        color: $primary2;
+        box-shadow: none;
+        border: 1px solid $primary2;
+        transition:
+                color .2s ease-out,
+                background-color .2s ease-out,
+                border .2s ease-out;
+    }
 }
 
 .c-password-label {

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -217,14 +217,18 @@ input[type="checkbox"] {
   }
 }
 
-
 #modx-login-btn {
   border: 1px solid transparent;
   &:hover {
     background-color: $primary1;
-    background-image: linear-gradient($primary1, $primary2);
     box-shadow: none;
-    color: white;
+    color: $white;
+    transition: color .2s ease-out,
+    background-color .2s ease-out,
+    border .2s ease-out;
+  }
+  &:focus{
+    box-shadow: none;
   }
 }
 
@@ -348,8 +352,8 @@ input[type="checkbox"] {
 }
 
 .is-success {
-  color: $primary1;
-  border: 0.125rem solid $primary1;
+  color: $green;
+  border: 0.125rem solid $green;
   padding: 1rem;
   border-radius: $borderRadius;
 }

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -217,6 +217,17 @@ input[type="checkbox"] {
   }
 }
 
+
+#modx-login-btn {
+  border: 1px solid transparent;
+  &:hover {
+    background-color: $primary1;
+    background-image: linear-gradient($primary1, $primary2);
+    box-shadow: none;
+    color: white;
+  }
+}
+
 .c-password-label {
   display: flex;
   justify-content: space-between;
@@ -332,6 +343,13 @@ input[type="checkbox"] {
 .is-error {
   color: $red;
   border: 0.125rem solid $red;
+  padding: 1rem;
+  border-radius: $borderRadius;
+}
+
+.is-success {
+  color: $primary1;
+  border: 0.125rem solid $primary1;
   padding: 1rem;
   border-radius: $borderRadius;
 }

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -220,9 +220,10 @@ input[type="checkbox"] {
 #modx-login-btn {
   border: 1px solid transparent;
   &:hover {
-    background-color: $primary1;
+    background-color: $white;
+    color: $primary2;
     box-shadow: none;
-    color: $white;
+    border: 1px solid $primary2;
     transition: color .2s ease-out,
     background-color .2s ease-out,
     border .2s ease-out;

--- a/manager/templates/default/css/login.css
+++ b/manager/templates/default/css/login.css
@@ -192,8 +192,8 @@ input[type="checkbox"] {
   cursor: pointer; }
 
 #modx-login-btn{
-  border: 1px solid transparent;
-}
+  border: 1px solid transparent; }
+
 #modx-login-btn:hover {
   background-color: #2b9385;
   background-image: linear-gradient(#2b9385, #007571);
@@ -311,3 +311,10 @@ input[type="checkbox"] {
   border: 0.125rem solid #BE0000;
   padding: 1rem;
   border-radius: 3px; }
+
+.is-success {
+  color: #2b9385;
+  border: 0.125rem solid #2b9385;
+  padding: 1rem;
+  border-radius: 3px;
+}

--- a/manager/templates/default/css/login.css
+++ b/manager/templates/default/css/login.css
@@ -191,11 +191,13 @@ input[type="checkbox"] {
   font-size: 1rem;
   cursor: pointer; }
 
+#modx-login-btn{
+  border: 1px solid transparent;
+}
 #modx-login-btn:hover {
   background-color: #2b9385;
   background-image: linear-gradient(#2b9385, #007571);
   box-shadow: none;
-  border: none;
   color: #FFF; }
 
 .c-button--ghost {

--- a/manager/templates/default/css/login.css
+++ b/manager/templates/default/css/login.css
@@ -191,15 +191,6 @@ input[type="checkbox"] {
   font-size: 1rem;
   cursor: pointer; }
 
-#modx-login-btn{
-  border: 1px solid transparent; }
-
-#modx-login-btn:hover {
-  background-color: #2b9385;
-  background-image: linear-gradient(#2b9385, #007571);
-  box-shadow: none;
-  color: #FFF; }
-
 .c-button--ghost {
   color: #3697cd;
   background: transparent;
@@ -311,10 +302,3 @@ input[type="checkbox"] {
   border: 0.125rem solid #BE0000;
   padding: 1rem;
   border-radius: 3px; }
-
-.is-success {
-  color: #2b9385;
-  border: 0.125rem solid #2b9385;
-  padding: 1rem;
-  border-radius: 3px;
-}

--- a/manager/templates/default/css/login.css
+++ b/manager/templates/default/css/login.css
@@ -191,6 +191,12 @@ input[type="checkbox"] {
   font-size: 1rem;
   cursor: pointer; }
 
+.c-button:hover {
+  background-color: #2b9385;
+  background-image: linear-gradient(#2b9385, #007571);
+  box-shadow: none;
+  color: #FFF; }
+
 .c-button--ghost {
   color: #3697cd;
   background: transparent;

--- a/manager/templates/default/css/login.css
+++ b/manager/templates/default/css/login.css
@@ -191,10 +191,11 @@ input[type="checkbox"] {
   font-size: 1rem;
   cursor: pointer; }
 
-.c-button:hover {
+#modx-login-btn:hover {
   background-color: #2b9385;
   background-image: linear-gradient(#2b9385, #007571);
   box-shadow: none;
+  border: none;
   color: #FFF; }
 
 .c-button--ghost {


### PR DESCRIPTION
### What does it do?
Added CSS styles for hovered and focused states of the login button on the login page.

### Why is it needed?
Add behavior rules when hovering over a login button
It's a fix for issue #13976 #13950

### Related issue(s)/PR(s)
Fixes #13976 
Fixes #13950

It's recreated PR after #13984 that was accidentally closed by my fail. :( Author's commits saved.