### PR TITLE
Fix resource checkbox animation

### DIFF
--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -685,7 +685,7 @@ input::-moz-focus-inner {
           z-index: 10;
         }
         &:after {
-          left: 1.6em;
+          left: 0.1em;
           top: 0.8em;
           margin-top: -.65em;
           height: 1.3em;
@@ -698,7 +698,7 @@ input::-moz-focus-inner {
       &:checked {
         & + .x-form-cb-label, & + .x-fieldset-header-text {
           &:after {
-            left: 0.1em;
+            left: 1.6em;
             top: 0.8em;
           }
           &:before {

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -685,7 +685,7 @@ input::-moz-focus-inner {
           z-index: 10;
         }
         &:after {
-          left: .1em;
+          left: 1.6em;
           top: 0.8em;
           margin-top: -.65em;
           height: 1.3em;

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -18281,7 +18281,7 @@ input::-moz-focus-inner {
       border-radius: 1.2em;
       z-index: 10; }
     #modx-resource-tabs .x-form-check-wrap [type="checkbox"] + .x-form-cb-label:after, #modx-resource-tabs .x-form-check-wrap [type="checkbox"] + .x-fieldset-header-text:after, #modx-resource-tabs .x-fieldset-checkbox-toggle legend [type="checkbox"] + .x-form-cb-label:after, #modx-resource-tabs .x-fieldset-checkbox-toggle legend [type="checkbox"] + .x-fieldset-header-text:after, #modx-resource-tabs .x-fieldset legend [type="checkbox"] + .x-form-cb-label:after, #modx-resource-tabs .x-fieldset legend [type="checkbox"] + .x-fieldset-header-text:after {
-      left: 1.6em;
+      left: .1em;
       top: 0.8em;
       margin-top: -.65em;
       height: 1.3em;

--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -18281,7 +18281,7 @@ input::-moz-focus-inner {
       border-radius: 1.2em;
       z-index: 10; }
     #modx-resource-tabs .x-form-check-wrap [type="checkbox"] + .x-form-cb-label:after, #modx-resource-tabs .x-form-check-wrap [type="checkbox"] + .x-fieldset-header-text:after, #modx-resource-tabs .x-fieldset-checkbox-toggle legend [type="checkbox"] + .x-form-cb-label:after, #modx-resource-tabs .x-fieldset-checkbox-toggle legend [type="checkbox"] + .x-fieldset-header-text:after, #modx-resource-tabs .x-fieldset legend [type="checkbox"] + .x-form-cb-label:after, #modx-resource-tabs .x-fieldset legend [type="checkbox"] + .x-fieldset-header-text:after {
-      left: .1em;
+      left: 1.6em;
       top: 0.8em;
       margin-top: -.65em;
       height: 1.3em;


### PR DESCRIPTION
### What does it do?
Fix animation of checkboxes in resource creating/updating page.

### Why is it needed?
When we click any resource checkbox (for example, `Published`), it change state. But type of animation - fading, not slide.
![screen-2019-04-16_09 17 22](https://user-images.githubusercontent.com/3328625/56182573-3f663080-602c-11e9-86f2-972f9fcb3eb1.gif)

With this change animation will work correctly:
![screen-2019-04-16_09 30 05](https://user-images.githubusercontent.com/3328625/56182624-763c4680-602c-11e9-81d6-4c995c9d6d05.gif)

### Related issue(s)/PR(s)
-
