### PR TITLE
Insert TV-tab before Settings-tab in resource editing form

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -399,6 +399,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             }
             ,items: this.getMainFields(config)
         });
+        if (config.show_tvs && MODx.config.tvs_below_content != 1) {
+            it.push(this.getTemplateVariablesPanel(config));
+        }
         it.push({
             id: 'modx-page-settings'
             ,title: _('settings')
@@ -415,9 +418,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             }
             ,items: this.getSettingFields(config)
         });
-        if (config.show_tvs && MODx.config.tvs_below_content != 1) {
-            it.push(this.getTemplateVariablesPanel(config));
-        }
         if (MODx.perm.resourcegroup_resource_list) {
             it.push(this.getAccessPermissionsTab(config));
         }


### PR DESCRIPTION
### Why is it needed?
The location of the TV-tab before Settings-tab is more appropriate in terms of UX / UI. More details in the related issue.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14067
