### PR TITLE
Log only flat file processor getRender usage

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -425,7 +425,6 @@ class modTemplateVar extends modElement {
             $output = $render->render($value,$params);
         } else {
             $deprecatedClassName = $method == 'input' ? 'modTemplateVarInputRenderDeprecated' : 'modTemplateVarOutputRenderDeprecated';
-            $this->xpdo->deprecated('2.2.0', '', 'Old modTemplateVar getRender ' . $method . 'method');
             $render = new $deprecatedClassName($this);
 
             foreach ($paths as $path) {
@@ -443,6 +442,7 @@ class modTemplateVar extends modElement {
                 /* 2.1< backwards compat */
                 $renderFile = $path.$type.'.php';
                 if (file_exists($renderFile)) {
+                    $this->xpdo->deprecated('2.2.0', '', 'Flat file processor support, used for modTemplateVar getRender \'' . $method . '\' method for TV type \'' . $type . '\'');
                     $render = new $deprecatedClassName($this);
                     $params['modx.renderFile'] = $renderFile;
                     break;


### PR DESCRIPTION
### What does it do?
Log only flat file processor modTemplateVar getRender usage. At the moment all (not registered) class based processors are logged deprecated too.

### Why is it needed?
Remove invalid deprecated logging.

### Related issue(s)/PR(s)
#14136
