### PR TITLE
Proper class name in DbRegistry implementation and fixed method clean

### DIFF
--- a/core/model/modx/registry/db/moddbregistermessage.class.php
+++ b/core/model/modx/registry/db/moddbregistermessage.class.php
@@ -15,7 +15,7 @@
  * @param string $id The ID of the message
  * @param datetime $created The time this message was created
  * @param datetime $valid The time this message was validated
- * @param timestamp $accessed The last time this message was accessed
+ * @param int $accessed The UNIX timestamp when this message was accessed
  * @param int $expires The UNIX timestamp when this message will automatically expire
  * @param string $payload The payload of this message
  * @param boolean Whether or not to kill the message

--- a/core/model/modx/registry/moddbregister.class.php
+++ b/core/model/modx/registry/moddbregister.class.php
@@ -75,9 +75,19 @@ class modDbRegister extends modRegister {
      *
      * {@inheritdoc}
      */
-    public function clear($topic) {
-        $result = $this->modx->removeCollection('modDbRegisterMessage', array('topic' => $topic));
-        return (bool)$result;
+    public function clear($topic)
+    {
+        $topicObject = $this->modx->getObject('registry.db.modDbRegisterTopic', array(
+            'queue' => $this->_queue->get('id'),
+            'name' => $topic
+        ));
+        if (!$topicObject) {
+            return false;
+        }
+
+        return (bool) $this->modx->removeCollection('registry.db.modDbRegisterMessage', array(
+            'topic' => $topicObject->get('id')
+        ));
     }
 
     /**
@@ -177,7 +187,7 @@ class modDbRegister extends modRegister {
         if (is_object($obj) && !empty($obj->payload)) {
             $message = eval($obj->payload);
             if ($remove || ($obj->expires > 1 && $obj->expires < time())) {
-                $this->modx->removeObject('modDbRegisterMessage', array('topic' => $obj->topic, 'id' => $obj->id));
+                $this->modx->removeObject('registry.db.modDbRegisterMessage', array('topic' => $obj->topic, 'id' => $obj->id));
             }
             if ($obj->kill) $this->__kill = true;
         }

--- a/core/model/modx/registry/moddbregister.class.php
+++ b/core/model/modx/registry/moddbregister.class.php
@@ -1,24 +1,26 @@
 <?php
-/**
- * This file contains a simple database implementation of modRegister.
+/*
+ * This file is part of MODX Revolution.
  *
- * @package modx
- * @subpackage registry
-*/
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
 
-/** Make sure the modRegister class is included. */
 require_once dirname(__FILE__) . '/modregister.class.php';
 
 /**
- * A simple, file-based implementation of modRegister.
+ * A simple, database-based implementation of modRegister.
  *
  * This implementation does not address transactional conflicts and should be
  * used in non-critical processes that are easily recoverable.
  *
  * @package modx
- * @subpackage registry
+ * @subpackage registry.db
  */
-class modDbRegister extends modRegister {
+class modDbRegister extends modRegister
+{
     /**
      * The queue object representing this modRegister instance.
      * @access protected


### PR DESCRIPTION
### What does it do?
It fixes the logic of method `clean`. In the database using the id of a topic but method waits for a string with a name. So this method converts the name to id before cleaning.
Also in some places fixed class name `modDbRegisterMessage` to fully qualified name `registry.db.modDbRegisterTopic`.

### Why is it needed?
The current state of code do clean up of registry totally broken (class not found, fatal errors). This change fixes it.

### Related issue(s)/PR(s)
Fixes #12965