### PR TITLE
Move "Deleted" checkbox from the resource settings to the main tab

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -752,16 +752,33 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,getState: function() {
                 return { collapsed: this.collapsed };
             }
-            ,items: [{
-                xtype: 'xcheckbox'
-                ,boxLabel: _('resource_published')
-                ,hideLabel: true
-                ,description: '<b>[[*published]]</b><br />'+_('resource_published_help')
-                ,name: 'published'
-                ,id: 'modx-resource-published'
-                ,inputValue: 1
-                ,checked: parseInt(config.record.published)
-            },{
+            ,items: [
+                [{
+                layout: 'column'
+                ,border: false
+                ,padding: '10px 0 0'
+                ,items: [{
+                        xtype: 'xcheckbox'
+                        ,boxLabel: _('resource_published')
+                        ,hideLabel: true
+                        ,description: '<b>[[*published]]</b><br />'+_('resource_published_help')
+                        ,name: 'published'
+                        ,id: 'modx-resource-published'
+                        ,inputValue: 1
+                        ,checked: parseInt(config.record.published)
+                    },{
+                        xtype: 'xcheckbox'
+                        ,boxLabel: _('deleted')
+                        ,description: '<b>[[*deleted]]</b>'
+                        ,hideLabel: true
+                        ,cls: 'danger'
+                        ,name: 'deleted'
+                        ,id: 'modx-resource-deleted'
+                        ,inputValue: 1
+                        ,checked: parseInt(config.record.deleted) || false
+                    }]
+                }]
+            ,{
                 xtype: 'xdatetime'
                 ,fieldLabel: _('resource_publishedon')
                 ,description: '<b>[[*publishedon]]</b><br />'+_('resource_publishedon_help')
@@ -1102,16 +1119,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,inputValue: 1
             ,checked: config.record.syncsite !== undefined && config.record.syncsite !== null ? parseInt(config.record.syncsite) : true
 
-        },{
-            xtype: 'xcheckbox'
-            ,boxLabel: _('deleted')
-            ,description: '<b>[[*deleted]]</b>'
-            ,hideLabel: true
-            ,cls: 'danger'
-            ,name: 'deleted'
-            ,id: 'modx-resource-deleted'
-            ,inputValue: 1
-            ,checked: parseInt(config.record.deleted) || false
         }];
     }
 

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -754,9 +754,8 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             }
             ,items: [
                 [{
-                layout: 'column'
+                layout: 'form'
                 ,border: false
-                ,padding: '10px 0 0'
                 ,items: [{
                         xtype: 'xcheckbox'
                         ,boxLabel: _('resource_published')


### PR DESCRIPTION
### What does it do?
It moves "Deleted" checkbox from the resource settings to the main tab

### Why is it needed?
Looks like this checkbox should be placed in the "Publishing" section as described in the related feature request.

### Related issue(s)/PR(s)
Feature request #14501 

### Comments
I'm not really sure if my decision of using the property "padding: '10px 0 0'" is correct. There could be some special class or something else for the layout (layout: 'column') to follow the general design but I couldn't find it. If anyone has the better idea please let me know.