### PR TITLE
Fixing bug #14024

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -93,6 +93,11 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $properties = $this->getPropertyList();
         $path = $this->fileHandler->postfixSlash($path);
         $bases = $this->getBases($path);
+
+        if (!$this->verifyContainer($bases)) {
+            return array();
+        }
+
         if (empty($bases['pathAbsolute'])) return array();
         $fullPath = $bases['pathAbsolute'].ltrim($path,'/');
 
@@ -1337,5 +1342,23 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
      */
     public function getObjectUrl($object = '') {
         return $this->getBaseUrl().$object;
+    }
+
+    /**
+     * Validate of folder/container exists for mediasource
+     *
+     * @param array $bases Contains path data
+     * @return boolean
+     */
+    public function verifyContainer($bases) {
+        if (!$bases['pathIsRelative'] && !realpath($bases['pathAbsolute'])) {
+            return false;
+        }
+
+        if (!realpath(MODX_BASE_PATH . ltrim($bases['path'], '/'))) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
### What does it do?
If you specify an invalid relative path for a Filesystem media source, it does not display the contents of the server root folder.

### Why is it needed?
If you specify an invalid relative path for a Filesystem media source, it displays the contents of the server root folder. #14024

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14024
