### PR TITLE
Fix padding in _windows.scss

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -103,16 +103,6 @@
     overflow-y: auto;
     padding: 15px;
   }
-  &.modx-window {
-    .x-window-body {
-      padding-top: 0;
-    }
-    &.modx-console, &.modx-alert, &.modx-confirm {
-      .x-window-body {
-        padding-top: 15px;
-      }
-    }
-  }
 
   .x-panel-bwrap {
     background: $winBodyBg;


### PR DESCRIPTION
### What does it do?
Removed `.x-window.modx-window .x-window-body {padding-top: 0;}`

### Why is it needed?
Missing indent in package update window.

Before
![before](https://user-images.githubusercontent.com/12523676/55347103-058e1980-54c5-11e9-8d01-b5ece6d9fdc4.png)

After
![after](https://user-images.githubusercontent.com/12523676/55347102-058e1980-54c5-11e9-95ce-ba0885ae8b2f.png)

I do not understand why the style is:
`.x-window.modx-window .x-window-body {padding-top: 0;}`

**I removed this styles and did not notice the changes, perhaps the community knows what these lines are for.**

### Related issue(s)/PR(s)
None