### PR TITLE
Enhance the error message of a wrong MODX_CORE_PATH

### DIFF
--- a/setup/templates/findcore.php
+++ b/setup/templates/findcore.php
@@ -101,7 +101,7 @@ if (!is_writable(MODX_SETUP_PATH . 'includes/config.core.php')) {
 } else {
 ?>
                         <span class="field_error">ERROR: Your MODX_CORE_PATH is invalid; please specify the correct path in the
-                        field above and click Submit.</span>
+                        field above and click Submit. The path has to contain a trailing slash.</span>
 <?php
 }
 ?>


### PR DESCRIPTION
### What does it do?
Add a message, that the core path has to contain a trailing slash.

### Why is it needed?
Make that mistake more obvious.

### Related issue(s)/PR(s)
#14262 
