### PR TITLE
Update editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 tab_width = 4
-max_line_length = 100
+max_line_length = off
 
 [**.js]
 tab_width = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,14 @@
+# https://editorconfig.org
 root = true
 
 [*]
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 tab_width = 4
+max_line_length = 100
 
 [**.js]
 tab_width = 4
@@ -24,3 +27,7 @@ tab_width = 4
 
 [**php]
 tab_width = 4
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false


### PR DESCRIPTION
### What does it do?
Updates the rules in the file .for editorconfig

### Why is it needed?
**Specifies**:
- the default file encoding of `charset = utf-8`
- the maximum length of a line is 100 characters.

**For files with extension .md:**
- the maximum length of a line in characters is not limited
- no spaces are removed at the end of the lines

### Related issue(s)/PR(s)
NA
