### PR TITLE
Bug fix where static files are removing if automated static files are turned off

### DIFF
--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -185,7 +185,7 @@ class modElement extends modAccessibleSimpleObject {
         }
 
         /* Removing old static file when succesfull saved and oldPath has been set. */
-        if ($saved && $oldPath) {
+        if ($saved && $oldPath && $this->isStaticFilesAutomated()) {
             if (@unlink($oldPath)) {
                 $pathinfo = pathinfo($oldPath);
                 $this->cleanupStaticFileDirectories($pathinfo['dirname']);
@@ -193,6 +193,36 @@ class modElement extends modAccessibleSimpleObject {
         }
 
         return $saved;
+    }
+
+    /**
+     * Determine if static files should be automated for current element class.
+     *
+     * @return bool
+     */
+    protected function isStaticFilesAutomated()
+    {
+        $type = '';
+
+        switch ($this->_class) {
+            case 'modTemplate':
+                $type = 'templates';
+                break;
+            case 'modTemplateVar':
+                $type = 'tvs';
+                break;
+            case 'modChunk':
+                $type = 'chunks';
+                break;
+            case 'modSnippet':
+                $type = 'snippets';
+                break;
+            case 'modPlugin':
+                $type = 'plugins';
+                break;
+        }
+
+        return (bool) $this->xpdo->getOption('static_elements_automate_' . $type, null, false);
     }
 
     /**

--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -202,27 +202,19 @@ class modElement extends modAccessibleSimpleObject {
      */
     protected function isStaticFilesAutomated()
     {
-        $type = '';
+        $elements = array(
+            'modTemplate'    => 'templates',
+            'modTemplateVar' => 'tvs',
+            'modChunk'       => 'chunks',
+            'modSnippet'     => 'snippets',
+            'modPlugin'      => 'plugins'
+        );
 
-        switch ($this->_class) {
-            case 'modTemplate':
-                $type = 'templates';
-                break;
-            case 'modTemplateVar':
-                $type = 'tvs';
-                break;
-            case 'modChunk':
-                $type = 'chunks';
-                break;
-            case 'modSnippet':
-                $type = 'snippets';
-                break;
-            case 'modPlugin':
-                $type = 'plugins';
-                break;
+        if (!array_key_exists($this->_class, $elements)) {
+            return false;
         }
 
-        return (bool) $this->xpdo->getOption('static_elements_automate_' . $type, null, false);
+        return (bool) $this->xpdo->getOption('static_elements_automate_' . $elements[$this->_class], null, false);
     }
 
     /**


### PR DESCRIPTION
This fixes the issue where old static files where removed even if the automate static files system setting was turned off for that element type.

### What does it do?
I've added a system setting check that checks if static files are automated for the current element type.

### Related issue(s)/PR(s)
Issue: https://github.com/modxcms/revolution/issues/14206
PR that created the issue: https://github.com/modxcms/revolution/pull/14135

