### PR TITLE
Allow in-line editing in FC sets grid

### DIFF
--- a/core/model/modx/processors/security/forms/set/updatefromgrid.class.php
+++ b/core/model/modx/processors/security/forms/set/updatefromgrid.class.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+require_once (dirname(__FILE__) . '/update.class.php');
+/**
+ * Update a FC Profile from grid
+ *
+ * @package modx
+ * @subpackage processors.security.forms.profile
+ */
+class modFormCustomizationSetUpdateFromGridProcessor extends modFormCustomizationSetUpdateProcessor {
+    public function initialize() {
+        $data = $this->getProperty('data');
+        if (empty($data)) return $this->modx->lexicon('invalid_data');
+        $properties = $this->modx->fromJSON($data);
+        $this->setProperties($properties);
+        $this->unsetProperty('data');
+
+        return parent::initialize();
+    }
+}
+return 'modFormCustomizationSetUpdateFromGridProcessor';

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -10,6 +10,7 @@ MODx.grid.FCSet = function(config) {
         ,fields: ['id','profile','action','description','active','template','templatename','constraint_data','constraint','constraint_field','constraint_class','rules','perm']
         ,paging: true
         ,autosave: true
+        ,save_action: 'security/forms/set/updatefromgrid'
         ,sm: this.sm
         ,remoteSort: true
         ,autoExpandColumn: 'controller'
@@ -22,7 +23,7 @@ MODx.grid.FCSet = function(config) {
             header: _('action')
             ,dataIndex: 'action'
             ,width: 200
-            ,editable: false
+            ,editable: true
             ,sortable: true
             ,editor: {
                 xtype: 'modx-combo-fc-action',
@@ -34,17 +35,40 @@ MODx.grid.FCSet = function(config) {
             ,width: 200
             ,editable: true
             ,sortable: true
+            ,editor: {
+                xtype: 'textfield',
+                renderer: true
+            }
         },{
             header: _('template')
-            ,dataIndex: 'templatename'
+            ,dataIndex: 'template'
             ,width: 150
             ,sortable: true
+            ,editable: true
+            ,editor: {
+                xtype: 'modx-combo-template',
+                renderer: true
+            }
+        },{
+            header: _('constraint_field')
+            ,dataIndex: 'constraint_field'
+            ,width: 200
+            ,editable: true
+            ,sortable: false
+            ,editor: {
+                xtype: 'textfield',
+                renderer: true
+            }
         },{
             header: _('constraint')
-            ,dataIndex: 'constraint_data'
+            ,dataIndex: 'constraint'
             ,width: 200
-            ,editable: false
+            ,editable: true
             ,sortable: false
+            ,editor: {
+                xtype: 'textfield',
+                renderer: true
+            }
         }]
         ,viewConfig: {
             forceFit:true


### PR DESCRIPTION
### What does it do?
Adds ability to edit as inline fields in grid in FC sets as in FC Profiles grid

### Why is it needed?
Increase productivity

### Related issue(s)/PR(s)
#5225
