### PR TITLE
Fixing images escaping their container in media browser

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -52,8 +52,8 @@
 }
   .modx-browser-thumb {
     border: 1px solid $borderColor;
-    height: 80px;
-    line-height: 80px;
+    height: 100px;
+    line-height: 100px;
     padding: 5px;
     text-align: center;
     width: 100px;
@@ -196,7 +196,7 @@
       opacity: 0.6;
       filter: alpha(opacity=60); /* for IE <= 8 */
     }
-  } 
+  }
 
   img {
     display: block;


### PR DESCRIPTION
### What does it do?
Changes the value of height and line-height on `.modx-browser-thumb`

### Why is it needed?
To prevent some images from escaping their container.

![44280094-b808b900-a221-11e8-9cee-3dac7d98da18](https://user-images.githubusercontent.com/2373940/44285409-7ef23800-a265-11e8-843a-a81000bf5aee.png)

### Related issue(s)/PR(s)
Fixes https://github.com/modxcms/revolution/issues/14051
