### PR TITLE
Minor fixes for installer screens

### DIFF
--- a/setup/templates/language.tpl
+++ b/setup/templates/language.tpl
@@ -13,6 +13,6 @@
     	</select>
     </p>
 
-    <input type="submit" name="proceed" value="{$_lang.select}" />
+    <input type="submit" name="proceed" value="{$_lang.next}" />
 </div>
 </form>

--- a/setup/templates/options.tpl
+++ b/setup/templates/options.tpl
@@ -24,7 +24,7 @@
         <img src="assets/images/im_inst_upgrade.gif" width="32" height="32" alt=""/>
 
         <label>
-            <input type="radio" name="installmode" id="installmode1" value="1"{if $installmode LT 1} disabled="disabled"{/if}{if $installmode EQ 1} checked="checked" autofocus="autofocus"{/if} />
+            <input type="radio" name="installmode" id="installmode1" value="1" {if $installmode EQ 1} checked="checked" autofocus="autofocus"{/if} />
             {$_lang.options_upgrade_existing}
         </label>
     </th>
@@ -43,7 +43,7 @@
     <th>
         <img src="assets/images/im_inst_upgrade.gif" width="32" height="32" alt="" />
         <label>
-            <input type="radio" name="installmode" id="installmode3" value="3"{if $installmode LT 1} disabled="disabled"{/if}{if $installmode EQ 3} checked="checked" autofocus="autofocus"{/if} />
+            <input type="radio" name="installmode" id="installmode3" value="3" {if $installmode EQ 3} checked="checked" autofocus="autofocus"{/if} />
             {$_lang.options_upgrade_advanced}
         </label>
     </th>

--- a/setup/templates/welcome.tpl
+++ b/setup/templates/welcome.tpl
@@ -24,5 +24,6 @@
 {/if}
 <div class="setup_navbar">
     <input type="submit" name="proceed" value="{$_lang.next}" autofocus="autofocus" />
+    <input type="button" onclick="MODx.go('language');" value="{$_lang.back}" />
 </div>
 </form>


### PR DESCRIPTION
### What does it do?
Describe the technical changes you did.

### Why is it needed?
**Corrects**:

- the name of the consistency of the test and the name of the button on the language selection screen
- adds a button with a return to the language selection screen from the configuration file path to the configuration file
- removes checks, which block checkboxes on the installation type selection screen

### Related issue(s)/PR(s)
#14582 
