### PR TITLE
Add missing changelog entries

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -101,6 +101,11 @@ MODX Revolution 2.7.0-pl (November 27, 2018)
 - Change modResource.description column to text [#13802]
 - Fix modDbRegister->clear and use fully qualified name [#12965]
 
+MODX Revolution 2.6.5-pl (July 11, 2018)
+====================================
+- Prevent directory traversal and limit files deleted when clearing modFileRegister [#13980]
+- Filter user input used in phpthumb [#13979]
+
 MODX Revolution 2.6.4-pl (June 7, 2018)
 ====================================
 - Fix sorting by access column in Template Access tab of Template Variable edit view [#13893]

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -121,7 +121,7 @@ $_lang['setting_automatic_alias'] = 'Automatically generate alias';
 $_lang['setting_automatic_alias_desc'] = 'Select \'Yes\' to have the system automatically generate an alias based on the Resource\'s page title when saving.';
 
 $_lang['setting_automatic_template_assignment'] = 'Automatic Template Assignment';
-$_lang['setting_automatic_template_assignment'] = 'Choose how templates are assigned to new Resources on creation. Options include: system (default template from system settings), parent (inherits the parent template), or sibling (inherits the most used sibling template)';
+$_lang['setting_automatic_template_assignment_desc'] = 'Choose how templates are assigned to new Resources on creation. Options include: system (default template from system settings), parent (inherits the parent template), or sibling (inherits the most used sibling template)';
 
 $_lang['setting_base_help_url'] = 'Base Help URL';
 $_lang['setting_base_help_url_desc'] = 'The base URL by which to build the Help links in the top right of pages in the manager.';


### PR DESCRIPTION
### What does it do?
This PR adds back the changelog for MODX Revolution 2.6.5-pl. 

### Why is it needed?
We don't want to lose history! 

### Related issue(s)/PR(s)
Fixes #14164 