### PR TITLE
Add widget welcome dashboard changes

### DIFF
--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -282,6 +282,11 @@ Ext.extend(MODx.window.DashboardWidgetAdd, MODx.Window, {
 
     getFields: function (config) {
         return [{
+            hideLabel: true,
+            xtype: 'displayfield',
+            html: _('widget_add_desc'),
+            anchor: '100%'
+        }, {
             fieldLabel: _('widget_add'),
             id: this.ident + '-widget',
             xtype: 'modx-combo-dashboard-widgets',
@@ -309,21 +314,11 @@ Ext.extend(MODx.window.DashboardWidgetAdd, MODx.Window, {
                 }
             }
         }, {
-            hideLabel: true,
-            xtype: 'displayfield',
-            html: _('widget_add_desc'),
-            anchor: '100%'
-        }, {
             fieldLabel: _('widget_size'),
             id: this.ident + '-size',
             xtype: 'modx-combo-dashboard-widget-size',
             name: 'size',
             value: 'half',
-            anchor: '100%'
-        }, {
-            hideLabel: true,
-            xtype: 'displayfield',
-            html: _('widget_size_desc'),
             anchor: '100%'
         }];
     },


### PR DESCRIPTION
### What does it do?
Changes to the 'Add Widget' window in the Manager.

It changes the order. It puts the text "Please select a Widget to add to your Dashboard." above the 'Add Widget'-field label.
It also removes the unnecessary description below the 'Size' select box. There are a lot other sizes, so the text does not cover the size options that are available.

![image](https://user-images.githubusercontent.com/15090785/59513566-67063780-8ebb-11e9-88a2-12509370106c.png)


### Why is it needed?
It makes the manager-interface more intuitive for end users.


### Related issue(s)/PR(s)
N/A
