### PR TITLE
Fixed bug for checking the table prefix while installing MODX

### DIFF
--- a/setup/processors/database/collation.php
+++ b/setup/processors/database/collation.php
@@ -75,22 +75,4 @@ if (!$xpdo->connect()) {
     $this->error->failure($install->lexicon('db_err_connect'), $errors);
 }
 
-/* test table prefix */
-$count = null;
-$database = $install->settings->get('dbase');
-$prefix = $install->settings->get('table_prefix');
-$stmt = $xpdo->query($install->driver->testTablePrefix($database,$prefix));
-if ($stmt) {
-    $row = $stmt->fetch(PDO::FETCH_ASSOC);
-    if ($row) {
-        $count = (integer) $row['ct'];
-    }
-    $stmt->closeCursor();
-}
-if ($mode == modInstall::MODE_NEW && $count !== null) {
-    $this->error->failure($install->lexicon('test_table_prefix_inuse'), $errors);
-} elseif (($mode == modInstall::MODE_UPGRADE_REVO || $mode == modInstall::MODE_UPGRADE_REVO_ADVANCED) && $count === null) {
-    $this->error->failure($install->lexicon('test_table_prefix_nf'), $errors);
-}
-
 $this->error->success($install->lexicon('db_success'), $data);

--- a/setup/processors/database/connection.php
+++ b/setup/processors/database/connection.php
@@ -120,4 +120,22 @@ $install->settings->store(array(
     'database_collation' => $data['collation'],
 ));
 
+/* test table prefix */
+$count = null;
+$database = $install->settings->get('dbase');
+$prefix = $install->settings->get('table_prefix');
+$stmt = $xpdo->query($install->driver->testTablePrefix($database,$prefix));
+if ($stmt) {
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row) {
+        $count = (integer) $row['ct'];
+    }
+    $stmt->closeCursor();
+}
+if ($mode == modInstall::MODE_NEW && $count !== null) {
+    $this->error->failure($install->lexicon('test_table_prefix_inuse'), $errors);
+} elseif (($mode == modInstall::MODE_UPGRADE_REVO || $mode == modInstall::MODE_UPGRADE_REVO_ADVANCED) && $count === null) {
+    $this->error->failure($install->lexicon('test_table_prefix_nf'), $errors);
+}
+
 $this->error->success($install->lexicon('db_success'), $data);


### PR DESCRIPTION
### What does it do?
It fixes the bug: The message "Table prefix already in use" doesn't disappear after changing the table prefix while installing MODX

### Why is it needed?
If the message "Table prefix already in use" appears and you change the table prefix, and click again on the link "Create or test selection", then the old value is still being used.

### Related issue(s)/PR(s)
Issue #10760