### PR TITLE
Fixing getlist processors for combos that have a pagesize 

### DIFF
--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -69,9 +69,9 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
         }
         return $c;
     }
-    
+
     /**
-     * {@inheritDoc}
+     * Filter the query by the valueField of MODx.combo.Context to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -32,6 +32,10 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
     /** @var boolean $canCreate Determines whether or not the user can create a context (/duplicate one) */
     public $canCreate = false;
 
+    /**
+     * {@inheritDoc}
+     * @return boolean
+     */
     public function initialize() {
         $initialized = parent::initialize();
         $this->setDefaultProperties(array(
@@ -44,6 +48,11 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
         return $initialized;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $search = $this->getProperty('search');
         if (!empty($search)) {
@@ -60,7 +69,12 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
         }
         return $c;
     }
-
+    
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $key = $this->getProperty('key','');
         if (!empty($key)) {

--- a/core/model/modx/processors/context/getlist.class.php
+++ b/core/model/modx/processors/context/getlist.class.php
@@ -61,6 +61,16 @@ class modContextGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $key = $this->getProperty('key','');
+        if (!empty($key)) {
+            $c->where(array(
+                $this->classKey . '.key:IN' => is_string($key) ? explode(',', $key) : $key,
+            ));
+        }
+        return $c;
+    }
+
     /**
      * {@inheritDoc}
      * @param xPDOObject $object

--- a/core/model/modx/processors/element/category/getlist.class.php
+++ b/core/model/modx/processors/element/category/getlist.class.php
@@ -96,7 +96,12 @@ class modElementCategoryGetListProcessor extends modObjectGetListProcessor {
         if ($this->getProperty('sort') == 'category') {
             $c->sortby('parent',$this->getProperty('dir','ASC'));
         }
-
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         return $c;
     }
 }

--- a/core/model/modx/processors/element/getclasses.class.php
+++ b/core/model/modx/processors/element/getclasses.class.php
@@ -42,6 +42,12 @@ class modElementGetClassesProcessor extends modProcessor {
             'class:!=' => 'modTemplate',
         ));
         $c->sortby($this->getProperty('sort'),$this->getProperty('dir'));
+        $name = $this->getProperty('name','');
+        if (!empty($name)) {
+            $c->where(array(
+                'modClassMap.name:IN' => is_string($name) ? explode(',', $name) : $name,
+            ));
+        }
         if ($isLimit) $c->limit($limit,$this->getProperty('start'));
         $classes = $this->modx->getCollection('modClassMap',$c);
 

--- a/core/model/modx/processors/element/getlist.class.php
+++ b/core/model/modx/processors/element/getlist.class.php
@@ -25,6 +25,12 @@ abstract class modElementGetListProcessor extends modObjectGetListProcessor {
         $c->select(array(
             'category_name' => 'Category.category',
         ));
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         return $c;
     }
 }

--- a/core/model/modx/processors/element/getlistbyclass.class.php
+++ b/core/model/modx/processors/element/getlistbyclass.class.php
@@ -61,6 +61,12 @@ class modElementGetListByClass extends modProcessor {
         $data['total'] = $this->modx->getCount($className,$c);
 
         $c->sortby($sort,$this->getProperty('dir','ASC'));
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $className.'.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         if ($isLimit) $c->limit($limit,$this->getProperty('start',0));
         $data['results'] = $this->modx->getCollection($className,$c);
         return $data;

--- a/core/model/modx/processors/element/propertyset/getlist.class.php
+++ b/core/model/modx/processors/element/propertyset/getlist.class.php
@@ -67,6 +67,16 @@ class modPropertySetGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
+        return $c;
+    }
+
     /**
      * If limiting to an Element, get default properties
      * @param array $list

--- a/core/model/modx/processors/element/propertyset/getlist.class.php
+++ b/core/model/modx/processors/element/propertyset/getlist.class.php
@@ -68,7 +68,7 @@ class modPropertySetGetListProcessor extends modObjectGetListProcessor {
     }
 
     /**
-     * {@inheritdoc}
+     * Filter the query by the valueField of MODx.combo.PropertySet to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/element/propertyset/getlist.class.php
+++ b/core/model/modx/processors/element/propertyset/getlist.class.php
@@ -67,6 +67,11 @@ class modPropertySetGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritdoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $id = $this->getProperty('id','');
         if (!empty($id)) {

--- a/core/model/modx/processors/security/access/permission/getlist.class.php
+++ b/core/model/modx/processors/security/access/permission/getlist.class.php
@@ -47,6 +47,12 @@ class modAccessPermissionGetListProcessor extends modObjectGetListProcessor {
             'Template.lexicon',
         ));
         $c->groupby('modAccessPermission.name');
+        $name = $this->getProperty('name','');
+        if (!empty($name)) {
+            $c->where(array(
+                $this->classKey . '.name:IN' => is_string($name) ? explode(',', $name) : $name
+            ));
+        }
         return $c;
     }
 

--- a/core/model/modx/processors/security/access/policy/getlist.class.php
+++ b/core/model/modx/processors/security/access/policy/getlist.class.php
@@ -76,6 +76,12 @@ class modAccessPolicyGetListProcessor extends modObjectGetListProcessor {
             'template_name' => 'Template.name',
         ));
         $c->select('('.$subc->toSql().') AS '.$this->modx->escape('total_permissions'));
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         return $c;
     }
 

--- a/core/model/modx/processors/security/access/policy/template/getlist.class.php
+++ b/core/model/modx/processors/security/access/policy/template/getlist.class.php
@@ -62,6 +62,12 @@ class modAccessPolicyTemplateGetListProcessor extends modObjectGetListProcessor 
             'template_group_name' => 'TemplateGroup.name',
         ));
         $c->select('('.$subQuery->toSql().') AS '.$this->modx->escape('total_permissions'));
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         return $c;
     }
 

--- a/core/model/modx/processors/security/resourcegroup/getlist.class.php
+++ b/core/model/modx/processors/security/resourcegroup/getlist.class.php
@@ -27,7 +27,7 @@ class modResourceGroupGetListProcessor extends modObjectGetListProcessor {
     public $permission = 'resourcegroup_view';
 
     /**
-     * {@inheritDoc}
+     * Filter the query by the valueField of MODx.combo.ResourceGroup to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/security/resourcegroup/getlist.class.php
+++ b/core/model/modx/processors/security/resourcegroup/getlist.class.php
@@ -25,5 +25,15 @@ class modResourceGroupGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'modResourceGroup';
     public $languageTopics = array('access');
     public $permission = 'resourcegroup_view';
+
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $key = $this->getProperty('key','');
+        if (!empty($key)) {
+            $c->where(array(
+                $this->classKey . '.key:IN' => is_string($key) ? explode(',', $key) : $key,
+            ));
+        }
+        return $c;
+    }
 }
 return 'modResourceGroupGetListProcessor';

--- a/core/model/modx/processors/security/resourcegroup/getlist.class.php
+++ b/core/model/modx/processors/security/resourcegroup/getlist.class.php
@@ -26,6 +26,11 @@ class modResourceGroupGetListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('access');
     public $permission = 'resourcegroup_view';
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $key = $this->getProperty('key','');
         if (!empty($key)) {

--- a/core/model/modx/processors/security/resourcegroup/getlist.class.php
+++ b/core/model/modx/processors/security/resourcegroup/getlist.class.php
@@ -32,10 +32,10 @@ class modResourceGroupGetListProcessor extends modObjectGetListProcessor {
      * @return xPDOQuery
      */
     public function prepareQueryAfterCount(xPDOQuery $c) {
-        $key = $this->getProperty('key','');
+        $key = $this->getProperty('id','');
         if (!empty($key)) {
             $c->where(array(
-                $this->classKey . '.key:IN' => is_string($key) ? explode(',', $key) : $key,
+                $this->classKey . '.id:IN' => is_string($key) ? explode(',', $key) : $key,
             ));
         }
         return $c;

--- a/core/model/modx/processors/security/role/getlist.class.php
+++ b/core/model/modx/processors/security/role/getlist.class.php
@@ -28,6 +28,10 @@ class modUserGroupRoleGetListProcessor extends modObjectGetListProcessor {
     public $defaultSortField = 'authority';
     public $canRemove = false;
 
+    /**
+     * {@inheritDoc}
+     * @return boolean
+     */
     public function initialize() {
         $initialized = parent::initialize();
         $this->setDefaultProperties(array(
@@ -39,6 +43,11 @@ class modUserGroupRoleGetListProcessor extends modObjectGetListProcessor {
         return $initialized;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $id = $this->getProperty('id','');
         if (!empty($id)) {
@@ -49,6 +58,11 @@ class modUserGroupRoleGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param array $list
+     * @return array
+     */
     public function beforeIteration(array $list) {
         if ($this->getProperty('addNone',false)) {
             $list[] = array('id' => 0, 'name' => $this->modx->lexicon('none'));
@@ -56,6 +70,11 @@ class modUserGroupRoleGetListProcessor extends modObjectGetListProcessor {
         return $list;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOObject $object
+     * @return array
+     */
     public function prepareRow(xPDOObject $object) {
         $objectArray = $object->toArray();
         $isCoreRole = $object->get('id') == 1 || $object->get('id') == 2 || $object->get('name') == 'Super User' || $object->get('name') == 'Member';

--- a/core/model/modx/processors/security/role/getlist.class.php
+++ b/core/model/modx/processors/security/role/getlist.class.php
@@ -39,6 +39,16 @@ class modUserGroupRoleGetListProcessor extends modObjectGetListProcessor {
         return $initialized;
     }
 
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
+        return $c;
+    }
+
     public function beforeIteration(array $list) {
         if ($this->getProperty('addNone',false)) {
             $list[] = array('id' => 0, 'name' => $this->modx->lexicon('none'));

--- a/core/model/modx/processors/security/role/getlist.class.php
+++ b/core/model/modx/processors/security/role/getlist.class.php
@@ -44,7 +44,7 @@ class modUserGroupRoleGetListProcessor extends modObjectGetListProcessor {
     }
 
     /**
-     * {@inheritDoc}
+     * Filter the query by the valueField of MODx.combo.Role to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/security/user/group/getlist.class.php
+++ b/core/model/modx/processors/security/user/group/getlist.class.php
@@ -47,6 +47,12 @@ class modUserUserGroupGetListProcessor extends modObjectGetListProcessor {
             'rolename' => 'UserGroupRole.name',
             'name' => 'UserGroup.name',
         ));
+        $id = $this->getProperty('id', 0);
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         return $c;
     }
 }

--- a/core/model/modx/processors/source/getlist.class.php
+++ b/core/model/modx/processors/source/getlist.class.php
@@ -91,7 +91,7 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         $id = $this->getProperty('id','');
         if (!empty($id)) {
             $c->where(array(
-                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+                $this->getSortClassKey() . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
             ));
         }
         return $c;

--- a/core/model/modx/processors/source/getlist.class.php
+++ b/core/model/modx/processors/source/getlist.class.php
@@ -64,6 +64,16 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
+        return $c;
+    }
+
     /**
      * Prepare the source for iteration and output
      *

--- a/core/model/modx/processors/source/getlist.class.php
+++ b/core/model/modx/processors/source/getlist.class.php
@@ -83,7 +83,7 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
     }
 
     /**
-     * {@inheritDoc}
+     * Filter the query by the valueField of MODx.combo.MediaSource to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/source/getlist.class.php
+++ b/core/model/modx/processors/source/getlist.class.php
@@ -25,6 +25,10 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('source');
     public $permission = 'source_view';
 
+    /**
+     * {@inheritDoc}
+     * @return boolean
+     */
     public function initialize() {
         $initialized = parent::initialize();
         $this->setDefaultProperties(array(
@@ -35,10 +39,19 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         return $initialized;
     }
 
+    /**
+     * {@inheritDoc}
+     * @return string
+     */
     public function getSortClassKey() {
         return 'modMediaSource';
     }
 
+    /**
+     * {@inheritDoc}
+     * @param array $list
+     * @return array
+     */
     public function beforeIteration(array $list) {
         if ($this->getProperty('showNone')) {
             $list[] = array(
@@ -50,6 +63,11 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         return $list;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $query = $this->getProperty('query');
         if (!empty($query)) {
@@ -64,6 +82,11 @@ class modMediaSourceGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $id = $this->getProperty('id','');
         if (!empty($id)) {

--- a/core/model/modx/processors/system/action/getlist.class.php
+++ b/core/model/modx/processors/system/action/getlist.class.php
@@ -47,6 +47,12 @@ class modActionGetListProcessor extends modObjectGetListProcessor {
 
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $c->sortby($this->modx->getSelectColumns('modAction','modAction','',array('namespace')),'ASC');
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         return $c;
     }
 }

--- a/core/model/modx/processors/system/classmap/getlist.class.php
+++ b/core/model/modx/processors/system/classmap/getlist.class.php
@@ -24,6 +24,11 @@ class modClassMapGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'modClassMap';
     public $permission = 'class_map';
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $parentClass = $this->getProperty('parentClass','');
         if (!empty($parentClass)) {
@@ -34,6 +39,11 @@ class modClassMapGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $class = $this->getProperty('class','');
         if (!empty($class)) {

--- a/core/model/modx/processors/system/classmap/getlist.class.php
+++ b/core/model/modx/processors/system/classmap/getlist.class.php
@@ -33,5 +33,15 @@ class modClassMapGetListProcessor extends modObjectGetListProcessor {
         }
         return $c;
     }
+
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $class = $this->getProperty('class','');
+        if (!empty($class)) {
+            $c->where(array(
+                $this->classKey . '.class:IN' => is_string($class) ? explode(',', $class) : $class,
+            ));
+        }
+        return $c;
+    }
 }
 return 'modClassMapGetListProcessor';

--- a/core/model/modx/processors/system/classmap/getlist.class.php
+++ b/core/model/modx/processors/system/classmap/getlist.class.php
@@ -40,7 +40,7 @@ class modClassMapGetListProcessor extends modObjectGetListProcessor {
     }
 
     /**
-     * {@inheritDoc}
+     * Filter the query by the valueField of MODx.combo.ClassMap to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/system/contenttype/getlist.class.php
+++ b/core/model/modx/processors/system/contenttype/getlist.class.php
@@ -25,7 +25,7 @@ class modContentTypeGetListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('content_type');
 
     /**
-     * {@inheritDoc}
+     * Filter the query by the valueField of MODx.combo.ContentType to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/system/contenttype/getlist.class.php
+++ b/core/model/modx/processors/system/contenttype/getlist.class.php
@@ -23,5 +23,15 @@
 class modContentTypeGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'modContentType';
     public $languageTopics = array('content_type');
+
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
+        return $c;
+    }
 }
 return 'modContentTypeGetListProcessor';

--- a/core/model/modx/processors/system/contenttype/getlist.class.php
+++ b/core/model/modx/processors/system/contenttype/getlist.class.php
@@ -24,6 +24,11 @@ class modContentTypeGetListProcessor extends modObjectGetListProcessor {
     public $classKey = 'modContentType';
     public $languageTopics = array('content_type');
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $id = $this->getProperty('id','');
         if (!empty($id)) {

--- a/core/model/modx/processors/system/dashboard/getlist.class.php
+++ b/core/model/modx/processors/system/dashboard/getlist.class.php
@@ -44,6 +44,12 @@ class modDashboardGetListProcessor extends modObjectGetListProcessor {
                 'UserGroups.id' => $userGroup,
             ));
         }
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
         return $c;
     }
 

--- a/core/model/modx/processors/system/dashboard/widget/getlist.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/getlist.class.php
@@ -31,6 +31,11 @@ class modDashboardWidgetGetListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('dashboards');
     public $permission = 'dashboards';
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $query = $this->getProperty('query');
         if (!empty($query)) {
@@ -40,6 +45,11 @@ class modDashboardWidgetGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $id = $this->getProperty('id','');
         if (!empty($id)) {
@@ -50,6 +60,11 @@ class modDashboardWidgetGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOObject $object
+     * @return array
+     */
     public function prepareRow(xPDOObject $object) {
         $objectArray = $object->toArray();
         $objectArray['cls'] = 'pupdate premove';

--- a/core/model/modx/processors/system/dashboard/widget/getlist.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/getlist.class.php
@@ -40,6 +40,16 @@ class modDashboardWidgetGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id
+            ));
+        }
+        return $c;
+    }
+
     public function prepareRow(xPDOObject $object) {
         $objectArray = $object->toArray();
         $objectArray['cls'] = 'pupdate premove';

--- a/core/model/modx/processors/system/dashboard/widget/getlist.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/getlist.class.php
@@ -22,7 +22,7 @@
  * @var modX $modx
  * @var array $scriptProperties
  * @var modProcessor $this
- * 
+ *
  * @package modx
  * @subpackage processors.system.dashboard.widget
  */
@@ -46,7 +46,7 @@ class modDashboardWidgetGetListProcessor extends modObjectGetListProcessor {
     }
 
     /**
-     * {@inheritDoc}
+     * Filter the query by the valueField of MODx.combo.DashboardWidgets to get the initially value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/system/event/getlist.class.php
+++ b/core/model/modx/processors/system/event/getlist.class.php
@@ -105,6 +105,13 @@ class modSystemEventGetListProcessor extends modProcessor
             ));
         }
 
+        $id = $this->getProperty('id', 0);
+        if (!empty($id)) {
+            $c->where(array(
+                'modEvent.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ));
+        }
+
         $data['total'] = $this->modx->getCount('modEvent', $c);
         $c->sortby($this->getProperty('sort'), $this->getProperty('dir'));
         if ($isLimit) {

--- a/core/model/modx/processors/system/event/grouplist.class.php
+++ b/core/model/modx/processors/system/event/grouplist.class.php
@@ -34,6 +34,12 @@ class modSystemEventsGroupListProcessor extends modProcessor {
 				'groupname:LIKE' => '%' . $query . '%',
 			));
 		}
+        $name = $this->getProperty('name','');
+        if (!empty($name)) {
+            $c->where(array(
+                'modEvent.groupname:IN' => is_string($name) ? explode(',', $name) : $name
+            ));
+        }
 
 		if ($c->prepare() && $c->stmt->execute()) {
 			foreach ($c->stmt->fetchAll(PDO::FETCH_ASSOC) as $row) {

--- a/core/model/modx/processors/workspace/getlist.php
+++ b/core/model/modx/processors/workspace/getlist.php
@@ -30,13 +30,20 @@ $start = $modx->getOption('start',$scriptProperties,0);
 $limit = $modx->getOption('limit',$scriptProperties,10);
 $sort = $modx->getOption('sort',$scriptProperties,'name');
 $dir = $modx->getOption('dir',$scriptProperties,'ASC');
+$id = $modx->getOption('id',$scriptProperties,'');
 
 /* build query */
 $c = $modx->newQuery('modWorkspace');
 $count = $modx->getCount('modWorkspace',$c);
 
 $c->sortby($sort,$dir);
+if (!empty($id)) {
+    $c->where(array(
+        'modWorkspace.id:IN' => is_string($id) ? explode(',', $id) : $id
+    ));
+}
 if ($isLimit) $c->limit($limit,$start);
+/** @var modWorkspace[] $workspaces */
 $workspaces = $modx->getCollection('modWorkspace',$c);
 
 /* iterate */

--- a/core/model/modx/processors/workspace/namespace/getlist.class.php
+++ b/core/model/modx/processors/workspace/namespace/getlist.class.php
@@ -45,6 +45,16 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $name = $this->getProperty('name','');
+        if (!empty($name)) {
+            $c->where(array(
+                $this->classKey . '.name:IN' => is_string($name) ? explode(',', $name) : $name,
+            ));
+        }
+        return $c;
+    }
+
     /**
      * Prepare the Namespace for listing
      *

--- a/core/model/modx/processors/workspace/namespace/getlist.class.php
+++ b/core/model/modx/processors/workspace/namespace/getlist.class.php
@@ -26,6 +26,10 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('namespace','workspace');
     public $permission = 'namespaces';
 
+    /**
+     * {@inheritDoc}
+     * @return boolean
+     */
     public function initialize() {
         $initialized = parent::initialize();
         $this->setDefaultProperties(array(
@@ -34,6 +38,11 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
         return $initialized;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $search = $this->getProperty('search','');
         if (!empty($search)) {
@@ -45,6 +54,11 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $name = $this->getProperty('name','');
         if (!empty($name)) {

--- a/core/model/modx/processors/workspace/namespace/getlist.class.php
+++ b/core/model/modx/processors/workspace/namespace/getlist.class.php
@@ -55,7 +55,7 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
     }
 
     /**
-     * {@inheritDoc}
+     * Filter the query by the name property to get the right value in preselectFirstValue of MODx.combo.Namespace
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/model/modx/processors/workspace/providers/getlist.class.php
+++ b/core/model/modx/processors/workspace/providers/getlist.class.php
@@ -37,6 +37,16 @@ class modProviderGetListProcessor extends modObjectGetListProcessor {
         return 'modTransportProvider';
     }
 
+    public function prepareQueryAfterCount(xPDOQuery $c) {
+        $id = $this->getProperty('id','');
+        if (!empty($id)) {
+            $c->where(array(
+                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id
+            ));
+        }
+        return $c;
+    }
+
     public function beforeIteration(array $list) {
         $isCombo = $this->getProperty('combo',false);
         if ($isCombo) {

--- a/core/model/modx/processors/workspace/providers/getlist.class.php
+++ b/core/model/modx/processors/workspace/providers/getlist.class.php
@@ -25,6 +25,10 @@ class modProviderGetListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('workspace');
     public $permission = 'providers';
 
+    /**
+     * {@inheritDoc}
+     * @return boolean
+     */
     public function initialize() {
         $initialized = parent::initialize();
         $this->setDefaultProperties(array(
@@ -33,10 +37,19 @@ class modProviderGetListProcessor extends modObjectGetListProcessor {
         return $initialized;
     }
 
+    /**
+     * {@inheritDoc}
+     * @return string
+     */
     public function getSortClassKey() {
         return 'modTransportProvider';
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
     public function prepareQueryAfterCount(xPDOQuery $c) {
         $id = $this->getProperty('id','');
         if (!empty($id)) {
@@ -47,6 +60,11 @@ class modProviderGetListProcessor extends modObjectGetListProcessor {
         return $c;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param array $list
+     * @return array
+     */
     public function beforeIteration(array $list) {
         $isCombo = $this->getProperty('combo',false);
         if ($isCombo) {
@@ -55,6 +73,11 @@ class modProviderGetListProcessor extends modObjectGetListProcessor {
         return $list;
     }
 
+    /**
+     * {@inheritDoc}
+     * @param xPDOObject $object
+     * @return array
+     */
     public function prepareRow(xPDOObject $object) {
         $objectArray = $object->toArray();
         if (!$this->getProperty('combo',false)) {


### PR DESCRIPTION
### What does it do?
Add a filtering query (in most cases by id) to the getlist processors of combos that have a pagesize set.

### Why is it needed?
Those combos show the following issue. If the current value of the combo is not returned in the valuefield value with the list of records limited by the pagesize, the combo displays the valuefield instead of the displayfield. I.e. the site has more than 20 contexts, and a modx-combo-context value is not in the first 20 contexts, the combo shows only the context key and not the context name.

### Related issue(s)/PR(s)
#14113