### PR TITLE
Fix friendly_alias_realtime setting not working

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -317,7 +317,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     }
     ,generateAliasRealTime: function(title) {
         // check some system settings before doing real time alias transliteration
-        if (MODx.config.friendly_alias_realtime && MODx.config.automatic_alias) {
+        if (parseInt(MODx.config.friendly_alias_realtime) && parseInt(MODx.config.automatic_alias)) {
             // handles the realtime-alias transliteration
             if (this.config.aliaswasempty && title !== '') {
                 this.translitAlias(title);


### PR DESCRIPTION
### What does it do?
Add parseInt to the MODx.config checks.

### Why is it needed?
The values of MODx.config.friendly_alias_realtime and MODx.config.automatic_alias contain a string value and "0" is not casted to false in Javascript.

### Related issue(s)/PR(s)
#14438