### PR TITLE
Using cltr/cmd and click will open the url in a new tab/window again

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -398,7 +398,7 @@ MODx.LayoutMgr = function() {
                 var e = window.event;
 
                 var middleMouseButtonClick = (e && (e.button === 4 || e.which === 2));
-                var keyboardKeyPressed = (e && (e.button === 1 || e.ctrlKey === 1 || e.metaKey === 1 || e.shiftKey === 1));
+                var keyboardKeyPressed = (e && (e.button === 1 || e.ctrlKey === true || e.metaKey === true || e.shiftKey === true));
                 if (middleMouseButtonClick || keyboardKeyPressed) {
                     // Middle mouse button click or keyboard key pressed,
                     // let the browser handle the way it should be opened (new tab/window)


### PR DESCRIPTION
### What does it do?
Using cltr/cmd and click will open the url in a new tab/window again for ExtJS elements that use `loadPage()` to open URLs

### Why is it needed?
The function to detect the ctrl/cmd + click did a wrong comparison causing the behaviour a lot of people use to misbehave.
