### PR TITLE
Minor design tweaks and fixes for MODX3

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -5,7 +5,6 @@
 .modx-browser-tree {
   background: $white;
   border-radius: $borderRadius;
-  box-shadow: $boxShadow;
 
   .x-window &,
   .modx-browser-rte & {
@@ -18,7 +17,6 @@
 .modx-browser-view-ct {
   background: $white;
   border-radius: $borderRadius;
-  box-shadow: $boxShadow;
   font: $fontSmall;
 
   .x-window &,
@@ -196,7 +194,6 @@
 .modx-browser-details-ct {
   background: $white;
   border-radius: $borderRadius;
-  box-shadow: $boxShadow;
 
   .x-window &,
   .modx-browser-rte & {

--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -261,8 +261,8 @@ button {
   top: 0;
   right: 0;
   left: auto;
-  background: #F2F2F2;
-  padding: 1rem 1.25rem 1rem 1rem;
+  background: $mainBg;
+  padding: 0.8rem 1rem;
   border: 0;
   font-family: $buttonfonts;
   border-radius: $borderRadius;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -47,7 +47,7 @@ $brandSelectedBg: darken($brandHover, 3%);
 $brandSelectedColor: $colorSplash;
 
 /* Backgrounds */
-$mainBg: #F2F2F2;
+$mainBg: #F1F1F1;
 $lightBg: $lighterGray;
 $mediumBg: $lighterGray;
 $darkBg: $darkestGray;
@@ -135,7 +135,7 @@ $treeBgSelected: #D6E7F8;
 $treeColor: $darkGray;
 $treeColorDesaturated: lighten(desaturate($treeColor,100%), 25%);
 $treeColor_2: #728DA7;
-$treePseudoRootBg: #F2F2F2;
+$treePseudoRootBg: #F1F1F1;
 $treePseudoRootColor: $darkestGray;
 $treePseudoRootOverBg: $brandHover;
 $treePseudoRootOverColor: $darkestGray;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -7,8 +7,8 @@
 
   .dashboard-button {
     padding: 5px 20px;
-    border: 1px solid $borderColor;
     border-radius: $borderRadius;
+    border: 1px solid transparent;
     background: $white;
     text-decoration: none;
     display: inline-block;
@@ -24,7 +24,7 @@
     }
 
     &:not([disabled]):hover {
-      box-shadow: $boxShadow;
+      border-color: $borderColor;
     }
   }
 
@@ -34,7 +34,6 @@
     &:not(.headless) {
       background-color: $white;
       border-radius: $borderRadius;
-      box-shadow: $boxShadow;
     }
 
     &.headless {
@@ -384,7 +383,6 @@
     align-items: center;
     background-color: $white;
     border-radius: $borderRadius;
-    box-shadow: $boxShadow;
     margin: 1rem 0 0 1rem;
     padding: 20px;
     text-decoration: none;

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -12,8 +12,6 @@
   background-color: $white;
   z-index: 0;
   min-width: 288px;
-  box-shadow: $boxShadow;
-
   .x-toolbar {
     padding: 0 !important;
     border: 0;
@@ -26,7 +24,6 @@
   position: absolute;
   z-index: 2;
   height: 100%;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 }
 
 #modx-navbar {

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -68,7 +68,6 @@
 }
 
 .x-tab-panel-bwrap {
-  box-shadow: $boxShadow;
   border-radius: $borderRadius;
   overflow: visible; /* prevent cut off box-shadow */
 
@@ -99,7 +98,6 @@ ul.x-tab-strip li {
   &.x-tab-strip-active {
     color: $tabActiveText;
     background-color: $tabActiveBg;
-    box-shadow: $boxShadow;
     cursor: default;
 
     .vertical-tabs-header & {

--- a/_build/templates/default/sass/_xtheme-modx.scss
+++ b/_build/templates/default/sass/_xtheme-modx.scss
@@ -1014,7 +1014,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 
     &:after {
       content: fa-content($fa-var-chevron-up);
-      padding-top: 1px;
+      padding-top: 2px;
     }
 
     &-over,
@@ -1029,6 +1029,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
     .x-panel-collapsed & {
       &:after {
         content: fa-content($fa-var-chevron-down);
+        padding-top: 3px;
       }
 
       &-over,
@@ -1036,6 +1037,7 @@ td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 
         &:after {
           content: fa-content($fa-var-chevron-down);
+          padding-top: 3px;
         }
       }
     }

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1372,7 +1372,6 @@ iframe[classname="x-hidden"] {
 .shadowbox,
 .x-form-label-left {
   border-radius: $borderRadius;
-  box-shadow: $boxShadow;
 
   /* prevent box-shadow in nested panels */
   .x-form-label-left,
@@ -1389,7 +1388,7 @@ iframe[classname="x-hidden"] {
 
 /* Panel description text */
 .panel-desc {
-  background-color: $lighterGray;
+  background-color: $white;
   border: none;
   border-radius: 0;
   color: $darkestGray;
@@ -1560,9 +1559,7 @@ iframe[classname="x-hidden"] {
     overflow: visible !important;
   }
 
-  &>.x-tab-panel-bwrap > .x-tab-panel-body > .x-panel:not(#modx-resource-settings) {
-    box-shadow: $boxShadow;
-
+  & > .x-tab-panel-bwrap > .x-tab-panel-body > .x-panel:not(#modx-resource-settings) {
     .panel-desc {
       margin-top: 0;
     }
@@ -1570,15 +1567,13 @@ iframe[classname="x-hidden"] {
 }
 
 #modx-resource-settings {
-  background: #F2F2F2;
-
+  background: $mainBg;
   #modx-resource-main-left {
     padding: 15px;
     background: $white;
     border-top-right-radius: $borderRadius;
     border-bottom-left-radius: $borderRadius;
     border-bottom-right-radius: $borderRadius;
-    box-shadow: $boxShadow;
     position: relative;
   }
 
@@ -1591,7 +1586,6 @@ iframe[classname="x-hidden"] {
       padding: 15px;
       background: $white;
       border-radius: $borderRadius;
-      box-shadow: $boxShadow;
     }
   }
 


### PR DESCRIPTION
### What does it do?

1. Removed box-shadow on most of the panels / tabs.
2. Slightly darken main background color (from #f2f2f2 to #f1f1f1) for a bit more contrast between tabs and background.
3. Fix panel collapse toggle arrow to correctly align in center
4. Decrease padding on `modx-action-buttons` element to better align with rest of elements, and prevent overlapping on pages without tabs
5. Make use of `$mainBg` sass variable where hardcoded background with same value was used.
6. Set `.panel-desc` background to white for more consistency with other panels.

### Why is it needed?
To give MODX3 a bit more modern look, and fix some inconsistencies in the sass files.

### Related issue(s)/PR(s)
None
