### PR TITLE
Allow a middle mouse click to open links in a new tab/window 

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -396,10 +396,15 @@ MODx.LayoutMgr = function() {
             var url = parts.join('&');
             if (MODx.fireEvent('beforeLoadPage', url)) {
                 var e = window.event;
-                if (e && (e.button == 1 || e.ctrlKey == 1 || e.metaKey == 1 || e.shiftKey == 1)) {
-                    // Keyboard key pressed, let the browser handle the way it should be opened (new tab/window)
+
+                var middleMouseButtonClick = (e && (e.button === 4 || e.which === 2));
+                var keyboardKeyPressed = (e && (e.button === 1 || e.ctrlKey === 1 || e.metaKey === 1 || e.shiftKey === 1));
+                if (middleMouseButtonClick || keyboardKeyPressed) {
+                    // Middle mouse button click or keyboard key pressed,
+                    // let the browser handle the way it should be opened (new tab/window)
                     return window.open(url);
                 }
+
                 location.href = url;
             }
             return false;


### PR DESCRIPTION
### What does it do?
It detects if the middle mouse key is pressed and makes the browser handle the way the link should be opened (new tab/window)

### Why is it needed?
> Without the middle mouse button - as if the finger was cut off, especially if it's standard browser behavior 

### Related issue(s)/PR(s)
#14059 