### PR TITLE
Changing the menuindex of the updating resource after sorting in tree

### DIFF
--- a/core/model/modx/processors/resource/sort.class.php
+++ b/core/model/modx/processors/resource/sort.class.php
@@ -24,6 +24,8 @@ class modResourceSortProcessor extends modProcessor {
 
     public $source;
     public $target;
+    public $activeTarget;
+    public $menuindex;
     public $point;
 
     public $autoIsFolder = true;
@@ -50,6 +52,7 @@ class modResourceSortProcessor extends modProcessor {
         $this->fireBeforeSort();
 
         $target = $this->getProperty('target', '');
+        $activeTarget = $this->getProperty('activeTarget', '');
         $source = $this->getProperty('source', '');
         $point = $this->getProperty('point', '');
 
@@ -84,6 +87,10 @@ class modResourceSortProcessor extends modProcessor {
             $this->getProperty('source_type'),
             $this->getProperty('source_pk')
         );
+
+        if (!empty($activeTarget) && $this->getActiveTargetMenuindex($activeTarget)) {
+            return $this->success('', array('menuindex' => (int) $this->menuindex));
+        }
 
         return $this->success();
     }
@@ -197,6 +204,17 @@ class modResourceSortProcessor extends modProcessor {
         $this->moveAffectedContexts($lastRank);
 
         return true;
+    }
+
+    public function getActiveTargetMenuindex(int $target) {
+        $resource = $this->modx->getObject('modResource', $target);
+
+        if($resource instanceof modResource) {
+            $this->menuindex = $resource->get('menuindex');
+        	return true;
+        }
+
+        return false;
     }
 
     public function moveToContext() {

--- a/core/model/modx/processors/resource/sort.class.php
+++ b/core/model/modx/processors/resource/sort.class.php
@@ -209,7 +209,7 @@ class modResourceSortProcessor extends modProcessor {
     public function getActiveTargetMenuindex(int $target) {
         $resource = $this->modx->getObject('modResource', $target);
 
-        if($resource instanceof modResource) {
+        if ($resource instanceof modResource) {
             $this->menuindex = $resource->get('menuindex');
         	return true;
         }

--- a/core/model/modx/processors/resource/sort.class.php
+++ b/core/model/modx/processors/resource/sort.class.php
@@ -52,7 +52,7 @@ class modResourceSortProcessor extends modProcessor {
         $this->fireBeforeSort();
 
         $target = $this->getProperty('target', '');
-        $activeTarget = $this->getProperty('activeTarget', '');
+        $activeTarget = (int) $this->getProperty('activeTarget', '');
         $source = $this->getProperty('source', '');
         $point = $this->getProperty('point', '');
 
@@ -88,11 +88,14 @@ class modResourceSortProcessor extends modProcessor {
             $this->getProperty('source_pk')
         );
 
-        if (!empty($activeTarget) && $this->getActiveTargetMenuindex($activeTarget)) {
-            return $this->success('', array('menuindex' => (int) $this->menuindex));
+        if (!empty($activeTarget)) {
+            $resource = $this->modx->getObject('modResource', $activeTarget);
+            if($resource instanceof modResource) {
+                $this->menuindex = $resource->get('menuindex');
+            }
         }
 
-        return $this->success();
+        return $this->success('',array('menuindex' => $this->menuindex));
     }
 
     protected function getNodesFormatted($currentLevel,$parent = 0) {
@@ -204,17 +207,6 @@ class modResourceSortProcessor extends modProcessor {
         $this->moveAffectedContexts($lastRank);
 
         return true;
-    }
-
-    public function getActiveTargetMenuindex(int $target) {
-        $resource = $this->modx->getObject('modResource', $target);
-
-        if($resource instanceof modResource) {
-            $this->menuindex = $resource->get('menuindex');
-        	return true;
-        }
-
-        return false;
     }
 
     public function moveToContext() {

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -377,12 +377,18 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ui.addClass('haschildren');
             ui.removeClass('icon-resource');
         }
-        if((MODx.request.a == MODx.action['resource/update']) && dropNode.attributes.pk == MODx.request.id){
-            var parentFieldCmb = Ext.getCmp('modx-resource-parent');
-            var parentFieldHidden = Ext.getCmp('modx-resource-parent-hidden');
-            if(parentFieldCmb && parentFieldHidden){
-                parentFieldHidden.setValue(dropNode.parentNode.attributes.pk);
-                parentFieldCmb.setValue(dropNode.parentNode.attributes.text.replace(/(<([^>]+)>)/ig,""));
+        if((MODx.request.a == MODx.action['resource/update'])){
+		    if(dropNode.attributes.pk == MODx.request.id) {
+                var parentFieldCmb = Ext.getCmp('modx-resource-parent');
+                var parentFieldHidden = Ext.getCmp('modx-resource-parent-hidden');
+                if(parentFieldCmb && parentFieldHidden){
+                    parentFieldHidden.setValue(dropNode.parentNode.attributes.pk);
+                    parentFieldCmb.setValue(dropNode.parentNode.attributes.text.replace(/(<([^>]+)>)/ig,""));
+                }
+            }
+            var menuindexField = Ext.getCmp('modx-resource-menuindex');
+            if(menuindexField && o.result.object.menuindex !== undefined){
+                menuindexField.setValue(o.result.object.menuindex);
             }
         }
     }
@@ -738,6 +744,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             url: this.config.url
             ,params: {
                 target: dropEvent.target.attributes.id
+                ,activeTarget: MODx.request.a == MODx.action['resource/update'] ? MODx.request.id : ''
                 ,source: dropEvent.source.dragData.node.attributes.id
                 ,point: dropEvent.point
                 ,data: encodeURIComponent(encNodes)


### PR DESCRIPTION
### What does it do?
Fixes the bug when sorting resources and locate on resource update page at the same time.

![ux](https://user-images.githubusercontent.com/20814058/53222054-b7ece880-369e-11e9-9b68-d811251cd0e9.gif)


### Why is it needed?
Description from #14299 

> If you edit a resource and at the same time move it in the tree through drag and drop, and then save > it, the resource position (menuindex) will remain the same at the time of opening the resource.
>
> However, if you edit a resource and change its parent (by moving through drag and drop to another folder) and then save, everything will be fine with the new parent.
>
> This bug is pretty old, but I did not find it in the list. Customers often complained about this issue.

### Related issue(s)/PR(s)
Closes #14299
