### PR TITLE
Apply Form Customization rules for TV's when a wildcard action is used

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -596,8 +596,9 @@ class modTemplateVar extends modElement {
                 ),xPDOQuery::SQL_AND,null,2);
             }
             if (!empty($this->xpdo->request) && !empty($this->xpdo->request->action)) {
+                $wildAction = substr($this->xpdo->request->action, 0, strrpos($this->xpdo->request->action, '/')) . '/*';
                 $c->where(array(
-                    'modActionDom.action' => $this->xpdo->request->action,
+                    'modActionDom.action:IN' => array($this->xpdo->request->action, $wildAction),
                 ));
             }
             $c->select($this->xpdo->getSelectColumns('modActionDom','modActionDom'));


### PR DESCRIPTION
### What does it do?
It also fetches Form Customization rules for TV's when a wildcard action is used.

### Why is it needed?
When creating a form customization set with the newly added action "Create & Update Resource" the TV rules where not applied because "Create & Update Resources" uses an wildcard action.

### Related issue(s)/PR(s)
Fixes #14223 
