### PR TITLE
Fix empty Constraint column in FC if constraint value is zero

### DIFF
--- a/core/model/modx/processors/security/forms/set/getlist.class.php
+++ b/core/model/modx/processors/security/forms/set/getlist.class.php
@@ -67,9 +67,13 @@ class modFormCustomizationSetGetListProcessor extends modObjectGetListProcessor 
     public function prepareRow(xPDOObject $object) {
         $objectArray = $object->toArray();
 
+        $constraint_field = $object->get('constraint_field');
         $constraint = $object->get('constraint');
-        if (!empty($constraint)) {
-            $objectArray['constraint_data'] = $object->get('constraint_class').'.'.$object->get('constraint_field').' = '.$constraint;
+        if (!empty($constraint_field)) {
+            if ($constraint === '') {
+                $constraint = "'{$constraint}'";
+            }
+            $objectArray['constraint_data'] = $object->get('constraint_class').'.'.$constraint_field.' = '.$constraint;
         }
         $objectArray['perm'] = array();
         if ($this->canEdit) $objectArray['perm'][] = 'pedit';


### PR DESCRIPTION
### What does it do?
Check `constraint_field`, not `constraint`, in processor `security/forms/set/getList`.

### Why is it needed?
If we check `constraint`, zero value will be defined as empty. And processor hide condition.

### Related issue(s)/PR(s)
Issue https://github.com/modxcms/revolution/issues/14285
