### PR TITLE
Prevent symlinks and weblink to target itself

### DIFF
--- a/core/lexicon/en/resource.inc.php
+++ b/core/lexicon/en/resource.inc.php
@@ -81,6 +81,7 @@ $_lang['resource_err_unpublish'] = 'An error occurred while trying to unpublish 
 $_lang['resource_err_unpublish_sitestart'] = 'The resource is linked to the site_start variable and cannot be unpublished!';
 $_lang['resource_err_unpublish_sitestart_dates'] = 'The resource is linked to the site_start variable and cannot have publish or unpublish dates set!';
 $_lang['resource_err_weblink_target_nf'] = 'You cannot set a weblink to a resource that does not exist.';
+$_lang['resource_err_weblink_target_self'] = 'You cannot set a weblink to itself.';
 $_lang['resource_folder'] = 'Container';
 $_lang['resource_folder_help'] = 'Check this to make the Resource also act as a Container for other Resources. A \'Container\' is like a folder, only it can also have content.';
 $_lang['resource_group_resource_err_ae'] = 'The resource is already a part of that resource group.';

--- a/core/lexicon/en/resource.inc.php
+++ b/core/lexicon/en/resource.inc.php
@@ -75,6 +75,7 @@ $_lang['resource_err_save'] = 'An error occurred while trying to save the resour
 $_lang['resource_err_select_parent'] = 'Please select a parent resource.';
 $_lang['resource_err_symlink_target_invalid'] = 'The symlink target does not contain an integer value.';
 $_lang['resource_err_symlink_target_nf'] = 'You cannot symlink to a resource that does not exist.';
+$_lang['resource_err_symlink_target_self'] = 'You cannot symlink to itself.';
 $_lang['resource_err_undelete'] = 'An error occurred while trying to undelete the resource.';
 $_lang['resource_err_undelete_children'] = 'An error occurred while trying to undelete the children of the resource.';
 $_lang['resource_err_unpublish'] = 'An error occurred while trying to unpublish the resource.';

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -516,6 +516,10 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
             return false;
         }
 
+        if ($targetResource->get('id') === $this->object->get('id')) {
+            $this->addFieldError('modx-symlink-content', $this->modx->lexicon('resource_err_symlink_target_self'));
+        }
+
         return true;
     }
 

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -518,6 +518,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
 
         if ($targetResource->get('id') === $this->object->get('id')) {
             $this->addFieldError('modx-symlink-content', $this->modx->lexicon('resource_err_symlink_target_self'));
+            return false;
         }
 
         return true;
@@ -546,6 +547,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
 
             if ($targetResource->get('id') === $this->object->get('id')) {
                 $this->addFieldError('modx-weblink-content', $this->modx->lexicon('resource_err_weblink_target_self'));
+                return false;
             }
         }
 

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -539,6 +539,10 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
                 $this->addFieldError('modx-weblink-content', $this->modx->lexicon('resource_err_weblink_target_nf'));
                 return false;
             }
+
+            if ($targetResource->get('id') === $this->object->get('id')) {
+                $this->addFieldError('modx-weblink-content', $this->modx->lexicon('resource_err_weblink_target_self'));
+            }
         }
 
         return true;


### PR DESCRIPTION
### What does it do?
When updating a symlink it checks if the target is not itself.

### Why is it needed?
Symlinks and weblinks should not be able to target itself.

### Related issue(s)/PR(s)
Fixes #14145 
