### PR TITLE
Check extracted files for allowed extensions by option

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -499,6 +499,9 @@ class modFile extends modFileSystemResource {
         /** @var xPDOZip $archive */
         $archive = $this->fileHandler->modx->getService('archive', 'compression.xPDOZip', XPDO_CORE_PATH, $this->path);
         if ($archive) {
+            if (isset($options['check_filetype']) && $options['check_filetype'] == true) {
+                $options[xPDOZip::ALLOWED_EXTENSIONS] = $this->getAllowedExtensions();
+            }
             $results = $archive->unpack($to, $options);
         }
 
@@ -567,7 +570,7 @@ class modFile extends modFileSystemResource {
      *
      * @param array $options Optional configuration options like mimetype and filename
      *
-     * @return downloadable file
+     * @noreturn downloadable file
      */
     public function download($options = array()) {
         $options = array_merge(array(
@@ -593,6 +596,24 @@ class modFile extends modFileSystemResource {
     public function remove() {
         if (!$this->exists()) return false;
         return @unlink($this->path);
+    }
+
+    /**
+     * Get allowed extensions
+     * @TODO use this for an upload check too
+     *
+     * @return mixed
+     */
+    public function getAllowedExtensions() {
+        if (!$this->fileHandler->modx->getOption('allowedExtensions')) {
+            $allowedFiles = $this->fileHandler->modx->getOption('upload_files') ? explode(',', $this->fileHandler->modx->getOption('upload_files')) : array();
+            $allowedImages = $this->fileHandler->modx->getOption('upload_images') ? explode(',', $this->fileHandler->modx->getOption('upload_images')) : array();
+            $allowedMedia = $this->fileHandler->modx->getOption('upload_media') ? explode(',', $this->fileHandler->modx->getOption('upload_media')) : array();
+            $allowedFlash = $this->fileHandler->modx->getOption('upload_flash') ? explode(',', $this->fileHandler->modx->getOption('upload_flash')) : array();
+            $allowedExtensions = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
+            $this->fileHandler->modx->setOption('allowedExtensions', $allowedExtensions);
+        }
+        return $this->fileHandler->modx->getOption('allowedExtensions');
     }
 }
 

--- a/core/xpdo/compression/xpdozip.class.php
+++ b/core/xpdo/compression/xpdozip.class.php
@@ -37,7 +37,6 @@ class xPDOZip {
     const CREATE = 'create';
     const OVERWRITE = 'overwrite';
     const ZIP_TARGET = 'zip_target';
-    const ALLOWED_EXTENSIONS = 'allowed_extensions';
 
     public $xpdo = null;
     protected $_filename = '';
@@ -143,24 +142,13 @@ class xPDOZip {
      *
      * @param string $target The path of the target location to unpack the files.
      * @param array $options An array of options for the operation.
-     * @return bool|array An array of results for the operation.
+     * @return array An array of results for the operation.
      */
     public function unpack($target, $options = array()) {
         $results = false;
         if ($this->_archive) {
             if (is_dir($target) && is_writable($target)) {
-                if (is_array($options[self::ALLOWED_EXTENSIONS])) {
-                    $fileIndex = array();
-                    for ($i = 0; $i < $this->_archive->numFiles; $i++) {
-                        $filename = $this->_archive->getNameIndex($i);
-                        if ($this->checkFiletype($filename, $options[self::ALLOWED_EXTENSIONS])) {
-                            $fileIndex[] = $filename;
-                        }
-                    }
-                    $results = $this->_archive->extractTo($target, $fileIndex);
-                } else {
-                    $results = $this->_archive->extractTo($target);
-                }
+                $results = $this->_archive->extractTo($target);
             }
         }
         return $results;
@@ -220,25 +208,5 @@ class xPDOZip {
      */
     public function getErrors() {
         return $this->_errors;
-    }
-
-    /**
-     * Check that the filename has a file type extension that is allowed
-     *
-     * @param string $filename The filename
-     * @param array $allowedExtensions The allowed file type extensions
-     * @return bool
-     */
-    private function checkFiletype($filename, $allowedExtensions)
-    {
-        if (is_array($allowedExtensions)) {
-            $ext = pathinfo($filename, PATHINFO_EXTENSION);
-            $ext = strtolower($ext);
-            if (!in_array($ext, $allowedExtensions)) {
-                $this->xpdo->log(XPDO::LOG_LEVEL_WARN, $filename .' can\'t be extracted, because the file type is not allowed.');
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/core/xpdo/compression/xpdozip.class.php
+++ b/core/xpdo/compression/xpdozip.class.php
@@ -37,6 +37,7 @@ class xPDOZip {
     const CREATE = 'create';
     const OVERWRITE = 'overwrite';
     const ZIP_TARGET = 'zip_target';
+    const ALLOWED_EXTENSIONS = 'allowed_extensions';
 
     public $xpdo = null;
     protected $_filename = '';
@@ -148,11 +149,11 @@ class xPDOZip {
         $results = false;
         if ($this->_archive) {
             if (is_dir($target) && is_writable($target)) {
-                if ($this->getOption('check_filetype', $options, false)) {
+                if (is_array($options[self::ALLOWED_EXTENSIONS])) {
                     $fileIndex = array();
                     for ($i = 0; $i < $this->_archive->numFiles; $i++) {
                         $filename = $this->_archive->getNameIndex($i);
-                        if ($this->checkFiletype($filename)) {
+                        if ($this->checkFiletype($filename, $options[self::ALLOWED_EXTENSIONS])) {
                             $fileIndex[] = $filename;
                         }
                     }
@@ -224,27 +225,19 @@ class xPDOZip {
     /**
      * Check that the filename has a file type extension that is allowed
      *
-     * @param $filename
+     * @param string $filename The filename
+     * @param array $allowedExtensions The allowed file type extensions
      * @return bool
      */
-    private function checkFiletype($filename)
+    private function checkFiletype($filename, $allowedExtensions)
     {
-        if ($this->xpdo->getOption('allowedFileTypes')) {
-            $allowedFileTypes = $this->getOption('allowedFileTypes');
-            $allowedFileTypes = (!is_array($allowedFileTypes)) ? explode(',', $allowedFileTypes) : $allowedFileTypes;
-        } else {
-            $allowedFiles = $this->xpdo->getOption('upload_files') ? explode(',', $this->xpdo->getOption('upload_files')) : array();
-            $allowedImages = $this->xpdo->getOption('upload_images') ? explode(',', $this->xpdo->getOption('upload_images')) : array();
-            $allowedMedia = $this->xpdo->getOption('upload_media') ? explode(',', $this->xpdo->getOption('upload_media')) : array();
-            $allowedFlash = $this->xpdo->getOption('upload_flash') ? explode(',', $this->xpdo->getOption('upload_flash')) : array();
-            $allowedFileTypes = array_unique(array_merge($allowedFiles, $allowedImages, $allowedMedia, $allowedFlash));
-            $this->xpdo->setOption('allowedFileTypes', $allowedFileTypes);
-        }
-        $ext = pathinfo($filename, PATHINFO_EXTENSION);
-        $ext = strtolower($ext);
-        if (!empty($allowedFileTypes) && !in_array($ext, $allowedFileTypes)) {
-            $this->xpdo->log(XPDO::LOG_LEVEL_WARN, $filename .' can\'t be extracted, because the file type is not allowed');
-            return false;
+        if (is_array($allowedExtensions)) {
+            $ext = pathinfo($filename, PATHINFO_EXTENSION);
+            $ext = strtolower($ext);
+            if (!in_array($ext, $allowedExtensions)) {
+                $this->xpdo->log(XPDO::LOG_LEVEL_WARN, $filename .' can\'t be extracted, because the file type is not allowed.');
+                return false;
+            }
         }
         return true;
     }


### PR DESCRIPTION
### What does it do?
Check extracted files for allowed extensions by option and enable that option in the file/unpack processor. Improved version of #14433 that fits better in xPDO.

I have included the xPDO changes here for testing. That part has to be merged into xPDO first.

### Why is it needed?
Without that patch, not allowed files could be unpacked.

### Related issue(s)/PR(s)
#14385, #14433