### PR TITLE
Fix Vertical Tabs explode if TV names longer than 169px #14240

### DIFF
--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -165,7 +165,7 @@
 }
 
 ul.x-tab-strip-top li:first-child {
-  /*margin-left: -1px*/;
+  /*margin-left: -1px*/
   margin-left: 0;
 }
 
@@ -301,7 +301,7 @@ ul.x-tab-strip-bottom {
     float: left;
     margin-bottom: -10000px; /* dirty hack to make vertical tabs container stretch to bottom */
     padding-bottom: 10000px !important; /* dirty hack to make vertical tabs container stretch to bottom */
-    width: 169px !important; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
+    width: auto !important; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
 
     .x-tab-strip-wrap {
       background-color: transparent; /* as vertical tab panels are nested ones too, do not apply the background color for nested tab panels */
@@ -338,7 +338,7 @@ ul.x-tab-strip-bottom {
             border-right-color: $white;
             box-shadow: none; /* removes the active tab strip on top */
             color: $tabActiveText;
-            width: 169px; /* make the active li 1px more wide to cover the containers right border, this makes the right border on inactive tabs necessary as the whole tab-strip wrap gets wider */
+            width: auto; /* make the active li 1px more wide to cover the containers right border, this makes the right border on inactive tabs necessary as the whole tab-strip wrap gets wider */
           }
 
           &.x-tab-edge {


### PR DESCRIPTION
### Why is it needed?
Change width Vertical Tabs explode if TV names longer from 169px to auto

### Related issue(s)/PR(s)
#14240
