### PR TITLE
Fixed issues with tab width and very long strings in the tabs

### DIFF
--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -301,7 +301,7 @@ ul.x-tab-strip-bottom {
     float: left;
     margin-bottom: -10000px; /* dirty hack to make vertical tabs container stretch to bottom */
     padding-bottom: 10000px !important; /* dirty hack to make vertical tabs container stretch to bottom */
-    width: 169px !important; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
+    width: 168px !important; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
 
     .x-tab-strip-wrap {
       background-color: transparent; /* as vertical tab panels are nested ones too, do not apply the background color for nested tab panels */
@@ -338,7 +338,7 @@ ul.x-tab-strip-bottom {
             border-right-color: $white;
             box-shadow: none; /* removes the active tab strip on top */
             color: $tabActiveText;
-            width: 169px; /* make the active li 1px more wide to cover the containers right border, this makes the right border on inactive tabs necessary as the whole tab-strip wrap gets wider */
+            width: 168px; /* make the active li 1px more wide to cover the containers right border, this makes the right border on inactive tabs necessary as the whole tab-strip wrap gets wider */
           }
 
           &.x-tab-edge {
@@ -353,7 +353,8 @@ ul.x-tab-strip-bottom {
           .x-tab-strip-text {
             line-height: 1.4;
             padding: 2px 0 2px 0;
-            white-space: normal; /* prevent long category names from breaking out of the tab strip width */
+            word-break: break-all;
+            white-space: pre-wrap;
           }
         }
       }


### PR DESCRIPTION
### What does it do?
It forces breaking for strings without spaces in vertical tabs and also fit the width of vertical tabs area by 1 pixel.

### Why is it needed?
It is needed to fix the issues when used very long strings (unbreakable) in the categories in vertical tabs.

ClientConfig with vertical tabs
![configuration _ modx revolution](https://user-images.githubusercontent.com/303498/52047221-98f4ae00-2559-11e9-8ea7-5b793246fca7.png)

TVs
![editing_ 123 _ modx revolution](https://user-images.githubusercontent.com/303498/52047238-a5790680-2559-11e9-8896-707529ecaa32.png)

![editing_ 123 _ modx revolution 1](https://user-images.githubusercontent.com/303498/52047256-ac077e00-2559-11e9-8f1a-26ee2ccc0edc.png)

Content Blocks
![content blocks _ parnassys](https://user-images.githubusercontent.com/303498/52047266-b164c880-2559-11e9-9fab-41471a908e6d.png)

### Related issue(s)/PR(s)
#14240
Alternative solution #14247
