### PR TITLE
Generate better tag for modElement

### DIFF
--- a/core/model/modx/modelement.class.php
+++ b/core/model/modx/modelement.class.php
@@ -224,17 +224,18 @@ class modElement extends modAccessibleSimpleObject {
      */
     public function getTag() {
         if (empty($this->_tag)) {
-            $propTemp = array();
             if (empty($this->_propertyString) && !empty($this->_properties)) {
+                $propTemp = array();
                 foreach ($this->_properties as $key => $value) {
+                    $key = trim($key);
                     if (is_scalar($value)) {
-                        $propTemp[] = trim($key) . '=`' . $value . '`';
-                    }
-                    else {
-                        $propTemp[] = trim($key) . '=`' . md5(uniqid(rand(), true)) . '`';
+                        $propTemp[$key] = $key . '=`' . $value . '`';
+                    } else {
+                        $propTemp[$key] = $key . '=`' . (is_array($value) ? json_encode($value) : md5(uniqid(rand(), true))) . '`';
                     }
                 }
                 if (!empty($propTemp)) {
+                    ksort($propTemp);
                     $this->_propertyString = '?' . implode('&', $propTemp);
                 }
             }


### PR DESCRIPTION
### What does it do?
This PR updates `modElement::getTag` to generate better tags in some cases as described below.

### Why is it needed?
When using non-default template engines in MODX (for example `Fenom` implementation by @bezumkin) we can pass arrays as properties. When tag is generated for element in such case, those arrays will be replaced with random strings (as arrays are not scalar values). This means that element output can not be taken from elements cache as that random string will not match on next render.
Also we can sort properties to be able to get cached output when similar element calls have different params order.