### PR TITLE
Minor bug fixes styles

### DIFF
--- a/_build/templates/default/sass/_breadcrumbs.scss
+++ b/_build/templates/default/sass/_breadcrumbs.scss
@@ -55,7 +55,7 @@
         }
 
         &:hover {
-          background-color: $colorSplash;
+          background-color: $darkGray;
         }
 
         .root {
@@ -102,25 +102,25 @@
         button,
         span,
         span:after {
-          background-color: $colorSplash;
+          background-color: $darkGray;
           color: $colorSplashContrast;
         }
 
         span:after,
         button:after {
           border: 1px solid $lightestGray;
-          border-left-color: $colorSplash;
-          border-bottom-color: $colorSplash;
+          border-left-color: $darkGray;
+          border-bottom-color: $darkGray;
         }
 
         span:before,
         button:before {
-          background-color: $colorSplash;
+          background-color: $darkGray;
         }
 
         + li span:before,
         + li button:before {
-          border-left-color: $colorSplash;
+          border-left-color: $darkGray;
         }
       }
 

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -5,8 +5,6 @@ $colorSplashMedium: lighten($colorSplash, 75%);
 $colorSplashDark: darken($colorSplash, 20%);
 $colorSplashDesaturated: lighten(desaturate($colorSplash,100%), 20%); /* unused */
 $colorSplashContrast: #FFFFFF; /* needs much more adaption, should be used as text color for elements with $colorSplash background */
-$primary1: #32AB9A;
-$primary2: #00948E;
 $lightestGray: #FBFBFB;
 $lighterGray: #F0F0F0;
 $lightGray: #E4E4E4;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -201,7 +201,7 @@ $headfonts: $bodyfonts;
 $codefonts: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 $tabFont: 14px $bodyfonts;
 $buttonfonts: $bodyfonts;
-$treePseudoRootFont: bold 14px/3 $headfonts;
+$treePseudoRootFont: 500 14px/3 $headfonts;
 $treeNodeFont: normal 14px/2.25 $bodyfonts;
 $baseText:   normal 13px/1.4 $bodyfonts;
 $baseTextHeight: 13px * 1.4;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -17,6 +17,7 @@ $black: darken($colorSplash, 42.5%); /* generate the black from the $colorSplash
 $lighterRed: #FFEEEE;
 $green: #6CB24A;
 $greener: darken($green, 12%);
+$lightGreen: lighten($green, 50%);
 $lighterGreen: #EFFCF6;
 $yellow: #FCE588;
 $orange: #F0B429;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -257,6 +257,21 @@
   }
 }
 
+#modx-resource-access-permissions,
+#modx-panel-users,
+#modx-panel-content-type,
+#modx-panel-resource-groups,
+#modx-panel-import-resources,
+#modx-panel-import-html,
+#modx-panel-property-sets,
+#modx-panel-namespaces,
+#modx-panel-actions,
+#modx-panel-contexts {
+  .x-panel-body {
+    padding-top: 15px;
+  }
+}
+
 .dashboard-buttons {
   display: flex;
   flex-wrap: wrap;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -272,6 +272,19 @@
   }
 }
 
+button.uninstall:hover,
+button.remove:hover {
+  background: $red;
+  color: $white;
+  box-shadow: 0 0 0 1px $red;
+}
+
+button.reinstall:hover {
+  background: $green;
+  color: $white;
+  box-shadow: 0 0 0 1px $green;
+}
+
 .dashboard-buttons {
   display: flex;
   flex-wrap: wrap;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -293,7 +293,7 @@ button.reinstall:hover {
   margin: -1rem 0 0 -1rem;
   .dashboard-button {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     background-color: $white;
     border-radius: $borderRadius;
     box-shadow: $boxShadow;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -272,19 +272,6 @@
   }
 }
 
-button.uninstall:hover,
-button.remove:hover {
-  background: $red;
-  color: $white;
-  box-shadow: 0 0 0 1px $red;
-}
-
-button.reinstall:hover {
-  background: $green;
-  color: $white;
-  box-shadow: 0 0 0 1px $green;
-}
-
 .dashboard-buttons {
   display: flex;
   flex-wrap: wrap;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -333,6 +333,28 @@ button.reinstall:hover {
   }
 }
 
+::-webkit-scrollbar,
+::-webkit-scrollbar-thumb {
+  width: 1rem;
+  height: 1rem;
+  border: .25rem solid transparent;
+  border-radius: .5rem;
+  background-color: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  box-shadow: inset 0 0 0 1rem rgba(85, 108, 136, .1);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  box-shadow: inset 0 0 0 1rem rgba(85, 108, 136, .2);
+}
+
+::-webkit-resizer,
+::-webkit-scrollbar-corner {
+  background-color: transparent;
+}
+
 .updates-widget {
   .updates-title { font-weight: bold; }
   .updates-updateable {

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -87,9 +87,6 @@
       list-style: circle outside;
       padding: 0 0 0 15px;
     }
-    img {
-      max-width:100%;
-    }
     .draggable {
       cursor: move;
     }
@@ -251,6 +248,12 @@
     .occurred-time {
       color: $mediumGray;
     }
+  }
+}
+
+#modx-news-feed-container {
+  img {
+    max-width: 100%;
   }
 }
 

--- a/_build/templates/default/sass/_help.scss
+++ b/_build/templates/default/sass/_help.scss
@@ -46,7 +46,7 @@
 }
 
 #managerbuttons ul li a {
-  background: linear-gradient(top, white, whitesmoke);
+  background-color: $white;
   border-radius: $borderRadius;
   border: 1px solid $borderColor;
   box-shadow: 0 1px 0 $borderColor;
@@ -103,7 +103,6 @@
 #helpBanner {
   margin-top: 1.5em;
   min-height: 112px;
-  background-color: transparent;
   background-image: url($imgPath + 'modx-logo-color.png');
   background-image: url($imgPath + 'modx-logo-color.svg'),none;
   background-repeat: no-repeat;
@@ -158,7 +157,7 @@
     }
   }
   i {
-    margin: 0 8px -6px 0;
+    margin: 0 15px -6px 0;
   }
 }
 

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -298,7 +298,7 @@
 
   .x-btn {
     &:hover, &:focus {
-      color: $primary2 !important;
+      color: $green !important;
     }
   }
 }
@@ -883,6 +883,9 @@
 #modx-leftbar-tabpanel__modx-trash-link {
   .icon {
     opacity: .5;
+    &:hover {
+      color: $red;
+    }
   }
   &.active {
     .icon {

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -311,7 +311,7 @@
   display: inline-block;
   float: left;
   position: relative;
-  width: 40px !important; /* override extjs default theme style */
+  width: 36px !important; /* override extjs default theme style */
 
   &:before {
     @extend %pseudo-font;

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -265,16 +265,14 @@
 
 /* the progress bar (ex. saving a resource), usually in a window too */
 .x-progress-wrap {
-  border: 1px solid $colorSplash;
+  border: 1px solid $green;
 
   .x-progress-inner {
-    background-color: $colorSplashLight;
-    /*background-image: url($imgPath + 'modx-theme/qtip/bg.gif');*/
+    background-color: $lightGreen;
   }
 
   .x-progress-bar {
-    background-color: $colorSplash;
-    /*background-image: url($imgPath + 'modx-theme/progress/progress-bg.gif');*/
+    background-color: $green;
     border: 0;
   }
 

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -668,7 +668,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
     &.x-menu-item-active {
       background-color: $menuSelectedBg;
       a {
-        color: $menuSelectedColor;
+        color: $menuTextColor;
       }
     }
   }

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -135,7 +135,7 @@ hr {
 }
 
 .primary {
-	color: $primary1 !important;
+	color: $green !important;
 }
 
 .centered {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1400,7 +1400,7 @@ iframe[classname="x-hidden"] {
 
     #modx-resource-header {
       order: 1;
-      font: bold 16px $bodyfonts;
+      font: 500 16px $bodyfonts;
       color: $darkestGray;
       margin: 0;
       padding-left: 0;


### PR DESCRIPTION
### What does it do?
Changed / added styles:
- Fixed `font-weight` property from 700 to 500 in menu and headers
- Improves consistency of green color when you hover over the menu items and in the progress bar
- Removed two color variables that are no longer used and are left over from 2.x
- Fixed bug with the adaptability of images in panels on the start page
- Fixed padding in `.x-panel-body `
- Fixed the position of the icons in the panels `.dashboard-buttons` and the icon in the pop-up window
- Stylized scrollbar
- Fixed the background color of the Help page in the panels

### Why is it needed?
Fixes minor bugs and improves the appearance of the admin panel

![screencast 2019-03-17 05-53-38](https://user-images.githubusercontent.com/2138260/54483144-4527f500-4879-11e9-9398-4d7cd6dcf8d4.gif)

![screencast 2019-03-17 05-54-56](https://user-images.githubusercontent.com/2138260/54483150-57a22e80-4879-11e9-9c07-330ae51c3d30.gif)

![screencast 2019-03-17 05-57-02](https://user-images.githubusercontent.com/2138260/54483208-9f28ba80-4879-11e9-9862-cb9813085bca.gif)

### Related issue(s)/PR(s)
NA
