### PR TITLE
Fix incorrect password behavior and message issue #14084

### DIFF
--- a/core/lexicon/en/login.inc.php
+++ b/core/lexicon/en/login.inc.php
@@ -8,7 +8,7 @@
  */
 $_lang['login_language'] = 'Language';
 $_lang['login_activation_key_err'] = 'Activation key does not match! Please check your activation email and make sure you loaded the right URL.';
-$_lang['login_blocked_admin'] = 'You have been blocked from the manager by an administrator.';
+$_lang['login_blocked_admin'] = 'You have been blocked by an administrator.';
 $_lang['login_blocked_error'] = 'You are temporarily blocked and cannot log in. Please try again later.';
 $_lang['login_blocked_ip'] = 'You are not allowed to login from your current IP address.';
 $_lang['login_blocked_time'] = 'You are not allowed to login at this time. Please try again later.';

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -145,6 +145,7 @@ class modSecurityLoginProcessor extends modProcessor {
         if ($profile->get('blockeduntil') < time()) {
             if ($profile->get('blockeduntil') > 0) {
                 $profile->set('failedlogincount', 0);
+                $flc = 0;
             }
             $profile->set('blockeduntil', 0);
             $profile->save();
@@ -152,6 +153,7 @@ class modSecurityLoginProcessor extends modProcessor {
         if ($this->user->passwordMatches($this->givenPassword) && $profile->get('blockeduntil') < time()) {
             $profile->set('failedlogincount', 0);
             $profile->save();
+            $flc = 0;
         }
         else {
             $flc++;

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -163,7 +163,7 @@ class modSecurityLoginProcessor extends modProcessor {
         }
         
         /* Validate block state */
-        if ($profile->get('failedlogincount') >= $this->modx->getOption('failed_login_attempts') &&
+        if ($flc >= $this->modx->getOption('failed_login_attempts') &&
             $profile->get('blockeduntil') > time()) {
             return $this->modx->lexicon('login_blocked_too_many_attempts');
         }

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -148,7 +148,7 @@ class modSecurityLoginProcessor extends modProcessor {
             $profile->set('blockeduntil', 0);
             $profile->save();
         }
-        if ($this->user->passwordMatches($this->givenPassword)) {
+        if ($this->user->passwordMatches($this->givenPassword) && $profile->get('blockeduntil') < time()) {
             $profile->set('failedlogincount', 0);
             $profile->save();
         }

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -140,22 +140,28 @@ class modSecurityLoginProcessor extends modProcessor {
         /** @var modUserProfile $profile */
         $profile = $this->user->Profile;
 
-        if ($profile->get('failed_logins') >= $this->modx->getOption('failed_login_attempts') &&
-            $profile->get('blockeduntil') > time()) {
-            return $this->modx->lexicon('login_blocked_too_many_attempts');
-        }
-
-        if ($profile->get('failedlogincount') >= $this->modx->getOption('failed_login_attempts')) {
-            $profile->set('failedlogincount', 0);
-            $profile->set('blocked', 1);
-            $profile->set('blockeduntil', time() + (60 * $this->modx->getOption('blocked_minutes')));
-            $profile->save();
-        }
-        if ($profile->get('blockeduntil') != 0 && $profile->get('blockeduntil') < time()) {
-            $profile->set('failedlogincount', 0);
-            $profile->set('blocked', 0);
+        /* Update block state */
+        if ($profile->get('blockeduntil') < time()) {
+            if ($profile->get('blockeduntil') > 0) {
+                $profile->set('failedlogincount', 0);
+            }
             $profile->set('blockeduntil', 0);
             $profile->save();
+        }
+        if ($this->user->passwordMatches($this->givenPassword)) {
+            $profile->set('failedlogincount', 0);
+            $profile->save();
+        }
+        if ($profile->get('failedlogincount') >= $this->modx->getOption('failed_login_attempts') &&
+            $profile->get('blockeduntil') < time()) {
+                $profile->set('blockeduntil', time() + (60 * $this->modx->getOption('blocked_minutes')));
+                $profile->save();
+        }
+        
+        /* Validate block state */
+        if ($profile->get('failedlogincount') >= $this->modx->getOption('failed_login_attempts') &&
+            $profile->get('blockeduntil') > time()) {
+            return $this->modx->lexicon('login_blocked_too_many_attempts');
         }
         if ($profile->get('blocked')) {
             return $this->modx->lexicon('login_blocked_admin');
@@ -167,7 +173,7 @@ class modSecurityLoginProcessor extends modProcessor {
             return $this->modx->lexicon('login_blocked_error');
         }
 
-        return false;
+        return false;    
     }
 
     /**

--- a/core/model/modx/processors/security/login.class.php
+++ b/core/model/modx/processors/security/login.class.php
@@ -139,6 +139,7 @@ class modSecurityLoginProcessor extends modProcessor {
 
         /** @var modUserProfile $profile */
         $profile = $this->user->Profile;
+        $flc = $profile->get('failedlogincount');
 
         /* Update block state */
         if ($profile->get('blockeduntil') < time()) {
@@ -152,7 +153,10 @@ class modSecurityLoginProcessor extends modProcessor {
             $profile->set('failedlogincount', 0);
             $profile->save();
         }
-        if ($profile->get('failedlogincount') >= $this->modx->getOption('failed_login_attempts') &&
+        else {
+            $flc++;
+        }
+        if ($flc >= $this->modx->getOption('failed_login_attempts') &&
             $profile->get('blockeduntil') < time()) {
                 $profile->set('blockeduntil', time() + (60 * $this->modx->getOption('blocked_minutes')));
                 $profile->save();


### PR DESCRIPTION
### What does it do?
Change the checks and the order of checks in checkIsBlocked method.

### Why is it needed?
When failed login is attempted N number of times, the account gets blocked as it was blocked by an admin, and displayed message is "login_blocked_admin" instead of "login_blocked_too_many_attempts"

### Related issue(s)/PR(s)
#14084
