### PR TITLE
Fixed changing language settings during installation / upgrade

### DIFF
--- a/setup/includes/new.install.php
+++ b/setup/includes/new.install.php
@@ -234,7 +234,7 @@ if ($usemb) {
     $setting->save();
 }
 
-/* if language != en, set cultureKey, manager_language, manager_lang_attribute to it */
+/* if language != en, set cultureKey, fe_editor_lang, manager_lang_attribute, manager_language to it */
 $language = $settings->get('language','en');
 if ($language != 'en') {
     /* cultureKey */
@@ -253,14 +253,14 @@ if ($language != 'en') {
     $setting->set('value',$language);
     $setting->save();
 
-    /* manager_language */
+    /* fe_editor_lang */
     $setting = $modx->getObject('modSystemSetting',array(
-        'key' => 'manager_language',
+        'key' => 'fe_editor_lang',
     ));
     if (!$setting) {
         $setting = $modx->newObject('modSystemSetting');
         $setting->fromArray(array(
-            'key' => 'manager_language',
+            'key' => 'fe_editor_lang',
             'namespace' => 'core',
             'xtype' => 'textfield',
             'area' => 'language',
@@ -277,6 +277,22 @@ if ($language != 'en') {
         $setting = $modx->newObject('modSystemSetting');
         $setting->fromArray(array(
             'key' => 'manager_lang_attribute',
+            'namespace' => 'core',
+            'xtype' => 'textfield',
+            'area' => 'language',
+        ));
+    }
+    $setting->set('value',$language);
+    $setting->save();
+
+    /* manager_language */
+    $setting = $modx->getObject('modSystemSetting',array(
+        'key' => 'manager_language',
+    ));
+    if (!$setting) {
+        $setting = $modx->newObject('modSystemSetting');
+        $setting->fromArray(array(
+            'key' => 'manager_language',
             'namespace' => 'core',
             'xtype' => 'textfield',
             'area' => 'language',

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -142,14 +142,30 @@ unset($adminPolicy,$adminGroup);
 
 $language = $settings->get('language','en');
 if ($language != 'en') {
-    /* manager_language */
+    /* cultureKey */
     $setting = $modx->getObject('modSystemSetting',array(
-        'key' => 'manager_language',
+        'key' => 'cultureKey',
     ));
     if (!$setting) {
         $setting = $modx->newObject('modSystemSetting');
         $setting->fromArray(array(
-            'key' => 'manager_language',
+            'key' => 'cultureKey',
+            'namespace' => 'core',
+            'xtype' => 'textfield',
+            'area' => 'language',
+        ));
+    }
+    $setting->set('value',$language);
+    $setting->save();
+
+    /* fe_editor_lang */
+    $setting = $modx->getObject('modSystemSetting',array(
+        'key' => 'fe_editor_lang',
+    ));
+    if (!$setting) {
+        $setting = $modx->newObject('modSystemSetting');
+        $setting->fromArray(array(
+            'key' => 'fe_editor_lang',
             'namespace' => 'core',
             'xtype' => 'textfield',
             'area' => 'language',
@@ -166,6 +182,22 @@ if ($language != 'en') {
         $setting = $modx->newObject('modSystemSetting');
         $setting->fromArray(array(
             'key' => 'manager_lang_attribute',
+            'namespace' => 'core',
+            'xtype' => 'textfield',
+            'area' => 'language',
+        ));
+    }
+    $setting->set('value',$language);
+    $setting->save();
+
+    /* manager_language */
+    $setting = $modx->getObject('modSystemSetting',array(
+        'key' => 'manager_language',
+    ));
+    if (!$setting) {
+        $setting = $modx->newObject('modSystemSetting');
+        $setting->fromArray(array(
+            'key' => 'manager_language',
             'namespace' => 'core',
             'xtype' => 'textfield',
             'area' => 'language',


### PR DESCRIPTION
### What does it do?
When installing and updating, no matter how the language was selected - in the editor settings (the "fe_editor_lang" key) was always "en". Added a change of settings depending on the selected.
Perhaps in MODX3 this setting will not be.

Added check of "cultureKey" settings when updating.

### Related issue(s)/PR(s)
NA
