### PR TITLE
Add recursive method to replace reserved characters

### DIFF
--- a/_build/test/Tests/Cases/Modx/ReplaceBracesTest.php
+++ b/_build/test/Tests/Cases/Modx/ReplaceBracesTest.php
@@ -1,0 +1,110 @@
+<?php
+
+class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        include_once dirname(dirname(dirname(dirname(dirname(__DIR__))))) . '/core/model/modx/modx.class.php';
+    }
+
+    public function testEmptyString()
+    {
+        $this->assertEquals(
+            '',
+            modX::replaceBraces('')
+        );
+
+        $this->assertEquals(
+            '',
+            modX::replaceBraces(new stdClass)
+        );
+
+        $this->assertEquals(
+            '',
+            modX::replaceBraces(null)
+        );
+    }
+
+    public function testDefaultProperty()
+    {
+        $this->assertEquals(
+            'clear string',
+            modX::replaceBraces('clear string')
+        );
+
+        $source = '[[tag? &param=`value`]]';
+        $replacing = '&#91;&#91;tag? &param=&#96;value&#96;&#93;&#93;';
+
+        $this->assertEquals(
+            $replacing,
+            modX::replaceBraces($source)
+        );
+
+        $this->assertEquals(
+            array($replacing => $replacing),
+            modX::replaceBraces(array(
+                $source => $source
+            ))
+        );
+
+        $this->assertEquals(
+            array(
+                $replacing => array(
+                    $replacing => $replacing
+                )
+            ),
+            modX::replaceBraces(array(
+                $source => array(
+                    $source => $source
+                )
+            ))
+        );
+    }
+
+    public function testChangingProperty()
+    {
+        $property = array('[' => '', ']' => '&#93;');
+
+        $this->assertEquals(
+            'clear string',
+            modX::replaceBraces('clear string', $property)
+        );
+
+        $source = '[[tag? &param=`value`]]';
+        $replacing = 'tag? &param=`value`&#93;&#93;';
+
+        $this->assertEquals(
+            $replacing,
+            modX::replaceBraces($source, $property)
+        );
+
+        $this->assertEquals(
+            array($replacing => $replacing),
+            modX::replaceBraces(
+                array(
+                    $source => $source
+                ),
+                $property
+            )
+        );
+
+        $this->assertEquals(
+            array(
+                $replacing => array(
+                    $replacing => $replacing
+                )
+            ),
+            modX::replaceBraces(
+                array(
+                    $source => array(
+                        $source => $source
+                    )
+                ),
+                $property
+            )
+        );
+    }
+}

--- a/_build/test/Tests/Cases/Modx/ReplaceReservedTest.php
+++ b/_build/test/Tests/Cases/Modx/ReplaceReservedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
+class ReplaceReservedTest extends \PHPUnit\Framework\TestCase
 {
 
     public function __construct()
@@ -14,17 +14,17 @@ class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(
             '',
-            modX::replaceBraces('')
+            modX::replaceReserved('')
         );
 
         $this->assertEquals(
             '',
-            modX::replaceBraces(new stdClass)
+            modX::replaceReserved(new stdClass)
         );
 
         $this->assertEquals(
             '',
-            modX::replaceBraces(null)
+            modX::replaceReserved(null)
         );
     }
 
@@ -32,7 +32,7 @@ class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals(
             'clear string',
-            modX::replaceBraces('clear string')
+            modX::replaceReserved('clear string')
         );
 
         $source = '[[tag? &param=`value`]]';
@@ -40,12 +40,12 @@ class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             $replacing,
-            modX::replaceBraces($source)
+            modX::replaceReserved($source)
         );
 
         $this->assertEquals(
             array($replacing => $replacing),
-            modX::replaceBraces(array(
+            modX::replaceReserved(array(
                 $source => $source
             ))
         );
@@ -56,7 +56,7 @@ class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
                     $replacing => $replacing
                 )
             ),
-            modX::replaceBraces(array(
+            modX::replaceReserved(array(
                 $source => array(
                     $source => $source
                 )
@@ -70,7 +70,7 @@ class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             'clear string',
-            modX::replaceBraces('clear string', $property)
+            modX::replaceReserved('clear string', $property)
         );
 
         $source = '[[tag? &param=`value`]]';
@@ -78,12 +78,12 @@ class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(
             $replacing,
-            modX::replaceBraces($source, $property)
+            modX::replaceReserved($source, $property)
         );
 
         $this->assertEquals(
             array($replacing => $replacing),
-            modX::replaceBraces(
+            modX::replaceReserved(
                 array(
                     $source => $source
                 ),
@@ -97,7 +97,7 @@ class ReplaceBracesTest extends \PHPUnit\Framework\TestCase
                     $replacing => $replacing
                 )
             ),
-            modX::replaceBraces(
+            modX::replaceReserved(
                 array(
                     $source => array(
                         $source => $source

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -54,6 +54,7 @@
             <directory>Tests/Processors/Resource</directory>-->
         </testsuite>
         <testsuite name="Cases">
+            <directory>Tests/Cases/Modx/</directory>
             <directory>Tests/Cases/Request/</directory>
         </testsuite>
         <testsuite name="Teardown">

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -226,7 +226,7 @@ class modOutputFilter {
                         case 'esc':
                         case 'escape':
                             $output = preg_replace("/&amp;(#[0-9]+|[a-z]+);/i", "&$1;", htmlspecialchars($output));
-                            $output = str_replace(array ("[", "]", "`"), array ("&#91;", "&#93;", "&#96;"), $output);
+                            $output = modX :: replaceBraces($output);
                             break;
                         case 'strip':
                             /* Replaces all linebreaks, tabs and multiple spaces with just one space */
@@ -348,7 +348,7 @@ class modOutputFilter {
                             /* Displays the raw element tag without :tag */
                             $tag = $element->_tag;
                             $tag = htmlentities($tag,ENT_QUOTES,$encoding);
-                            $tag = str_replace(array ("[", "]", "`"), array ("&#91;", "&#93;", "&#96;"), $tag);
+                            $tag = modX :: replaceBraces($tag);
                             $tag = str_replace(":tag","",$tag);
                             $output = $tag;
                             break;

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -226,7 +226,7 @@ class modOutputFilter {
                         case 'esc':
                         case 'escape':
                             $output = preg_replace("/&amp;(#[0-9]+|[a-z]+);/i", "&$1;", htmlspecialchars($output));
-                            $output = modX :: replaceBraces($output);
+                            $output = modX :: replaceReserved($output);
                             break;
                         case 'strip':
                             /* Replaces all linebreaks, tabs and multiple spaces with just one space */
@@ -348,7 +348,7 @@ class modOutputFilter {
                             /* Displays the raw element tag without :tag */
                             $tag = $element->_tag;
                             $tag = htmlentities($tag,ENT_QUOTES,$encoding);
-                            $tag = modX :: replaceBraces($tag);
+                            $tag = modX :: replaceReserved($tag);
                             $tag = str_replace(":tag","",$tag);
                             $output = $tag;
                             break;

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -350,6 +350,28 @@ class modX extends xPDO {
     }
 
     /**
+     * @param array|string $data The target data to sanitize.
+     * @param array $replaceable
+     * @return array|string The sanitized data
+     */
+    public static function replaceBraces($data, array $replaceable = array ('[' => '&#91;', ']' => '&#93;', '`' => '&#96;'))
+    {
+        if (\is_array($data)) {
+            $result = array();
+            foreach ($data as $key => &$value) {
+                $key = self::replaceBraces($key, $replaceable);
+                $result[$key] = self::replaceBraces($value, $replaceable);
+            }
+        } elseif (\is_scalar($data)) {
+            $result = \str_replace(\array_keys($replaceable), \array_values($replaceable), $data);
+        } else {
+            $result = '';
+        }
+
+        return $result;
+    }
+
+    /**
      * Sanitizes a string
      *
      * @param string $str The string to sanitize

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -354,13 +354,13 @@ class modX extends xPDO {
      * @param array $replaceable
      * @return array|string The sanitized data
      */
-    public static function replaceBraces($data, array $replaceable = array ('[' => '&#91;', ']' => '&#93;', '`' => '&#96;'))
+    public static function replaceReserved($data, array $replaceable = array ('[' => '&#91;', ']' => '&#93;', '`' => '&#96;'))
     {
         if (\is_array($data)) {
             $result = array();
             foreach ($data as $key => &$value) {
-                $key = self::replaceBraces($key, $replaceable);
-                $result[$key] = self::replaceBraces($value, $replaceable);
+                $key = self::replaceReserved($key, $replaceable);
+                $result[$key] = self::replaceReserved($value, $replaceable);
             }
         } elseif (\is_scalar($data)) {
             $result = \str_replace(\array_keys($replaceable), \array_values($replaceable), $data);

--- a/core/model/modx/processors/element/importproperties.class.php
+++ b/core/model/modx/processors/element/importproperties.class.php
@@ -56,7 +56,7 @@ class modElementImportPropertiesProcessor extends modProcessor {
                 $property['desc'] = empty($property['description']) ? '' : $property['description'];
             }
 
-            $property['desc'] = modX :: replaceBraces(
+            $property['desc'] = modX :: replaceReserved(
                 $property['desc'],
                 array(
                     "\\n" => '',
@@ -68,7 +68,7 @@ class modElementImportPropertiesProcessor extends modProcessor {
                     ']' => '&#93;')
             );
             $property['desc_trans'] = $this->modx->lexicon($property['desc']);
-            $property['value'] = modX :: replaceBraces(
+            $property['value'] = modX :: replaceReserved(
                 $property['value'],
                 array('<' => "&lt;", '>' => "&gt;")
             );

--- a/core/model/modx/processors/element/importproperties.class.php
+++ b/core/model/modx/processors/element/importproperties.class.php
@@ -52,11 +52,26 @@ class modElementImportPropertiesProcessor extends modProcessor {
 
 
             /* backwards compat */
-            if (empty($property['desc'])) { $property['desc'] = empty($property['description']) ? '' : $property['description']; }
+            if (empty($property['desc'])) {
+                $property['desc'] = empty($property['description']) ? '' : $property['description'];
+            }
 
-            $property['desc'] = str_replace(array("\\n",'\"',"'",'<','>','[',']'),array('','&quot;','"',"&lt;","&gt;",'&#91;','&#93;'),$property['desc']);
+            $property['desc'] = modX :: replaceBraces(
+                $property['desc'],
+                array(
+                    "\\n" => '',
+                    '\"' => '&quot;',
+                    "'" => '"',
+                    '<' => "&lt;",
+                    '>' => "&gt;",
+                    '[' => '&#91;',
+                    ']' => '&#93;')
+            );
             $property['desc_trans'] = $this->modx->lexicon($property['desc']);
-            $property['value'] = str_replace(array('<','>'),array("&lt;","&gt;"),$property['value']);
+            $property['value'] = modX :: replaceBraces(
+                $property['value'],
+                array('<' => "&lt;", '>' => "&gt;")
+            );
             $data[] = array(
                 $property['name'],
                 $property['desc'],


### PR DESCRIPTION
### What does it do?
Adds a static method to the modX class to allow recursive replacement of reserved characters.

### Why is it needed?
Security implications.

### Related issue(s)/PR(s)
This is a #14099 with the method renamed from modX::replaceBraces() to modX::replaceReserved().