### PR TITLE
Make working Preview menu option in the recent edited resources widget

### DIFF
--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -102,9 +102,10 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         $resourceArray['menu'][] = '-';
         $resourceArray['menu'][] = array(
             'text' => $this->modx->lexicon('view'),
-            'link' => $this->modx->makeUrl($object->get('id'), $object->get('context')),
             'handler' => 'this.preview',
         );
+
+        $resourceArray['link'] = $this->modx->makeUrl($object->get('id'), $object->get('context_key'));
 
         return $resourceArray;
     }

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -84,7 +84,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         $resourceArray['pagetitle'] = htmlspecialchars($resourceArray['pagetitle'], ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
         $resourceArray['menu'] = array();
         $resourceArray['menu'][] = array(
-            'text' => $this->modx->lexicon('resource_view'),
+            'text' => $this->modx->lexicon('resource_overview'),
             'params' => array(
                 'a' => 'resource/data',
                 'id' => $object->get('id'),
@@ -101,7 +101,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         }
         $resourceArray['menu'][] = '-';
         $resourceArray['menu'][] = array(
-            'text' => $this->modx->lexicon('resource_preview'),
+            'text' => $this->modx->lexicon('view'),
             'link' => $this->modx->makeUrl($object->get('id'), $object->get('context')),
             'handler' => 'this.preview',
         );

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -102,6 +102,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         $resourceArray['menu'][] = '-';
         $resourceArray['menu'][] = array(
             'text' => $this->modx->lexicon('resource_preview'),
+            'link' => $this->modx->makeUrl($object->get('id'), $object->get('context')),
             'handler' => 'this.preview',
         );
 

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -18,7 +18,7 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         ,autosave: true
         ,save_action: 'resource/updatefromgrid'
         ,pageSize: 10
-        ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu']
+        ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu', 'link']
         ,columns: [{
             header: _('id')
             ,dataIndex: 'id'
@@ -27,7 +27,6 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         },{
             header: _('pagetitle')
             ,dataIndex: 'pagetitle'
-            //,width: 150
         },{
             header: _('published')
             ,dataIndex: 'published'

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -46,7 +46,7 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
 };
 Ext.extend(MODx.grid.RecentlyEditedResourcesByUser,MODx.grid.Grid,{
     preview: function() {
-        window.open(MODx.config.base_url+'?id='+this.menu.record.id);
+        window.open(this.menu.record.link);
     }
     ,refresh: function() {
         var tree = Ext.getCmp('modx-resource-tree');


### PR DESCRIPTION
### What does it do?
It fixes the wrong behavior of the preview button in recent edited resources widget. 

### Why is it needed?
Make a menu option (button) working as expected.

### Related issue(s)/PR(s)
#14142 point 1.1