### PR TITLE
Improve deprecated notice for "Old modTemplateVar getRender input"

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -425,7 +425,6 @@ class modTemplateVar extends modElement {
             $output = $render->render($value,$params);
         } else {
             $deprecatedClassName = $method == 'input' ? 'modTemplateVarInputRenderDeprecated' : 'modTemplateVarOutputRenderDeprecated';
-            $this->xpdo->deprecated('2.2.0', '', 'Old modTemplateVar getRender ' . $method . 'method');
             $render = new $deprecatedClassName($this);
 
             foreach ($paths as $path) {
@@ -443,6 +442,7 @@ class modTemplateVar extends modElement {
                 /* 2.1< backwards compat */
                 $renderFile = $path.$type.'.php';
                 if (file_exists($renderFile)) {
+                    $this->xpdo->deprecated('2.2.0', '', '<2.2 style template variable flat render file ' . $renderFile . ', for TV ' . $this->get('name'));
                     $render = new $deprecatedClassName($this);
                     $params['modx.renderFile'] = $renderFile;
                     break;

--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -442,7 +442,7 @@ class modTemplateVar extends modElement {
                 /* 2.1< backwards compat */
                 $renderFile = $path.$type.'.php';
                 if (file_exists($renderFile)) {
-                    $this->xpdo->deprecated('2.2.0', '', '<2.2 style template variable flat render file ' . $renderFile . ', for TV ' . $this->get('name'));
+                    $this->xpdo->deprecated('2.2.0', '', 'Old style template variable with flat render file ' . $renderFile . ', for TV ' . $this->get('name'));
                     $render = new $deprecatedClassName($this);
                     $params['modx.renderFile'] = $renderFile;
                     break;


### PR DESCRIPTION
### What does it do?
Aside from changing the wording and adding context to make it a bit clearer what's the problem, this also moves the deprecated notice into the conditional. 

Before, the message would get logged a lot for each first TV of a certain type due to the way the foreach handles registered render methods. Now it only gets logged when a deprecated flat file is used.

### Why is it needed?
Make sure only relevant deprecated notices get logged and with appropriate context.

### Related issue(s)/PR(s)
#14136 