### PR TITLE
Add new event "OnBeforeRegScripts"

### DIFF
--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -63,6 +63,7 @@ class modResponse {
 
             /*FIXME: only do this for HTML content ?*/
             if (strpos($this->contentType->get('mime_type'), 'text/html') !== false) {
+                 $this->modx->invokeEvent('OnBeforeRegScripts');
                 /* Insert Startup jscripts & CSS scripts into template - template must have a </head> tag */
                 if (($js= $this->modx->getRegisteredClientStartupScripts()) && (strpos($this->modx->resource->_output, '</head>') !== false)) {
                     /* change to just before closing </head> */


### PR DESCRIPTION
New event "OnBeforeRegScripts" for scripts manipulation before they will be added to the page.

### What does it do?
It fires new event "OnBeforeRegScripts" after all the tags were parsed (after all the "OnParseDocument" events)  and before the registered scripts will be added to the page (before the "OnWebPagePrerender" event).

### Why is it needed?
It can be useful for manipulation of registered scripts: 
- to check  registration of the specified script;
- to remove the specified scripts.
- to remove all "head" or "body" scripts or both.

#### Plugin example
Remove all js scripts from the "head" group to the "body" one.
```php
foreach ($modx->sjscripts as $key => $script) {
    if (preg_match('#.*\.js#', $script)) {
        $modx->jscripts[] = $script;
        unset($modx->sjscripts[$key]);
    }
}
```

### Related issue(s)/PR(s)
I could't find it.
