### PR TITLE
Fix uninstall errors

### DIFF
--- a/core/model/modx/processors/workspace/packages/remove.class.php
+++ b/core/model/modx/processors/workspace/packages/remove.class.php
@@ -51,8 +51,9 @@ class modPackageRemoveProcessor extends modProcessor {
         if (file_exists($transportZip) && file_exists($transportDir)) {
             /* remove transport package */
             if ($this->package->removePackage($this->getProperty('force')) == false) {
-                $this->modx->log(xPDO::LOG_LEVEL_ERROR,$this->modx->lexicon('package_err_remove'));
-                return $this->failure($this->modx->lexicon('package_err_remove',array('signature' => $this->package->getPrimaryKey())));
+                $packageSignature = $this->package->getPrimaryKey();
+                $this->modx->log(xPDO::LOG_LEVEL_ERROR,$this->modx->lexicon('package_err_remove',array('signature' => $packageSignature)));
+                return $this->failure($this->modx->lexicon('package_err_remove',array('signature' => $packageSignature)));
             }
         } else {
             /* for some reason the files were removed, so just remove the DB object instead */

--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -344,7 +344,7 @@ class modTransportPackage extends xPDOObject {
                 $this->save();
             } else {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$this->xpdo->lexicon('package_err_uninstall',array(
-                    'signature' => $this->package->get('signature'),
+                    'signature' => $this->get('signature'),
                 )));
             }
         } else {


### PR DESCRIPTION
### What does it do?
Fixes not passing property to a lexicon string & an error when uninstall fails.

### Why is it needed?
Currently if package uninstall fails, current messages are shown in the console:
```
Recoverable error: Object of class xPDOObjectVehicle could not be converted to string
Error uninstalling package with signature: Object
Error removing package with signature: [[+signature]]
```
