### PR TITLE
Fix for undefined constant IMG_WEBP

### DIFF
--- a/core/src/Revolution/modPhpThumb.php
+++ b/core/src/Revolution/modPhpThumb.php
@@ -37,6 +37,11 @@ class modPhpThumb extends phpthumb
         $this->modx =& $modx;
         $this->config = $config;
 
+        if (version_compare(PHP_VERSION, '7.0.10', '<')) {
+            // The constant IMG_WEBP is available as of PHP 7.0.10, respectively.
+            define('IMG_WEBP', 32);
+        }
+
         parent::__construct();
     }
 


### PR DESCRIPTION
### What does it do?
Same as PR #14494

### Why is it needed?
To make sure changes from 2.x are in 3.x

### Related issue(s)/PR(s)
PR #14494