### PR TITLE
Fixing user combo with preselected user ids #13267

### DIFF
--- a/core/model/modx/processors/security/user/getlist.class.php
+++ b/core/model/modx/processors/security/user/getlist.class.php
@@ -84,6 +84,14 @@ class modUserGetListProcessor extends modObjectGetListProcessor {
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $c->select($this->modx->getSelectColumns('modUser','modUser'));
         $c->select($this->modx->getSelectColumns('modUserProfile','Profile','',array('fullname','email','blocked')));
+
+        $id = $this->getProperty('id', 0);
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
+
         return $c;
     }
 


### PR DESCRIPTION
### What does it do?
Adding a where clause to the query, if an id property is requested. 

### Why is it needed?
Fixing showing an id instead of an username, if the selected user id is not returned in the list of users using the default limit.

It seems that most of the getlist processors have the same issue. But this will be fixed in a different PR.

### Related issue(s)/PR(s)
#13267