### PR TITLE
Change the RSS feed URLs to HTTPS

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -558,7 +558,7 @@ $settings['fe_editor_lang']->fromArray(array (
 $settings['feed_modx_news']= $xpdo->newObject('modSystemSetting');
 $settings['feed_modx_news']->fromArray(array (
   'key' => 'feed_modx_news',
-  'value' => 'http://feeds.feedburner.com/modx-announce',
+  'value' => 'https://feeds.feedburner.com/modx-announce',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',
@@ -576,7 +576,7 @@ $settings['feed_modx_news_enabled']->fromArray(array (
 $settings['feed_modx_security']= $xpdo->newObject('modSystemSetting');
 $settings['feed_modx_security']->fromArray(array (
   'key' => 'feed_modx_security',
-  'value' => 'http://forums.modx.com/board.xml?board=294',
+  'value' => 'https://forums.modx.com/board.xml?board=294',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',

--- a/setup/includes/upgrades/common/2.7.2-feed-modx-https.php
+++ b/setup/includes/upgrades/common/2.7.2-feed-modx-https.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Update the RSS feed URLs to HTTPS
+ */
+
+/** @var modSystemSetting $feed_modx_security */
+$feed_modx_security = $modx->getObject('modSystemSetting', array(
+    'key' => 'feed_modx_security',
+    'value' => 'http://forums.modx.com/board.xml?board=294',
+));
+if ($feed_modx_security) {
+    $feed_modx_security->set('value', 'https://forums.modx.com/board.xml?board=294');
+    $feed_modx_security->save();
+}
+
+/** @var modSystemSetting $feed_modx_news */
+$feed_modx_news = $modx->getObject('modSystemSetting', array(
+    'key' => 'feed_modx_news',
+    'value' => 'http://feeds.feedburner.com/modx-announce',
+));
+if ($feed_modx_news) {
+    $feed_modx_news->set('value', 'https://feeds.feedburner.com/modx-announce');
+    $feed_modx_news->save();
+}

--- a/setup/includes/upgrades/mysql/2.7.2-pl.php
+++ b/setup/includes/upgrades/mysql/2.7.2-pl.php
@@ -1,0 +1,3 @@
+<?php
+/* run upgrades common to all db platforms */
+include dirname(dirname(__FILE__)) . '/common/2.7.2-feed-modx-https.php';

--- a/setup/includes/upgrades/sqlsrv/2.7.2-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.7.2-pl.php
@@ -1,0 +1,3 @@
+<?php
+/* run upgrades common to all db platforms */
+include dirname(dirname(__FILE__)) . '/common/2.7.2-feed-modx-https.php';


### PR DESCRIPTION
### What does it do?
Change the feed links to https for the system settings `feed_modx_security` and `feed_modx_news`.

### Why is it needed?
To reduce the chance of a MITM-attack.

### Related issue(s)/PR(s)
#14390