### PR TITLE
Media browser reload

### DIFF
--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -107,7 +107,7 @@
         onInputFileChange: function (e) {
             var files = FileAPI.getFiles(e);
             this.input_file.value = '';
-            this.startUpload(files);
+            this.startUpload(files, this.browser);
         },
 
         startUpload: function (files, browser) {

--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -167,7 +167,7 @@
                             upload.progress.hide();
                         }
                         // Reload the modx-browser tree/dataview
-                        if (browser && typeof browser.run !== "undefined") {
+                        if (typeof browser !== "undefined" && typeof browser.run !== "undefined") {
                             browser.run();
                         }
                     } else {

--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -167,7 +167,7 @@
                             upload.progress.hide();
                         }
                         // Reload the modx-browser tree/dataview
-                        if (typeof browser.run !== "undefined") {
+                        if (browser && typeof browser.run !== "undefined") {
                             browser.run();
                         }
                     } else {

--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -78,7 +78,7 @@
             document.getElementsByTagName('body')[0].appendChild(this.input_file);
         },
 
-        addDropZone: function(dnd) {
+        addDropZone: function(dnd, browser) {
             var el = dnd.getEl().dom;
             var upload = this;
             el.className += ' drag-n-drop';
@@ -91,7 +91,7 @@
                     el.className = el.className.replace(' drag-over', '');
                 }
             }, function (files) {
-                upload.startUpload(files);
+                upload.startUpload(files, browser);
             });
         },
 
@@ -110,7 +110,7 @@
             this.startUpload(files);
         },
 
-        startUpload: function (files) {
+        startUpload: function (files, browser) {
             var upload = this;
             var approved = [];
             this.fireEvent('beforeupload', files);
@@ -165,6 +165,10 @@
                         upload.fireEvent('uploadsuccess');
                         if (upload.progress) {
                             upload.progress.hide();
+                        }
+                        // Reload the modx-browser tree/dataview
+                        if (typeof browser.run !== "undefined") {
+                            browser.run();
                         }
                     } else {
                         upload.fireEvent('uploadfailed', xhr);

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -86,8 +86,9 @@ MODx.browser.View = function(config) {
                     this.lazyLoad();
                 }, this);
                 if (this.tree != undefined && this.tree.uploader != undefined) {
-                    this.tree.uploader.addDropZone(this.ownerCt);
+                    this.tree.uploader.addDropZone(this.ownerCt, this);
                 }
+                MODx.config.browserview = this;
             }, scope: this}
         }
         ,prepareData: this.formatData.createDelegate(this)

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -730,6 +730,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
 
     ,uploadFiles: function() {
         this.uploader.setBaseParams({source: this.getSource()});
+        this.uploader.browser = MODx.config.browserview;
         this.uploader.show();
     }
 


### PR DESCRIPTION
### What does it do?
Add the MODx.browser Ext component to the uploader, and call the browser.run() method when uploading via drag-n-drop, the main upload button, or the tree right click upload button.

### Why is it needed?
In 3.x after uploading files in the media browser (through drag-n-drop or upload button) the view does not get updated with the newly uploaded files. This PR fixes that.

### Related issue(s)/PR(s)
- #14565
- #13962