### PR TITLE
Fix modprocessor and modconnectorresponse deprecated create_function()

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -266,7 +266,7 @@ class modConnectorResponse extends modResponse {
         $pattern = '/"@@(.*?)@@"/';
         $string = preg_replace_callback(
             $pattern,
-            create_function('$matches', 'return base64_decode($matches[1]);'),
+            function ($matches) { return base64_decode($matches[1]); },
             $string
         );
         return $string;

--- a/core/model/modx/modprocessor.class.php
+++ b/core/model/modx/modprocessor.class.php
@@ -308,7 +308,7 @@ abstract class modProcessor {
         $pattern = '/"@@(.*?)@@"/';
         $string = preg_replace_callback(
             $pattern,
-            create_function('$matches', 'return base64_decode($matches[1]);'),
+            function ($matches) { return base64_decode($matches[1]); },
             $string
         );
         return $string;


### PR DESCRIPTION
### What does it do?
Change preg_replace_callback call with deprecated create_function() with new one with anonymous function.

### Why is it needed?
Due to multiple warning in log "(WARN @\www\core\model\modx\modprocessor.class.php : 314) PHP deprecated: Function create_function() is deprecated" and the fact that "This function create_function() has been deprecated as of PHP 7.2.0. Relying on this function is highly discouraged." I think better to fix it.

### Related issue(s)/PR(s)
I've made a search through opened issues and pull requests and didn't find any.