### PR TITLE
Enhance the main application class

### DIFF
--- a/_build/resolvers/resolve.core.php
+++ b/_build/resolvers/resolve.core.php
@@ -15,7 +15,7 @@ switch (MODX_SETUP_KEY) {
                     . " */\n"
                     . "define('MODX_CORE_PATH', '" . MODX_CORE_PATH . "');\n"
                     . "define('MODX_CONFIG_KEY', '" . MODX_CONFIG_KEY . "');\n"
-                    . "?>";
+                    . "define('MODX_APP_CLASS', 'modX');";
                 $written= $cacheManager->writeFile($targetFile, $configContent);
                 $success= $written !== false ? true : false;
             }

--- a/_build/templates/config.core.php.txt
+++ b/_build/templates/config.core.php.txt
@@ -6,3 +6,4 @@
  */
 define('MODX_CORE_PATH', @core-path@);
 define('MODX_CONFIG_KEY', 'config');
+define('MODX_APP_CLASS', 'modX');

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -431,7 +431,7 @@ class modX extends xPDO {
      * @throws xPDOException
      */
     public static function getInstance($id = null, $config = null, $forceNew = false) {
-        $class = __CLASS__;
+        $class = class_exists($id) ? $id : __CLASS__;
         if (is_null($id)) {
             if (!is_null($config) || $forceNew || empty(self::$instances)) {
                 $id = uniqid($class);

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -957,13 +957,6 @@
         <index alias="show_in_tree" name="show_in_tree" primary="false" unique="false" type="BTREE">
             <column key="show_in_tree" length="" collation="A" null="false" />
         </index>
-        <index alias="content_ft_idx" name="content_ft_idx" primary="false" unique="false" type="FULLTEXT">
-            <column key="pagetitle" length="" collation="A" null="false" />
-            <column key="longtitle" length="" collation="A" null="false" />
-            <column key="description" length="" collation="A" null="false" />
-            <column key="introtext" length="" collation="A" null="true" />
-            <column key="content" length="" collation="A" null="true" />
-        </index>
         <index alias="cache_refresh_index" name="cache_refresh_idx" primary="false" unique="false" type="BTREE">
             <column key="parent" length="" collation="A" null="false" />
             <column key="menuindex" length="" collation="A" null="false" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -910,13 +910,6 @@
         <index alias="show_in_tree" name="show_in_tree" primary="false" unique="false" type="BTREE">
             <column key="show_in_tree" length="" collation="A" null="false" />
         </index>
-        <index alias="content_ft_idx" name="content_ft_idx" primary="false" unique="false" type="FULLTEXT">
-            <column key="pagetitle" length="" collation="A" null="false" />
-            <column key="longtitle" length="" collation="A" null="false" />
-            <column key="description" length="" collation="A" null="false" />
-            <column key="introtext" length="" collation="A" null="true" />
-            <column key="content" length="" collation="A" null="true" />
-        </index>
 
         <aggregate alias="Parent" class="modResource" local="parent" foreign="id" cardinality="one" owner="foreign" />
         <aggregate alias="CreatedBy" class="modUser" local="createdby" foreign="id" cardinality="one" owner="foreign" />


### PR DESCRIPTION
For discussion...

### What does it do?
Adds ability for enhancing the main application class (modX). And move the composer autoloader from modX class to the index.php.

### Why is it needed?
This PR allows to extend the modX class correctly. All you need is to specify the desired class in the _config.core.php_ file. 
One more advantage - no need to pass the modx object to classes like that
```php
function __construct(modX &$modx) {
        $this->modx= & $modx;
    }
```
Now you can get the application object at any part of yuor application
```php
function __construct() {
        $this->modx = modX::getInstance(MODX_APP_CLASS);
    }
```

### Related issue(s)/PR(s)
No.
