### PR TITLE
Displayed a link to the context in the grid

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -508,8 +508,8 @@ jumping around */
   color: #999 !important;
 }
 
-a.x-grid-link{ color:$mainText; text-decoration: none; }
-a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: underline; }
+a.x-grid-link{ color: $colorSplash; text-decoration: underline; }
+a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: none; }
 
 /* panel stylings */
 .modx-page-header, .modx-page-header div {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -508,8 +508,30 @@ jumping around */
   color: #999 !important;
 }
 
-a.x-grid-link{ color: $colorSplash; text-decoration: underline; }
-a.x-grid-link:hover, a.x-grid-link:focus{ text-decoration: none; }
+a.x-grid-link {
+  color: $colorSplash;
+  text-decoration: underline;
+}
+
+a.x-grid-link:hover, a.x-grid-link:focus{
+  text-decoration: none;
+}
+
+.x-grid-buttons {
+  text-align: center;
+}
+
+.x-grid-buttons li {
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1.1em;
+  line-height: .7;
+  margin-right: 5px;
+}
+
+.x-grid-buttons li:last-child {
+  margin-right: 0;
+}
 
 /* panel stylings */
 .modx-page-header, .modx-page-header div {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -526,7 +526,7 @@ a.x-grid-link:hover, a.x-grid-link:focus{
   display: inline-block;
   font-size: 1.1em;
   line-height: .7;
-  margin-right: 5px;
+  margin-right: 10px;
 }
 
 .x-grid-buttons li:last-child {

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -232,8 +232,22 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
             ,url: this.config.url
             ,params: p
             ,listeners: {
-            	'success': {fn:this.refresh,scope:this}
+                'success': {fn:this.refresh,scope:this}
             }
+        });
+    }
+
+    ,getButtonColumnTpl: function () {
+        return new Ext.XTemplate('<tpl for=".">'
+            + '<tpl if="action_buttons !== null">'
+            + '<ul class="x-grid-buttons">'
+            + '<tpl for="action_buttons">'
+            + '<li><i class="icon {className:htmlEncode} icon-{icon:htmlEncode}" title="{text:htmlEncode}"></i></li>'
+            + '</tpl>'
+            + '</ul>'
+            + '</tpl>'
+            + '</tpl>', {
+            compiled: true
         });
     }
 
@@ -255,7 +269,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,url: this.config.url
                 ,params: p
                 ,listeners: {
-                	'success': {fn:function() {
+                    'success': {fn:function() {
                         this.removeActiveRow(r);
                     },scope:this}
                 }
@@ -314,10 +328,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,groupField: this.config.groupBy || 'name'
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
+                    }
                 }
             });
         } else {
@@ -330,10 +344,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,remoteSort: this.config.remoteSort || false
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
+                    }
                 }
             });
         }
@@ -472,8 +486,8 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     }
 
     ,editorYesNo: function(r) {
-    	r = r || {};
-    	Ext.applyIf(r,{
+        r = r || {};
+        Ext.applyIf(r,{
             store: new Ext.data.SimpleStore({
                 fields: ['d','v']
                 ,data: [[_('yes'),true],[_('no'),false]]
@@ -582,14 +596,14 @@ MODx.grid.LocalGrid = function(config) {
 
     if (config.grouping) {
         Ext.applyIf(config,{
-          view: new Ext.grid.GroupingView({
-            forceFit: true
-            ,scrollOffset: 0
-            ,hideGroupedColumn: config.hideGroupedColumn ? true : false
-            ,groupTextTpl: config.groupTextTpl || ('{text} ({[values.rs.length]} {[values.rs.length > 1 ? "'
-                +(config.pluralText || _('records')) + '" : "'
-                +(config.singleText || _('record'))+'"]})' )
-          })
+            view: new Ext.grid.GroupingView({
+                forceFit: true
+                ,scrollOffset: 0
+                ,hideGroupedColumn: config.hideGroupedColumn ? true : false
+                ,groupTextTpl: config.groupTextTpl || ('{text} ({[values.rs.length]} {[values.rs.length > 1 ? "'
+                    +(config.pluralText || _('records')) + '" : "'
+                    +(config.singleText || _('record'))+'"]})' )
+            })
         });
     }
     if (config.tbar) {
@@ -787,6 +801,19 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
         }
     }
 
+    ,getButtonColumnTpl: function () {
+        return new Ext.XTemplate('<tpl for=".">'
+            + '<tpl if="action_buttons !== null">'
+            + '<ul class="x-grid-buttons">'
+            + '<tpl for="action_buttons">'
+            + '<li><i class="icon {className:htmlEncode} icon-{icon:htmlEncode}" title="{text:htmlEncode}"></i></li>'
+            + '</tpl>'
+            + '</ul>'
+            + '</tpl>'
+            + '</tpl>', {
+            compiled: true
+        });
+    }
 
     ,remove: function(config) {
         if (this.destroying) {
@@ -812,9 +839,9 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
             r = s.getAt(j).data;
             r.menu = null;
             if (this.config.encodeAssoc) {
-               rs[r[this.config.encodeByPk || 'id']] = r;
+                rs[r[this.config.encodeByPk || 'id']] = r;
             } else {
-               rs.push(r);
+                rs.push(r);
             }
         }
 

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -32,6 +32,9 @@ MODx.grid.Context = function(config) {
             ,width: 150
             ,sortable: true
             ,editor: { xtype: 'textfield' }
+            ,renderer: function(value, p, record){
+                return String.format('<a href="?a=context/update&key={0}" title="{1}" class="x-grid-link">{2}</a>', record.data.key, _('context_update'), Ext.util.Format.htmlEncode( value ) );
+            }
         },{
             header: _('description')
             ,dataIndex: 'description'

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -8,17 +8,6 @@
  */
 MODx.grid.Context = function(config) {
     config = config || {};
-    this.buttonColumnTpl = new Ext.XTemplate('<tpl for=".">'
-        + '<tpl if="action_buttons !== null">'
-        + '<ul class="x-grid-buttons">'
-        + '<tpl for="action_buttons">'
-        + '<li><i class="icon {className} icon-{icon}" title="{text}"></i></li>'
-        + '</tpl>'
-        + '</ul>'
-        + '</tpl>'
-        + '</tpl>', {
-        compiled: true
-    });
     Ext.applyIf(config,{
         title: _('contexts')
         ,id: 'modx-grid-context'
@@ -162,6 +151,7 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         //this.refresh();
         return true;
     }
+
     ,clearFilter: function() {
         this.getStore().baseParams = {
             action: 'context/getList'
@@ -224,24 +214,31 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         this.refresh();
     }
 
-    ,buttonColumnRenderer: function () {
+    ,buttonColumnRenderer: function (a,id,row,ri) {
+        var p = row.data.perm;
         var b = [];
-        b.push({
-            className: 'update',
-            icon: 'pencil-square-o',
-            text: _('context_update')
-        });
-        b.push({
-            className: 'duplicate',
-            icon: 'files-o',
-            text: _('context_duplicate')
-        });
-        b.push({
-            className: 'remove',
-            icon: 'trash-o',
-            text: _('context_remove')
-        });
-        return this.buttonColumnTpl.apply({
+        if (p.indexOf('pedit') != -1) {
+            b.push({
+                className: 'update',
+                icon: 'pencil-square-o',
+                text: _('context_update')
+            });
+        }
+        if (p.indexOf('pnew') != -1) {
+            b.push({
+                className: 'duplicate',
+                icon: 'files-o',
+                text: _('context_duplicate')
+            });
+        }
+        if (p.indexOf('premove') != -1) {
+            b.push({
+                className: 'remove',
+                icon: 'trash-o',
+                text: _('context_remove')
+            });
+        }
+        return this.getButtonColumnTpl().apply({
             action_buttons: b
         });
     },

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -49,17 +49,17 @@ MODx.grid.Context = function(config) {
         },{
             header: _('description')
             ,dataIndex: 'description'
-            ,width: 600
+            ,width: 450
             ,sortable: false
             ,editor: { xtype: 'textfield' }
         },{
             header: _('rank')
             ,dataIndex: 'rank'
-            ,width: 100
+            ,width: 50
             ,sortable: true
             ,editor: { xtype: 'numberfield' }
         },{
-            width: 100
+            width: 50
             ,renderer: {
                 fn: this.buttonColumnRenderer,
                 scope: this

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -59,7 +59,7 @@ MODx.grid.Context = function(config) {
             ,sortable: true
             ,editor: { xtype: 'numberfield' }
         },{
-            width: 50
+            width: 100
             ,renderer: {
                 fn: this.buttonColumnRenderer,
                 scope: this
@@ -232,6 +232,11 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
             text: _('context_update')
         });
         b.push({
+            className: 'duplicate',
+            icon: 'files-o',
+            text: _('context_duplicate')
+        });
+        b.push({
             className: 'remove',
             icon: 'trash-o',
             text: _('context_remove')
@@ -250,6 +255,9 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
             switch (act) {
                 case 'update':
                     this.updateContext(record, e);
+                    break;
+                case 'duplicate':
+                    this.duplicateContext(record, e);
                     break;
                 case 'remove':
                     this.remove(record, e);


### PR DESCRIPTION
### What does it do?
In MODX many settings are edited via the context menu, but this is not obvious, especially if you are not familiar with MODX.
I think it is worth add the link on the item name, clicked on the link and the page with settings was opened.

What it looks like:

![contexts-links](https://user-images.githubusercontent.com/12523676/57559678-18cdb800-7394-11e9-924c-0f9539190050.gif)

![icons_grid](https://user-images.githubusercontent.com/12523676/63063149-8990ed00-bf0c-11e9-9033-3222462237e1.png)

**Unfortunately, there are 1 unresolved questions:**
- How to display a link to an element in the grid if there is no update controller, for example, in the "System Settings"?

Need help.

In general, the task is not easy, because there is no logic in the name of the scripts, somewhere .grid.js, somewhere .panel.js, and in both scripts tables can be generated.
Some tables are initially hidden in nested other tables, for example, in the section "Form Customization".

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14125