### PR TITLE
Remove support for "Uploadable Flash Types"

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1862,15 +1862,6 @@ $settings['upload_files']->fromArray(array (
   'area' => 'file',
   'editedon' => null,
 ), '', true, true);
-$settings['upload_flash']= $xpdo->newObject('modSystemSetting');
-$settings['upload_flash']->fromArray(array (
-  'key' => 'upload_flash',
-  'value' => 'swf,fla',
-  'xtype' => 'textfield',
-  'namespace' => 'core',
-  'area' => 'file',
-  'editedon' => null,
-), '', true, true);
 $settings['upload_images']= $xpdo->newObject('modSystemSetting');
 $settings['upload_images']->fromArray(array (
   'key' => 'upload_images',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -768,9 +768,6 @@ $_lang['setting_unauthorized_page_err'] = 'Please specify a Resource ID for the 
 $_lang['setting_upload_files'] = 'Uploadable File Types';
 $_lang['setting_upload_files_desc'] = 'Here you can enter a list of files that can be uploaded into \'assets/files/\' using the Resource Manager. Please enter the extensions for the filetypes, seperated by commas.';
 
-$_lang['setting_upload_flash'] = 'Uploadable Flash Types';
-$_lang['setting_upload_flash_desc'] = 'Here you can enter a list of files that can be uploaded into \'assets/flash/\' using the Resource Manager. Please enter the extensions for the flash types, separated by commas.';
-
 $_lang['setting_upload_images'] = 'Uploadable Image Types';
 $_lang['setting_upload_images_desc'] = 'Here you can enter a list of files that can be uploaded into \'assets/images/\' using the Resource Manager. Please enter the extensions for the image types, separated by commas.';
 

--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -1721,9 +1721,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 ? explode(',', $this->xpdo->getOption('upload_images')) : [];
             $allowedMedia = $this->xpdo->getOption('upload_media')
                 ? explode(',', $this->xpdo->getOption('upload_media')) : [];
-            $allowedFlash = $this->xpdo->getOption('upload_flash')
-                ? explode(',', $this->xpdo->getOption('upload_flash')) : [];
-            $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+            $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia));
             $allowedFileTypes = array_map('trim', $allowedFileTypes);
             $this->setOption('allowedFileTypes', $allowedFileTypes);
         }

--- a/setup/includes/upgrades/common/3.0.0-remove-upload-flash-system-setting.php
+++ b/setup/includes/upgrades/common/3.0.0-remove-upload-flash-system-setting.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Common upgrade script to remove system setting "Uploadable Flash Types"
+ *
+ * @var modX
+ *
+ * @package setup
+ */
+$settings = [
+    'upload_flash'
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+foreach ($settings as $key) {
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject('modSystemSetting', ['key' => $key]);
+    if ($setting instanceof modSystemSetting) {
+        if ($setting->remove()) {
+            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+                sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])));
+        } else {
+            $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+                sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
+        }
+    }
+}

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -12,3 +12,4 @@ include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-upload-flash-system-setting.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -12,3 +12,4 @@ include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-upload-flash-system-setting.php';


### PR DESCRIPTION
### What does it do?
Removes all references and code related to the "Upload Flash" functionality.
I'm not sure if I should delete the lexicon entries for the other languages or if this is done automatically when changes are imported from Crowdin. 

### Why is it needed?
Flash is deprecated and should not be used.

### Related issue(s)/PR(s)
Fixes issue #14245 