### PR TITLE
Fix Width Manager Sidebar - is increased after browser resize #13954

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -20,7 +20,7 @@
 
 #modx-header {
   background: $colorSplash;
-  min-width: $navbarWidth;
+  max-width: $navbarWidth;
   position: absolute;
   z-index: 2;
   height: 100%;


### PR DESCRIPTION
### What does it do?
If you resize your browser window to a small size and then increase it, the sidebar width becomes very large and overlaps content below.

### Why is it needed?
Change min-width #modx-header -> max-width.

Before fix:
![Before](https://user-images.githubusercontent.com/2373940/42213474-22ae2f1a-7eb9-11e8-826e-dc42aa7f0a39.png)

After fix:
![After](https://github.com/Ibochkarev/other-repo/blob/6f3f684556c16925b5e49e7e543c2573177f1b84/13954.gif?raw=true)

### Related issue(s)/PR(s)
#13954
