### PR TITLE
Fixed position of context menu in the media browser

### DIFF
--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -115,7 +115,7 @@ Ext.extend(MODx.DataView,Ext.DataView,{
         m.removeAll();
         if (data.menu) {
             this._addContextMenuItem(data.menu);
-            m.show(n,'tl-c?');
+            m.showAt(e.xy);
         }
         m.activeNode = n;
     }


### PR DESCRIPTION
### What does it do?
Make context menu in Media Browser position on mouse
![issue_cont_pos](https://user-images.githubusercontent.com/13381556/49879664-7ab4e080-fe3b-11e8-8d12-e2608431efac.PNG)

### Why is it needed?
Pic from issue request
![](https://user-images.githubusercontent.com/10890005/49295920-f3538e80-f484-11e8-9ec0-9ef9a33e151d.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14170
