### PR TITLE
Changed the order of tabs in the Template and TV form

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -263,14 +263,6 @@ MODx.panel.Template = function(config) {
 				}]
 			}]
         },{
-            xtype: 'modx-panel-element-properties'
-            ,preventRender: true
-            ,collapsible: true
-            ,elementPanel: 'modx-panel-template'
-            ,elementId: config.template
-            ,elementType: 'modTemplate'
-            ,record: config.record
-        },{
             title: _('template_variables')
             ,itemId: 'form-template'
             ,defaults: { autoHeight: true }
@@ -290,6 +282,14 @@ MODx.panel.Template = function(config) {
                     ,'afterRemoveRow': {fn:this.markDirty,scope:this}
                }
             }]
+        },{
+            xtype: 'modx-panel-element-properties'
+            ,preventRender: true
+            ,collapsible: true
+            ,elementPanel: 'modx-panel-template'
+            ,elementId: config.template
+            ,elementType: 'modTemplate'
+            ,record: config.record
         }],{
             id: 'modx-template-tabs'
         })]

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -245,13 +245,6 @@ MODx.panel.TV = function(config) {
                 }]
 			}]
         },{
-            xtype: 'modx-panel-element-properties'
-            ,itemId: 'panel-properties'
-            ,elementPanel: 'modx-panel-tv'
-            ,elementId: config.tv
-            ,elementType: 'modTemplateVar'
-            ,record: config.record
-        },{
             xtype: 'modx-panel-tv-input-properties'
             ,record: config.record
         },{
@@ -270,31 +263,6 @@ MODx.panel.TV = function(config) {
                 xtype: 'modx-grid-tv-template'
                 ,itemId: 'grid-template'
 				,cls:'main-wrapper'
-                ,tv: config.tv
-                ,preventRender: true
-                ,anchor: '100%'
-                ,listeners: {
-                    'rowclick': {fn:this.markDirty,scope:this}
-                    ,'afteredit': {fn:this.markDirty,scope:this}
-                    ,'afterRemoveRow': {fn:this.markDirty,scope:this}
-                }
-            }]
-        },{
-            title: _('access_permissions')
-            ,id: 'modx-tv-access-form'
-            ,itemId: 'form-access'
-            ,forceLayout: true
-            ,hideMode: 'offsets'
-            ,defaults: {autoHeight: true}
-            ,layout: 'form'
-            ,items: [{
-                html: '<p>'+_('tv_access_msg')+'</p>'
-                ,id: 'modx-tv-access-msg'
-                ,xtype: 'modx-description'
-            },{
-                xtype: 'modx-grid-tv-security'
-                ,itemId: 'grid-access'
-                ,cls:'main-wrapper'
                 ,tv: config.tv
                 ,preventRender: true
                 ,anchor: '100%'
@@ -328,6 +296,38 @@ MODx.panel.TV = function(config) {
                     ,'afterRemoveRow': {fn:this.markDirty,scope:this}
                 }
             }]
+        },{
+            title: _('access_permissions')
+            ,id: 'modx-tv-access-form'
+            ,itemId: 'form-access'
+            ,forceLayout: true
+            ,hideMode: 'offsets'
+            ,defaults: {autoHeight: true}
+            ,layout: 'form'
+            ,items: [{
+                html: '<p>'+_('tv_access_msg')+'</p>'
+                ,id: 'modx-tv-access-msg'
+                ,xtype: 'modx-description'
+            },{
+                xtype: 'modx-grid-tv-security'
+                ,itemId: 'grid-access'
+                ,cls:'main-wrapper'
+                ,tv: config.tv
+                ,preventRender: true
+                ,anchor: '100%'
+                ,listeners: {
+                    'rowclick': {fn:this.markDirty,scope:this}
+                    ,'afteredit': {fn:this.markDirty,scope:this}
+                    ,'afterRemoveRow': {fn:this.markDirty,scope:this}
+                }
+            }]
+        },{
+            xtype: 'modx-panel-element-properties'
+            ,itemId: 'panel-properties'
+            ,elementPanel: 'modx-panel-tv'
+            ,elementId: config.tv
+            ,elementType: 'modTemplateVar'
+            ,record: config.record
         }],{
             id: 'modx-tv-tabs'
             ,forceLayout: true


### PR DESCRIPTION
### Why is it needed?
Changed the order in the form of "Template" and "TV" in accordance with the frequency of use of the tab.
Tabs are arranged in different forms in different ways. For example, the tab "Properties" in the form of "Plugin" in last place, and in the form of "Template" and "TV" - in second place

### Related issue(s)/PR(s)
Not directly, but the logic is the same - https://github.com/modxcms/revolution/issues/14067
