### PR TITLE
Clear system/phpthumb connector properties

### DIFF
--- a/core/model/modx/processors/system/phpthumb.class.php
+++ b/core/model/modx/processors/system/phpthumb.class.php
@@ -32,6 +32,7 @@ class modSystemPhpThumbProcessor extends modProcessor {
         $this->modx->getService('fileHandler','modFileHandler','',array(
             'context' => $this->getProperty('wctx')
         ));
+        $this->unsetProperty('wctx');
         error_reporting(E_ALL);
         return true;
     }
@@ -44,11 +45,11 @@ class modSystemPhpThumbProcessor extends modProcessor {
     public function process() {
         $src = $this->getProperty('src');
         if (empty($src)) return $this->failure();
-
         $this->unsetProperty('src');
 
         $this->getSource($this->getProperty('source'));
         if (empty($this->source)) $this->failure($this->modx->lexicon('source_err_nf'));
+        $this->unsetProperty('source');
 
         $src = $this->source->prepareSrcForThumb($src);
         if (empty($src)) return '';
@@ -76,7 +77,7 @@ class modSystemPhpThumbProcessor extends modProcessor {
      * Get the source to load the paths from
      *
      * @param int $sourceId
-     * @return modMediaSource|modFileMediaSource
+     * @return modMediaSource|modFileMediaSource|boolean
      */
     public function getSource($sourceId) {
         /** @var modMediaSource|modFileMediaSource $source */


### PR DESCRIPTION
### What does it do?
Clear system/phpthumb connector properties before they are sent to modPhpThumb

### Why is it needed?
Fix logging of not allowed properties in modPhpThumb class.

### Related issue(s)/PR(s)
Fixes #14093
