### PR TITLE
Make working distrib building of 3.x branch

### DIFF
--- a/_build/build.sample.properties
+++ b/_build/build.sample.properties
@@ -7,6 +7,9 @@ php.command = /opt/local/bin/php
 # Git related properties (set you local path here)
 git.command = git
 
+# Composer related properties (set you local path here)
+composer.command = composer
+
 # override the project name used to generate the distribution filename
 #project.name.fs = modx
 

--- a/_build/build.xml
+++ b/_build/build.xml
@@ -46,6 +46,7 @@
     <target name="complete" description="--> Complete Build">
         <phingcall target="prepare-build-image" />
         <phingcall target="git-export-build-image" />
+        <phingcall target="composer-install-dependencies" />
         <!--<phingcall target="copy-core-transport" />-->
         <phingcall target="prepare-build-distrib" />
         <!--<phingcall target="generate-phpdocs" />-->
@@ -75,6 +76,11 @@
               command="${git.command} archive -o ${absolute.image.basedir}/${build.distrib.name}.zip --format=zip --prefix=${build.distrib.name}/ ${build.src.tree}"
               escape="false" />
         <unzip file="${build.image.dir}.zip" todir="${build.image.basedir}" />
+    </target>
+
+    <!-- Install all core dependencies via composer -->
+    <target name="composer-install-dependencies" description="" if="build.distrib">
+        <exec dir="${build.image.dir}" command="${composer.command} install" escape="false" />
     </target>
 
     <!-- Run the core data generation script -->
@@ -303,6 +309,7 @@
                 <include name="core/lexicon/**" />
                 <include name="core/model/**" />
                 <include name="core/xpdo/**" />
+                <include name="core/vendor/**" />
                 <include name="core/packages/core.transport.zip" />
                 <include name="core/packages/core/manifest.php" />
                 <include name="core/packages/core/*/*.vehicle" />
@@ -371,6 +378,7 @@
                 <include name="core/lexicon/**" />
                 <include name="core/model/**" />
                 <include name="core/xpdo/**" />
+                <include name="core/vendor/**" />
                 <include name="core/packages/core.transport.zip" />
             </fileset>
         </zip>

--- a/_build/build.xml
+++ b/_build/build.xml
@@ -51,8 +51,10 @@
         <phingcall target="prepare-build-distrib" />
         <!--<phingcall target="generate-phpdocs" />-->
         <phingcall target="generate-core-transport" />
+        <phingcall target="copy-core-transport" />
         <phingcall target="build-sdk" />
         <phingcall target="generate-core-transport" />
+        <phingcall target="copy-core-transport" />
         <phingcall target="build-traditional" />
         <phingcall target="build-advanced" />
     </target>

--- a/_build/build.xml
+++ b/_build/build.xml
@@ -82,7 +82,7 @@
 
     <!-- Install all core dependencies via composer -->
     <target name="composer-install-dependencies" description="" if="build.distrib">
-        <exec dir="${build.image.dir}" command="${composer.command} install" escape="false" />
+        <exec dir="${build.image.dir}" command="${composer.command} install --no-dev" escape="false" />
     </target>
 
     <!-- Run the core data generation script -->


### PR DESCRIPTION
### What does it do?
It adds an intermediate step in the build process (in Phing configuration file) for installing composer dependencies of the core.

### Why is it needed?
To make build process working again. Now, vendor dir is missed in the build and build becomes totally broken.

### Related issue(s)/PR(s)
N/A