### PR TITLE
Check extracted files for allowed extensions by option

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -49,7 +49,7 @@ class modFileHandler {
      * @param array $options Optional. An array of options for the object.
      * @param string $overrideClass Optional. If provided, will force creation
      * of the object as the specified class.
-     * @return mixed The appropriate modFile/modDirectory object
+     * @return modFile|modDirectory The appropriate modFile/modDirectory object
      */
     public function make($path, array $options = array(), $overrideClass = '') {
         $path = $this->sanitizePath($path);
@@ -496,8 +496,10 @@ class modFile extends modFileSystemResource {
 
         $results = false;
 
-        if ($this->fileHandler->modx->getService('archive', 'compression.xPDOZip', XPDO_CORE_PATH, $this->path)) {
-            $results = $this->fileHandler->modx->archive->unpack($to);
+        /** @var xPDOZip $archive */
+        $archive = $this->fileHandler->modx->getService('archive', 'compression.xPDOZip', XPDO_CORE_PATH, $this->path);
+        if ($archive) {
+            $results = $archive->unpack($to, $options);
         }
 
         return $results;

--- a/core/model/modx/processors/browser/file/unpack.class.php
+++ b/core/model/modx/processors/browser/file/unpack.class.php
@@ -36,18 +36,19 @@ class modUnpackProcessor extends modProcessor {
      */
     public function process() {
 
-        $this->modx->getService('fileHandler', 'modFileHandler');
+        /** @var modFileHandler $fileHandler */
+        $fileHandler = $this->modx->getService('fileHandler', 'modFileHandler');
 
         $target = $this->modx->getOption('base_path') . $this->properties['path'] . $this->properties['file'];
         $target = preg_replace('/[\.]{2,}/', '', htmlspecialchars($target));
-        $fileobj = $this->modx->fileHandler->make($target);
+        $fileobj = $fileHandler->make($target);
 
         if (!$this->validate($fileobj)) {
             return $this->failure($this->modx->lexicon('file_err_unzip_invalid_path') . ': ' . $fileobj->getPath());
         }
 
         // currently the archive content is extracted to the folder where the archive is stored
-        if (!$fileobj->unpack(dirname($target))) {
+        if (!$fileobj->unpack(dirname($target), array('check_filetype' => true))) {
             return $this->failure($this->modx->lexicon('file_err_unzip'));
         }
 

--- a/core/xpdo/compression/xpdozip.class.php
+++ b/core/xpdo/compression/xpdozip.class.php
@@ -234,7 +234,7 @@ class xPDOZip {
             $allowedFileTypes = (!is_array($allowedFileTypes)) ? explode(',', $allowedFileTypes) : $allowedFileTypes;
         } else {
             $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
-            $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+            $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_images')) : array();
             $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
             $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
             $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));

--- a/core/xpdo/compression/xpdozip.class.php
+++ b/core/xpdo/compression/xpdozip.class.php
@@ -142,13 +142,24 @@ class xPDOZip {
      *
      * @param string $target The path of the target location to unpack the files.
      * @param array $options An array of options for the operation.
-     * @return array An array of results for the operation.
+     * @return bool|array An array of results for the operation.
      */
     public function unpack($target, $options = array()) {
         $results = false;
         if ($this->_archive) {
             if (is_dir($target) && is_writable($target)) {
-                $results = $this->_archive->extractTo($target);
+                if ($this->getOption('check_filetype', $options, false)) {
+                    $fileIndex = array();
+                    for ($i = 0; $i < $this->_archive->numFiles; $i++) {
+                        $filename = $this->_archive->getNameIndex($i);
+                        if ($this->checkFiletype($filename)) {
+                            $fileIndex[] = $filename;
+                        }
+                    }
+                    $results = $this->_archive->extractTo($target, $fileIndex);
+                } else {
+                    $results = $this->_archive->extractTo($target);
+                }
             }
         }
         return $results;
@@ -208,5 +219,33 @@ class xPDOZip {
      */
     public function getErrors() {
         return $this->_errors;
+    }
+
+    /**
+     * Check that the filename has a file type extension that is allowed
+     *
+     * @param $filename
+     * @return bool
+     */
+    private function checkFiletype($filename)
+    {
+        if ($this->xpdo->getOption('allowedFileTypes')) {
+            $allowedFileTypes = $this->getOption('allowedFileTypes');
+            $allowedFileTypes = (!is_array($allowedFileTypes)) ? explode(',', $allowedFileTypes) : $allowedFileTypes;
+        } else {
+            $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+            $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
+            $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
+            $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
+            $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+            $this->xpdo->setOption('allowedFileTypes', $allowedFileTypes);
+        }
+        $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        $ext = strtolower($ext);
+        if (!empty($allowedFileTypes) && !in_array($ext, $allowedFileTypes)) {
+            $this->xpdo->log(XPDO::LOG_LEVEL_WARN, $filename .' can\'t be extracted, because the file type is not allowed');
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
### What does it do?
Check extracted files for allowed extensions by option and enable that option in the file/unpack processor

### Why is it needed?
Without that patch, not allowed files could be unpacked.

### Related issue(s)/PR(s)
#14385 
