### PR TITLE
set published status when pub_date exactly == now

### DIFF
--- a/core/model/modx/processors/resource/create.class.php
+++ b/core/model/modx/processors/resource/create.class.php
@@ -224,7 +224,7 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
                 $scriptProperties['pub_date'] = 0;
             } else {
                 $scriptProperties['pub_date'] = strtotime($scriptProperties['pub_date']);
-                if ($scriptProperties['pub_date'] < $now) $scriptProperties['published'] = 1;
+                if ($scriptProperties['pub_date'] <= $now) $scriptProperties['published'] = 1;
                 if ($scriptProperties['pub_date'] > $now) $scriptProperties['published'] = 0;
             }
         }

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -344,7 +344,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
             } else {
                 $strPubDate = $publishDate;
                 $publishDate = strtotime($publishDate);
-                if ($publishDate < $now) { /* if we're past publish date, publish resource */
+                if ($publishDate <= $now) { /* if we're past publish date, publish resource */
                     $this->setProperty('published',true);
                     $this->setProperty('publishedon',$strPubDate);
                     $publishDate = 0;


### PR DESCRIPTION
### What does it do?
when using the create or update processors of resources,
set published status to "published" (1) when pub_date exactly == now

### Why is it needed?

In the function setFieldDefaults when creating a resource, $scriptProperties['published'] status is not set if the pub_date is exactly equal to "now" when we create the resource....

When updating the resource, we can consider too that the 'published' status should be considered to "published" (1) when pub_date is equal to "now".

This PR fixes these two points...