### PR TITLE
Add input prompt per setting to script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ mysql:
   username: root
   encoding: utf8
 
-before_script: 'cd _build/test && yes [] |./generateConfigs.sh'
+before_script: 'cd _build/test && ./generateConfigs.sh'
 
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ mysql:
   username: root
   encoding: utf8
 
-before_script: 'cd _build/test && ./generateConfigs.sh'
+before_script: 'cd _build/test && yes [] |./generateConfigs.sh'
 
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ mysql:
   username: root
   encoding: utf8
 
-before_script: 'cd _build/test && ./generateConfigs.sh'
+before_script: 'cd _build/test && ./generateConfigs.sh auto'
 
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi

--- a/_build/test/generateConfigs.sh
+++ b/_build/test/generateConfigs.sh
@@ -1,8 +1,29 @@
 #!/bin/bash
 
-DBNAME="revo_test"
-DBUSER="root"
-DBPASS=""
+read -p "Enter your database [revo_test]: " input
+DBNAME=${input:-revo_test}
+
+read -p "Enter your database user [root]: " input
+DBUSER=${input:-revo_test}
+
+read -p "Enter your database []: " input
+DBPASS=${input:-}
+
+read -p "Enter your host [unit.modx.com]: " input
+MDXHOST=${input:-unit.modx.com}
+
+read -p "Enter your language [en]: " input
+MDXLANG=${input:-en}
+
+read -p "Enter your modx admin userinput [admin]: " input
+MDXUSER=${input:-admin}
+
+read -p "Enter your modx admin password [admin]: " input
+MDXPASS=${input:-admin}
+
+read -p "Enter your modx admin email [admin@modx.com]: " input
+MDXEMAIL=${input:-admin@modx.com}
+
 CWD=`pwd`
 BUILDDIR=${TRAVIS_BUILD_DIR:=`echo $(dirname $(dirname "$CWD"))`}
 BUILDDIR=$BUILDDIR"/"
@@ -29,11 +50,11 @@ CONFIG=`cat revo_install.sample.xml`
 CONFIG="${CONFIG/\{\$dbName\}/$DBNAME}"
 CONFIG="${CONFIG/\{\$dbUser\}/$DBUSER}"
 CONFIG="${CONFIG/\{\$dbPass\}/$DBPASS}"
-CONFIG="${CONFIG/\{\$host\}/unit.modx.com}"
-CONFIG="${CONFIG/\{\$language\}/en}"
-CONFIG="${CONFIG/\{\$managerUser\}/admin}"
-CONFIG="${CONFIG/\{\$managerPass\}/admin}"
-CONFIG="${CONFIG/\{\$managerEmail\}/admin@modx.com}"
+CONFIG="${CONFIG/\{\$host\}/$MDXHOST}"
+CONFIG="${CONFIG/\{\$language\}/$MDXLANG}"
+CONFIG="${CONFIG/\{\$managerUser\}/$MDXUSER}"
+CONFIG="${CONFIG/\{\$managerPass\}/$MDXPASS}"
+CONFIG="${CONFIG/\{\$managerEmail\}/$MDXEMAIL}"
 CONFIG="${CONFIG/\{\$directory\}/$BUILDDIR}"
 CONFIG="${CONFIG/\{\$directory\}/$BUILDDIR}"
 CONFIG="${CONFIG/\{\$directory\}/$BUILDDIR}"

--- a/_build/test/generateConfigs.sh
+++ b/_build/test/generateConfigs.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 
-read -p "Enter your database [revo_test]: " input
+read -t 60 -p "Enter your database [revo_test]: " input
 DBNAME=${input:-revo_test}
 
-read -p "Enter your database user [root]: " input
+read -t 60 -p "Enter your database user [root]: " input
 DBUSER=${input:-root}
 
-read -p "Enter your database []: " input
+read -t 60 -p "Enter your database []: " input
 DBPASS=${input:-}
 
-read -p "Enter your host [unit.modx.com]: " input
+read -t 60 -p "Enter your host [unit.modx.com]: " input
 MDXHOST=${input:-unit.modx.com}
 
-read -p "Enter your language [en]: " input
+read -t 60 -p "Enter your language [en]: " input
 MDXLANG=${input:-en}
 
-read -p "Enter your modx admin userinput [admin]: " input
+read -t 60 -p "Enter your modx admin userinput [admin]: " input
 MDXUSER=${input:-admin}
 
-read -p "Enter your modx admin password [admin]: " input
+read -t 60 -p "Enter your modx admin password [admin]: " input
 MDXPASS=${input:-admin}
 
-read -p "Enter your modx admin email [admin@modx.com]: " input
+read -t 60 -p "Enter your modx admin email [admin@modx.com]: " input
 MDXEMAIL=${input:-admin@modx.com}
 
 CWD=`pwd`

--- a/_build/test/generateConfigs.sh
+++ b/_build/test/generateConfigs.sh
@@ -29,7 +29,7 @@ then
     read -p "Enter your language [en]: " input
     MDXLANG=${input}
 
-    read -p "Enter your modx admin userinput [admin]: " input
+    read -p "Enter your modx admin user [admin]: " input
     MDXUSER=${input}
 
     read -s -p "Enter your modx admin password [admin]: " input

--- a/_build/test/generateConfigs.sh
+++ b/_build/test/generateConfigs.sh
@@ -1,28 +1,48 @@
 #!/bin/bash
 
-read -t 60 -p "Enter your database [revo_test]: " input
-DBNAME=${input:-revo_test}
+DBNAME=revo_test
+DBUSER=root
+DBPASS=
+MDXHOST=unit.modx.com
+MDXLANG=en
+MDXUSER=admin
+MDXPASS=admin
+MDXEMAIL=admin@modx.com
 
-read -t 60 -p "Enter your database user [root]: " input
-DBUSER=${input:-root}
+if [[ "$1" != "auto" ]]
+then
 
-read -t 60 -p "Enter your database []: " input
-DBPASS=${input:-}
+    echo "Please setup MODX in this prompt."
 
-read -t 60 -p "Enter your host [unit.modx.com]: " input
-MDXHOST=${input:-unit.modx.com}
+    read -p "Enter your database [revo_test]: " input
+    DBNAME=${input}
 
-read -t 60 -p "Enter your language [en]: " input
-MDXLANG=${input:-en}
+    read -p "Enter your database user [root]: " input
+    DBUSER=${input}
 
-read -t 60 -p "Enter your modx admin userinput [admin]: " input
-MDXUSER=${input:-admin}
+    read -s -p "Enter your database password []: " input
+    DBPASS=${input}
 
-read -t 60 -p "Enter your modx admin password [admin]: " input
-MDXPASS=${input:-admin}
+    read -p "Enter your host [unit.modx.com]: " input
+    MDXHOST=${input}
 
-read -t 60 -p "Enter your modx admin email [admin@modx.com]: " input
-MDXEMAIL=${input:-admin@modx.com}
+    read -p "Enter your language [en]: " input
+    MDXLANG=${input}
+
+    read -p "Enter your modx admin userinput [admin]: " input
+    MDXUSER=${input}
+
+    read -s -p "Enter your modx admin password [admin]: " input
+    MDXPASS=${input}
+
+    read -p "Enter your modx admin email [admin@modx.com]: " input
+    MDXEMAIL=${input}
+
+else
+
+    echo "Script started without a prompt. Default values are used."
+
+fi
 
 CWD=`pwd`
 BUILDDIR=${TRAVIS_BUILD_DIR:=`echo $(dirname $(dirname "$CWD"))`}

--- a/_build/test/generateConfigs.sh
+++ b/_build/test/generateConfigs.sh
@@ -4,7 +4,7 @@ read -p "Enter your database [revo_test]: " input
 DBNAME=${input:-revo_test}
 
 read -p "Enter your database user [root]: " input
-DBUSER=${input:-revo_test}
+DBUSER=${input:-root}
 
 read -p "Enter your database []: " input
 DBPASS=${input:-}


### PR DESCRIPTION
Still uses default values but also able to receive prompt info to setup modx

### What does it do?
Add input prompt on running script to set custom values.

### Why is it needed?
So the file doesn't need to be changed for installing modx via this script thus being processed as changed in git

### Related issue(s)/PR(s)
None
