### PR TITLE
Fixed empty date TVs can be saved even if "allow blank" is set to false  #12302 

### DIFF
--- a/manager/assets/modext/util/datetime.js
+++ b/manager/assets/modext/util/datetime.js
@@ -102,6 +102,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             ,maxValue: this.maxDateValue || ''
             ,minValue: this.minDateValue || ''
             ,startDay: this.startDay || 0
+            ,allowBlank: this.allowBlank
             ,listeners:{
                   blur:{scope:this, fn:this.onBlur}
                  ,focus:{scope:this, fn:this.onFocus}
@@ -127,6 +128,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             ,maxValue: this.maxTimeValue || null
             ,minValue: this.minTimeValue || null
             ,hidden: this.hideTime
+            ,allowBlank: this.allowBlank
             ,listeners:{
                   blur:{scope:this, fn:this.onBlur}
                  ,focus:{scope:this, fn:this.onFocus}


### PR DESCRIPTION
### What does it do?
Passing `allowBlank` option to `dateConfig` and `timeConfig` constructors of `xdatetime` field to apply correct "Allow Blank" option of TV input setting.

### Why is it needed?
Resource with empty date TV could be saved although "Allow Blank" was set to false in TV input settings.

### Related issue(s)/PR(s)
Fix for #12302 
