### PR TITLE
New static Slack badge in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MODX Revolution
 
-[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=2.x)](https://travis-ci.org/modxcms/revolution) [![Slack Status](https://modx.org/badge.svg)](https://modx.org)
+[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=2.x)](https://travis-ci.org/modxcms/revolution) [![Slack Chat](https://img.shields.io/badge/chat_in_slack-online-f3005a.svg?longCache=true&style=flat&logo=slack)](https://modx.org)
 
 ## Content Management System and Application Framework
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MODX Revolution
 
-[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=2.x)](https://travis-ci.org/modxcms/revolution) [![Slack Chat](https://img.shields.io/badge/chat_in_slack-online-f3005a.svg?longCache=true&style=flat&logo=slack)](https://modx.org)
+[![Build Status](https://travis-ci.org/modxcms/revolution.svg?branch=2.x)](https://travis-ci.org/modxcms/revolution) [![Slack Chat](https://img.shields.io/badge/chat_in_slack-online-green.svg?longCache=true&style=flat&logo=slack)](https://modx.org)
 
 ## Content Management System and Application Framework
 


### PR DESCRIPTION
### What does it do?
It adds a new image for the Slack badge in the readme file of the repository. Using [shields.io](https://shields.io/) service

### Why is it needed?
Slackin application has gone and now link just redirects to the community page in Slack web version. And image does not exist and it seems broken. Need to fix it.

### Related issue(s)/PR(s)
Fixes #14015 
