### PR TITLE
Fixed bug with unexpected incremented TV ranks in Form Customization

### DIFF
--- a/core/model/modx/modformcustomizationset.class.php
+++ b/core/model/modx/modformcustomizationset.class.php
@@ -151,7 +151,8 @@ class modFormCustomizationSet extends xPDOSimpleObject {
                         break;
                     case 'tvMove':
                         $tvArray['tab'] = $rule->get('value');
-                        $tvArray['rank'] = ((int)$rule->get('rank'))-10;
+                        /* subtract 20 from rank that have been added in update processor */
+                        $tvArray['rank'] = ((int)$rule->get('rank'))-20;
                         if ($tvArray['rank'] < 0) $tvArray['rank'] = 0;
                         break;
                 }


### PR DESCRIPTION
### What does it do?
Fix for issue https://github.com/modxcms/revolution/issues/5537

### Why is it needed?
There are bug in form customisation when updating FC set - ranks for TVs goes up in increments of 10 every saving.

### Related issue(s)/PR(s)
Issue https://github.com/modxcms/revolution/issues/5537
