### PR TITLE
date.tpl input tv: Date and time configurations with nested smarty

### DIFF
--- a/manager/templates/default/element/tv/renders/input/date.tpl
+++ b/manager/templates/default/element/tv/renders/input/date.tpl
@@ -14,12 +14,12 @@ Ext.onReady(function() {
         ,dateFormat: MODx.config.manager_date_format
         ,timeFormat: MODx.config.manager_time_format
         {if $params.disabledDays|default},disabledDays: {$params.disabledDays|default}{/if}
-        {if $params.minDateValue|default},minDateValue: '{$params.minDateValue|default}'{/if}
-        {if $params.maxDateValue|default},maxDateValue: '{$params.maxDateValue|default}'{/if}
+        {if $params.minDateValue|default},minDateValue: '{eval var=$params.minDateValue|default}'{/if}
+        {if $params.maxDateValue|default},maxDateValue: '{eval var=$params.maxDateValue|default}'{/if}
         {if $params.startDay|default},startDay: {$params.startDay|default}{/if}
 
-        {if $params.minTimeValue|default},minTimeValue: '{$params.minTimeValue|default}'{/if}
-        {if $params.maxTimeValue|default},maxTimeValue: '{$params.maxTimeValue|default}'{/if}
+        {if $params.minTimeValue|default},minTimeValue: '{eval var=$params.minTimeValue|default}'{/if}
+        {if $params.maxTimeValue|default},maxTimeValue: '{eval var=$params.maxTimeValue|default}'{/if}
         {if $params.timeIncrement|default},timeIncrement: {$params.timeIncrement|default}{/if}
         {if $params.hideTime|default},hideTime: {$params.hideTime|default}{/if}
 


### PR DESCRIPTION
According to the documentation below:
https://docs.modx.com/revolution/2.x/making-sites-with-modx/customizing-content/template-variables/template-variable-input-types#TemplateVariableInputTypes-Date

We are able to use date TV input type configuration json that can be applied on migx and other extras or customizations.
When using JSON you are not able to allow dynamic minDateValue, maxDateValue, minTimeValue and maxTimeValue values due to the /manager/templates/default/element/tv/renders/input/date.tpl file that converts JSON string to javascript directly without parsing any possible code inside each JSON config value.



### What does it do?
This change will allow `minDateValue`, `maxDateValue`, `minTimeValue` and `maxTimeValue` config parameters to accept nested smarty.


### Why is it needed?
This will be important allow user input limit when inserting, for instance, ID Card Issue date (you will not have an ID card issued in the future). Any other similar use cases will apply on this idea as well (like purchase dates, etc)

Final result using the config parameters with Migx (as an example) will be like this:
By Adding eval, we will be able to use these fields with dynamic dates. Here is an example:
```
          {
            "allowBlank":true,
            "disabledDates":"0000-00-00",
            "disabledDays":"",
            "minDateValue":"",
            "minTimeValue":"",
            "maxDateValue":"{$smarty.now|date_format:'%Y-%m-%d'}",
            "maxTimeValue":"",
            "startDay":"",
            "timeIncrement":"",
            "hideTime":true
          }
```


This pull request follows the improvement suggestion posted on issue #14575 