### PR TITLE
Added an additional .sub class in the menu for nested li

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -121,6 +121,17 @@
   }
 }
 
+#modx-navbar .sub {
+  &:after {
+    border: 5px solid transparent;
+    border-left: 5px solid #60727c;
+    position: absolute;
+    content: ' ';
+    right: 12px;
+    top: 24px;
+  }
+}
+
 #modx-user-menu li.top > a,
 #modx-topnav li.top > a {
   cursor: default;

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -311,7 +311,8 @@ class TopMenu
             if (!$this->hasPermission($menu['permissions'])) {
                 continue;
             }
-            $smTpl = '<li id="'.$menu['id'].'">'."\n";
+            $sub = (!empty($menu['children'])) ? ' class="sub"' : '';
+            $smTpl = '<li id="'.$menu['id'].'"'.$sub.'>'."\n";
 
             $description = '';
             if ($this->showDescriptions && !empty($menu['description'])) {


### PR DESCRIPTION
### What does it do?
Added an additional .sub class in the menu for nested li which have child items. 
Added an extra icon to the .sub class.

![sub_info](https://user-images.githubusercontent.com/12523676/51253930-2ca27800-19b9-11e9-9762-61a283e35416.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/11579
