### PR TITLE
Use the right table name when fetching the MODX package providers

### DIFF
--- a/core/model/modx/processors/workspace/providers/getlist.class.php
+++ b/core/model/modx/processors/workspace/providers/getlist.class.php
@@ -54,7 +54,7 @@ class modProviderGetListProcessor extends modObjectGetListProcessor {
         $id = $this->getProperty('id','');
         if (!empty($id)) {
             $c->where(array(
-                $this->classKey . '.id:IN' => is_string($id) ? explode(',', $id) : $id
+                $this->getSortClassKey() . '.id:IN' => is_string($id) ? explode(',', $id) : $id
             ));
         }
         return $c;


### PR DESCRIPTION
### What does it do?
The where statement for fetching the MODX package providers should use the right table name (`modTransportProvider`).

### Why is it needed?
It will show the dropdown with package providers correctly when viewing the details of a package and it stops an error from being logged.
```
[2018-12-25 04:01:35] (ERROR @ /.................../public_html/core/xpdo/om/xpdoobject.class.php : 240) 
Error 42S22 executing statement: 
Array
(
    [0] => 42S22
    [1] => 1054
    [2] => Unknown column 'transport.modTransportProvider' in 'where clause'
)
```

### Related issue(s)/PR(s)
Fixes issue #14219 