### PR TITLE
Fix the create new Content Type button

### DIFF
--- a/manager/assets/modext/widgets/system/modx.grid.content.type.js
+++ b/manager/assets/modext/widgets/system/modx.grid.content.type.js
@@ -254,7 +254,6 @@ MODx.window.CreateContentType = function(config) {
                     ,hiddenName: 'binary'
                     ,id: this.ident+'-binary'
                     ,anchor: '100%'
-                    ,checked: config.record.binary || false
                 },{
                     fieldLabel: _('description')
                     ,name: 'description'


### PR DESCRIPTION
### What does it do?
When clicking the button to create a new content type it doesn't check a non-existing record when determining wether to check the "is binary" checkbox.

### Why is it needed?
To make the button work again.

### Related issue(s)/PR(s)
Fixes issue #14617