### PR TITLE
changed resource query to count children via subqueries

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -194,7 +194,7 @@ class modResourceGetNodesProcessor extends modProcessor {
                 'parent' => $this->startNode,
             ));
         }
-        $c->groupby($this->modx->getSelectColumns('modResource', 'modResource', '', $resourceColumns), '');
+        $c->groupby('modResource.id', '');
         $sortBy = $this->modx->escape($this->getProperty('sortBy'));
         $c->sortby('modResource.' . $sortBy,$this->getProperty('sortDir'));
         return $c;

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -175,10 +175,9 @@ class modResourceGetNodesProcessor extends modProcessor {
         );
         $this->itemClass= 'modResource';
         $c= $this->modx->newQuery($this->itemClass);
-        $c->leftJoin('modResource', 'Child', array('modResource.id = Child.parent'));
         $c->select($this->modx->getSelectColumns('modResource', 'modResource', '', $resourceColumns));
         $c->select(array(
-            'childrenCount' => 'COUNT(Child.id)',
+            'childrenCount' => "(SELECT COUNT(*) FROM {$this->modx->getTableName('modResource')} WHERE parent = modResource.id)",
         ));
         $c->where(array(
             'context_key' => $this->contextKey,
@@ -194,7 +193,6 @@ class modResourceGetNodesProcessor extends modProcessor {
                 'parent' => $this->startNode,
             ));
         }
-        $c->groupby('modResource.id', '');
         $sortBy = $this->modx->escape($this->getProperty('sortBy'));
         $c->sortby('modResource.' . $sortBy,$this->getProperty('sortDir'));
         return $c;


### PR DESCRIPTION
### What does it do?
It removes group by and adds a subquery to make the query faster.

### Why is it needed?
It generates a faster resource query.

### Related issue(s)/PR(s)
It fixes #14064
