### PR TITLE
Default Constrain Window To Browser

### DIFF
--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -128,6 +128,8 @@ MODx.Window = function(config) {
         ,autoScroll: true
         ,allowDrop: true
         ,width: 400
+        ,constrain: true
+        ,constrainHeader: true
         ,cls: 'modx-window'
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')


### PR DESCRIPTION
Prevent MODx.Window from being hidden outside the browser's viewable area by default.

### What does it do?
This changes two default values for Ext.Window in MODx.Window, constrain and constrainHeader, to true.

### Why is it needed?
Without this option selected it is possible to have a window popup outside of the browsers viewable area, and not be able to access it again.  This happens in 3PC CMPs quite a bit, and I end up having to manually edit the CMPs code.  It should just be fixed in the core MODx.Window class as I can't see a reason to let the window go outside the browser area anyway. 
