### PR TITLE
Change default automatic_template_assignment, tree node fallback, and preserve_menuindex

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -117,7 +117,7 @@ $settings['automatic_alias']->fromArray(array (
 $settings['automatic_template_assignment']= $xpdo->newObject('modSystemSetting');
 $settings['automatic_template_assignment']->fromArray(array (
     'key' => 'automatic_template_assignment',
-    'value' => 'parent',
+    'value' => 'sibling',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'site',
@@ -1487,7 +1487,7 @@ $settings['resource_tree_node_name']->fromArray(array (
 $settings['resource_tree_node_name_fallback']= $xpdo->newObject('modSystemSetting');
 $settings['resource_tree_node_name_fallback']->fromArray(array (
   'key' => 'resource_tree_node_name_fallback',
-  'value' => 'pagetitle',
+  'value' => 'alias',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
@@ -2094,7 +2094,7 @@ $settings['parser_recurse_uncacheable']->fromArray(array (
 $settings['preserve_menuindex']= $xpdo->newObject('modSystemSetting');
 $settings['preserve_menuindex']->fromArray(array (
     'key' => 'preserve_menuindex',
-    'value' => true,
+    'value' => false,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'manager',


### PR DESCRIPTION
### What does it do?
- Automatic Template Assignment (`automatic_template_assignment`) - `parent` changed to `sibling`, Because more often, resources with the same template are siblings pages, for example, news or articles.
- Resource Tree Node Fallback Field `resource_tree_node_name_fallback` Is set to `pagetitle`, changed to `alias`
- Preserve Menu Index When Duplicating Resources `preserve_menuindex` Currently `True`, Changed to `False`

### Why is it needed?
A clean install of MODX is currently too clean. It's missing some very essential things, which will make the install more tailored to our needs.

### Related issue(s)/PR(s)
#13876 #14273 
