### PR TITLE
Remove min folder from core transport package builder

### DIFF
--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -506,11 +506,6 @@ $attributes['resolve'][] = array (
 );
 $attributes['resolve'][] = array (
     'type' => 'file',
-    'source' => MODX_BASE_PATH . 'manager/min',
-    'target' => "return MODX_MANAGER_PATH;",
-);
-$attributes['resolve'][] = array (
-    'type' => 'file',
     'source' => MODX_BASE_PATH . 'manager/ht.access',
     'target' => "return MODX_MANAGER_PATH;",
 );


### PR DESCRIPTION
### What does it do?
Deletes memorization of the `min` folder from the core package builder script.

### Why is it needed?
To fix error during building the package:
```
[2019-03-11 19:44:37] (ERROR @ ~/3x/src/core/vendor/xpdo/xpdo/src/xPDO/Transport/xPDOVehicle.php : 352) Source file ~/3x/src/manager/min is missing or ~/3x/src/core/packages/core/modContext/0ac5c924712d3f79523c0b11b48d4b10/3/ is not writable
```

### Related issue(s)/PR(s)
#14416