### PR TITLE
Handle deprecated $type and $responseCode parameters in $modx->sendRedirect

### DIFF
--- a/core/model/modx/modresponse.class.php
+++ b/core/model/modx/modresponse.class.php
@@ -198,8 +198,8 @@ class modResponse {
             $options = array('count_attempts' => (boolean) $options);
         }
 
-        if ($responseCode) {
-            $this->modx->deprecated('2.0.5', 'Use responseCode in options array instead.', 'sendRedirect method parameter $type');
+        if ($type) {
+            $this->modx->deprecated('2.0.5', 'Use type in options array instead.', 'sendRedirect method parameter $type');
         }
         if ($responseCode) {
             $this->modx->deprecated('2.0.5', 'Use responseCode in options array instead.', 'sendRedirect method parameter $responseCode');

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1124,6 +1124,19 @@ class modX extends xPDO {
         if (!$this->getResponse()) {
             $this->log(modX::LOG_LEVEL_FATAL, "Could not load response class.");
         }
+        if (!is_array($options)) {
+            $options = array('count_attempts' => (boolean) $options);
+        }
+        if ($type) {
+            $this->deprecated('2.0.5', 'Use type in options array instead.', 'sendRedirect method parameter $type');
+            $options['type'] = $type;
+            $type = '';
+        }
+        if ($responseCode) {
+            $this->deprecated('2.0.5', 'Use responseCode in options array instead.', 'sendRedirect method parameter $responseCode');
+            $options['responseCode'] = $responseCode;
+            $responseCode = '';
+        }
         $this->response->sendRedirect($url, $options, $type, $responseCode);
     }
 


### PR DESCRIPTION
### What does it do?
Handle deprecated $type and $responseCode parameters in modX::sendRedirect instead of modResponse::sendRedirect.

### Why is it needed?

When calling $modx->sendRedirect with the $type / $responseCode parameter set (instead of the values in an options array), the deprecation error message would look like this:

    [2019-01-11 21:42:21] (ERROR in modX::sendRedirect @ core/model/modx/modx.class.php : 1139) sendRedirect method parameter $type is deprecated since version 2.0.5. Use responseCode in options array instead.

Most notably, the message says it was triggered from `modX::sendRedirect`, while `modX::deprecated` is supposed to show you where it was called from. That's because the deprecated handling is being done in `modResponse->sendRedirect`, so the "offending" call is the `$this->response->sendRedirect` call in `modX::sendRedirect`. While accurate, it's not helpful in tracking down the source of the original sendRedirect call, which is likely in a snippet or plugin.

With these changes, the `modX::sendRedirect` method handles the same deprecation notices. So any offending caller to `modX::sendRedirect` will get logged with a useful message. By also moving the `$type` and `$responseCode` into the options array, it prevents `modResponse::sendRedirect` from triggering the deprecated log again.

Also fixed a minor error in the deprecation message in modResponse.

### Related issue(s)/PR(s)
None
