### PR TITLE
Fix position icon x-btn-arrow

### DIFF
--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -50,7 +50,7 @@
       color: inherit;
       content: fa-content($fa-var-caret-down);
       font-size: 14px;
-      margin-top: -7px; /* pull up half of height */
+      margin-top: 0;
       position: absolute; top: 50%; right: 0; /* vertically center the arrow */
     }
 


### PR DESCRIPTION
### What does it do?
After updating the font awesome, the positioning of the icon on the buttons with a drop-down list of actions has disappeared.

### Why is it needed?
Change positioning in styles

Before fix:
![Before](https://github.com/Ibochkarev/other-repo/blob/master/x-btn-arrow-before.png?raw=true)

After fix:
![After](https://github.com/Ibochkarev/other-repo/blob/master/x-btn-arrow-after.png?raw=true)

### Related issue(s)/PR(s)
Not know 