### PR TITLE
Added 'async' optional param to 'regClientScript' and 'regClientStartupScript'

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1548,9 +1548,11 @@ class modX extends xPDO {
      * tag of an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
+     * @param string $async String literal 'async' or 'defer' which is added 
+     * as attribute to html script tag
      * @return void
      */
-    public function regClientStartupScript($src, $plaintext= false) {
+    public function regClientStartupScript($src, $plaintext= false, $async='') {
         if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
             if (isset ($this->loadedjscripts[$src]))
                 return;
@@ -1560,7 +1562,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '" '.htmlentities($async).'></script>';
             }
         }
     }
@@ -1572,9 +1574,11 @@ class modX extends xPDO {
      * tag in an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
+     * @param string $async String literal 'async' or 'defer' which is added 
+     * as attribute to html script tag
      * @return void
      */
-    public function regClientScript($src, $plaintext= false) {
+    public function regClientScript($src, $plaintext= false, $async='') {
         if (isset ($this->loadedjscripts[$src]))
             return;
         $this->loadedjscripts[$src]= true;
@@ -1583,7 +1587,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '" '.htmlentities($async).'></script>';
         }
     }
 

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1548,11 +1548,12 @@ class modX extends xPDO {
      * tag of an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
-     * @param string $async String literal 'async' or 'defer' which is added 
+     * @param string $async Optional string literal 'async' or 'defer' which is added 
      * as attribute to html script tag
      * @return void
      */
     public function regClientStartupScript($src, $plaintext= false, $async='') {
+        if (!in_array($async, array('async','defer'))) $async = '';
         if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
             if (isset ($this->loadedjscripts[$src]))
                 return;
@@ -1562,7 +1563,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '" '.htmlentities($async).'></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '" '.$async.'></script>';
             }
         }
     }
@@ -1574,11 +1575,12 @@ class modX extends xPDO {
      * tag in an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
-     * @param string $async String literal 'async' or 'defer' which is added 
+     * @param string $async Optional string literal 'async' or 'defer' which is added 
      * as attribute to html script tag
      * @return void
      */
     public function regClientScript($src, $plaintext= false, $async='') {
+        if (!in_array($async, array('async','defer'))) $async = '';
         if (isset ($this->loadedjscripts[$src]))
             return;
         $this->loadedjscripts[$src]= true;
@@ -1587,7 +1589,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '" '.htmlentities($async).'></script>';
+            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '" '.$async.'></script>';
         }
     }
 


### PR DESCRIPTION
### What does it do?
Added optional param 'async' for methods **regClientScript** and **regClientStartupScript** of modx object, which allows to get 

`<script type="text/javascript" src="/assets/js/script.js" async></script>` 
**or** 
`<script type="text/javascript" src="/assets/js/script.js" defer></script>`

**instead of**
``<script type="text/javascript" src="/assets/js/script.js"></script>``

### Why is it needed?
to avoid "blocking-like" synchronous behaviour when browser builds DOM and stops and execute scripts tags, allows to use asynchronous behaviour instead

### Related issue(s)/PR(s)
#14520
