### PR TITLE
Compatibility with PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 
 # Set php versions
 php:
+  - 7.3
   - 7.2
   - 7.1
   - 7.0
@@ -29,4 +30,4 @@ before_script: 'cd _build/test && ./generateConfigs.sh'
 
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi
-  -  if [[ "(7.0 7.1 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  -  if [[ "(7.0 7.1 7.2 7.3 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -602,7 +602,7 @@ class modCacheManager extends xPDOCacheManager {
                     break;
                 case 'db':
                     if (!$this->getOption('cache_db', $partOptions, false)) {
-                        continue;
+                        break;
                     }
                     $results[$partition] = $this->clean($partOptions);
                     break;

--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -484,7 +484,7 @@ class modTransportPackage extends xPDOObject {
                         $latest->parseSignature();
                         if (xPDOTransport::satisfies($latest->version, $constraint)) {
                             unset($latest);
-                            continue;
+                            break;
                         }
                     }
                     $unsatisfied[$package] = $constraint;

--- a/core/xpdo/transport/xpdovehicle.class.php
+++ b/core/xpdo/transport/xpdovehicle.class.php
@@ -142,7 +142,7 @@ abstract class xPDOVehicle {
                     case 'file' :
                         if (isset ($options[xPDOTransport::RESOLVE_FILES]) && !$options[xPDOTransport::RESOLVE_FILES]) {
                             $resolved = true;
-                            continue;
+                            break;
                         }
                         if ($transport->xpdo->getDebug() === true) {
                             $transport->xpdo->log(xPDO::LOG_LEVEL_DEBUG, "Resolving transport files: " . print_r($this, true));
@@ -219,7 +219,7 @@ abstract class xPDOVehicle {
 
                     case 'php' :
                         if (isset ($options[xPDOTransport::RESOLVE_PHP]) && !$options[xPDOTransport::RESOLVE_PHP]) {
-                            continue;
+                            break;
                         }
                         $fileMeta = $transport->xpdo->fromJSON($body, true);
                         $fileName = $fileMeta['name'];


### PR DESCRIPTION
## Work in progress
### What does it do?
For now it only adds PHP 7.3 as test target for Travis

### Why is it needed?
[PHP 7.3.0 is released](http://php.net/archive/2018.php#id2018-12-06-1).

### Related issue(s)/PR(s)
None