### PR TITLE
Fix Duplicate behavior on resource update page

### DIFF
--- a/core/lexicon/en/resource.inc.php
+++ b/core/lexicon/en/resource.inc.php
@@ -48,7 +48,6 @@ $_lang['resource_delete_confirm'] = 'Are you sure you want to delete this resour
 $_lang['resource_description'] = 'Description';
 $_lang['resource_description_help'] = 'This is an optional description of the resource.';
 $_lang['resource_duplicate'] = 'Duplicate';
-$_lang['resource_duplicate_confirm'] = 'Are you sure you want to duplicate this resource? Any item(s) it contains will also be duplicated.';
 $_lang['resource_edit'] = 'Edit';
 $_lang['resource_editedby'] = 'Edited By';
 $_lang['resource_editedon'] = 'Edited On';

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -55,8 +55,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
     ,duplicateResource: function(btn,e) {
         var t = Ext.getCmp('modx-resource-tree');
         var id = this.config.resource;
-        var nodeId = this.config.record.context_key + '_' + id;
-        var node = t.getNodeById(nodeId);
+        var node = t.getNodeById(this.config.record.context_key + '_' + id);
 
         var r = {
             resource: id
@@ -69,7 +68,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             ,hasChildren: node ? node.attributes.hasChildren : false
             ,childCount: node ? node.attributes.childCount : 0
             ,listeners: {
-                'success': {fn:function(r) {
+                success: {fn:function(r) {
                     MODx.loadPage('resource/update', 'id='+r.a.result.object.id);
                 },scope:this}
             }

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -53,19 +53,30 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
     }
 
     ,duplicateResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_duplicate_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/duplicate'
-                ,id: this.config.resource
-            }
+        var t = Ext.getCmp('modx-resource-tree');
+        var id = this.config.resource;
+        var nodeId = this.config.record.context_key + '_' + id;
+        var node = t.getNodeById(nodeId);
+
+        var r = {
+            resource: id
+            ,is_folder: node ? node.getUI().hasClass('folder') : this.config.record.isfolder
+        };
+        var w = MODx.load({
+            xtype: 'modx-window-resource-duplicate'
+            ,resource: this.config.resource
+            ,pagetitle: this.config.record.pagetitle
+            ,hasChildren: node ? node.attributes.hasChildren : false
+            ,childCount: node ? node.attributes.childCount : 0
             ,listeners: {
-                success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
+                'success': {fn:function(r) {
+                    MODx.loadPage('resource/update', 'id='+r.a.result.object.id);
                 },scope:this}
             }
         });
+        w.config.hasChildren = node ? node.attributes.hasChildren : false;
+        w.setValues(r);
+        w.show(e.target);
     }
 
     ,deleteResource: function(btn,e) {


### PR DESCRIPTION
### What does it do?
Adds normal dialog option like duplicating via context menu in resource tree

![ux](https://user-images.githubusercontent.com/20814058/52916667-03a53800-3315-11e9-88f5-3412ba427326.gif)

### Why is it needed?
Description from related issue #4834 

> Duplicating a resource behaves inconsistently when used via context menu in resource tree and via a button on resource edit form. The former opens a dialog with option to include children resources and setting title for a duplicate and allows to cancel duplication. The latter issues warning about all child resources being duplicated and creates new resource. User is presented with a form for a new resource and if cancels edition an empty untitled resource is left.
>
> Both should have the same behavior of the former (there was an issue for it), ie. context menu command.

### Note for testers
1. There are a few bugs, but they are not related to this PR. Later, I or someone will post the issues.
2. Checks for the existance on node in this PR are needed for these cases when resource hide in tree (for example: miniShop2 uses show in tree 0 to hide products).

### Related issue(s)/PR(s)
Closes #4834 
