### PR TITLE
Placed the changelog entries under the right release

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -6,11 +6,11 @@ MODX Revolution 2.7.2-pl (TBD)
 ====================================
 - The default RSS feed URLs `feed_modx_security` and `feed_modx_news` now use HTTPS [#14392]
 - The value for the preview tooltip in the trash manager is now properly encoded [#14401]
+- Change icon to propper one for descending sort order [#14413]
+- Don't execute the upgrade script for the last installed version again [#14396]
 
 MODX Revolution 2.7.1-pl (February 14, 2019)
 ====================================
-- Change icon to popper one for descending sort order [#14413]
-- Don't execute the upgrade script for the last installed version again [#14396]
 - Fix ctl/cmd+click behavior to open URL in new window/tab [#14348]
 - Show all resources to purge in the trash manager and change tree options for deleted resources [#14350]
 - Handle deprecated warnings for sendRedirect in modX class instead of modResponse [#14359]


### PR DESCRIPTION
### What does it do?
Placed 2 changelog entries under the right release.

### Why is it needed?
The changelog should be consistent so users are properly informed about what release brings what changes. 

### Related issue(s)/PR(s)
PR #14413 and PR #14396
