### PR TITLE
Enhance the main application class

### DIFF
--- a/_build/resolvers/resolve.core.php
+++ b/_build/resolvers/resolve.core.php
@@ -15,7 +15,7 @@ switch (MODX_SETUP_KEY) {
                     . " */\n"
                     . "define('MODX_CORE_PATH', '" . MODX_CORE_PATH . "');\n"
                     . "define('MODX_CONFIG_KEY', '" . MODX_CONFIG_KEY . "');\n"
-                    . "define('MODX_APP_CLASS', 'modX');";
+                    . "define('MODX_APP_CLASS', modX::class);";
                 $written= $cacheManager->writeFile($targetFile, $configContent);
                 $success= $written !== false ? true : false;
             }

--- a/_build/resolvers/resolve.core.php
+++ b/_build/resolvers/resolve.core.php
@@ -15,7 +15,7 @@ switch (MODX_SETUP_KEY) {
                     . " */\n"
                     . "define('MODX_CORE_PATH', '" . MODX_CORE_PATH . "');\n"
                     . "define('MODX_CONFIG_KEY', '" . MODX_CONFIG_KEY . "');\n"
-                    . "?>";
+                    . "define('MODX_APP_CLASS', 'modX');";
                 $written= $cacheManager->writeFile($targetFile, $configContent);
                 $success= $written !== false ? true : false;
             }

--- a/_build/templates/config.core.php.txt
+++ b/_build/templates/config.core.php.txt
@@ -6,3 +6,4 @@
  */
 define('MODX_CORE_PATH', @core-path@);
 define('MODX_CONFIG_KEY', 'config');
+define('MODX_APP_CLASS', 'modX');

--- a/_build/templates/config.core.php.txt
+++ b/_build/templates/config.core.php.txt
@@ -6,4 +6,4 @@
  */
 define('MODX_CORE_PATH', @core-path@);
 define('MODX_CONFIG_KEY', 'config');
-define('MODX_APP_CLASS', 'modX');
+define('MODX_APP_CLASS', modX::class);

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -431,7 +431,7 @@ class modX extends xPDO {
      * @throws xPDOException
      */
     public static function getInstance($id = null, $config = null, $forceNew = false) {
-        $class = __CLASS__;
+        $class = defined('MODX_APP_CLASS') ? MODX_APP_CLASS : __CLASS__;
         if (is_null($id)) {
             if (!is_null($config) || $forceNew || empty(self::$instances)) {
                 $id = uniqid($class);

--- a/index.php
+++ b/index.php
@@ -8,43 +8,55 @@
  * files found in the top-level directory of this distribution.
  */
 
-$tstart= microtime(true);
+$tstart = microtime(true);
+
+if (!function_exists('modx_site_unavailable')) {
+    /**
+     * @param string $errorMessage
+     * @param string $errorPageTitle
+     */
+    function modx_site_unavailable($errorMessage, $errorPageTitle = '') {
+        @include MODX_CORE_PATH . 'error/unavailable.include.php';
+        /* if including is failed */
+        echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
+        exit();
+    }
+}
 
 /* define this as true in another entry file, then include this file to simply access the API
  * without executing the MODX request handler */
-if (!defined('MODX_API_MODE')) {
-    define('MODX_API_MODE', false);
+defined('MODX_API_MODE') or define('MODX_API_MODE', false);
+
+/* include custom core config and define some important constants */
+@include __DIR__ . '/config.core.php';
+
+defined('MODX_CORE_PATH') or define('MODX_CORE_PATH', __DIR__ . '/core/');
+defined('MODX_APP_CLASS') or define('MODX_APP_CLASS', 'modX');
+
+/* include the composer autoloader */
+if (!file_exists(MODX_CORE_PATH . 'vendor/autoload.php')) {
+    modx_site_unavailable('Site temporarily unavailable - missing dependencies.');
 }
 
-/* include custom core config and define core path */
-@include(dirname(__FILE__) . '/config.core.php');
-if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__FILE__) . '/core/');
-
-/* include the modX class */
-if (!@include_once (MODX_CORE_PATH . "model/modx/modx.class.php")) {
-    $errorMessage = 'Site temporarily unavailable';
-    @include(MODX_CORE_PATH . 'error/unavailable.include.php');
-    header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
-    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
-    exit();
-}
+require 'vendor/autoload.php';
 
 /* start output buffering */
 ob_start();
 
-/* Create an instance of the modX class */
-$modx= new modX();
+/* Create an instance of the application class */
+try {
+    $modx = modX::getInstance(MODX_APP_CLASS);
+} catch (Exception $e) {
+    modx_site_unavailable($e->getMessage());
+}
+
 if (!is_object($modx) || !($modx instanceof modX)) {
     ob_get_level() && @ob_end_flush();
-    $errorMessage = '<a href="setup/">MODX not installed. Install now?</a>';
-    @include(MODX_CORE_PATH . 'error/unavailable.include.php');
-    header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
-    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
-    exit();
+    modx_site_unavailable('<a href="setup/">MODX not installed. Install now?</a>');
 }
 
 /* Set the actual start time */
-$modx->startTime= $tstart;
+$modx->startTime = $tstart;
 
 /* Initialize the default 'web' context */
 $modx->initialize('web');


### PR DESCRIPTION
For discussion...

### What does it do?
Adds ability for enhancing the main application class (modX). And move the composer autoloader from modX class to the index.php.

### Why is it needed?
This PR allows to extend the modX class correctly following the "Open/Close" principle. All you need is to specify the desired class in the `config.core.php` file. 
One more advantage - no need to pass the modx object to classes like that
```php
function __construct(modX &$modx) {
        $this->modx= & $modx;
    }
```
Now you can get the application object at any part of yuor application
```php
function __construct() {
        $this->modx = modX::getInstance();
    }
```

The same must be done for `manager/index.php` and `connectors/index.php`.

### Related issue(s)/PR(s)
No.
