### PR TITLE
Set default for check_filetype

### DIFF
--- a/core/xpdo/compression/xpdozip.class.php
+++ b/core/xpdo/compression/xpdozip.class.php
@@ -40,7 +40,9 @@ class xPDOZip {
 
     public $xpdo = null;
     protected $_filename = '';
-    protected $_options = array();
+    protected $_options = array(
+        'check_filetype' => false
+    );
     protected $_archive = null;
     protected $_errors = array();
 
@@ -54,7 +56,7 @@ class xPDOZip {
     public function __construct(xPDO &$xpdo, $filename, array $options = array()) {
         $this->xpdo =& $xpdo;
         $this->_filename = is_string($filename) ? $filename : '';
-        $this->_options = is_array($options) ? $options : array();
+        $this->_options = is_array($options) ? array_merge($this->_options, $options) : $this->_options;
         $this->_archive = new ZipArchive();
         if (!empty($this->_filename) && file_exists(dirname($this->_filename))) {
             if (file_exists($this->_filename)) {


### PR DESCRIPTION
### What does it do?
Set a default for the check_file type option.

### Why is it needed?
The check_file type option introduced with #14433 could be overridden by a (normally not existing) xPDO option. This should be quite impossible after that patch.

### Related issue(s)/PR(s)
#14433
