### PR TITLE
Added physical links to the href attribute for elements in the tree

### DIFF
--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -234,7 +234,7 @@ Ext.override(Ext.tree.TreeNodeUI,{
 
         var cb = Ext.isBoolean(a.checked),
             nel,
-            href = this.getHref(a.href),
+            href = n.attributes.page,
             iconMarkup = '<i class="icon'+(a.icon ? " x-tree-node-inline-icon" : "")+(a.iconCls ? " "+a.iconCls : "")+'" unselectable="on"></i>',
             elbowMarkup = n.attributes.pseudoroot ?
                 '<i class="icon-sort-down expanded-icon"></i>' :

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -234,7 +234,7 @@ Ext.override(Ext.tree.TreeNodeUI,{
 
         var cb = Ext.isBoolean(a.checked),
             nel,
-            href = n.attributes.page,
+            href = a.page,
             iconMarkup = '<i class="icon'+(a.icon ? " x-tree-node-inline-icon" : "")+(a.iconCls ? " "+a.iconCls : "")+'" unselectable="on"></i>',
             elbowMarkup = n.attributes.pseudoroot ?
                 '<i class="icon-sort-down expanded-icon"></i>' :

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -234,7 +234,7 @@ Ext.override(Ext.tree.TreeNodeUI,{
 
         var cb = Ext.isBoolean(a.checked),
             nel,
-            href = a.page,
+            href = this.getHref(a.page),
             iconMarkup = '<i class="icon'+(a.icon ? " x-tree-node-inline-icon" : "")+(a.iconCls ? " "+a.iconCls : "")+'" unselectable="on"></i>',
             elbowMarkup = n.attributes.pseudoroot ?
                 '<i class="icon-sort-down expanded-icon"></i>' :


### PR DESCRIPTION
Added physical links to the href attribute for elements in the tree. Without correct links in the href attribute, the middle and right mouse buttons in Windows / Linux do not work. Read more here - https://github.com/modxcms/revolution/issues/14242

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14059
