### PR TITLE
Fixed bug for checking the table prefix while installing MODX

### DIFF
--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -91,7 +91,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
             return [];
         }
 
-        $resourceArray = $object->get(array('id','pagetitle','description','published','deleted','context_key'));
+        $resourceArray = $resource->get(array('id','pagetitle','description','published','deleted','context_key', 'editedon'));
         $resourceArray['pagetitle'] = htmlspecialchars($resourceArray['pagetitle'], ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
 
         $row = array_merge($row, $resourceArray);
@@ -114,7 +114,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
             'text' => $this->modx->lexicon('resource_overview'),
             'params' => [
                 'a' => 'resource/data',
-                'id' => $object->get('id'),
+                'id' => $resource->get('id'),
                 'type' => 'view',
             ],
         ];
@@ -123,7 +123,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
                 'text' => $this->modx->lexicon('resource_edit'),
                 'params' => [
                     'a' => 'resource/update',
-                    'id' => $object->get('id'),
+                    'id' => $resource->get('id'),
                     'type' => 'edit',
                 ],
             ];
@@ -132,7 +132,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         $row['menu'][] = [
             'text' => $this->modx->lexicon('resource_preview'),
             'params' => [
-                'url' => $this->modx->makeUrl($object->get('id'), null, '', 'full'),
+                'url' => $this->modx->makeUrl($resource->get('id'), null, '', 'full'),
                 'type' => 'open',
             ],
             'handler' => 'this.preview',

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -58,8 +58,13 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
      */
     public function prepareQueryBeforeCount(xPDOQuery $c)
     {
+        $user = $this->getProperty('user');
         $q = $this->modx->newQuery($this->classKey, ['classKey:IN' => $this->classKeys]);
         $q->select('MAX(id), item');
+        if (!empty($user)) {
+            $q->where(['user' => $user]);
+            $c->where(['user' => $user]);
+        }
         $q->groupby('item');
         $q->limit($this->getProperty('limit', 10));
         if ($q->prepare() && $q->stmt->execute()) {

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -8,6 +8,7 @@
  */
 MODx.grid.RecentlyEditedResourcesByUser = function(config) {
     config = config || {};
+    var dateFormat = MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format;
     Ext.applyIf(config,{
         title: _('recent_docs')
         ,url: MODx.config.connector_url
@@ -18,7 +19,7 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         ,autosave: true
         ,save_action: 'resource/updatefromgrid'
         ,pageSize: 10
-        ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu', 'link']
+        ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu', 'link', 'occurred']
         ,columns: [{
             header: _('id')
             ,dataIndex: 'id'
@@ -27,6 +28,10 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         },{
             header: _('pagetitle')
             ,dataIndex: 'pagetitle'
+        },{
+            header: _('editedon')
+            ,dataIndex: 'occurred'
+            ,renderer : Ext.util.Format.dateRenderer(dateFormat)
         },{
             header: _('published')
             ,dataIndex: 'published'

--- a/setup/processors/database/collation.php
+++ b/setup/processors/database/collation.php
@@ -75,22 +75,4 @@ if (!$xpdo->connect()) {
     $this->error->failure($install->lexicon('db_err_connect'), $errors);
 }
 
-/* test table prefix */
-$count = null;
-$database = $install->settings->get('dbase');
-$prefix = $install->settings->get('table_prefix');
-$stmt = $xpdo->query($install->driver->testTablePrefix($database,$prefix));
-if ($stmt) {
-    $row = $stmt->fetch(PDO::FETCH_ASSOC);
-    if ($row) {
-        $count = (integer) $row['ct'];
-    }
-    $stmt->closeCursor();
-}
-if ($mode == modInstall::MODE_NEW && $count !== null) {
-    $this->error->failure($install->lexicon('test_table_prefix_inuse'), $errors);
-} elseif (($mode == modInstall::MODE_UPGRADE_REVO || $mode == modInstall::MODE_UPGRADE_REVO_ADVANCED) && $count === null) {
-    $this->error->failure($install->lexicon('test_table_prefix_nf'), $errors);
-}
-
 $this->error->success($install->lexicon('db_success'), $data);

--- a/setup/processors/database/connection.php
+++ b/setup/processors/database/connection.php
@@ -120,4 +120,22 @@ $install->settings->store(array(
     'database_collation' => $data['collation'],
 ));
 
+/* test table prefix */
+$count = null;
+$database = $install->settings->get('dbase');
+$prefix = $install->settings->get('table_prefix');
+$stmt = $xpdo->query($install->driver->testTablePrefix($database,$prefix));
+if ($stmt) {
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row) {
+        $count = (integer) $row['ct'];
+    }
+    $stmt->closeCursor();
+}
+if ($mode == modInstall::MODE_NEW && $count !== null) {
+    $this->error->failure($install->lexicon('test_table_prefix_inuse'), $errors);
+} elseif (($mode == modInstall::MODE_UPGRADE_REVO || $mode == modInstall::MODE_UPGRADE_REVO_ADVANCED) && $count === null) {
+    $this->error->failure($install->lexicon('test_table_prefix_nf'), $errors);
+}
+
 $this->error->success($install->lexicon('db_success'), $data);


### PR DESCRIPTION
### What does it do?
It fixes the bug: The message "Table prefix already in use" doesn't disappear after changing the table prefix while installing MODX

### Why is it needed?
If the message "Table prefix already in use" appears and you change the table prefix, and click again on the link "Create or test selection", then the old value is still being used.

### Related issue(s)/PR(s)
Issue #10760