### PR TITLE
Added date and time to the list of recently edited resources in the personal profile

### DIFF
--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -91,7 +91,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
             return [];
         }
 
-        $resourceArray = $object->get(array('id','pagetitle','description','published','deleted','context_key'));
+        $resourceArray = $resource->get(array('id','pagetitle','description','published','deleted','context_key', 'editedon'));
         $resourceArray['pagetitle'] = htmlspecialchars($resourceArray['pagetitle'], ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
 
         $row = array_merge($row, $resourceArray);
@@ -114,7 +114,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
             'text' => $this->modx->lexicon('resource_overview'),
             'params' => [
                 'a' => 'resource/data',
-                'id' => $object->get('id'),
+                'id' => $resource->get('id'),
                 'type' => 'view',
             ],
         ];
@@ -123,7 +123,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
                 'text' => $this->modx->lexicon('resource_edit'),
                 'params' => [
                     'a' => 'resource/update',
-                    'id' => $object->get('id'),
+                    'id' => $resource->get('id'),
                     'type' => 'edit',
                 ],
             ];
@@ -132,7 +132,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         $row['menu'][] = [
             'text' => $this->modx->lexicon('resource_preview'),
             'params' => [
-                'url' => $this->modx->makeUrl($object->get('id'), null, '', 'full'),
+                'url' => $this->modx->makeUrl($resource->get('id'), null, '', 'full'),
                 'type' => 'open',
             ],
             'handler' => 'this.preview',

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -58,8 +58,13 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
      */
     public function prepareQueryBeforeCount(xPDOQuery $c)
     {
+        $user = $this->getProperty('user');
         $q = $this->modx->newQuery($this->classKey, ['classKey:IN' => $this->classKeys]);
         $q->select('MAX(id), item');
+        if (!empty($user)) {
+            $q->where(['user' => $user]);
+            $c->where(['user' => $user]);
+        }
         $q->groupby('item');
         $q->limit($this->getProperty('limit', 10));
         if ($q->prepare() && $q->stmt->execute()) {

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -8,6 +8,7 @@
  */
 MODx.grid.RecentlyEditedResourcesByUser = function(config) {
     config = config || {};
+    var dateFormat = MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format;
     Ext.applyIf(config,{
         title: _('recent_docs')
         ,url: MODx.config.connector_url
@@ -18,7 +19,7 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         ,autosave: true
         ,save_action: 'resource/updatefromgrid'
         ,pageSize: 10
-        ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu', 'link']
+        ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu', 'link', 'occurred']
         ,columns: [{
             header: _('id')
             ,dataIndex: 'id'
@@ -27,6 +28,10 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         },{
             header: _('pagetitle')
             ,dataIndex: 'pagetitle'
+        },{
+            header: _('editedon')
+            ,dataIndex: 'occurred'
+            ,renderer : Ext.util.Format.dateRenderer(dateFormat)
         },{
             header: _('published')
             ,dataIndex: 'published'


### PR DESCRIPTION
### What does it do?
Adds date and time to the list of recently edited resources in the personal profile.

### Why is it needed?
Currently the list of recently edited resources doesn't show the date & time when the resource was edited.  There is also a small bug: the list of YOUR recently edited resources in the personal profile shows the most recently edited resources without filtering by the current user ID.

### Related issue(s)/PR(s)
Issue #11264 
PR #14511