### PR TITLE
Fixes media sources no-icon in media browser

### DIFF
--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -487,6 +487,7 @@ MODx.browser.Window = function(config) {
         ,hideTooltips: config.hideTooltips || MODx.config.modx_browser_tree_hide_tooltips || true // by default do not request image preview tooltips in the media browser
         ,openTo: config.openTo || ''
         ,ident: this.ident
+        ,rootIconCls: MODx.config.mgr_source_icon
         ,rootId: config.rootId || '/'
         ,rootName: _('files')
         ,rootVisible: config.rootVisible == undefined || !Ext.isEmpty(config.rootId)
@@ -871,6 +872,7 @@ MODx.Media = function(config) {
         ,hideTooltips: config.hideTooltips || MODx.config.modx_browser_tree_hide_tooltips || true // by default do not request image preview tooltips in the media browser
         ,openTo: config.openTo || ''
         ,ident: this.ident
+        ,rootIconCls: MODx.config.mgr_source_icon
         ,rootId: config.rootId || '/'
         ,rootName: _('files')
         ,rootVisible: config.rootVisible == undefined || !Ext.isEmpty(config.rootId)
@@ -1218,6 +1220,7 @@ MODx.browser.RTE = function(config) {
         ,hideTooltips: config.hideTooltips || MODx.config.modx_browser_tree_hide_tooltips || true // by default do not request image preview tooltips in the media browser
         ,openTo: config.openTo || ''
         ,ident: this.ident
+        ,rootIconCls: MODx.config.mgr_source_icon
         ,rootId: config.rootId || '/'
         ,rootName: _('files')
         ,rootVisible: config.rootVisible == undefined || !Ext.isEmpty(config.rootId)


### PR DESCRIPTION
### What does it do?
Fixes media sources no-icon in media browser

**before**:
![image](https://user-images.githubusercontent.com/8276064/55445969-67827800-55c6-11e9-8f64-eaab5fcc5900.png)

**after**:
![image](https://user-images.githubusercontent.com/8276064/55446016-93056280-55c6-11e9-8cf5-84a0f4a69f05.png)


### Why is it needed?
UI fix

### Related issue(s)/PR(s)
#14487
