### PR TITLE
Fix, added escape field content for tooltip

### DIFF
--- a/core/model/modx/processors/resource/trash/getlist.class.php
+++ b/core/model/modx/processors/resource/trash/getlist.class.php
@@ -100,6 +100,7 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
         $charset = $this->modx->getOption('modx_charset', null, 'UTF-8');
         $objectArray = $object->toArray();
         $objectArray['pagetitle'] = htmlentities($objectArray['pagetitle'], ENT_COMPAT, $charset);
+        $objectArray['content'] = htmlentities($objectArray['content'], ENT_COMPAT, $charset);
 
         // to enable a better detection of the resource's location, we also construct the
         // parent-child path to the resource

--- a/manager/assets/modext/widgets/resource/modx.grid.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.trash.js
@@ -469,6 +469,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
                 + ((record.json.longtitle) ? '<p><strong>' + _('long_title') + ':</strong> ' + record.json.longtitle + '</p>' : '')
                 + ((record.data.parentPath) ? '<p><strong>' + _('trash.parent_path') + ':</strong> ' + record.data.parentPath + '</p>' : '')
                 + ((record.json.content) ? '<p><strong>' + _('content') + ':</strong> ' + Ext.util.Format.ellipsis(record.json.content.replace(/<\/?[^>]+>/gi, ''), 100) + '</p>' : '');
+            preview = Ext.util.Format.htmlEncode(preview);
             return '<div ext:qtip="' + preview + '">' + value + '</div>';
         } else {
             return '';


### PR DESCRIPTION
### What does it do?
Added escape html entities on server-side in processor trash/getlist and on frontend in renderTooltip

### Why is it needed?
![image](https://user-images.githubusercontent.com/13381556/52912471-037c4c80-32c3-11e9-9648-ceb75629fa39.png)

### Related issue(s)/PR(s)
#14338 