### PR TITLE
Restore PHP 5.3 compatibility (while dreaming of 7.1)

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -280,7 +280,7 @@ class modX extends xPDO {
      *
      * @var array
      */
-    private $loggedDeprecatedFunctions = [];
+    private $loggedDeprecatedFunctions = array();
 
     /**
      * Harden the environment against common security flaws.


### PR DESCRIPTION
### What does it do?
Fixes a PHP 5.3 incompatibility that I introduced in 2.7.0 with the deprecated functions.

### Why is it needed?
While you'd think PHP 5.3 is long dead by now, since SiteDash does remote upgrades which run the setup in CLI mode, it is often failing because the CLI version of the installer is 5.3.3 (even tho the frontend might be using a comfortable 7.1 or 7.2). I'm honestly stunned at how often that happens and how little hosters seem to care...

Anyway. It's a small change to revert an accidental minimum version increase that will benefit many people trying to CLI installs on negligent hosts, and we can all keep dreaming of the days when we look back and laugh.

### Related issue(s)/PR(s)
Introduced in #14127.