### PR TITLE
Enable automating static elements workflow rebased

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1748,13 +1748,49 @@ $settings['site_unavailable_page']->fromArray(array (
   'area' => 'site',
   'editedon' => null,
 ), '', true, true);
-$settings['static_elements_automate']= $xpdo->newObject('modSystemSetting');
-$settings['static_elements_automate']->fromArray(array (
-  'key' => 'static_elements_automate',
+$settings['static_elements_automate_templates']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_automate_templates']->fromArray(array (
+  'key' => 'static_elements_automate_templates',
   'value' => '0',
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
-  'area' => 'manager',
+  'area' => 'static_elements',
+  'editedon' => null,
+), '', true, true);
+$settings['static_elements_automate_tvs']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_automate_tvs']->fromArray(array (
+  'key' => 'static_elements_automate_tvs',
+  'value' => '0',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'static_elements',
+  'editedon' => null,
+), '', true, true);
+$settings['static_elements_automate_chunks']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_automate_chunks']->fromArray(array (
+  'key' => 'static_elements_automate_chunks',
+  'value' => '0',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'static_elements',
+  'editedon' => null,
+), '', true, true);
+$settings['static_elements_automate_snippets']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_automate_snippets']->fromArray(array (
+  'key' => 'static_elements_automate_snippets',
+  'value' => '0',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'static_elements',
+  'editedon' => null,
+), '', true, true);
+$settings['static_elements_automate_plugins']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_automate_plugins']->fromArray(array (
+  'key' => 'static_elements_automate_plugins',
+  'value' => '0',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'static_elements',
   'editedon' => null,
 ), '', true, true);
 $settings['static_elements_default_mediasource']= $xpdo->newObject('modSystemSetting');
@@ -1763,7 +1799,16 @@ $settings['static_elements_default_mediasource']->fromArray(array (
   'value' => '0',
   'xtype' => 'modx-combo-source',
   'namespace' => 'core',
-  'area' => 'manager',
+  'area' => 'static_elements',
+  'editedon' => null,
+), '', true, true);
+$settings['static_elements_default_category']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_default_category']->fromArray(array (
+  'key' => 'static_elements_default_category',
+  'value' => '0',
+  'xtype' => 'modx-combo-category',
+  'namespace' => 'core',
+  'area' => 'static_elements',
   'editedon' => null,
 ), '', true, true);
 $settings['static_elements_basepath']= $xpdo->newObject('modSystemSetting');
@@ -1772,7 +1817,7 @@ $settings['static_elements_basepath']->fromArray(array (
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
-  'area' => 'manager',
+  'area' => 'static_elements',
   'editedon' => null,
 ), '', true, true);
 $settings['strip_image_paths']= $xpdo->newObject('modSystemSetting');

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1748,6 +1748,33 @@ $settings['site_unavailable_page']->fromArray(array (
   'area' => 'site',
   'editedon' => null,
 ), '', true, true);
+$settings['static_elements_automate']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_automate']->fromArray(array (
+  'key' => 'static_elements_automate',
+  'value' => '0',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
+$settings['static_elements_default_mediasource']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_default_mediasource']->fromArray(array (
+  'key' => 'static_elements_default_mediasource',
+  'value' => '0',
+  'xtype' => 'modx-combo-source',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
+$settings['static_elements_basepath']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_basepath']->fromArray(array (
+  'key' => 'static_elements_basepath',
+  'value' => '',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 $settings['strip_image_paths']= $xpdo->newObject('modSystemSetting');
 $settings['strip_image_paths']->fromArray(array (
   'key' => 'strip_image_paths',

--- a/core/lexicon/en/element.inc.php
+++ b/core/lexicon/en/element.inc.php
@@ -8,6 +8,7 @@
 $_lang['element'] = 'Element';
 $_lang['element_err_nf'] = 'Element not found.';
 $_lang['element_err_ns'] = 'Element not specified.';
+$_lang['element_err_staticfile_exists'] = 'A static file already exists within the specified path.';
 $_lang['element_static_source_immutable'] = 'The static file specified as the element source is not writable! You cannot edit the content of this element in the manager.';
 $_lang['element_static_source_protected_invalid'] = 'You cannot point your Element to the MODX configuration directory; this is a protected, non-accessible directory.';
 $_lang['is_static'] = 'Is Static';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -21,6 +21,7 @@ $_lang['area_manager'] = 'Back-end Manager';
 $_lang['area_phpthumb'] = 'phpThumb';
 $_lang['area_proxy'] = 'Proxy';
 $_lang['area_session'] = 'Session and Cookie';
+$_lang['area_static_elements'] = 'Static Elements';
 $_lang['area_lexicon_string'] = 'Area Lexicon Entry';
 $_lang['area_lexicon_string_msg'] = 'Enter the key of the lexicon entry for the area here. If there is no lexicon entry, it will just display the area key.<br />Core Areas: authentication, caching, file, furls, gateway, language, manager, session, site, system';
 $_lang['area_site'] = 'Site';
@@ -714,11 +715,26 @@ $_lang['setting_site_unavailable_page'] = 'Site unavailable page';
 $_lang['setting_site_unavailable_page_desc'] = 'Enter the ID of the Resource you want to use as an offline page here. <strong>NOTE: make sure this ID you enter belongs to an existing Resource, and that it has been published!</strong>';
 $_lang['setting_site_unavailable_page_err'] = 'Please specify the document ID for the site unavailable page.';
 
-$_lang['setting_static_elements_automate'] = 'Automate static elements?';
-$_lang['setting_static_elements_automate_desc'] = 'This will automate the handling of static files, such as creating and removing static files';
+$_lang['setting_static_elements_automate_templates'] = 'Automate static elements for templates?';
+$_lang['setting_static_elements_automate_templates_desc'] = 'This will automate the handling of static files, such as creating and removing static files for templates.';
+
+$_lang['setting_static_elements_automate_tvs'] = 'Automate static elements for template variables?';
+$_lang['setting_static_elements_automate_tvs_desc'] = 'This will automate the handling of static files, such as creating and removing static files for template variables.';
+
+$_lang['setting_static_elements_automate_chunks'] = 'Automate static elements for chunks?';
+$_lang['setting_static_elements_automate_chunks_desc'] = 'This will automate the handling of static files, such as creating and removing static files for chunks.';
+
+$_lang['setting_static_elements_automate_snippets'] = 'Automate static elements for snippets?';
+$_lang['setting_static_elements_automate_snippets_desc'] = 'This will automate the handling of static files, such as creating and removing static files for snippets.';
+
+$_lang['setting_static_elements_automate_plugins'] = 'Automate static elements for plugins?';
+$_lang['setting_static_elements_automate_plugins_desc'] = 'This will automate the handling of static files, such as creating and removing static files for plugins.';
 
 $_lang['setting_static_elements_default_mediasource'] = 'Static elements default mediasource';
 $_lang['setting_static_elements_default_mediasource_desc'] = 'Specify a default mediasource where you want to store the static elements in.';
+
+$_lang['setting_static_elements_default_category'] = 'Static elements default category';
+$_lang['setting_static_elements_default_category_desc'] = 'Specify a default category for creating new static elements.';
 
 $_lang['setting_static_elements_basepath'] = 'Static elements basepath';
 $_lang['setting_static_elements_basepath_desc'] = 'Basepath of where to store the static elements files.';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -714,6 +714,15 @@ $_lang['setting_site_unavailable_page'] = 'Site unavailable page';
 $_lang['setting_site_unavailable_page_desc'] = 'Enter the ID of the Resource you want to use as an offline page here. <strong>NOTE: make sure this ID you enter belongs to an existing Resource, and that it has been published!</strong>';
 $_lang['setting_site_unavailable_page_err'] = 'Please specify the document ID for the site unavailable page.';
 
+$_lang['setting_static_elements_automate'] = 'Automate static elements?';
+$_lang['setting_static_elements_automate_desc'] = 'This will automate the handling of static files, such as creating and removing static files';
+
+$_lang['setting_static_elements_default_mediasource'] = 'Static elements default mediasource';
+$_lang['setting_static_elements_default_mediasource_desc'] = 'Specify a default mediasource where you want to store the static elements in.';
+
+$_lang['setting_static_elements_basepath'] = 'Static elements basepath';
+$_lang['setting_static_elements_basepath_desc'] = 'Basepath of where to store the static elements files.';
+
 $_lang['setting_strip_image_paths'] = 'Rewrite browser paths?';
 $_lang['setting_strip_image_paths_desc'] = 'If this is set to \'No\', MODX will write file browser resource src\'s (images, files, flash, etc.) as absolute URLs. Relative URLs are helpful should you wish to move your MODX install, e.g., from a staging site to a production site. If you have no idea what this means, it\'s best just to leave it set to \'Yes\'.';
 

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -180,7 +180,7 @@ class modElement extends modAccessibleSimpleObject {
 
         /* Removing old static file when succesfull saved and oldPath has been set. */
         if ($saved && $oldPath) {
-            if (unlink($oldPath)) {
+            if (@unlink($oldPath)) {
                 $pathinfo = pathinfo($oldPath);
                 $this->cleanupStaticFileDirectories($pathinfo['dirname']);
             }

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -169,7 +169,8 @@ class modElement extends modAccessibleSimpleObject {
         }
 
         /* If element is empty, set to true in order to create an empty static file. */
-        if (empty($this->getFileContent())) {
+        $filecontent = $this->getFileContent();
+        if (empty($filecontent)) {
             $staticContentChanged = true;
         }
 

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -166,12 +166,11 @@ class modElement extends modAccessibleSimpleObject {
                 $this->setContent($this->getFileContent());
                 $staticContentChanged = false;
             }
-        }
 
-        /* If element is empty, set to true in order to create an empty static file. */
-        $filecontent = $this->getFileContent();
-        if (empty($filecontent)) {
-            $staticContentChanged = true;
+            /* If element is empty, set to true in order to create an empty static file. */
+            if (empty($this->get('content')) && $this->isStatic()) {
+                $staticContentChanged = true;
+            }
         }
 
         /* Set oldPath before saving object. */

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -180,7 +180,10 @@ class modElement extends modAccessibleSimpleObject {
 
         /* Removing old static file when succesfull saved and oldPath has been set. */
         if ($saved && $oldPath) {
-            @unlink($oldPath);
+            if (unlink($oldPath)) {
+                $pathinfo = pathinfo($oldPath);
+                $this->cleanupStaticFileDirectories($pathinfo['dirname']);
+            }
         }
 
         return $saved;
@@ -837,6 +840,25 @@ class modElement extends modAccessibleSimpleObject {
      */
     public function staticContentChanged() {
         return $this->isStatic() && $this->isDirty('content');
+    }
+
+    /**
+     * Check if directories are empty after moving a static element and remove empty directories.
+     *
+     * @param $dirname
+     */
+    public function cleanupStaticFileDirectories($dirname) {
+        $contents = array_diff(scandir($dirname), array('..', '.', '.DS_Store'));
+
+        @unlink($dirname .'/.DS_Store');
+        if (count($contents) === 0) {
+            if (is_dir($dirname)) {
+                if (rmdir($dirname)) {
+                    /* Check if parent directory is also empty. */
+                    $this->cleanupStaticFileDirectories(dirname($dirname));
+                }
+            }
+        }
     }
 
     /**

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -168,7 +168,8 @@ class modElement extends modAccessibleSimpleObject {
             }
 
             /* If element is empty, set to true in order to create an empty static file. */
-            if (empty($this->get('content')) && $this->isStatic()) {
+            $content = $this->get('content');
+            if (empty($content) && $this->isStatic()) {
                 $staticContentChanged = true;
             }
         }

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -160,18 +160,29 @@ class modElement extends modAccessibleSimpleObject {
                 }
                 unset($staticContent);
             }
+
             $staticContentChanged = $this->staticContentChanged();
             if ($staticContentChanged && !$this->isStaticSourceMutable()) {
                 $this->setContent($this->getFileContent());
                 $staticContentChanged = false;
             }
         }
+
+        /* Set oldPath before saving object. */
+        $oldPath = $this->getOldStaticFilePath();
+
         $saved = parent::save($cacheFlag);
         if (!$this->getOption(xPDO::OPT_SETUP)) {
             if ($saved && $staticContentChanged) {
                 $saved = $this->setFileContent($this->get('content'));
             }
         }
+
+        /* Removing old static file when succesfull saved and oldPath has been set. */
+        if ($saved && $oldPath) {
+            @unlink($oldPath);
+        }
+
         return $saved;
     }
 
@@ -826,6 +837,41 @@ class modElement extends modAccessibleSimpleObject {
      */
     public function staticContentChanged() {
         return $this->isStatic() && $this->isDirty('content');
+    }
+
+    /**
+     * Returns static file path if the file path or source has changed.
+     */
+    public function getOldStaticFilePath() {
+        $oldFilePath = '';
+        $sourceId    = 0;
+
+        $result = $this->xpdo->getObject($this->_class, array('id' => $this->_fields['id']));
+        if ($result) {
+            $staticFilePath = $result->get('static_file');
+            $sourceId       = $result->get('source');
+            if ($staticFilePath !== $this->_fields['static_file'] || $sourceId !== $this->_fields['source']) {
+                $oldFilePath = $staticFilePath;
+            }
+        }
+
+        if (!empty($oldFilePath)) {
+            if ($sourceId > 0) {
+                /** @var modMediaSource $source */
+                $source = $this->xpdo->getObject('sources.modFileMediaSource', array('id' => $sourceId));
+                if ($source && $source->get('is_stream')) {
+                    $source->initialize();
+                    $oldFilePath = $source->getBasePath() . $oldFilePath;
+                }
+            }
+
+            if (!file_exists($oldFilePath) && $this->get('source') < 1) {
+                $this->getSourcePath();
+                $oldFilePath = $this->_sourcePath . $oldFilePath;
+            }
+        }
+
+        return $oldFilePath;
     }
 
     /**

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -168,6 +168,11 @@ class modElement extends modAccessibleSimpleObject {
             }
         }
 
+        /* If element is empty, set to true in order to create an empty static file. */
+        if (empty($this->getFileContent())) {
+            $staticContentChanged = true;
+        }
+
         /* Set oldPath before saving object. */
         $oldPath = $this->getOldStaticFilePath();
 

--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -1004,7 +1004,7 @@ class modObjectDuplicateProcessor extends modObjectProcessor {
         }
 
         /* Check if a static file already exists within specified static file path. */
-        if ($this->staticFileAlreadyExists($staticFilename)) {
+        if ($staticFilename && $this->staticFileAlreadyExists($staticFilename)) {
             $this->modx->lexicon->load('core:element');
             $this->addFieldError($this->staticfileField, $this->modx->lexicon('element_err_staticfile_exists'));
         }

--- a/core/model/modx/processors/element/chunk/remove.class.php
+++ b/core/model/modx/processors/element/chunk/remove.class.php
@@ -24,5 +24,27 @@ class modChunkRemoveProcessor extends modElementRemoveProcessor {
     public $objectType = 'chunk';
     public $beforeRemoveEvent = 'OnBeforeChunkFormDelete';
     public $afterRemoveEvent = 'OnChunkFormDelete';
+
+    public $staticFile = '';
+    public $staticFilePath = '';
+
+    public function beforeRemove() {
+        if ($this->object->get('static_file')) {
+            $source = $this->modx->getObject('sources.modFileMediaSource', array('id' => $this->object->get('source')));
+            if ($source && $source->get('is_stream')) {
+                $source->initialize();
+                $this->staticFile = $this->object->get('static_file');
+                $this->staticFilePath = $source->getBasePath() . $this->object->get('static_file');
+            }
+        }
+
+        return true;
+    }
+
+    public function afterRemove() {
+        $this->cleanupStaticFiles();
+
+        return true;
+    }
 }
 return 'modChunkRemoveProcessor';

--- a/core/model/modx/processors/element/plugin/remove.class.php
+++ b/core/model/modx/processors/element/plugin/remove.class.php
@@ -24,5 +24,27 @@ class modPluginRemoveProcessor extends modElementRemoveProcessor {
     public $objectType = 'plugin';
     public $beforeRemoveEvent = 'OnBeforePluginFormDelete';
     public $afterRemoveEvent = 'OnPluginFormDelete';
+
+    public $staticFile = '';
+    public $staticFilePath = '';
+
+    public function beforeRemove() {
+        if ($this->object->get('static_file')) {
+            $source = $this->modx->getObject('sources.modFileMediaSource', array('id' => $this->object->get('source')));
+            if ($source && $source->get('is_stream')) {
+                $source->initialize();
+                $this->staticFile = $this->object->get('static_file');
+                $this->staticFilePath = $source->getBasePath() . $this->object->get('static_file');
+            }
+        }
+
+        return true;
+    }
+
+    public function afterRemove() {
+        $this->cleanupStaticFiles();
+
+        return true;
+    }
 }
 return 'modPluginRemoveProcessor';

--- a/core/model/modx/processors/element/remove.class.php
+++ b/core/model/modx/processors/element/remove.class.php
@@ -22,4 +22,36 @@ abstract class modElementRemoveProcessor extends modObjectRemoveProcessor {
     public function clearCache() {
         $this->modx->cacheManager->refresh();
     }
+<<<<<<< HEAD
 }
+=======
+
+    public function cleanupStaticFiles() {
+        /* Remove file. */
+        $count = $this->modx->getCount($this->classKey, array('static_file' => $this->staticFile));
+        if ($this->staticFilePath && $count === 0) {
+            @unlink($this->staticFilePath);
+        }
+
+        /* Check if parent directory is empty, if so remove parent directory. */
+        $pathinfo = pathinfo($this->staticFilePath);
+
+        $this->cleanupStaticDirectories($pathinfo['dirname']);
+    }
+
+    public function cleanupStaticDirectories($dirname) {
+        $contents = array_diff(scandir($dirname), array('..', '.', '.DS_Store'));
+
+
+        @unlink($dirname .'/.DS_Store');
+        if (count($contents) === 0) {
+            if (is_dir($dirname)) {
+                if (rmdir($dirname)) {
+                    /* Check if parent directory is also empty. */
+                    $this->cleanupStaticDirectories(dirname($dirname));
+                }
+            }
+        }
+    }
+}
+>>>>>>> 2867f79ee... Finishing automating static elements

--- a/core/model/modx/processors/element/remove.class.php
+++ b/core/model/modx/processors/element/remove.class.php
@@ -22,9 +22,6 @@ abstract class modElementRemoveProcessor extends modObjectRemoveProcessor {
     public function clearCache() {
         $this->modx->cacheManager->refresh();
     }
-<<<<<<< HEAD
-}
-=======
 
     public function cleanupStaticFiles() {
         /* Remove file. */
@@ -55,4 +52,3 @@ abstract class modElementRemoveProcessor extends modObjectRemoveProcessor {
         }
     }
 }
->>>>>>> 2867f79ee... Finishing automating static elements

--- a/core/model/modx/processors/element/remove.class.php
+++ b/core/model/modx/processors/element/remove.class.php
@@ -36,12 +36,13 @@ abstract class modElementRemoveProcessor extends modObjectRemoveProcessor {
         /* Check if parent directory is empty, if so remove parent directory. */
         $pathinfo = pathinfo($this->staticFilePath);
 
-        $this->cleanupStaticDirectories($pathinfo['dirname']);
+        if (!empty($pathinfo['dirname'])) {
+            $this->cleanupStaticDirectories($pathinfo['dirname']);
+        }
     }
 
     public function cleanupStaticDirectories($dirname) {
         $contents = array_diff(scandir($dirname), array('..', '.', '.DS_Store'));
-
 
         @unlink($dirname .'/.DS_Store');
         if (count($contents) === 0) {

--- a/core/model/modx/processors/element/snippet/remove.class.php
+++ b/core/model/modx/processors/element/snippet/remove.class.php
@@ -24,5 +24,27 @@ class modSnippetRemoveProcessor extends modElementRemoveProcessor {
     public $objectType = 'snippet';
     public $beforeRemoveEvent = 'OnBeforeSnipFormDelete';
     public $afterRemoveEvent = 'OnSnipFormDelete';
+
+    public $staticFile = '';
+    public $staticFilePath = '';
+
+    public function beforeRemove() {
+        if ($this->object->get('static_file')) {
+            $source = $this->modx->getObject('sources.modFileMediaSource', array('id' => $this->object->get('source')));
+            if ($source && $source->get('is_stream')) {
+                $source->initialize();
+                $this->staticFile = $this->object->get('static_file');
+                $this->staticFilePath = $source->getBasePath() . $this->object->get('static_file');
+            }
+        }
+
+        return true;
+    }
+
+    public function afterRemove() {
+        $this->cleanupStaticFiles();
+
+        return true;
+    }
 }
 return 'modSnippetRemoveProcessor';

--- a/core/model/modx/processors/element/template/remove.class.php
+++ b/core/model/modx/processors/element/template/remove.class.php
@@ -26,6 +26,7 @@ class modTemplateRemoveProcessor extends modElementRemoveProcessor {
     public $afterRemoveEvent = 'OnTempFormDelete';
 
     public $TemplateVarTemplates = array();
+
     public $staticFile = '';
     public $staticFilePath = '';
 
@@ -63,10 +64,7 @@ class modTemplateRemoveProcessor extends modElementRemoveProcessor {
     }
 
     public function afterRemove() {
-        $count = $this->modx->getCount($this->classKey, array('static_file' => $this->staticFile));
-        if ($this->staticFilePath && $count === 0) {
-            @unlink($this->staticFilePath);
-        }
+        $this->cleanupStaticFiles();
 
         /** @var modTemplateVarTemplate $ttv */
         foreach ($this->TemplateVarTemplates as $ttv) {

--- a/core/model/modx/processors/element/template/remove.class.php
+++ b/core/model/modx/processors/element/template/remove.class.php
@@ -26,6 +26,7 @@ class modTemplateRemoveProcessor extends modElementRemoveProcessor {
     public $afterRemoveEvent = 'OnTempFormDelete';
 
     public $TemplateVarTemplates = array();
+    public $staticFile = '';
 
     public function beforeRemove() {
         /* check to make sure it doesn't have any resources using it */
@@ -47,11 +48,23 @@ class modTemplateRemoveProcessor extends modElementRemoveProcessor {
             return $this->modx->lexicon('template_err_default_template');
         }
 
+        if ($this->object->get('static_file')) {
+            $source = $this->modx->getObject('sources.modFileMediaSource', array('id' => $this->object->get('source')));
+            if ($source && $source->get('is_stream')) {
+                $source->initialize();
+                $this->staticFile = $source->getBasePath() . $this->object->get('static_file');
+            }
+        }
+
         $this->TemplateVarTemplates = $this->object->getMany('TemplateVarTemplates');
         return true;
     }
 
     public function afterRemove() {
+        if ($this->staticFile) {
+            @unlink($this->staticFile);
+        }
+
         /** @var modTemplateVarTemplate $ttv */
         foreach ($this->TemplateVarTemplates as $ttv) {
             if ($ttv->remove() == false) {

--- a/core/model/modx/processors/element/template/remove.class.php
+++ b/core/model/modx/processors/element/template/remove.class.php
@@ -27,6 +27,7 @@ class modTemplateRemoveProcessor extends modElementRemoveProcessor {
 
     public $TemplateVarTemplates = array();
     public $staticFile = '';
+    public $staticFilePath = '';
 
     public function beforeRemove() {
         /* check to make sure it doesn't have any resources using it */
@@ -52,7 +53,8 @@ class modTemplateRemoveProcessor extends modElementRemoveProcessor {
             $source = $this->modx->getObject('sources.modFileMediaSource', array('id' => $this->object->get('source')));
             if ($source && $source->get('is_stream')) {
                 $source->initialize();
-                $this->staticFile = $source->getBasePath() . $this->object->get('static_file');
+                $this->staticFile = $this->object->get('static_file');
+                $this->staticFilePath = $source->getBasePath() . $this->object->get('static_file');
             }
         }
 
@@ -61,8 +63,9 @@ class modTemplateRemoveProcessor extends modElementRemoveProcessor {
     }
 
     public function afterRemove() {
-        if ($this->staticFile) {
-            @unlink($this->staticFile);
+        $count = $this->modx->getCount($this->classKey, array('static_file' => $this->staticFile));
+        if ($this->staticFilePath && $count === 0) {
+            @unlink($this->staticFilePath);
         }
 
         /** @var modTemplateVarTemplate $ttv */

--- a/core/xpdo/om/xpdoobject.class.php
+++ b/core/xpdo/om/xpdoobject.class.php
@@ -1122,7 +1122,6 @@ class xPDOObject {
                     $criteria= array($fkdef['criteria']['foreign'], $criteria);
                 }
             }
-
             if ($object= $this->xpdo->getObject($fkdef['class'], $criteria, $cacheFlag)) {
                 $this->_relatedObjects[$alias]= $object;
             }

--- a/core/xpdo/om/xpdoobject.class.php
+++ b/core/xpdo/om/xpdoobject.class.php
@@ -1122,6 +1122,7 @@ class xPDOObject {
                     $criteria= array($fkdef['criteria']['foreign'], $criteria);
                 }
             }
+
             if ($object= $this->xpdo->getObject($fkdef['class'], $criteria, $cacheFlag)) {
                 $this->_relatedObjects[$alias]= $object;
             }

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -375,7 +375,11 @@ Ext.extend(MODx,Ext.Component,{
         name = name.replace(/[^\w\s-]/gi, '');
         name = name.replace(/\s/g, '-').toLowerCase();
 
-        path += "/" + type + category + name + ext;
+        if (name.length > 0) {
+            path += "/" + type + category + name + ext;
+        } else {
+            path += "/" + type + category;
+        }
 
         return path;
     }

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -298,6 +298,34 @@ Ext.extend(MODx,Ext.Component,{
         return c;
     }
 
+    ,getStaticElementsPath: function(name, category, type) {
+        var path = MODx.config.static_elements_basepath,
+            ext  = '';
+
+        if (category.length > 0) {
+            category = category.replace(/[^\w\s]/gi, '');
+            category = category.replace(/\s/g, '-').toLowerCase();
+            category = '/' + category + '/';
+        } else {
+            category = '/';
+        }
+
+        /* Remove trailing slash. */
+        path = path.replace(/\/$/, "");
+
+        if (type === 'templates') {
+            ext = '.template.tpl';
+        }
+
+        /* Remove special characters and spaces. */
+        name = name.replace(/[^\w\s]/gi, '');
+        name = name.replace(/\s/g, '-').toLowerCase();
+
+        path += '/' + type + category + name + ext;
+
+        return path;
+    }
+
     ,helpUrl: false
     ,loadHelpPane: function(b) {
         var url = MODx.helpUrl || MODx.config.help_url || '';

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -298,30 +298,84 @@ Ext.extend(MODx,Ext.Component,{
         return c;
     }
 
+    ,setStaticElementPath: function(type) {
+        var category   = '',
+            path       = '',
+            name       = '',
+            nameField  = 'name',
+            typePlural = type + "s";
+
+        if (type === "template") {
+            nameField = 'templatename';
+        }
+
+        if (MODx.config["static_elements_automate_" + typePlural] == 1) {
+            if (Ext.getCmp("modx-" + type + "-category").getValue() > 0) {
+                category = Ext.getCmp("modx-" + type + "-category").lastSelectionText;
+            }
+
+            name = Ext.getCmp("modx-" + type + "-" + nameField).getValue();
+            path = MODx.getStaticElementsPath(name, category, typePlural);
+            Ext.getCmp("modx-" + type + "-static-file").setValue(path);
+        }
+    }
+
+    ,setStaticElementsConfig: function (config, type) {
+        var typePlural = type + 's';
+
+        if (MODx.request.a === 'element/' + type + '/create' && MODx.config['static_elements_automate_' + typePlural] == 1) {
+            config.record['static'] = 1;
+            config.record['static_file'] = MODx.config.static_elements_basepath + typePlural + '/';
+            config.record['category'] = MODx.config.static_elements_default_category;
+
+            if (MODx.config.static_elements_default_mediasource) {
+                config.record['source'] = MODx.config.static_elements_default_mediasource;
+            }
+        }
+
+        return config;
+    }
+
     ,getStaticElementsPath: function(name, category, type) {
         var path = MODx.config.static_elements_basepath,
             ext  = '';
 
         if (category.length > 0) {
-            category = category.replace(/[^\w\s]/gi, '');
+            category = category.replace(/[^\w\s-]/gi, "");
             category = category.replace(/\s/g, '-').toLowerCase();
-            category = '/' + category + '/';
+            // Convert nested elements to nested directory structure.
+            category = category.replace(/--/gi, '/');
+            category = "/" + category + "/";
         } else {
-            category = '/';
+            category = "/";
         }
 
-        /* Remove trailing slash. */
+        // Remove trailing slash.
         path = path.replace(/\/$/, "");
 
-        if (type === 'templates') {
-            ext = '.template.tpl';
+        switch(type) {
+            case "templates":
+                ext = ".template.tpl";
+                break;
+            case "tvs":
+                ext = ".tv.tpl";
+                break;
+            case "chunks":
+                ext = ".chunk.tpl";
+                break;
+            case "snippets":
+                ext = ".snippet.php";
+                break;
+            case "plugins":
+                ext = ".plugin.php";
+                break;
         }
 
-        /* Remove special characters and spaces. */
-        name = name.replace(/[^\w\s]/gi, '');
+        // Remove special characters and spaces.
+        name = name.replace(/[^\w\s-]/gi, '');
         name = name.replace(/\s/g, '-').toLowerCase();
 
-        path += '/' + type + category + name + ext;
+        path += "/" + type + category + name + ext;
 
         return path;
     }

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -54,6 +54,9 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             id: this.record.id
             ,type: 'chunk'
             ,name: _('duplicate_of',{name: this.record.name})
+            ,source: this.record.source
+            ,static: this.record.static
+            ,static_file: this.record.static_file
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -54,6 +54,9 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             id: this.record.id
             ,type: 'plugin'
             ,name: _('duplicate_of',{name: this.record.name})
+            ,source: this.record.source
+            ,static: this.record.static
+            ,static_file: this.record.static_file
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -54,6 +54,9 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             id: this.record.id
             ,type: 'snippet'
             ,name: _('duplicate_of',{name: this.record.name})
+            ,source: this.record.source
+            ,static: this.record.static
+            ,static_file: this.record.static_file
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -54,6 +54,9 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             id: this.record.id
             ,type: 'template'
             ,name: _('duplicate_of',{name: this.record.templatename})
+            ,source: this.record.source
+            ,static: this.record.static
+            ,static_file: this.record.static_file
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -55,6 +55,9 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             ,type: 'tv'
             ,name: _('duplicate_of',{name: this.record.name})
             ,caption: _('duplicate_of',{name: this.record.caption})
+            ,source: this.record.source
+            ,static: this.record.static
+            ,static_file: this.record.static_file
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -77,7 +77,7 @@ MODx.panel.Chunk = function(config) {
 
                                 Ext.getCmp('modx-chunk-header').getEl().update(title);
 
-                                MODx.setStaticElementPath("chunk");
+                                MODx.setStaticElementPath('chunk');
                             }}
                         }
                     },{
@@ -149,8 +149,13 @@ MODx.panel.Chunk = function(config) {
                         ,anchor: '100%'
                         ,value: config.record.category || 0
                         ,listeners: {
-                            'change': {scope:this,fn:function(f,e) {
-                                MODx.setStaticElementPath("chunk");
+                            'afterrender': {scope:this,fn:function(f,e) {
+                                setTimeout(function(){
+                                    MODx.setStaticElementPath('chunk');
+                                }, 200);
+                            }}
+                            ,'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath('chunk');
                             }}
                         }
                     },{

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -6,6 +6,9 @@
  */
 MODx.panel.Chunk = function(config) {
     config = config || {};
+    config.record = config.record || {};
+    config = MODx.setStaticElementsConfig(config, 'chunk');
+
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
@@ -73,6 +76,8 @@ MODx.panel.Chunk = function(config) {
                                 }
 
                                 Ext.getCmp('modx-chunk-header').getEl().update(title);
+
+                                MODx.setStaticElementPath("chunk");
                             }}
                         }
                     },{
@@ -143,6 +148,11 @@ MODx.panel.Chunk = function(config) {
                         ,id: 'modx-chunk-category'
                         ,anchor: '100%'
                         ,value: config.record.category || 0
+                        ,listeners: {
+                            'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath("chunk");
+                            }}
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-chunk-category'

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -7,6 +7,9 @@
  */
 MODx.panel.Plugin = function(config) {
     config = config || {};
+    config.record = config.record || {};
+    config = MODx.setStaticElementsConfig(config, 'plugin');
+
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
@@ -75,6 +78,8 @@ MODx.panel.Plugin = function(config) {
                                 }
 
                                 Ext.getCmp('modx-plugin-header').getEl().update(title);
+
+                                MODx.setStaticElementPath('plugin');
                             }}
                         }
                     },{
@@ -146,6 +151,11 @@ MODx.panel.Plugin = function(config) {
                         ,id: 'modx-plugin-category'
                         ,anchor: '100%'
                         ,value: config.record.category || 0
+                        ,listeners: {
+                            'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath('plugin');
+                            }}
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-plugin-category'

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -152,7 +152,12 @@ MODx.panel.Plugin = function(config) {
                         ,anchor: '100%'
                         ,value: config.record.category || 0
                         ,listeners: {
-                            'change': {scope:this,fn:function(f,e) {
+                            'afterrender': {scope:this,fn:function(f,e) {
+                                setTimeout(function(){
+                                    MODx.setStaticElementPath('plugin');
+                                }, 200);
+                            }}
+                            ,'change': {scope:this,fn:function(f,e) {
                                 MODx.setStaticElementPath('plugin');
                             }}
                         }

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -6,6 +6,9 @@
  */
 MODx.panel.Snippet = function(config) {
     config = config || {};
+    config.record = config.record || {};
+    config = MODx.setStaticElementsConfig(config, 'snippet');
+
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
@@ -74,6 +77,8 @@ MODx.panel.Snippet = function(config) {
                                 }
 
                                 Ext.getCmp('modx-snippet-header').getEl().update(title);
+
+                                MODx.setStaticElementPath("snippet");
                             }}
                         }
                     },{
@@ -144,6 +149,11 @@ MODx.panel.Snippet = function(config) {
                         ,id: 'modx-snippet-category'
                         ,anchor: '100%'
                         ,value: config.record.category || 0
+                        ,listeners: {
+                            'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath("snippet");
+                            }}
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-snippet-category'

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -78,7 +78,7 @@ MODx.panel.Snippet = function(config) {
 
                                 Ext.getCmp('modx-snippet-header').getEl().update(title);
 
-                                MODx.setStaticElementPath("snippet");
+                                MODx.setStaticElementPath('snippet');
                             }}
                         }
                     },{
@@ -150,8 +150,13 @@ MODx.panel.Snippet = function(config) {
                         ,anchor: '100%'
                         ,value: config.record.category || 0
                         ,listeners: {
-                            'change': {scope:this,fn:function(f,e) {
-                                MODx.setStaticElementPath("snippet");
+                            'afterrender': {scope:this,fn:function(f,e) {
+                                setTimeout(function(){
+                                    MODx.setStaticElementPath('snippet');
+                                }, 200);
+                            }}
+                            ,'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath('snippet');
                             }}
                         }
                     },{

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -10,15 +10,7 @@
 MODx.panel.Template = function(config) {
     config = config || {record:{}};
     config.record = config.record || {};
-
-    if (MODx.request.a === 'element/template/create' && MODx.config.static_elements_automate) {
-        config.record['static'] = 1;
-        config.record['static_file'] = MODx.config.static_elements_basepath;
-
-        if (MODx.config.static_elements_default_mediasource) {
-            config.record['source'] = MODx.config.static_elements_default_mediasource;
-        }
-    }
+    config = MODx.setStaticElementsConfig(config, 'template');
 
     Ext.applyIf(config,{
         url: MODx.config.connector_url
@@ -80,10 +72,6 @@ MODx.panel.Template = function(config) {
                         ,value: config.record.templatename
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
-                                Ext.getCmp('modx-template-header').getEl().update(_('template')+': '+f.getValue());
-
-                                this.setStaticElementPath();
-
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('template')+': '+Ext.util.Format.htmlEncode(title);
                                 if (MODx.request.a !== 'element/template/create' && MODx.perm.tree_show_element_ids === 1) {
@@ -91,6 +79,8 @@ MODx.panel.Template = function(config) {
                                 }
 
                                 Ext.getCmp('modx-template-header').getEl().update(title);
+
+                                MODx.setStaticElementPath("template");
                             }}
                         }
                     },{
@@ -179,7 +169,7 @@ MODx.panel.Template = function(config) {
                         ,value: config.record.category || 0
                         ,listeners: {
                             'change': {scope:this,fn:function(f,e) {
-                                this.setStaticElementPath();
+                                MODx.setStaticElementPath("template");
                             }}
                         }
                     },{
@@ -346,26 +336,6 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
 
         browser.config.source = source;
     }
-
-    /**
-     * Set the static element path.
-     */
-    ,setStaticElementPath: function() {
-        var category = '',
-            path     = '',
-            name     = '';
-
-        if (MODx.config.static_elements_automate) {
-            if (Ext.getCmp('modx-template-category').getValue() > 0) {
-                category = Ext.getCmp('modx-template-category').lastSelectionText;
-            }
-
-            name = Ext.getCmp('modx-template-templatename').getValue();
-            path = MODx.getStaticElementsPath(name, category, 'templates');
-            Ext.getCmp('modx-template-static-file').setValue(path);
-        }
-    }
-
     ,beforeSubmit: function(o) {
         var g = Ext.getCmp('modx-grid-template-tv');
         Ext.apply(o.form.baseParams,{

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -10,6 +10,16 @@
 MODx.panel.Template = function(config) {
     config = config || {record:{}};
     config.record = config.record || {};
+
+    if (MODx.request.a === 'element/template/create' && MODx.config.static_elements_automate) {
+        config.record['static'] = 1;
+        config.record['static_file'] = MODx.config.static_elements_basepath;
+
+        if (MODx.config.static_elements_default_mediasource) {
+            config.record['source'] = MODx.config.static_elements_default_mediasource;
+        }
+    }
+
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
@@ -70,6 +80,10 @@ MODx.panel.Template = function(config) {
                         ,value: config.record.templatename
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
+                                Ext.getCmp('modx-template-header').getEl().update(_('template')+': '+f.getValue());
+
+                                this.setStaticElementPath();
+
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('template')+': '+Ext.util.Format.htmlEncode(title);
                                 if (MODx.request.a !== 'element/template/create' && MODx.perm.tree_show_element_ids === 1) {
@@ -163,6 +177,11 @@ MODx.panel.Template = function(config) {
                         ,id: 'modx-template-category'
                         ,anchor: '100%'
                         ,value: config.record.category || 0
+                        ,listeners: {
+                            'change': {scope:this,fn:function(f,e) {
+                                this.setStaticElementPath();
+                            }}
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-template-category'
@@ -326,6 +345,25 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
             ,source = Ext.getCmp('modx-template-static-source').getValue();
 
         browser.config.source = source;
+    }
+
+    /**
+     * Set the static element path.
+     */
+    ,setStaticElementPath: function() {
+        var category = '',
+            path     = '',
+            name     = '';
+
+        if (MODx.config.static_elements_automate) {
+            if (Ext.getCmp('modx-template-category').getValue() > 0) {
+                category = Ext.getCmp('modx-template-category').lastSelectionText;
+            }
+
+            name = Ext.getCmp('modx-template-templatename').getValue();
+            path = MODx.getStaticElementsPath(name, category, 'templates');
+            Ext.getCmp('modx-template-static-file').setValue(path);
+        }
     }
 
     ,beforeSubmit: function(o) {

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -80,7 +80,7 @@ MODx.panel.Template = function(config) {
 
                                 Ext.getCmp('modx-template-header').getEl().update(title);
 
-                                MODx.setStaticElementPath("template");
+                                MODx.setStaticElementPath('template');
                             }}
                         }
                     },{
@@ -168,8 +168,13 @@ MODx.panel.Template = function(config) {
                         ,anchor: '100%'
                         ,value: config.record.category || 0
                         ,listeners: {
-                            'change': {scope:this,fn:function(f,e) {
-                                MODx.setStaticElementPath("template");
+                            'afterrender': {scope:this,fn:function(f,e) {
+                                setTimeout(function(){
+                                    MODx.setStaticElementPath('template');
+                                }, 200);
+                            }}
+                            ,'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath('template');
                             }}
                         }
                     },{

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -81,7 +81,7 @@ MODx.panel.TV = function(config) {
 
                                 Ext.getCmp('modx-tv-header').getEl().update(title);
 
-                                MODx.setStaticElementPath("tv");
+                                MODx.setStaticElementPath('tv');
                             }}
                         }
                     },{
@@ -153,8 +153,13 @@ MODx.panel.TV = function(config) {
                         ,anchor: '100%'
                         ,value: config.record.category || 0
                         ,listeners: {
-                            'change': {scope:this,fn:function(f,e) {
-                                MODx.setStaticElementPath("tv");
+                            'afterrender': {scope:this,fn:function(f,e) {
+                                setTimeout(function(){
+                                    MODx.setStaticElementPath('tv');
+                                }, 200);
+                            }}
+                            ,'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath('tv');
                             }}
                         }
                     },{

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -8,6 +8,9 @@
  */
 MODx.panel.TV = function(config) {
     config = config || {};
+    config.record = config.record || {};
+    config = MODx.setStaticElementsConfig(config, 'tv');
+
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
@@ -77,6 +80,8 @@ MODx.panel.TV = function(config) {
                                 }
 
                                 Ext.getCmp('modx-tv-header').getEl().update(title);
+
+                                MODx.setStaticElementPath("tv");
                             }}
                         }
                     },{
@@ -147,6 +152,11 @@ MODx.panel.TV = function(config) {
                         ,id: 'modx-tv-category'
                         ,anchor: '100%'
                         ,value: config.record.category || 0
+                        ,listeners: {
+                            'change': {scope:this,fn:function(f,e) {
+                                MODx.setStaticElementPath("tv");
+                            }}
+                        }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-tv-category'

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -146,21 +146,37 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
     }
 
     ,duplicateElement: function(itm,e,id,type) {
-        var r = {
-            id: id
-            ,type: type
-            ,name: _('duplicate_of',{name: this.cm.activeNode.attributes.name})
-            ,caption: _('duplicate_of',{name: this.cm.activeNode.attributes.caption})
-        };
-        var w = MODx.load({
-            xtype: 'modx-window-element-duplicate'
-            ,record: r
+        MODx.Ajax.request({
+            url: MODx.config.connector_url
+            ,params: {
+                action: 'element/' + type + '/get'
+                ,id: id
+            }
             ,listeners: {
-                'success': {fn:function() {this.refreshNode(this.cm.activeNode.id);},scope:this}
-                ,'hide':{fn:function() {this.destroy();}}
+                'success': {fn:function(results) {
+                    var r = {
+                        id: id
+                        ,type: type
+                        ,name: _('duplicate_of',{name: this.cm.activeNode.attributes.name})
+                        ,caption: _('duplicate_of',{name: this.cm.activeNode.attributes.caption})
+                        ,category: results.object.category
+                        ,source: results.object.source
+                        ,static: results.object.static
+                        ,static_file: results.object.static_file
+                    };
+                    var w = MODx.load({
+                        xtype: 'modx-window-element-duplicate'
+                        ,record: r
+                        ,listeners: {
+                            'success': {fn:function() {this.refreshNode(this.cm.activeNode.id);},scope:this}
+                            ,'hide':{fn:function() {this.destroy();}}
+                        }
+                    });
+                    w.show(e.target);
+
+                },scope:this}
             }
         });
-        w.show(e.target);
     }
 
     ,removeElement: function(itm,e) {

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -112,6 +112,7 @@ Ext.reg('modx-window-resource-duplicate',MODx.window.DuplicateResource);
  */
 MODx.window.DuplicateElement = function(config) {
     config = config || {};
+
     this.ident = config.ident || 'dupeel-'+Ext.id();
     var flds = [{
         xtype: 'hidden'
@@ -129,31 +130,14 @@ MODx.window.DuplicateElement = function(config) {
         ,anchor: '100%'
         ,enableKeyEvents: true
         ,listeners: {
+            'afterRender' : {scope:this,fn:function(f,e) {
+                this.setStaticElementsPath(f);
+            }},
             'keyup': {scope:this,fn:function(f,e) {
-                if (config.record.static === true) {
-                    var category = '';
-                    if (Ext.getCmp('modx-template-category').getValue() > 0) {
-                        category = Ext.getCmp('modx-template-category').lastSelectionText;
-                    }
-
-                    var path = MODx.getStaticElementsPath(f.getValue(), category, 'templates');
-                    Ext.getCmp('modx-'+this.ident+'-static_file').setValue(path);
-                }
+                this.setStaticElementsPath(f);
             }}
         }
     }];
-
-    if (config.record.static === true) {
-        flds.push({
-              xtype: 'textfield'
-              ,fieldLabel: _('static_file')
-              ,name: 'static_file'
-              ,id: 'modx-'+this.ident+'-static_file'
-              ,anchor: '100%'
-          }
-        );
-    }
-
 
     if (config.record.type == 'tv') {
         flds.push({
@@ -174,6 +158,18 @@ MODx.window.DuplicateElement = function(config) {
             ,checked: false
         });
     }
+
+    if (config.record.static === true) {
+        flds.push({
+                xtype: 'textfield'
+                ,fieldLabel: _('static_file')
+                ,name: 'static_file'
+                ,id: 'modx-'+this.ident+'-static_file'
+                ,anchor: '100%'
+            }
+        );
+    }
+
     Ext.applyIf(config,{
         title: _('element_duplicate')
         ,url: MODx.config.connector_url
@@ -183,7 +179,47 @@ MODx.window.DuplicateElement = function(config) {
     });
     MODx.window.DuplicateElement.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.window.DuplicateElement,MODx.Window);
+
+Ext.extend(MODx.window.DuplicateElement,MODx.Window, {
+    setStaticElementsPath: function(f) {
+        if (this.config.record.static === true) {
+            var category = this.config.record.category;
+
+            if (typeof category !== 'number') {
+                if (Ext.getCmp('modx-' + this.config.record.type + '-category').getValue() > 0) {
+                    category = Ext.getCmp('modx-' + this.config.record.type + '-category').lastSelectionText;
+                }
+
+                var path = MODx.getStaticElementsPath(f.getValue(), category, this.config.record.type + 's');
+                Ext.getCmp('modx-' + this.ident + '-static_file').setValue(path);
+            } else {
+                // If category is set but is a number, retrieve full category name.
+                if (typeof category === "number" && category > 0) {
+                    MODx.Ajax.request({
+                        url: MODx.config.connector_url
+                        ,params: {
+                            action: 'element/category/getlist'
+                            ,id: category
+                        }
+                        ,listeners: {
+                            'success': {fn:function(response) {
+                                for (var i = 0; i < response.results.length; i++) {
+                                    if (response.results[i].id === category) {
+                                        category = response.results[i].name;
+                                    }
+                                }
+
+                                var path = MODx.getStaticElementsPath(f.getValue(), category, this.config.record.type + 's');
+                                Ext.getCmp('modx-' + this.ident + '-static_file').setValue(path);
+                            },scope:this}
+                        }
+                  });
+                }
+            }
+        }
+    }
+});
+
 Ext.reg('modx-window-element-duplicate',MODx.window.DuplicateElement);
 
 MODx.window.CreateCategory = function(config) {

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -118,12 +118,43 @@ MODx.window.DuplicateElement = function(config) {
         ,name: 'id'
         ,id: 'modx-'+this.ident+'-id'
     },{
+        xtype: 'hidden'
+        ,name: 'source'
+        ,id: 'modx-'+this.ident+'-source'
+    }, {
         xtype: 'textfield'
         ,fieldLabel: _('element_name_new')
         ,name: config.record.type == 'template' ? 'templatename' : 'name'
         ,id: 'modx-'+this.ident+'-name'
         ,anchor: '100%'
+        ,enableKeyEvents: true
+        ,listeners: {
+            'keyup': {scope:this,fn:function(f,e) {
+                if (config.record.static === true) {
+                    var category = '';
+                    if (Ext.getCmp('modx-template-category').getValue() > 0) {
+                        category = Ext.getCmp('modx-template-category').lastSelectionText;
+                    }
+
+                    var path = MODx.getStaticElementsPath(f.getValue(), category, 'templates');
+                    Ext.getCmp('modx-'+this.ident+'-static_file').setValue(path);
+                }
+            }}
+        }
     }];
+
+    if (config.record.static === true) {
+        flds.push({
+              xtype: 'textfield'
+              ,fieldLabel: _('static_file')
+              ,name: 'static_file'
+              ,id: 'modx-'+this.ident+'-static_file'
+              ,anchor: '100%'
+          }
+        );
+    }
+
+
     if (config.record.type == 'tv') {
         flds.push({
             xtype: 'textfield'

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -174,6 +174,7 @@ MODx.window.DuplicateElement = function(config) {
         title: _('element_duplicate')
         ,url: MODx.config.connector_url
         ,action: 'element/'+config.record.type+'/duplicate'
+        ,width: 600
         ,fields: flds
         ,labelWidth: 150
     });


### PR DESCRIPTION
# Note: This is a rebased PR for https://github.com/modxcms/revolution/pull/13646

# What does it do?
Added settings to allow for an automated static elements workflow and added the handling of creating/removing automated static files.

## Features:

- Added System settings allowing an automated static elements workflow for each element type (Templates, Template Variables, Chunks, Snippets and Plugins)
- Added System setting for setting a default mediasource for your static elements
- Added System setting for setting a default category for your static elements
- Added System setting for setting a static elements basepath
- If set, will automatically create a static file where the static filename is based on the name of the element, stripping it from special characters, removing spaces and making it lowercased.
- When removing/deleting a static element, it will remove the static file (if not used by another -element) and will also remove the parent directory automatically for you if the directory is empty.
- Added static file path to duplicate element window

# Why is it needed?
We use static elements in our workflow and by automating the creation of static elements it will save a lot of manual work and it also keeps the static elements free of clutter by removing unused static element files.