### PR TITLE
Set the min-height of a x-combo-list-item

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -182,6 +182,7 @@ $buttonfonts: $bodyfonts;
 $treePseudoRootFont: normal 14px/35px $headfonts;
 $treeNodeFont: normal 13px/22px $bodyfonts;
 $baseText:   normal 13px/1.4 $bodyfonts;
+$baseTextHeight: 13px * 1.4;
 $fontSmall:  normal 11px $bodyfonts;
 $fontMedium: normal 12px $bodyfonts;
 $fontNormal: normal $bodyFontSize $bodyfonts;

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -1104,6 +1104,7 @@ input::-moz-focus-inner {
     border: 0;
     padding: 5px;
     color: $dropdownTextColor;
+    min-height: $baseTextHeight;
 
     &.x-combo-selected {
       background-color: $brandHover;


### PR DESCRIPTION
### What does it do?
Set the min-height of a x-combo-list-item.

### Why is it needed?
Empty lines in a combo box are displayed with a reduced height.

Before:
<img width="437" alt="bildschirmfoto 2018-09-19 um 10 22 56" src="https://user-images.githubusercontent.com/148371/45740824-6a9fb300-bbf6-11e8-8d74-69ec0ee27a5b.png">

After:
<img width="438" alt="bildschirmfoto 2018-09-19 um 10 22 33" src="https://user-images.githubusercontent.com/148371/45740835-6ecbd080-bbf6-11e8-97c5-175ddf6afa02.png">

### Related issue(s)/PR(s)
None
