### PR TITLE
Change the Manager date and time format after a clean installation.

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -963,7 +963,7 @@ $settings['mail_smtp_user']->fromArray(array (
 $settings['manager_date_format']= $xpdo->newObject('modSystemSetting');
 $settings['manager_date_format']->fromArray(array (
   'key' => 'manager_date_format',
-  'value' => 'Y-m-d',
+  'value' => 'd-m-Y',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1008,7 +1008,7 @@ $settings['manager_js_document_root']->fromArray(array (
 $settings['manager_time_format']= $xpdo->newObject('modSystemSetting');
 $settings['manager_time_format']->fromArray(array (
   'key' => 'manager_time_format',
-  'value' => 'g:i a',
+  'value' => 'H:i',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -963,7 +963,7 @@ $settings['mail_smtp_user']->fromArray(array (
 $settings['manager_date_format']= $xpdo->newObject('modSystemSetting');
 $settings['manager_date_format']->fromArray(array (
   'key' => 'manager_date_format',
-  'value' => 'd-m-Y',
+  'value' => 'Y-m-d',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',


### PR DESCRIPTION
### What does it do?
- Changes the Manager Time Format `manager_time_format` values ​​to 24 hour format after a clean installation.
- Changes the Manager Date Format `manager_date_format` values ​​to `d-m-Y` format after a clean installation.

### Why is it needed?
To change a specific setting. In most cases, the 24 hour format and format date `d-m-Y` is used.

### Related issue(s)/PR(s)
#13876 
