### PR TITLE
Add $modx->deprecated method to log usage of deprecated methods

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -854,6 +854,15 @@ $settings['log_target']->fromArray(array (
   'area' => 'system',
   'editedon' => null,
 ), '', true, true);
+$settings['log_deprecated']= $xpdo->newObject('modSystemSetting');
+$settings['log_deprecated']->fromArray(array (
+  'key' => 'log_deprecated',
+  'value' => 1,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'system',
+  'editedon' => null,
+), '', true, true);
 $settings['link_tag_scheme']= $xpdo->newObject('modSystemSetting');
 $settings['link_tag_scheme']->fromArray(array (
   'key' => 'link_tag_scheme',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -383,6 +383,9 @@ $_lang['setting_log_level_desc'] = 'The default logging level; the lower the lev
 $_lang['setting_log_target'] = 'Logging Target';
 $_lang['setting_log_target_desc'] = 'The default logging target where log messages are written. Available options: \'FILE\', \'HTML\', or \'ECHO\'. Default is \'FILE\' if not specified.';
 
+$_lang['setting_log_deprecated'] = 'Log Deprecated Functions';
+$_lang['setting_log_deprecated_desc'] = 'Enable to receive notices in your error log when deprecated functions are used.';
+
 $_lang['setting_mail_charset'] = 'Mail Charset';
 $_lang['setting_mail_charset_desc'] = 'The default charset for emails, e.g., \'iso-8859-1\' or \'utf-8\'';
 

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -728,6 +728,7 @@ class modCacheManager extends xPDOCacheManager {
      * @return array
      */
     public function clearCache(array $paths= array(), array $options= array()) {
+        $this->modx->deprecated('2.1.0', 'Use modCacheManager::refresh() instead.');
         $results= array();
         $delObjs= array();
         if ($clearObjects = $this->getOption('objects', $options)) {

--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -526,6 +526,12 @@ class modRequest {
      * @return array
      */
     public function getAllActionIDs($namespace = '') {
+        // This method is deprecated, but also still in use by the core in
+        // core/model/modx/processors/system/config.js.php, which runs on each
+        // manager page, so leaving the deprecated notice commented out until
+        // that is resolved.
+        // $this->modx->deprecated('2.3.0', 'Support for modAction has been replaced with routing based on a namespace and action name.', 'modAction support');
+
         $c = array();
         if (!empty($namespace)) $c['namespace'] = $namespace;
         $actions = $this->modx->getCollection('modAction',$c);

--- a/core/model/modx/modrequest.class.php
+++ b/core/model/modx/modrequest.class.php
@@ -526,12 +526,6 @@ class modRequest {
      * @return array
      */
     public function getAllActionIDs($namespace = '') {
-        // This method is deprecated, but also still in use by the core in
-        // core/model/modx/processors/system/config.js.php, which runs on each
-        // manager page, so leaving the deprecated notice commented out until
-        // that is resolved.
-        // $this->modx->deprecated('2.3.0', 'Support for modAction has been replaced with routing based on a namespace and action name.', 'modAction support');
-
         $c = array();
         if (!empty($namespace)) $c['namespace'] = $namespace;
         $actions = $this->modx->getCollection('modAction',$c);

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2354,8 +2354,8 @@ class modX extends xPDO {
 
         // We use the trace to identify both the method that is deprecated, and the caller
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        $deprecatedMethod = isset($trace[1]) ? $trace[1] : [];
-        $caller = isset($trace[2]) ? $trace[2] : [];
+        $deprecatedMethod = isset($trace[1]) ? $trace[1] : array();
+        $caller = isset($trace[2]) ? $trace[2] : array();
 
         // Format the deprecated function definition with the class, if it has one
         if ($deprecatedDef === '') {

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1815,6 +1815,7 @@ class modX extends xPDO {
      * @param string $line
      */
     public function messageQuit($msg='unspecified error', $query='', $is_error=true, $nr='', $file='', $source='', $text='', $line='') {
+        $this->deprecated('2.2.0', 'Use modX::log with modX::LOG_LEVEL_FATAL instead.');
         $this->log(modX::LOG_LEVEL_FATAL, 'msg: ' . $msg . "\n" . 'query: ' . $query . "\n" . 'nr: ' . $nr . "\n" . 'file: ' . $file . "\n" . 'source: ' . $source . "\n" . 'text: ' . $text . "\n" . 'line: ' . $line . "\n");
     }
 

--- a/core/model/modx/rest/modrestclient.class.php
+++ b/core/model/modx/rest/modrestclient.class.php
@@ -94,6 +94,7 @@ class modRestClient {
             modRestClient::OPT_PATH => '/',
             modRestClient::OPT_USERAGENT => "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0)"
         ),$config);
+        $this->modx->deprecated('2.3.0', 'Use the modRest classes instead.');
     }
 
     /**

--- a/core/model/modx/rest/modrestserver.class.php
+++ b/core/model/modx/rest/modrestserver.class.php
@@ -59,6 +59,7 @@ class modRestServer {
             modRestServer::OPT_ERROR_NODE => 'error',
             modRestServer::OPT_ERROR_MESSAGE_NODE => 'message',
         ),$config);
+        $this->modx->deprecated('2.3.0', 'Use the modRestService classes instead.');
     }
 
     /**

--- a/core/model/modx/transport/modpackagebuilder.class.php
+++ b/core/model/modx/transport/modpackagebuilder.class.php
@@ -96,6 +96,7 @@ class modPackageBuilder {
      * @see modPackageBuilder::createPackage
      */
     public function create($name, $version, $release = '') {
+        $this->modx->deprecated('2.1.2', 'Use modPackageBuilder::createPackage instead.');
         $this->createPackage($name, $version, $release);
     }
 


### PR DESCRIPTION
### What does it do?
This PR adds a new method to the modX object, `deprecated`, which is to be used to log usage of deprecated methods across the core. Each unique message (deprecated method + caller) is only logged once per request. A setting is added that allows disabling the logging. 

I've also done a search for `@deprecated` docblocks, and added appropriate messages in various locations. Some code was deprecated way back in 2.1, so I look forward to seeing that removed in 3.0. 

### Why is it needed?
As we get ready to cleanup some code with 3.0, it's important users can be sure their site can be safely upgraded. Old or custom extras may use functionality that is no longer supported and will be removed in 3.0, which will require manual intervention. 

The `deprecated` method will allow a site to function normally with the deprecated methods still available in 2.7, but thanks to the logging the site owner will have more information on what should be taken care of first. 

### Related issue(s)/PR(s)
#13199, which mentions some deprecated methods for 3.0. 
