### PR TITLE
Using a single pattern for elements action buttons like a resource

### DIFF
--- a/manager/assets/modext/sections/element/chunk/create.js
+++ b/manager/assets/modext/sections/element/chunk/create.js
@@ -11,9 +11,38 @@ MODx.page.CreateChunk = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-chunk'
         ,buttons: [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: [{
+                    text: _('cancel') + ' <i class="icon icon-times"></i>'
+                    ,id: 'modx-abtn-cancel'
+                    ,handler: function() {
+                        MODx.loadPage('?');
+                    }
+                },{
+                    text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+                    ,id: 'modx-abtn-help'
+                    ,handler: MODx.loadHelpPane
+                }]
+            }
+        },{
             process: 'element/chunk/create'
             ,reload: true
-            ,text: _('save')
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
@@ -22,13 +51,6 @@ MODx.page.CreateChunk = function(config) {
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
         }]
         ,components: [{
             xtype: 'modx-panel-chunk'

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -10,35 +10,7 @@ MODx.page.UpdateChunk = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-chunk'
-        ,buttons: [{
-            process: 'element/chunk/update'
-            ,text: _('save')
-            ,id: 'modx-abtn-save'
-            ,cls: 'primary-button'
-            ,method: 'remote'
-            // ,checkDirty: true
-            ,keys: [{
-                key: MODx.config.keymap_save || 's'
-                ,ctrl: true
-            }]
-        },{
-            text: _('delete')
-            ,id: 'modx-abtn-delete'
-            ,handler: this.delete
-            ,scope: this
-        },{
-            text: _('duplicate')
-            ,id: 'modx-abtn-duplicate'
-            ,handler: this.duplicate
-            ,scope: this
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        }]
+        ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-chunk'
             ,renderTo: 'modx-panel-chunk-div'
@@ -96,6 +68,62 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
                     },scope:this}
             }
         });
+    }
+    ,getButtons: function(config) {
+        var config = config || {};
+
+        var menu = [{
+            text: _('duplicate') + ' <i class="icon icon-copy"></i>'
+            ,id: 'modx-abtn-duplicate'
+            ,handler: this.duplicate
+            ,scope: this
+        },{
+            text: _('delete') + ' <i class="icon icon-trash-o"></i>'
+            ,id: 'modx-abtn-delete'
+            ,handler: this.delete
+            ,scope: this
+        },{
+            text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+            ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
+        }]
+
+        var btns = [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: menu
+            }
+        },{
+            text: _('cancel') + ' <i class="icon icon-times"></i>'
+            ,id: 'modx-abtn-cancel'
+        },{
+            process: 'element/chunk/update'
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
+            ,keys: [{
+                key: MODx.config.keymap_save || 's'
+                ,ctrl: true
+            }]
+        }]
+
+        return btns;
     }
 });
 Ext.reg('modx-page-chunk-update',MODx.page.UpdateChunk);

--- a/manager/assets/modext/sections/element/plugin/create.js
+++ b/manager/assets/modext/sections/element/plugin/create.js
@@ -11,9 +11,38 @@ MODx.page.CreatePlugin = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-plugin'
         ,buttons: [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: [{
+                    text: _('cancel') + ' <i class="icon icon-times"></i>'
+                    ,id: 'modx-abtn-cancel'
+                    ,handler: function() {
+                        MODx.loadPage('?');
+                    }
+                },{
+                    text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+                    ,id: 'modx-abtn-help'
+                    ,handler: MODx.loadHelpPane
+                }]
+            }
+        },{
             process: 'element/plugin/create'
             ,reload: true
-            ,text: _('save')
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
@@ -22,13 +51,6 @@ MODx.page.CreatePlugin = function(config) {
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
         }]
         ,components: [{
             xtype: 'modx-panel-plugin'

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -10,35 +10,7 @@ MODx.page.UpdatePlugin = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-plugin'
-        ,buttons: [{
-            process: 'element/plugin/update'
-            ,text: _('save')
-            ,id: 'modx-abtn-save'
-            ,cls: 'primary-button'
-            ,method: 'remote'
-            // ,checkDirty: true
-            ,keys: [{
-                key: MODx.config.keymap_save || 's'
-                ,ctrl: true
-            }]
-        },{
-            text: _('delete')
-            ,id: 'modx-abtn-delete'
-            ,handler: this.delete
-            ,scope: this
-        },{
-            text: _('duplicate')
-            ,id: 'modx-abtn-duplicate'
-            ,handler: this.duplicate
-            ,scope: this
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        }]
+        ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-plugin'
             ,renderTo: 'modx-panel-plugin-div'
@@ -96,6 +68,62 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
                     },scope:this}
             }
         });
+    }
+    ,getButtons: function(config) {
+        var config = config || {};
+
+        var menu = [{
+            text: _('duplicate') + ' <i class="icon icon-copy"></i>'
+            ,id: 'modx-abtn-duplicate'
+            ,handler: this.duplicate
+            ,scope: this
+        },{
+            text: _('delete') + ' <i class="icon icon-trash-o"></i>'
+            ,id: 'modx-abtn-delete'
+            ,handler: this.delete
+            ,scope: this
+        },{
+            text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+            ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
+        }]
+
+        var btns = [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: menu
+            }
+        },{
+            text: _('cancel') + ' <i class="icon icon-times"></i>'
+            ,id: 'modx-abtn-cancel'
+        },{
+            process: 'element/plugin/update'
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
+            ,keys: [{
+                key: MODx.config.keymap_save || 's'
+                ,ctrl: true
+            }]
+        }]
+
+        return btns;
     }
 });
 Ext.reg('modx-page-plugin-update',MODx.page.UpdatePlugin);

--- a/manager/assets/modext/sections/element/snippet/create.js
+++ b/manager/assets/modext/sections/element/snippet/create.js
@@ -11,24 +11,46 @@ MODx.page.CreateSnippet = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-snippet'
         ,buttons: [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: [{
+                    text: _('cancel') + ' <i class="icon icon-times"></i>'
+                    ,id: 'modx-abtn-cancel'
+                    ,handler: function() {
+                        MODx.loadPage('?');
+                    }
+                },{
+                    text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+                    ,id: 'modx-abtn-help'
+                    ,handler: MODx.loadHelpPane
+                }]
+            }
+        },{
             process: 'element/snippet/create'
             ,reload: true
-            ,text: _('save')
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
             // ,checkDirty: true
             ,keys: [{
-                key: MODx.config.keymap_save || "s"
+                key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
         }]
         ,components: [{
             xtype: 'modx-panel-snippet'

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -10,35 +10,7 @@ MODx.page.UpdateSnippet = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-snippet'
-        ,buttons: [{
-            process: 'element/snippet/update'
-            ,text: _('save')
-            ,id: 'modx-abtn-save'
-            ,cls: 'primary-button'
-            ,method: 'remote'
-            // ,checkDirty: true
-            ,keys: [{
-                key: MODx.config.keymap_save || 's'
-                ,ctrl: true
-            }]
-        },{
-            text: _('delete')
-            ,id: 'modx-abtn-delete'
-            ,handler: this.delete
-            ,scope: this
-        },{
-            text: _('duplicate')
-            ,id: 'modx-abtn-duplicate'
-            ,handler: this.duplicate
-            ,scope: this
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        }]
+        ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-snippet'
             ,renderTo: 'modx-panel-snippet-div'
@@ -96,6 +68,62 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
                     },scope:this}
             }
         });
+    }
+    ,getButtons: function(config) {
+        var config = config || {};
+
+        var menu = [{
+            text: _('duplicate') + ' <i class="icon icon-copy"></i>'
+            ,id: 'modx-abtn-duplicate'
+            ,handler: this.duplicate
+            ,scope: this
+        },{
+            text: _('delete') + ' <i class="icon icon-trash-o"></i>'
+            ,id: 'modx-abtn-delete'
+            ,handler: this.delete
+            ,scope: this
+        },{
+            text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+            ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
+        }]
+
+        var btns = [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: menu
+            }
+        },{
+            text: _('cancel') + ' <i class="icon icon-times"></i>'
+            ,id: 'modx-abtn-cancel'
+        },{
+            process: 'element/snippet/update'
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
+            ,keys: [{
+                key: MODx.config.keymap_save || 's'
+                ,ctrl: true
+            }]
+        }]
+
+        return btns;
     }
 });
 Ext.reg('modx-page-snippet-update',MODx.page.UpdateSnippet);

--- a/manager/assets/modext/sections/element/template/create.js
+++ b/manager/assets/modext/sections/element/template/create.js
@@ -11,9 +11,38 @@ MODx.page.CreateTemplate = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-template'
         ,buttons: [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: [{
+                    text: _('cancel') + ' <i class="icon icon-times"></i>'
+                    ,id: 'modx-abtn-cancel'
+                    ,handler: function() {
+                        MODx.loadPage('?');
+                    }
+                },{
+                    text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+                    ,id: 'modx-abtn-help'
+                    ,handler: MODx.loadHelpPane
+                }]
+            }
+        },{
             process: 'element/template/create'
             ,reload: true
-            ,text: _('save')
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
@@ -22,13 +51,6 @@ MODx.page.CreateTemplate = function(config) {
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
         }]
         ,components: [{
             xtype: 'modx-panel-template'

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -10,35 +10,7 @@ MODx.page.UpdateTemplate = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-template'
-        ,buttons: [{
-            process: 'element/template/update'
-            ,text: _('save')
-            ,id: 'modx-abtn-save'
-            ,cls: 'primary-button'
-            ,method: 'remote'
-            // ,checkDirty: true
-            ,keys: [{
-                key: MODx.config.keymap_save || 's'
-                ,ctrl: true
-            }]
-        },{
-            text: _('delete')
-            ,id: 'modx-abtn-delete'
-            ,handler: this.delete
-            ,scope: this
-        },{
-            text: _('duplicate')
-            ,id: 'modx-abtn-duplicate'
-            ,handler: this.duplicate
-            ,scope: this
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        }]
+        ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-template'
             ,renderTo: 'modx-panel-template-div'
@@ -96,6 +68,62 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
                     },scope:this}
             }
         });
+    }
+    ,getButtons: function(config) {
+        var config = config || {};
+
+        var menu = [{
+            text: _('duplicate') + ' <i class="icon icon-copy"></i>'
+            ,id: 'modx-abtn-duplicate'
+            ,handler: this.duplicate
+            ,scope: this
+        },{
+            text: _('delete') + ' <i class="icon icon-trash-o"></i>'
+            ,id: 'modx-abtn-delete'
+            ,handler: this.delete
+            ,scope: this
+        },{
+            text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+            ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
+        }]
+
+        var btns = [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: menu
+            }
+        },{
+            text: _('cancel') + ' <i class="icon icon-times"></i>'
+            ,id: 'modx-abtn-cancel'
+        },{
+            process: 'element/template/update'
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
+            ,keys: [{
+                key: MODx.config.keymap_save || 's'
+                ,ctrl: true
+            }]
+        }]
+
+        return btns;
     }
 });
 Ext.reg('modx-page-template-update',MODx.page.UpdateTemplate);

--- a/manager/assets/modext/sections/element/tv/create.js
+++ b/manager/assets/modext/sections/element/tv/create.js
@@ -11,9 +11,38 @@ MODx.page.CreateTV = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-tv'
         ,buttons: [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: [{
+                    text: _('cancel') + ' <i class="icon icon-times"></i>'
+                    ,id: 'modx-abtn-cancel'
+                    ,handler: function() {
+                        MODx.loadPage('?');
+                    }
+                },{
+                    text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+                    ,id: 'modx-abtn-help'
+                    ,handler: MODx.loadHelpPane
+                }]
+            }
+        },{
             process: 'element/tv/create'
             ,reload: true
-            ,text: _('save')
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
@@ -22,13 +51,6 @@ MODx.page.CreateTV = function(config) {
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
             }]
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
         }]
         ,components: [{
             xtype: 'modx-panel-tv'

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -10,35 +10,7 @@ MODx.page.UpdateTV = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         formpanel: 'modx-panel-tv'
-        ,buttons: [{
-            process: 'element/tv/update'
-            ,text: _('save')
-            ,id: 'modx-abtn-save'
-            ,cls: 'primary-button'
-            ,method: 'remote'
-            // ,checkDirty: true
-            ,keys: [{
-                key: MODx.config.keymap_save || 's'
-                ,ctrl: true
-            }]
-        },{
-            text: _('delete')
-            ,id: 'modx-abtn-delete'
-            ,handler: this.delete
-            ,scope: this
-        },{
-            text: _('duplicate')
-            ,id: 'modx-abtn-duplicate'
-            ,handler: this.duplicate
-            ,scope: this
-        },{
-            text: _('cancel')
-            ,id: 'modx-abtn-cancel'
-        },{
-            text: _('help_ex')
-            ,id: 'modx-abtn-help'
-            ,handler: MODx.loadHelpPane
-        }]
+        ,buttons: this.getButtons(config)
         ,components: [{
             xtype: 'modx-panel-tv'
             ,renderTo: 'modx-panel-tv-div'
@@ -97,6 +69,62 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
                     },scope:this}
             }
         });
+    }
+    ,getButtons: function(config) {
+        var config = config || {};
+
+        var menu = [{
+            text: _('duplicate') + ' <i class="icon icon-copy"></i>'
+            ,id: 'modx-abtn-duplicate'
+            ,handler: this.duplicate
+            ,scope: this
+        },{
+            text: _('delete') + ' <i class="icon icon-trash-o"></i>'
+            ,id: 'modx-abtn-delete'
+            ,handler: this.delete
+            ,scope: this
+        },{
+            text: _('help_ex') + ' <i class="icon icon-question-circle"></i>'
+            ,id: 'modx-abtn-help'
+            ,handler: MODx.loadHelpPane
+        }]
+
+        var btns = [{
+            text: '<i class="icon icon-ellipsis-h"></i>'
+            ,id: 'modx-abtn-menu'
+            ,xtype: 'splitbutton'
+            ,split: false
+            ,arrowSelector: false
+            ,handler: function(btn, e) {
+                if (!btn.menu.isVisible() && !btn.ignoreNextClick) {
+                    btn.showMenu();
+                }
+                btn.fireEvent('arrowclick', btn, e);
+                if (btn.arrowHandler) {
+                    btn.arrowHandler.call(btn.scope || btn, btn, e);
+                }
+            }
+            ,menu: {
+                id: 'modx-abtn-menu-list'
+                ,items: menu
+            }
+        },{
+            text: _('cancel') + ' <i class="icon icon-times"></i>'
+            ,id: 'modx-abtn-cancel'
+        },{
+            process: 'element/tv/update'
+            ,text: _('save') + ' <i class="icon icon-check"></i>'
+            ,id: 'modx-abtn-save'
+            ,cls: 'primary-button'
+            ,method: 'remote'
+            // ,checkDirty: true
+            ,keys: [{
+                key: MODx.config.keymap_save || 's'
+                ,ctrl: true
+            }]
+        }]
+
+        return btns;
     }
 });
 Ext.reg('modx-page-tv-update',MODx.page.UpdateTV);


### PR DESCRIPTION
### What does it do?
Uses a single pattern for action buttons like a resource.

![screenshot-revolution-2019 03 03-18-35-08](https://user-images.githubusercontent.com/20814058/53855299-1048b200-3fde-11e9-8477-64e08ad172c5.png)
![screenshot-revolution-2019 03 03-18-41-35](https://user-images.githubusercontent.com/20814058/53855300-1048b200-3fde-11e9-9932-dee4c51d8303.png)


### Why is it needed?
On the pages of creating and updating resources, some buttons are hidden in one button with ellipsis. My PR copies them for elements.

### Related issue(s)/PR(s)
None
