### PR TITLE
Fixing single purge resource

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.grid.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.trash.js
@@ -200,7 +200,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             url: this.config.url,
             params: {
                 action: 'resource/trash/purge',
-                id: this.menu.record.id
+                ids: this.menu.record.id
             },
             listeners: {
                 'success': {


### PR DESCRIPTION
### What does it do?
Set the ids property instead of the id property for the resource/trash/purge processor.

### Why is it needed?
The wrong property was submitted

### Related issue(s)/PR(s)
#14138 
