### PR TITLE
Add a Unit Test for testing the build process

### DIFF
--- a/_build/test/Tests/Transport/TransportCoreTest.php
+++ b/_build/test/Tests/Transport/TransportCoreTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+*/
+
+/**
+ * Tests related to creating transport packages
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Transport
+ */
+class TransportCoreTest extends MODxTestCase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!defined('MODX_SOURCE_PATH')) {
+            define('MODX_SOURCE_PATH', dirname(__DIR__) . '/../../../');
+        }
+
+        if (!defined('MODX_BUILD_DIR')) {
+            define('MODX_BUILD_DIR', MODX_SOURCE_PATH . '_build/');
+        }
+
+        if (!defined('MODX_PACKAGES_PATH')) {
+            define('MODX_PACKAGES_PATH', MODX_SOURCE_PATH . 'core/packages/');
+        }
+    }
+
+    public function tearDown()
+    {
+        @unlink(MODX_PACKAGES_PATH. "core.transport.zip");
+    }
+
+    public function testBuildCoreTransportPackage()
+    {
+        $transportCoreFile = MODX_BUILD_DIR. 'transport.core.php';
+        $transportCorePackFile = MODX_PACKAGES_PATH. 'core.transport.zip';
+
+        $result = shell_exec("php $transportCoreFile");
+        $this->assertContains('Transport zip created. Build script finished.', $result);
+
+        $this->assertFileExists($transportCorePackFile);
+    }
+}

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -53,6 +53,9 @@
             <!--<directory>Tests/Processors/System</directory>
             <directory>Tests/Processors/Resource</directory>-->
         </testsuite>
+        <testsuite name="Transport">
+            <directory>Tests/Transport</directory>
+        </testsuite>
         <testsuite name="Cases">
             <directory>Tests/Cases/Modx/</directory>
             <directory>Tests/Cases/Request/</directory>


### PR DESCRIPTION
### What does it do?
It tests if the build script is successful and if the `core.transport.zip` file is created.

### Why is it needed?
To make sure changes don't break the build process.

### Related issue(s)/PR(s)
Fixes issue #13015
