### PR TITLE
Show additional properties again when creating a TV

### DIFF
--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
@@ -90,7 +90,7 @@ class GetInputProperties extends modProcessor {
      */
     public function renderController() {
         $c = new TvInputPropertiesManagerController($this->modx);
-        $this->modx->controller = call_user_func_array(array($c,'getInstance'),array(&$this->modx,'TvInputPropertiesManagerController'));
+        $this->modx->controller = call_user_func_array(array($c,'getInstance'),array(&$this->modx,TvInputPropertiesManagerController::class));
         return $this->modx->controller->render();
     }
 


### PR DESCRIPTION
### What does it do?
Load classes using the ::class constant

### Why is it needed?
Fixes errors about classes that could not be found

### Related issue(s)/PR(s)
Fixes issue #14620