### PR TITLE
Don't execute the upgrade script for the last installed version again

### DIFF
--- a/setup/includes/modinstallversion.class.php
+++ b/setup/includes/modinstallversion.class.php
@@ -125,7 +125,7 @@ class modInstallVersion {
                 if (is_dir($path.$script)) continue;
                 $sc = str_replace('.php','',$script);
 
-                if (version_compare($this->version,$sc,'<=')) {
+                if (version_compare($this->version,$sc,'<')) {
                     $scripts[] = $path.$sc.'.php';
                 }
             }


### PR DESCRIPTION
### What does it do?
Fix the version compare for detecting the needed upgrade scripts.

### Why is it needed?
The scripts of the last installed version are executed again because of the equal sign. With the change only the scripts larger than the last installed version are executed.

### Related issue(s)/PR(s)
#14382 