### PR TITLE
Widen searchbar

### DIFF
--- a/_build/templates/default/sass/_uberbar.scss
+++ b/_build/templates/default/sass/_uberbar.scss
@@ -48,7 +48,7 @@
   border: 1px solid $subnavBorder;
   box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.2);
   position: relative;
-  width: 302px !important;
+  width: 402px !important;
   height: auto !important;
   box-sizing: border-box;
 

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -29,7 +29,7 @@ MODx.SearchBar = function(config) {
         ,minChars: 1
         ,displayField: 'name'
         ,valueField: '_action'
-        ,width: 280
+        ,width: 380
         ,itemSelector: '.x-combo-list-item'
         ,tpl: new Ext.XTemplate(
             '<tpl for=".">',


### PR DESCRIPTION
### What does it do?
I widened the searchbar/uberbar width 100 pixels to increase readability of uberbar search results and decrease the vertical space it would take.

### Why is it needed?
The searchbar was a bit too narrow which results in many results would be displayed over 2 lines instead of 1. So I increased the width to minimize the vertical space the result list would require. 

For example, before the baseTemplate including the description would be displayed using 3 lines, now it has been decreased to 2.

![Screenshot 2019-06-14 at 15 40 47](https://user-images.githubusercontent.com/7802465/59513347-f6f7b180-8eba-11e9-97f1-bc1b033e12a6.png)


