### PR TITLE
Adds check for tree render on Access Control Lists page

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -170,13 +170,15 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
     }
     ,fixPanelHeight: function() {
         // fixing border layout's height regarding to tree panel's
-        var treeEl = Ext.getCmp('modx-tree-usergroup').getEl();
-        var treeH = treeEl.getHeight();
-        var cHeight = Ext.getCmp('modx-usergroup-users').getHeight(); // .main-wrapper
-        var maxH = (treeH > cHeight) ? treeH : cHeight;
-        maxH = maxH > 500 ? maxH : 500;
-        Ext.getCmp('modx-tree-panel-usergroup').setHeight(maxH);
-        Ext.getCmp('modx-content').doLayout();
+        var treeEl = Ext.getCmp('modx-tree-usergroup');
+        if (treeEl && treeEl.rendered) {
+            var treeH = treeEl.getEl().getHeight();
+            var cHeight = Ext.getCmp('modx-usergroup-users').getHeight(); // .main-wrapper
+            var maxH = (treeH > cHeight) ? treeH : cHeight;
+            maxH = maxH > 500 ? maxH : 500;
+            Ext.getCmp('modx-tree-panel-usergroup').setHeight(maxH);
+            Ext.getCmp('modx-content').doLayout();
+        }
     }
 });
 Ext.reg('modx-panel-groups-roles',MODx.panel.GroupsRoles);


### PR DESCRIPTION
### What does it do?
Adds check for tree render on Access Control Lists page

### Why is it needed?
Description from related issue #14450 

> There is an error in the browser console. The modx-tree-usergroup is not defined
>
> 
![image](https://user-images.githubusercontent.com/20814058/53689029-da959600-3d5d-11e9-87e4-7d0b8a248eca.png)


### Related issue(s)/PR(s)
Closes #14450 
