### PR TITLE
Version number fix Smarty, PHPmailer

### DIFF
--- a/manager/assets/modext/sections/system/info.js
+++ b/manager/assets/modext/sections/system/info.js
@@ -56,11 +56,11 @@ MODx.panel.SystemInfo = function(config) {
     },{
         fieldLabel: _('smarty_version')
         ,name: 'smarty_version'
-        ,value: '3.1.27'
+        ,value: '3.1.33'
     },{
         fieldLabel: _('phpmailer_version')
         ,name: 'phpmailer_version'
-        ,value: '5.2.14'
+        ,value: '5.2.26'
     },{
         fieldLabel: _('magpie_version')
         ,name: 'magpie_version'


### PR DESCRIPTION
### What does it do?
Version number fix Smarty, PHPmailer

### Why is it needed?
This fix is necessary for the correct display of information.

### Related issue(s)/PR(s)
#14515 
