### PR TITLE
Fix the bug with copying TVs when caption is empty

### DIFF
--- a/core/model/modx/processors/element/tv/duplicate.class.php
+++ b/core/model/modx/processors/element/tv/duplicate.class.php
@@ -116,20 +116,6 @@ class modTemplateVarDuplicateProcessor extends modElementDuplicateProcessor {
     }
 
     /**
-     * Get the new caption for the duplicate
-     * @return string
-     */
-    public function getNewCaption()
-    {
-        $caption = $this->getProperty($this->captionField);
-        $newCaption = !empty($caption)
-            ? $caption
-            : $this->modx->lexicon('duplicate_of', array('name' => $this->object->get($this->captionField)));
-
-        return $newCaption;
-    }
-
-    /**
      * Set the new caption to the new object
      * @param $caption
      * @return string
@@ -146,7 +132,7 @@ class modTemplateVarDuplicateProcessor extends modElementDuplicateProcessor {
      */
     public function beforeSave()
     {
-        $caption = $this->getNewCaption();
+        $caption = $this->getProperty($this->captionField);
         $this->setNewCaption($caption);
 
         return parent::beforeSave();

--- a/core/model/modx/processors/element/tv/duplicate.class.php
+++ b/core/model/modx/processors/element/tv/duplicate.class.php
@@ -116,6 +116,15 @@ class modTemplateVarDuplicateProcessor extends modElementDuplicateProcessor {
     }
 
     /**
+     * Get the new caption for the duplicate
+     * @return string
+     */
+    public function getNewCaption()
+    {
+        return $this->getProperty($this->captionField);
+    }
+
+    /**
      * Set the new caption to the new object
      * @param $caption
      * @return string
@@ -132,7 +141,7 @@ class modTemplateVarDuplicateProcessor extends modElementDuplicateProcessor {
      */
     public function beforeSave()
     {
-        $caption = $this->getProperty($this->captionField);
+        $caption = $this->getNewCaption();
         $this->setNewCaption($caption);
 
         return parent::beforeSave();


### PR DESCRIPTION
### What does it do?
Removing a check for the presence of a caption field

### Why is it needed?
Caption field for TV is not required and may be empty. So, during copying if you leave the field blank, then be written "Copy (TV caption)"

### Related issue(s)/PR(s)
Closes #14381 