### PR TITLE
Fix watch grunt task where used outdated and already removed growl plugin

### DIFF
--- a/_build/templates/default/gruntfile.js
+++ b/_build/templates/default/gruntfile.js
@@ -168,7 +168,7 @@ module.exports = function(grunt) {
 		watch: { /* trigger tasks on save */
 			scss: {
 				files: ['<%= dirs.scss %>/**/*'],
-				tasks: ['sass:dev', 'growl:sass']
+				tasks: ['sass:dev', 'notify:sass']
 			},
             css: {
                 options: {


### PR DESCRIPTION
### What does it do?
It replaces `growl` by `notify`

### Why is it needed?
To get the task `grunt watch` working.
It happened after replacing growl by notify by in one place I forgot to replace the call.

### Related issue(s)/PR(s)
#14315