### PR TITLE
Adds modifiers to get information from filepath: dirname, basename, fi…

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -595,16 +595,16 @@ class modOutputFilter {
                             break;
 
                         case 'dirname':
-                            $output = pathinfo($output)['dirname'];
+                            $output = pathinfo($output, PATHINFO_DIRNAME);
                             break;
                         case 'basename':
-                            $output = pathinfo($output)['basename'];
+                            $output = pathinfo($output, PATHINFO_BASENAME);
                             break;
                         case 'filename':
-                            $output = pathinfo($output)['filename'];
+                            $output = pathinfo($output, PATHINFO_FILENAME);
                             break;
                         case 'extension':
-                            $output = pathinfo($output)['extension'];
+                            $output = pathinfo($output, PATHINFO_EXTENSION);
                             break;
 
                         case 'toPlaceholder':

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -594,6 +594,19 @@ class modOutputFilter {
                             $output = urldecode($output);
                             break;
 
+                        case 'dirname':
+                            $output = pathinfo($output)['dirname'];
+                            break;
+                        case 'basename':
+                            $output = pathinfo($output)['basename'];
+                            break;
+                        case 'filename':
+                            $output = pathinfo($output)['filename'];
+                            break;
+                        case 'extension':
+                            $output = pathinfo($output)['extension'];
+                            break;
+
                         case 'toPlaceholder':
                             $this->modx->toPlaceholder($m_val,$output);
                             $output = '';


### PR DESCRIPTION
### What does it do?
Adds group of modifiers to work with placeholders contain filepath. This modifiers allow:

- dirname - get directory name only (without filename)
- basename - get file basename (filename with extension)
- filename - get filename (filename without extension)
- extension - get file extension

In fact this is a wrapper for PHP's pathinfo() function.

### Why is it needed?
Using modifiers more convenient and simple way to work with placeholders contain filepath.

### Related issue(s)/PR(s)
This PR don't related to any issue. This is proposal only.