### PR TITLE
Remove negative margin top

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -168,7 +168,6 @@
 
           content: fa-content($fa-var-clipboard);
           font-size: 14px;
-          margin-top: -7px; /* half of the height to center vertically with top 50% */
           opacity: .6;
           filter: alpha(opacity=60); /* for IE <= 8 */
           position: absolute;


### PR DESCRIPTION
### What does it do?
Removes negative margin top, this fixes the alignment of the clipboard icon in the media browser at the bottom of page: /manager/?a=media/browser.

### Why is it needed?
Clipboard icon was not aligning with the file path.

Icon alignment before:
![Screenshot 2019-06-28 at 14 47 19](https://user-images.githubusercontent.com/7802465/60343569-91c0b780-99b4-11e9-8e31-780c6a5076e4.png)

Icon alignment after:
![Screenshot 2019-06-28 at 14 47 25](https://user-images.githubusercontent.com/7802465/60343580-9be2b600-99b4-11e9-8234-98d3eb324164.png)

