### PR TITLE
Fix position .action-buttons

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -113,8 +113,8 @@
       position: relative;
       .action-buttons {
         position: absolute;
-        top: 5px;
-        right: 5px;
+        top: 20px;
+        right: -5px;
       }
     }
     .title-wrapper {


### PR DESCRIPTION
### What does it do?
Corrects position .action-buttons

### Why is it needed?
Fix position .action-buttons

Before fix:
![Before](https://github.com/Ibochkarev/other-repo/blob/f74cb2aa12b9ecd89c40bbb46095b6ccfe764a33/action_button.png?raw=true)

After fix:
![After](https://github.com/Ibochkarev/other-repo/blob/f1df2ed24a02cbe08c07d54ceb274071a4dd8c07/finish_fix_button.png?raw=true)

### Related issue(s)/PR(s)
Not know 