### PR TITLE
Skip target validation when MODX tags detected in the content field

### DIFF
--- a/core/model/modx/processors/resource/create.class.php
+++ b/core/model/modx/processors/resource/create.class.php
@@ -648,7 +648,10 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
     public function checkSymLinkTarget() {
         $target = $this->getProperty('content', null);
 
-        if ($target === null || $target === '') {
+        $matches = array();
+        $countFoundTags = $this->modx->getParser()->collectElementTags($target, $matches);
+
+        if ($target === null || $target === '' || $countFoundTags) {
             return true;
         }
 
@@ -673,7 +676,10 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
     public function checkWebLinkTarget() {
         $target = $this->getProperty('content', null);
 
-        if ($target === null || $target === '') {
+        $matches = array();
+        $countFoundTags = $this->modx->getParser()->collectElementTags($target, $matches);
+
+        if ($target === null || $target === '' || $countFoundTags) {
             return true;
         }
 

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -498,7 +498,10 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
     public function checkSymLinkTarget() {
         $target = $this->getProperty('content', null);
 
-        if ($target === null || $target === '') {
+        $matches = array();
+        $countFoundTags = $this->modx->getParser()->collectElementTags($target, $matches);
+
+        if ($target === null || $target === '' || $countFoundTags) {
             return true;
         }
 
@@ -523,7 +526,10 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
     public function checkWebLinkTarget() {
         $target = $this->getProperty('content', null);
 
-        if ($target === null || $target === '') {
+        $matches = array();
+        $countFoundTags = $this->modx->getParser()->collectElementTags($target, $matches);
+
+        if ($target === null || $target === '' || $countFoundTags) {
             return true;
         }
 


### PR DESCRIPTION
### What does it do?
It skips the target validation when MODX tags detected in the content field.

### Why is it needed?
Original PR broke BC and should be fixed.

### Related issue(s)/PR(s)
#14041