### PR TITLE
Added styles for scroll

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1805,3 +1805,23 @@ iframe[classname="x-hidden"] {
     margin-top: 0 !important;
   }
 }
+
+::-webkit-scrollbar, ::-webkit-scrollbar-thumb {
+  width: 1rem;
+  height: 1rem;
+  border: .25rem solid transparent;
+  border-radius: .5rem;
+  background-color: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  box-shadow: inset 0 0 0 1rem rgba(85,108,136,.2);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  box-shadow: inset 0 0 0 1rem rgba(85,108,136,.3);
+}
+
+::-webkit-resizer, ::-webkit-scrollbar-corner {
+  background-color: transparent;
+}

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1815,11 +1815,11 @@ iframe[classname="x-hidden"] {
 }
 
 ::-webkit-scrollbar-thumb {
-  box-shadow: inset 0 0 0 1rem rgba(85,108,136,.2);
+  box-shadow: inset 0 0 0 1rem fade-out($darkestGray,.8);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  box-shadow: inset 0 0 0 1rem rgba(85,108,136,.3);
+  box-shadow: inset 0 0 0 1rem fade-out($darkestGray,.7);
 }
 
 ::-webkit-resizer, ::-webkit-scrollbar-corner {


### PR DESCRIPTION
### What does it do?
Added styles for scrolling.
In MODX on Windows OS there were flaws with a tree on the left due to the large width of the scroll. 

This PR made the scroll universal for different OS and it became more beautiful :)

Before
![before](https://user-images.githubusercontent.com/12523676/56046492-739fcf80-5d54-11e9-9aab-9724d73822ea.png)

After
![scroll](https://user-images.githubusercontent.com/12523676/56046498-77335680-5d54-11e9-856f-b0d97f0e88dc.gif)

### Related issue(s)/PR(s)
None
