### PR TITLE
Added an icon in the menu tree

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.menu.js
+++ b/manager/assets/modext/widgets/system/modx.tree.menu.js
@@ -9,8 +9,9 @@
 MODx.tree.Menu = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        root_id: 'n_'
-        ,root_name: _('menu_top')
+        rootIconCls: 'icon-navicon'
+        ,rootId: 'n_'
+        ,rootName: _('menu_top')
         ,rootVisible: true
         ,expandFirst: true
         ,enableDrag: true


### PR DESCRIPTION
### What does it do?
Added icon in the menu tree in the "Menu" section.

Before:
![menu-icon-before](https://user-images.githubusercontent.com/12523676/55574700-11284d00-571e-11e9-9193-583db2180e9f.png)

After:
![menu-icon-after](https://user-images.githubusercontent.com/12523676/55574699-11284d00-571e-11e9-96e1-f48958d37d28.png)

**Maybe it is worth hiding the root category so that you can’t add an element by dragging?**

`rootVisible: false`

For details, see issue

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14521
