### PR TITLE
Bugfix for transport resolution, if the package is not found on the current provider

### DIFF
--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -606,7 +606,7 @@ class modTransportPackage extends xPDOObject {
                     $resolution = $provider->latest($package, $constraint);
                 }
                 /* loop through active providers if all else fails */
-                if ($resolution === false) {
+                if (empty($resolution)) {
                     $query = $this->xpdo->newQuery('transport.modTransportProvider', $conditions);
                     $query->sortby('priority', 'ASC');
                     /** @var modTransportProvider $p */
@@ -618,7 +618,7 @@ class modTransportPackage extends xPDOObject {
                         }
                     }
                 }
-                if ($resolution === false) {
+                if (empty($resolution)) {
                     $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not find package to satisfy dependency {$package} @ {$constraint} from your currently active providers", '', __METHOD__, __FILE__, __LINE__);
                 }
                 break;


### PR DESCRIPTION
### What does it do?
Check $resolution for emptiness instead of false.

### Why is it needed?
$resolution can't be false since it is initialised as array in https://github.com/modxcms/revolution/blob/2.x/core/model/modx/transport/modtransportprovider.class.php#L164

If a dependent package is not found in the provider of the package with the dependency, it is never found because of this bug.

### Related issue(s)/PR(s)
#12666
