### PR TITLE
Change sanitize behavior for files with two dots in filename

### DIFF
--- a/core/model/modx/processors/browser/file/create.class.php
+++ b/core/model/modx/processors/browser/file/create.class.php
@@ -33,7 +33,7 @@ class modBrowserFileCreateProcessor extends modProcessor {
         $directory = ltrim(strip_tags(preg_replace('/[\.]{2,}/', '', htmlspecialchars($directory))),'/');
 
         $name = $this->getProperty('name');
-        $name = ltrim(strip_tags(preg_replace('/[\.]{2,}/', '', htmlspecialchars($name))),'/');
+        $name = ltrim(strip_tags(htmlspecialchars($name)),'/');
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -33,12 +33,13 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (empty($file)) {
             return $this->modx->error->failure($this->modx->lexicon('file_err_ns'));
         }
-        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars(pathinfo($file, PATHINFO_DIRNAME)));
-        if (!empty($directory)) {
-            $directory .= DIRECTORY_SEPARATOR;
-        }
-        $name = htmlspecialchars(end(explode( DIRECTORY_SEPARATOR, $file )));
-        $path = $directory.$name;
+        $oldlocale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL,'C.UTF-8');
+        $pathinfo = pathinfo($file);
+        setlocale(LC_ALL,$oldlocale);
+        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars($pathinfo['dirname']));
+        $name = htmlspecialchars($pathinfo['basename']);
+        $path = $directory.DIRECTORY_SEPARATOR.$name;
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -33,10 +33,10 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (empty($file)) {
             return $this->modx->error->failure($this->modx->lexicon('file_err_ns'));
         }
-        $oldlocale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL,'C.UTF-8');
         $pathinfo = pathinfo($file);
-        setlocale(LC_ALL,$oldlocale);
+        if ($pathinfo['dirname'].DIRECTORY_SEPARATOR.$pathinfo['basename'] != $file) {
+            $this->modx->log (modX::LOG_LEVEL_ERROR, 'Could not prepare the filepath ' . $file . '. Please set a valid UTF8 capable locale in the MODX system setting "locale".');
+        }
         $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars($pathinfo['dirname']));
         $name = htmlspecialchars($pathinfo['basename']);
         $path = $directory.DIRECTORY_SEPARATOR.$name;

--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -34,7 +34,10 @@ class modBrowserFileRemoveProcessor extends modProcessor {
             return $this->modx->error->failure($this->modx->lexicon('file_err_ns'));
         }
         $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars(pathinfo($file, PATHINFO_DIRNAME)));
-        $name = htmlspecialchars(pathinfo($file, PATHINFO_BASENAME));
+        if (!empty($directory)) {
+            $directory .= DIRECTORY_SEPARATOR;
+        }
+        $name = htmlspecialchars(end(explode( DIRECTORY_SEPARATOR, $file )));
         $path = $directory.$name;
 
         $loaded = $this->getSource();
@@ -44,7 +47,7 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (!$this->source->checkPolicy('remove')) {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
-        $success = $this->source->removeObject($file);
+        $success = $this->source->removeObject($path);
 
         if (empty($success)) {
             $errors = $this->source->getErrors();

--- a/core/model/modx/processors/browser/file/remove.class.php
+++ b/core/model/modx/processors/browser/file/remove.class.php
@@ -33,7 +33,9 @@ class modBrowserFileRemoveProcessor extends modProcessor {
         if (empty($file)) {
             return $this->modx->error->failure($this->modx->lexicon('file_err_ns'));
         }
-        $file = preg_replace('/[\.]{2,}/', '', $file);
+        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars(pathinfo($file, PATHINFO_DIRNAME)));
+        $name = htmlspecialchars(pathinfo($file, PATHINFO_BASENAME));
+        $path = $directory.$name;
 
         $loaded = $this->getSource();
         if (!($this->source instanceof modMediaSource)) {

--- a/core/model/modx/processors/browser/file/rename.class.php
+++ b/core/model/modx/processors/browser/file/rename.class.php
@@ -40,10 +40,21 @@ class modBrowserFileRenameProcessor extends modProcessor {
         }
 
         $oldFile = $this->getProperty('path');
-        $oldFile = preg_replace('/[\.]{2,}/', '', htmlspecialchars($oldFile));
-        $name = $this->getProperty('name');
-        $name = preg_replace('/[\.]{2,}/', '', htmlspecialchars($name));
-        $success = $this->source->renameObject($oldFile, $name);
+        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars(pathinfo($oldFile, PATHINFO_DIRNAME)));
+        if (!empty($directory)) {
+            $directory .= DIRECTORY_SEPARATOR;
+        }
+        $name = htmlspecialchars(end(explode( DIRECTORY_SEPARATOR, $oldFile )));
+        $oldFile = $directory.$name;
+
+        $newFile = $this->getProperty('name');
+        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars(pathinfo($newFile, PATHINFO_DIRNAME)));
+        if (!empty($directory)) {
+            $directory .= DIRECTORY_SEPARATOR;
+        }
+        $name = htmlspecialchars(end(explode( DIRECTORY_SEPARATOR, $newFile )));
+        $newFile = $directory.$name;
+        $success = $this->source->renameObject($oldFile, $newFile);
 
         if (empty($success)) {
             $msg = '';

--- a/core/model/modx/processors/browser/file/rename.class.php
+++ b/core/model/modx/processors/browser/file/rename.class.php
@@ -40,20 +40,19 @@ class modBrowserFileRenameProcessor extends modProcessor {
         }
 
         $oldFile = $this->getProperty('path');
-        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars(pathinfo($oldFile, PATHINFO_DIRNAME)));
-        if (!empty($directory)) {
-            $directory .= DIRECTORY_SEPARATOR;
-        }
-        $name = htmlspecialchars(end(explode( DIRECTORY_SEPARATOR, $oldFile )));
-        $oldFile = $directory.$name;
+        $oldlocale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL,'C.UTF-8');
+        $pathinfo = pathinfo($oldFile);
+        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars($pathinfo['dirname']));
+        $name = htmlspecialchars($pathinfo['basename']);
+        $oldFile = $directory.DIRECTORY_SEPARATOR.$name;
 
         $newFile = $this->getProperty('name');
-        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars(pathinfo($newFile, PATHINFO_DIRNAME)));
-        if (!empty($directory)) {
-            $directory .= DIRECTORY_SEPARATOR;
-        }
-        $name = htmlspecialchars(end(explode( DIRECTORY_SEPARATOR, $newFile )));
-        $newFile = $directory.$name;
+        $pathinfo = pathinfo($newFile);
+        $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars($pathinfo['dirname']));
+        $name = htmlspecialchars($pathinfo['basename']);
+        $newFile = $directory.DIRECTORY_SEPARATOR.$name;
+        setlocale(LC_ALL,$oldlocale);
         $success = $this->source->renameObject($oldFile, $newFile);
 
         if (empty($success)) {

--- a/core/model/modx/processors/browser/file/rename.class.php
+++ b/core/model/modx/processors/browser/file/rename.class.php
@@ -40,19 +40,22 @@ class modBrowserFileRenameProcessor extends modProcessor {
         }
 
         $oldFile = $this->getProperty('path');
-        $oldlocale = setlocale(LC_ALL, 0);
-        setlocale(LC_ALL,'C.UTF-8');
         $pathinfo = pathinfo($oldFile);
+        if ($pathinfo['dirname'].DIRECTORY_SEPARATOR.$pathinfo['basename'] != $oldFile) {
+            $this->modx->log (modX::LOG_LEVEL_ERROR, 'Could not prepare the filepath ' . $oldFile . '. Please set a valid UTF8 capable locale in the MODX system setting "locale".');
+        }
         $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars($pathinfo['dirname']));
         $name = htmlspecialchars($pathinfo['basename']);
         $oldFile = $directory.DIRECTORY_SEPARATOR.$name;
 
         $newFile = $this->getProperty('name');
         $pathinfo = pathinfo($newFile);
+        if ($pathinfo['basename'] != $newFile) {
+            $this->modx->log (modX::LOG_LEVEL_ERROR, 'Could not prepare the filepath ' . $newFile . '. Please set a valid UTF8 capable locale in the MODX system setting "locale".');
+        }
         $directory = preg_replace('/[\.]{2,}/', '', htmlspecialchars($pathinfo['dirname']));
         $name = htmlspecialchars($pathinfo['basename']);
         $newFile = $directory.DIRECTORY_SEPARATOR.$name;
-        setlocale(LC_ALL,$oldlocale);
         $success = $this->source->renameObject($oldFile, $newFile);
 
         if (empty($success)) {


### PR DESCRIPTION
### What does it do?
For files uploaded via media-manager name with two or more dots will sanitize as when creating file.
**UPD:**
Change behavior. Now sanitize path before filename and allow filename had two dots. Update related browser/file processors.

### Why is it needed?
To avoid the mistake like described in issue (cannot be removed).
And for consistency with behavior creating file.

### Related issue(s)/PR(s)
This fixes issue #14320 