### PR TITLE
Recognize error_log_file* settings when switching contexts

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -554,18 +554,6 @@ class modX extends xPDO {
             $this->getCacheManager();
             $this->getConfig();
             $this->_initContext($contextKey, false, $options);
-            $logTarget = $this->getLogTarget();
-            if ($logTarget === 'FILE') {
-                $options = array();
-                $filename = $this->getOption('error_log_filename', $options, '');
-                if (!empty($filename)) $options['filename'] = $filename;
-                $filepath = $this->getOption('error_log_filepath', $options, '');
-                if (!empty($filepath)) $options['filepath'] = rtrim($filepath, '/') . '/';
-                $this->setLogTarget(array(
-                    'target' => 'FILE',
-                    'options' => $options
-                ));
-            }
             $this->_loadExtensionPackages($options);
             $this->_initSession($options);
             $this->_initErrorHandler($options);
@@ -2462,7 +2450,22 @@ class modX extends xPDO {
         }
         if ($initialized) {
             $this->setLogLevel($this->getOption('log_level', $options, xPDO::LOG_LEVEL_ERROR));
-            $this->setLogTarget($this->getOption('log_target', $options, 'FILE', true));
+                
+            $logTarget = $this->getOption('log_target', $options, 'FILE', true);
+            if ($logTarget === 'FILE') {
+                $options = array();
+                $filename = $this->getOption('error_log_filename', $options, '');
+                if (!empty($filename)) $options['filename'] = $filename;
+                $filepath = $this->getOption('error_log_filepath', $options, '');
+                if (!empty($filepath)) $options['filepath'] = rtrim($filepath, '/') . '/';
+                $this->setLogTarget(array(
+                    'target' => 'FILE',
+                    'options' => $options
+                ));
+            } else {
+                $this->setLogTarget($logTarget);
+            }
+            
             $debug = $this->getOption('debug');
             if (!is_null($debug) && $debug !== '') {
                 $this->setDebug($debug);


### PR DESCRIPTION
### What does it do?
This PR moves the logic for handling the `error_log_filename` and `error_log_filepath` system-settings into the `_initContext` method instead of the modx `initialize` method. (`_initContext` is also called in `initialize`, so no breaking change)

### Why is it needed?
Previously those settings worked, but only after the modx initialization and before any potential context switching. For multi-context projects, where you use a context switching / routing plugin (e.g. XRouting), those plugins normally use `switchContext()` which calls `_initContext` which uses
```
$this->setLogTarget($this->getOption('log_target', $options, 'FILE', true));
```
So here the previous logTarget gets overridden by any context/systemsetting or the default `FILE`. The potentially targetoptions filename/filepath get lost. So we end up writing to the default error.log after any context switch.

Moving the logic in the `_initContext` function solves this easily and keeps existing functionality.

### Related issue(s)/PR(s)
This is a follow up of https://github.com/modxcms/revolution/pull/13763
Same goal as https://github.com/modxcms/revolution/pull/14119

#### Regarding #14119 
#14119 was a recent try to also move the error log easily, however, this strategy has the exact same issue as discussed here. So I'd promote those 2 systemsettings (which can now also be used as context settings) instead when developers want to move the modx error log.