### PR TITLE
Fix issue with resourcelist preventing parents from working correctly (Fixes #14207)

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/resourcelist.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/resourcelist.class.php
@@ -19,7 +19,7 @@ class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
     public function process($value,array $params = array()) {
         $parents = $this->getInputOptions();
         $params['parents'] = isset($params['parents']) ? $params['parents'] : '';
-        $parents = empty($params['parents']) || $params['parents'] === '0' ? explode(',',$params['parents']) : $parents;
+        $parents = !empty($params['parents']) || $params['parents'] === '0' ? explode(',',$params['parents']) : $parents;
         $params['depth'] = !empty($params['depth']) ? $params['depth'] : 10;
         if (empty($parents) || (empty($parents[0]) && $parents[0] !== '0')) {
             $parents = array();


### PR DESCRIPTION
### What does it do?
2.7.0 introduced a regression that prevented Resource List from correctly generating the list of resources when one or more parents was selected.

### Why is it needed?
A change in 2.7 removed an bang and effectively made it such that the "parents" parameter would be ignored. Essentially, `$params['parents']` is only being used if it's empty.

### Related issue(s)/PR(s)
This fixes issue #14207
