### PR TITLE
Adds ability to turn on/off autocompletion for 'pagetitle' field

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1475,6 +1475,15 @@ $settings['resolve_hostnames']->fromArray(array (
   'area' => 'system',
   'editedon' => null,
 ), '', true, true);
+$settings['resource_pagetitle_autocomplete']= $xpdo->newObject('modSystemSetting');
+$settings['resource_pagetitle_autocomplete']->fromArray(array (
+  'key' => 'resource_pagetitle_autocomplete',
+  'value' => '1',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 $settings['resource_tree_node_name']= $xpdo->newObject('modSystemSetting');
 $settings['resource_tree_node_name']->fromArray(array (
   'key' => 'resource_tree_node_name',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -625,6 +625,9 @@ $_lang['setting_resolve_hostnames_desc'] = 'Do you want MODX to try to resolve y
 $_lang['setting_resource_tree_node_name'] = 'Resource Tree Node Field';
 $_lang['setting_resource_tree_node_name_desc'] = 'Specify the Resource field to use when rendering the nodes in the Resource Tree. Defaults to pagetitle, although any Resource field can be used, such as menutitle, alias, longtitle, etc.';
 
+$_lang['setting_resource_pagetitle_autocomplete'] = 'Enables autocomplete for pagetitle field';
+$_lang['setting_resource_pagetitle_autocomplete_desc'] = 'Select \'Yes\' if you want to see hints/autocomplete data based on the previous entered values for the pagetitle field of the resource.';
+
 $_lang['setting_resource_tree_node_name_fallback'] = 'Resource Tree Node Fallback Field';
 $_lang['setting_resource_tree_node_name_fallback_desc'] = 'Specify the Resource field to use as fallback when rendering the nodes in the Resource Tree. This will be used if the resource has an empty value for the configured Resource Tree Node Field.';
 

--- a/core/lexicon/ru/setting.inc.php
+++ b/core/lexicon/ru/setting.inc.php
@@ -634,6 +634,9 @@ $_lang['setting_resolve_hostnames_desc'] = 'Хотите ли вы, чтобы M
 $_lang['setting_resource_tree_node_name'] = 'Поле для названия узла в дереве ресурсов';
 $_lang['setting_resource_tree_node_name_desc'] = 'Укажите поле ресурса, которое будет использоваться в качестве названия узла в дереве ресурсов. По умолчанию поле «pagetitle», любое поле ресурса может быть использовано: «menutitle», «alias», «longtitle», и т.п.';
 
+$_lang['setting_resource_pagetitle_autocomplete'] = 'Включить автозаполнение для поля заголовка';
+$_lang['setting_resource_pagetitle_autocomplete_desc'] = 'Выберите «Да», если хотите видеть подсказки/автозаполнение данных на основе предыдущих введеных значений для поля pagetitle (заголовок) ресурса.';
+
 $_lang['setting_resource_tree_node_name_fallback'] = 'Запасное поле для узла в дереве ресурсов';
 $_lang['setting_resource_tree_node_name_fallback_desc'] = 'Укажите поле ресурса для использования в качестве запасного названия узла в дереве ресурсов. Это значение будет использоваться, если ресурс имеет пустое значение для заданного поля ресурса в дереве.';
 

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -36,6 +36,7 @@ Ext.extend(MODx,Ext.Component,{
 
     ,startup: function() {
         this.initQuickTips();
+        this.initAutocompletePagetitle();
         this.request = this.getURLParameters();
         this.Ajax = this.load({ xtype: 'modx-ajax' });
         Ext.override(Ext.form.Field,{
@@ -92,6 +93,14 @@ Ext.extend(MODx,Ext.Component,{
         Ext.apply(Ext.QuickTips.getQuickTip(), {
             dismissDelay: 2300
             ,interceptTitles: true
+        });
+    }
+
+    ,initAutocompletePagetitle: function() {
+        Ext.ComponentMgr.onAvailable("modx-resource-pagetitle", function(field) {
+            var setting_pagetitle_autocomplete = +MODx.config.resource_pagetitle_autocomplete;
+            var autocomplete = setting_pagetitle_autocomplete ? "on" : "off";
+            field.defaultAutoCreate = {tag: "input", type: "text", size: "20", autocomplete: autocomplete, msgTarget: 'under' }
         });
     }
 


### PR DESCRIPTION
### What does it do?
Adds ability to turn on/off autocompletion for 'pagetitle' field with system setting `resource_pagetitle_autocomplete`

### Why is it needed?
to avoid long sheet of available autocompletions

### Related issue(s)/PR(s)
#6703 
