### PR TITLE
Fixes the bug when matches names of policy before saving

### DIFF
--- a/core/model/modx/processors/security/access/policy/create.class.php
+++ b/core/model/modx/processors/security/access/policy/create.class.php
@@ -30,7 +30,7 @@ class modAccessPolicyCreateProcessor extends modObjectCreateProcessor {
     public function beforeSet() {
         $name = $this->getProperty('name');
         if (empty($name)) {
-            $this->addFieldError('name',$this->modx->lexicon('policy_err_name_ns'));
+            $this->addFieldError('name',$this->modx->lexicon('field_required'));
         }
 
         if ($this->doesAlreadyExist(array('name' => $name))) {

--- a/core/model/modx/processors/security/access/policy/update.class.php
+++ b/core/model/modx/processors/security/access/policy/update.class.php
@@ -27,6 +27,20 @@ class modAccessPolicyUpdateProcessor extends modObjectUpdateProcessor {
     public $permission = 'policy_save';
     public $objectType = 'policy';
 
+    public function beforeSet() {
+        $name = $this->getProperty('name');
+        if (empty($name)) {
+            $this->addFieldError('name',$this->modx->lexicon('field_required'));
+        }
+        if ($this->doesAlreadyExist(array(
+            'name' => $name,
+            'id:!=' => $this->object->get('id')
+        ))) {
+            $this->addFieldError('name',$this->modx->lexicon('policy_err_ae',array('name' => $name)));
+        }
+        return parent::beforeSet();
+    }
+
     public function beforeSave() {
         /* now store the permissions into the modAccessPermission table */
         /* and cache the data into the policy table */

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -281,11 +281,12 @@ MODx.window.CreateAccessPolicy = function(config) {
         ,url: MODx.config.connector_url
         ,action: 'security/access/policy/create'
         ,fields: [{
-            fieldLabel: _('name')
+            fieldLabel: _('name')+'<span class="required">*</span>'
             ,description: MODx.expandHelp ? '' : _('policy_desc_name')
             ,name: 'name'
             ,id: 'modx-'+this.ident+'-name'
             ,xtype: 'textfield'
+            ,allowBlank: false
             ,anchor: '100%'
         },{
             xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -293,7 +294,7 @@ MODx.window.CreateAccessPolicy = function(config) {
             ,html: _('policy_desc_name')
             ,cls: 'desc-under'
         },{
-            fieldLabel: _('policy_template')
+            fieldLabel: _('policy_template')+'<span class="required">*</span>'
             ,description: MODx.expandHelp ? '' : _('policy_desc_template')
             ,name: 'template'
             ,hiddenName: 'template'

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.js
@@ -45,6 +45,9 @@ MODx.panel.AccessPolicy = function(config) {
                     ,layout: 'form'
                     ,labelAlign: 'top'
                     ,labelSeparator: ''
+                    ,defaults: {
+                        msgTarget: 'under'
+                    }
                     ,items: [{
                         xtype: 'hidden'
                         ,name: 'id'


### PR DESCRIPTION
### What does it do?
1. Fix behavior when matching names of access policy (See picture below)
2. Adds asterisks to required fields on creating policy window (See picture below)
3. Change the call of non-existent "policy_err_name_ns" lexicon entry

### Why is it needed?
If we type the name of the exiting Access Policy being on update page, then we see the next error message "An error occurred while trying to save the Policy", and all. It is not clear what is the error.

**Before:**

![before](https://user-images.githubusercontent.com/20814058/53688450-36a7ec80-3d55-11e9-8b2a-c56bc6aa5cf8.png)

**After:**

![after](https://user-images.githubusercontent.com/20814058/53688462-58a16f00-3d55-11e9-9e9e-93e7f95111cb.png)

And when we create a policy, at once we can't understand what fields are required

**Before:**

![before2](https://user-images.githubusercontent.com/20814058/53688485-b766e880-3d55-11e9-9818-d03ccd86df9f.png)

**After:**

![after2](https://user-images.githubusercontent.com/20814058/53688490-c057ba00-3d55-11e9-9ff2-eea56a4aaa72.png)

By the way, someone indicated a call to a nonexistent lexicon key "policy_err_name_ns"


### Related issue(s)/PR(s)
I did not create a issue, everything seems to be clear here.
