### PR TITLE
Fix connector deprecated each()

### DIFF
--- a/connectors/lang.js.php
+++ b/connectors/lang.js.php
@@ -30,7 +30,7 @@ $entries = $modx->lexicon->fetch();
 echo '
 MODx.lang = {';
 $s = '';
-while (list($k,$v) = each ($entries)) {
+foreach ($entries as $k => $v) {
     $s .= "'$k': ".'"'.esc($v).'",';
 }
 $s = trim($s,',');


### PR DESCRIPTION
**Backporting of https://github.com/modxcms/revolution/pull/14397 to 2.x**

### What does it do?
Change array iteration construction with deprecated each() method to new one with foreach().

### Why is it needed?
Due to multiple warning in log "(WARN @www\connectors\lang.js.php : 33) PHP deprecated: The each() function is deprecated." and the fact that "Function each() has been deprecated as of PHP 7.2.0. Relying on this function is highly discouraged." I think better to fix it.

### Related issue(s)/PR(s)
I made a search through opened issues and pull requests and didn't find any.