### PR TITLE
Fixed missed imports for modSystemEvent class

### DIFF
--- a/manager/controllers/default/security/user/create.class.php
+++ b/manager/controllers/default/security/user/create.class.php
@@ -9,6 +9,7 @@
  */
 
 use MODX\Revolution\modManagerController;
+use MODX\Revolution\modSystemEvent;
 
 /**
  * Loads the create user page
@@ -16,8 +17,10 @@ use MODX\Revolution\modManagerController;
  * @package modx
  * @subpackage manager.controllers
  */
-class SecurityUserCreateManagerController extends modManagerController {
+class SecurityUserCreateManagerController extends modManagerController
+{
     public $onUserFormRender;
+
     /**
      * Check for any permissions or requirements to load page
      * @return bool

--- a/manager/controllers/default/security/user/update.class.php
+++ b/manager/controllers/default/security/user/update.class.php
@@ -9,6 +9,7 @@
  */
 
 use MODX\Revolution\modManagerController;
+use MODX\Revolution\modSystemEvent;
 
 /**
  * Loads update user page


### PR DESCRIPTION
### What does it do?
It adds import statements (use) for class modSystemEvent

### Why is it needed?
Imports are missed and it raises a fatal error on the users management page.

### Related issue(s)/PR(s)
N/A