### PR TITLE
Fix styles for error messages and search button

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -1044,6 +1044,7 @@ input::-moz-focus-inner {
   font: $fontSmall;
   margin-top: 2px;
   position: relative;
+  min-width: 95%;
 	&:before {
 		@extend %pseudo-font;
 		content: $fa-var-exclamation-triangle; /* : "\f071" */

--- a/_build/templates/default/sass/_uberbar.scss
+++ b/_build/templates/default/sass/_uberbar.scss
@@ -134,6 +134,7 @@
   .x-form-trigger {
     color: rgba(255,255,255,.25);
     transition: color 0.25s;
+    margin: 0;
     /* the following styles are already provided by the default combobox .x-form-trigger styles */
     /*cursor: default;
     height: 16px;


### PR DESCRIPTION
### What does it do?
Set the minimum width for error messages (for example in TV) and fixed the indent of the search button.

_Error messages:_
![width-error-1](https://user-images.githubusercontent.com/12523676/50598455-437aa200-0ec4-11e9-88de-bedc04637c82.png)
![width-error-2](https://user-images.githubusercontent.com/12523676/50598456-437aa200-0ec4-11e9-92c5-52f6dd391ddf.png)
p.s. Error with width does not always appear, often after refreshing the page and saving

_Search button:_
![search-1](https://user-images.githubusercontent.com/12523676/50598620-b6841880-0ec4-11e9-8227-eaa5924470bb.png)
![search-2](https://user-images.githubusercontent.com/12523676/50598621-b71caf00-0ec4-11e9-8492-a5c5e9b80d88.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14142