### PR TITLE
PHP 5.6 - minimum required version

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -15,12 +15,6 @@
  *
  * @package modx
  */
-/* fix for PHP float bug: http://bugs.php.net/bug.php?id=53632 (php 4 <= 4.4.9 and php 5 <= 5.3.4) */
-if (strstr(str_replace('.','',serialize(array_merge($_GET, $_POST, $_COOKIE))), '22250738585072011')) {
-    header('Status: 422 Unprocessable Entity');
-    die();
-}
-
 if (!defined('MODX_CORE_PATH')) {
     define('MODX_CORE_PATH', dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR);
 }

--- a/manager/index.php
+++ b/manager/index.php
@@ -23,9 +23,9 @@ if (!defined('MODX_API_MODE')) {
 }
 
 /* check for correct version of php */
-$php_ver_comp = version_compare(phpversion(),'5.3.3');
+$php_ver_comp = version_compare(phpversion(),'5.6');
 if ($php_ver_comp < 0) {
-    die('Wrong php version! You\'re using PHP version "'.phpversion().'", and MODX Revolution only works on 5.3.3 or higher.');
+    die('Wrong php version! You\'re using PHP version "'.phpversion().'", and MODX Revolution only works on 5.6 or higher.');
 }
 
 /* set the document_root */

--- a/setup/includes/test/modinstalltest.class.php
+++ b/setup/includes/test/modinstalltest.class.php
@@ -69,8 +69,8 @@ abstract class modInstallTest {
         $this->title('php_version',$this->install->lexicon('test_php_version_start').' ');
         $phpVersion = phpversion();
 
-        $recommended_version = "5.6";
-        $required_version = "5.3.3";
+        $recommended_version = "7.2";
+        $required_version = "5.6";
 
         $php_ver_comp = version_compare($phpVersion,$required_version,'>=');
 

--- a/setup/index.php
+++ b/setup/index.php
@@ -39,7 +39,7 @@ if ($isCommandLine) {
 
 /* check for compatible PHP version */
 define('MODX_SETUP_PHP_VERSION', phpversion());
-$php_ver_comp = version_compare(MODX_SETUP_PHP_VERSION, '5.4.0');
+$php_ver_comp = version_compare(MODX_SETUP_PHP_VERSION, '5.6.0');
 if ($php_ver_comp < 0) {
     die('<html><head><title></title></head><body><h1>FATAL ERROR: MODX Setup cannot continue.</h1><p>Wrong PHP version! You\'re using PHP version '.MODX_SETUP_PHP_VERSION.', and MODX requires version 5.4.0 or higher.</p></body></html>');
 }
@@ -50,13 +50,13 @@ if (!function_exists('json_encode')) {
 }
 
 /* make sure date.timezone is set for PHP 5.3.0+ users */
-if (version_compare(MODX_SETUP_PHP_VERSION,'5.3.0') >= 0) {
+if (version_compare(MODX_SETUP_PHP_VERSION,'5.6.0') >= 0) {
     $phptz = @ini_get('date.timezone');
     if (empty($phptz)) {
         date_default_timezone_set('UTC');
     }
     if (!date_default_timezone_get()) {
-        die('<html><head><title></title></head><body><h1>FATAL ERROR: MODX Setup cannot continue.</h1><p>To use PHP 5.3.0+, you must set the date.timezone setting in your php.ini (or have at least UTC in the list of supported timezones). Please do set it to a proper timezone before proceeding. A list can be found <a href="http://us.php.net/manual/en/timezones.php">here</a>.</p></body></html>');
+        die('<html><head><title></title></head><body><h1>FATAL ERROR: MODX Setup cannot continue.</h1><p>To use PHP 5.6.0+, you must set the date.timezone setting in your php.ini (or have at least UTC in the list of supported timezones). Please do set it to a proper timezone before proceeding. A list can be found <a href="http://us.php.net/manual/en/timezones.php">here</a>.</p></body></html>');
     }
 }
 if (!$isCommandLine) {


### PR DESCRIPTION
### What does it do?
Minimum required php version. Synchronization with composer.json