### PR TITLE
Fix for undefined constant IMG_WEBP

### DIFF
--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -33,6 +33,13 @@ class modPhpThumb extends phpThumb
         $this->modx =& $modx;
         $this->config = $config;
 
+        if (version_compare(PHP_VERSION, '5.6.25', '<')
+            || (version_compare(PHP_VERSION, '7.0.0', '>=')
+                && version_compare(PHP_VERSION, '7.0.10', '<'))) {
+            // The constant IMG_WEBP is available as of PHP 5.6.25 and PHP 7.0.10, respectively.
+            define('IMG_WEBP', 32);
+        }
+
         parent::__construct();
     }
 


### PR DESCRIPTION
### What does it do?
Define the IMG_WEBP constant.

### Why is it needed?
The IMG_WEBP constant is used as a return value by imagetypes() and available as of PHP 5.6.25 and PHP 7.0.10, respectively. This would cause some notices when using an not up-to-date install of, for example, PHP 7.

### Related issue(s)/PR(s)
Fixes issue #14489
