### PR TITLE
Protect MODx.grid.Grid against XSS vulnerabilities by default

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -163,12 +163,13 @@ Ext.extend(MODx.combo.ComboBox,Ext.form.ComboBox, {
 });
 Ext.reg('modx-combo',MODx.combo.ComboBox);
 
-Ext.util.Format.comboRenderer = function (combo,val) {
-    return function (v,md,rec,ri,ci,s) {
+Ext.util.Format.comboRenderer = function (combo, val) {
+    return function (v, md, rec, ri, ci, s) {
         if (!s) return v;
         if (!combo.findRecord) return v;
         var record = combo.findRecord(combo.valueField, v);
-        return record ? record.get(combo.displayField) : val;
+        val = record ? record.get(combo.displayField) : val;
+        return Ext.util.Format.htmlEncode(val);
     }
 };
 

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -371,6 +371,15 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                         c[i].renderer = eval(c[i].renderer);
                     }
                 }
+
+                /**
+                 * When no renderer is provided, automatically apply the htmlEncode renderer to protect
+                 * against XSS vulnerabilities. Columns that do have a renderer applied are assumed to
+                 * implement their own protection.
+                 */
+                if (Ext.isEmpty(c[i].renderer)) {
+                    c[i].renderer = Ext.util.Format.htmlEncode;
+                }
             }
             this.cm = new Ext.grid.ColumnModel(c);
         }

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -705,6 +705,15 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
                         c[i].renderer = eval(c[i].renderer);
                     }
                 }
+
+                /**
+                 * When no renderer is provided, automatically apply the htmlEncode renderer to protect
+                 * against XSS vulnerabilities. Columns that do have a renderer applied are assumed to
+                 * implement their own protection.
+                 */
+                if (Ext.isEmpty(c[i].renderer)) {
+                    c[i].renderer = Ext.util.Format.htmlEncode;
+                }
             }
             this.cm = new Ext.grid.ColumnModel(c);
         }


### PR DESCRIPTION
### What does it do?

When a MODx.grid.Grid/MODx.grid.LocalGrid implementation does not define a renderer for a column, automatically add the Ext.util.Format.htmlEncode renderer which protects the grid from XSS vulnerabilities. 

When a renderer is set, no action is taken, and the implementation is assumed to handle its own protections. This allows implementations to still do things like add links or buttons into grids. 

### Why is it needed?

The manager is very prone to XSS vulnerabilities. This has been discussed in different places, most notably #14094. In the past week, a lot of XSS-related issues [were raised](https://github.com/modxcms/revolution/issues?utf8=%E2%9C%93&q=is%3Aissue+xss) and [also fixed](https://github.com/modxcms/revolution/pulls?q=is%3Apr+xss), but those are all putting bandaids on the core problem, which is that ExtJS was not configured in a way to treat any value as potentially hostile user input.

This PR changes that and automatically escapes all values in grids, unless otherwise instructed. The PR also escapes values from a combobox that are rendered through an `editor` configuration. 

That's also why this targets 3.x - while security issues would typically go into a bugfix release, it is likely that compatibility issues in both core and third party extras will surface where those grids took advantage of the lack of encoding to insert links/buttons/other html into values. 

This does not fix all XSS issues in the manager, but it does stop a lot of them (like [the list here](https://github.com/modxcms/revolution/issues/14341#issuecomment-461382325)).  

### Related issue(s)/PR(s)

#14094 