### PR TITLE
Disabled Gravatar by default for new installations

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2031,7 +2031,7 @@ $settings['xhtml_urls']->fromArray(array (
 $settings['enable_gravatar']= $xpdo->newObject('modSystemSetting');
 $settings['enable_gravatar']->fromArray(array (
   'key' => 'enable_gravatar',
-  'value' => true,
+  'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',


### PR DESCRIPTION
### What does it do?
Gravatar is disabled by default for new installations

### Why is it needed?
Gravatar is a third party service used to show a profile image when a user has not uploaded a profile picture.

Information is collected automatically when using Gravatar as described in their [Privacy Policy](https://automattic.com/privacy/). This means when installing MODX the first admin user that logs in is almost certain of being tracked by a third party service.

### Related issue(s)/PR(s)
#14212
