### PR TITLE
Fix Fatal error: Uncaught Error: Class 'xPDO' not found #14241

### DIFF
--- a/setup/includes/drivers/modinstalldriver_mysql.class.php
+++ b/setup/includes/drivers/modinstalldriver_mysql.class.php
@@ -14,6 +14,9 @@ require_once (strtr(realpath(dirname(__FILE__)), '\\', '/') . '/modinstalldriver
  * @package setup
  * @subpackage drivers
  */
+
+use xPDO\xPDO;
+
 class modInstallDriver_mysql extends modInstallDriver {
     /**
      * MySQL only needs PDO extension


### PR DESCRIPTION
### What does it do?
Fatal error: Uncaught Error: Class 'xPDO' not found in Z:\site\modx30.test\www\setup\includes\drivers\modinstalldriver_mysql.class.php

### Why is it needed?
Need to add the string use xPDO/xPDO to modinstalldriver_mysql.class.php

### Related issue(s)/PR(s)
#14241 