### PR TITLE
Fix icon layout in action buttons

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1456,7 +1456,7 @@ iframe[classname="x-hidden"] {
       .icon {
         text-align: center;
         margin-left: 10px;
-        width: 18px;
+        @extend .#{$fa-css-prefix}-fw;
       }
     }
   }

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1456,6 +1456,7 @@ iframe[classname="x-hidden"] {
       .icon {
         text-align: center;
         margin-left: 10px;
+        width: 18px;
       }
     }
   }


### PR DESCRIPTION
### What does it do?
Fix icon layout in action buttons.

### Why is it needed?
Icons have different widths and because of this they are not aligned.

**Before:**

![screenshot-revolution-2019 03 04-01-41-35](https://user-images.githubusercontent.com/20814058/53855887-a7166e00-3fe0-11e9-98e8-e9bb7803ef42.png)

**After:**

![screenshot-revolution-2019 03 04-01-39-59](https://user-images.githubusercontent.com/20814058/53855893-ad0c4f00-3fe0-11e9-8b56-a6a66041fd5e.png)


### Related issue(s)/PR(s)
None
