### PR TITLE
Add a reloadContext option to modResourceUpdateProcessor

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -735,7 +735,11 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         }
         $returnArray['class_key'] = $this->object->get('class_key');
         $this->workingContext->prepare(false);
-        $this->modx->reloadContext($this->workingContext->key);
+        
+        if ($this->getProperty('_reloadContext', true)) {
+            $this->modx->reloadContext($this->workingContext->key);
+        }
+        
         $returnArray['preview_url'] = '';
         if (!$this->object->get('deleted')) {
             $returnArray['preview_url'] = $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');


### PR DESCRIPTION
Added context reload check for bulk actions on resources, for example for bulk import of goods.

### What does it do?
Reducing execution time of the processor.

### Why is it needed?
При массовой выгрузке товаров у нас экономится время.

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)
