### PR TITLE
Added an additional .sub class in the menu for li which have child items #11579

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -192,6 +192,24 @@
           border-right-color: $subnavBgHover;
         }
       }
+      &:hover {
+        &:after {
+          border-right-color: $subnavBgHover;
+        }
+
+      }
+      &.sub {
+        &:after {
+          @extend %pseudo-font;
+          position: absolute;
+          color: $subnavDescriptionColor;
+          content: fa-content($fa-var-caret-right);
+          font-size: 14px;
+          margin-top: 0;
+          top: 20px;
+          right: 10px;
+        }
+      }
       a {
         border-radius: $borderRadius;
         text-align: left;

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -192,12 +192,6 @@
           border-right-color: $subnavBgHover;
         }
       }
-      &:hover {
-        &:after {
-          border-right-color: $subnavBgHover;
-        }
-
-      }
       &.sub {
         &:after {
           @extend %pseudo-font;

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -311,7 +311,9 @@ class TopMenu
             if (!$this->hasPermission($menu['permissions'])) {
                 continue;
             }
-            $smTpl = '<li id="'.$menu['id'].'">'."\n";
+            
+            $sub = (!empty($menu['children'])) ? ' class="sub"' : '';
+            $smTpl = '<li id="'.$menu['id'].'"'.$sub.'>'."\n";
 
             $description = '';
             if ($this->showDescriptions && !empty($menu['description'])) {


### PR DESCRIPTION
### What does it do?
Added an additional class .sub in the menu for li in #modx-footer .modx-subnav which have child items.
Added an extra icon to the .sub class (:after).

![14289](https://user-images.githubusercontent.com/2138260/51274337-20d6a600-19f9-11e9-9291-ed6ab3dc81db.gif)

### Related issue(s)/PR(s)
Issue #11579
