### PR TITLE
Fixed missed FQCN of modRestResponse class

### DIFF
--- a/core/src/Revolution/Rest/modRestClient.php
+++ b/core/src/Revolution/Rest/modRestClient.php
@@ -143,7 +143,7 @@ class modRestClient {
         $this->host = $host;
         $response = $this->conn->request($this->host,$path,$method,$params,$options);
 
-        $responseClass = $this->modx->getOption(modRestClient::OPT_RESPONSE_CLASS,$this->config,'modRestResponse');
+        $responseClass = $this->modx->getOption(modRestClient::OPT_RESPONSE_CLASS, $this->config, modRestResponse::class);
         $this->response = new $responseClass($this,$response,$this->responseType);
 
         return $this->response;


### PR DESCRIPTION
### What does it do?
Replaces string class name by FQCN name

### Why is it needed?
Package manager does not work because class no found.

### Related issue(s)/PR(s)
#14611