### PR TITLE
Make the flat file processor deprecated message more useful

### DIFF
--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -353,7 +353,8 @@ class modDeprecatedProcessor extends modProcessor {
      * @return mixed
      */
     public function process() {
-        $this->modx->deprecated('2.7.0', '', 'Flat file processor support');
+        $info = 'Flat file processor support, used for action ' . $this->getProperty('action', 'unknown action') . ' with path ' . $this->path . ',';
+        $this->modx->deprecated('2.7.0', '', $info);
 
         $modx =& $this->modx;
         $scriptProperties = $this->getProperties();


### PR DESCRIPTION
### What does it do?
The new deprecated messages introduced in #14136 are being triggered now that 2.7 is out, but the one for flat file processors is missing some context. This PR changes that message a bit, to include the calling action and the path. 

### Why is it needed?

Previous message lacked the information needed to identify the problem:

> [2018-11-28 21:50:14] (ERROR in modProcessor::run @ /home/user/public_html/core/model/modx/modprocessor.class.php : 177) Flat file processor support is deprecated since version 2.7.0. 

Now, it's more helpful:

> [2018-11-28 21:59:26] (ERROR in modProcessor::run @ /home/user/public_html/core/model/modx/modprocessor.class.php : 177) Flat file processor support, used for action system/event with path /home/user/public_html/core/model/modx/processors/system/config.js.php,  is deprecated since version 2.7.0. 

### Related issue(s)/PR(s)
#14136, #14127 