### PR TITLE
Fix a potential PHP 7.4/8.0 compatibility issue

### DIFF
--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -143,9 +143,13 @@ class ResourceUpdateManagerController extends ResourceManagerController
         foreach ($fields as $field) {
             $this->resourceArray[$field] = !empty($this->resourceArray[$field]);
         }
-        $this->resourceArray['syncsite'] = isset($this->resourceArray['syncsite'])
-            ? !empty($this->resourceArray['syncsite'])
-            : !empty($this->context->getOption('syncsite_default', 1, $this->modx->_userConfig));
+        if (isset($this->resourceArray['syncsite'])) {
+            $this->resourceArray['syncsite'] = !empty($this->resourceArray['syncsite']);
+        } else {
+            $syncsiteDefault = $this->context->getOption('syncsite_default', 1,
+                $this->modx->_userConfig);
+            $this->resourceArray['syncsite'] = !empty($syncsiteDefault);
+        }
         if (!empty($this->resourceArray['parent'])) {
             if ($this->parent->get('id') == $this->resourceArray['parent']) {
                 $this->resourceArray['parent_pagetitle'] = $this->modx->stripTags($this->parent->get('pagetitle'));


### PR DESCRIPTION
### What does it do?
Switched the ternary operator with an if/else statement.

### Why is it needed?
The left-associativity of the ternary operator has been deprecated in PHP 7.4 and removed in PHP 8.0.

### Related issue(s)/PR(s)
issue #14655
pr #14656