### PR TITLE
Change the default request_method_strict and friendly_alias_restrict_chars

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1442,11 +1442,7 @@ $settings['request_controller']->fromArray(array (
 $settings['request_method_strict']= $xpdo->newObject('modSystemSetting');
 $settings['request_method_strict']->fromArray(array (
   'key' => 'request_method_strict',
-<<<<<<< HEAD
   'value' => '0',
-=======
-  'value' => 0,
->>>>>>> d8941327784a9af4817acc22ca24644da4d1d603
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'gateway',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1442,7 +1442,7 @@ $settings['request_controller']->fromArray(array (
 $settings['request_method_strict']= $xpdo->newObject('modSystemSetting');
 $settings['request_method_strict']->fromArray(array (
   'key' => 'request_method_strict',
-  'value' => '0',
+  'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'gateway',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1442,7 +1442,7 @@ $settings['request_controller']->fromArray(array (
 $settings['request_method_strict']= $xpdo->newObject('modSystemSetting');
 $settings['request_method_strict']->fromArray(array (
   'key' => 'request_method_strict',
-  'value' => '1',
+  'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'gateway',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -657,7 +657,7 @@ $settings['friendly_alias_realtime']->fromArray(array (
 $settings['friendly_alias_restrict_chars']= $xpdo->newObject('modSystemSetting');
 $settings['friendly_alias_restrict_chars']->fromArray(array (
   'key' => 'friendly_alias_restrict_chars',
-  'value' => 'pattern',
+  'value' => 'alphanumeric',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
@@ -1442,7 +1442,7 @@ $settings['request_controller']->fromArray(array (
 $settings['request_method_strict']= $xpdo->newObject('modSystemSetting');
 $settings['request_method_strict']->fromArray(array (
   'key' => 'request_method_strict',
-  'value' => '0',
+  'value' => '1',
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'gateway',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1442,7 +1442,11 @@ $settings['request_controller']->fromArray(array (
 $settings['request_method_strict']= $xpdo->newObject('modSystemSetting');
 $settings['request_method_strict']->fromArray(array (
   'key' => 'request_method_strict',
-  'value' => true,
+<<<<<<< HEAD
+  'value' => '0',
+=======
+  'value' => 0,
+>>>>>>> d8941327784a9af4817acc22ca24644da4d1d603
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'gateway',


### PR DESCRIPTION
### What does it do?
- FURL Alias Character Restriction Method (`friendly_alias_restrict_chars`) - `pattern` changed to `alphanumeric`. 
- Strict Request Method (`request_method_strict`) - `no` changed to `yes`. 

### Why is it needed?

1. FURL Alias Character Restriction Method (`friendly_alias_restrict_chars`). Because It happens that in the current variant can stay incorrect characters in url, but with `alphanumeric` there is no such problem and this option will is suitable for most users.
2. Strict Request Method (`request_method_strict`). Because in the current version, if FURL is enabled, then the url opens with both index.php and sef-url, which is bad for search engines.

### Related issue(s)/PR(s)
#14273 