### PR TITLE
Restore the setup options window title, if two packages are installed…

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -159,6 +159,7 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
 			});
 		} else {
 			this.win.signature = btn.signature || '';
+            this.win.title = _('setup_options');
 		}
 		this.win.show(btn);
 		var opts = Ext.getCmp('modx-package-beforeinstall').getOptions();


### PR DESCRIPTION
### What does it do?
Restore the setup options window title, if two packages are installed with setup options.

### Why is it needed?
Some extras change the setup options title by javascript. It will not be changed back if the window is opened again.

### Related issue(s)/PR(s)
#13879
