### PR TITLE
Fix duplicating static templates, snippets etc. with an empty category

### DIFF
--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -57,6 +57,7 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             ,source: this.record.source
             ,static: this.record.static
             ,static_file: this.record.static_file
+            ,category: this.record.category
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -57,6 +57,7 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             ,source: this.record.source
             ,static: this.record.static
             ,static_file: this.record.static_file
+            ,category: this.record.category
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -57,6 +57,7 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             ,source: this.record.source
             ,static: this.record.static
             ,static_file: this.record.static_file
+            ,category: this.record.category
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -57,6 +57,7 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             ,source: this.record.source
             ,static: this.record.static
             ,static_file: this.record.static_file
+            ,category: this.record.category
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -58,6 +58,7 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             ,source: this.record.source
             ,static: this.record.static
             ,static_file: this.record.static_file
+            ,category: this.record.category
         };
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'


### PR DESCRIPTION
### What does it do?
Add the category to the duplicated record.

### Why is it needed?
Fix the duplicate method for static templates, snippets etc. without a category (when static_elements_automate... is disabled) because the category is needed afterwards. 

### Related issue(s)/PR(s)
#14188, #14135
