### PR TITLE
Fixed transparency in .png for TV

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -1732,8 +1732,8 @@ class phpthumb {
 					if (is_array($getimagesize) && isset($getimagesize[2]) && ($getimagesize[2] == IMAGETYPE_PNG)) {
 						// explicitly exclude PNG from "-flatten" to make sure transparency is preserved
 						// https://github.com/JamesHeinrich/phpThumb/issues/65#issuecomment-256454015
-						$commandline .= ' -flatten';
 					} else {
+						$commandline .= ' -flatten';
 						$commandline .= ' -density '.phpthumb_functions::escapeshellarg_replacement($this->dpi);
 					}
 				}

--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -1731,9 +1731,9 @@ class phpthumb {
 					// for vector source formats only (WMF, PDF, etc)
 					if (is_array($getimagesize) && isset($getimagesize[2]) && ($getimagesize[2] == IMAGETYPE_PNG)) {
 						// explicitly exclude PNG from "-flatten" to make sure transparency is preserved
-						// https://github.com/JamesHeinrich/phpThumb/issues/65
-					} else {
+						// https://github.com/JamesHeinrich/phpThumb/issues/65#issuecomment-256454015
 						$commandline .= ' -flatten';
+					} else {
 						$commandline .= ' -density '.phpthumb_functions::escapeshellarg_replacement($this->dpi);
 					}
 				}

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,6 +1,6 @@
 <div id="tv-image-{$tv->id}"></div>
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&ra=1&src={$tv->value}&source={$source}" alt="" />{/if}
+    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}" alt="" />{/if}
 </div>
 {if $disabled}
 <script type="text/javascript">
@@ -48,7 +48,7 @@ Ext.onReady(function() {
                     d.update('');
                 } else {
                     {/literal}
-                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&ra=1&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
+                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
                     {literal}
                 }
             }}

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,6 +1,6 @@
 <div id="tv-image-{$tv->id}"></div>
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&src={$tv->value}&source={$source}" alt="" />{/if}
+    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&ra=1&src={$tv->value}&source={$source}" alt="" />{/if}
 </div>
 {if $disabled}
 <script type="text/javascript">
@@ -48,7 +48,7 @@ Ext.onReady(function() {
                     d.update('');
                 } else {
                     {/literal}
-                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
+                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&ra=1&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
                     {literal}
                 }
             }}


### PR DESCRIPTION
### Upd
I made a mistake with the &ra=1 parameter, it is not needed, &f=png is enough. &f=png adds transparency for png, but does not touch jpg.
Apparently when I tested only the &f=png parameter, the picture was cached.

### What does it do?
Pretty old bug with transparency in .png for TV. Regardless of the fixes previously, there was still no transparency.

**In general, png with white edges is not noticeable in the standard manager area, because the background is white, but sometimes artifacts appear on the png background.**

**For MODX3 this bug is also relevant.**

![f=png](https://user-images.githubusercontent.com/12523676/64127801-4e276700-cdc4-11e9-8afd-9c07c99019a5.png)