### PR TITLE
Fix the composer phpunit script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,8 +80,8 @@
             "@php -r \"file_exists('_build/build.config.php') || copy('_build/build.config.sample.php', '_build/build.config.php');\"",
             "@php _build/transport.core.php"
         ],
-        "phpunit": "vendor/bin/phpunit -c _build/test/phpunit.xml --coverage-text --colors",
-        "coverage": "vendor/bin/phpunit -c _build/test/phpunit.xml --colors --coverage-html ./.coverage"
+        "phpunit": "phpunit -c _build/test/phpunit.xml --coverage-text --colors",
+        "coverage": "phpunit -c _build/test/phpunit.xml --colors --coverage-html ./.coverage"
     },
     "scripts-descriptions": {
         "phpunit": "Run PHPUnit test",


### PR DESCRIPTION
### What does it do?
It will just call `phpunit` without providing the path without the vendor directory because before executing scripts, Composer's bin-dir is temporarily pushed on top of the PATH environment variable so that binaries of dependencies are easily accessible. In this example no matter if the phpunit binary is actually in vendor/bin/phpunit or bin/phpunit it will be found and executed.
Source: [Composer documentation](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands)

### Why is it needed?
To fix the "No such file or directory" error when running the composer script `phpunit` because the vendor directory has been moved.

### Related issue(s)/PR(s)
-
