### PR TITLE
[ReUp] Fix image content being too wide for the dashboard widget.

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -87,6 +87,9 @@
       list-style: circle outside;
       padding: 0 0 0 15px;
     }
+    img {
+      max-width:100%;
+    }
     .draggable {
       cursor: move;
     }


### PR DESCRIPTION
### What does it do?
Sets max-width on img tags within the body of a dashboard-block. 

### Why is it needed?
Currently images in the feed are not resized to the container and this means horizontal scrollbars are appearing. Adding `max-width:100%;` to the img tags allows images to fit properly.
See image:
![screenshot_2019-03-06 dashboard modx revolution](https://user-images.githubusercontent.com/5160368/53858005-566c3880-4013-11e9-8478-fa61d2736fe8.png)

### Related issue(s)/PR(s)
None

This PR changes a SASS file, so the CSS will need to be regenerated.