### PR TITLE
Fixing Double-click of image in Media Browser goes to blank page

### DIFF
--- a/manager/assets/modext/widgets/media/browser.js
+++ b/manager/assets/modext/widgets/media/browser.js
@@ -126,8 +126,6 @@ Ext.extend(MODx.Media, Ext.Container, {
     }
 
     ,setReturn: function(el) {
-        // @todo make sure this is never used
-        console.log('MODx.Media#setReturn', el);
         this.returnEl = el;
     }
 

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -1117,6 +1117,7 @@ Ext.extend(MODx.Media, Ext.Container, {
     }
 
     ,onSelect: function(data) {
+        return false;
         // @todo make sure this is never used
         console.log('MODx.Media#onSelect', data);
         var selNode = this.view.getSelectedNodes()[0];

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -754,8 +754,6 @@ Ext.extend(MODx.browser.Window,Ext.Window,{
     }
 
     ,setReturn: function(el) {
-        // @todo make sure this is never used
-        console.log('MODx.Media#setReturn', el);
         this.returnEl = el;
     }
 
@@ -1111,31 +1109,14 @@ Ext.extend(MODx.Media, Ext.Container, {
     }
 
     ,setReturn: function(el) {
-        // @todo make sure this is never used
-        console.log('MODx.Media#setReturn', el);
         this.returnEl = el;
     }
 
     ,onSelect: function(data) {
-        return false;
-        // @todo make sure this is never used
-        console.log('MODx.Media#onSelect', data);
-        var selNode = this.view.getSelectedNodes()[0];
-        var callback = this.config.onSelect || this.onSelectHandler;
-        var lookup = this.view.lookup;
-        var scope = this.config.scope;
-        this.hide(this.config.animEl || null,function(){
-            if (selNode && callback) {
-                var data = lookup[selNode.id];
-                Ext.callback(callback,scope || this,[data]);
-                this.fireEvent('select',data);
-            }
-        },scope);
+        return;
     }
 
     ,onSelectHandler: function(data) {
-        // @todo make sure this is never used
-        console.log('MODx.Media#onSelectHandler', data);
         Ext.get(this.returnEl).dom.value = unescape(data.url);
     }
 });
@@ -1503,8 +1484,6 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
     }
 
     ,setReturn: function(el) {
-        // @todo make sure this is never used
-        console.log('MODx.Media#setReturn', el);
         this.returnEl = el;
     }
 


### PR DESCRIPTION
### What does it do?
Make sure that MODx.Media.onSelect code is not executed by removing the code.

### Why is it needed?
MODx.Media.onSelect has hidden `this.config.animEl || null` before, which means that MODx.Media is hidden accidentally. That way a double-click of an image in the Media Browser goes to blank page.

### Related issue(s)/PR(s)
#14075 
