### PR TITLE
Applied unused before configuration options with charset and collation during database creation

### DIFF
--- a/setup/includes/tables_create.php
+++ b/setup/includes/tables_create.php
@@ -100,7 +100,7 @@ if (!$connected) {
     $dsnArray= xPDO :: parseDSN($modx->getOption('dsn'));
     $containerOptions['charset']= $install->settings->get('database_charset', 'utf8');
     $containerOptions['collation']= $install->settings->get('database_collation', 'utf8_general_ci');
-    $created= $modx->manager->createSourceContainer($dsnArray, $modx->config['username'], $modx->config['password']);
+    $created = $modx->manager->createSourceContainer($dsnArray, $modx->config['username'], $modx->config['password'], $containerOptions);
     if (!$created) {
         $results[]= array ('class' => 'failed', 'msg' => '<p class="notok">'.$install->lexicon('db_err_create').'</p>');
     }


### PR DESCRIPTION
### What does it do?
It passes `$containerOptions` variables with proper charset and collation to the `createSourceContainer` method that creates a database during the installation.

### Why is it needed?
I have often been faced with it a long time, using Gitify (and other tools for CLI installation) when after installing the MODX, all non-latin strings become "???" because the wrong charset was applied to the database and tables (the default charset, that was configured for MySQL server, usually `latin`). It was happening even if charset and collation were defined in the configuration (they are predefined as urtf8 by default, but were ignored). 
This changes should fix the wrong behavior for new installations.

### Related issue(s)/PR(s)
N/A
