### PR TITLE
Alter modUserProfile gender field to tinyint from int

### DIFF
--- a/core/model/modx/mysql/moduserprofile.map.inc.php
+++ b/core/model/modx/mysql/moduserprofile.map.inc.php
@@ -157,7 +157,7 @@ $xpdo_meta_map['modUserProfile']= array (
     ),
     'gender' => 
     array (
-      'dbtype' => 'int',
+      'dbtype' => 'tinyint',
       'precision' => '1',
       'phptype' => 'integer',
       'null' => false,

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1383,7 +1383,7 @@
         <field key="failedlogincount" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         <field key="sessionid" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="dob" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
-        <field key="gender" dbtype="int" precision="1" phptype="integer" null="false" default="0" />
+        <field key="gender" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
         <field key="address" dbtype="text" phptype="string" null="false" default="" />
         <field key="country" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
         <field key="city" dbtype="varchar" precision="191" phptype="string" null="false" default="" />

--- a/setup/includes/upgrades/common/3.0.0-trim-gender-field-size.php
+++ b/setup/includes/upgrades/common/3.0.0-trim-gender-field-size.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Changes type of gender field to `tinyint` instead of `int` as this field shouldn't contain a lot of information.
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+$class = 'modUserProfile';
+$table = $modx->getTableName($class);
+
+$description = $this->install->lexicon(
+    'modify_column', [
+        'column' => 'gender',
+        'old' => 'int',
+        'new' => 'tinyint',
+        'table' => $table
+    ]
+);
+$this->processResults($class, $description, [$modx->manager, 'alterField'], [$class, 'gender']);

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -13,3 +13,4 @@ include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php
 include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-trim-gender-field-size.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -13,3 +13,4 @@ include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-copy-to-clipboard.php
 include dirname(dirname(__FILE__)) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(dirname(__FILE__)) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(dirname(__FILE__)) . '/common/3.0.0-trim-gender-field-size.php';


### PR DESCRIPTION
### What does it do?
Changes type of gender field to `tinyint` instead of `int` as this field shouldn't contain a lot of information.

### Why is it needed?
- to take less place and memory for storing this data
- to keep consistency between different database drivers (sqlsrv uses `tinyint` as well).

### Related issue(s)/PR(s)
#11902
