### PR TITLE
Activation of tabs with errors for elements on failure

### DIFF
--- a/manager/assets/modext/widgets/core/modx.panel.js
+++ b/manager/assets/modext/widgets/core/modx.panel.js
@@ -296,6 +296,59 @@ Ext.extend(MODx.FormPanel,Ext.FormPanel,{
         }
         MODx.FormPanel.superclass.destroy.call(this);
     }
+
+    /**
+     * Find errored field in the panel and activates the tab where the first error was found.
+     *
+     * @param {Array} detectingForms - array of forms where we should find errors
+     * @param {String} tabsId - id of tab component for a given panel
+     */
+    ,showErroredTab: function(detectingForms, tabsId) {
+        var tab = null, index = null;
+        for (var i = 0; i < detectingForms.length; i++) {
+            var component = Ext.getCmp(detectingForms[i]);
+            if (component && component.el && component.el.dom) {
+                if (this.detectErrors(component.el.dom)) {
+                    tab = component.itemId ? component.itemId : detectingForms[i];
+                    break;
+                }
+            }
+        }
+
+        if (tab === null) {
+            return;
+        }
+
+        var tabs = Ext.getCmp(tabsId);
+
+        if (tabs && tabs.items && tabs.items.keys) {
+            index = tabs.items.keys.indexOf(tab);
+        }
+
+        if (!tabs.items.items[index].hidden)  {
+            return;
+        }
+
+        tabs.activate(tab);
+    }
+
+    ,detectErrors: function(node) {
+        if (typeof node.classList !== 'undefined' && node.classList.contains('x-form-invalid')) {
+            return true;
+        }
+
+        if (typeof node.children == 'undefined') {
+            return false;
+        }
+
+        for (var i = 0; i < node.children.length; i++) {
+            if (this.detectErrors(node.children[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 });
 Ext.reg('modx-formpanel',MODx.FormPanel);
 

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -260,9 +260,7 @@ MODx.panel.Chunk = function(config) {
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
             ,'failureSubmit': {
                 fn: function () {
-                    this.showErroredTab(
-                        ['modx-chunk-form'],
-                        'modx-chunk-tabs')
+                    this.showErroredTab(['modx-chunk-form'], 'modx-chunk-tabs')
                 },
                 scope: this
             }

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -258,6 +258,14 @@ MODx.panel.Chunk = function(config) {
             'setup': {fn:this.setup,scope:this}
             ,'success': {fn:this.success,scope:this}
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
+            ,'failureSubmit': {
+                fn: function () {
+                    this.showErroredTab(
+                        ['modx-chunk-form'],
+                        'modx-chunk-tabs')
+                },
+                scope: this
+            }
         }
     });
     MODx.panel.Chunk.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -305,9 +305,7 @@ MODx.panel.Plugin = function(config) {
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
             ,'failureSubmit': {
                 fn: function () {
-                    this.showErroredTab(
-                        ['modx-plugin-form'],
-                        'modx-plugin-tabs')
+                    this.showErroredTab(['modx-plugin-form'], 'modx-plugin-tabs')
                 },
                 scope: this
             }

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -303,6 +303,14 @@ MODx.panel.Plugin = function(config) {
             'setup': {fn:this.setup,scope:this}
             ,'success': {fn:this.success,scope:this}
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
+            ,'failureSubmit': {
+                fn: function () {
+                    this.showErroredTab(
+                        ['modx-plugin-form'],
+                        'modx-plugin-tabs')
+                },
+                scope: this
+            }
         }
     });
     MODx.panel.Plugin.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -259,6 +259,14 @@ MODx.panel.Snippet = function(config) {
             'setup': {fn:this.setup,scope:this}
             ,'success': {fn:this.success,scope:this}
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
+            ,'failureSubmit': {
+                fn: function () {
+                    this.showErroredTab(
+                        ['modx-snippet-form'],
+                        'modx-snippet-tabs')
+                },
+                scope: this
+            }
         }
     });
     MODx.panel.Snippet.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -261,9 +261,7 @@ MODx.panel.Snippet = function(config) {
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
             ,'failureSubmit': {
                 fn: function () {
-                    this.showErroredTab(
-                        ['modx-snippet-form'],
-                        'modx-snippet-tabs')
+                    this.showErroredTab(['modx-snippet-form'], 'modx-snippet-tabs')
                 },
                 scope: this
             }

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -108,7 +108,6 @@ MODx.panel.Template = function(config) {
                         ,fieldLabel: _('static_file')
                         ,description: MODx.expandHelp ? '' : _('static_file_msg')
                         ,name: 'static_file'
-                        // ,hideFiles: true
                         ,source: config.record.source != null ? config.record.source : MODx.config.default_media_source
                         ,openTo: config.record.openTo || ''
                         ,id: 'modx-template-static-file'
@@ -298,6 +297,14 @@ MODx.panel.Template = function(config) {
             'setup': {fn:this.setup,scope:this}
             ,'success': {fn:this.success,scope:this}
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
+            ,'failureSubmit': {
+                fn: function () {
+                    this.showErroredTab(
+                        ['modx-template-form'],
+                        'modx-template-tabs')
+                },
+                scope: this
+            }
         }
     });
     MODx.panel.Template.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -299,9 +299,7 @@ MODx.panel.Template = function(config) {
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
             ,'failureSubmit': {
                 fn: function () {
-                    this.showErroredTab(
-                        ['modx-template-form'],
-                        'modx-template-tabs')
+                    this.showErroredTab(['modx-template-form'], 'modx-template-tabs')
                 },
                 scope: this
             }

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -348,9 +348,7 @@ MODx.panel.TV = function(config) {
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
             ,'failureSubmit': {
                 fn: function () {
-                    this.showErroredTab(
-                        ['modx-tv-form'],
-                        'modx-tv-tabs')
+                    this.showErroredTab(['modx-tv-form'], 'modx-tv-tabs')
                 },
                 scope: this
             }

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -346,6 +346,14 @@ MODx.panel.TV = function(config) {
             'setup': {fn:this.setup,scope:this}
             ,'success': {fn:this.success,scope:this}
             ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
+            ,'failureSubmit': {
+                fn: function () {
+                    this.showErroredTab(
+                        ['modx-tv-form'],
+                        'modx-tv-tabs')
+                },
+                scope: this
+            }
         }
     });
     MODx.panel.TV.superclass.constructor.call(this,config);
@@ -431,7 +439,6 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
             t.refreshNode(u,true);
         }
     }
-
     ,changeEditor: function() {
         this.cleanupEditor();
         this.submit();


### PR DESCRIPTION
### What does it do?
It makes possible to activate tab where placed field with validation errors on failure form submit.

### Why is it needed?
Before it just showed the popup with error but it was difficult to fast determine where it happened. Now UX/DX improved.

### Related issue(s)/PR(s)
#14142 point 2