### PR TITLE
Fixed #14448 (Spaces before or after search word distort the result)

### DIFF
--- a/core/model/modx/processors/search/search.class.php
+++ b/core/model/modx/processors/search/search.class.php
@@ -30,7 +30,7 @@ class modSearchProcessor extends modProcessor
      */
     public function process()
     {
-        $this->query = $this->getProperty('query');
+        $this->query = trim($this->getProperty('query'));
         if (!empty($this->query)) {
             if (strpos($this->query, ':') === 0) {
                 // upcoming "launch actions"


### PR DESCRIPTION
### What does it do?
trims spaces in query

### Why is it needed?
to avoid issue when spaces before or after query

### Related issue(s)/PR(s)
#14448
