### PR TITLE
Don't force the manager date time format for the date of birth field

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -554,7 +554,6 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,xtype: 'datefield'
                     ,width: 200
                     ,allowBlank: true
-                    ,format: MODx.config.manager_date_format
                 },{
                     id: 'modx-user-gender'
                     ,name: 'gender'


### PR DESCRIPTION
### What does it do?
Don't force the manager date time format for the date of birth field.

### Why is it needed?
If we do force it and the manager date format is set diffrently than 'Y-m-d' the date of birth can not be saved.

### Related issue(s)/PR(s)
Issue fixed #11873

**Note:** later we should actually take the manager date format in consideration and fix the conversion properly. **_This is just a temporary solution_** (the issue mentioned above gets a lot of traffic, giving the impression people are actually affected by it).
