### PR TITLE
Restore html in resource tree (#14358) while preserving XSS protections by default

### DIFF
--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -486,11 +486,12 @@ class modResourceGetNodesProcessor extends modProcessor {
             $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
         }
 
-        $text = strip_tags($resource->get($nodeField));
+        $text = $resource->get($nodeField);
         if (empty($text)) {
             $text = $resource->get($nodeFieldFallback);
-            $text = strip_tags($text);
         }
+        $charset = $this->modx->getOption('modx_charset', null, 'UTF-8');
+        $text = htmlentities($text, ENT_QUOTES, $charset);
         $itemArray = array(
             'text' => $text.$idNote,
             'id' => $resource->context_key . '_'.$resource->id,

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -229,10 +229,10 @@ Ext.override(Ext.tree.TreeNodeUI,{
         return className && (' '+el.dom.className+' ').indexOf(' '+className+' ') !== -1;
     }
     ,renderElements : function(n, a, targetNode, bulkRender){
-
         this.indentMarkup = n.parentNode ? n.parentNode.ui.getChildIndent() : '';
 
         var cb = Ext.isBoolean(a.checked),
+            renderer = n.ownerTree && n.ownerTree.renderItemText ? n.ownerTree.renderItemText : this.renderItemText,
             nel,
             href = this.getHref(a.page),
             iconMarkup = '<i class="icon'+(a.icon ? " x-tree-node-inline-icon" : "")+(a.iconCls ? " "+a.iconCls : "")+'" unselectable="on"></i>',
@@ -247,7 +247,7 @@ Ext.override(Ext.tree.TreeNodeUI,{
                     iconMarkup,
                     cb ? ('<input class="x-tree-node-cb" type="checkbox" ' + (a.checked ? 'checked="checked" />' : '/>')) : '',
                     '<a hidefocus="on" class="x-tree-node-anchor" href="',href,'" tabIndex="1" ',
-                    a.hrefTarget ? ' target="'+a.hrefTarget+'"' : "", '><span unselectable="on">',Ext.util.Format.htmlEncode(n.text),"</span></a></div>",
+                    a.hrefTarget ? ' target="'+a.hrefTarget+'"' : "", '><span unselectable="on">',renderer(a),"</span></a></div>",
                     '<ul class="x-tree-node-ct" style="display:none;"></ul>',
                     "</li>"].join('');
 
@@ -272,6 +272,14 @@ Ext.override(Ext.tree.TreeNodeUI,{
         }
         this.anchor = cs[index];
         this.textNode = cs[index].firstChild;
+    }
+    /**
+     * Renders the item text as a XSS-safe value. Can be overridden with a renderItemText method on the Tree.
+     * @param text
+     * @returns string
+     */
+    ,renderItemText: function(item) {
+        return Ext.util.Format.htmlEncode(item.text)
     }
     ,getChildIndent : function(){
         if(!this.childIndent){

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -836,6 +836,13 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             classKey: 'modDocument'
         });
     }
+
+    /**
+     * Renders the item text without any special formatting. The resource/getnodes processor already protects against XSS.
+     */
+    ,renderItemText: function(item) {
+        return item.text;
+    }
 });
 Ext.reg('modx-tree-resource',MODx.tree.Resource);
 

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.simple.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.simple.js
@@ -20,5 +20,12 @@ MODx.tree.SimpleResource = function(config) {
     });
     MODx.tree.SimpleResource.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.tree.SimpleResource,MODx.tree.Tree);
-Ext.reg('modx-tree-resource-simple',MODx.tree.SimpleResource);
+Ext.extend(MODx.tree.SimpleResource, MODx.tree.Tree, {
+    /**
+     * Renders the item text without any special formatting. The resource/getnodes processor already protects against XSS.
+     */
+    renderItemText: function(item) {
+        return item.text;
+    }
+});
+Ext.reg('modx-tree-resource-simple', MODx.tree.SimpleResource);

--- a/manager/assets/modext/widgets/system/modx.tree.menu.js
+++ b/manager/assets/modext/widgets/system/modx.tree.menu.js
@@ -109,6 +109,13 @@ Ext.extend(MODx.tree.Menu, MODx.tree.Tree, {
         }
         return m;
     }
+
+    /**
+     * Renders the item text without any special formatting. The menu/getnodes processor already protects against XSS.
+     */
+    ,renderItemText: function(item) {
+        return item.text;
+    }
 });
 Ext.reg('modx-tree-menu',MODx.tree.Menu);
 


### PR DESCRIPTION
### What does it do?

This introduces a new renderItemText function that trees can define to determine how their text field should be rendered. When not set, the htmlEncode formatter is used.

This new function is added to the resource and menu trees to bypass the htmlEncode formatter. Those elements already have XSS protection server-side, where the user input is escaped and the resulting text contains HTML that the system expects to be rendered.

### Why is it needed?
Fixes #14358, while making sure no new vulnerabilities are exposed.

### Related issue(s)/PR(s)
Fixes #14358, bug was introduced in #14335.
