### PR TITLE
Fix Call to undefined function URLschemeDefaultPort()

### DIFF
--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -723,7 +723,7 @@ class phpthumb_functions {
 		$cleaned_url  = $parsed_url['scheme'].'://';
 		$cleaned_url .= ($parsed_url['username'] ? $parsed_url['username'].($parsed_url['password'] ? ':'.$parsed_url['password'] : '').'@' : '');
 		$cleaned_url .= $parsed_url['host'];
-		$cleaned_url .= (($parsed_url['port'] && ($parsed_url['port'] != URLschemeDefaultPort($parsed_url['scheme']))) ? ':'.$parsed_url['port'] : '');
+		$cleaned_url .= (($parsed_url['port'] && ($parsed_url['port'] != self::URLschemeDefaultPort($parsed_url['scheme']))) ? ':'.$parsed_url['port'] : '');
 		$cleaned_url .= '/'.implode('/', $CleanPathElements);
 		$cleaned_url .= (!empty($CleanQueries) ? '?'.implode($queryseperator, $CleanQueries) : '');
 		return $cleaned_url;
@@ -745,7 +745,7 @@ class phpthumb_functions {
 				$parsedURL[$key] = null;
 			}
 		}
-		$parsedURL['port'] = ($parsedURL['port'] ? $parsedURL['port'] : URLschemeDefaultPort($scheme));
+		$parsedURL['port'] = ($parsedURL['port'] ? $parsedURL['port'] : self::URLschemeDefaultPort($scheme));
 		return $parsedURL;
 	}
 


### PR DESCRIPTION
### What does it do?
Add two missing self:: to fix a Fatal error: Uncaught Error: Call to undefined function URLschemeDefaultPort() in \core\model\phpthumb\phpthumb.functions.php:748

### Why is it needed?
phpthumb connector is unable to generate thumbnails in the manager (media browser and/or template vars preview) due to a fatal error.
