### PR TITLE
Remove the FULLTEXT index from the mysql and sqlsrv schemas.

### DIFF
--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -957,13 +957,6 @@
         <index alias="show_in_tree" name="show_in_tree" primary="false" unique="false" type="BTREE">
             <column key="show_in_tree" length="" collation="A" null="false" />
         </index>
-        <index alias="content_ft_idx" name="content_ft_idx" primary="false" unique="false" type="FULLTEXT">
-            <column key="pagetitle" length="" collation="A" null="false" />
-            <column key="longtitle" length="" collation="A" null="false" />
-            <column key="description" length="" collation="A" null="false" />
-            <column key="introtext" length="" collation="A" null="true" />
-            <column key="content" length="" collation="A" null="true" />
-        </index>
         <index alias="cache_refresh_index" name="cache_refresh_idx" primary="false" unique="false" type="BTREE">
             <column key="parent" length="" collation="A" null="false" />
             <column key="menuindex" length="" collation="A" null="false" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -910,13 +910,6 @@
         <index alias="show_in_tree" name="show_in_tree" primary="false" unique="false" type="BTREE">
             <column key="show_in_tree" length="" collation="A" null="false" />
         </index>
-        <index alias="content_ft_idx" name="content_ft_idx" primary="false" unique="false" type="FULLTEXT">
-            <column key="pagetitle" length="" collation="A" null="false" />
-            <column key="longtitle" length="" collation="A" null="false" />
-            <column key="description" length="" collation="A" null="false" />
-            <column key="introtext" length="" collation="A" null="true" />
-            <column key="content" length="" collation="A" null="true" />
-        </index>
 
         <aggregate alias="Parent" class="modResource" local="parent" foreign="id" cardinality="one" owner="foreign" />
         <aggregate alias="CreatedBy" class="modUser" local="createdby" foreign="id" cardinality="one" owner="foreign" />


### PR DESCRIPTION
Little SQL optimization. For discussion...

### What does it do?
Removed FULLTEXT index from the mysql and sqlsrv schemas of the site_content table.

### Why is it needed?
This is a multi-columns index ('pagetitle', 'longtitle', 'description', 'introtext' and 'content'). I think it was supposed for searching in the table of contents. But it's not used in the core.
Reason to remove:
- it takes more disk space then other indexes;
- it's very expensive for INSERT/UPDATE/DELETE operations;
- it's never used in the core.

Let developers or DBAs create it themselves if it needed.

### Related issue(s)/PR(s)
No.
