### PR TITLE
Solution for long dropdown submenu

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1856,6 +1856,15 @@ $settings['topmenu_show_descriptions']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
+$settings['topmenu_submenu_max_items']= $xpdo->newObject('modSystemSetting');
+$settings['topmenu_submenu_max_items']->fromArray(array (
+  'key' => 'topmenu_submenu_max_items',
+  'value' => '',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 $settings['tree_default_sort']= $xpdo->newObject('modSystemSetting');
 $settings['tree_default_sort']->fromArray(array (
   'key' => 'tree_default_sort',

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -139,6 +139,7 @@ $navbarBg: $lighterGray; // unused
 $navbarHover: $softGray; // unused
 $navbarDrop: $navbarBg; // unused
 $navbarText: $white;
+$navbarDropArrowColor: rgb(96,114,124);
 $navbarBorder: #2F4150;
 $subnavBg: #2B3948;
 $subnavBgHover: #3E5268;

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -107,18 +107,29 @@
   }
 }
 
-#modx-navbar .top {
+#modx-navbar .top,
+#modx-navbar .right {
   padding-right: 15px;
 
   &:after {
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 5px solid rgb(96,114,124);
     position: absolute;
     content: ' ';
     right: 12px;
-    top: 26px;
   }
+}
+
+#modx-navbar .top:after {
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid $navbarDropArrowColor;
+    top: 26px;
+}
+
+#modx-navbar .right:after {
+    border-top: 5px solid transparent;
+    border-bottom: 5px solid transparent;
+    border-left: 5px solid $navbarDropArrowColor;
+    top: calc(50% - 5px);
 }
 
 #modx-user-menu li.top > a,
@@ -178,6 +189,11 @@
     padding-left: 0;
     position: absolute; left: 270px; top: -1px;
     z-index: 24;
+
+	&.more {
+		top: unset;
+		bottom: -1px;
+	}
   }
 }
 

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -752,6 +752,9 @@ $_lang['setting_syncsite_default_err'] = 'Please state whether or not you want t
 $_lang['setting_topmenu_show_descriptions'] = 'Show Descriptions in Top Menu';
 $_lang['setting_topmenu_show_descriptions_desc'] = 'If set to \'No\', MODX will hide the descriptions from top menu items in the manager.';
 
+$_lang['setting_topmenu_submenu_max_items'] = 'Maximum items in the drop-down lists of the top menu bar';
+$_lang['setting_topmenu_submenu_max_items_desc'] = 'The maximum number of items displayed in the drop-down lists of the top menu bar. The remaining items will be hidden in the "More" item.';
+
 $_lang['setting_tree_default_sort'] = 'Resource Tree Default Sort Field';
 $_lang['setting_tree_default_sort_desc'] = 'The default sort field for the Resource tree when loading the manager.';
 

--- a/core/lexicon/en/topmenu.inc.php
+++ b/core/lexicon/en/topmenu.inc.php
@@ -63,6 +63,7 @@ $_lang['media'] = 'Media';
 $_lang['media_desc'] = 'Update Media and Media Sources';
 $_lang['messages'] = 'Messages';
 $_lang['messages_desc'] = 'View and send messages';
+$_lang['more'] = 'More';
 $_lang['namespaces'] = 'Namespaces';
 $_lang['namespaces_desc'] = 'Distinguish between Add-on settings';
 $_lang['new_document'] = 'New Document';

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -310,7 +310,7 @@ class TopMenu
         //$output .= '<ul class="modx-subnav">'."\n";
 
 		$moreMenu = '';
-		if($maxItems && count($menus) > $maxItems) {
+		if ($maxItems && count($menus) > $maxItems) {
 			$moreMenu = array_slice($menus, $maxItems);
 			$menus = array_slice($menus, 0, $maxItems);
 		}

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -305,7 +305,7 @@ class TopMenu
      *
      * @return void
      */
-    public function processSubMenus(&$output, array $menus = array(), int $maxItems)
+    public function processSubMenus(&$output, array $menus = array(), $maxItems = false)
     {
         //$output .= '<ul class="modx-subnav">'."\n";
 

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -305,7 +305,7 @@ class TopMenu
      *
      * @return void
      */
-    public function processSubMenus(&$output, array $menus = array(), int $maxItems = 0)
+    public function processSubMenus(&$output, array $menus = array(), int $maxItems)
     {
         //$output .= '<ul class="modx-subnav">'."\n";
 

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -355,7 +355,7 @@ class TopMenu
             $this->childrenCt++;
         }
 
-		if(!empty($moreMenu)) {
+		if (!empty($moreMenu)) {
 			$output .= '<li><a class="right">'.$this->modx->lexicon('more').'</a>'."\n";
 			$output .= '<ul class="modx-subsubnav more">'."\n";
 			$this->processSubMenus($output, $moreMenu);


### PR DESCRIPTION
### What does it do?
1. Add new system setting `topmenu_submenu_max_items`
2. Check this setting and moves remainings items to new item with label "More"
3. Add right arrow/triangle for menu items that have children

**Process gif**

![ux](https://user-images.githubusercontent.com/20814058/51438670-bddb5c80-1ce1-11e9-8f15-f2ac1bc3011f.gif)



![screenshot-revolution-2019 01 20-18-23-00](https://user-images.githubusercontent.com/20814058/51438637-4f969a00-1ce1-11e9-969e-5a45c0e96196.png)


### Why is it needed?
Description from #11939

> When there's a long Extras dropdown menu, and not enough screen space, the bottom items get cut off. It's not possible to scroll down or access them.

### Related issue
Closes #11939
