### PR TITLE
Fix "undefined" text in Trash manager button tooltip

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -18,7 +18,7 @@
 <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
 {/if}
 <script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}" type="text/javascript"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,trash,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}" type="text/javascript"></script>
 <script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
 
 {$maincssjs}


### PR DESCRIPTION
### What does it do?
Add trash as default lexicon to the manager controller template.

### Why is it needed?
Fix "undefined" text in Trash manager button tooltip. I hope it is the right place for this addition. The trash lexicon is only loaded in the trash manager.

### Related issue(s)/PR(s)
#14189
