### PR TITLE
[ReUp] fix manager header height on resize

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -1,7 +1,8 @@
 /* Main MODX Manager navbar */
 #modx-header {
   background: rgb(63,72,80);
-  min-height: 55px; /* #janky #extjs */
+  height: 55px; /* #janky #extjs */
+  max-height: 55px;
   @include media($mobile) {
 	  height:auto !important;
   }

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -1,7 +1,7 @@
 /* Main MODX Manager navbar */
 #modx-header {
   background: rgb(63,72,80);
-  height: 55px; /* #janky #extjs */
+  height: 55px;
   max-height: 55px;
   @include media($mobile) {
 	  height:auto !important;


### PR DESCRIPTION
### What does it do?
Adds height and max-height values to #modx-header to prevent a gap appearing on resize.

![modx_issue_header](https://user-images.githubusercontent.com/2373940/45354796-dd89a800-b5be-11e8-8821-bf28fce6bbcc.gif)

### Why is it needed?
To fix a gap on browser resize.

### Related issue(s)/PR(s)
Fixes https://github.com/modxcms/revolution/issues/14082