### PR TITLE
Refactored behavior for duplicating resources and elements

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -133,7 +133,6 @@ $_lang['edit_tv'] = 'Edit TV';
 $_lang['editing'] = 'Editing: [[+name]]';
 $_lang['editedon'] = 'Edit Date';
 $_lang['editing_form'] = 'Editing Form';
-$_lang['element_duplicate'] = 'Duplicate Element';
 $_lang['element_duplicate_values'] = 'Duplicate Resource Values?';
 $_lang['element_name_new'] = 'Name of New Element';
 $_lang['element_caption_new'] = 'Caption of New Element';

--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -121,6 +121,7 @@ $_lang['duplicate_plugin'] = 'Duplicate Plugin';
 $_lang['duplicate_snippet'] = 'Duplicate Snippet';
 $_lang['duplicate_template'] = 'Duplicate Template';
 $_lang['duplicate_tv'] = 'Duplicate TV';
+$_lang['duplicate_redirect'] = 'Redirect to duplicate';
 $_lang['duplication_options'] = 'Duplication Options';
 $_lang['edit'] = 'Edit';
 $_lang['edit_chunk'] = 'Edit Chunk';

--- a/core/lexicon/en/resource.inc.php
+++ b/core/lexicon/en/resource.inc.php
@@ -48,7 +48,6 @@ $_lang['resource_delete_confirm'] = 'Are you sure you want to delete this resour
 $_lang['resource_description'] = 'Description';
 $_lang['resource_description_help'] = 'This is an optional description of the resource.';
 $_lang['resource_duplicate'] = 'Duplicate';
-$_lang['resource_duplicate_confirm'] = 'Are you sure you want to duplicate this resource? Any item(s) it contains will also be duplicated.';
 $_lang['resource_edit'] = 'Edit';
 $_lang['resource_editedby'] = 'Edited By';
 $_lang['resource_editedon'] = 'Edited On';

--- a/core/lexicon/ru/default.inc.php
+++ b/core/lexicon/ru/default.inc.php
@@ -133,6 +133,7 @@ $_lang['edit_tv'] = 'Редактировать TV';
 $_lang['editing'] = 'Редактируем: [[+name]]';
 $_lang['editedon'] = 'Редактировать дату';
 $_lang['editing_form'] = 'Редактирование формы';
+$_lang['element_duplicate'] = 'Копировать элемент';
 $_lang['element_duplicate_values'] = 'Копировать значения?';
 $_lang['element_name_new'] = 'Имя нового элемента';
 $_lang['element_caption_new'] = 'Заголовок нового элемента';

--- a/core/lexicon/ru/default.inc.php
+++ b/core/lexicon/ru/default.inc.php
@@ -133,7 +133,6 @@ $_lang['edit_tv'] = 'Редактировать TV';
 $_lang['editing'] = 'Редактируем: [[+name]]';
 $_lang['editedon'] = 'Редактировать дату';
 $_lang['editing_form'] = 'Редактирование формы';
-$_lang['element_duplicate'] = 'Копировать элемент';
 $_lang['element_duplicate_values'] = 'Копировать значения?';
 $_lang['element_name_new'] = 'Имя нового элемента';
 $_lang['element_caption_new'] = 'Заголовок нового элемента';

--- a/core/model/modx/processors/element/duplicate.class.php
+++ b/core/model/modx/processors/element/duplicate.class.php
@@ -17,7 +17,9 @@
  */
 class modElementDuplicateProcessor extends modObjectDuplicateProcessor {
     public function cleanup() {
-        return $this->success('',$this->newObject->get(array('id', 'name', 'description', 'category', 'locked')));
+        $fields = $this->newObject->get(array('id', 'name', 'description', 'category', 'locked'));
+        $fields['redirect'] = (boolean) $this->getProperty('redirect');
+        return $this->success('',$fields);
     }
 
     public function afterSave() {

--- a/core/model/modx/processors/element/duplicate.class.php
+++ b/core/model/modx/processors/element/duplicate.class.php
@@ -18,7 +18,7 @@
 class modElementDuplicateProcessor extends modObjectDuplicateProcessor {
     public function cleanup() {
         $fields = $this->newObject->get(array('id', 'name', 'description', 'category', 'locked'));
-        $fields['redirect'] = (boolean) $this->getProperty('redirect');
+        $fields['redirect'] = (boolean) $this->getProperty('redirect',false);
         return $this->success('',$fields);
     }
 

--- a/core/model/modx/processors/resource/duplicate.class.php
+++ b/core/model/modx/processors/resource/duplicate.class.php
@@ -74,7 +74,10 @@ class modResourceDuplicateProcessor extends modProcessor {
         $this->fireDuplicateEvent();
         $this->logManagerAction();
 
-        return $this->success('', array ('id' => $this->newResource->get('id')));
+        return $this->success('', array(
+            'id' => $this->newResource->get('id'),
+            'redirect' => (boolean) $this->getProperty('redirect',false),
+        ));
     }
 
     /**

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -61,11 +61,19 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec
+            ,redirect: true
             ,listeners: {
                 success: {
                     fn: function(r) {
                         var response = Ext.decode(r.a.response.responseText);
-                        MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        if (response.object.redirect) {
+                            MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        } else {
+                            var t = Ext.getCmp('modx-tree-element');
+                            if (t && t.rendered) {
+                                t.refresh();
+                            }
+                        }
                     },scope:this}
                 ,hide:{fn:function() {this.destroy();}}
             }

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -61,11 +61,19 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec
+            ,redirect: true
             ,listeners: {
                 success: {
                     fn: function(r) {
                         var response = Ext.decode(r.a.response.responseText);
-                        MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        if (response.object.redirect) {
+                            MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        } else {
+                            var t = Ext.getCmp('modx-tree-element');
+                            if (t && t.rendered) {
+                                t.refresh();
+                            }
+                        }
                     },scope:this}
                 ,hide:{fn:function() {this.destroy();}}
             }

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -61,11 +61,19 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec
+            ,redirect: true
             ,listeners: {
                 success: {
                     fn: function(r) {
                         var response = Ext.decode(r.a.response.responseText);
-                        MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        if (response.object.redirect) {
+                            MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        } else {
+                            var t = Ext.getCmp('modx-tree-element');
+                            if (t && t.rendered) {
+                                t.refresh();
+                            }
+                        }
                     },scope:this}
                 ,hide:{fn:function() {this.destroy();}}
             }

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -61,11 +61,19 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec
+            ,redirect: true
             ,listeners: {
                 success: {
                     fn: function(r) {
                         var response = Ext.decode(r.a.response.responseText);
-                        MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        if (response.object.redirect) {
+                            MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        } else {
+                            var t = Ext.getCmp('modx-tree-element');
+                            if (t && t.rendered) {
+                                t.refresh();
+                            }
+                        }
                     },scope:this}
                 ,hide:{fn:function() {this.destroy();}}
             }

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -62,11 +62,19 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec
+            ,redirect: true
             ,listeners: {
                 success: {
                     fn: function(r) {
                         var response = Ext.decode(r.a.response.responseText);
-                        MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        if (response.object.redirect) {
+                            MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                        } else {
+                            var t = Ext.getCmp('modx-tree-element');
+                            if (t && t.rendered) {
+                                t.refresh();
+                            }
+                        }
                     },scope:this}
                 ,hide:{fn:function() {this.destroy();}}
             }

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -55,19 +55,44 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
     }
 
     ,duplicateResource: function(btn,e) {
-        MODx.msg.confirm({
-            text: _('resource_duplicate_confirm')
-            ,url: MODx.config.connector_url
-            ,params: {
-                action: 'resource/duplicate'
-                ,id: this.config.resource
-            }
+        var t = Ext.getCmp('modx-resource-tree');
+        var id = this.config.resource;
+        var node = t.getNodeById(this.config.record.context_key + '_' + id);
+
+        var r = {
+            resource: id
+            ,pagetitle: this.config.record.pagetitle
+            ,hasChildren: false
+            ,is_folder: this.config.record.isfolder
+        };
+
+        if (node) {
+            r.pagetitle = node.ui.textNode.innerText;
+            r.hasChildren = node.attributes.hasChildren;
+            r.childCount = node.attributes.childCount;
+            r.is_folder = node.getUI().hasClass('folder');
+        }
+        var w = MODx.load({
+            xtype: 'modx-window-resource-duplicate'
+            ,resource: id
+            ,pagetitle: r.pagetitle
+            ,hasChildren: r.hasChildren
+            ,childCount: r.childCount
+            ,redirect: true
             ,listeners: {
                 success: {fn:function(r) {
-                    MODx.loadPage('resource/update', 'id='+r.object.id);
+                    var response = Ext.decode(r.a.response.responseText);
+                    if (response.object.redirect) {
+                        MODx.loadPage('resource/update', 'id='+response.object.id);
+                    } else if (node) {
+                        node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
+                        t.refreshNode(node.id);
+                    }
                 },scope:this}
             }
         });
+        w.setValues(r);
+        w.show(e.target);
     }
 
     ,deleteResource: function(btn,e) {

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -156,7 +156,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             }
             ,listeners: {
                 'success': {fn:function(results) {
-                    var r = {
+                    var rec = {
                         id: id
                         ,type: type
                         ,name: _('duplicate_of',{name: this.cm.activeNode.attributes.name})
@@ -168,9 +168,18 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                     };
                     var w = MODx.load({
                         xtype: 'modx-window-element-duplicate'
-                        ,record: r
+                        ,record: rec
+                        ,redirect: false
                         ,listeners: {
-                            'success': {fn:function() {this.refreshNode(this.cm.activeNode.id);},scope:this}
+                            'success': {
+                                fn:function(r) {
+                                    var response = Ext.decode(r.a.response.responseText);
+                                    if (response.object.redirect) {
+                                        MODx.loadPage('element/'+ rec.type +'/update', 'id='+ response.object.id);
+                                    } else {
+                                        this.refreshNode(this.cm.activeNode.id)
+                                    };
+                                },scope:this}
                             ,'hide':{fn:function() {this.destroy();}}
                         }
                     });

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -149,12 +149,17 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,pagetitle: name
             ,hasChildren: node.attributes.hasChildren
             ,childCount: node.attributes.childCount
+            ,redirect: false
             ,listeners: {
-                'success': {fn:function() {
-                    node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
-                    this.refreshNode(node.id);
-                },scope:this
-                }
+                'success': {fn:function(r) {
+                    var response = Ext.decode(r.a.response.responseText);
+                    if (response.object.redirect) {
+                        MODx.loadPage('resource/update', 'id='+response.object.id);
+                    } else {
+                        node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
+                        this.refreshNode(node.id);
+                    }
+                },scope:this}
             }
         });
         w.config.hasChildren = node.attributes.hasChildren;

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -44,15 +44,6 @@ Ext.extend(MODx.window.DuplicateResource,MODx.Window,{
                 ,name: 'duplicate_children'
                 ,id: 'modx-'+this.ident+'-duplicate-children'
                 ,checked: true
-                ,listeners: {
-                    'check': {fn: function(cb,checked) {
-                        if (checked) {
-                            this.fp.getForm().findField('modx-'+this.ident+'-name').disable();
-                        } else {
-                            this.fp.getForm().findField('modx-'+this.ident+'-name').enable();
-                        }
-                    },scope:this}
-                }
             });
         }
 

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -56,6 +56,15 @@ Ext.extend(MODx.window.DuplicateResource,MODx.Window,{
             });
         }
 
+        items.push({
+            xtype: 'xcheckbox'
+            ,boxLabel: _('duplicate_redirect')
+            ,hideLabel: true
+            ,name: 'redirect'
+            ,id: 'modx-'+this.ident+'-duplicate-redirect'
+            ,checked: this.config.redirect
+        });
+
         var pov = MODx.config.default_duplicate_publish_option || 'preserve';
         items.push({
             xtype: 'fieldset'
@@ -112,8 +121,8 @@ Ext.reg('modx-window-resource-duplicate',MODx.window.DuplicateResource);
  */
 MODx.window.DuplicateElement = function(config) {
     config = config || {};
-
     this.ident = config.ident || 'dupeel-'+Ext.id();
+    
     var flds = [{
         xtype: 'hidden'
         ,name: 'id'
@@ -122,7 +131,7 @@ MODx.window.DuplicateElement = function(config) {
         xtype: 'hidden'
         ,name: 'source'
         ,id: 'modx-'+this.ident+'-source'
-    }, {
+    },{
         xtype: 'textfield'
         ,fieldLabel: _('element_name_new')
         ,name: config.record.type == 'template' ? 'templatename' : 'name'
@@ -149,7 +158,8 @@ MODx.window.DuplicateElement = function(config) {
         });
         flds.push({
             xtype: 'xcheckbox'
-            ,fieldLabel: _('element_duplicate_values')
+            ,hideLabel: true
+            ,boxLabel: _('element_duplicate_values')
             ,labelSeparator: ''
             ,name: 'duplicateValues'
             ,id: 'modx-'+this.ident+'-duplicate-values'
@@ -161,17 +171,25 @@ MODx.window.DuplicateElement = function(config) {
 
     if (config.record.static === true) {
         flds.push({
-                xtype: 'textfield'
-                ,fieldLabel: _('static_file')
-                ,name: 'static_file'
-                ,id: 'modx-'+this.ident+'-static_file'
-                ,anchor: '100%'
-            }
-        );
+            xtype: 'textfield'
+            ,fieldLabel: _('static_file')
+            ,name: 'static_file'
+            ,id: 'modx-'+this.ident+'-static_file'
+            ,anchor: '100%'
+        });
     }
 
+    flds.push({
+        xtype: 'xcheckbox'
+        ,boxLabel: _('duplicate_redirect')
+        ,hideLabel: true
+        ,name: 'redirect'
+        ,id: 'modx-'+this.ident+'-duplicate-redirect'
+        ,checked: config.redirect
+    });
+
     Ext.applyIf(config,{
-        title: _('element_duplicate')
+        title: _('duplicate_'+config.record.type)
         ,url: MODx.config.connector_url
         ,action: 'element/'+config.record.type+'/duplicate'
         ,width: 600


### PR DESCRIPTION
### What does it do?
1. Adds normal resource duplication dialog like duplicating via context menu in resource tree
2. Adds new **redirect to duplicate** option before duplicating resources and elements (Templates, TVs, Chunks, Snippets and Plugins)
3. Fixs misbehavior duplicate children checkbox
4. Adds related headers for duplicating modal

![ux](https://user-images.githubusercontent.com/20814058/53052535-94287780-34d1-11e9-8763-c73ec154ca62.gif)


### Why is it needed?
Good UX behavior + description from related issue #4834

> Duplicating a resource behaves inconsistently when used via context menu in resource tree and via a button on resource edit form. The former opens a dialog with option to include children resources and setting title for a duplicate and allows to cancel duplication. The latter issues warning about all child resources being duplicated and creates new resource. User is presented with a form for a new resource and if cancels edition an empty untitled resource is left.
>
>Both should have the same behavior of the former (there was an issue for it), ie. context menu command.

### Note for testers
1. There are a few bugs, but they are not related to this PR. Later, I or someone will post the issues.
2. Checks for the existance on node in this PR are needed for these cases when resource hide in tree (for example: miniShop2 uses show in tree 0 to hide products).

### Related issue(s)/PR(s)
Closes #4834 and closes #14409
