### PR TITLE
Fix error loading files to Media Source root 

### DIFF
--- a/core/model/modx/processors/browser/file/upload.class.php
+++ b/core/model/modx/processors/browser/file/upload.class.php
@@ -30,7 +30,8 @@ class modBrowserFileUploadProcessor extends modBrowserProcessor
      */
     public function process()
     {
-        $path = $this->sanitize($this->getProperty('path'));
+        $path = $this->getProperty('path');
+        $path = ($path != '/') ? $this->sanitize($path) : $path;
         if (empty($path)) {
             return $this->failure($this->modx->lexicon('file_folder_err_ns'));
         }


### PR DESCRIPTION
### What does it do?
Check Upload path and if it root of media source ( "/"), it do not sanitaze path. Because after sanitaze path we get empty string that cause error.

### Why is it needed?
To upload files in Media Source root

### Related issue(s)/PR(s)
#14380 
