### PR TITLE
Prevent an infinite loop in sendErrorPage()

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1114,6 +1114,7 @@ class modX extends xPDO {
      *
      * @param integer $id The resource identifier.
      * @param string $options An array of options for the process.
+     * @param boolean $sendErrorPage Whether we should skip the sendErrorPage if the resource does not exist.
      */
     public function sendForward($id, $options = null, $sendErrorPage = true) {
         if (!$this->getRequest()) {

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1167,7 +1167,7 @@ class modX extends xPDO {
                 }
                 $this->request->prepareResponse();
                 exit();
-            } else if ($sendErrorPage) {
+            } elseif ($sendErrorPage) {
                 $this->sendErrorPage();
             }
             $options= array_merge(

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1115,7 +1115,7 @@ class modX extends xPDO {
      * @param integer $id The resource identifier.
      * @param string $options An array of options for the process.
      */
-    public function sendForward($id, $options = null) {
+    public function sendForward($id, $options = null, $sendErrorPage = true) {
         if (!$this->getRequest()) {
             $this->log(modX::LOG_LEVEL_FATAL, "Could not load request class.");
         }
@@ -1167,7 +1167,7 @@ class modX extends xPDO {
                 }
                 $this->request->prepareResponse();
                 exit();
-            } else {
+            } else if ($sendErrorPage) {
                 $this->sendErrorPage();
             }
             $options= array_merge(
@@ -1204,7 +1204,7 @@ class modX extends xPDO {
             $options
         );
         $this->invokeEvent('OnPageNotFound', $options);
-        $this->sendForward($this->getOption('error_page', $options, $this->getOption('site_start')), $options);
+        $this->sendForward($this->getOption('error_page', $options, $this->getOption('site_start')), $options, false);
     }
 
     /**


### PR DESCRIPTION
### What does it do?
It makes it possible to skip the `sendErrorPage` if the resource does not exist.

### Why is it needed?
To prevent an infinite loop if the defined `error_page` in system settings is a non-existent resource.

### Related issue(s)/PR(s)
#14107 