### PR TITLE
Update phpThumb to fix an issue with converting images

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -208,7 +208,7 @@ class phpthumb {
 	public $tempFilesToDelete = array();
 	public $cache_filename    = null;
 
-	public $AlphaCapableFormats = array( 'png', 'ico', 'gif');
+    public $AlphaCapableFormats = array( 'png', 'ico', 'gif', 'webp');
 	public $is_alpha = false;
 
 	public $iswindows        = null;
@@ -1747,7 +1747,7 @@ class phpthumb {
 					if (!preg_match('#('.implode('|', $this->AlphaCapableFormats).')#i', $outputFormat)) {
 						// not a transparency-capable format
 						$commandline .= ' -background '.phpthumb_functions::escapeshellarg_replacement('#'.($this->bg ? $this->bg : 'FFFFFF'));
-						if ($getimagesize[2] == IMAGETYPE_GIF) {
+                        if (!stristr($commandline, ' -flatten')) {
 							$commandline .= ' -flatten';
 						}
 					} else {


### PR DESCRIPTION
### What does it do?
Update phpThumb to the most recent version: 
https://github.com/JamesHeinrich/phpThumb/commit/08f57de651717b1e2fb9f86b9965227e8e5d903c

### Why is it needed?
There was a bug in phpThumb where an image would get a black background color when converting an image with transparency to a format without alpha support.

### Related issue(s)/PR(s)
Fixes issue #14474 
