### PR TITLE
Fixed correct translation display for [[+type]] in confirm delete popup window

### DIFF
--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -185,7 +185,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         MODx.msg.confirm({
             title: _('warning')
             ,text: _('remove_this_confirm',{
-                type: oar[0]
+                type: _(oar[0])
                 ,name: this.cm.activeNode.attributes.name
             })
             ,url: MODx.config.connector_url


### PR DESCRIPTION
### What does it do?
Fixed the correct translation display for [[+type]] in the delete confirmation popup window.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14256
