### PR TITLE
Refactored tag input renreder to fix rendering with empty options list

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/tag.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/tag.class.php
@@ -32,11 +32,11 @@ class modTemplateVarInputRenderTag extends modTemplateVarInputRender
             if (count($option) === 1) {
                 $option[] = $option[0];
             }
-            list($label, $meaning) = $option;
+            list($inputOptionText, $inputOptionValue) = $option;
             $options[] = array(
-                'value' => htmlspecialchars($meaning, ENT_COMPAT, 'UTF-8'),
-                'text' => htmlspecialchars($label,ENT_COMPAT,'UTF-8'),
-                'checked' => in_array($meaning, $value, false),
+                'value' => htmlspecialchars($inputOptionValue, ENT_COMPAT, 'UTF-8'),
+                'text' => htmlspecialchars($inputOptionText,ENT_COMPAT,'UTF-8'),
+                'checked' => in_array($inputOptionValue, $value, false),
             );
         }
 

--- a/core/model/modx/processors/element/tv/renders/mgr/input/tag.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/tag.class.php
@@ -13,42 +13,43 @@
  * @package modx
  * @subpackage processors.element.tv.renders.mgr.input
  */
-class modTemplateVarInputRenderTag extends modTemplateVarInputRender {
-    public function process($value,array $params = array()) {
-        $value = is_array($value) ? $value : explode(',',$value);
+class modTemplateVarInputRenderTag extends modTemplateVarInputRender
+{
+    /**
+     * @param string|array $value
+     * @param array $params
+     * @return mixed|void
+     */
+    public function process($value, array $params = array())
+    {
+        $value = is_array($value) ? $value : explode(',', $value);
 
-        $default = explode('||',$this->tv->get('default_text'));
+        $options = array();
 
-        $options = $this->getInputOptions();
-        $opts = array();
-        $defaults = array();
-        $i = 0;
-
-        while (list($item, $itemValue) = each ($options)) {
-            $checked = false;
-            $itemValue = is_array($itemValue) ? $itemValue : explode('==',$itemValue);
-            $item = $itemValue[0];
-            $itemValue = isset($itemValue[1]) ? $itemValue[1] : $item;
-            if (in_array($itemValue,$value)) {
-                $checked = true;
+        foreach ($this->getInputOptions() as $option) {
+            if (!$option) { continue; }
+            $option = is_array($option) ? $option : explode('==', $option);
+            if (count($option) === 1) {
+                $option[] = $option[0];
             }
-            if (in_array($itemValue,$default)) {
-                $defaults[] = 'tv'.$this->tv->get('id').'-'.$i;
-            }
-
-            $opts[] = array(
-                'value' => htmlspecialchars($itemValue,ENT_COMPAT,'UTF-8'),
-                'text' => htmlspecialchars($item,ENT_COMPAT,'UTF-8'),
-                'checked' => $checked,
+            list($label, $meaning) = $option;
+            $options[] = array(
+                'value' => htmlspecialchars($meaning, ENT_COMPAT, 'UTF-8'),
+                'text' => htmlspecialchars($label,ENT_COMPAT,'UTF-8'),
+                'checked' => in_array($meaning, $value, false),
             );
-            $i++;
         }
 
-        $this->setPlaceholder('cbdefaults',implode(',',$defaults));
-        $this->setPlaceholder('opts',$opts);
+        $this->setPlaceholder('options', $options);
     }
-    public function getTemplate() {
+
+    /**
+     * @return string
+     */
+    public function getTemplate()
+    {
         return 'element/tv/renders/input/tag.tpl';
     }
 }
+
 return 'modTemplateVarInputRenderTag';

--- a/manager/templates/default/element/tv/renders/input/tag.tpl
+++ b/manager/templates/default/element/tv/renders/input/tag.tpl
@@ -37,14 +37,11 @@ Ext.onReady(function() {
 // ]]>
 </script>
 
-
-
 <ul class="modx-tag-list" id="tv-{$tv->id}-tag-list">
-{foreach from=$opts item=item key=k name=cbs}
+{foreach from=$options item=item key=k name=cbs}
     <li class="modx-tag-opt{if $item.checked} modx-tag-checked{/if}" title="{$item.value}">{$item.text}</li>
 {/foreach}
 </ul>
-
 
 <script type="text/javascript">
 // <![CDATA[


### PR DESCRIPTION
### What does it do?
It fixes the issue with displaying tag input component (TV) when options list set as empty.

### Why is it needed?
It needed to avoid glitches that described in the issue.

### Related issue(s)/PR(s)
#14177
