### PR TITLE
Make MODX 3 require at least PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ php:
   - 7.2
   - 7.1
   - 7.0
-  - 5.6
   - nightly
 
 matrix:
@@ -27,5 +26,4 @@ mysql:
 before_script: 'composer install -n && cd _build/test && ./generateConfigs.sh'
 
 before_install:
-  -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi
-  -  if [[ "(7.0 7.1 7.2 7.3 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  -  if [[ "(7.0 7.1 7.2 7.3 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-6.5.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "vendor-dir": "core/vendor"
     },
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "xpdo/xpdo": "^3.0@dev",
         "league/flysystem": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0",
@@ -91,7 +91,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "~5.7|~6.5",
+        "phpunit/phpunit": "^6",
         "php-coveralls/php-coveralls": "~2.1"
     }
 }

--- a/manager/index.php
+++ b/manager/index.php
@@ -24,9 +24,9 @@ if (!defined('MODX_API_MODE')) {
 }
 
 /* check for correct version of php */
-$php_ver_comp = version_compare(phpversion(),'5.6');
+$php_ver_comp = version_compare(phpversion(),'7.0');
 if ($php_ver_comp < 0) {
-    die('Wrong php version! You\'re using PHP version "'.phpversion().'", and MODX Revolution only works on 5.6 or higher.');
+    die('Wrong php version! You\'re using PHP version "'.phpversion().'", and MODX Revolution only works on 7.0 or higher.');
 }
 
 /* set the document_root */

--- a/setup/includes/test/modinstalltest.class.php
+++ b/setup/includes/test/modinstalltest.class.php
@@ -79,7 +79,7 @@ abstract class modInstallTest {
         $phpVersion = phpversion();
 
         $recommended_version = "7.2";
-        $required_version = "5.6";
+        $required_version = "7.0";
 
         $php_ver_comp = version_compare($phpVersion,$required_version,'>=');
 


### PR DESCRIPTION
### What does it do?
Update the minimum required PHP version to PHP 7.0

### Why is it needed?
This allows use to modernise the codebase and drop support for legact version of PHP.
