### PR TITLE
[ReUp] Copy file/folder path to clipboard

### DIFF
--- a/core/lexicon/en/file.inc.php
+++ b/core/lexicon/en/file.inc.php
@@ -15,6 +15,7 @@ $_lang['file_delete_folder'] = 'Delete Folder';
 $_lang['file_download'] = 'Download File';
 $_lang['file_download_file'] = 'Download File';
 $_lang['file_download_unzip'] = 'Unzip File';
+$_lang['file_copy_path'] = 'Copy File Path';
 $_lang['file_edit'] = 'Edit File';
 $_lang['file_err_ae'] = 'File %s already exists';
 $_lang['file_err_chmod'] = 'An unknown error occurred while trying to chmod the target.';

--- a/core/lexicon/en/file.inc.php
+++ b/core/lexicon/en/file.inc.php
@@ -46,6 +46,7 @@ $_lang['file_folder_create'] = 'Create Directory';
 $_lang['file_folder_create_here'] = 'Create Directory Here';
 $_lang['file_folder_created'] = 'Folder created successfully!';
 $_lang['file_folder_deleted'] = 'Folder was successfully deleted!';
+$_lang['file_folder_copy_path'] = 'Copy Folder Path';
 $_lang['file_folder_err_ae'] = 'A directory already exists with that name in that location.';
 $_lang['file_folder_err_chmod'] = 'Unable to change permissions, you will need to change permissions outside of MODX.';
 $_lang['file_folder_err_create'] = 'An unknown error occurred while trying to create the directory.';

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -387,6 +387,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 'text' => $this->xpdo->lexicon('directory_refresh'),
                 'handler' => 'this.refreshActiveNode',
             );
+
+            $menu[] = array(
+                'text' => $this->xpdo->lexicon('file_folder_copy_path'),
+                'handler' => 'this.copyFilePath',
+            );
             if ($this->hasPermission('file_upload') && $canCreate) {
                 $menu[] = '-';
                 $menu[] = array(

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -345,6 +345,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     'text' => $this->xpdo->lexicon('file_download'),
                     'handler' => 'this.downloadFile',
                 );
+
+                $menu[] = array(
+                    'text' => $this->xpdo->lexicon('file_copy_path'),
+                    'handler' => 'this.copyFilePath',
+                );
             }
             if ($this->hasPermission('file_unpack') && $canView && pathinfo($file->getFilename(), PATHINFO_EXTENSION) === 'zip') {
                 $menu[] = array(

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -348,7 +348,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                 $menu[] = array(
                     'text' => $this->xpdo->lexicon('file_copy_path'),
-                    'handler' => 'this.copyFilePath',
+                    'handler' => 'this.copyRelativePath',
                 );
             }
             if ($this->hasPermission('file_unpack') && $canView && pathinfo($file->getFilename(), PATHINFO_EXTENSION) === 'zip') {
@@ -390,7 +390,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
             $menu[] = array(
                 'text' => $this->xpdo->lexicon('file_folder_copy_path'),
-                'handler' => 'this.copyFilePath',
+                'handler' => 'this.copyRelativePath',
             );
             if ($this->hasPermission('file_upload') && $canCreate) {
                 $menu[] = '-';

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -203,6 +203,20 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         });
     }
 
+    ,copyFilePath: function(item,e) {
+        var node = this.cm.activeNode;
+        var data = this.lookup[node.id];
+
+        var dummyFilePathInput = document.createElement("input");
+        document.body.appendChild(dummyFilePathInput);
+        dummyFilePathInput.setAttribute('value', data.pathRelative);
+
+        dummyFilePathInput.select();
+        document.execCommand("copy");
+
+        document.body.removeChild(dummyFilePathInput);
+    }
+
     ,removeFile: function(item,e) {
         var node = this.cm.activeNode;
         var data = this.lookup[node.id];

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -203,18 +203,18 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         });
     }
 
-    ,copyFilePath: function(item,e) {
+    ,copyRelativePath: function(item,e) {
         var node = this.cm.activeNode;
         var data = this.lookup[node.id];
 
-        var dummyFilePathInput = document.createElement("input");
-        document.body.appendChild(dummyFilePathInput);
-        dummyFilePathInput.setAttribute('value', data.pathRelative);
+        var dummyRelativePathInput = document.createElement("input");
+        document.body.appendChild(dummyRelativePathInput);
+        dummyRelativePathInput.setAttribute('value', data.pathRelative);
 
-        dummyFilePathInput.select();
+        dummyRelativePathInput.select();
         document.execCommand("copy");
 
-        document.body.removeChild(dummyFilePathInput);
+        document.body.removeChild(dummyRelativePathInput);
     }
 
     ,removeFile: function(item,e) {

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -664,13 +664,13 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         var node = this.cm.activeNode;
 
         var dummyRelativePathInput = document.createElement("input");
-        document.body.appendChild(dummRelativePathInput);
-        dummRelativePathInput.setAttribute('value', node.attributes.pathRelative);
+        document.body.appendChild(dummyRelativePathInput);
+        dummyRelativePathInput.setAttribute('value', node.attributes.pathRelative);
 
-        dummRelativePathInput.select();
+        dummyRelativePathInput.select();
         document.execCommand("copy");
 
-        document.body.removeChild(dummRelativePathInput);
+        document.body.removeChild(dummyRelativePathInput);
     }
 
     ,getSource: function() {

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -660,17 +660,17 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         });
     }
 
-    ,copyFilePath: function(item,e) {
+    ,copyRelativePath: function(item,e) {
         var node = this.cm.activeNode;
 
-        var dummyFilePathInput = document.createElement("input");
-        document.body.appendChild(dummyFilePathInput);
-        dummyFilePathInput.setAttribute('value', node.attributes.pathRelative);
+        var dummyRelativePathInput = document.createElement("input");
+        document.body.appendChild(dummRelativePathInput);
+        dummRelativePathInput.setAttribute('value', node.attributes.pathRelative);
 
-        dummyFilePathInput.select();
+        dummRelativePathInput.select();
         document.execCommand("copy");
 
-        document.body.removeChild(dummyFilePathInput);
+        document.body.removeChild(dummRelativePathInput);
     }
 
     ,getSource: function() {

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -660,6 +660,19 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         });
     }
 
+    ,copyFilePath: function(item,e) {
+        var node = this.cm.activeNode;
+
+        var dummyFilePathInput = document.createElement("input");
+        document.body.appendChild(dummyFilePathInput);
+        dummyFilePathInput.setAttribute('value', node.attributes.pathRelative);
+
+        dummyFilePathInput.select();
+        document.execCommand("copy");
+
+        document.body.removeChild(dummyFilePathInput);
+    }
+
     ,getSource: function() {
         return this.config.baseParams.source;
     }


### PR DESCRIPTION
### What does it do?
It adds an option to copy the path to a file/folder in the MODX file tree and media browser.

### Why is it needed?
To make life easier for manager users.

### Related issue(s)/PR(s)
Issue #11666