### PR TITLE
Fix the parser when using nested output filters

### DIFF
--- a/_build/test/Tests/Model/Element/modChunkTest.php
+++ b/_build/test/Tests/Model/Element/modChunkTest.php
@@ -93,6 +93,10 @@ class modChunkTest extends MODxTestCase {
             ['<p>Hello, Mark!</p>', ['name' => 'Mark']],
             ['<p>Having fun.</p>', [],'<p>Having fun.</p>'],
             ['<p>Test 1</p>', ['number' => 1],'<p>Test [[+number]]</p>'],
+            ['1', ['id' => '1'], '[[+id:is=`1`:then=`[[+id]]`:else=`[[+id:is=`2`:then=`[[+id]]`:else=`[[+id:is=`3`:then=`[[+id]]`:else=`More`]]`]]`]]'],
+            ['2', ['id' => '2'], '[[+id:is=`1`:then=`[[+id]]`:else=`[[+id:is=`2`:then=`[[+id]]`:else=`[[+id:is=`3`:then=`[[+id]]`:else=`More`]]`]]`]]'],
+            ['3', ['id' => '3'], '[[+id:is=`1`:then=`[[+id]]`:else=`[[+id:is=`2`:then=`[[+id]]`:else=`[[+id:is=`3`:then=`[[+id]]`:else=`More`]]`]]`]]'],
+            ['More', ['id' => '4'], '[[+id:is=`1`:then=`[[+id]]`:else=`[[+id:is=`2`:then=`[[+id]]`:else=`[[+id:is=`3`:then=`[[+id]]`:else=`More`]]`]]`]]'],
         ];
     }
 }

--- a/core/src/Revolution/Filters/modInputFilter.php
+++ b/core/src/Revolution/Filters/modInputFilter.php
@@ -53,7 +53,7 @@ class modInputFilter
             $matches = [];
             $name = trim(substr($output, 0, $splitPos));
             $modifiers = substr($output, $splitPos);
-            if (preg_match_all('~:([^:=]+)(?:=`(.*?)`[\r\n\s]*(?=:[^:=]+|$))?~s', $modifiers, $matches)) {
+            if (preg_match_all('~:([^:=]+)(?:=`((?:(?:[^:=][\s\S]*?|(?R))*?))`)?~s', $modifiers, $matches)) {
                 $this->_commands = $matches[1]; /* modifier commands */
                 $this->_modifiers = $matches[2]; /* modifier values */
             }


### PR DESCRIPTION
### What does it do?
Order the matching results in the order they match and don't include the full matched string. This way to parser doesn't break.

### Why is it needed?
It fixes a problem where nested output filters might break in certain situations.

### Related issue(s)/PR(s)
Fixes issue #14095
