### PR TITLE
[3.x] [ReUp] Make dashboard buttons go full width

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -249,7 +249,7 @@
   margin: -1rem 0 0 -1rem;
   .dashboard-button {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     background-color: $white;
     border-radius: $borderRadius;
     box-shadow: $boxShadow;
@@ -257,7 +257,7 @@
     padding: 20px;
     text-decoration: none;
     color: $darkestGray;
-    max-width: 185px;
+    flex: 1;
     &:hover {
       color: $black;
       .icon {
@@ -316,6 +316,7 @@
       flex-wrap: wrap;
       flex-direction: column;
       text-align: center;
+      align-items: center;
       &-wrapper {
         margin-left: 0;
         margin-top: 5px;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -57,9 +57,19 @@
     }
     &.double {
       width: calc(100% - 1rem);
-      min-height: 500px;
+      min-height: 250px;
+      margin-top: 2rem;
       .body {
         max-height: 100%;
+        height: 100%;
+      }
+      .dashboard {
+          &-buttons {
+              height: 100%;
+          }
+          &-button {
+              align-items: center;
+          }
       }
     }
     h4 {


### PR DESCRIPTION
### What does it do?
Makes the dashboard buttons go full width and fill all horizontal space. When the largest size is selected, it makes the buttons _go large_.

![screen shot 2018-09-11 at 09 38 54](https://user-images.githubusercontent.com/2373940/45345416-8bd52380-b5a6-11e8-8feb-d54c1a3017fd.png)

### Why is it needed?
To make MODX great again.

This is a quick fix. Some native flexbox kicks in, in a row of 6 buttons, on smaller viewports, the last 2 items might be split 50/50, whilst the top row will be split 4 across.

This can be fixed, but it gets complicated rather quickly;
1. How many buttons are there? Just 4 or unlimited?
2. Size of viewport with tree
3. Size of viewport with no tree
4. Stacked button vs 2 column button and at what viewport?

Feedback welcome.

### Related issue(s)/PR(s)
This fixes https://github.com/modxcms/revolution/issues/13964
