### PR TITLE
Displayed id in categories and number of children in tooltip

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -51,6 +51,7 @@ $_lang['caption'] = 'Caption';
 $_lang['caption_desc'] = 'The name to show beside the input when editing a TV on a Resource form.';
 $_lang['categories'] = 'Categories';
 $_lang['category'] = 'Category';
+$_lang['category_child'] = 'Child elements: ';
 $_lang['category_create'] = 'Create New Category';
 $_lang['category_confirm_delete'] = 'Are you sure you want to remove this category? All Elements within it will revert to having no category.';
 $_lang['category_rename'] = 'Rename Category';

--- a/core/model/modx/processors/element/getnodes.class.php
+++ b/core/model/modx/processors/element/getnodes.class.php
@@ -349,9 +349,10 @@ class modElementGetNodesProcessor extends modProcessor {
                 }
             }
 
-            $cc = ($category->get('elementCount') > 0) ? ' (' . $category->get('elementCount') . ')' : '';
+            $idNote = $this->modx->hasPermission('tree_show_element_ids') ? ' (' . $category->get('id') . ')' : '';
+            $cc = ($category->get('elementCount') > 0) ? $this->modx->lexicon('category_child') . $category->get('elementCount') : '';
             $nodes[] = array(
-                'text' => strip_tags($category->get('category')) . $cc,
+                'text' => strip_tags($category->get('category')) . $idNote,
                 'id' => 'n_'.$map[0].'_category_'.($category->get('id') != null ? $category->get('id') : 0),
                 'pk' => $category->get('id'),
                 'category' => $category->get('id'),
@@ -363,6 +364,7 @@ class modElementGetNodesProcessor extends modProcessor {
                 'elementType' => $elementType,
                 'page' => '',
                 'type' => $elementIdentifier,
+                'qtip' => $cc
             );
         }
 
@@ -543,10 +545,10 @@ class modElementGetNodesProcessor extends modProcessor {
                 }
             }
 
-            $cc = $elCount > 0 ? ' ('.$elCount.')' : '';
-
+            $idNote = $this->modx->hasPermission('tree_show_element_ids') ? ' (' . $category->get('id') . ')' : '';
+            $cc = $elCount > 0 ? $this->modx->lexicon('category_child') . $elCount : '';
             $nodes[] = array(
-                'text' => strip_tags($category->get('category')).$cc,
+                'text' => strip_tags($category->get('category')) . $idNote,
                 'id' => 'n_'.$map[1].'_category_'.($category->get('id') != null ? $category->get('id') : 0),
                 'pk' => $category->get('id'),
                 'category' => $category->get('id'),
@@ -558,6 +560,7 @@ class modElementGetNodesProcessor extends modProcessor {
                 'classKey' => 'modCategory',
                 'elementType' => $elementType,
                 'type' => $map[1],
+                'qtip' => $cc
             );
             unset($elCount,$childCats);
         }


### PR DESCRIPTION
### What does it do?
In categories, in brackets next to the name, displayed the number of nested elements, although in other elements is output id (chunks, TV) in brackets, which is confusing.

Now displayed id in brackets, and the number in the tooltip.

Screen for MODX 2.x, but the essence is the same.
![cat_tooltip](https://user-images.githubusercontent.com/12523676/59506421-345b3f80-8eb9-11e9-8721-929fda1bc792.gif)

p.s. The only thing, now the number of elements is shown only in the parent category, i.e. if the category contains only categories, then the number of elements will not appear.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14598
