### PR TITLE
Make path to MODX error handler class configurable

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2426,9 +2426,9 @@ class modX extends xPDO {
         if ($this->errorHandler == null || !is_object($this->errorHandler)) {
             if ($ehClass = $this->getOption('error_handler_class', $options, 'modErrorHandler', true)) {
                 $ehPath = $this->getOption('error_handler_path', $options, '', true);
-                if ($ehClass= $this->loadClass($ehClass, $ehPath, false, true)) {
-                    if ($this->errorHandler= new $ehClass($this)) {
-                        $result= set_error_handler(array ($this->errorHandler, 'handleError'), $this->getOption('error_handler_types', $options, error_reporting(), true));
+                if ($ehClass = $this->loadClass($ehClass, $ehPath, false, true)) {
+                    if ($this->errorHandler = new $ehClass($this)) {
+                        $result = set_error_handler(array ($this->errorHandler, 'handleError'), $this->getOption('error_handler_types', $options, error_reporting(), true));
                         if ($result === false) {
                             $this->log(modX::LOG_LEVEL_ERROR, 'Could not set error handler.  Make sure your class has a function called handleError(). Result: ' . print_r($result, true));
                         }

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2425,7 +2425,8 @@ class modX extends xPDO {
     protected function _initErrorHandler($options = null) {
         if ($this->errorHandler == null || !is_object($this->errorHandler)) {
             if ($ehClass = $this->getOption('error_handler_class', $options, 'modErrorHandler', true)) {
-                if ($ehClass= $this->loadClass($ehClass, '', false, true)) {
+                $ehPath = $this->getOption('error_handler_path', $options, '', true);
+                if ($ehClass= $this->loadClass($ehClass, $ehPath, false, true)) {
                     if ($this->errorHandler= new $ehClass($this)) {
                         $result= set_error_handler(array ($this->errorHandler, 'handleError'), $this->getOption('error_handler_types', $options, error_reporting(), true));
                         if ($result === false) {


### PR DESCRIPTION
### What does it do?
This introduces a new config setting "error_handler_path" to make the path to a custom MODX error handler configurable.

### Why is it needed?
When using custom MODX error handlers they currently have to be placed in `core/model/modx/*` since a path is not configurable.
