### PR TITLE
Sanitize parameters in the RestServiceRequest class

### DIFF
--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -373,8 +373,7 @@ class modRestServiceRequest {
 			default:
 				break;
 		}
-
-        if ($this->getProperty('sanitize', false) {
+        if ($this->service->getOption('sanitize', false)) {
             $this->sanitizeRequest();
         }
     }

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -271,6 +271,8 @@ class modRestServiceRequest {
     public $headers = array();
     /** @var array $parameters The request parameters on the request */
     public $parameters = array();
+    /** @var bool $sanitize Sanitize the request parameters */
+    public $sanitize = false;
 
     /**
      * @param modRestService $service A reference to the modRestService instance
@@ -374,7 +376,9 @@ class modRestServiceRequest {
 				break;
 		}
 
-		$this->sanitizeRequest();
+        if ($this->sanitize) {
+            $this->sanitizeRequest();
+        }
     }
 
     /**

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -271,8 +271,6 @@ class modRestServiceRequest {
     public $headers = array();
     /** @var array $parameters The request parameters on the request */
     public $parameters = array();
-    /** @var bool $sanitize Sanitize the request parameters */
-    public $sanitize = false;
 
     /**
      * @param modRestService $service A reference to the modRestService instance
@@ -376,7 +374,7 @@ class modRestServiceRequest {
 				break;
 		}
 
-        if ($this->sanitize) {
+        if ($this->getProperty('sanitize', false) {
             $this->sanitizeRequest();
         }
     }

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -59,6 +59,7 @@ class modRestService {
             'responseSuccessKey' => 'success',
             'trimParameters' => false,
             'xmlRootNode' => 'response',
+            'sanitize' => false
 		),$config);
 		$this->modx->getService('lexicon','modLexicon');
         if ($this->modx->lexicon) {

--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -373,6 +373,21 @@ class modRestServiceRequest {
 			default:
 				break;
 		}
+
+		$this->sanitizeRequest();
+    }
+
+    /**
+     * Sanitize the request parameters
+     *
+     * @return void
+     */
+    protected function sanitizeRequest() {
+        $modxtags = array_values($this->service->modx->sanitizePatterns);
+        $this->parameters= modX :: sanitize($this->parameters, $modxtags);
+
+        modX :: sanitize($_COOKIE, $modxtags);
+        modX :: sanitize($_REQUEST, $modxtags);
     }
 
     /**


### PR DESCRIPTION
Added missing sanitize logic for sanitizing the parameters in the modRestServiceRequest class.

### What does it do?
It sanitize the parameters in the modRestServiceRequest class.
The sanitizing is based on the modX sanitizePatterns.

### Why is it needed?
To avoid potential  XSS and other attacks

### Related issue(s)/PR(s)
-
