### PR TITLE
Check if modx-content is defined before calling doLayout

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -317,7 +317,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,autoDestroy: true
                 ,listeners:{
                     load: function(){
-                        cmp = Ext.getCmp('modx-content');
+                        var cmp = Ext.getCmp('modx-content');
                         if(typeof cmp !== "undefined") {
                             cmp.doLayout(); /* Fix layout bug with absolute positioning */
                         }

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -315,10 +315,13 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,groupField: this.config.groupBy || 'name'
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        cmp = Ext.getCmp('modx-content');
+                        if(cmp !== undefined) {
+                            cmp.doLayout(); /* Fix layout bug with absolute positioning */
+                        }
+                    }
                 }
             });
         } else {
@@ -331,10 +334,13 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,remoteSort: this.config.remoteSort || false
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        cmp = Ext.getCmp('modx-content');
+                        if(cmp !== undefined) {
+                            cmp.doLayout(); /* Fix layout bug with absolute positioning */
+                        }
+                    }
                 }
             });
         }

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -336,7 +336,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,autoDestroy: true
                 ,listeners:{
                     load: function(){
-                        cmp = Ext.getCmp('modx-content');
+                        var cmp = Ext.getCmp('modx-content');
                         if(typeof cmp !== "undefined") {
                             cmp.doLayout(); /* Fix layout bug with absolute positioning */
                         }

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -337,7 +337,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,listeners:{
                     load: function(){
                         cmp = Ext.getCmp('modx-content');
-                        if(cmp !== undefined) {
+                        if(typeof cmp !== "undefined") {
                             cmp.doLayout(); /* Fix layout bug with absolute positioning */
                         }
                     }

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -318,7 +318,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,listeners:{
                     load: function(){
                         cmp = Ext.getCmp('modx-content');
-                        if(cmp !== undefined) {
+                        if(typeof cmp !== "undefined") {
                             cmp.doLayout(); /* Fix layout bug with absolute positioning */
                         }
                     }


### PR DESCRIPTION
I have been having an issue where occasionally widgets would fail to load properly in the manager. I tracked it down to the call to doLayout() and found that sometimes when the listener gets called getCmp('modx-content') returned undefined. If I had to guess I'd say it's a race condition wherein sometimes the listener fires too early. Adding a check has resolved the issue entirely and I haven't encountered any ill effects.

### What does it do?
Adds a check to verify modx-content is defined before calling doLayout

### Why is it needed?
Intermittent issue of certain widgets not loading in the manager
