### PR TITLE
Change the indents on the System Info page

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -323,6 +323,12 @@
   .updates-available { background: $red; }
 }
 
+#modx-panel-system-info {
+  .x-form-label-left .x-form-item {
+    padding: 0;
+  }
+}
+
 @media screen and (max-width: 1023px) {
   .dashboard-buttons {
     .dashboard-button {


### PR DESCRIPTION
### What does it do?
Indenting `.x-form-item` in `#modx-panel-system-info`

### Why is it needed?
Improves visual presentation of information in the modx-panel-system-info panel

Before:
![System Info  MODX Revolution 2019-03-19 04-55-27](https://user-images.githubusercontent.com/2138260/54569066-c4e1cb00-4a03-11e9-9e29-a4e13e4881b3.jpg)
After:
![System Info  MODX Revolution 2019-03-19 04-54-55](https://user-images.githubusercontent.com/2138260/54569088-d4611400-4a03-11e9-9cfd-4076d11927f3.jpg)


### Related issue(s)/PR(s)
NA
