### PR TITLE
[ReUp] "Use current alias in alias path" in Form Customization sets

### DIFF
--- a/core/model/schema/modx.action.fields.schema.xml
+++ b/core/model/schema/modx.action.fields.schema.xml
@@ -46,6 +46,7 @@
         <tab name="modx-page-settings-right-box-left">
             <field name="isfolder" />
             <field name="searchable" />
+            <field name="alias_visible" />
             <field name="richtext" />
             <field name="uri_override" />
             <field name="uri" />
@@ -97,6 +98,7 @@
         <tab name="modx-page-settings-right-box-left">
             <field name="isfolder" />
             <field name="searchable" />
+            <field name="alias_visible" />
             <field name="richtext" />
             <field name="uri_override" />
             <field name="uri" />


### PR DESCRIPTION
### What does it do?
It adds the field `alias_visible` in the schema for modActionField objects.

### Why is it needed?
In 2.7.0 a new resource option "Use current alias in alias path" to allow hiding resources from the URI was introduced. This option was missing in Form Customization.

### Related issue(s)/PR(s)
Fixes #14193
