### PR TITLE
Add modifiers to get information from filepath: dirname, basename, fi…

### DIFF
--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -791,6 +791,131 @@ goes here'),
     }
 
     /**
+     * Tests :dirname filter
+     *
+     * @param string $filepath
+     * @param array $expected
+     * @dataProvider providerDirname
+     */
+    public function testDirname($filepath, $expected)
+    {
+        $this->modx->setPlaceholder('filepath', $filepath);
+        $this->tag->set('name', 'filepath:dirname');
+        $o = $this->tag->process();
+        $this->modx->unsetPlaceholder('filepath');
+        $this->assertEquals($expected, $o);
+    }
+    /**
+     * @return array
+     */
+    public function providerDirname()
+    {
+        return array(
+            array('/icon.ico', '/'),
+            array('/assets/images/logo.jpg', '/assets/images'),
+            array('./assets/files/doc.pdf', './assets/files'),
+            // last three tests for pathinfo() function documentation notes
+            array('/test/test.inc.php', '/test'),
+            array('/test/test', '/test'),
+            array('/test/.test', '/test'),
+        );
+    }
+
+    /**
+     * Tests :basename filter
+     *
+     * @param string $filepath
+     * @param array $expected
+     * @dataProvider providerBasename
+     */
+    public function testBasename($filepath, $expected)
+    {
+
+        $this->modx->setPlaceholder('filepath', $filepath);
+        $this->tag->set('name', 'filepath:basename');
+        $o = $this->tag->process();
+        $this->modx->unsetPlaceholder('filepath');
+        $this->assertEquals($expected, $o);
+    }
+    /**
+     * @return array
+     */
+    public function providerBasename()
+    {
+        return array(
+            array('/icon.ico', 'icon.ico'),
+            array('/assets/images/logo.jpg', 'logo.jpg'),
+            array('./assets/files/doc.pdf', 'doc.pdf'),
+            // last three tests for pathinfo() function documentation notes
+            array('/test/test.inc.php', 'test.inc.php'),
+            array('/test/test', 'test'),
+            array('/test/.test', '.test'),
+        );
+    }
+
+    /**
+     * Tests :filename filter
+     *
+     * @param string $filepath
+     * @param array $expected
+     * @dataProvider providerFilename
+     */
+    public function testFilename($filepath, $expected)
+    {
+        $this->modx->setPlaceholder('filepath', $filepath);
+        $this->tag->set('name', 'filepath:filename');
+        $o = $this->tag->process();
+        $this->modx->unsetPlaceholder('filepath');
+        $this->assertEquals($expected, $o);
+    }
+    /**
+     * @return array
+     */
+    public function providerFilename()
+    {
+        return array(
+            array('/icon.ico', 'icon'),
+            array('/assets/images/logo.jpg', 'logo'),
+            array('./assets/files/doc.pdf', 'doc'),
+            // last three tests for pathinfo() function documentation notes
+            array('/test/test.inc.php', 'test.inc'),
+            array('/test/test', 'test'),
+            array('/test/.test', ''),
+        );
+    }
+
+    /**
+     * Tests :extension filter
+     *
+     * @param string $filepath
+     * @param array $expected
+     * @dataProvider providerExtension
+     */
+    public function testExtension($filepath, $expected)
+    {
+        $this->modx->setPlaceholder('filepath', $filepath);
+        $this->tag->set('name', 'filepath:extension');
+        $o = $this->tag->process();
+        $this->modx->unsetPlaceholder('filepath');
+        $this->assertEquals($expected, $o);
+    }
+    /**
+     * @return array
+     */
+    public function providerExtension()
+    {
+        return array(
+            array('/icon.ico', 'ico'),
+            array('/assets/images/logo.jpg', 'jpg'),
+            array('./assets/files/doc.pdf', 'pdf'),
+            // last three tests for pathinfo() function documentation notes
+            array('/test/test.inc.php', 'php'),
+            array('/test/test', ''),
+            array('/test/.test', 'test'),
+        );
+    }
+
+    /**
      * Test :toPlaceholder=`phName` filter
      *
      * @param string $toPlaceholder

--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -594,6 +594,19 @@ class modOutputFilter {
                             $output = urldecode($output);
                             break;
 
+                        case 'dirname':
+                            $output = pathinfo($output, PATHINFO_DIRNAME);
+                            break;
+                        case 'basename':
+                            $output = pathinfo($output, PATHINFO_BASENAME);
+                            break;
+                        case 'filename':
+                            $output = pathinfo($output, PATHINFO_FILENAME);
+                            break;
+                        case 'extension':
+                            $output = pathinfo($output, PATHINFO_EXTENSION);
+                            break;
+
                         case 'toPlaceholder':
                             $this->modx->toPlaceholder($m_val,$output);
                             $output = '';


### PR DESCRIPTION
### What does it do?
Adds group of modifiers to work with placeholders contain filepath. This modifiers allow:

- dirname - get directory name only (without filename)
- basename - get file basename (filename with extension)
- filename - get filename (filename without extension)
- extension - get file extension

In fact this is a wrapper for PHP's pathinfo() function.

### Why is it needed?
Using modifiers more convenient and simple way to work with placeholders contain filepath.

### Related issue(s)/PR(s)
PR #14194 updated to clean merge with 3.x branch.
