### PR TITLE
Fix saving the content of Symlink/Weblink/Static resources

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -25,7 +25,7 @@ MODx.panel.Resource = function(config) {
         }
     });
     MODx.panel.Resource.superclass.constructor.call(this,config);
-    var ta = Ext.get('ta');
+    var ta = Ext.get(this.contentField);
     if (ta) { ta.on('keydown',this.fieldChangeEvent,this); }
     this.on('ready',this.onReady,this);
     var urio = Ext.getCmp('modx-resource-uri-override');
@@ -38,6 +38,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     ,classLexiconKey: 'document'
     ,rteElements: 'ta'
     ,rteLoaded: false
+    ,contentField: 'ta'
     ,warnUnsavedChanges: false
     ,setup: function() {
         if (!this.initialized) {
@@ -181,7 +182,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
     }
 
     ,beforeSubmit: function(o) {
-        var ta = Ext.get('ta');
+        var ta = Ext.get(this.contentField);
         if (ta) {
             var v = ta.dom.value;
             var hc = Ext.getCmp('hiddenContent');

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
@@ -19,6 +19,7 @@ Ext.extend(MODx.panel.Static,MODx.panel.Resource,{
     defaultClassKey: 'modStaticResource'
     ,classLexiconKey: 'static_resource'
     ,rteElements: false
+    ,contentField: 'modx-resource-content-static'
 
     ,getContentField: function(config) {
         return {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.symlink.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.symlink.js
@@ -29,6 +29,7 @@ Ext.extend(MODx.panel.SymLink,MODx.panel.Resource,{
     defaultClassKey: 'modSymLink'
     ,classLexiconKey: 'symlink'
     ,rteElements: false
+    ,contentField: 'modx-symlink-content'
 
     ,getContentField: function(config) {
         return {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.weblink.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.weblink.js
@@ -18,6 +18,7 @@ Ext.extend(MODx.panel.WebLink,MODx.panel.Resource,{
     defaultClassKey: 'modWebLink'
     ,classLexiconKey: 'weblink'
     ,rteElements: false
+    ,contentField: 'modx-weblink-content'
 
     ,getContentField: function(config) {
         return {


### PR DESCRIPTION
### What does it do?
It adds a property `contentField` to the `modx-panel-resource` component. When saving the resource it will get the element defined in `contentField` whose value is being used to set a value for the `content` field.

### Why is it needed?
This way it's possible to tell where to  get the correct value from for using as value in the `content` field. It fixes an issue where the `content` field for symlink, weblink and static resources was not updated with the right value after saving such resource.

### Related issue(s)/PR(s)
Fixes issue #14087
