### PR TITLE
Add a new event "OnBeforeRegScripts"

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -688,6 +688,12 @@ $events['OnUserRemoveFromGroup']->fromArray(array (
 ), '', true, true);
 
 /* System */
+$events['OnBeforeRegScripts']= $xpdo->newObject('modEvent');
+$events['OnBeforeRegScripts']->fromArray(array (
+    'name' => 'OnBeforeRegScripts',
+    'service' => 5,
+    'groupname' => 'System',
+), '', true, true);
 $events['OnWebPagePrerender']= $xpdo->newObject('modEvent');
 $events['OnWebPagePrerender']->fromArray(array (
   'name' => 'OnWebPagePrerender',

--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -76,6 +76,7 @@ class modResponse {
 
             /*FIXME: only do this for HTML content ?*/
             if (strpos($this->contentType->get('mime_type'), 'text/html') !== false) {
+                $this->modx->invokeEvent('OnBeforeRegScripts');
                 /* Insert Startup jscripts & CSS scripts into template - template must have a </head> tag */
                 if (($js= $this->modx->getRegisteredClientStartupScripts()) && (strpos($this->modx->resource->_output, '</head>') !== false)) {
                     /* change to just before closing </head> */


### PR DESCRIPTION
New event "OnBeforeRegScripts" is used for scripts manipulation before they will be added to the page.

### What does it do?
It fires new event "OnBeforeRegScripts" after all MODX tags were parsed (after all the "OnParseDocument" events)  and before the registered scripts will be added to the page (before the "OnWebPagePrerender" event).

### Why is it needed?
It can be useful for manipulation of registered scripts: 
- to check  registration of the specified script;
- to remove the specified scripts.
- to remove all "head" or "body" scripts or both.
- to grab assets from the page content and register them in the scripts store.

#### Plugin example
Remove all js scripts from the "head" group to the "body" one.
```php
foreach ($modx->sjscripts as $key => $script) {
    if (preg_match('#.*\.js#', $script)) {
        $modx->jscripts[] = $script;
        unset($modx->sjscripts[$key]);
    }
}
```

### Related issue(s)/PR(s)
I could't find it.