### PR TITLE
Fix edit empty files from tree

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -155,7 +155,7 @@ class modFileHandler {
             return false;
         }
 
-        if (class_exists('\finfo')) {
+        if (filesize($file) > 0 && class_exists('\finfo')) {
             $finfo = new \finfo(FILEINFO_MIME);
 
             return substr($finfo->file($file), 0, 4) !== 'text';


### PR DESCRIPTION
### What does it do?
Check filesize before check "is file binary"

### Why is it needed?
Empty files allways is binary. Binary files is not editable from tree. Users can not edit empty files.

### Related issue(s)/PR(s)
PR https://github.com/modxcms/revolution/pull/14027
