### PR TITLE
Deprecate 0.9.x parser migration utilities for removal in 3.0

### DIFF
--- a/core/model/modx/modparser095.class.php
+++ b/core/model/modx/modparser095.class.php
@@ -19,8 +19,13 @@ include_once (strtr(realpath(dirname(__FILE__)) . '/modparser.class.php', '\\', 
  * legacy MODX plugins.
  *
  * @package modx
+ * @deprecated
  */
 class modParser095 extends modParser {
+    function __construct(xPDO &$modx) {
+        parent::__construct($modx);
+        $this->modx->deprecated('2.7.0', 'Switch to the standard modParser. If you\'re still actively using 0.9.5-style templates, use the modTranslator utility for a one-time conversion.', 'modParser095');
+    }
     /**
      * An array of translation strings from migrating from Evolution
      * @var array $tagTranslation

--- a/core/model/modx/modtranslate095.class.php
+++ b/core/model/modx/modtranslate095.class.php
@@ -12,6 +12,7 @@
  * Utility class for assisting in migrating content from older MODX releases.
  *
  * @package modx
+ * @deprecated
  */
 class modTranslate095 {
     /**

--- a/core/model/modx/transport/modtranslator.class.php
+++ b/core/model/modx/transport/modtranslator.class.php
@@ -13,6 +13,7 @@ require_once MODX_CORE_PATH . 'model/modx/modtranslate095.class.php';
  *
   * @package modx
   * @subpackage transport
+  * @deprecated
  */
 class modTranslator extends modTranslate095 {
     /**
@@ -44,6 +45,7 @@ class modTranslator extends modTranslate095 {
      */
     function __construct(xPDO &$modx, $recursive = true) {
         parent :: __construct($modx);
+        $this->modx->deprecated('2.7.0', 'Make sure to run your Evo-to-Revo conversion before 3.0.');
         $this->recursive = $recursive;
         $this->files = array();
         $this->paths = array();


### PR DESCRIPTION
### What does it do?
Marks `modParser095`, `modTranslate095` and `modTranslator` as deprecated, allowing it to be removed in 3.0. 

### Why is it needed?
This code has been around since 2008, with the only purpose of helping people migrate from 0.9.x/1.x to 2.x. The only usage I can find of this is in the Provisioner extra, which still gets some downloads, but does not seem like enough of a reason to keep this in core. If there's still a demand for it, I would suggest spending some time on Provisioner to update that, as there are a number of reported compatibility issues in that repo as well.

### Related issue(s)/PR(s)
#13199 
