### PR TITLE
Add required and suggested PHP extensions to composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ before_script: 'composer install -n && cd _build/test && ./generateConfigs.sh'
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi
   -  if [[ "(7.0 7.1 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  -  yes | pecl install imagick

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,3 @@ before_script: 'composer install -n && cd _build/test && ./generateConfigs.sh'
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi
   -  if [[ "(7.0 7.1 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
-  -  yes | pecl install imagick

--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,7 @@
         "simplepie/simplepie": "^1.5",
         "ext-curl": "*",
         "ext-dom": "*",
-        "ext-gd": "*",
         "ext-zlib": "*",
-        "ext-imagick": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
         "ext-pdo": "*",
@@ -65,6 +63,7 @@
         "ext-zip": "*"
     },
     "suggest": {
+        "ext-gd": "To create and manipulate image files",
         "ext-iconv": "Needed if you want to use the built-in transliteration service",
         "ext-mbstring": "Needed when use_multibyte is enabled or when using some extras like Gallery",
         "ext-xmlwriter": "To use the export functionalities"

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "simplepie/simplepie": "^1.5",
         "ext-curl": "*",
         "ext-dom": "*",
+        "ext-gd": "*",
         "ext-zlib": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
@@ -63,7 +64,7 @@
         "ext-zip": "*"
     },
     "suggest": {
-        "ext-gd": "To create and manipulate image files",
+        "ext-imagick": "To process images in a more advanced way",
         "ext-iconv": "Needed if you want to use the built-in transliteration service",
         "ext-mbstring": "Needed when use_multibyte is enabled or when using some extras like Gallery",
         "ext-xmlwriter": "To use the export functionalities"

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,22 @@
         "james-heinrich/phpthumb": "^1.7",
         "erusev/parsedown": "^1.7",
         "pelago/emogrifier": "^2.0",
-        "simplepie/simplepie": "^1.5"
+        "simplepie/simplepie": "^1.5",
+        "ext-curl": "*",
+        "ext-dom": "*",
+        "ext-gd": "*",
+        "ext-zlib": "*",
+        "ext-imagick": "*",
+        "ext-json": "*",
+        "ext-simplexml": "*",
+        "ext-pdo": "*",
+        "ext-xml": "*",
+        "ext-zip": "*"
+    },
+    "suggest": {
+        "ext-iconv": "Needed if you want to use the built-in transliteration service",
+        "ext-mbstring": "Needed when use_multibyte is enabled or when using some extras like Gallery",
+        "ext-xmlwriter": "To use the export functionalities"
     },
     "autoload": {
       "classmap": [


### PR DESCRIPTION
### What does it do?
This adds required and suggested PHP extensions to composer.json.

### Why is it needed?
We want to check and suggest the system requirements when installing MODX via composer.

### Related issue(s)/PR(s)
Fixes issue #14048 
