### PR TITLE
Return empty string for empty xml tag in modRestService

### DIFF
--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -498,6 +498,9 @@ class modRestServiceRequest {
                 $return = array_merge($return, $attributes);
             }
         }
+        if (is_array($return) && empty($return)) {
+            $return = '';
+        }
         return $return;
     }
 }


### PR DESCRIPTION
### What does it do?
Check output for empty `array`. If it is empty, return empty `string`.

### Why is it needed?
When modRestService parse XML to array empty XML-tags returning as empty `array`.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13132
