### PR TITLE
Increase width on modx-leftbar, prevents trash tab from hiding

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -10,7 +10,7 @@
 #modx-leftbar {
   background-color: $white;
   z-index: 0;
-  min-width: 270px;
+  min-width: 288px;
   box-shadow: $boxShadow;
   .x-toolbar {
     padding: 0 !important;

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -221,8 +221,8 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
             ,applyTo: 'modx-leftbar'
             ,id: 'modx-leftbar-tabs'
             ,split: true
-            ,width: 270
-            ,minSize: 270
+            ,width: 310
+            ,minSize: 288
             ,autoScroll: true
             ,unstyled: true
             ,useSplitTips: true


### PR DESCRIPTION
### What does it do?
Increases the width of modx-leftbar to 310px (like in 2.x) to prevent hiding trash tab in non-english languages (Dutch for example).

### Why is it needed?
This allows for all the tabs to be visible when using non-english language which have longer strings for the tab titles (Resources, Elements etc.)

### Related issue(s)/PR(s)
none.
