### PR TITLE
Corrected headers in resource edit / overview forms

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -18,7 +18,7 @@ MODx.panel.ResourceData = function(config) {
         ,items: [{
             html: ''
             ,id: 'modx-resource-header'
-            ,xtype: 'modx-description'
+            ,xtype: 'modx-header'
         },MODx.getPageStructure([{
             title: _('general')
             ,id: 'modx-rdata-tab-general'

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -57,7 +57,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 if (MODx.perm.tree_show_resource_ids === 1) {
                     title = title+ ' <small>('+this.config.record.id+')</small>';
                 }
-                Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
+                Ext.getCmp('modx-resource-header').getEl().update(title);
             }
             // initial check to enable realtime alias
             if (Ext.isEmpty(this.config.record.alias)) {
@@ -553,7 +553,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     if (MODx.request.a !== 'resource/create' && MODx.perm.tree_show_resource_ids === 1) {
                         title = title+ ' <small>('+this.config.record.id+')</small>';
                     }
-                    Ext.getCmp('modx-resource-header').getEl().update('<h2>'+title+'</h2>');
+                    Ext.getCmp('modx-resource-header').getEl().update(title);
 
                     // check some system settings before doing real time alias transliteration
                     if (parseInt(MODx.config.friendly_alias_realtime, 10) && parseInt(MODx.config.automatic_alias, 10)) {


### PR DESCRIPTION
### What does it do?
Removed unnecessary h2 in the header of the resource editing form.
Fixed x-type for the header in the resource overview form.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14142
