### PR TITLE
Changes the font stack for displaying code

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -198,7 +198,7 @@ $bodyFontSize: 13px;
 $altfonts: titilliumregular, $bodyfonts; /* unused */
 $altfontslight: titilliumlight, $bodyfonts; /* unused */
 $headfonts: $bodyfonts;
-$codefonts: "Courier New", Courier, monospace;
+$codefonts: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 $tabFont: 14px $bodyfonts;
 $buttonfonts: $bodyfonts;
 $treePseudoRootFont: bold 14px/3 $headfonts;


### PR DESCRIPTION
### What does it do?
Changes the font stack to display code

### Why is it needed?
For more correct display of fonts to display code using native fonts.
This stack is used in the latest version of `Bootstrap 4.3.x` [Native fonts](https://getbootstrap.com/docs/4.3/content/reboot/#native-font-stack)

Change from `$codefonts: "Courier New", Courier, monospace;` to `$codefonts: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;`

**Before**:
![modx revolution 2019-02-26 13-19-07](https://user-images.githubusercontent.com/2138260/53395233-82603c00-39cb-11e9-8ac7-ca1484399200.jpg)
**After**:
![modx revolution 2019-02-26 13-34-56](https://user-images.githubusercontent.com/2138260/53395243-8ab87700-39cb-11e9-8137-01a706bbea2e.jpg)

**Environment**:
* MODX 3.x
* MacOS 10.13.6 (17G5019)
* Google Chrome: 72.0.3626.109

### Related issue(s)/PR(s)
#14415 
