### PR TITLE
Log deprecated modAction for the current installed package only during package install/uninstall

### DIFF
--- a/core/model/modx/modmenu.class.php
+++ b/core/model/modx/modmenu.class.php
@@ -116,7 +116,9 @@ class modMenu extends modAccessibleObject {
             // allow 2.2 and earlier actions
             $deprecatedNamespace = $menu->get('action_namespace');
             if (!empty($deprecatedNamespace)) {
-                $this->xpdo->deprecated('2.3.0', 'Support for modAction has been replaced with routing based on a namespace and action name. Please update the extra with the namespace ' . $deprecatedNamespace . ' to the routing based system.', 'modAction support');
+                if (!defined('MODX_PACKAGE_INSTALL') || MODX_PACKAGE_INSTALL == $deprecatedNamespace) {
+                    $this->xpdo->deprecated('2.3.0', 'Support for modAction has been replaced with routing based on a namespace and action name. Please update the extra with the namespace ' . $deprecatedNamespace . ' to the routing based system.', 'modAction support');
+                }
                 $namespace = $deprecatedNamespace;
             }
             if ($namespace != 'core') {

--- a/core/model/modx/modmenu.class.php
+++ b/core/model/modx/modmenu.class.php
@@ -116,7 +116,8 @@ class modMenu extends modAccessibleObject {
             // allow 2.2 and earlier actions
             $deprecatedNamespace = $menu->get('action_namespace');
             if (!empty($deprecatedNamespace)) {
-                if (!defined('MODX_PACKAGE_INSTALL') || MODX_PACKAGE_INSTALL == $deprecatedNamespace) {
+                $identifiers = $this->xpdo->getOption('package_install_identifiers', null, array());
+                if (empty($identifiers) || in_array($deprecatedNamespace, $identifiers)) {
                     $this->xpdo->deprecated('2.3.0', 'Support for modAction has been replaced with routing based on a namespace and action name. Please update the extra with the namespace ' . $deprecatedNamespace . ' to the routing based system.', 'modAction support');
                 }
                 $namespace = $deprecatedNamespace;

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2384,10 +2384,8 @@ class modX extends xPDO {
         }
         $this->loggedDeprecatedFunctions[] = $msg.$callerDef;
 
-        if (!defined('MODX_PACKAGE_INSTALL')) {
-            // Send to the standard log, providing also the file and line the deprecated method was called from
-            $this->log(self::LOG_LEVEL_ERROR, $msg, '', $callerDef, $deprecatedMethod['file'], $deprecatedMethod['line']);
-        }
+        // Send to the standard log, providing also the file and line the deprecated method was called from
+        $this->log(self::LOG_LEVEL_ERROR, $msg, '', $callerDef, $deprecatedMethod['file'], $deprecatedMethod['line']);
     }
 
     /**

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2384,8 +2384,10 @@ class modX extends xPDO {
         }
         $this->loggedDeprecatedFunctions[] = $msg.$callerDef;
 
-        // Send to the standard log, providing also the file and line the deprecated method was called from
-        $this->log(self::LOG_LEVEL_ERROR, $msg, '', $callerDef, $deprecatedMethod['file'], $deprecatedMethod['line']);
+        if (!defined('MODX_PACKAGE_INSTALL')) {
+            // Send to the standard log, providing also the file and line the deprecated method was called from
+            $this->log(self::LOG_LEVEL_ERROR, $msg, '', $callerDef, $deprecatedMethod['file'], $deprecatedMethod['line']);
+        }
     }
 
     /**

--- a/core/model/modx/processors/workspace/packages/install.class.php
+++ b/core/model/modx/processors/workspace/packages/install.class.php
@@ -47,7 +47,9 @@ class modPackageInstallProcessor extends modProcessor {
 
     public function process() {
         $this->package->parseSignature();
-        define('MODX_PACKAGE_INSTALL', $this->package->identifier);
+        $identifiers = $this->modx->getOption('package_install_identifiers', null, array());
+        $identifiers[] = $this->package->identifier;
+        $this->modx->setOption('package_install_identifiers', $identifiers);
 
         $this->modx->log(xPDO::LOG_LEVEL_INFO,$this->modx->lexicon('package_install_info_found'));
 

--- a/core/model/modx/processors/workspace/packages/install.class.php
+++ b/core/model/modx/processors/workspace/packages/install.class.php
@@ -46,7 +46,8 @@ class modPackageInstallProcessor extends modProcessor {
     }
 
     public function process() {
-        define('MODX_PACKAGE_INSTALL', true);
+        $this->package->parseSignature();
+        define('MODX_PACKAGE_INSTALL', $this->package->identifier);
 
         $this->modx->log(xPDO::LOG_LEVEL_INFO,$this->modx->lexicon('package_install_info_found'));
 

--- a/core/model/modx/processors/workspace/packages/install.class.php
+++ b/core/model/modx/processors/workspace/packages/install.class.php
@@ -46,6 +46,8 @@ class modPackageInstallProcessor extends modProcessor {
     }
 
     public function process() {
+        define('MODX_PACKAGE_INSTALL', true);
+
         $this->modx->log(xPDO::LOG_LEVEL_INFO,$this->modx->lexicon('package_install_info_found'));
 
         $installed = $this->package->install($this->getProperties());

--- a/core/model/modx/processors/workspace/packages/uninstall.class.php
+++ b/core/model/modx/processors/workspace/packages/uninstall.class.php
@@ -49,7 +49,9 @@ class modPackageUninstallProcessor extends modProcessor {
 
     public function process() {
         $this->package->parseSignature();
-        define('MODX_PACKAGE_INSTALL', $this->package->package_name);
+        $identifiers = $this->modx->getOption('package_install_identifiers', null, array());
+        $identifiers[] = $this->package->identifier;
+        $this->modx->setOption('package_install_identifiers', $identifiers);
 
         $transport = $this->package->getTransport();
         $this->modx->log(modX::LOG_LEVEL_INFO,$this->modx->lexicon('package_uninstall_info_prep'));

--- a/core/model/modx/processors/workspace/packages/uninstall.class.php
+++ b/core/model/modx/processors/workspace/packages/uninstall.class.php
@@ -48,7 +48,8 @@ class modPackageUninstallProcessor extends modProcessor {
     }
 
     public function process() {
-        define('MODX_PACKAGE_INSTALL', true);
+        $this->package->parseSignature();
+        define('MODX_PACKAGE_INSTALL', $this->package->package_name);
 
         $transport = $this->package->getTransport();
         $this->modx->log(modX::LOG_LEVEL_INFO,$this->modx->lexicon('package_uninstall_info_prep'));

--- a/core/model/modx/processors/workspace/packages/uninstall.class.php
+++ b/core/model/modx/processors/workspace/packages/uninstall.class.php
@@ -48,6 +48,8 @@ class modPackageUninstallProcessor extends modProcessor {
     }
 
     public function process() {
+        define('MODX_PACKAGE_INSTALL', true);
+
         $transport = $this->package->getTransport();
         $this->modx->log(modX::LOG_LEVEL_INFO,$this->modx->lexicon('package_uninstall_info_prep'));
 


### PR DESCRIPTION
### What does it do?
Set a modX/xPDO class option, that allows to bypass the $this->xpdo->deprecated call in the modMenu->getSubMenus method while running the install/uninstall processors.

### Why is it needed?
Log deprecation of modAction for the current installed package only during package install/uninstall, since the log entry is visible in red in the installation logs and the deprecated message is often triggered by a previous installed package.

### Related issue(s)/PR(s)
#14302 