### PR TITLE
Actual versions of PHP in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,17 @@ script:
 
 # Set php versions
 php:
+  - 7.2
   - 7.1
   - 7.0
   - 5.6
   - nightly
   - 5.5
   - 5.4
-#  - 5.3
-  - hhvm
 
 matrix:
   allow_failures:
     - php: nightly
-    - php: hhvm
 
 # database credentials
 mysql:


### PR DESCRIPTION
### What does it do?
It removes hhvm as unsupported from Travis builds. As well it adds actual 7.2 version of PHP.

### Why is it needed?
HHVM build always failed so it makes sense just remove it to do not load Travis by useless tasks. Also, the current actual and latest version of PHP is 7.2 and we need to be sure that MODX works on the actual version of PHP as well.

### Related issue(s)/PR(s)
None