### PR TITLE
Fix checkDownloadedDependencies query

### DIFF
--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -497,14 +497,15 @@ class modTransportPackage extends xPDOObject {
     public function checkDownloadedDependencies(array $dependencies) {
         $satisfied = array();
         foreach ($dependencies as $package => $constraint) {
-            if (strtolower($package) === strtolower($this->identifier)) continue;
+            if (strtolower($package) === strtolower($this->identifier) || $package === 'php' || $package === 'modx') continue;
 
             /* get latest installed package version */
             $latestQuery = $this->xpdo->newQuery(
                 'modTransportPackage',
                 array(
                     array(
-                        "UCASE({$this->xpdo->escape('package_name')}) LIKE UCASE({$this->xpdo->quote($package)})"
+                        "UCASE({$this->xpdo->escape('package_name')}) LIKE UCASE({$this->xpdo->quote($package)})",
+                        'OR:signature:LIKE' => $package . '-%'
                     ),
                     'installed:IS' => null,
                 )


### PR DESCRIPTION
### What does it do?
Fix the query in the checkDownloadedDependencies method.

### Why is it needed?
A dependency package could only be downloaded from the MODX Extras package provider by the signature (before the version number). After the package it is successful downloaded, the signature is searched in the modTransportPackage package_name column. Both values could be different i.e. `seopro` vs `SEO Pro` or `imageplus` vs `Image+`.

Because of the restrictions of the MODX Extras package provider and the package dependency system (only 'name' + 'constraint' available) either the download dependency check has to be extended or the MODX Extras package provider download search has to be extended.

`php` and `modx` could be excluded from download dependencies, since the package dependency checks could check both, but checking them here does not make sense. 

### Related issue(s)/PR(s)
#12666 
