### PR TITLE
Fixed positioning of icons near fields with a drop-down list

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -159,9 +159,9 @@ button {
       border: 0;
       margin: 0 !important;
     }
-    /*.x-form-trigger {
-      margin-top: 2px;
-    }*/
+    .x-form-trigger:before{
+      margin-top: 0;
+    }
     &.x-trigger-wrap-focus {
       box-shadow: $shadowBorderHover;
     }


### PR DESCRIPTION
### What does it do?
After updating font awesome, positioning the icon near the fields with the drop-down list has disappeared.

### Why is it needed?
Change positioning in styles

Before fix:
![Before](https://github.com/Ibochkarev/other-repo/blob/9cb6dfc597387e8a16154b3c2e678ff5327c75b0/%2314282-before.png?raw=true)

After fix:
![After](https://github.com/Ibochkarev/other-repo/blob/9cb6dfc597387e8a16154b3c2e678ff5327c75b0/%2314282-after.png?raw=true)

### Related issue(s)/PR(s)
Not know 