### PR TITLE
Made template selection list as traditional select list in Resource editing form

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -617,10 +617,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,name: 'template'
             ,id: 'modx-resource-template'
             ,anchor: '100%'
-            ,editable: true
-            ,typeAhead: true
-            ,typeAheadDelay: 300
-            ,forceSelection: true
+            ,editable: false
             ,baseParams: {
                 action: 'element/template/getList'
                 ,combo: '1'


### PR DESCRIPTION
### What does it do?
The template selection is an editable field, but to select a template such functionality is not needed, and to expand the entire list of templates, you need to click on the button on the right, which is not convenient.

Now the **list works across the entire width**, a bit more convenient for the UX.

![template](https://user-images.githubusercontent.com/12523676/57785270-78381900-7742-11e9-8abd-8cea08e67f73.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14143
