### PR TITLE
Add new rule for .scss in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ indent_style = space
 tab_width = 4
 max_line_length = off
 
+[**.scss]
+tab_width = 2
+
 [**.js]
 tab_width = 4
 


### PR DESCRIPTION
### What does it do?
Specifies the number of spaces for scss files from the beginning of the line.
```
[**. scss]
tab_width = 2
```

### Why is it needed?
Reduces the number of spaces when writing large cascades of styles in scss files

### Related issue(s)/PR(s)
NA
