### PR TITLE
Fix escaping for image template variables #12126

### DIFF
--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -12,7 +12,7 @@ Ext.onReady(function() {
         xtype: 'displayfield'
         ,tv: '{$tv->id}'
         ,renderTo: 'tv-image-{$tv->id}'
-        ,value: '{$tv->value|escape}'
+        ,value: '{$tv->value|escape:'javascript'}'
         ,width: 400
         ,msgTarget: 'under'
     {literal}
@@ -31,8 +31,8 @@ Ext.onReady(function() {
         xtype: 'modx-panel-tv-image'
         ,renderTo: 'tv-image-{$tv->id}'
         ,tv: '{$tv->id}'
-        ,value: '{$tv->value|escape}'
-        ,relativeValue: '{$tv->value|escape}'
+        ,value: '{$tv->value|escape:'javascript'}'
+        ,relativeValue: '{$tv->value|escape:'javascript'}'
         ,width: 400
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         ,wctx: '{if $params.wctx|default}{$params.wctx}{else}web{/if}'


### PR DESCRIPTION
### What does it do?
Had a directory with "&" in it and the manager showed it as "&"
E.g. "pictures/Something & Something/nice-logo.png" ==> "pictures/Something & Something/nice-logo.png"

When this resource got updated the wrong path was in the template variable and the image wasn't displayed anymore.

### Why is it needed?
Wrong escaping in the Smarty template manager/templates/default/element/tv/renders/input/image.tpl
Default is escaping for HTML. You need to specify JavaScript.

### Related issue(s)/PR(s)
#12126 
