### PR TITLE
Fix broken avatar for dashboard widgets and left menu

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -916,12 +916,17 @@ class modUser extends modPrincipal {
         $this->xpdo->loadClass('sources.modMediaSource');
         /** @var modMediaSource $source */
         $source = modMediaSource::getDefaultSource($this->xpdo, $this->xpdo->getOption('photo_profile_source'));
-        $source->initialize();
-
-        $path = $source->prepareSrcForThumb($this->Profile->photo);
+        
+        $thumb_param = array(
+            "zc" => 1,
+            "h" => $height,
+            "w" => $width,
+            "src" => $this->Profile->photo,
+            "source" => $source->id
+        );
 
         return $this->xpdo->getOption('connectors_url', null, MODX_CONNECTORS_URL)
-            . "system/phpthumb.php?" . http_build_query(array("zc" => 1, "h" => $height, "w" => $width, "src" => $path));
+            . "system/phpthumb.php?" . http_build_query($thumb_param);
     }
 
     /**

--- a/core/model/modx/processors/security/user/getonline.class.php
+++ b/core/model/modx/processors/security/user/getonline.class.php
@@ -71,10 +71,9 @@ class modUserWhoIsOnlineProcessor extends modObjectGetListProcessor
         if ($user = $object->getOne('User')) {
             $row = array_merge($row,
                 $user->get(['username']),
-                $user->Profile->get(['fullname', 'email', 'photo']),
-                ['gravatar' => $user->getGravatar(64)]
+                $user->Profile->get(['fullname', 'email']),
+                ['photo' => $user->getPhoto(64, 64)]
             );
-            $row['photo'] = $user->getPhoto(64, 64);
             /** @var modUserGroup $group */
             $row['group'] = ($group = $user->getOne('PrimaryGroup'))
                 ? $group->get('name')

--- a/core/model/modx/processors/security/user/getonline.class.php
+++ b/core/model/modx/processors/security/user/getonline.class.php
@@ -74,6 +74,7 @@ class modUserWhoIsOnlineProcessor extends modObjectGetListProcessor
                 $user->Profile->get(['fullname', 'email', 'photo']),
                 ['gravatar' => $user->getGravatar(64)]
             );
+            $row['photo'] = $user->getPhoto(64, 64);
             /** @var modUserGroup $group */
             $row['group'] = ($group = $user->getOne('PrimaryGroup'))
                 ? $group->get('name')

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -100,10 +100,9 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
         if ($user = $object->getOne('User')) {
             $row = array_merge($row,
                 $user->get(['username']),
-                $user->Profile->get(['fullname', 'email', 'photo']),
-                ['gravatar' => $user->getGravatar(64)]
+                $user->Profile->get(['fullname', 'email']),
+                ['photo' => $user->getPhoto(64, 64)]
             );
-            $row['photo'] = $user->getPhoto(64, 64);
             /** @var modUserGroup $group */
             $row['group'] = ($group = $user->getOne('PrimaryGroup'))
                 ? $group->get('name')

--- a/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
+++ b/core/model/modx/processors/security/user/getrecentlyeditedresources.class.php
@@ -103,6 +103,7 @@ class modUserGetRecentlyEditedResourcesProcessor extends modObjectGetListProcess
                 $user->Profile->get(['fullname', 'email', 'photo']),
                 ['gravatar' => $user->getGravatar(64)]
             );
+            $row['photo'] = $user->getPhoto(64, 64);
             /** @var modUserGroup $group */
             $row['group'] = ($group = $user->getOne('PrimaryGroup'))
                 ? $group->get('name')

--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -1467,9 +1467,16 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         }
 
         $properties = $this->getPropertyList();
+        $prefix = '';
         if ($properties['url']) {
-            $src = $properties['url'] . DIRECTORY_SEPARATOR . ltrim($src, DIRECTORY_SEPARATOR);
+            $prefix = $properties['url'];
+        } elseif ($properties['baseUrl']) {
+            $prefix = $properties['baseUrl'];
         }
+        if ($prefix) {
+            $src = $prefix . DIRECTORY_SEPARATOR . ltrim($src, DIRECTORY_SEPARATOR);
+        }
+
 
         // don't strip stuff for absolute URLs
         if (substr($src, 0, 4) != 'http') {

--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -1467,16 +1467,9 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         }
 
         $properties = $this->getPropertyList();
-        $prefix = '';
         if ($properties['url']) {
-            $prefix = $properties['url'];
-        } elseif ($properties['baseUrl']) {
-            $prefix = $properties['baseUrl'];
+            $src = $properties['url'] . DIRECTORY_SEPARATOR . ltrim($src, DIRECTORY_SEPARATOR);
         }
-        if ($prefix) {
-            $src = $prefix . DIRECTORY_SEPARATOR . ltrim($src, DIRECTORY_SEPARATOR);
-        }
-
 
         // don't strip stuff for absolute URLs
         if (substr($src, 0, 4) != 'http') {

--- a/manager/templates/default/dashboard/onlineusers.tpl
+++ b/manager/templates/default/dashboard/onlineusers.tpl
@@ -16,7 +16,11 @@
                 <tr>
                     <td class="user-with-avatar">
                         <div class="user-avatar">
-                            <img src="{$record.photo}" width="32" height="32">
+                            {if $record.photo}
+                                <img src="{$record.photo}" width="32" height="32">
+                            {else}
+                                <i class="icon icon-user icon-2x"></i>
+                            {/if}
                         </div>
                         <div class="user-data">
                             <div class="user-name">{$record.fullname}</div>

--- a/manager/templates/default/dashboard/onlineusers.tpl
+++ b/manager/templates/default/dashboard/onlineusers.tpl
@@ -16,7 +16,7 @@
                 <tr>
                     <td class="user-with-avatar">
                         <div class="user-avatar">
-                            <img src="{(!empty($record.photo)) ? $record.photo : $record.gravatar}" width="32" height="32">
+                            <img src="{$record.photo}" width="32" height="32">
                         </div>
                         <div class="user-data">
                             <div class="user-name">{$record.fullname}</div>

--- a/manager/templates/default/dashboard/recentlyeditedresources.tpl
+++ b/manager/templates/default/dashboard/recentlyeditedresources.tpl
@@ -36,8 +36,7 @@
                         </td>
                         <td class="user-with-avatar">
                             <div class="user-avatar">
-                                <img src="{(!empty($record.photo)) ? $record.photo : $record.gravatar}" width="32"
-                                     height="32">
+                                <img src="{$record.photo}" width="32" height="32">
                             </div>
                             <div class="user-data">
                                 <div class="user-name">{$record.fullname}</div>

--- a/manager/templates/default/dashboard/recentlyeditedresources.tpl
+++ b/manager/templates/default/dashboard/recentlyeditedresources.tpl
@@ -36,7 +36,11 @@
                         </td>
                         <td class="user-with-avatar">
                             <div class="user-avatar">
-                                <img src="{$record.photo}" width="32" height="32">
+                                {if $record.photo}
+                                    <img src="{$record.photo}" width="32" height="32">
+                                {else}
+                                    <i class="icon icon-user icon-2x"></i>
+                                {/if}
                             </div>
                             <div class="user-data">
                                 <div class="user-name">{$record.fullname}</div>


### PR DESCRIPTION
### What does it do?
Fix avatar URL when default media source setting is set.

### Why is it needed?
If you change default media source, URL for avatars in `Recently edited resources` and `Users online` widgets will be wrong. Also avatar in left menu.

![53228824-d43b5600-369b-11e9-903b-2c902bcade65](https://user-images.githubusercontent.com/3328625/55932223-292e2e00-5c42-11e9-8de0-686f76a35bd5.png)


### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13650
