### PR TITLE
Fix set label or value of weblink/symlink field with Form Customization

### DIFF
--- a/core/model/schema/modx.action.fields.schema.xml
+++ b/core/model/schema/modx.action.fields.schema.xml
@@ -60,6 +60,8 @@
         <tab name="modx-resource-access-permissions" />
         <tab name="modx-resource-content">
             <field name="modx-resource-content" />
+            <field name="modx-symlink-content" />
+            <field name="modx-weblink-content" />
         </tab>
     </action>
 


### PR DESCRIPTION
### What does it do?
Makes it possible to customize  label or value of weblink/symlink field with Form Customization on weblinks or symlinks 

### Related issue(s)/PR(s)
#5700
![fc-weblink](https://user-images.githubusercontent.com/966234/55268629-494e0c80-5294-11e9-8a96-a507d54b3dc6.png)
