### PR TITLE
Added line-through style to unpublished resources

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -123,7 +123,7 @@ $deactivatedTextColor: lighten($treeColor, 35%); // do not use 50% here - makes 
 $disabledTextColor: $deactivatedTextColor;
 
 $hidden: lighten($treeText, 10%) !important;
-$unpubText: italic;
+$unpubTextDeco: line-through;
 // locked is already signaled with lock-icon, no need to use other semantic style here
 // as italic is used for "unpublished"
 $lockedText: inherit; // italic;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -301,7 +301,7 @@
 .unpublished,
 .unpublished a span {
   color: $unpublished;
-  font-style: $unpubText;
+  text-decoration: $unpubTextDeco;
 
   i.icon,
   i.icon-large {
@@ -315,7 +315,7 @@
 
   &.unpublished,
   &.unpublished a span {
-    font-style: $unpubText;
+    text-decoration: $unpubTextDeco;
   }
 
   i.icon,


### PR DESCRIPTION
### What does it do?
Changed the style for unpublished resources in the tree to line-through.

**The current version is not informative at all**, we have already discussed this for version 3. And I constantly get confused with the style of states  of resources in the menu, except deleted ones :)
Unpublished resource difficult to find if the tree is large, especially if the resource is not shown in the menu and is not published (font-style: italic does not help much).
Still confusing is that the hidden from the menu, but the published resource looks paler than the unpublished resource, but not hidden from the menu - strange logic.

The line-through style is immediately noticeable and again similar to the deleted of a resource, and both of these states (publication and deletion) give 404, i.e. and visually the logic will be similar.

What it looks like

![menu_tree](https://user-images.githubusercontent.com/12523676/56957179-5c841e80-6b57-11e9-93cc-b8dfa58c3793.png)
![menu_tree_2](https://user-images.githubusercontent.com/12523676/56957511-68241500-6b58-11e9-83eb-95a2b4425d3f.png)

I decided to make PR for version 2, because this will be useful for 2.