### PR TITLE
Don't remove the trailing slash when redirecting to the manager after logging in

### DIFF
--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -198,7 +198,7 @@ class SecurityLoginManagerController extends modManagerController {
             $response = $this->modx->runProcessor('security/login',$this->scriptProperties);
             if (($response instanceof modProcessorResponse) && !$response->isError()) {
                 $url = !empty($this->scriptProperties['returnUrl']) ? $this->scriptProperties['returnUrl'] : $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
-                $url = $this->modx->getOption('url_scheme', null, MODX_URL_SCHEME).$this->modx->getOption('http_host', null, MODX_HTTP_HOST).rtrim($url,'/');
+                $url = $this->modx->getOption('url_scheme', null, MODX_URL_SCHEME).$this->modx->getOption('http_host', null, MODX_HTTP_HOST).$url;
                 $this->modx->sendRedirect($url);
             } else {
                 $errors = $response->getAllErrors();


### PR DESCRIPTION
### What does it do?
It prevents the trailing slash from being removed if you loggin into the manager.

### Why is it needed?
The URL for the manager needs to stay intact since the trailing slash is sometimes required. 

### Related issue(s)/PR(s)
Fixes issue #5634