### PR TITLE
Change System font stack

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -193,7 +193,7 @@ $winFooterBg: $white;
 $winFooterBorderColor: $white;
 
 /* Font stacks */
-$bodyfonts: 'Helvetica Neue', Helvetica, Arial, Tahoma, sans-serif;
+$bodyfonts: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
 $bodyFontSize: 13px;
 $altfonts: titilliumregular, $bodyfonts; /* unused */
 $altfontslight: titilliumlight, $bodyfonts; /* unused */


### PR DESCRIPTION
### What does it do?
Change System font stack.
Defaulting to the system font of a particular operating system can boost performance because the browser doesn't have to download any font files, it's using one it already had. That's true of any "web safe" font, though. The beauty of "system" fonts is that it matches what the current OS uses, so it can be a comfortable look.

### Why is it needed?
Change the current base font set to suggested:
`font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;`

**This set of fonts is used:**
- https://medium.com/
- https://wptavern.com/wordpress-4-6-to-drop-open-sans-in-the-admin-in-favor-of-system-fonts

**Before**:
![2019-02-21_11-09-25](https://user-images.githubusercontent.com/2138260/53145485-97535e80-35ca-11e9-8c7f-f357c38cf4fd.png)

**After**:
![2019-02-21_11-11-39](https://user-images.githubusercontent.com/2138260/53145501-a0443000-35ca-11e9-9595-1015ea607962.png)

**Before**:
![2019-02-21_11-00-18](https://user-images.githubusercontent.com/2138260/53145533-bb16a480-35ca-11e9-8011-97839135d10e.png)

**After**:
![2019-02-21_11-06-13](https://user-images.githubusercontent.com/2138260/53145522-b2be6980-35ca-11e9-9dbe-ff1a84a80063.png)

**Before**:
![2019-02-21_10-58-52](https://user-images.githubusercontent.com/2138260/53145612-09c43e80-35cb-11e9-84ae-17ee8ed4e7e2.png)

**After**:
![2019-02-21_11-06-35](https://user-images.githubusercontent.com/2138260/53145617-0f218900-35cb-11e9-9740-67e82f87193d.png)

**Before**:
![2019-02-21_10-59-35](https://user-images.githubusercontent.com/2138260/53145633-1fd1ff00-35cb-11e9-9465-2df3a69dea8f.png)

**After**:
![2019-02-21_11-24-20](https://user-images.githubusercontent.com/2138260/53145657-4001be00-35cb-11e9-900d-8a0e968a91b9.png)

**More information here:**

- https://css-tricks.com/snippets/css/system-font-stack/
- https://css-tricks.com/implementing-system-fonts-booking-com%E2%80%8A-%E2%80%8Aa-lesson-learned/

**Environment**:
- MODX 3.x
- MacOS 10.13.6 (17G5019)
- Google Chrome: 72.0.3626.109

### Related issue(s)/PR(s)
NA
