### PR TITLE
Fix context menu position on user page "Access Permissions" tab

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -144,7 +144,7 @@ Ext.extend(MODx.grid.UserGroups,MODx.grid.LocalGrid,{
             ,handler: this.remove.createDelegate(this,[{text: _('user_group_remove_confirm')}])
             ,scope: this
         });
-        m.show(e.target);
+        m.showAt(e.xy);
     }
 });
 Ext.reg('modx-grid-user-groups',MODx.grid.UserGroups);


### PR DESCRIPTION
### What does it do?
Fix context menu position on user page "Access Permissions" tab

### Related issue
Closes #14286
