### PR TITLE
Fix unnecessary scroll on welcome modal

### DIFF
--- a/manager/assets/modext/sections/welcome.js
+++ b/manager/assets/modext/sections/welcome.js
@@ -27,7 +27,25 @@ MODx.loadWelcomePanel = function(url) {
         ,height: 500
         ,modal: true
         ,layout: 'fit'
-        ,html: '<iframe onload="parent.MODx.helpWindow.getEl().unmask();" src="' + url + '" width="100%" height="100%" frameborder="0"></iframe>'
+        ,items: [{
+            xtype: 'container',
+            layout: {
+                type: 'vbox',
+                align: 'stretch'
+            },
+            width: '100%',
+            height: '100%',
+            items: [{
+                autoEl: {
+                    tag: 'iframe',
+                    src: url,
+                    width: '100%',
+                    height: '100%',
+                    frameBorder	: 0,
+                    onload: 'parent.MODx.helpWindow.getEl().unmask();'
+                }
+            }]
+        }]
     });
     MODx.helpWindow.show(Ext.getBody());
 };

--- a/manager/assets/modext/sections/welcome.js
+++ b/manager/assets/modext/sections/welcome.js
@@ -41,7 +41,7 @@ MODx.loadWelcomePanel = function(url) {
                     ,src: url
                     ,width: '100%'
                     ,height: '100%'
-                    ,frameBorder	: 0
+                    ,frameBorder: 0
                     ,onload: 'parent.MODx.helpWindow.getEl().unmask();'
                 }
             }]

--- a/manager/assets/modext/sections/welcome.js
+++ b/manager/assets/modext/sections/welcome.js
@@ -28,21 +28,21 @@ MODx.loadWelcomePanel = function(url) {
         ,modal: true
         ,layout: 'fit'
         ,items: [{
-            xtype: 'container',
-            layout: {
-                type: 'vbox',
-                align: 'stretch'
-            },
-            width: '100%',
-            height: '100%',
-            items: [{
+            xtype: 'container'
+            ,layout: {
+                type: 'vbox'
+                ,align: 'stretch'
+            }
+            ,width: '100%'
+            ,height: '100%'
+            ,items: [{
                 autoEl: {
-                    tag: 'iframe',
-                    src: url,
-                    width: '100%',
-                    height: '100%',
-                    frameBorder	: 0,
-                    onload: 'parent.MODx.helpWindow.getEl().unmask();'
+                    tag: 'iframe'
+                    ,src: url
+                    ,width: '100%'
+                    ,height: '100%'
+                    ,frameBorder	: 0
+                    ,onload: 'parent.MODx.helpWindow.getEl().unmask();'
                 }
             }]
         }]


### PR DESCRIPTION
### What does it do?
Changed welcome iframe output.

### Why is it needed?
Now the modal welcome window has 2 vertical scrolls, one of them is unnecessary. PR fixes it.

**Before:**

![Аннотация 2019-06-27 201936](https://user-images.githubusercontent.com/20814058/60270583-edd6fd80-991a-11e9-8568-2a9a17ad5ecd.png)


**After:**

![Аннотация 2019-06-27 202025](https://user-images.githubusercontent.com/20814058/60270597-f16a8480-991a-11e9-8961-1319be12470f.png)


### Related issue(s)/PR(s)
None
