### PR TITLE
Add Slack to the list of support channels in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "email": "help@modx.com",
         "forum": "http://forums.modx.com/",
         "irc": "irc://irc.freenode.org/modx",
+        "chat": "https://modx.org/",
         "issues": "https://github.com/modxcms/revolution/issues/",
         "source": "https://github.com/modxcms/revolution/"
     },


### PR DESCRIPTION
### What does it do?
This will add a link to Slack (modx.org) to the list of support channels in composer.json

### Why is it needed?
Composer 1.8.0 adds `chat` to the list of `support` channels you can list in composer.json.

### Related issue(s)/PR(s)
None