### PR TITLE
Allow safe html in system setting description

### DIFF
--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -129,13 +129,22 @@ MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
     var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi,
         attributes = /([a-z][a-z0-9]*)\s*=\s*".*?"/gi,
         commentsAndPhpTags = /<!--[\s\S]*?-->|<\?(?:php)?[\s\S]*?\?>/gi,
-        hrefJavascript = /href(\s*?=\s*?(["'])javascript:.*?\2|\s*?=\s*?javascript:.*?(?![^> ]))/gi;
-    return input.replace(commentsAndPhpTags, '')
-        .replace(tags, function ($0, $1) {
+        hrefJavascript = /href(\s*?=\s*?(["'])javascript:.*?\2|\s*?=\s*?javascript:.*?(?![^> ]))/gi,
+        length;
+    input = input.replace(commentsAndPhpTags, '').replace(hrefJavascript, 'href="javascript:void(0)"');
+    do {
+        length = input.length;
+        input = input.replace(tags, function ($0, $1) {
             return allowedTags.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
-        }).replace(attributes, function ($0, $1) {
+        });
+    } while (length !== input.length);
+    do {
+        length = input.length;
+        input = input.replace(attributes, function ($0, $1) {
             return allowedAttributes.indexOf($1.toLowerCase() + ',') > -1 ? $0 : '';
-        }).replace(hrefJavascript, 'href="javascript:void(0)"');
+        });
+    } while (length !== input.length);
+    return input;
 };
 
 /****************************************************************************

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -129,13 +129,13 @@ MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
     var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi,
         attributes = /([a-z][a-z0-9]*)\s*=\s*".*?"/gi,
         commentsAndPhpTags = /<!--[\s\S]*?-->|<\?(?:php)?[\s\S]*?\?>/gi,
-        javascript = /href="javascript:.*?"/gi;
+        hrefJavascript = /href(\s*?=\s*?(["'])javascript:.*?\2|\s*?=\s*?javascript:.*?(?![^> ]))/gi;
     return input.replace(commentsAndPhpTags, '')
         .replace(tags, function ($0, $1) {
             return allowedTags.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
         }).replace(attributes, function ($0, $1) {
             return allowedAttributes.indexOf($1.toLowerCase() + ',') > -1 ? $0 : '';
-        }).replace(javascript, 'href="javascript:void(0)"');
+        }).replace(hrefJavascript, 'href="javascript:void(0)"');
 };
 
 /****************************************************************************

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -134,14 +134,14 @@ MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
     input = input.replace(commentsAndPhpTags, '').replace(hrefJavascript, 'href="javascript:void(0)"');
     do {
         length = input.length;
-        input = input.replace(tags, function ($0, $1) {
-            return allowedTags.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
+        input = input.replace(attributes, function ($0, $1) {
+            return allowedAttributes.indexOf($1.toLowerCase() + ',') > -1 ? $0 : '';
         });
     } while (length !== input.length);
     do {
         length = input.length;
-        input = input.replace(attributes, function ($0, $1) {
-            return allowedAttributes.indexOf($1.toLowerCase() + ',') > -1 ? $0 : '';
+        input = input.replace(tags, function ($0, $1) {
+            return allowedTags.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
         });
     } while (length !== input.length);
     return input;

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -117,6 +117,26 @@ MODx.StaticBoolean = Ext.extend(Ext.form.TextField, {
 });
 Ext.reg('staticboolean',MODx.StaticBoolean);
 
+MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
+    allowedTags = (((allowedTags || '<a><br><i><em><b><strong>') + '')
+        .toLowerCase()
+        .match(/<[a-z][a-z0-9]*>/g) || [])
+        .join(''); // making sure the allowedTags arg is a string containing only tags in lowercase (<a><b><c>)
+    allowedAttributes = (((allowedAttributes || 'href,class') + '')
+        .toLowerCase()
+        .match(/[a-z\-,]*/g) || [])
+        .join('').concat(','); // making sure the allowedAttributes arg is a comma separated string containing only attributes in lowercase (a,b,c)
+    var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi,
+        attributes = /([a-z][a-z0-9]*)\s*=\s*".*?"/gi,
+        commentsAndPhpTags = /<!--[\s\S]*?-->|<\?(?:php)?[\s\S]*?\?>/gi,
+        javascript = /href="javascript:.*?"/gi;
+    return input.replace(commentsAndPhpTags, '')
+        .replace(tags, function ($0, $1) {
+            return allowedTags.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
+        }).replace(attributes, function ($0, $1) {
+            return allowedAttributes.indexOf($1.toLowerCase() + ',') > -1 ? $0 : '';
+        }).replace(javascript, 'href="javascript:void(0)"');
+};
 
 /****************************************************************************
  *    Ext-specific overrides/extensions                                     *

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -118,6 +118,13 @@ MODx.StaticBoolean = Ext.extend(Ext.form.TextField, {
 Ext.reg('staticboolean',MODx.StaticBoolean);
 
 MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
+    var strip = function(input, allowedTags, allowedAttributes) {
+        return input.replace(tags, function ($0, $1) {
+            return allowedTags.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
+        }).replace(attributes, function ($0, $1) {
+            return allowedAttributes.indexOf($1.toLowerCase() + ',') > -1 ? $0 : '';
+        });
+    };
     allowedTags = (((allowedTags || '<a><br><i><em><b><strong>') + '')
         .toLowerCase()
         .match(/<[a-z][a-z0-9]*>/g) || [])
@@ -134,15 +141,7 @@ MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
     input = input.replace(commentsAndPhpTags, '').replace(hrefJavascript, 'href="javascript:void(0)"');
     do {
         length = input.length;
-        input = input.replace(attributes, function ($0, $1) {
-            return allowedAttributes.indexOf($1.toLowerCase() + ',') > -1 ? $0 : '';
-        });
-    } while (length !== input.length);
-    do {
-        length = input.length;
-        input = input.replace(tags, function ($0, $1) {
-            return allowedTags.indexOf('<' + $1.toLowerCase() + '>') > -1 ? $0 : '';
-        });
+        input = strip(input, allowedTags, allowedAttributes);
     } while (length !== input.length);
     return input;
 };

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -117,6 +117,9 @@ MODx.StaticBoolean = Ext.extend(Ext.form.TextField, {
 });
 Ext.reg('staticboolean',MODx.StaticBoolean);
 
+// This method strips not allowed html tags/attributes, html comments and php tags,
+// replaces javascript invocation in a href attribute and masks html event attributes
+// in an input string - assuming the result is safe to be displayed by a browser
 MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
     var strip = function(input, allowedTags, allowedAttributes) {
         return input.replace(tags, function ($0, $1) {

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -135,6 +135,7 @@ MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
         .join('').concat(','); // making sure the allowedAttributes arg is a comma separated string containing only attributes in lowercase (a,b,c)
     var tags = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi,
         attributes = /([a-z][a-z0-9]*)\s*=\s*".*?"/gi,
+        eventAttributes = /on([a-z][a-z0-9]*\s*=)/gi,
         commentsAndPhpTags = /<!--[\s\S]*?-->|<\?(?:php)?[\s\S]*?\?>/gi,
         hrefJavascript = /href(\s*?=\s*?(["'])javascript:.*?\2|\s*?=\s*?javascript:.*?(?![^> ]))/gi,
         length;
@@ -143,7 +144,7 @@ MODx.util.safeHtml = function (input, allowedTags, allowedAttributes) {
         length = input.length;
         input = strip(input, allowedTags, allowedAttributes);
     } while (length !== input.length);
-    return input;
+    return input.replace(eventAttributes, 'on&#8203;$1');
 };
 
 /****************************************************************************

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -1,8 +1,8 @@
 MODx.grid.SettingsGrid = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
-        tpl : new Ext.Template(
-            '<p class="desc">{description_trans:htmlEncode}</p>'
+        tpl : new Ext.XTemplate(
+            '<p class="desc">{[MODx.util.safeHtml(values.description_trans)]}</p>'
         )
     });
 


### PR DESCRIPTION
### What does it do?
Create a safeHtml method in MODx.util, that strips all not allowed html tags, html attributes and javascript in the href attribute.

### Why is it needed?
Allow a reduced set of html attributes in the system setting grid.

It should be checked carefully, wether there could get some executable script though this.  

### Related issue(s)/PR(s)
#14437