### PR TITLE
Fix and normalize combo-boolean tv option values

### DIFF
--- a/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -38,7 +38,6 @@ MODx.load({
         ,fieldLabel: _('checkbox_columns')
         ,description: MODx.expandHelp ? '' : _('checkbox_columns_desc')
         ,name: 'inopt_columns'
-        ,hiddenName: 'inopt_columns'
         ,id: 'inopt_columns{/literal}{$tv|default}{literal}'
         ,value: params['columns'] || 1
         ,width: 300

--- a/manager/templates/default/element/tv/renders/inputproperties/date.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/date.tpl
@@ -155,7 +155,7 @@ MODx.load({
         ,hiddenName: 'inopt_hideTime'
         ,id: 'inopt_hideTime{/literal}{$tv|default}{literal}'
         ,width: 200
-        ,value: params['hideTime'] ? !(params['hideTime'] === 0 || params['hideTime'] === 'false') : false
+        ,value: (params['hideTime']) ? !(params['hideTime'] === 0 || params['hideTime'] === 'false') : false
         ,listeners: oc
     }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'

--- a/manager/templates/default/element/tv/renders/inputproperties/date.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/date.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: !(params['allowBlank'] == 0 || params['allowBlank'] == 'false')
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -148,14 +148,14 @@ MODx.load({
         ,html: _('time_increment_desc')
         ,cls: 'desc-under'
     },{
-        xtype: 'modx-combo-boolean'
+        xtype: 'combo-boolean'
         ,fieldLabel: _('hide_time')
         ,description: MODx.expandHelp ? '' : _('hide_time')
         ,name: 'inopt_hideTime'
         ,hiddenName: 'inopt_hideTime'
         ,id: 'inopt_hideTime{/literal}{$tv|default}{literal}'
-        ,value: params['hideTime'] ? !(params['hideTime'] == 0 || params['hideTime'] == 'false') : false
         ,width: 200
+        ,value: params['hideTime'] ? !(params['hideTime'] === 0 || params['hideTime'] === 'false') : false
         ,listeners: oc
     }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'

--- a/manager/templates/default/element/tv/renders/inputproperties/email.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/email.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -66,8 +66,8 @@ MODx.load({
         ,name: 'inopt_typeAhead'
         ,hiddenName: 'inopt_typeAhead'
         ,id: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
-        ,value: params['typeAhead'] || false
         ,width: 200
+        ,value: (params['typeAhead']) ? !(params['typeAhead'] === 0 || params['typeAhead'] === 'false') : false
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -109,8 +109,8 @@ MODx.load({
         ,name: 'inopt_stackItems'
         ,hiddenName: 'inopt_stackItems'
         ,id: 'inopt_stackItems{/literal}{$tv|default}{literal}'
-        ,value: params['stackItems'] || false
         ,width: 200
+        ,value: (params['stackItems']) ? !(params['stackItems'] === 0 || params['stackItems'] === 'false') : false
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -66,8 +66,8 @@ MODx.load({
         ,name: 'inopt_typeAhead'
         ,hiddenName: 'inopt_typeAhead'
         ,id: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
-        ,value: params['typeAhead'] || false
         ,width: 200
+        ,value: (params['typeAhead']) ? !(params['typeAhead'] === 0 || params['typeAhead'] === 'false') : false
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -96,8 +96,8 @@ MODx.load({
         ,name: 'inopt_forceSelection'
         ,hiddenName: 'inopt_forceSelection'
         ,id: 'inopt_forceSelection{/literal}{$tv|default}{literal}'
-        ,value: params['forceSelection'] || false
         ,width: 200
+        ,value: (params['forceSelection']) ? !(params['forceSelection'] === 0 || params['forceSelection'] === 'false') : false
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/number.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/number.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -35,9 +35,10 @@ MODx.load({
         xtype: 'combo-boolean'
         ,fieldLabel: _('number_allowdecimals')
         ,name: 'inopt_allowDecimals'
+        ,hiddenName: 'inopt_allowDecimals'
         ,id: 'inopt_allowDecimals{/literal}{$tv|default}{literal}'
-        ,value: params['allowDecimals'] || true
         ,width: 200
+        ,value: (params['allowDecimals']) ? !(params['allowDecimals'] === 0 || params['allowDecimals'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -48,9 +49,10 @@ MODx.load({
         xtype: 'combo-boolean'
         ,fieldLabel: _('number_allownegative')
         ,name: 'inopt_allowNegative'
+        ,hiddenName: 'inopt_allowNegative'
         ,id: 'inopt_allowNegative{/literal}{$tv|default}{literal}'
-        ,value: params['allowNegative'] || true
         ,width: 200
+        ,value: (params['allowNegative']) ? !(params['allowNegative'] === 0 || params['allowNegative'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? 0 : 1
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -38,8 +38,8 @@ MODx.load({
         ,name: 'inopt_showNone'
         ,hiddenName: 'inopt_showNone'
         ,id: 'inopt_showNone{/literal}{$tv|default}{literal}'
-        ,value: params['showNone'] == 0 || params['showNone'] == 'false' ? 0 : 1
         ,width: 200
+        ,value: (params['showNone']) ? !(params['showNone'] === 0 || params['showNone'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -81,8 +81,8 @@ MODx.load({
         ,name: 'inopt_includeParent'
         ,hiddenName: 'inopt_includeParent'
         ,id: 'inopt_includeParent{/literal}{$tv|default}{literal}'
-        ,value: params['includeParent'] == 0 || params['includeParent'] == 'false' ? 0 : 1
         ,width: 200
+        ,value: (params['includeParent']) ? !(params['includeParent'] === 0 || params['includeParent'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -96,8 +96,8 @@ MODx.load({
         ,name: 'inopt_limitRelatedContext'
         ,hiddenName: 'inopt_limitRelatedContext'
         ,id: 'inopt_limitRelatedContext{/literal}{$tv|default}{literal}'
-        ,value: params['limitRelatedContext'] == 1 || params['limitRelatedContext'] == 'true' ? 1 : 0
         ,width: 200
+        ,value: (params['limitRelatedContext']) ? !(params['limitRelatedContext'] === 0 || params['limitRelatedContext'] === 'false') : false
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/text.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/text.tpl
@@ -25,8 +25,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
@@ -23,8 +23,8 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,value: params['allowBlank'] == 0 || params['allowBlank'] == 'false' ? false : true
         ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'


### PR DESCRIPTION
### What does it do?
Fix and normalize combo-boolean values in template variable input options. Fix a bug in the number template variable type in a non english manager. 

### Why is it needed?
If a number template variable was created by i.e. a package, the allowDecimals and allowNegative option shows a 'true' or 'false' as the combo box value, instead of a 'Yes' or 'No'. In other languages than english the saved template variable options of a number template variable were saved with the language string because of a missing hiddenName option.

### Related issue(s)/PR(s)
None
