### PR TITLE
Delete files in Media Browser with '&' in the file name

### DIFF
--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -33,7 +33,7 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (empty($file)) {
             return $this->modx->error->failure($this->modx->lexicon('file_err_ns'));
         }
-        $file = preg_replace('/[\.]{2,}/', '', htmlspecialchars($file));
+        $file = preg_replace('/[\.]{2,}/', '', $file);
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {


### PR DESCRIPTION
### What does it do?
In November 2016 extra protection was added to [prevent local file inclusion/traversal/manipulation](https://github.com/modxcms/revolution/commit/d3df889703f712e71eb0cdca4f9b316731f51143#diff-ea84051473ef39b6641bf6f3d3f33e5a). One side-effect was that files uploaded with '&' in the file name could no longer be deleted.

With MODX 2.6.5 it is still the case that files uploaded do not have their filename encoded with `htmlspecialchars()`, but requests to delete a file do.

This PR reverses that so the treatment of file names is symmetrical, and a file that is uploaded can be removed.

### Steps to reproduce
1. Log into the MODX manager and go to `Media > Media Browser`.
2. Upload an image with `&` in the filename. Mine is `Test - B&W.jpg`
3. Confirm it's uploaded, you can view it etc
4. Right click and choose `Delete file`
5. Without the patch, you will get a popup saying _Please specify a valid directory.: /paas/cXXX/www/uploads/Test - B&W.jpg_. The file will not be removed
6. With the patch, the file will be deleted

### Security considerations
I am not a security professional. But I don't see this making the system less secure.

Not sanitising filenames on upload is a potential issue; to be able to delete files we need to have the same behaviour when deleting. Even if new filenames were sanitised in the same way, files previously uploaded would need to be deleted.

### Related issue(s)/PR(s)
#13412
