### PR TITLE
Add PHP 7.3 as test target for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 
 # Set php versions
 php:
+  - 7.3
   - 7.2
   - 7.1
   - 7.0
@@ -27,4 +28,4 @@ before_script: 'composer install -n && cd _build/test && ./generateConfigs.sh'
 
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi
-  -  if [[ "(7.0 7.1 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  -  if [[ "(7.0 7.1 7.2 7.3 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi

--- a/core/model/modx/modcachemanager.class.php
+++ b/core/model/modx/modcachemanager.class.php
@@ -605,7 +605,7 @@ class modCacheManager extends xPDOCacheManager {
                     break;
                 case 'db':
                     if (!$this->getOption('cache_db', $partOptions, false)) {
-                        continue;
+                        break;
                     }
                     $results[$partition] = $this->clean($partOptions);
                     break;

--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -483,7 +483,7 @@ class modTransportPackage extends xPDOObject {
                         $latest->parseSignature();
                         if (xPDOTransport::satisfies($latest->version, $constraint)) {
                             unset($latest);
-                            continue;
+                            break;
                         }
                     }
                     $unsatisfied[$package] = $constraint;


### PR DESCRIPTION
### What does it do?
Cherry pick a commit from the 2.x branch 

### Why is it needed?
To make Travis pass builds again in the 3.x branch

### Related issue(s)/PR(s)
PR #14351, PR #14356