### PR TITLE
Resolved required 0 integer values being incorrectly marked as undefined

### DIFF
--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -140,7 +140,7 @@ abstract class modRestController {
 	    $missing = array();
 	    foreach ($fields as $field) {
 	        $value = $this->getProperty($field);
-	        if (empty($value)) {
+	        if (empty($value) && (is_int($value) && $value == 0)) {
 	            $missing[] = $field;
 	            if ($setFieldError) {
                     $this->addFieldError($field,$this->modx->lexicon('rest.err_field_required'));

--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -139,8 +139,12 @@ abstract class modRestController {
 	public function checkRequiredFields(array $fields = array(),$setFieldError = true) {
 	    $missing = array();
 	    foreach ($fields as $field) {
-	        $value = $this->getProperty($field);
-	        if (empty($value) && $value !== "0") {
+            $value = $this->getProperty($field);
+
+            $isEmptyString = empty($value) && $value !== "0";
+            $isNotBase = !is_int($value) && !is_bool($value);
+
+	        if ($isEmptyString && $isNotBase) {
 	            $missing[] = $field;
 	            if ($setFieldError) {
                     $this->addFieldError($field,$this->modx->lexicon('rest.err_field_required'));

--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -140,7 +140,7 @@ abstract class modRestController {
 	    $missing = array();
 	    foreach ($fields as $field) {
 	        $value = $this->getProperty($field);
-	        if (empty($value) && $value != 0) {
+	        if (empty($value) && $value !== "0") {
 	            $missing[] = $field;
 	            if ($setFieldError) {
                     $this->addFieldError($field,$this->modx->lexicon('rest.err_field_required'));

--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -140,7 +140,7 @@ abstract class modRestController {
 	    $missing = array();
 	    foreach ($fields as $field) {
 	        $value = $this->getProperty($field);
-	        if (empty($value) && (is_int($value) && $value == 0)) {
+	        if (empty($value) && $value != 0) {
 	            $missing[] = $field;
 	            if ($setFieldError) {
                     $this->addFieldError($field,$this->modx->lexicon('rest.err_field_required'));


### PR DESCRIPTION
### What does it do?
Resolved required `0` integer values being incorrectly marked as `undefined`

### Why is it needed?
Sending a `0` value in a `POST`/`PUT` request should be possible to facilitate enumerable TV fields, switching boolean values, ...

### Related issue(s)/PR(s)
None that I know of.
