### PR TITLE
Fix the system actions related to the database widgets

### DIFF
--- a/core/src/Revolution/Processors/System/DatabaseTable/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/GetList.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\System\DatabaseTable;
+
+
+use MODX\Revolution\modX;
+
+/**
+ * Gets a list of database tables
+ */
+class GetList extends GetListAbstract
+{
+
+    /**
+     * @var GetListAbstract
+     */
+    protected $concreteProcessor;
+
+    /**
+     * Creates a modProcessor object.
+     *
+     * @param modX $modx A reference to the modX instance
+     * @param array $properties An array of properties
+     */
+    public function __construct(modX &$modx, array $properties = [])
+    {
+        parent::__construct($modx, $properties);
+
+        $this->concreteProcessor = self::getInstance($modx, GetList::class, $properties);
+
+        return $this->concreteProcessor;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTables()
+    {
+        return $this->concreteProcessor->getTables();
+    }
+}

--- a/core/src/Revolution/Processors/System/DatabaseTable/Optimize.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/Optimize.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\System\DatabaseTable;
+
+use MODX\Revolution\modX;
+
+/**
+ * Optimize a database table
+ */
+class Optimize extends OptimizeAbstract
+{
+
+    /**
+     * @var OptimizeAbstract
+     */
+    protected $concreteProcessor;
+
+    /**
+     * Creates a modProcessor object.
+     *
+     * @param modX $modx A reference to the modX instance
+     * @param array $properties An array of properties
+     */
+    public function __construct(modX &$modx, array $properties = [])
+    {
+        parent::__construct($modx, $properties);
+
+        $this->concreteProcessor = self::getInstance($modx, GetList::class, $properties);
+
+        return $this->concreteProcessor;
+    }
+
+    /**
+     * Optimize a database table
+     * @param $table
+     * @return boolean
+     */
+    public function optimize($table)
+    {
+        return $this->concreteProcessor->optimize($table);
+    }
+}

--- a/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabase.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabase.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\System\DatabaseTable;
+
+use MODX\Revolution\modX;
+
+/**
+ * Optimize a database
+ */
+class OptimizeDatabase extends OptimizeDatabaseAbstract
+{
+
+    /**
+     * @var OptimizeDatabaseAbstract
+     */
+    protected $concreteProcessor;
+
+    /**
+     * Creates a modProcessor object.
+     *
+     * @param modX $modx A reference to the modX instance
+     * @param array $properties An array of properties
+     */
+    public function __construct(modX &$modx, array $properties = [])
+    {
+        parent::__construct($modx, $properties);
+
+        $this->concreteProcessor = self::getInstance($modx, GetList::class, $properties);
+
+        return $this->concreteProcessor;
+    }
+
+    /**
+     * Optimize a database table
+     * @param $table
+     * @return boolean
+     */
+    public function optimize()
+    {
+        return $this->concreteProcessor->optimize();
+    }
+}

--- a/core/src/Revolution/Processors/System/DatabaseTable/Truncate.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/Truncate.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\System\DatabaseTable;
+
+use MODX\Revolution\modX;
+
+/**
+ * Truncate a database table
+ */
+class Truncate extends TruncateAbstract
+{
+
+    /**
+     * @var TruncateAbstract
+     */
+    protected $concreteProcessor;
+
+    /**
+     * Creates a modProcessor object.
+     *
+     * @param modX $modx A reference to the modX instance
+     * @param array $properties An array of properties
+     */
+    public function __construct(modX &$modx, array $properties = [])
+    {
+        parent::__construct($modx, $properties);
+
+        $this->concreteProcessor = self::getInstance($modx, GetList::class, $properties);
+
+        return $this->concreteProcessor;
+    }
+
+    /**
+     * Truncate a database table
+     * @param string $table
+     * @return boolean
+     */
+    public function truncate($table)
+    {
+        return $this->concreteProcessor->truncate($table);
+    }
+}

--- a/manager/assets/modext/widgets/system/mysql/modx.grid.databasetables.js
+++ b/manager/assets/modext/widgets/system/mysql/modx.grid.databasetables.js
@@ -13,7 +13,7 @@ MODx.grid.DatabaseTables = function(config) {
         ,id: 'modx-grid-dbtable'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/databasetable/getlist'
+            action: 'System/DatabaseTable/mysql/GetList'
         }
         ,fields: ['Name','Rows','Data_size','Data_free','Effective_size','Index_length','Total_size']
         ,paging: false
@@ -64,7 +64,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/databasetable/truncate'
+                action: 'System/DatabaseTable/mysql/Truncate'
                 ,t: table
             }
             ,listeners: {
@@ -81,7 +81,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/databasetable/optimize'
+                action: 'System/DatabaseTable/mysql/Optimize'
                 ,t: table
             }
             ,listeners: {
@@ -108,7 +108,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/databasetable/optimizeDatabase'
+                action: 'System/DatabaseTable/mysql/OptimizeDatabase'
             }
             ,listeners: {
                 'success': {

--- a/manager/assets/modext/widgets/system/mysql/modx.grid.databasetables.js
+++ b/manager/assets/modext/widgets/system/mysql/modx.grid.databasetables.js
@@ -13,7 +13,7 @@ MODx.grid.DatabaseTables = function(config) {
         ,id: 'modx-grid-dbtable'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'System/DatabaseTable/mysql/GetList'
+            action: 'System/DatabaseTable/GetList'
         }
         ,fields: ['Name','Rows','Data_size','Data_free','Effective_size','Index_length','Total_size']
         ,paging: false
@@ -64,7 +64,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'System/DatabaseTable/mysql/Truncate'
+                action: 'System/DatabaseTable/Truncate'
                 ,t: table
             }
             ,listeners: {
@@ -81,7 +81,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'System/DatabaseTable/mysql/Optimize'
+                action: 'System/DatabaseTable/Optimize'
                 ,t: table
             }
             ,listeners: {
@@ -108,7 +108,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'System/DatabaseTable/mysql/OptimizeDatabase'
+                action: 'System/DatabaseTable/OptimizeDatabase'
             }
             ,listeners: {
                 'success': {

--- a/manager/assets/modext/widgets/system/sqlsrv/modx.grid.databasetables.js
+++ b/manager/assets/modext/widgets/system/sqlsrv/modx.grid.databasetables.js
@@ -13,7 +13,7 @@ MODx.grid.DatabaseTables = function(config) {
         ,id: 'modx-grid-dbtable'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'System/DatabaseTable/sqlsrv/GetList'
+            action: 'System/DatabaseTable/GetList'
         }
         ,fields: ['Name','Rows','Reserved','Data_size','Index_length','Data_free']
         ,paging: false
@@ -60,7 +60,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'System/DatabaseTable/sqlsrv/Truncate'
+                action: 'System/DatabaseTable/Truncate'
                 ,t: table
             }
             ,listeners: {
@@ -77,7 +77,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'System/DatabaseTable/sqlsrv/Optimize'
+                action: 'System/DatabaseTable/Optimize'
                 ,t: table
             }
             ,listeners: {
@@ -104,7 +104,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'System/DatabaseTable/sqlsrv/OptimizeDatabase'
+                action: 'System/DatabaseTable/OptimizeDatabase'
             }
             ,listeners: {
                 'success': {

--- a/manager/assets/modext/widgets/system/sqlsrv/modx.grid.databasetables.js
+++ b/manager/assets/modext/widgets/system/sqlsrv/modx.grid.databasetables.js
@@ -13,7 +13,7 @@ MODx.grid.DatabaseTables = function(config) {
         ,id: 'modx-grid-dbtable'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/databasetable/getlist'
+            action: 'System/DatabaseTable/sqlsrv/GetList'
         }
         ,fields: ['Name','Rows','Reserved','Data_size','Index_length','Data_free']
         ,paging: false
@@ -60,7 +60,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/databasetable/truncate'
+                action: 'System/DatabaseTable/sqlsrv/Truncate'
                 ,t: table
             }
             ,listeners: {
@@ -77,7 +77,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/databasetable/optimize'
+                action: 'System/DatabaseTable/sqlsrv/Optimize'
                 ,t: table
             }
             ,listeners: {
@@ -104,7 +104,7 @@ Ext.extend(MODx.grid.DatabaseTables,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/databasetable/optimizeDatabase'
+                action: 'System/DatabaseTable/sqlsrv/OptimizeDatabase'
             }
             ,listeners: {
                 'success': {


### PR DESCRIPTION
### What does it do?
Call the driver specific processors in the system database widget(s)

### Why is it needed?
There are no generic actions for some processors with driver specific processors after the refactor.

This is a quick fix. 

### Related issue(s)/PR(s)
Closes issue #14616
