### PR TITLE
Improved display of "double" height dashboard widget 

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -75,8 +75,12 @@
 .dashboard-block-double {
   clear: both;
   height: auto;
-  min-height: 400px;
+  min-height: 600px;
   width: 100%;
+
+  .body {
+      max-height: 600px;
+  }
 }
 
 .dashboard-block-variable .body {


### PR DESCRIPTION
### What does it do?
Dashboard widgets come in 3 heights; half, full and double. When double was selected, it was not actually double in size. For more info see https://github.com/modxcms/revolution/issues/14101.

On `.dashboard-block-double`, the min-height was increased to 600px so it looks double in size. A `.body` selector was also added to `.dashboard-block-double` so that it overrides the default `.dashboard-block` max-height.

### Why is it needed?
Better UX.

### Related issue(s)/PR(s)
Fixes https://github.com/modxcms/revolution/issues/14101
