### PR TITLE
Don't remove static files if automated static files are turned off

### DIFF
--- a/core/model/modx/processors/element/remove.class.php
+++ b/core/model/modx/processors/element/remove.class.php
@@ -16,6 +16,9 @@
  * @subpackage processors.element
  */
 abstract class modElementRemoveProcessor extends modObjectRemoveProcessor {
+    public $staticFilePath;
+    public $staticFile;
+
     public function cleanup() {
         $this->clearCache();
     }
@@ -24,18 +27,42 @@ abstract class modElementRemoveProcessor extends modObjectRemoveProcessor {
     }
 
     public function cleanupStaticFiles() {
-        /* Remove file. */
-        $count = $this->modx->getCount($this->classKey, array('static_file' => $this->staticFile));
-        if ($this->staticFilePath && $count === 0) {
-            @unlink($this->staticFilePath);
+        if ($this->isStaticFilesAutomated()) {
+            /* Remove file. */
+            $count = $this->modx->getCount($this->classKey, array('static_file' => $this->staticFile));
+            if ($this->staticFilePath && $count === 0) {
+                @unlink($this->staticFilePath);
+            }
+
+            /* Check if parent directory is empty, if so remove parent directory. */
+            $pathinfo = pathinfo($this->staticFilePath);
+
+            if (!empty($pathinfo['dirname'])) {
+                $this->cleanupStaticDirectories($pathinfo['dirname']);
+            }
+        }
+    }
+
+    /**
+     * Determine if static files should be automated for current element class.
+     *
+     * @return bool
+     */
+    protected function isStaticFilesAutomated()
+    {
+        $elements = array(
+            'modTemplate'    => 'templates',
+            'modTemplateVar' => 'tvs',
+            'modChunk'       => 'chunks',
+            'modSnippet'     => 'snippets',
+            'modPlugin'      => 'plugins'
+        );
+
+        if (!array_key_exists($this->classKey, $elements)) {
+            return false;
         }
 
-        /* Check if parent directory is empty, if so remove parent directory. */
-        $pathinfo = pathinfo($this->staticFilePath);
-
-        if (!empty($pathinfo['dirname'])) {
-            $this->cleanupStaticDirectories($pathinfo['dirname']);
-        }
+        return (bool) $this->modx->getOption('static_elements_automate_' . $elements[$this->classKey], null, false);
     }
 
     public function cleanupStaticDirectories($dirname) {


### PR DESCRIPTION
This really fixes the issue where old static files where removed even if the automate static files system setting was turned off for that element type. It was only partly fixed in #14208, which added a check for removing the file, when the static file path was changed.

### What does it do?
A check for the automatic static files system setting is added to the modElementRemoveProcessor class.

### Related issue(s)/PR(s)
Issue: #14206, #140206
PR that created the issue: #14135