### PR TITLE
Check config in root for search moved core path

### DIFF
--- a/setup/includes/config.core.php
+++ b/setup/includes/config.core.php
@@ -1,4 +1,10 @@
 <?php
-if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', MODX_INSTALL_PATH . 'core/');
+if (!defined('MODX_CORE_PATH')) {
+    if (file_exists(MODX_INSTALL_PATH . 'config.core.php')) {
+        require_once(MODX_INSTALL_PATH . 'config.core.php');
+    } else {
+        define('MODX_CORE_PATH', MODX_INSTALL_PATH . 'core/');
+    }
+}
 if (!defined('MODX_CONFIG_KEY')) define ('MODX_CONFIG_KEY', 'config');
 define ('MODX_SETUP_KEY', '@git@');


### PR DESCRIPTION
### What does it do?
Check `config.core.php` file when installing MODX. Now we can find moved or renamed core path automaticly.

### Why is it needed?
Installer can't find core path when core is moved/renamed

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/11888