### PR TITLE
Customized icons for content types

### DIFF
--- a/_build/data/transport.core.content_types.php
+++ b/_build/data/transport.core.content_types.php
@@ -6,6 +6,7 @@ $collection['1']->fromArray(array (
   'description' => 'HTML content',
   'mime_type' => 'text/html',
   'file_extensions' => '.html',
+  'icon' => '',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);
@@ -16,6 +17,7 @@ $collection['2']->fromArray(array (
   'description' => 'XML content',
   'mime_type' => 'text/xml',
   'file_extensions' => '.xml',
+  'icon' => 'icon-xml',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);
@@ -26,6 +28,7 @@ $collection['3']->fromArray(array (
   'description' => 'plain text content',
   'mime_type' => 'text/plain',
   'file_extensions' => '.txt',
+  'icon' => 'icon-txt',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);
@@ -36,6 +39,7 @@ $collection['4']->fromArray(array (
   'description' => 'CSS content',
   'mime_type' => 'text/css',
   'file_extensions' => '.css',
+  'icon' => 'icon-css',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);
@@ -46,6 +50,7 @@ $collection['5']->fromArray(array (
   'description' => 'javascript content',
   'mime_type' => 'text/javascript',
   'file_extensions' => '.js',
+  'icon' => 'icon-js',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);
@@ -56,6 +61,7 @@ $collection['6']->fromArray(array (
   'description' => 'For RSS feeds',
   'mime_type' => 'application/rss+xml',
   'file_extensions' => '.rss',
+  'icon' => 'icon-rss',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);
@@ -66,6 +72,7 @@ $collection['7']->fromArray(array (
   'description' => 'JSON',
   'mime_type' => 'application/json',
   'file_extensions' => '.json',
+  'icon' => 'icon-json',
   'headers' => 'NULL',
   'binary' => 0,
 ), '', true, true);
@@ -76,6 +83,7 @@ $collection['8']->fromArray(array (
   'description' => 'PDF Files',
   'mime_type' => 'application/pdf',
   'file_extensions' => '.pdf',
+  'icon' => 'icon-pdf',
   'headers' => 'NULL',
   'binary' => 1,
 ), '', true, true);

--- a/_build/data/transport.core.content_types.php
+++ b/_build/data/transport.core.content_types.php
@@ -24,8 +24,8 @@ $collection['2']->fromArray(array (
 $collection['3']= $xpdo->newObject('modContentType');
 $collection['3']->fromArray(array (
   'id' => 3,
-  'name' => 'text',
-  'description' => 'plain text content',
+  'name' => 'Text',
+  'description' => 'Plain text content',
   'mime_type' => 'text/plain',
   'file_extensions' => '.txt',
   'icon' => 'icon-txt',
@@ -46,8 +46,8 @@ $collection['4']->fromArray(array (
 $collection['5']= $xpdo->newObject('modContentType');
 $collection['5']->fromArray(array (
   'id' => 5,
-  'name' => 'javascript',
-  'description' => 'javascript content',
+  'name' => 'JavaScript',
+  'description' => 'JavaScript content',
   'mime_type' => 'text/javascript',
   'file_extensions' => '.js',
   'icon' => 'icon-js',

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -647,6 +647,7 @@
   content: fa-content($fa-var-file-code);
 }
 .icon-js:before,
+.icon-json:before,
 .icon-coffeescript:before {
   @extend %pseudo-font;
   content: fa-content($fa-var-file-code);

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -773,36 +773,6 @@
   width: 12px;
 }
 
-/* icons for the various tree elements */
-.tree-context:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-globe);
-}
-.x-tree-node-expanded .tree-folder:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-folder-open);
-}
-.tree-folder:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-folder);
-}
-.tree-resource:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-file);
-}
-.tree-static-resource:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-file-alt);
-}
-.tree-weblink:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-link);
-}
-.tree-symlink:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-copy);
-}
-
 .x-tree-node {
   color: $treeColor;
 }

--- a/core/model/modx/mysql/modcontenttype.map.inc.php
+++ b/core/model/modx/mysql/modcontenttype.map.inc.php
@@ -18,6 +18,7 @@ $xpdo_meta_map['modContentType']= array (
     'description' => NULL,
     'mime_type' => NULL,
     'file_extensions' => NULL,
+    'icon' => NULL,
     'headers' => NULL,
     'binary' => 0,
   ),

--- a/core/model/modx/mysql/modcontenttype.map.inc.php
+++ b/core/model/modx/mysql/modcontenttype.map.inc.php
@@ -47,6 +47,11 @@ $xpdo_meta_map['modContentType']= array (
       'dbtype' => 'tinytext',
       'phptype' => 'string',
     ),
+    'icon' =>
+    array(
+      'dbtype' => 'tinytext',
+      'phptype' => 'string',
+    ),
     'headers' => 
     array (
       'dbtype' => 'mediumtext',

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -436,11 +436,13 @@ class modResourceGetNodesProcessor extends modProcessor {
 
         $contentType = $resource->getOne('ContentType');
         if ($contentType && $contentType->get('icon')) {
+            $iconCls = [];
             $iconCls[] = $contentType->get('icon');
         }
 
         $template = $resource->getOne('Template');
         if ($template && $template->get('icon')) {
+            $iconCls = [];
             $iconCls[] = $template->get('icon');
         }
 

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -436,17 +436,15 @@ class modResourceGetNodesProcessor extends modProcessor {
 
         $contentType = $resource->getOne('ContentType');
         if ($contentType && $contentType->get('icon')) {
-            $iconCls = [];
-            $iconCls[] = $contentType->get('icon');
+            $iconCls = [$contentType->get('icon')];
         }
 
         $template = $resource->getOne('Template');
         if ($template && $template->get('icon')) {
-            $iconCls = [];
-            $iconCls[] = $template->get('icon');
+            $iconCls = [$template->get('icon')];
         }
 
-        if (!count($iconCls)) {
+        if (empty($iconCls)) {
             $iconCls[] = $this->modx->getOption('mgr_tree_icon_' . $classKey, null, 'tree-resource', true);
         }
 

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -426,21 +426,26 @@ class modResourceGetNodesProcessor extends modProcessor {
             }
         }
 
-        // Check for an icon class on the resource template
-        $tplIcon = $resource->Template ? $resource->Template->icon : '';
-
         // Assign an icon class based on the class_key
         $classKey = strtolower($resource->get('class_key'));
         if (substr($classKey, 0, 3) == 'mod') {
             $classKey = substr($classKey, 3);
         }
 
-        $classKeyIcon = $this->modx->getOption('mgr_tree_icon_' . $classKey, null, 'tree-resource', true);
+        $iconCls = [];
 
-        if (!empty($tplIcon)) {
-            $iconCls[] = $tplIcon;
-        } else {
-            $iconCls[] = $classKeyIcon;
+        $contentType = $resource->getOne('ContentType');
+        if ($contentType && $contentType->get('icon')) {
+            $iconCls[] = $contentType->get('icon');
+        }
+
+        $template = $resource->getOne('Template');
+        if ($template && $template->get('icon')) {
+            $iconCls[] = $template->get('icon');
+        }
+
+        if (!count($iconCls)) {
+            $iconCls[] = $this->modx->getOption('mgr_tree_icon_' . $classKey, null, 'tree-resource', true);
         }
 
         switch($classKey) {

--- a/core/model/modx/processors/system/contenttype/create.class.php
+++ b/core/model/modx/processors/system/contenttype/create.class.php
@@ -22,22 +22,22 @@
  * @package modx
  * @subpackage processors.system.contenttype
  */
-class modContentTypeCreateProcessor extends modObjectCreateProcessor {
+class modContentTypeCreateProcessor extends modObjectCreateProcessor
+{
     public $classKey = 'modContentType';
-    public $languageTopics = array('content_type');
+    public $languageTopics = ['content_type'];
     public $permission = 'content_types';
     public $objectType = 'content_type';
 
-    public function beforeSave() {
+    public function beforeSave()
+    {
+        $this->setCheckbox('binary');
+
         $headers = $this->modx->fromJSON($this->getProperty('headers', '[]'));
         $this->object->set('headers', $headers);
-
-        $binary = $this->getProperty('binary',null);
-        if ($binary !== null) {
-            $this->object->set('binary', ($binary == 'true'));
-        }
 
         return parent::beforeSave();
     }
 }
-return 'modContentTypeCreateProcessor';
+
+return modContentTypeCreateProcessor::class;

--- a/core/model/modx/processors/system/contenttype/update.class.php
+++ b/core/model/modx/processors/system/contenttype/update.class.php
@@ -26,20 +26,18 @@
  */
 class modContentTypeUpdateProcessor extends modObjectUpdateProcessor {
     public $classKey = 'modContentType';
-    public $languageTopics = array('content_type');
+    public $languageTopics = ['content_type'];
     public $permission = 'content_types';
     public $objectType = 'content_type';
 
     public $refreshURIs = false;
 
-    public function beforeSave() {
+    public function beforeSave()
+    {
+        $this->setCheckbox('binary');
+
         $headers = $this->modx->fromJSON($this->getProperty('headers', '[]'));
         $this->object->set('headers', $headers);
-
-        $binary = $this->getProperty('binary',null);
-        if ($binary !== null) {
-            $this->object->set('binary', ($binary == 'true'));
-        }
 
         $name = $this->getProperty('name');
         if (empty($name)) {
@@ -62,4 +60,4 @@ class modContentTypeUpdateProcessor extends modObjectUpdateProcessor {
         return parent::afterSave();
     }
 }
-return 'modContentTypeUpdateProcessor';
+return modContentTypeUpdateProcessor::class;

--- a/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
+++ b/core/model/modx/processors/system/contenttype/updatefromgrid.class.php
@@ -55,12 +55,12 @@ class modContentTypeUpdateFromGridProcessor extends modProcessor {
             return $this->failure($this->modx->lexicon('content_type_err_nfs', array('id', $field['id'])));
         };
 
-        /* save content type */
-        $field['binary'] = !empty($field['binary']) ? true : false;
+        $this->setCheckbox('binary');
+
         $contentType->fromArray($field);
 
         $refresh[] = $contentType->isDirty('file_extensions') && $this->modx->getCount('modResource', array('content_type' => $contentType->get('id')));
-        if ($contentType->save() == false) {
+        if ($contentType->save() === false) {
             $msg = $this->modx->error->checkValidation($contentType);
             return $this->failure(empty($mg) ? $this->modx->lexicon('content_type_err_save') : $msg);
         }
@@ -68,10 +68,10 @@ class modContentTypeUpdateFromGridProcessor extends modProcessor {
         /* log manager action */
         $this->modx->logManagerAction('content_type_save','modContentType',$contentType->get('id'));
 
-        if (array_search(true, $refresh, true) !== false) {
+        if (in_array(true, $refresh, true)) {
             $this->modx->call('modResource', 'refreshURIs', array(&$this->modx));
         }
         return $this->success();
     }
 }
-return 'modContentTypeUpdateFromGridProcessor';
+return modContentTypeUpdateFromGridProcessor::class;

--- a/core/model/modx/sqlsrv/modcontenttype.map.inc.php
+++ b/core/model/modx/sqlsrv/modcontenttype.map.inc.php
@@ -14,6 +14,7 @@ $xpdo_meta_map['modContentType']= array (
     'description' => NULL,
     'mime_type' => NULL,
     'file_extensions' => NULL,
+    'icon' => NULL,
     'headers' => NULL,
     'binary' => 0,
   ),

--- a/core/model/modx/sqlsrv/modcontenttype.map.inc.php
+++ b/core/model/modx/sqlsrv/modcontenttype.map.inc.php
@@ -46,6 +46,10 @@ $xpdo_meta_map['modContentType']= array (
       'precision' => '512',
       'phptype' => 'string',
     ),
+    array(
+      'dbtype' => 'tinytext',
+      'phptype' => 'string',
+    ),
     'headers' => 
     array (
       'dbtype' => 'nvarchar',

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -420,6 +420,7 @@
         <field key="description" dbtype="tinytext" phptype="string" null="true" />
         <field key="mime_type" dbtype="tinytext" phptype="string" />
         <field key="file_extensions" dbtype="tinytext" phptype="string" />
+        <field key="icon" dbtype="tinytext" phptype="string" null="true" />
         <field key="headers" dbtype="mediumtext" phptype="array" />
         <field key="binary" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
 

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -340,6 +340,7 @@
         <field key="description" dbtype="nvarchar" precision="512" phptype="string" null="true" />
         <field key="mime_type" dbtype="nvarchar" precision="512" phptype="string" />
         <field key="file_extensions" dbtype="nvarchar" precision="512" phptype="string" />
+        <field key="icon" dbtype="tinytext" phptype="string" null="true" />
         <field key="headers" dbtype="nvarchar" precision="max" phptype="array" />
         <field key="binary" dbtype="bit" phptype="boolean" null="false" default="0" />
 

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -245,7 +245,6 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         text = text || 'confirm_remove';
         var p = this.config.saveParams || {};
         Ext.apply(p,{ action: action || 'remove' });
-        //console.log(action, p);
         var k = this.config.primaryKey || 'id';
         p[k] = r[k];
 
@@ -1158,9 +1157,51 @@ Ext.preg('rowexpander', Ext.ux.grid.RowExpander);
 //backwards compat
 Ext.grid.RowExpander = Ext.ux.grid.RowExpander;
 
-Ext.ns('Ext.ux.grid');Ext.ux.grid.CheckColumn=function(a){Ext.apply(this,a);if(!this.id){this.id=Ext.id()}this.renderer=this.renderer.createDelegate(this)};Ext.ux.grid.CheckColumn.prototype={init:function(b){this.grid=b;this.grid.on('render',function(){var a=this.grid.getView();a.mainBody.on('mousedown',this.onMouseDown,this)},this);this.grid.on('destroy',this.onDestroy,this)},onMouseDown:function(e,t){this.grid.fireEvent('rowclick');if(t.className&&t.className.indexOf('x-grid3-cc-'+this.id)!=-1){e.stopEvent();var a=this.grid.getView().findRowIndex(t);var b=this.grid.store.getAt(a);b.set(this.dataIndex,!b.data[this.dataIndex]);this.grid.fireEvent('afteredit')}},renderer:function(v,p,a){p.css+=' x-grid3-check-col-td';return'<div class="x-grid3-check-col'+(v?'-on':'')+' x-grid3-cc-'+this.id+'">&#160;</div>'},onDestroy:function(){var mainBody = this.grid.getView().mainBody;
-        if(mainBody){
+Ext.ns('Ext.ux.grid');
+
+Ext.ux.grid.CheckColumn = function (a) {
+    Ext.apply(this, a);
+    if (!this.id) {
+        this.id = Ext.id()
+    }
+    this.renderer = this.renderer.createDelegate(this)
+};
+Ext.ux.grid.CheckColumn.prototype = {
+    init: function (b) {
+        this.grid = b;
+        this.grid.on('render', function () {
+            var a = this.grid.getView();
+            a.mainBody.on('mousedown', this.onMouseDown, this)
+        }, this);
+        this.grid.on('destroy', this.onDestroy, this)
+    }, onMouseDown: function (e, t) {
+        this.grid.fireEvent('rowclick');
+        if (t.className && t.className.indexOf('x-grid3-cc-' + this.id) != -1) {
+            e.stopEvent();
+            var a = this.grid.getView().findRowIndex(t);
+            var b = this.grid.store.getAt(a);
+            var sv = b.data[this.dataIndex];
+            b.set(this.dataIndex, !sv);
+            this.grid.fireEvent('afteredit', {
+                grid: this.grid,
+                record: b,
+                field: this.dataIndex,
+                originalValue: sv,
+                value: b.data[this.dataIndex],
+                cancel: false
+            });
+        }
+    }, renderer: function (v, p, a) {
+        p.css += ' x-grid3-check-col-td';
+        return '<div class="x-grid3-check-col' + (v ? '-on' : '') + ' x-grid3-cc-' + this.id + '">&#160;</div>'
+    }, onDestroy: function () {
+        var mainBody = this.grid.getView().mainBody;
+        if (mainBody) {
             mainBody.un('mousedown', this.onMouseDown, this);
-        }}};Ext.preg('checkcolumn',Ext.ux.grid.CheckColumn);Ext.grid.CheckColumn=Ext.ux.grid.CheckColumn;
+        }
+    }
+};
+Ext.preg('checkcolumn', Ext.ux.grid.CheckColumn);
+Ext.grid.CheckColumn = Ext.ux.grid.CheckColumn;
 
 Ext.grid.PropertyColumnModel=function(a,b){var g=Ext.grid,f=Ext.form;this.grid=a;g.PropertyColumnModel.superclass.constructor.call(this,[{header:this.nameText,width:50,sortable:true,dataIndex:'name',id:'name',menuDisabled:true},{header:this.valueText,width:50,resizable:false,dataIndex:'value',id:'value',menuDisabled:true}]);this.store=b;var c=new f.Field({autoCreate:{tag:'select',children:[{tag:'option',value:'true',html:'true'},{tag:'option',value:'false',html:'false'}]},getValue:function(){return this.el.dom.value=='true'}});this.editors={'date':new g.GridEditor(new f.DateField({selectOnFocus:true})),'string':new g.GridEditor(new f.TextField({selectOnFocus:true})),'number':new g.GridEditor(new f.NumberField({selectOnFocus:true,style:'text-align:left;'})),'boolean':new g.GridEditor(c)};this.renderCellDelegate=this.renderCell.createDelegate(this);this.renderPropDelegate=this.renderProp.createDelegate(this)};Ext.extend(Ext.grid.PropertyColumnModel,Ext.grid.ColumnModel,{nameText:'Name',valueText:'Value',dateFormat:'m/j/Y',renderDate:function(a){return a.dateFormat(this.dateFormat)},renderBool:function(a){return a?'true':'false'},isCellEditable:function(a,b){return a==1},getRenderer:function(a){return a==1?this.renderCellDelegate:this.renderPropDelegate},renderProp:function(v){return this.getPropertyName(v)},renderCell:function(a){var b=a;if(Ext.isDate(a)){b=this.renderDate(a)}else if(typeof a=='boolean'){b=this.renderBool(a)}return Ext.util.Format.htmlEncode(b)},getPropertyName:function(a){var b=this.grid.propertyNames;return b&&b[a]?b[a]:a},getCellEditor:function(a,b){var p=this.store.getProperty(b),n=p.data.name,val=p.data.value;if(this.grid.customEditors[n]){return this.grid.customEditors[n]}if(Ext.isDate(val)){return this.editors.date}else if(typeof val=='number'){return this.editors.number}else if(typeof val=='boolean'){return this.editors['boolean']}else{return this.editors.string}},destroy:function(){Ext.grid.PropertyColumnModel.superclass.destroy.call(this);for(var a in this.editors){Ext.destroy(a)}}});

--- a/manager/assets/modext/widgets/system/modx.grid.content.type.js
+++ b/manager/assets/modext/widgets/system/modx.grid.content.type.js
@@ -148,11 +148,10 @@ Ext.extend(MODx.grid.ContentType,MODx.grid.Grid,{
     }
 
     ,renderIconField: function (v, md, rec) {
-        return new Ext.XTemplate('<i class="icon icon-lg {icon}"></i>&nbsp;&nbsp; {icon}').apply(rec.data);
+        return new Ext.XTemplate('<i class="icon icon-lg {icon:htmlEncode}"></i>&nbsp;&nbsp; {icon:htmlEncode}').apply(rec.data);
     }
 });
-Ext.reg('modx-grid-content-type',MODx.grid.ContentType);
-
+Ext.reg('modx-grid-content-type', MODx.grid.ContentType);
 
 /**
  * Generates the ContentType window.

--- a/setup/includes/upgrades/common/3.0.0-content-type-icon.php
+++ b/setup/includes/upgrades/common/3.0.0-content-type-icon.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Upgrade script for adding icon field to content types.
+ *
+ * @var modX
+ * @package setup
+ */
+
+$class = 'modContentType';
+$column = 'icon';
+
+$table = $modx->getTableName($class);
+$description = $this->install->lexicon('add_column', ['column' => $column, 'table' => $table]);
+$this->processResults($class, $description, [$modx->manager, 'addField'], [$class, $column]);

--- a/setup/includes/upgrades/common/3.0.0-content-type-icon.php
+++ b/setup/includes/upgrades/common/3.0.0-content-type-icon.php
@@ -12,3 +12,30 @@ $column = 'icon';
 $table = $modx->getTableName($class);
 $description = $this->install->lexicon('add_column', ['column' => $column, 'table' => $table]);
 $this->processResults($class, $description, [$modx->manager, 'addField'], [$class, $column]);
+
+
+$map = [
+    'text/html' => '',
+    'text/xml' => 'icon-xml',
+    'text/plain' => 'icon-txt',
+    'text/css' => 'icon-css',
+    'text/javascript' => 'icon-js',
+    'application/rss+xml' => 'icon-rss',
+    'application/json' => 'icon-json',
+    'application/pdf' => 'icon-pdf',
+];
+
+$succeeded = $failed = 0;
+
+/** @var modContentType $contentType */
+foreach ($modx->getIterator($class) as $contentType) {
+    $data = $contentType->toArray();
+    $defaultValue = array_key_exists($data['mime_type'], $map)
+        ? $map[$data['mime_type']]
+        : '';
+
+    if (empty($data['icon'])) {
+        $contentType->set($column, $defaultValue);
+        $contentType->save();
+    }
+}

--- a/setup/includes/upgrades/common/3.0.0-content-type-icon.php
+++ b/setup/includes/upgrades/common/3.0.0-content-type-icon.php
@@ -29,12 +29,12 @@ $succeeded = $failed = 0;
 
 /** @var modContentType $contentType */
 foreach ($modx->getIterator($class) as $contentType) {
-    $data = $contentType->toArray();
-    $defaultValue = array_key_exists($data['mime_type'], $map)
-        ? $map[$data['mime_type']]
+    $mimeType = $contentType->get('mime_type');
+    $defaultValue = array_key_exists($mimeType, $map)
+        ? $map[$mimeType]
         : '';
 
-    if (empty($data['icon'])) {
+    if (empty($contentType->get('icon'))) {
         $contentType->set($column, $defaultValue);
         $contentType->save();
     }

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -8,8 +8,9 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(__DIR__) . '/common/3.0.0-remove-copy-to-clipboard.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
+include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -8,8 +8,9 @@
  */
 
 /* run upgrades common to all db platforms */
-include dirname(dirname(__FILE__)) . '/common/3.0.0-dashboard-widgets.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
-include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-dashboard-widgets.php';
+include dirname(__DIR__) . '/common/3.0.0-remove-copy-to-clipboard.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
+include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';


### PR DESCRIPTION
### What does it do?
It adds to content types new field (column) with icon class that will be shown in the resource tree.

Also, during work on this, I've fixed one issue about updating grid when CheckColumn plugin is used. See details in https://github.com/modxcms/revolution/pull/14383/commits/4a89afe8453d6c7bb180ad0ad906c05f086774cf

### Why is it needed?
It will allow to easier determine that resource has a different content type. 
NOTE: Template icon can override the content type icon as content type more basic entity than a template.

For HTML content type icon is set to empty to not change existing condition.

Small animation about how it works.

![content-type-icons](https://user-images.githubusercontent.com/303498/52955433-b02afc80-339d-11e9-9059-c6bdac842345.gif)


### Related issue(s)/PR(s)
#4841
