### PR TITLE
Rename manager actions

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -202,7 +202,7 @@ Ext.extend(MODx,Ext.Component,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'system/clearcache'
+                action: 'System/ClearCache'
                 ,register: 'mgr'
                 ,topic: topic
                 ,media_sources: true
@@ -228,7 +228,7 @@ Ext.extend(MODx,Ext.Component,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'system/refreshuris'
+                action: 'System/RefreshUris'
                 ,register: 'mgr'
                 ,topic: topic
                 ,menu: true
@@ -251,7 +251,7 @@ Ext.extend(MODx,Ext.Component,{
             MODx.Ajax.request({
                 url: MODx.config.connector_url
                 ,params: {
-                    action: 'resource/locks/release'
+                    action: 'Resource/Locks/Release'
                     ,id: id
                 }
                 ,listeners: {
@@ -266,7 +266,7 @@ Ext.extend(MODx,Ext.Component,{
 			,text: _('confirm_remove_locks')
 			,url: MODx.config.connectors_url
 			,params: {
-				action: 'system/removelocks'
+				action: 'System/RemoveLocks'
 			}
 			,listeners: {
 				'success': {
@@ -306,7 +306,7 @@ Ext.extend(MODx,Ext.Component,{
                 ,text: _('logout_confirm')
                 ,url: MODx.config.connector_url
                 ,params: {
-                    action: 'security/logout'
+                    action: 'Security/Logout'
                     ,login_context: 'mgr'
                 }
                 ,listeners: {
@@ -880,7 +880,7 @@ MODx.HttpProvider = function(config) {
             ,topic: ''
         }
         ,writeBaseParams: {
-            action: 'system/registry/register/send'
+            action: 'System/Registry/Register/Send'
             ,message: ''
             ,message_key: ''
             ,message_format: 'json'
@@ -889,7 +889,7 @@ MODx.HttpProvider = function(config) {
             ,kill: 0
         }
         ,readBaseParams: {
-            action: 'system/registry/register/read'
+            action: 'System/Registry/Register/Read'
             ,format: 'json'
             ,poll_limit: 1
             ,poll_interval: 1

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -259,7 +259,7 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                         MODx.Ajax.request({
                                 url: MODx.config.connector_url,
                                 params: {
-                                    action: 'resource/gettoolbar',
+                                    action: 'Resource/GetToolbar',
                                 },
                                 listeners: {
                                     success: {fn: function (res) {

--- a/manager/assets/modext/core/modx.view.js
+++ b/manager/assets/modext/core/modx.view.js
@@ -93,7 +93,7 @@ Ext.extend(MODx.DataView,Ext.DataView,{
         this.store = new Ext.data.JsonStore({
             url: config.url
             ,baseParams: config.baseParams || {
-                action: 'browser/directory/getList'
+                action: 'Browser/Directory/GetList'
                 ,wctx: config.wctx || MODx.ctx
                 ,dir: config.openTo || ''
                 ,source: config.source || 0

--- a/manager/assets/modext/sections/context/update.js
+++ b/manager/assets/modext/sections/context/update.js
@@ -9,13 +9,13 @@ MODx.page.UpdateContext = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-context'
         ,actions: {
-            'new': 'context/create'
-            ,edit: 'context/update'
+            'new': 'Context/Create'
+            ,edit: 'Context/Update'
             ,'delete': 'context/delete'
             ,cancel: 'context/view'
         }
         ,buttons: [{
-            process: 'context/update'
+            process: 'Context/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls:'primary-button'

--- a/manager/assets/modext/sections/context/view.js
+++ b/manager/assets/modext/sections/context/view.js
@@ -9,8 +9,8 @@ MODx.page.ViewContext = function(config) {
 	Ext.applyIf(config,{
 		form: 'context_data'
 		,actions: {
-            'new': 'context/create'
-            ,'edit': 'context/update'
+            'new': 'Context/Create'
+            ,'edit': 'Context/Update'
             ,'delete': 'context/delete'
             ,'cancel': 'context/view'
         }
@@ -26,14 +26,14 @@ Ext.extend(MODx.page.ViewContext,MODx.Component,{
 	        ,text: _('new')
 	        ,id: 'modx-abtn-new'
 	        ,params: {
-	            a: 'context/create'
+	            a: 'Context/Create'
 	        }
 	    },{
 	        process: 'edit'
 	        ,text: _('edit')
 	        ,id: 'modx-abtn-edit'
 	        ,params: {
-	            a: 'context/update'
+	            a: 'Context/Update'
 	            ,key: config.key
 	        }
 	    },{

--- a/manager/assets/modext/sections/element/chunk/create.js
+++ b/manager/assets/modext/sections/element/chunk/create.js
@@ -40,7 +40,7 @@ MODx.page.CreateChunk = function(config) {
                 }]
             }
         },{
-            process: 'element/chunk/create'
+            process: 'Element/Chunk/Create'
             ,reload: true
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -58,7 +58,7 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             text: _('chunk_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'element/chunk/remove'
+                action: 'Element/Chunk/Remove'
                 ,id: this.record.id
             }
             ,listeners: {
@@ -111,7 +111,7 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             text: _('cancel') + ' <i class="icon icon-times"></i>'
             ,id: 'modx-abtn-cancel'
         },{
-            process: 'element/chunk/update'
+            process: 'Element/Chunk/Update'
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/element/plugin/create.js
+++ b/manager/assets/modext/sections/element/plugin/create.js
@@ -40,7 +40,7 @@ MODx.page.CreatePlugin = function(config) {
                 }]
             }
         },{
-            process: 'element/plugin/create'
+            process: 'Element/Plugin/Create'
             ,reload: true
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -58,7 +58,7 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             text: _('plugin_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'element/plugin/remove'
+                action: 'Element/Plugin/Remove'
                 ,id: this.record.id
             }
             ,listeners: {
@@ -111,7 +111,7 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             text: _('cancel') + ' <i class="icon icon-times"></i>'
             ,id: 'modx-abtn-cancel'
         },{
-            process: 'element/plugin/update'
+            process: 'Element/Plugin/Update'
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/element/snippet/create.js
+++ b/manager/assets/modext/sections/element/snippet/create.js
@@ -40,7 +40,7 @@ MODx.page.CreateSnippet = function(config) {
                 }]
             }
         },{
-            process: 'element/snippet/create'
+            process: 'Element/Snippet/Create'
             ,reload: true
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -58,7 +58,7 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             text: _('snippet_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'element/snippet/remove'
+                action: 'Element/Snippet/Remove'
                 ,id: this.record.id
             }
             ,listeners: {
@@ -111,7 +111,7 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             text: _('cancel') + ' <i class="icon icon-times"></i>'
             ,id: 'modx-abtn-cancel'
         },{
-            process: 'element/snippet/update'
+            process: 'Element/Snippet/Update'
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/element/template/create.js
+++ b/manager/assets/modext/sections/element/template/create.js
@@ -40,7 +40,7 @@ MODx.page.CreateTemplate = function(config) {
                 }]
             }
         },{
-            process: 'element/template/create'
+            process: 'Element/Template/Create'
             ,reload: true
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -58,7 +58,7 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             text: _('template_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'element/template/remove'
+                action: 'Element/Template/Remove'
                 ,id: this.record.id
             }
             ,listeners: {
@@ -111,7 +111,7 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             text: _('cancel') + ' <i class="icon icon-times"></i>'
             ,id: 'modx-abtn-cancel'
         },{
-            process: 'element/template/update'
+            process: 'Element/Template/Update'
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/fc/profile/update.js
+++ b/manager/assets/modext/sections/fc/profile/update.js
@@ -11,12 +11,12 @@ MODx.page.UpdateFCProfile = function(config) {
 	Ext.applyIf(config,{
 	   formpanel: 'modx-panel-fc-profile'
 	   ,actions: {
-            'new': 'security/forms/profile/create'
-            ,edit: 'security/forms/profile/update'
+            'new': 'Security/Forms/Profile/Create'
+            ,edit: 'Security/Forms/Profile/Update'
             ,cancel: 'security/forms'
         }
         ,buttons: [{
-            process: 'security/forms/profile/update'
+            process: 'Security/Forms/Profile/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls:'primary-button'

--- a/manager/assets/modext/sections/fc/set/update.js
+++ b/manager/assets/modext/sections/fc/set/update.js
@@ -11,12 +11,12 @@ MODx.page.UpdateFCSet = function(config) {
 	Ext.applyIf(config,{
 	   formpanel: 'modx-panel-fc-set'
 	   ,actions: {
-            'new': 'security/forms/set/create'
-            ,edit: 'security/forms/set/update'
+            'new': 'Security/Forms/Set/Create'
+            ,edit: 'Security/Forms/Set/Update'
             ,cancel: 'security/forms'
         }
         ,buttons: [{
-            process: 'security/forms/set/update'
+            process: 'Security/Forms/Set/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls:'primary-button'
@@ -30,7 +30,7 @@ MODx.page.UpdateFCSet = function(config) {
             process: 'cancel'
             ,text: _('cancel')
             ,id: 'modx-abtn-cancel'
-            ,params: {a:'security/forms/profile/update', id: config.record.profile}
+            ,params: {a:'Security/Forms/Profile/Update', id: config.record.profile}
         },{
             text: _('help_ex')
             ,id: 'modx-abtn-help'

--- a/manager/assets/modext/sections/resource/create.js
+++ b/manager/assets/modext/sections/resource/create.js
@@ -13,7 +13,7 @@ MODx.page.CreateResource = function(config) {
         ,formpanel: 'modx-panel-resource'
         ,id: 'modx-page-update-resource'
         ,which_editor: 'none'
-        ,action: 'resource/create'
+        ,action: 'Resource/Create'
     	,buttons: this.getButtons(config)
         ,components: [{
             xtype: config.panelXType || 'modx-panel-resource'
@@ -58,7 +58,7 @@ Ext.extend(MODx.page.CreateResource,MODx.Component,{
             ,handler: MODx.loadHelpPane
         }];
         var save = {
-            process: 'resource/create'
+            process: 'Resource/Create'
             ,reload: true
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -33,7 +33,7 @@ Ext.extend(MODx.page.ResourceData,MODx.Component,{
     }
 
     ,editResource: function() {
-        MODx.loadPage('resource/update', 'id='+this.config.record.id);
+        MODx.loadPage('Resource/Update', 'id='+this.config.record.id);
     }
 
     ,cancel: function() {

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -17,7 +17,7 @@ MODx.page.UpdateResource = function(config) {
         ,which_editor: 'none'
         ,formpanel: 'modx-panel-resource'
         ,id: 'modx-page-update-resource'
-        ,action: 'resource/update'
+        ,action: 'Resource/Update'
         ,components: [{
             xtype: config.panelXType || 'modx-panel-resource'
             ,renderTo: config.panelRenderTo || 'modx-panel-resource-div'
@@ -83,7 +83,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 success: {fn:function(r) {
                     var response = Ext.decode(r.a.response.responseText);
                     if (response.object.redirect) {
-                        MODx.loadPage('resource/update', 'id='+response.object.id);
+                        MODx.loadPage('Resource/Update', 'id='+response.object.id);
                     } else if (node) {
                         node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
                         t.refreshNode(node.id);
@@ -101,12 +101,12 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             ,text: _('resource_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'resource/delete'
+                action: 'Resource/Delete'
                 ,id: this.config.resource
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('resource/update', 'id='+r.object.id);
+                    //MODx.loadPage('Resource/Update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(true);
@@ -121,12 +121,12 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'resource/undelete'
+                action: 'Resource/Undelete'
                 ,id: this.config.resource
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('resource/update', 'id='+r.object.id);
+                    //MODx.loadPage('Resource/Update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(false);
@@ -230,7 +230,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
         });
 
         btns.push({
-            process: 'resource/update'
+            process: 'Resource/Update'
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/security/access/policy/template/update.js
+++ b/manager/assets/modext/sections/security/access/policy/template/update.js
@@ -12,11 +12,11 @@ MODx.page.UpdateAccessPolicyTemplate = function(config) {
         formpanel: 'modx-panel-access-policy-template'
         ,actions: {
             'new': 'security/access/policy/template'
-            ,edit: 'security/access/policy/template/update'
+            ,edit: 'Security/Access/Policy/Template/Update'
             ,cancel: 'security/permission'
         }
         ,buttons: [{
-            process: 'security/access/policy/template/update'
+            process: 'Security/Access/Policy/Template/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/security/access/policy/update.js
+++ b/manager/assets/modext/sections/security/access/policy/update.js
@@ -12,11 +12,11 @@ MODx.page.UpdateAccessPolicy = function(config) {
         formpanel: 'modx-panel-access-policy'
         ,actions: {
             'new': 'security/access/policy'
-            ,edit: 'security/access/policy/update'
+            ,edit: 'Security/Access/Policy/Update'
             ,cancel: 'security/permission'
         }
         ,buttons: [{
-            process: 'security/access/policy/update'
+            process: 'Security/Access/Policy/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -93,7 +93,7 @@ MODx.panel.UpdateProfile = function(config) {
         ,id: 'modx-panel-profile-update'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/profile/update'
+            action: 'Security/Profile/Update'
             ,id: config.user
         }
         ,layout: 'form'
@@ -176,7 +176,7 @@ Ext.extend(MODx.panel.UpdateProfile,MODx.FormPanel,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'security/profile/get'
+                action: 'Security/Profile/Get'
                 ,id: this.config.user
             }
             ,listeners: {
@@ -203,7 +203,7 @@ MODx.panel.ChangeProfilePassword = function(config) {
         title: _('reset_password')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/profile/changepassword'
+            action: 'Security/Profile/ChangePassword'
             ,id: config.user
         }
         // ,frame: true

--- a/manager/assets/modext/sections/security/role/create.js
+++ b/manager/assets/modext/sections/security/role/create.js
@@ -15,8 +15,8 @@ MODx.page.CreateRole = function(config) {
 	Ext.applyIf(config,{
 		form: 'mutate_role'
 		,actions: {
-            'new': 'security/role/create'
-            ,edit: 'security/role/update'
+            'new': 'Security/Role/Create'
+            ,edit: 'Security/Role/Update'
             ,cancel: 'security/role'
         }
         ,buttons: [{

--- a/manager/assets/modext/sections/security/role/list.js
+++ b/manager/assets/modext/sections/security/role/list.js
@@ -19,7 +19,7 @@ MODx.page.ListRoles = function(config) {
             ,id: 'modx-abtn-new'
             ,cls: 'primary-button'
             ,params: {
-                a:'security/role/create'
+                a:'Security/Role/Create'
             }
         },{
             text: _('cancel')

--- a/manager/assets/modext/sections/security/user/create.js
+++ b/manager/assets/modext/sections/security/user/create.js
@@ -11,7 +11,7 @@ MODx.page.CreateUser = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-user'
         ,buttons: [{
-            process: 'security/user/create'
+            process: 'Security/User/Create'
             ,reload: true
             ,text: _('save')
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/security/user/update.js
+++ b/manager/assets/modext/sections/security/user/update.js
@@ -11,12 +11,12 @@ MODx.page.UpdateUser = function(config) {
 	Ext.applyIf(config,{
        formpanel: 'modx-panel-user'
        ,actions: {
-            'new': 'security/user/create'
-            ,edit: 'security/user/update'
+            'new': 'Security/User/Create'
+            ,edit: 'Security/User/Update'
             ,cancel: 'security/user'
        }
         ,buttons: [{
-            process: 'security/user/update'
+            process: 'Security/User/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
@@ -60,7 +60,7 @@ Ext.extend(MODx.page.UpdateUser,MODx.Component,{
             ,text: _('user_confirm_remove')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'security/user/delete'
+                action: 'Security/User/Delete'
                 ,id: this.config.user
             }
             ,listeners: {

--- a/manager/assets/modext/sections/security/usergroup/update.js
+++ b/manager/assets/modext/sections/security/usergroup/update.js
@@ -12,7 +12,7 @@ MODx.page.UpdateUserGroup = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-user-group'
         ,buttons: [{
-            process: 'security/group/update'
+            process: 'Security/Group/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/source/update.js
+++ b/manager/assets/modext/sections/source/update.js
@@ -3,12 +3,12 @@ MODx.page.UpdateSource = function(config) {
 	Ext.applyIf(config,{
        formpanel: 'modx-panel-source'
        ,actions: {
-            'new': 'source/create'
-            ,edit: 'source/update'
+            'new': 'Source/Create'
+            ,edit: 'Source/Update'
             ,cancel: 'source'
        }
        ,buttons: [{
-            process: 'source/update'
+            process: 'Source/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/system/dashboards/create.js
+++ b/manager/assets/modext/sections/system/dashboards/create.js
@@ -3,12 +3,12 @@ MODx.page.CreateDashboard = function(config) {
 	Ext.applyIf(config,{
         formpanel: 'modx-panel-dashboard'
         ,actions: {
-            'new': 'system/dashboard/create'
-            ,edit: 'system/dashboard/update'
+            'new': 'System/Dashboard/Create'
+            ,edit: 'System/Dashboard/Update'
             ,cancel: 'system/dashboards'
         }
         ,buttons: [{
-            process: 'system/dashboard/create'
+            process: 'System/Dashboard/Create'
             ,reload: true
             ,text: _('save')
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/system/dashboards/update.js
+++ b/manager/assets/modext/sections/system/dashboards/update.js
@@ -3,12 +3,12 @@ MODx.page.UpdateDashboard = function(config) {
 	Ext.applyIf(config,{
         formpanel: 'modx-panel-dashboard'
         ,actions: {
-            'new': 'system/dashboard/create'
-            ,edit: 'system/dashboard/update'
+            'new': 'System/Dashboard/Create'
+            ,edit: 'System/Dashboard/Update'
             ,cancel: 'system/dashboards'
         }
         ,buttons: [{
-            process: 'system/dashboard/update'
+            process: 'System/Dashboard/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/system/dashboards/widget/create.js
+++ b/manager/assets/modext/sections/system/dashboards/widget/create.js
@@ -3,12 +3,12 @@ MODx.page.CreateDashboardWidget = function(config) {
 	Ext.applyIf(config,{
         formpanel: 'modx-panel-dashboard-widget'
         ,actions: {
-            'new': 'system/dashboard/widget/create'
-            ,edit: 'system/dashboard/widget/update'
+            'new': 'System/Dashboard/Widget/Create'
+            ,edit: 'System/Dashboard/Widget/Update'
             ,cancel: 'system/dashboards'
         }
         ,buttons: [{
-            process: 'system/dashboard/widget/create'
+            process: 'System/Dashboard/Widget/Create'
             ,reload: true
             ,text: _('save')
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/system/dashboards/widget/update.js
+++ b/manager/assets/modext/sections/system/dashboards/widget/update.js
@@ -3,12 +3,12 @@ MODx.page.UpdateDashboardWidget = function(config) {
 	Ext.applyIf(config,{
         formpanel: 'modx-panel-dashboard-widget'
         ,actions: {
-            'new': 'system/dashboard/widget/create'
-            ,edit: 'system/dashboard/widget/update'
+            'new': 'System/Dashboard/Widget/Create'
+            ,edit: 'System/Dashboard/Widget/Update'
             ,cancel: 'system/dashboards'
         }
         ,buttons: [{
-            process: 'system/dashboard/widget/update'
+            process: 'System/Dashboard/Widget/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/system/error.log.js
+++ b/manager/assets/modext/sections/system/error.log.js
@@ -44,7 +44,7 @@ Ext.extend(MODx.page.ErrorLog,MODx.Component,{
         MODx.Ajax.request({
             url: panel.config.url
             ,params: {
-                action: 'system/errorlog/clear'
+                action: 'System/ErrorLog/Clear'
             }
             ,listeners: {
                 'success': {fn:function(r) {
@@ -64,7 +64,7 @@ Ext.extend(MODx.page.ErrorLog,MODx.Component,{
         MODx.Ajax.request({
             url: panel.config.url
             ,params: {
-                action: 'system/errorlog/get'
+                action: 'System/ErrorLog/Get'
             }
             ,listeners: {
                 'success': {fn:function(r) {

--- a/manager/assets/modext/sections/system/file/create.js
+++ b/manager/assets/modext/sections/system/file/create.js
@@ -10,7 +10,7 @@ MODx.page.CreateFile = function(config) {
     config = config || {};
     var btns = [];
     btns.push({
-        process: 'browser/file/create'
+        process: 'Browser/File/Create'
         ,text: _('save')
         ,id: 'modx-abtn-save'
         ,cls: 'primary-button'
@@ -53,7 +53,7 @@ MODx.panel.CreateFile = function(config) {
         id: 'modx-panel-file-create'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'browser/file/create'
+            action: 'Browser/File/Create'
             ,directory: config.directory
             ,wctx: MODx.request.wctx
         }

--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -11,7 +11,7 @@ MODx.page.EditFile = function(config) {
     var btns = [];
     if (config.canSave) {
         btns.push({
-            process: 'browser/file/update'
+            process: 'Browser/File/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
@@ -55,7 +55,7 @@ MODx.panel.EditFile = function(config) {
         id: 'modx-panel-file-edit'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'browser/file/update'
+            action: 'Browser/File/Update'
             ,file: config.file
             ,wctx: MODx.request.wctx
         }

--- a/manager/assets/modext/sections/system/import/html.js
+++ b/manager/assets/modext/sections/system/import/html.js
@@ -3,7 +3,7 @@ MODx.page.ImportHTML = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-import-html'
         ,buttons: [{
-            process: 'system/import/html'
+            process: 'System/Import/Html'
             ,text: _('import_site')
             ,id: 'modx-abtn-import'
             ,cls:'primary-button'

--- a/manager/assets/modext/sections/system/import/resource.js
+++ b/manager/assets/modext/sections/system/import/resource.js
@@ -3,7 +3,7 @@ MODx.page.ImportResource = function(config) {
     Ext.applyIf(config,{
         formpanel: 'modx-panel-import-resources'
         ,buttons: [{
-            process: 'system/import/index'
+            process: 'System/Import/Index'
             ,text: _('import_resources')
             ,id: 'modx-abtn-import'
             ,cls: 'primary-button'

--- a/manager/assets/modext/sections/system/info.js
+++ b/manager/assets/modext/sections/system/info.js
@@ -22,7 +22,7 @@ Ext.reg('modx-page-system-info',MODx.page.SystemInfo);
 
 
 var viewPHPInfo = function() {
-    window.open(MODx.config.connector_url+'?action=system/phpinfo&HTTP_MODAUTH='+MODx.siteId);
+    window.open(MODx.config.connector_url+'?action=System/PhpInfo&HTTP_MODAUTH='+MODx.siteId);
 };
 
 MODx.panel.SystemInfo = function(config) {
@@ -184,7 +184,7 @@ Ext.extend(MODx.panel.SystemInfo,MODx.FormPanel,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/info'
+                action: 'System/Info'
             }
             ,listeners: {
                 'success': {

--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -52,7 +52,7 @@
             url: MODx.config.connector_url,
             permitted_extensions: permittedFileTypes,
             base_params: {
-                action: 'browser/file/upload',
+                action: 'Browser/File/Upload',
                 wctx: MODx.ctx || '',
                 source: 1,
             },

--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -81,7 +81,7 @@ Ext.extend(MODx.Console,Ext.Window,{
             ,url: MODx.config.connector_url
             ,interval: 1000
             ,baseParams: {
-                action: 'system/console'
+                action: 'System/Console'
                 ,register: this.config.register || ''
                 ,topic: this.config.topic || ''
                 ,clear: false
@@ -121,12 +121,12 @@ Ext.extend(MODx.Console,Ext.Window,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'system/downloadoutput'
+                action: 'System/DownloadOutput'
                 ,data: c
             }
             ,listeners: {
                 'success':{fn:function(r) {
-                    location.href = MODx.config.connector_url+'?action=system/downloadOutput&HTTP_MODAUTH='+MODx.siteId+'&download='+r.message;
+                    location.href = MODx.config.connector_url+'?action=System/DownloadOutput&HTTP_MODAUTH='+MODx.siteId+'&download='+r.message;
                 },scope:this}
             }
         });

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -108,7 +108,7 @@ MODx.SearchBar = function(config) {
         ,store: new Ext.data.JsonStore({
             url: MODx.config.connector_url
             ,baseParams: {
-                action: 'search/search'
+                action: 'Search/Search'
             }
             ,root: 'results'
             ,totalProperty: 'total'

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -119,7 +119,7 @@ MODx.grid.ElementProperties = function(config) {
             xtype: 'modx-combo-property-set'
             ,id: 'modx-combo-property-set'
             ,baseParams: {
-                action: 'element/propertyset/getList'
+                action: 'Element/PropertySet/GetList'
                 ,showAssociated: true
                 ,elementId: config.elementId
                 ,elementType: config.elementType
@@ -225,7 +225,7 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
             return true;
         }
         var p = {
-            action: 'element/propertyset/updatefromelement'
+            action: 'Element/PropertySet/UpdateFromElement'
             ,id: cb.getValue()
             ,data: d
         };
@@ -321,7 +321,7 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'element/propertyset/get'
+                action: 'Element/PropertySet/Get'
                 ,id: ps
                 ,elementId: this.config.elementId
                 ,elementType: this.config.elementType
@@ -437,7 +437,7 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
 
     ,exportProperties: function (btn,e) {
         var id = Ext.getCmp('modx-combo-property-set').getValue();
-        location.href = MODx.config.connector_url+'?action=element/exportProperties&download=1&id='+id+'&data='+this.encode()+'&HTTP_MODAUTH='+MODx.siteId;
+        location.href = MODx.config.connector_url+'?action=Element/ExportProperties&download=1&id='+id+'&data='+this.encode()+'&HTTP_MODAUTH='+MODx.siteId;
     }
 
     ,importProperties: function (btn,e) {
@@ -1040,7 +1040,7 @@ MODx.combo.PropertySet = function(config) {
         ,hiddenName: 'propertyset'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/propertyset/getList'
+            action: 'Element/PropertySet/GetList'
         }
         ,displayField: 'name'
         ,valueField: 'id'
@@ -1066,7 +1066,7 @@ MODx.window.AddPropertySet = function(config) {
         title: _('propertyset_add')
         ,id: 'modx-window-element-property-set-add'
         ,url: MODx.config.connector_url
-        ,action: 'element/propertyset/associate'
+        ,action: 'Element/PropertySet/Associate'
         ,autoHeight: true // makes window grow when the fieldset is toggled
         ,fields: [{
             xtype: 'hidden'
@@ -1087,7 +1087,7 @@ MODx.window.AddPropertySet = function(config) {
             ,id: 'modx-aps-propertyset'
             ,anchor: '100%'
             ,baseParams: {
-                action: 'element/propertyset/getList'
+                action: 'Element/PropertySet/GetList'
                 ,showNotAssociated: true
                 ,elementId: config.record.elementId
                 ,elementType: config.record.elementType
@@ -1142,7 +1142,7 @@ MODx.window.ImportProperties = function(config) {
         title: _('properties_import')
         ,id: 'modx-window-properties-import'
         ,url: MODx.config.connector_url
-        ,action: 'element/importProperties'
+        ,action: 'Element/ImportProperties'
         ,fileUpload: true
         ,saveBtnText: _('import')
         ,fields: [{

--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -21,7 +21,7 @@ MODx.grid.PluginEvent = function(config) {
         ,id: 'modx-grid-plugin-event'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/plugin/event/getList'
+            action: 'Element/Plugin/Event/GetList'
             ,plugin: config.plugin
             ,limit: 0
         }
@@ -61,7 +61,7 @@ MODx.grid.PluginEvent = function(config) {
                 xtype: 'modx-combo-property-set'
                 ,renderer: true
                 ,baseParams: {
-                    action: 'element/propertyset/getList'
+                    action: 'Element/PropertySet/GetList'
                     ,showAssociated: true
                     ,elementId: config.plugin
                     ,elementType: 'modPlugin'
@@ -169,7 +169,7 @@ MODx.window.UpdatePluginEvent = function(config) {
         title: _('plugin_event_update')
         ,id: 'modx-window-plugin-event-update'
         ,url: MODx.config.connector_url
-        ,action: 'element/plugin/event/associate'
+        ,action: 'Element/Plugin/Event/Associate'
         ,autoHeight: true // needed here or the window will always show a scrollbar
         ,width: 600
         ,fields: [{
@@ -195,7 +195,7 @@ Ext.extend(MODx.window.UpdatePluginEvent,MODx.Window,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'element/plugin/event/getAssoc'
+                action: 'Element/Plugin/Event/GetAssoc'
                 ,'event': evt
             }
             ,listeners: {
@@ -213,7 +213,7 @@ Ext.extend(MODx.window.UpdatePluginEvent,MODx.Window,{
     }
     ,beforeSubmit: function(vs) {
         this.fp.getForm().baseParams = {
-            action: 'element/plugin/event/associate'
+            action: 'Element/Plugin/Event/Associate'
             ,plugins: Ext.getCmp('modx-grid-'+this.ident+'-assoc').encode()
         };
     }
@@ -229,7 +229,7 @@ MODx.grid.PluginEventAssoc = function(config) {
         ,id: this.ident
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/plugin/event/getPlugins'
+            action: 'Element/Plugin/Event/GetPlugins'
             ,plugin: config.plugin
         }
         ,saveParams: {
@@ -257,7 +257,7 @@ MODx.grid.PluginEventAssoc = function(config) {
                 xtype: 'modx-combo-property-set'
                 ,renderer: true
                 ,baseParams: {
-                    action: 'element/propertyset/getList'
+                    action: 'Element/PropertySet/GetList'
                     ,showAssociated: true
                     ,elementId: config.plugin
                     ,elementType: 'modPlugin'
@@ -377,7 +377,7 @@ MODx.combo.Plugin = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/plugin/getlist'
+            action: 'Element/Plugin/GetList'
         }
         ,fields: ['id','name','description']
         ,name: 'plugin'

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -12,7 +12,7 @@ MODx.panel.Chunk = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/chunk/get'
+            action: 'Element/Chunk/Get'
         }
         ,id: 'modx-panel-chunk'
 		,cls: 'container form-with-labels'
@@ -71,7 +71,7 @@ MODx.panel.Chunk = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('chunk')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/chunk/create' && MODx.perm.tree_show_element_ids === true) {
+                                if (MODx.request.a !== 'Element/Chunk/Create' && MODx.perm.tree_show_element_ids === true) {
                                     title += ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -208,7 +208,7 @@ MODx.panel.Chunk = function(config) {
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
                         ,baseParams: {
-                            action: 'source/getList'
+                            action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
                         }

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -13,7 +13,7 @@ MODx.panel.Plugin = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/plugin/get'
+            action: 'Element/Plugin/Get'
         }
         ,id: 'modx-panel-plugin'
 		,cls: 'container form-with-labels'
@@ -73,7 +73,7 @@ MODx.panel.Plugin = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('plugin')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/plugin/create' && MODx.perm.tree_show_element_ids === true) {
+                                if (MODx.request.a !== 'Element/Plugin/Create' && MODx.perm.tree_show_element_ids === true) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -235,7 +235,7 @@ MODx.panel.Plugin = function(config) {
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
                         ,baseParams: {
-                            action: 'source/getList'
+                            action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
                         }
@@ -383,7 +383,7 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
         this.on('success',function(o) {
             var id = o.result.object.id;
             var w = Ext.getCmp('modx-plugin-which-editor').getValue();
-            MODx.request.a = 'element/plugin/update';
+            MODx.request.a = 'Element/Plugin/Update';
             location.href = '?'+Ext.urlEncode(MODx.request)+'&which_editor='+w+'&id='+id;
         });
         this.submit();

--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -73,7 +73,7 @@ MODx.grid.PropertySetProperties = function(config) {
             xtype: 'modx-combo-property-set'
             ,id: 'modx-combo-property-set'
             ,baseParams: {
-                action: 'element/propertyset/getList'
+                action: 'Element/PropertySet/GetList'
             }
             ,listeners: {
                 'select': {fn:function(cb) { Ext.getCmp('modx-grid-element-properties').changePropertySet(cb); },scope:this}
@@ -114,7 +114,7 @@ MODx.tree.PropertySets = function(config) {
         ,enableDD: false
         ,title: ''
         ,url: MODx.config.connector_url
-        ,action: 'element/propertyset/getNodes'
+        ,action: 'Element/PropertySet/GetNodes'
         ,tbar: ['->', {
             text: _('propertyset_new')
             ,cls: 'primary-button'
@@ -133,7 +133,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
             MODx.Ajax.request({
                 url: MODx.config.connector_url
                 ,params: {
-                    action: 'element/propertyset/getProperties'
+                    action: 'Element/PropertySet/GetProperties'
                     ,id: ar[1]
                 }
                 ,listeners: {
@@ -155,7 +155,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
             MODx.Ajax.request({
                 url: MODx.config.connector_url
                 ,params: {
-                    action: 'element/propertyset/getProperties'
+                    action: 'Element/PropertySet/GetProperties'
                     ,id: ar[1]
                     ,element: ar[2]
                     ,element_class: ar[3]
@@ -240,7 +240,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
             text: _('propertyset_remove_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'element/propertyset/remove'
+                action: 'Element/PropertySet/Remove'
                 ,id: id
             }
             ,listeners: {
@@ -281,7 +281,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
             text: _('propertyset_element_remove_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'element/propertyset/removeElement'
+                action: 'Element/PropertySet/RemoveElement'
                 ,element: d.pk
                 ,element_class: d.element_class
                 ,propertyset: d.propertyset
@@ -306,7 +306,7 @@ MODx.window.AddElementToPropertySet = function(config) {
         title: _('propertyset_element_add')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/propertyset/addElement'
+            action: 'Element/PropertySet/AddElement'
         }
         // ,width: 400
         ,fields: [{
@@ -376,7 +376,7 @@ MODx.combo.ElementClass = function(config) {
         ,editable: false
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/getClasses'
+            action: 'Element/GetClasses'
         }
     });
     MODx.combo.ElementClass.superclass.constructor.call(this,config);
@@ -403,7 +403,7 @@ MODx.combo.Elements = function(config) {
         ,editable: false
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/getListByClass'
+            action: 'Element/GetListByClass'
             ,element_class: 'modSnippet'
         }
     });
@@ -424,7 +424,7 @@ MODx.window.CreatePropertySet = function(config) {
         title: _('propertyset_create')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/propertyset/create'
+            action: 'Element/PropertySet/Create'
         }
         ,autoHeight: true
         // ,width: 550
@@ -471,7 +471,7 @@ MODx.window.UpdatePropertySet = function(config) {
     Ext.applyIf(config,{
         title: _('propertyset_update')
         ,baseParams: {
-            action: 'element/propertyset/update'
+            action: 'Element/PropertySet/Update'
         }
         ,autoHeight: true
     });
@@ -494,7 +494,7 @@ MODx.window.DuplicatePropertySet = function(config) {
         title: _('propertyset_duplicate')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/propertyset/duplicate'
+            action: 'Element/PropertySet/Duplicate'
         }
         ,autoHeight: true
         // ,width: 550

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -12,7 +12,7 @@ MODx.panel.Snippet = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/snippet/get'
+            action: 'Element/Snippet/Get'
         }
         ,id: 'modx-panel-snippet'
 		,cls: 'container form-with-labels'
@@ -72,7 +72,7 @@ MODx.panel.Snippet = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('snippet')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/snippet/create' && MODx.perm.tree_show_element_ids === true) {
+                                if (MODx.request.a !== 'Element/Snippet/Create' && MODx.perm.tree_show_element_ids === true) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -209,7 +209,7 @@ MODx.panel.Snippet = function(config) {
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
                         ,baseParams: {
-                            action: 'source/getList'
+                            action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
                         }
@@ -336,7 +336,7 @@ Ext.extend(MODx.panel.Snippet,MODx.FormPanel,{
         this.on('success',function(o) {
             var id = o.result.object.id;
             var w = Ext.getCmp('modx-snippet-which-editor').getValue();
-            MODx.request.a = 'element/snippet/update';
+            MODx.request.a = 'Element/Snippet/Update';
             location.href = '?'+Ext.urlEncode(MODx.request)+'&which_editor='+w+'&id='+id;
         });
         this.submit();

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -15,7 +15,7 @@ MODx.panel.Template = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'element/template/get'
+            action: 'Element/Template/Get'
         }
         ,id: 'modx-panel-template'
 		,cls: 'container form-with-labels'
@@ -74,7 +74,7 @@ MODx.panel.Template = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('template')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/template/create' && MODx.perm.tree_show_element_ids === true) {
+                                if (MODx.request.a !== 'Element/Template/Create' && MODx.perm.tree_show_element_ids === true) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 
@@ -225,7 +225,7 @@ MODx.panel.Template = function(config) {
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
                         ,baseParams: {
-                            action: 'source/getList'
+                            action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
                         }
@@ -377,7 +377,7 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         this.on('success',function(o) {
             var id = o.result.object.id;
             var w = Ext.getCmp('modx-template-which-editor').getValue();
-            MODx.request.a = 'element/template/update';
+            MODx.request.a = 'Element/Template/Update';
             location.href = '?'+Ext.urlEncode(MODx.request)+'&which_editor='+w+'&id='+id;
         });
         this.submit();

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -222,7 +222,7 @@ MODx.panel.TV = function(config) {
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
                         ,baseParams: {
-                            action: 'source/getList'
+                            action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
                         }

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -14,8 +14,8 @@ MODx.tree.Element = function(config) {
         ,ddGroup: 'modx-treedrop-elements-dd'
         ,title: ''
         ,url: MODx.config.connector_url
-        ,action: 'element/getnodes'
-        ,sortAction: 'element/sort'
+        ,action: 'Element/GetNodes'
+        ,sortAction: 'Element/Sort'
         // ,useDefaultToolbar: false
         ,baseParams: {
             currentElement: MODx.request.id || 0
@@ -25,7 +25,7 @@ MODx.tree.Element = function(config) {
             cls: 'tree-new-template'
             ,tooltip: {text: _('new')+' '+_('template')}
             ,handler: function() {
-                this.redirect('?a=element/template/create');
+                this.redirect('?a=Element/Template/Create');
             }
             ,scope: this
             ,hidden: MODx.perm.new_template ? false : true
@@ -41,7 +41,7 @@ MODx.tree.Element = function(config) {
             cls: 'tree-new-chunk'
             ,tooltip: {text: _('new')+' '+_('chunk')}
             ,handler: function() {
-                this.redirect('?a=element/chunk/create');
+                this.redirect('?a=Element/Chunk/Create');
             }
             ,scope: this
             ,hidden: MODx.perm.new_chunk ? false : true
@@ -49,7 +49,7 @@ MODx.tree.Element = function(config) {
             cls: 'tree-new-snippet'
             ,tooltip: {text: _('new')+' '+_('snippet')}
             ,handler: function() {
-                this.redirect('?a=element/snippet/create');
+                this.redirect('?a=Element/Snippet/Create');
             }
             ,scope: this
             ,hidden: MODx.perm.new_snippet ? false : true
@@ -57,7 +57,7 @@ MODx.tree.Element = function(config) {
             cls: 'tree-new-plugin'
             ,tooltip: {text: _('new')+' '+_('plugin')}
             ,handler: function() {
-                this.redirect('?a=element/plugin/create');
+                this.redirect('?a=Element/Plugin/Create');
             }
             ,scope: this
             ,hidden: MODx.perm.new_plugin ? false : true
@@ -136,7 +136,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             ,text: _('category_confirm_delete')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'element/category/remove'
+                action: 'Element/Category/Remove'
                 ,id: id
             }
             ,listeners: {
@@ -222,7 +222,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'element/plugin/activate'
+                action: 'Element/Plugin/Activate'
                 ,id: oar[2]
             }
             ,listeners: {
@@ -239,7 +239,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'element/plugin/deactivate'
+                action: 'Element/Plugin/Deactivate'
                 ,id: oar[2]
             }
             ,listeners: {

--- a/manager/assets/modext/widgets/fc/modx.fc.common.js
+++ b/manager/assets/modext/widgets/fc/modx.fc.common.js
@@ -5,8 +5,8 @@ MODx.combo.FCAction = function(config) {
         store: new Ext.data.SimpleStore({
             fields: ['d','v']
             ,data: [
-                [_('fc.action_create'),'resource/create']
-                ,[_('fc.action_update'),'resource/update']
+                [_('fc.action_create'),'Resource/Create']
+                ,[_('fc.action_update'),'Resource/Update']
                 ,[_('fc.action_resource_wildcard'),'resource/*']
             ]
         })

--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -37,12 +37,12 @@ MODx.grid.FCProfile = function(config) {
         id: 'modx-grid-fc-profile'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/forms/profile/getlist'
+            action: 'Security/Forms/Profile/GetList'
         }
         ,fields: ['id','name','description','usergroups','active','rank','sets','perm']
         ,paging: true
         ,autosave: true
-        ,save_action: 'security/forms/profile/updatefromgrid'
+        ,save_action: 'Security/Forms/Profile/UpdateFromGrid'
         ,sm: this.sm
         ,remoteSort: true
         ,columns: [this.sm,{
@@ -177,7 +177,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
             if (p.indexOf('premove') != -1) {
                 m.push('-',{
                     text: _('remove')
-                    ,handler: this.confirm.createDelegate(this,['security/forms/profile/remove','profile_remove_confirm'])
+                    ,handler: this.confirm.createDelegate(this,['Security/Forms/Profile/Remove','profile_remove_confirm'])
                 });
             }
         }
@@ -196,7 +196,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'security/forms/profile/getlist'
+            action: 'Security/Forms/Profile/GetList'
     	};
         Ext.getCmp('modx-fcp-search').reset();
     	this.getBottomToolbar().changePage(1);
@@ -219,13 +219,13 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
 
     ,updateProfile: function(btn,e) {
         var r = this.menu.record;
-        location.href = '?a=security/forms/profile/update&id='+r.id;
+        location.href = '?a=Security/Forms/Profile/Update&id='+r.id;
     }
     ,duplicateProfile: function(btn,e) {
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/profile/duplicate'
+                action: 'Security/Forms/Profile/Duplicate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -238,7 +238,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/profile/activate'
+                action: 'Security/Forms/Profile/Activate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -254,7 +254,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/profile/activateMultiple'
+                action: 'Security/Forms/Profile/ActivateMultiple'
                 ,profiles: cs
             }
             ,listeners: {
@@ -270,7 +270,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/profile/deactivate'
+                action: 'Security/Forms/Profile/Deactivate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -285,7 +285,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/profile/deactivateMultiple'
+                action: 'Security/Forms/Profile/DeactivateMultiple'
                 ,profiles: cs
             }
             ,listeners: {
@@ -306,7 +306,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
             ,text: _('profile_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/forms/profile/removeMultiple'
+                action: 'Security/Forms/Profile/RemoveMultiple'
                 ,profiles: cs
             }
             ,listeners: {
@@ -327,7 +327,7 @@ MODx.window.CreateFCProfile = function(config) {
     Ext.applyIf(config,{
         title: _('profile_create')
         ,url: MODx.config.connector_url
-        ,action: 'security/forms/profile/create'
+        ,action: 'Security/Forms/Profile/Create'
         // ,height: 150
         // ,width: 375
         ,fields: [{

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -5,7 +5,7 @@ MODx.grid.FCSet = function(config) {
         id: 'modx-grid-fc-set'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/forms/set/getlist'
+            action: 'Security/Forms/Set/GetList'
         }
         ,fields: ['id','profile','action','description','active','template','templatename','constraint_data','constraint','constraint_field','constraint_class','rules','perm']
         ,paging: true
@@ -162,7 +162,7 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
             if (p.indexOf('premove') != -1) {
                 m.push('-',{
                     text: _('remove')
-                    ,handler: this.confirm.createDelegate(this,['security/forms/set/remove','set_remove_confirm'])
+                    ,handler: this.confirm.createDelegate(this,['Security/Forms/Set/Remove','set_remove_confirm'])
                 });
             }
         }
@@ -182,7 +182,7 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'security/forms/set/getList'
+            action: 'Security/Forms/Set/GetList'
             ,profile: MODx.request.id
     	};
         Ext.getCmp('modx-fcs-search').reset();
@@ -195,12 +195,12 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/set/export'
+                action: 'Security/Forms/Set/Export'
                 ,id: id
             }
             ,listeners: {
                 'success': {fn:function(r) {
-                    location.href = this.config.url+'?action=security/forms/set/export&download='+r.message+'&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
+                    location.href = this.config.url+'?action=Security/Forms/Set/Export&download='+r.message+'&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
                 },scope:this}
             }
         });
@@ -249,13 +249,13 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
 
     ,updateSet: function(btn,e) {
         var r = this.menu.record;
-        location.href = '?a=security/forms/set/update&id='+r.id;
+        location.href = '?a=Security/Forms/Set/Update&id='+r.id;
     }
     ,duplicateSet: function(btn,e) {
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/set/duplicate'
+                action: 'Security/Forms/Set/Duplicate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -268,7 +268,7 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/set/activate'
+                action: 'Security/Forms/Set/Activate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -284,7 +284,7 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/set/activateMultiple'
+                action: 'Security/Forms/Set/ActivateMultiple'
                 ,sets: cs
             }
             ,listeners: {
@@ -300,7 +300,7 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/set/deactivate'
+                action: 'Security/Forms/Set/Deactivate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -315,7 +315,7 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/forms/set/deactivateMultiple'
+                action: 'Security/Forms/Set/DeactivateMultiple'
                 ,sets: cs
             }
             ,listeners: {
@@ -336,7 +336,7 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
             ,text: _('set_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/forms/set/removeMultiple'
+                action: 'Security/Forms/Set/RemoveMultiple'
                 ,sets: cs
             }
             ,listeners: {
@@ -357,7 +357,7 @@ MODx.window.CreateFCSet = function(config) {
     Ext.applyIf(config,{
         title: _('set_create')
         ,url: MODx.config.connector_url
-        ,action: 'security/forms/set/create'
+        ,action: 'Security/Forms/Set/Create'
         // ,height: 150
         ,width: 600
         ,fields: [{
@@ -418,7 +418,7 @@ MODx.window.CreateFCSet = function(config) {
                     ,description: MODx.expandHelp ? '' : _('set_template_desc')
                     ,id: 'modx-fcsc-template'
                     ,anchor: '100%'
-                    ,baseParams: { action: 'element/template/getList', combo: true }
+                    ,baseParams: { action: 'Element/Template/GetList', combo: true }
                 },{
                     xtype: MODx.expandHelp ? 'label' : 'hidden'
                     ,forId: 'modx-fcsc-template'
@@ -470,7 +470,7 @@ MODx.window.ImportFCSet = function(config) {
         title: _('import_from_xml')
         ,id: 'modx-window-fc-set-import'
         ,url: MODx.config.connector_url
-        ,action: 'security/forms/set/import'
+        ,action: 'Security/Forms/Set/Import'
         ,fileUpload: true
         ,saveBtnText: _('import')
         ,fields: [{

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -74,7 +74,7 @@ MODx.panel.FCProfile = function(config) {
                 xtype: 'modx-grid-fc-set'
 				,cls:'main-wrapper'
                 ,baseParams: {
-                    action: 'security/forms/set/getList'
+                    action: 'Security/Forms/Set/GetList'
                     ,profile: config.record.id
                 }
                 ,preventRender: true

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -9,7 +9,7 @@ MODx.panel.FCSet = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/forms/set/update'
+            action: 'Security/Forms/Set/Update'
         }
         ,id: 'modx-panel-fc-set'
         ,class_key: 'MODX\\Revolution\\modFormCustomizationSet'
@@ -64,7 +64,7 @@ MODx.panel.FCSet = function(config) {
                     ,lazyInit: false
                     ,lazyRender: false
                     ,baseParams: {
-                        action: 'element/template/getList'
+                        action: 'Element/Template/GetList'
                         ,combo: true
                     }
                     ,listeners: {

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -47,7 +47,7 @@ MODx.browser.View = function(config) {
             ,'menu', 'visibility'
         ]
         ,baseParams: {
-            action: 'browser/directory/getfiles'
+            action: 'Browser/Directory/GetFiles'
             ,prependPath: config.prependPath || null
             ,prependUrl: config.prependUrl || null
             ,source: config.source || 1
@@ -103,7 +103,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         p = p || {};
         if (p.dir) { this.dir = p.dir; }
         Ext.applyIf(p,{
-            action: 'browser/directory/getFiles'
+            action: 'Browser/Directory/GetFiles'
             ,dir: this.dir
             ,source: this.config.source || MODx.config.default_media_source
         });
@@ -133,7 +133,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'browser/file/get'
+                action: 'Browser/File/Get'
                 ,file:  data.pathRelative
                 ,wctx: MODx.ctx || ''
                 ,source: this.config.source
@@ -191,7 +191,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'browser/file/download'
+                action: 'Browser/File/Download'
                 ,file: data.pathRelative
                 ,wctx: MODx.ctx || ''
                 ,source: this.config.source
@@ -199,7 +199,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             ,listeners: {
                 'success':{fn:function(r) {
                     if (!Ext.isEmpty(r.object.url)) {
-                        location.href = MODx.config.connector_url+'?action=browser/file/download&download=1&file='+r.object.url+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.config.source+'&wctx='+MODx.ctx;
+                        location.href = MODx.config.connector_url+'?action=Browser/File/Download&download=1&file='+r.object.url+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.config.source+'&wctx='+MODx.ctx;
                     }
                 },scope:this}
             }
@@ -234,7 +234,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
             text: _('file_remove_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'browser/file/remove'
+                action: 'Browser/File/Remove'
                 ,file: files.pop()
                 ,source: this.config.source
                 ,wctx: this.config.wctx || 'web'

--- a/manager/assets/modext/widgets/modx.panel.search.js
+++ b/manager/assets/modext/widgets/modx.panel.search.js
@@ -218,7 +218,7 @@ Ext.extend(MODx.panel.Search,MODx.FormPanel,{
 
     ,filter: function(tf,newValue,oldValue) {
         var p = this.getForm().getValues();
-        p.action = 'resource/search';
+        p.action = 'Resource/Search';
 
         var g = Ext.getCmp('modx-grid-search');
         if (g) {
@@ -251,7 +251,7 @@ MODx.grid.Search = function(config) {
         ,id: 'modx-grid-search'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'resource/search'
+            action: 'Resource/Search'
         }
         ,fields: ['id','pagetitle','description','published','deleted','menu']
         ,paging: true

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -80,7 +80,7 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
         MODx.Ajax.request({
                 url: MODx.config.connector_url,
                 params: {
-                    action: 'system/dashboard/widget/feed',
+                    action: 'System/Dashboard/Widget/Feed',
                     feed: feed
                 },
                 listeners: {
@@ -128,7 +128,7 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
                 MODx.Ajax.request({
                     url: MODx.config.connector_url,
                     params: {
-                        action: 'system/dashboard/user/sort',
+                        action: 'System/Dashboard/User/Sort',
                         widget: e.item.getAttribute('data-id'),
                         dashboard: dashboard.id,
                         from: e.oldIndex,
@@ -244,7 +244,7 @@ MODx.window.DashboardWidgetAdd = function (config) {
         id: this.ident,
         url: MODx.config.connector_url,
         baseParams: {
-            action: 'system/dashboard/user/create',
+            action: 'System/Dashboard/User/Create',
             dashboard: config.dashboard.id,
         },
         modal: true,
@@ -291,7 +291,7 @@ Ext.extend(MODx.window.DashboardWidgetAdd, MODx.Window, {
             id: this.ident + '-widget',
             xtype: 'modx-combo-dashboard-widgets',
             baseParams: {
-                action: 'system/dashboard/user/getlist',
+                action: 'System/Dashboard/User/GetList',
                 dashboard: config.dashboard.id,
                 combo: true
             },

--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -213,7 +213,7 @@ MODx.window.InsertElement = function(config) {
         ,labelAlign: 'left'
         ,labelWidth: 160
         ,url: MODx.config.connector_url
-        ,action: 'element/template/create'
+        ,action: 'Element/Template/Create'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'pk'
@@ -236,7 +236,7 @@ MODx.window.InsertElement = function(config) {
             ,id: 'modx-dise-propset'
             ,width: 300
             ,baseParams: {
-                action: 'element/propertyset/getList'
+                action: 'Element/PropertySet/GetList'
                 ,showAssociated: true
                 ,elementId: config.record.pk
                 ,elementType: config.record.classKey
@@ -250,7 +250,7 @@ MODx.window.InsertElement = function(config) {
             ,autoLoad: {
                 url: MODx.config.connector_url
                 ,params: {
-                   'action': 'element/getinsertproperties'
+                   'action': 'Element/GetInsertProperties'
                    ,classKey: config.record.classKey
                    ,pk: config.record.pk
                    ,resourceId: resourceId
@@ -294,7 +294,7 @@ Ext.extend(MODx.window.InsertElement,MODx.Window,{
         u.update({
             url: MODx.config.connector_url
             ,params: {
-                'action': 'element/getinsertproperties'
+                'action': 'Element/GetInsertProperties'
                 ,classKey: this.config.record.classKey
                 ,pk: this.config.record.pk
                 ,resourceId: resourceId

--- a/manager/assets/modext/widgets/resource/modx.grid.resource.active.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.resource.active.js
@@ -5,7 +5,7 @@ MODx.grid.ActiveResources = function(config) {
         ,id: 'modx-grid-resource-active'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/activeresource/getlist'
+            action: 'System/ActiveResource/GetList'
         }
 		,fields: ['id','pagetitle','username','editedon']
         ,columns: [{

--- a/manager/assets/modext/widgets/resource/modx.grid.resource.security.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.resource.security.js
@@ -13,7 +13,7 @@ MODx.grid.ResourceSecurity = function(config) {
         id: 'modx-grid-resource-security'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'resource/resourcegroup/getList'
+            action: 'Resource/ResourceGroup/GetList'
             ,resource: config.resource
             ,"parent": config["parent"]
             ,mode: config.mode || 'update'

--- a/manager/assets/modext/widgets/resource/modx.grid.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.trash.js
@@ -6,7 +6,7 @@ MODx.grid.Trash = function (config) {
     Ext.applyIf(config, {
         url: MODx.config.connector_url,
         baseParams: {
-            action: 'resource/trash/getlist'
+            action: 'Resource/Trash/GetList'
         },
         fields: [
             'id',
@@ -23,7 +23,7 @@ MODx.grid.Trash = function (config) {
         ],
         paging: true,
         autosave: true,
-        save_action: 'resource/updatefromgrid',
+        save_action: 'Resource/UpdateFromGrid',
         save_callback: this.refreshEverything,
         remoteSort: true,
         sm: this.sm,
@@ -199,7 +199,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             }),
             url: this.config.url,
             params: {
-                action: 'resource/trash/purge',
+                action: 'Resource/Trash/Purge',
                 ids: this.menu.record.id
             },
             listeners: {
@@ -232,7 +232,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             }),
             url: this.config.url,
             params: {
-                action: 'resource/undelete',
+                action: 'Resource/Undelete',
                 id: this.menu.record.id
             },
             listeners: {
@@ -264,7 +264,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             }),
             url: this.config.url,
             params: {
-                action: 'resource/trash/purge',
+                action: 'Resource/Trash/Purge',
                 ids: cs
             },
             listeners: {
@@ -299,7 +299,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             }),
             url: this.config.url,
             params: {
-                action: 'resource/trash/restore',
+                action: 'Resource/Trash/Restore',
                 ids: cs
             },
             listeners: {
@@ -335,7 +335,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             }),
             url: this.config.url,
             params: {
-                action: 'resource/trash/purge',
+                action: 'Resource/Trash/Purge',
                 // we can't just purge everything, because it might happen that in
                 // the meantime something was deleted by another user which is not yet
                 // shown in the trash manager list because of missing reload.
@@ -382,7 +382,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             }),
             url: this.config.url,
             params: {
-                action: 'resource/trash/restore',
+                action: 'Resource/Trash/Restore',
                 // we can't just restore everything, because it might happen that in
                 // the meantime something was deleted by another user which is not yet
                 // shown in the trash manager list because of missing reload.

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -8,7 +8,7 @@ MODx.panel.ResourceData = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'resource/data'
+            action: 'Resource/Data'
         }
         ,id: 'modx-panel-resource-data'
         ,class_key: 'MODX\\Revolution\\modResource'
@@ -142,7 +142,7 @@ MODx.panel.ResourceData = function(config) {
                 ,preventRender: true
                 ,formpanel: 'modx-panel-manager-log'
                 ,baseParams: {
-                    action: 'system/log/getlist'
+                    action: 'System/Log/GetList'
                     ,item: MODx.request.id
                     ,classKey: 'MODX\\Revolution\\modResource'
                 }
@@ -193,7 +193,7 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'resource/data'
+                action: 'Resource/Data'
                 ,id: this.config.resource
                 ,class_key: this.config.class_key
             }
@@ -230,7 +230,7 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
                     }
                     trail.push({
                         text: parents[i].pagetitle
-                        ,href: MODx.config.manager_url + '?a=resource/data&id=' + parents[i].id
+                        ,href: MODx.config.manager_url + '?a=Resource/Data&id=' + parents[i].id
                         ,cls: function(data) {
                             var cls = [];
                             if (!data.published) {
@@ -245,7 +245,7 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
                 } else {
                     trail.push({
                         text: '<i class="icon icon-globe"></i> ' + (parents[i].name || parents[i].key)
-                        //,href: MODx.config.manager_url + '?a=context/update&key=' + parents[i].key
+                        //,href: MODx.config.manager_url + '?a=Context/Update&key=' + parents[i].key
                         ,href: false
                     });
                 }

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -197,7 +197,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         if (ta) {
             this.cleanupEditor();
         }
-        if(this.getForm().baseParams.action == 'resource/create') {
+        if(this.getForm().baseParams.action == 'Resource/Create') {
             var btn = Ext.getCmp('modx-abtn-save');
             if (btn) { btn.disable(); }
         }
@@ -297,7 +297,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
 
     ,failure: function(o) {
         this.warnUnsavedChanges = true;
-        if(this.getForm().baseParams.action == 'resource/create') {
+        if(this.getForm().baseParams.action == 'Resource/Create') {
             var btn = Ext.getCmp('modx-abtn-save');
             if (btn) { btn.enable(); }
         }
@@ -321,7 +321,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             MODx.Ajax.request({
                 url: MODx.config.connector_url
                 ,params: {
-                    action: 'resource/translit'
+                    action: 'Resource/Translit'
                     ,string: string
                 }
                 ,listeners: {
@@ -353,7 +353,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 if (e == 'yes') {
                     var nt = t.getValue();
                     var f = Ext.getCmp('modx-page-update-resource');
-                    f.config.action = 'resource/reload';
+                    f.config.action = 'Resource/Reload';
                     this.warnUnsavedChanges = false;
                     MODx.activePage.submitForm({
                         success: {fn:function(r) {
@@ -471,7 +471,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     }
                     trail.push({
                         text: parents[i].pagetitle
-                        ,href: MODx.config.manager_url + '?a=resource/update&id=' + parents[i].id
+                        ,href: MODx.config.manager_url + '?a=Resource/Update&id=' + parents[i].id
                         ,cls: function(data) {
                             var cls = [];
                             if (!data.published) {
@@ -486,7 +486,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 } else {
                     trail.push({
                         text: parents[i].name || parents[i].key
-                        //,href: MODx.config.manager_url + '?a=context/update&key=' + parents[i].key
+                        //,href: MODx.config.manager_url + '?a=Context/Update&key=' + parents[i].key
                         ,href: false
                     });
                 }
@@ -645,7 +645,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     this.generateAliasRealTime(title);
 
                                 title = Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'resource/create' && MODx.perm.tree_show_resource_ids === true) {
+                                if (MODx.request.a !== 'Resource/Create' && MODx.perm.tree_show_resource_ids === true) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
                                 Ext.getCmp('modx-resource-header').getEl().update(title);
@@ -828,7 +828,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 ,typeAheadDelay: 300
                 ,forceSelection: true
                 ,baseParams: {
-                    action: 'element/template/getList'
+                    action: 'Element/Template/GetList'
                     ,combo: '1'
                     ,limit: 0
                 }

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
@@ -40,7 +40,7 @@ MODx.grid.ResourceSchedule = function(config) {
         title: _('site_schedule')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'resource/event/getList'
+            action: 'Resource/Event/GetList'
             ,mode: 'pub_date'
         }
         ,fields: ['id','pagetitle','class_key'
@@ -48,7 +48,7 @@ MODx.grid.ResourceSchedule = function(config) {
             ,{name: 'unpub_date', type:'date'}
             ,'menu']
         ,paging: true
-        ,save_action: 'resource/event/updatefromgrid'
+        ,save_action: 'Resource/Event/UpdateFromGrid'
         ,autosave: true
         ,columns: [
             { header: _('id') ,dataIndex: 'id' ,width: 40 }

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -10,15 +10,15 @@ MODx.tree.Resource = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         url: MODx.config.connector_url
-        ,action: 'resource/getNodes'
+        ,action: 'Resource/GetNodes'
         ,title: ''
         ,rootVisible: false
         ,expandFirst: true
         ,enableDD: (MODx.config.enable_dragdrop != '0') ? true : false
         ,ddGroup: 'modx-treedrop-dd'
         // ,remoteToolbar: true
-        // ,remoteToolbarAction: 'resource/gettoolbar'
-        ,sortAction: 'resource/sort'
+        // ,remoteToolbarAction: 'Resource/GetToolbar'
+        ,sortAction: 'Resource/Sort'
         ,sortBy: this.getDefaultSortBy(config)
         ,tbarCfg: {
         //    hidden: true
@@ -154,7 +154,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 'success': {fn:function(r) {
                     var response = Ext.decode(r.a.response.responseText);
                     if (response.object.redirect) {
-                        MODx.loadPage('resource/update', 'id='+response.object.id);
+                        MODx.loadPage('Resource/Update', 'id='+response.object.id);
                     } else {
                         node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
                         this.refreshNode(node.id);
@@ -193,7 +193,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,text: _('context_remove_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'context/remove'
+                action: 'Context/Remove'
                 ,key: key
             }
             ,listeners: {
@@ -223,7 +223,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,text: _('resource_delete_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'resource/delete'
+                action: 'Resource/Delete'
                 ,id: id
             }
             ,listeners: {
@@ -267,7 +267,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'resource/undelete'
+                action: 'Resource/Undelete'
                 ,id: id
             }
             ,listeners: {
@@ -313,7 +313,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,text: _('resource_publish_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'resource/publish'
+                action: 'Resource/Publish'
                 ,id: id
             }
             ,listeners: {
@@ -334,7 +334,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ,text: _('resource_unpublish_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'resource/unpublish'
+                action: 'Resource/Unpublish'
                 ,id: id
             }
             ,listeners: {
@@ -388,7 +388,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ui.addClass('haschildren');
             ui.removeClass('icon-resource');
         }
-        if((MODx.request.a == MODx.action['resource/update'])){
+        if((MODx.request.a == MODx.action['Resource/Update'])){
 		    if(dropNode.attributes.pk == MODx.request.id) {
                 var parentFieldCmb = Ext.getCmp('modx-resource-parent');
                 var parentFieldHidden = Ext.getCmp('modx-resource-parent-hidden');
@@ -491,7 +491,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'resource/get'
+                action: 'Resource/Get'
                 ,id: this.cm.activeNode.attributes.pk
                 ,skipFormatDates: true
             }
@@ -538,7 +538,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 text: _('edit_context')
                 ,handler: function() {
                     var at = this.cm.activeNode.attributes;
-                    this.loadAction('a=context/update&key='+at.pk);
+                    this.loadAction('a=Context/Update&key='+at.pk);
                 }
             });
         }
@@ -574,13 +574,13 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         return m;
     }
 
-    ,overviewResource: function() {this.loadAction('a=resource/data')}
+    ,overviewResource: function() {this.loadAction('a=Resource/Data')}
 
     ,quickUpdateResource: function(itm,e) {
         this.quickUpdate(itm,e,itm.classKey);
     }
 
-    ,editResource: function() {this.loadAction('a=resource/update');}
+    ,editResource: function() {this.loadAction('a=Resource/Update');}
 
     ,_getModResourceMenu: function(n) {
         var a = n.attributes;
@@ -677,7 +677,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         var at = this.cm.activeNode.attributes;
         var p = itm.usePk ? itm.usePk : at.pk;
         this.loadAction(
-            'a=resource/create&class_key=' + itm.classKey + '&parent=' + p + (at.ctx ? '&context_key='+at.ctx : '')
+            'a=Resource/Create&class_key=' + itm.classKey + '&parent=' + p + (at.ctx ? '&context_key='+at.ctx : '')
         );
     }
 
@@ -755,7 +755,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             url: this.config.url
             ,params: {
                 target: dropEvent.target.attributes.id
-                ,activeTarget: MODx.request.a == MODx.action['resource/update'] ? MODx.request.id : ''
+                ,activeTarget: MODx.request.a == MODx.action['Resource/Update'] ? MODx.request.id : ''
                 ,source: dropEvent.source.dragData.node.attributes.id
                 ,point: dropEvent.point
                 ,data: encodeURIComponent(encNodes)
@@ -858,7 +858,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
     }
 
     /**
-     * Renders the item text without any special formatting. The resource/getnodes processor already protects against XSS.
+     * Renders the item text without any special formatting. The Resource/GetNodes processor already protects against XSS.
      */
     ,renderItemText: function(item) {
         return item.text;
@@ -880,7 +880,7 @@ MODx.window.QuickCreateResource = function(config) {
         // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
-        ,action: 'resource/create'
+        ,action: 'Resource/Create'
         // ,shadow: false
         ,fields: [{
             xtype: 'modx-tabs'
@@ -954,7 +954,7 @@ MODx.window.QuickCreateResource = function(config) {
                             ,editable: false
                             ,anchor: '100%'
                             ,baseParams: {
-                                action: 'element/template/getList'
+                                action: 'Element/Template/GetList'
                                 ,combo: '1'
                                 ,limit: 0
                             }
@@ -1036,7 +1036,7 @@ MODx.window.QuickUpdateResource = function(config) {
     Ext.applyIf(config,{
         title: _('quick_update_resource')
         ,id: this.ident
-        ,action: 'resource/update'
+        ,action: 'Resource/Update'
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')
             ,scope: this

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.simple.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.simple.js
@@ -13,7 +13,7 @@ MODx.tree.SimpleResource = function(config) {
         ,root_name: _('resources')
         ,enableDrag: true
         ,enableDrop: true
-        ,action: 'resource/getNodes'
+        ,action: 'Resource/GetNodes'
         ,baseParams: {
             nohref: true
         }
@@ -22,7 +22,7 @@ MODx.tree.SimpleResource = function(config) {
 };
 Ext.extend(MODx.tree.SimpleResource, MODx.tree.Tree, {
     /**
-     * Renders the item text without any special formatting. The resource/getnodes processor already protects against XSS.
+     * Renders the item text without any special formatting. The Resource/GetNodes processor already protects against XSS.
      */
     renderItemText: function(item) {
         return item.text;

--- a/manager/assets/modext/widgets/security/modx.grid.access.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.context.js
@@ -12,7 +12,7 @@ MODx.grid.AccessContext = function(config) {
         id: 'modx-grid-access-context'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/getList'
+            action: 'Security/Access/GetList'
             ,type: config.type || 'modAccessContext'
             ,target: config.context_key
         }
@@ -114,7 +114,7 @@ Ext.extend(MODx.grid.AccessContext,MODx.grid.Grid,{
             ,text: _('access_confirm_remove')
             ,url: this.config.url
             ,params: {
-                action: 'security/access/removeAcl'
+                action: 'Security/Access/RemoveAcl'
                 ,id: this.menu.record.id
                 ,type: this.config.type || 'modAccessContext'
             }
@@ -136,7 +136,7 @@ MODx.window.CreateAccessContext = function(config) {
         title: _('ugc_mutate')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/addAcl'
+            action: 'Security/Access/AddAcl'
             ,type: config.type || 'modAccessContext'
         }
         // ,height: 250
@@ -163,7 +163,7 @@ MODx.window.CreateAccessContext = function(config) {
             ,anchor: '100%'
             ,value: r.principal || ''
             ,baseParams: {
-                action: 'security/group/getList'
+                action: 'Security/Group/GetList'
                 ,combo: true
             }
         },{
@@ -194,7 +194,7 @@ MODx.window.UpdateAccessContext = function(config) {
     Ext.applyIf(config,{
         title: _('ugc_mutate')
         ,baseParams: {
-            action: 'security/access/updateAcl'
+            action: 'Security/Access/UpdateAcl'
             ,type: config.type || 'modAccessContext'
         }
     });

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -48,12 +48,12 @@ MODx.grid.AccessPolicy = function(config) {
         id: 'modx-grid-access-policy'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/policy/getlist'
+            action: 'Security/Access/Policy/GetList'
         }
         ,fields: ['id','name','description','class','data','parent','template','template_name','active_permissions','total_permissions','active_of','cls']
         ,paging: true
         ,autosave: true
-        ,save_action: 'security/access/policy/updatefromgrid'
+        ,save_action: 'Security/Access/Policy/UpdateFromGrid'
         ,remoteSort: true
         ,sm: this.sm
         ,columns: [this.sm,{
@@ -138,7 +138,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'security/access/policy/getList'
+            action: 'Security/Access/Policy/GetList'
     	};
         Ext.getCmp('modx-policy-search').reset();
     	this.getBottomToolbar().changePage(1);
@@ -146,7 +146,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
     }
 
     ,editPolicy: function(itm,e) {
-        MODx.loadPage('security/access/policy/update', 'id='+this.menu.record.id);
+        MODx.loadPage('Security/Access/Policy/Update', 'id='+this.menu.record.id);
     }
 
     ,createPolicy: function(btn,e) {
@@ -171,12 +171,12 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/access/policy/export'
+                action: 'Security/Access/Policy/Export'
                 ,id: id
             }
             ,listeners: {
                 'success': {fn:function(r) {
-                    location.href = this.config.url+'?action=security/access/policy/export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
+                    location.href = this.config.url+'?action=Security/Access/Policy/Export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
                 },scope:this}
             }
         });
@@ -218,7 +218,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
                 });
                 m.push({
                     text: _('policy_duplicate')
-                    ,handler: this.confirm.createDelegate(this,["security/access/policy/duplicate","policy_duplicate_confirm"])
+                    ,handler: this.confirm.createDelegate(this,["Security/Access/Policy/Duplicate","policy_duplicate_confirm"])
                 });
             }
             if (m.length > 0) { m.push('-'); }
@@ -230,7 +230,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
                 if (m.length > 0) m.push('-');
                 m.push({
                     text: _('policy_remove')
-                    ,handler: this.confirm.createDelegate(this,["security/access/policy/remove","policy_remove_confirm"])
+                    ,handler: this.confirm.createDelegate(this,["Security/Access/Policy/Remove","policy_remove_confirm"])
                 });
             }
         }
@@ -249,7 +249,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
             ,text: _('policy_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/access/policy/removeMultiple'
+                action: 'Security/Access/Policy/RemoveMultiple'
                 ,policies: cs
             }
             ,listeners: {
@@ -279,7 +279,7 @@ MODx.window.CreateAccessPolicy = function(config) {
         // width: 500
         title: _('policy_create')
         ,url: MODx.config.connector_url
-        ,action: 'security/access/policy/create'
+        ,action: 'Security/Access/Policy/Create'
         ,fields: [{
             fieldLabel: _('name') + '<span class="required">*</span>'
             ,description: MODx.expandHelp ? '' : _('policy_desc_name')
@@ -350,7 +350,7 @@ MODx.combo.AccessPolicyTemplate = function(config) {
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/policy/template/getlist'
+            action: 'Security/Access/Policy/Template/GetList'
         }
         ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{name:htmlEncode}</span>'
             ,'<p style="margin: 0; font-size: 11px; color: gray;">{description:htmlEncode}</p></div></tpl>')
@@ -367,7 +367,7 @@ MODx.window.ImportPolicy = function(config) {
         title: _('policy_import')
         ,id: 'modx-window-policy-import'
         ,url: MODx.config.connector_url
-        ,action: 'security/access/policy/import'
+        ,action: 'Security/Access/Policy/Import'
         ,fileUpload: true
         ,saveBtnText: _('import')
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -48,12 +48,12 @@ MODx.grid.AccessPolicyTemplate = function(config) {
         id: 'modx-grid-access-policy-template'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/policy/template/getlist'
+            action: 'Security/Access/Policy/Template/GetList'
         }
         ,fields: ['id','name','description','template_group','template_group_name','total_permissions','cls']
         ,paging: true
         ,autosave: true
-        ,save_action: 'security/access/policy/template/updatefromgrid'
+        ,save_action: 'Security/Access/Policy/Template/UpdateFromGrid'
         ,remoteSort: true
         ,sm: this.sm
         ,columns: [this.sm,{
@@ -141,14 +141,14 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'security/access/policy/template/getList'
+            action: 'Security/Access/Policy/Template/GetList'
     	};
         Ext.getCmp('modx-policy-template-search').reset();
     	this.getBottomToolbar().changePage(1);
        // this.refresh();
     }
     ,editPolicyTemplate: function(itm,e) {
-        MODx.loadPage('security/access/policy/template/update', 'id='+this.menu.record.id);
+        MODx.loadPage('Security/Access/Policy/Template/Update', 'id='+this.menu.record.id);
     }
 
     ,createPolicyTemplate: function(btn,e) {
@@ -173,12 +173,12 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/access/policy/template/export'
+                action: 'Security/Access/Policy/Template/Export'
                 ,id: id
             }
             ,listeners: {
                 'success': {fn:function(r) {
-                    location.href = this.config.url+'?action=security/access/policy/template/export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
+                    location.href = this.config.url+'?action=Security/Access/Policy/Template/Export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
                 },scope:this}
             }
         });
@@ -222,7 +222,7 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
                 });
                 m.push({
                     text: _('policy_template_duplicate')
-                    ,handler: this.confirm.createDelegate(this,["security/access/policy/template/duplicate","policy_template_duplicate_confirm"])
+                    ,handler: this.confirm.createDelegate(this,["Security/Access/Policy/Template/Duplicate","policy_template_duplicate_confirm"])
                 });
             }
             if (m.length > 0) { m.push('-'); }
@@ -235,7 +235,7 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
                 if (m.length > 0) m.push('-');
                 m.push({
                     text: _('policy_template_remove')
-                    ,handler: this.confirm.createDelegate(this,["security/access/policy/template/remove","policy_template_remove_confirm"])
+                    ,handler: this.confirm.createDelegate(this,["Security/Access/Policy/Template/Remove","policy_template_remove_confirm"])
                 });
             }
         }
@@ -253,7 +253,7 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
             ,text: _('policy_template_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/access/policy/template/removeMultiple'
+                action: 'Security/Access/Policy/Template/RemoveMultiple'
                 ,templates: cs
             }
             ,listeners: {
@@ -283,7 +283,7 @@ MODx.window.CreateAccessPolicyTemplate = function(config) {
         // width: 500
         title: _('policy_template_create')
         ,url: MODx.config.connector_url
-        ,action: 'security/access/policy/template/create'
+        ,action: 'Security/Access/Policy/Template/Create'
         ,fields: [{
             fieldLabel: _('name')
             ,name: 'name'
@@ -341,7 +341,7 @@ MODx.combo.AccessPolicyTemplateGroups = function(config) {
         // ,listWidth: 300
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/policy/template/group/getlist'
+            action: 'Security/Access/Policy/Template/Group/GetList'
         }
         ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{name:htmlEncode}</span>'
             ,'<p style="margin: 0; font-size: 11px; color: gray;">{description:htmlEncode}</p></div></tpl>')
@@ -359,7 +359,7 @@ MODx.window.ImportPolicyTemplate = function(config) {
         title: _('policy_template_import')
         ,id: 'modx-window-policy-template-import'
         ,url: MODx.config.connector_url
-        ,action: 'security/access/policy/template/import'
+        ,action: 'Security/Access/Policy/Template/Import'
         ,fileUpload: true
         ,saveBtnText: _('import')
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.grid.message.js
+++ b/manager/assets/modext/widgets/security/modx.grid.message.js
@@ -15,7 +15,7 @@ MODx.panel.Messages = function(config) {
         ,defaults: { collapsible: false ,autoHeight: true }
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/message/getlist'
+            action: 'Security/Message/GetList'
         }
         ,items: [{
             html: _('messages')
@@ -81,7 +81,7 @@ MODx.grid.Message = function(config) {
         ,id: 'modx-grid-message'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/message/getlist'
+            action: 'Security/Message/GetList'
         }
         ,fields: ['id','type','subject','message','sender','recipient','private'
             ,'date_sent','read','sender_name','recipient_name']
@@ -177,7 +177,7 @@ Ext.extend(MODx.grid.Message,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/message/read'
+                action: 'Security/Message/Read'
                 ,id: r.id
             }
             ,listeners: {
@@ -195,7 +195,7 @@ Ext.extend(MODx.grid.Message,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/message/unread'
+                action: 'Security/Message/Unread'
                 ,id: rec.data.id
             }
             ,listeners: {
@@ -227,7 +227,7 @@ Ext.extend(MODx.grid.Message,MODx.grid.Grid,{
         if (MODx.user.id != r.data.sender) {
             m.push({
                 text: _('delete')
-                ,handler: this.remove.createDelegate(this, ['message_remove_confirm', 'security/message/remove'])
+                ,handler: this.remove.createDelegate(this, ['message_remove_confirm', 'Security/Message/Remove'])
             });
         }
         return m;
@@ -277,7 +277,7 @@ Ext.extend(MODx.grid.Message,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'security/message/getList'
+            action: 'Security/Message/GetList'
     	};
         Ext.getCmp('modx-messages-search').reset();
         Ext.getCmp('modx-messages-filter').reset();
@@ -299,7 +299,7 @@ MODx.window.CreateMessage = function(config) {
     Ext.applyIf(config,{
         title: _('message_create')
         ,url: MODx.config.connector_url
-        ,action: 'security/message/create'
+        ,action: 'Security/Message/Create'
         ,fields: this.getFields()
         ,keys: []
     });

--- a/manager/assets/modext/widgets/security/modx.grid.role.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.js
@@ -14,12 +14,12 @@ MODx.grid.Role = function(config) {
         ,id: 'modx-grid-role'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/role/getlist'
+            action: 'Security/Role/GetList'
         }
         ,fields: ['id','name','description','authority','perm']
         ,paging: true
         ,autosave: true
-        ,save_action: 'security/role/updatefromgrid'
+        ,save_action: 'Security/Role/UpdateFromGrid'
         ,columns: [{
             header: _('id')
             ,dataIndex: 'id'
@@ -66,7 +66,7 @@ Ext.extend(MODx.grid.Role,MODx.grid.Grid,{
         if (p.indexOf('remove') != -1) {
             m.push({
                 text: _('role_remove')
-                ,handler: this.remove.createDelegate(this,['role_remove_confirm', 'security/role/remove'])
+                ,handler: this.remove.createDelegate(this,['role_remove_confirm', 'Security/Role/Remove'])
             });
         }
         return m;
@@ -93,7 +93,7 @@ MODx.window.CreateRole = function(config) {
         // ,height: 150
         // ,width: 400
         ,url: MODx.config.connector_url
-        ,action: 'security/role/create'
+        ,action: 'Security/Role/Create'
         ,fields: [{
             name: 'name'
             ,fieldLabel: _('name')+'<span class="required">*</span>'

--- a/manager/assets/modext/widgets/security/modx.grid.role.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.user.js
@@ -15,7 +15,7 @@ MODx.grid.RoleUser = function(config) {
         ,url: MODx.config.connector_url
         ,fields: ['id','username','fullname','email']
         ,baseParams: {
-            action: 'security/role/getUsers'
+            action: 'Security/Role/GetUsers'
             ,role: config.role
         }
         ,autosave: true
@@ -41,7 +41,7 @@ Ext.extend(MODx.grid.RoleUser,MODx.grid.Grid,{
             ,text: _('role_user_confirm_remove')
             ,url: this.config.url
             ,params: {
-                action: 'security/role/removeUser'
+                action: 'Security/Role/RemoveUser'
                 ,user: this.menu.record.id
                 ,role: this.config.role
             }
@@ -65,7 +65,7 @@ Ext.extend(MODx.grid.RoleUser,MODx.grid.Grid,{
             ,listeners: {
                 'success': {fn:function(r) {
                     this.getStore().baseParams = {
-                        action: 'security/role/getUsers'
+                        action: 'Security/Role/GetUsers'
                         ,role: this.config.role
                     };
                     Ext.getCmp('rugrid-combo-usergroup').setValue('');
@@ -108,7 +108,7 @@ Ext.extend(MODx.grid.RoleUser,MODx.grid.Grid,{
                 ,listeners: {
                     'select': {fn:function(btn,e) {
                         this.store.baseParams = {
-                            action: 'security/role/getUsers'
+                            action: 'Security/Role/GetUsers'
                             ,role: this.config.role
                             ,group: Ext.getCmp('rugrid-combo-usergroup').getValue()
                         };
@@ -121,7 +121,7 @@ Ext.extend(MODx.grid.RoleUser,MODx.grid.Grid,{
 				,scope: this
 				,handler: function(btn,e) {
 					this.getStore().baseParams = { 
-						action: 'security/role/getUsers'
+						action: 'Security/Role/GetUsers'
 						,role: this.config.role
 					};
                     Ext.getCmp('rugrid-combo-usergroup').setValue('');

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
@@ -10,7 +10,7 @@ MODx.grid.UserGroupCategory = function(config) {
         id: 'modx-grid-user-group-categories'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/usergroup/category/getList'
+            action: 'Security/Access/UserGroup/Category/GetList'
             ,usergroup: config.usergroup
         }
         ,paging: true
@@ -63,7 +63,7 @@ MODx.grid.UserGroupCategory = function(config) {
             ,emptyText: _('filter_by_policy')
             ,allowBlank: true
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Object'
             }
             ,listeners: {
@@ -149,7 +149,7 @@ MODx.window.CreateUGCat = function(config) {
     Ext.applyIf(config,{
         title: _('category_add')
         ,url: MODx.config.connector_url
-        ,action: 'security/access/usergroup/category/create'
+        ,action: 'Security/Access/UserGroup/Category/Create'
         // ,height: 250
         // ,width: 500
         ,fields: [{
@@ -212,7 +212,7 @@ MODx.window.CreateUGCat = function(config) {
             ,name: 'policy'
             ,hiddenName: 'policy'
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Element,Object'
                 ,combo: '1'
             }
@@ -277,7 +277,7 @@ MODx.window.UpdateUGCat = function(config) {
 
     Ext.applyIf(config,{
         title: _('access_category_update')
-        ,action: 'security/access/usergroup/category/update'
+        ,action: 'Security/Access/UserGroup/Category/Update'
     });
     MODx.window.UpdateUGCat.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -10,7 +10,7 @@ MODx.grid.UserGroupContext = function(config) {
         id: 'modx-grid-user-group-contexts'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/usergroup/context/getList'
+            action: 'Security/Access/UserGroup/Context/GetList'
             ,usergroup: config.usergroup
         }
         ,fields: ['id','target','principal','authority','authority_name','policy','policy_name','permissions','cls']
@@ -59,7 +59,7 @@ MODx.grid.UserGroupContext = function(config) {
             ,emptyText: _('filter_by_policy')
             ,allowBlank: true
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Admin'
             }
             ,listeners: {
@@ -97,7 +97,7 @@ Ext.extend(MODx.grid.UserGroupContext,MODx.grid.Grid,{
                 if (m.length > 0) { m.push('-'); }
                 m.push({
                     text: _('access_context_remove')
-                    ,handler: this.remove.createDelegate(this,["confirm_remove","security/access/usergroup/context/remove"])
+                    ,handler: this.remove.createDelegate(this,["confirm_remove","Security/Access/UserGroup/Context/Remove"])
                 });
             }
         }
@@ -174,7 +174,7 @@ MODx.window.CreateUGAccessContext = function(config) {
     Ext.applyIf(config,{
         title: _('ugc_mutate')
         ,url: MODx.config.connector_url
-        ,action: 'security/access/usergroup/context/create'
+        ,action: 'Security/Access/UserGroup/Context/Create'
         // ,width: 600
         ,fields: [{
             xtype: 'hidden'
@@ -215,7 +215,7 @@ MODx.window.CreateUGAccessContext = function(config) {
             ,name: 'policy'
             ,hiddenName: 'policy'
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Admin,Object'
                 ,combo: '1'
             }
@@ -283,7 +283,7 @@ MODx.window.UpdateUGAccessContext = function(config) {
     this.ident = config.ident || 'uugactx'+Ext.id();
     Ext.applyIf(config,{
         title: _('ugc_mutate')
-        ,action: 'security/access/usergroup/context/update'
+        ,action: 'Security/Access/UserGroup/Context/Update'
     });
     MODx.window.UpdateUGAccessContext.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -18,7 +18,7 @@ MODx.grid.UserGroups = function(config) {
         ,id: 'modx-grid-user-groups'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/group/getlist'
+            action: 'Security/Group/GetList'
         }
         ,fields: ['usergroup','name','member','role','rolename','primary_group','rank','user_group_desc']
         ,cls: 'modx-grid modx-grid-draggable'
@@ -158,7 +158,7 @@ MODx.window.AddGroupToUser = function(config) {
         // ,height: 150
         // ,width: 375
         ,url: MODx.config.connector_url
-        ,action: 'security/group/user/create'
+        ,action: 'Security/Group/User/Create'
         ,fields: [{
             fieldLabel: _('user_group')
             ,name: 'usergroup'
@@ -216,7 +216,7 @@ MODx.window.UpdateUserGroupsRole = function(config) {
         id: 'modx-window-user-groups-role-update'
         ,title: _('user_group_user_update_role')
         ,url: MODx.config.connector_url
-        ,action: 'security/group/user/update'
+        ,action: 'Security/Group/User/Update'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'user'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
@@ -58,7 +58,7 @@ MODx.grid.UserGroupNamespace = function(config) {
             ,emptyText: _('filter_by_policy')
             ,allowBlank: true
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Namespace'
             }
             ,listeners: {
@@ -197,7 +197,7 @@ MODx.window.CreateUGNamespace = function(config) {
             ,name: 'policy'
             ,hiddenName: 'policy'
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Namespace'
             }
             ,anchor: '100%'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
@@ -10,7 +10,7 @@ MODx.grid.UserGroupResourceGroup = function(config) {
         id: 'modx-grid-user-group-resource-groups'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/usergroup/resourcegroup/getList'
+            action: 'Security/Access/UserGroup/ResourceGroup/GetList'
             ,usergroup: config.usergroup
         }
         ,paging: true
@@ -62,7 +62,7 @@ MODx.grid.UserGroupResourceGroup = function(config) {
             ,id: 'modx-ugrg-policy-filter'
             ,emptyText: _('filter_by_policy')
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Object'
             }
             ,allowBlank: true
@@ -149,7 +149,7 @@ MODx.window.CreateUGRG = function(config) {
     Ext.applyIf(config,{
         title: _('resource_group_add')
         ,url: MODx.config.connector_url
-        ,action: 'security/access/usergroup/resourcegroup/create'
+        ,action: 'Security/Access/UserGroup/ResourceGroup/Create'
         // ,height: 250
         // ,width: 600
         ,fields: [{
@@ -212,7 +212,7 @@ MODx.window.CreateUGRG = function(config) {
             ,name: 'policy'
             ,hiddenName: 'policy'
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'Resource,Object'
                 ,combo: '1'
             }
@@ -275,7 +275,7 @@ MODx.window.UpdateUGRG = function(config) {
     this.ident = config.ident || 'ugrgactx'+Ext.id();
     Ext.applyIf(config,{
         title: _('access_rgroup_update')
-        ,action: 'security/access/usergroup/resourcegroup/update'
+        ,action: 'Security/Access/UserGroup/ResourceGroup/Update'
     });
     MODx.window.UpdateUGRG.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
@@ -13,13 +13,13 @@ MODx.grid.GroupSettings = function(config) {
         ,id: 'modx-grid-group-settings'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/group/setting/getList'
+            action: 'Security/Group/Setting/GetList'
             ,group: config.group
         }
         ,saveParams: {
             group: config.group
         }
-        ,save_action: 'security/group/setting/updatefromgrid'
+        ,save_action: 'Security/Group/Setting/UpdateFromGrid'
         ,fk: config.group
         ,tbar: [{
             text: _('create_new')
@@ -29,7 +29,7 @@ MODx.grid.GroupSettings = function(config) {
                 xtype: 'modx-window-setting-create'
                 ,url: MODx.config.connector_url
                 ,baseParams: {
-                    action: 'security/group/setting/create'
+                    action: 'Security/Group/Setting/Create'
                 }
                 ,fk: config.group
             }
@@ -56,7 +56,7 @@ Ext.extend(MODx.grid.GroupSettings,MODx.grid.SettingsGrid, {
                 ,handler: this.updateSetting
             },'-',{
                 text: _('setting_remove')
-                ,handler: this.remove.createDelegate(this,['setting_remove_confirm', 'security/group/setting/remove'])
+                ,handler: this.remove.createDelegate(this,['setting_remove_confirm', 'Security/Group/Setting/Remove'])
             });
         }
         if (m.length > 0) {
@@ -70,7 +70,7 @@ Ext.extend(MODx.grid.GroupSettings,MODx.grid.SettingsGrid, {
         r.fk = Ext.isDefined(this.config.fk) ? this.config.fk : 0;
         var uss = MODx.load({
             xtype: 'modx-window-setting-update'
-            ,action: 'security/group/setting/update'
+            ,action: 'Security/Group/Setting/Update'
             ,record: r
             ,grid: this
             ,listeners: {

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
@@ -10,7 +10,7 @@ MODx.grid.UserGroupSource = function(config) {
         id: 'modx-grid-user-group-sources'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/usergroup/source/getList'
+            action: 'Security/Access/UserGroup/Source/GetList'
             ,usergroup: config.usergroup
         }
         ,paging: true
@@ -58,7 +58,7 @@ MODx.grid.UserGroupSource = function(config) {
             ,emptyText: _('filter_by_policy')
             ,allowBlank: true
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'MediaSource'
             }
             ,listeners: {
@@ -144,7 +144,7 @@ MODx.window.CreateUGSource = function(config) {
     Ext.applyIf(config,{
         title: _('source_add')
         ,url: MODx.config.connector_url
-        ,action: 'security/access/usergroup/source/create'
+        ,action: 'Security/Access/UserGroup/Source/Create'
         // ,height: 250
         // ,width: 500
         ,fields: [{
@@ -198,7 +198,7 @@ MODx.window.CreateUGSource = function(config) {
             ,name: 'policy'
             ,hiddenName: 'policy'
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'MediaSource'
             }
             ,anchor: '100%'
@@ -261,7 +261,7 @@ MODx.window.UpdateUGSource = function(config) {
     this.ident = config.ident || 'updugsrc'+Ext.id();
     Ext.applyIf(config,{
         title: _('access_source_update')
-        ,action: 'security/access/usergroup/source/update'
+        ,action: 'Security/Access/UserGroup/Source/Update'
     });
     MODx.window.UpdateUGSource.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -33,13 +33,13 @@ MODx.grid.User = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/user/getList'
+            action: 'Security/User/GetList'
             ,usergroup: MODx.request['usergroup'] ? MODx.request['usergroup'] : ''
         }
         ,fields: ['id','username','fullname','email','gender','blocked','role','active','cls']
         ,paging: true
         ,autosave: true
-        ,save_action: 'security/user/updatefromgrid'
+        ,save_action: 'Security/User/UpdateFromGrid'
         ,autosaveErrorMsg: _('user_err_save')
         ,remoteSort: true
         ,viewConfig: {
@@ -64,7 +64,7 @@ MODx.grid.User = function(config) {
             ,width: 150
             ,sortable: true
             ,renderer: function(value, p, record){
-                return String.format('<a href="?a=security/user/update&id={0}" title="{1}" class="x-grid-link">{2}</a>', record.id, _('user_update'), Ext.util.Format.htmlEncode( value ) );
+                return String.format('<a href="?a=Security/User/Update&id={0}" title="{1}" class="x-grid-link">{2}</a>', record.id, _('user_update'), Ext.util.Format.htmlEncode( value ) );
             }
         },{
             header: _('user_full_name')
@@ -119,7 +119,7 @@ MODx.grid.User = function(config) {
             ,itemId: 'usergroup'
             ,emptyText: _('user_group')+'...'
             ,baseParams: {
-                action: 'security/group/getList'
+                action: 'Security/Group/GetList'
                 ,addAll: true
             }
             ,value: MODx.request['usergroup'] ? MODx.request['usergroup'] : ''
@@ -210,7 +210,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
 
     ,createUser: function() {
-        MODx.loadPage('security/user/create');
+        MODx.loadPage('Security/User/Create');
     }
 
     ,activateSelected: function() {
@@ -220,7 +220,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/user/activateMultiple'
+                action: 'Security/User/ActivateMultiple'
                 ,users: cs
             }
             ,listeners: {
@@ -239,7 +239,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/user/deactivateMultiple'
+                action: 'Security/User/DeactivateMultiple'
                 ,users: cs
             }
             ,listeners: {
@@ -260,7 +260,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
             ,text: _('user_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/user/removeMultiple'
+                action: 'Security/User/RemoveMultiple'
                 ,users: cs
             }
             ,listeners: {
@@ -279,7 +279,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
             ,text: _('user_confirm_remove')
             ,url: this.config.url
             ,params: {
-                action: 'security/user/delete'
+                action: 'Security/User/Delete'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -292,7 +292,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/user/duplicate'
+                action: 'Security/User/Duplicate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -302,7 +302,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
 
     ,updateUser: function() {
-        MODx.loadPage('security/user/update', 'id='+this.menu.record.id);
+        MODx.loadPage('Security/User/Update', 'id='+this.menu.record.id);
     }
 
     ,rendGender: function(d,c) {
@@ -329,7 +329,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
         this.getStore().baseParams = {
-            action: 'security/user/getList'
+            action: 'Security/User/GetList'
         };
         Ext.getCmp('modx-user-search').reset();
         Ext.getCmp('modx-user-filter-usergroup').reset();

--- a/manager/assets/modext/widgets/security/modx.grid.user.online.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.online.js
@@ -14,7 +14,7 @@ MODx.grid.WhoIsOnline = function(config) {
     title: _('onlineusers_title')
     ,url: MODx.config.connector_url
     ,baseParams: {
-      action: 'security/user/getonline'
+      action: 'Security/User/GetOnline'
     }
     ,autosave: false
     ,save_action: ''

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -12,11 +12,11 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         title: _('recent_docs')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/user/getRecentlyEditedResources'
+            action: 'Security/User/GetRecentlyEditedResources'
             ,user: config.user
         }
         ,autosave: true
-        ,save_action: 'resource/updatefromgrid'
+        ,save_action: 'Resource/UpdateFromGrid'
         ,pageSize: 10
         ,fields: ['id','pagetitle','description','editedon','deleted','published','context_key','menu', 'link']
         ,columns: [{

--- a/manager/assets/modext/widgets/security/modx.grid.user.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.settings.js
@@ -13,13 +13,13 @@ MODx.grid.UserSettings = function(config) {
         ,id: 'modx-grid-user-settings'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/user/setting/getList'
+            action: 'Security/User/Setting/GetList'
             ,user: config.user
         }
         ,saveParams: {
             user: config.user
         }
-        ,save_action: 'security/user/setting/updatefromgrid'
+        ,save_action: 'Security/User/Setting/UpdateFromGrid'
         ,fk: config.user
         ,tbar: [{
             text: _('create_new')
@@ -29,7 +29,7 @@ MODx.grid.UserSettings = function(config) {
                 xtype: 'modx-window-setting-create'
                 ,url: MODx.config.connector_url
                 ,baseParams: {
-                    action: 'security/user/setting/create'
+                    action: 'Security/User/Setting/Create'
                 }
                 ,keyField: {
                     xtype: 'modx-combo-setting-key'
@@ -77,7 +77,7 @@ Ext.extend(MODx.grid.UserSettings,MODx.grid.SettingsGrid, {
                 ,handler: this.updateSetting
             },'-',{
                 text: _('setting_remove')
-                ,handler: this.remove.createDelegate(this,['setting_remove_confirm', 'security/user/setting/remove'])
+                ,handler: this.remove.createDelegate(this,['setting_remove_confirm', 'Security/User/Setting/Remove'])
             });
         }
         if (m.length > 0) {
@@ -91,7 +91,7 @@ Ext.extend(MODx.grid.UserSettings,MODx.grid.SettingsGrid, {
         r.fk = Ext.isDefined(this.config.fk) ? this.config.fk : 0;
         var uss = MODx.load({
             xtype: 'modx-window-setting-update'
-            ,action: 'security/user/setting/update'
+            ,action: 'Security/User/Setting/Update'
             ,record: r
             ,grid: this
             ,listeners: {

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.js
@@ -10,7 +10,7 @@ MODx.panel.AccessPolicy = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/policy/update'
+            action: 'Security/Access/Policy/Update'
             ,id: MODx.request.id
         }
         ,id: 'modx-panel-access-policy'
@@ -217,7 +217,7 @@ MODx.combo.AccessPolicyTemplate = function(config) {
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/policy/template/getlist'
+            action: 'Security/Access/Policy/Template/GetList'
         }
         ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{name:htmlEncode}</span>'
             ,'<p style="margin: 0; font-size: 11px; color: gray;">{description:htmlEncode}</p></div></tpl>')

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
@@ -12,7 +12,7 @@ MODx.panel.AccessPolicyTemplate = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/policy/template/update'
+            action: 'Security/Access/Policy/Template/Update'
             ,id: MODx.request.id
         }
         ,id: 'modx-panel-access-policy-template'

--- a/manager/assets/modext/widgets/security/modx.panel.resource.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.resource.group.js
@@ -40,7 +40,7 @@ MODx.panel.ResourceGroups = function(config) {
                         ,id: 'modx-gr-tree-resource'
                         ,url: MODx.config.connector_url
                         ,baseParams: {
-                            action: 'resource/getNodes'
+                            action: 'Resource/GetNodes'
                             ,noMenu: true
                         }
                         ,ddGroup: 'rg2resource'

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -5,7 +5,7 @@ MODx.panel.UserGroup = function(config) {
 		,cls: 'container form-with-labels'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/group/update'
+            action: 'Security/Group/Update'
         }
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
@@ -101,7 +101,7 @@ MODx.panel.UserGroup = function(config) {
                                 ,anchor: '100%'
                                 ,disabled: config.record.id === 0
                                 ,baseParams: {
-                                    action: 'security/group/getList'
+                                    action: 'Security/Group/GetList'
                                     ,addNone: true
                                     ,exclude: config.record.id
                                 }
@@ -327,7 +327,7 @@ MODx.grid.UserGroupUsers = function(config) {
         ,id: 'modx-grid-user-group-users'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/group/user/getList'
+            action: 'Security/Group/User/GetList'
             ,usergroup: config.usergroup
         }
         ,paging: true
@@ -459,7 +459,7 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
             ,text: _('user_group_user_remove_confirm') || _('confirm_remove')
             ,url: this.config.url
             ,params: {
-                action: 'security/group/user/remove'
+                action: 'Security/Group/User/Remove'
                 ,user: r.id
                 ,usergroup: this.config.usergroup
             }
@@ -477,7 +477,7 @@ MODx.window.UpdateUserGroupRole = function(config) {
         id: 'modx-window-user-group-role-update'
         ,title: _('user_group_user_update_role')
         ,url: MODx.config.connector_url
-        ,action: 'security/group/user/update'
+        ,action: 'Security/Group/User/Update'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'usergroup'
@@ -507,7 +507,7 @@ MODx.window.AddUserToUserGroup = function(config) {
         // ,height: 150
         // ,width: 500
         ,url: MODx.config.connector_url
-        ,action: 'security/group/user/create'
+        ,action: 'Security/Group/User/Create'
         ,fields: [{
             fieldLabel: _('user')
             ,description: MODx.expandHelp ? '' : _('user_group_user_add_user_desc')

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -50,7 +50,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'security/user/get'
+                action: 'Security/User/Get'
                 ,id: this.config.user
                 ,getGroups: true
             }
@@ -98,14 +98,14 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                 ,buttons: Ext.Msg.OK
                 ,fn: function(btn) {
                     if (userId == 0) {
-                        MODx.loadPage('security/user/update', 'id='+o.result.object.id);
+                        MODx.loadPage('Security/User/Update', 'id='+o.result.object.id);
                     }
                     return false;
                 }
             });
             this.clearDirty();
         } else if (userId == 0) {
-            MODx.loadPage('security/user/update', 'id='+o.result.object.id);
+            MODx.loadPage('Security/User/Update', 'id='+o.result.object.id);
         }
     }
 

--- a/manager/assets/modext/widgets/security/modx.tree.resource.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.resource.group.js
@@ -11,7 +11,7 @@ MODx.tree.ResourceGroup = function(config) {
     Ext.applyIf(config,{
         title: _('resource_groups')
         ,url: MODx.config.connector_url
-        ,action: 'security/resourcegroup/getnodes'
+        ,action: 'Security/ResourceGroup/GetNodes'
         ,root_id: '0'
         ,root_name: _('resource_groups')
         ,enableDrag: false
@@ -89,7 +89,7 @@ Ext.extend(MODx.tree.ResourceGroup,MODx.tree.Tree,{
             text: _('resource_group_access_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/resourcegroup/removeResource'
+                action: 'Security/ResourceGroup/RemoveResource'
                 ,resource: resourceId
                 ,resourceGroup: resourceGroupId
             }
@@ -107,7 +107,7 @@ Ext.extend(MODx.tree.ResourceGroup,MODx.tree.Tree,{
             text: _('resource_group_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/resourcegroup/remove'
+                action: 'Security/ResourceGroup/Remove'
                 ,id: id
             }
             ,listeners: {
@@ -194,7 +194,7 @@ Ext.extend(MODx.tree.ResourceGroup,MODx.tree.Tree,{
             ,params: {
                 resource: dropEvent.dropNode.attributes.id
                 ,resourceGroup: dropEvent.target.attributes.id
-                ,action: 'security/resourcegroup/updateResourcesIn'
+                ,action: 'Security/ResourceGroup/UpdateResourcesIn'
             }
             ,listeners: {
                 'success': {fn: function(r,o) {
@@ -224,7 +224,7 @@ MODx.window.CreateResourceGroup = function(config) {
         ,width: 600
         ,stateful: false
         ,url: MODx.config.connector_url
-        ,action: 'security/resourcegroup/create'
+        ,action: 'Security/ResourceGroup/Create'
         ,fields: [{
             fieldLabel: _('name')
             ,name: 'name'
@@ -340,7 +340,7 @@ MODx.window.UpdateResourceGroup = function(config) {
         // ,height: 150
         // ,width: 350
         ,url: MODx.config.connector_url
-        ,action: 'security/resourcegroup/update'
+        ,action: 'Security/ResourceGroup/Update'
         ,fields: [{
             name: 'id'
             ,xtype: 'hidden'

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -12,8 +12,8 @@ MODx.tree.UserGroup = function(config) {
         title: _('user_groups')
         ,id: 'modx-tree-usergroup'
         ,url: MODx.config.connector_url
-        ,action: 'security/group/getnodes'
-        ,sortAction: 'security/group/sort'
+        ,action: 'Security/Group/GetNodes'
+        ,sortAction: 'Security/Group/Sort'
         ,root_id: 'n_ug_0'
         ,root_name: _('user_groups')
         ,enableDrag: true
@@ -149,7 +149,7 @@ Ext.extend(MODx.tree.UserGroup,MODx.tree.Tree,{
             ,text: _('user_group_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/group/remove'
+                action: 'Security/Group/Remove'
                 ,id: id
             }
             ,listeners: {
@@ -168,7 +168,7 @@ Ext.extend(MODx.tree.UserGroup,MODx.tree.Tree,{
             ,text: _('user_group_user_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/group/user/remove'
+                action: 'Security/Group/User/Remove'
                 ,user: user_id
                 ,usergroup: group_id
             }
@@ -205,7 +205,7 @@ MODx.window.CreateUserGroup = function(config) {
         ,width: 700
         ,stateful: false
         ,url: MODx.config.connector_url
-        ,action: 'security/group/create'
+        ,action: 'Security/Group/Create'
         ,fields: [{
             name: 'parent'
             ,id: 'modx-'+this.ident+'-parent'
@@ -316,7 +316,7 @@ MODx.window.CreateUserGroup = function(config) {
                     },{
                         xtype: 'modx-combo-policy'
                         ,baseParams: {
-                            action: 'security/access/policy/getList'
+                            action: 'Security/Access/Policy/GetList'
                             ,group: 'Admin'
                             ,combo: '1'
                         }
@@ -366,7 +366,7 @@ MODx.window.AddUserToUserGroup = function(config) {
         // ,height: 150
         // ,width: 375
         ,url: MODx.config.connector_url
-        ,action: 'security/group/user/create'
+        ,action: 'Security/Group/User/Create'
         ,fields: [{
             fieldLabel: _('name')
             ,description: MODx.expandHelp ? '' : _('user_group_user_add_user_desc')

--- a/manager/assets/modext/widgets/source/modx.grid.source.access.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.access.js
@@ -93,7 +93,7 @@ Ext.extend(MODx.grid.MediaSourceAccess,MODx.grid.LocalGrid,{
             ,text: _('source_access_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'security/access/removeAcl'
+                action: 'Security/Access/RemoveAcl'
                 ,id: this.menu.record.id
                 ,type: this.config.type || 'modAccessMediaSource'
             }
@@ -159,7 +159,7 @@ MODx.window.CreateSourceAccess = function(config) {
             ,hiddenName: 'principal'
             ,value: r.principal || ''
             ,baseParams: {
-                action: 'security/group/getList'
+                action: 'Security/Group/GetList'
                 ,combo: '1'
             }
             ,anchor: '100%'
@@ -177,7 +177,7 @@ MODx.window.CreateSourceAccess = function(config) {
             ,hiddenName: 'policy'
             ,value: r.policy || ''
             ,baseParams: {
-                action: 'security/access/policy/getList'
+                action: 'Security/Access/Policy/GetList'
                 ,group: 'MediaSource'
             }
             ,anchor: '100%'

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -4,7 +4,7 @@ MODx.panel.Source = function(config) {
         id: 'modx-panel-source'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'source/update'
+            action: 'Source/Update'
         }
         ,defaults: { collapsible: false ,autoHeight: true }
 		,cls: 'container form-with-labels'
@@ -202,7 +202,7 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
     }
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            MODx.loadPage('source/update', 'id='+o.result.object.id);
+            MODx.loadPage('Source/Update', 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-abtn-save').setDisabled(false);
             var wg = Ext.getCmp('modx-grid-source-properties');

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -52,12 +52,12 @@ MODx.grid.Sources = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'source/getlist'
+            action: 'Source/GetList'
         }
         ,fields: ['id','name','description','class_key','cls']
         ,paging: true
         ,autosave: true
-        ,save_action: 'source/updatefromgrid'
+        ,save_action: 'Source/UpdateFromGrid'
         ,remoteSort: true
         ,sm: this.sm
         ,columns: [this.sm,{
@@ -165,7 +165,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'source/duplicate'
+                action: 'Source/Duplicate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -174,7 +174,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         });
     }
     ,createSource: function() {
-        MODx.loadPage('system/source/create');
+        MODx.loadPage('system/Source/Create');
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
@@ -185,7 +185,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
             ,text: _('source_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'source/removeMultiple'
+                action: 'Source/RemoveMultiple'
                 ,sources: cs
             }
             ,listeners: {
@@ -204,7 +204,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
             ,text: _('source_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'source/remove'
+                action: 'Source/Remove'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -214,7 +214,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
     }
 
     ,updateSource: function() {
-        MODx.loadPage('source/update', 'id='+this.menu.record.id);
+        MODx.loadPage('Source/Update', 'id='+this.menu.record.id);
     }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
@@ -225,7 +225,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'source/getList'
+            action: 'Source/GetList'
     	};
         Ext.getCmp('modx-source-search').reset();
     	this.getBottomToolbar().changePage(1);
@@ -248,7 +248,7 @@ MODx.window.CreateSource = function(config) {
         title: _('source_create')
         ,url: MODx.config.connector_url
         ,autoHeight: true
-        ,action: 'source/create'
+        ,action: 'Source/Create'
         ,fields: [{
             xtype: 'textfield'
             ,fieldLabel: _('name')
@@ -284,7 +284,7 @@ MODx.grid.SourceTypes = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'source/type/getlist'
+            action: 'Source/Type/GetList'
         }
         ,fields: ['class','name','description']
         ,paging: true

--- a/manager/assets/modext/widgets/system/modx.grid.content.type.js
+++ b/manager/assets/modext/widgets/system/modx.grid.content.type.js
@@ -53,10 +53,10 @@ MODx.grid.ContentType = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/contenttype/getlist'
+            action: 'System/ContentType/GetList'
         }
         ,autosave: true
-        ,save_action: 'system/contenttype/updatefromgrid'
+        ,save_action: 'System/ContentType/UpdateFromGrid'
         ,fields: ['id','name','mime_type','file_extensions','icon','headers','binary','description']
         ,paging: true
         ,remoteSort: true
@@ -114,7 +114,7 @@ Ext.extend(MODx.grid.ContentType,MODx.grid.Grid,{
             ,handler: function(btn, e) {
                 var window = new MODx.window.CreateContentType({
                     record: this.menu.record
-                    ,action: 'system/contenttype/update'
+                    ,action: 'System/ContentType/Update'
                     ,listeners: {
                         success: {
                             fn: this.refresh
@@ -129,7 +129,7 @@ Ext.extend(MODx.grid.ContentType,MODx.grid.Grid,{
         });
         m.push({
             text: _('content_type_remove')
-            ,handler: this.confirm.createDelegate(this,['system/contenttype/remove',_('content_type_remove_confirm')])
+            ,handler: this.confirm.createDelegate(this,['System/ContentType/Remove',_('content_type_remove_confirm')])
         });
 
         return m;
@@ -168,7 +168,7 @@ MODx.window.CreateContentType = function(config) {
         title: _('content_type_new')
         ,width: 600
         ,url: MODx.config.connector_url
-        ,action: 'system/contenttype/create'
+        ,action: 'System/ContentType/Create'
         ,bwrapCssClass: 'x-window-with-tabs'
         ,fields: [{
             xtype: 'modx-tabs'

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -13,12 +13,12 @@ MODx.grid.Context = function(config) {
         ,id: 'modx-grid-context'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'context/getlist'
+            action: 'Context/GetList'
         }
         ,fields: ['key','name','description','perm', 'rank']
         ,paging: true
         ,autosave: true
-        ,save_action: 'context/updatefromgrid'
+        ,save_action: 'Context/UpdateFromGrid'
         ,remoteSort: true
         ,primaryKey: 'key'
         ,columns: [{
@@ -84,7 +84,7 @@ MODx.grid.Context = function(config) {
 };
 Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
     updateContext: function(itm,e) {
-        MODx.loadPage('context/update', 'key='+this.menu.record.key);
+        MODx.loadPage('Context/Update', 'key='+this.menu.record.key);
     }
     ,getMenu: function() {
         var r = this.getSelectionModel().getSelected();
@@ -144,7 +144,7 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'context/getList'
+            action: 'Context/GetList'
     	};
         Ext.getCmp('modx-ctx-search').reset();
     	this.getBottomToolbar().changePage(1);
@@ -178,7 +178,7 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         	text		: _('context_remove_confirm'),
         	url			: this.config.url,
         	params		: {
-            	action		: 'context/remove',
+            	action		: 'Context/Remove',
             	key			: this.menu.record.key
             },
             listeners	: {
@@ -220,7 +220,7 @@ MODx.window.CreateContext = function(config) {
     Ext.applyIf(config,{
         title: _('context_create')
         ,url: MODx.config.connector_url
-        ,action: 'context/create'
+        ,action: 'Context/Create'
         ,fields: [{
             xtype: 'textfield'
             ,fieldLabel: _('context_key')

--- a/manager/assets/modext/widgets/system/modx.grid.context.settings.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.settings.js
@@ -13,14 +13,14 @@ MODx.grid.ContextSettings = function(config) {
         ,id: 'modx-grid-context-settings'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'context/setting/getList'
+            action: 'Context/Setting/GetList'
             ,context_key: config.context_key
         }
         ,saveParams: {
             context_key: config.context_key
         }
         ,fk: config.context_key
-        ,save_action: 'context/setting/updatefromgrid'
+        ,save_action: 'Context/Setting/UpdateFromGrid'
         ,tbar: [{
             text: _('create_new')
             ,scope: this
@@ -29,7 +29,7 @@ MODx.grid.ContextSettings = function(config) {
                 xtype: 'modx-window-setting-create'
                 ,url: MODx.config.connector_url
                 ,baseParams: {
-                    action: 'context/setting/create'
+                    action: 'Context/Setting/Create'
                 }
                 ,keyField: {
                     xtype: 'modx-combo-setting-key'
@@ -60,14 +60,14 @@ MODx.grid.ContextSettings = function(config) {
 };
 Ext.extend(MODx.grid.ContextSettings,MODx.grid.SettingsGrid, {
     removeSetting: function() {
-        return this.remove('setting_remove_confirm', 'context/setting/remove');
+        return this.remove('setting_remove_confirm', 'Context/Setting/Remove');
     }
     ,updateSetting: function(btn,e) {
         var r = this.menu.record;
         r.fk = Ext.isDefined(this.config.fk) ? this.config.fk : 0;
         var uss = MODx.load({
             xtype: 'modx-window-setting-update'
-            ,action: 'context/setting/update'
+            ,action: 'Context/Setting/Update'
             ,record: r
             ,grid: this
             ,listeners: {
@@ -98,7 +98,7 @@ MODx.window.UpdateContextSetting = function(config) {
     var r = config.record;
     Ext.applyIf(config,{
         title: _('setting_update')
-        ,action: 'context/setting/update'
+        ,action: 'Context/Setting/Update'
         ,fk: r.context_key
     });
     MODx.window.UpdateContextSetting.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -11,7 +11,7 @@ MODx.grid.DashboardWidgets = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/dashboard/widget/getlist'
+            action: 'System/Dashboard/Widget/GetList'
         }
         ,fields: ['id','name','name_trans','description','description_trans','type','content','namespace','lexicon','size','cls']
         ,paging: true
@@ -128,7 +128,7 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
             ,text: _('widget_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'system/dashboard/widget/removeMultiple'
+                action: 'System/Dashboard/Widget/RemoveMultiple'
                 ,widgets: cs
             }
             ,listeners: {
@@ -147,7 +147,7 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
             ,text: _('widget_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'system/dashboard/widget/remove'
+                action: 'System/Dashboard/Widget/Remove'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -168,7 +168,7 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'system/dashboard/widget/getlist'
+            action: 'System/Dashboard/Widget/GetList'
     	};
         Ext.getCmp('modx-dashboard-widget-search').reset();
     	this.getBottomToolbar().changePage(1);

--- a/manager/assets/modext/widgets/system/modx.grid.manager.log.js
+++ b/manager/assets/modext/widgets/system/modx.grid.manager.log.js
@@ -13,7 +13,7 @@ MODx.grid.ManagerLog = function(config) {
         ,id: 'modx-grid-manager-log'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/log/getlist'
+            action: 'System/Log/GetList'
         }
         ,fields: ['id','user','username','occurred','action','classKey','item','name','menu']
         ,autosave: false
@@ -187,7 +187,7 @@ Ext.extend(MODx.panel.ManagerLog,MODx.FormPanel,{
     filter: function(tf,newValue,oldValue) {
         var p = this.getForm().getValues();
         var g = Ext.getCmp('modx-grid-manager-log');
-        p.action = 'system/log/getList';
+        p.action = 'System/Log/GetList';
         g.getStore().baseParams = p;
         g.getStore().load({
             params: p
@@ -209,7 +209,7 @@ Ext.extend(MODx.panel.ManagerLog,MODx.FormPanel,{
             ,text: _('mgrlog_clear_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'system/log/truncate'
+                action: 'System/Log/Truncate'
             }
             ,listeners: {
                 'success': {fn:function() {

--- a/manager/assets/modext/widgets/system/modx.grid.system.event.js
+++ b/manager/assets/modext/widgets/system/modx.grid.system.event.js
@@ -12,7 +12,7 @@ MODx.grid.SystemEvent = function(config) {
         title: _('system_events')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/event/getlist'
+            action: 'System/Event/GetList'
         }
         ,fields: ['id','name','service','groupname','plugins']
         ,autosave: true
@@ -115,7 +115,7 @@ Ext.extend(MODx.grid.SystemEvent,MODx.grid.Grid,{
 			,text: _('system_events.remove_confirm', { name: this.menu.record.name })
 			,url: this.config.url
 			,params: {
-				action: 'system/event/remove'
+				action: 'System/Event/Remove'
 				,name: this.menu.record.name
 			}
 			,listeners: {
@@ -149,7 +149,7 @@ MODx.window.CreateUpdateEvent = function(config) {
         ,width: 450
 		,autoHeight: true
         ,url: config.url
-        ,action: 'system/event/create'
+        ,action: 'System/Event/Create'
         ,fields: [{
 			xtype: 'hidden'
 			,name: 'service'
@@ -204,7 +204,7 @@ MODx.combo.SystemEventGroups = function(config) {
 		,pageSize: 10
 		,url: MODx.config.connector_url
 		,baseParams: {
-            action: 'system/event/groupList'
+            action: 'System/Event/GroupList'
 			,combo: true
         }
     });

--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -9,7 +9,7 @@ MODx.panel.Context = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'context/get'
+            action: 'Context/Get'
         }
         ,id: 'modx-panel-context'
 		,cls: 'container'
@@ -116,7 +116,7 @@ Ext.extend(MODx.panel.Context,MODx.FormPanel,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'context/get'
+                action: 'Context/Get'
                 ,key: this.config.context
             }
             ,listeners: {

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -4,7 +4,7 @@ MODx.panel.Dashboard = function(config) {
         id: 'modx-panel-dashboard'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/dashboard/update'
+            action: 'System/Dashboard/Update'
         }
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
@@ -478,7 +478,7 @@ MODx.combo.DashboardWidgets = function(config) {
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/dashboard/widget/getlist'
+            action: 'System/Dashboard/Widget/GetList'
             ,combo: true
         }
         ,tpl: new Ext.XTemplate('<tpl for=".">'

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -239,7 +239,7 @@ MODx.panel.DashboardWidget = function(config) {
         id: 'modx-panel-dashboard-widget'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/dashboard/widget/update'
+            action: 'System/Dashboard/Widget/Update'
         }
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
@@ -329,7 +329,7 @@ MODx.grid.DashboardWidgetDashboards = function(config) {
     Ext.applyIf(config,{
         id: 'modx-grid-dashboard-widget-dashboards'
         ,url: MODx.config.connector_url
-        ,action: 'system/dashboard/getList'
+        ,action: 'System/Dashboard/GetList'
         ,fields: ['id','name','description']
         ,autoHeight: true
         ,primaryKey: 'widget'

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -51,12 +51,12 @@ MODx.grid.Dashboards = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/dashboard/getlist'
+            action: 'System/Dashboard/GetList'
         }
         ,fields: ['id','name','description','cls']
         ,paging: true
         ,autosave: true
-        ,save_action: 'system/dashboard/updatefromgrid'
+        ,save_action: 'System/Dashboard/UpdateFromGrid'
         ,remoteSort: true
         ,sm: this.sm
         ,columns: [this.sm,{
@@ -96,7 +96,7 @@ MODx.grid.Dashboards = function(config) {
             ,itemId: 'usergroup'
             ,emptyText: _('user_group_filter')+'...'
             ,baseParams: {
-                action: 'security/group/getlist'
+                action: 'Security/Group/GetList'
                 ,addAll: true
             }
             ,value: ''
@@ -189,7 +189,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
             ,text: _('dashboard_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'system/dashboard/removeMultiple'
+                action: 'System/Dashboard/RemoveMultiple'
                 ,dashboards: cs
             }
             ,listeners: {
@@ -208,7 +208,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
             ,text: _('dashboard_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'system/dashboard/remove'
+                action: 'System/Dashboard/Remove'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -221,7 +221,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'system/dashboard/duplicate'
+                action: 'System/Dashboard/Duplicate'
                 ,id: this.menu.record.id
             }
             ,listeners: {
@@ -249,7 +249,7 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'system/dashboard/getList'
+            action: 'System/Dashboard/GetList'
     	};
         Ext.getCmp('modx-dashboard-search').reset();
         Ext.getCmp('modx-user-filter-usergroup').reset();

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -5,7 +5,7 @@ MODx.panel.ErrorLog = function(config) {
         ,id: 'modx-panel-error-log'
         ,cls: 'container'
         ,baseParams: {
-            action: 'system/errorlog/clear'
+            action: 'System/ErrorLog/Clear'
         }
         // ,layout: 'form' // unnecessary and creates a wrong box shadow
         ,items: [{
@@ -67,7 +67,7 @@ Ext.extend(MODx.panel.ErrorLog,MODx.FormPanel,{
         return true;
     }
     ,download: function() {
-        location.href = this.config.url+'?action=system/errorlog/download&HTTP_MODAUTH='+MODx.siteId;
+        location.href = this.config.url+'?action=System/ErrorLog/Download&HTTP_MODAUTH='+MODx.siteId;
     }
     /**
      * Set the textarea height to make use of the maximum "space" the client viewport allows

--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -27,7 +27,7 @@ Ext.extend(MODx.panel.FileTree, Ext.Container, {
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'source/getList'
+                action: 'Source/GetList'
                 ,limit: 0
             }
             ,listeners: {

--- a/manager/assets/modext/widgets/system/modx.panel.import.html.js
+++ b/manager/assets/modext/widgets/system/modx.panel.import.html.js
@@ -3,7 +3,7 @@ MODx.panel.ImportHTML = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/import/html'
+            action: 'System/Import/Html'
         }
         ,id: 'modx-panel-import-html'
 		,cls: 'container'
@@ -54,7 +54,7 @@ MODx.panel.ImportHTML = function(config) {
 					xtype: 'modx-tree-resource-simple'
 					,title: _('import_use_doc_tree')
 					,url: MODx.config.connector_url
-                    ,action: 'resource/getnodes'
+                    ,action: 'Resource/GetNodes'
 					,id: 'modx-ih-resource-tree'
 					,enableDrop: false
 					,rootVisible: false

--- a/manager/assets/modext/widgets/system/modx.panel.import.resources.js
+++ b/manager/assets/modext/widgets/system/modx.panel.import.resources.js
@@ -3,7 +3,7 @@ MODx.panel.ImportResources = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/import/index'
+            action: 'System/Import/Index'
         }
         ,id: 'modx-panel-import-resources'
 		,cls: 'container'
@@ -78,7 +78,7 @@ MODx.panel.ImportResources = function(config) {
 					xtype: 'modx-tree-resource-simple'
 					,title: _('import_use_doc_tree')
 					,url: MODx.config.connector_url
-                    ,action: 'resource/getnodes'
+                    ,action: 'Resource/GetNodes'
 					,id: 'modx-ih-resource-tree'
 					,enableDrop: false
 					,rootVisible: false

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -26,7 +26,7 @@ MODx.tree.Directory = function(config) {
             ,currentFile: MODx.request.file || ''
             ,source: config.source || 0
         }
-        ,action: 'browser/directory/getList'
+        ,action: 'Browser/Directory/GetList'
         ,primaryKey: 'dir'
         ,useDefaultToolbar: true
         ,autoExpandRoot: false
@@ -102,7 +102,7 @@ MODx.tree.Directory = function(config) {
     this.uploader = new MODx.util.MultiUploadDialog.Upload({
         url: MODx.config.connector_url,
         base_params: {
-            action: 'browser/file/upload',
+            action: 'Browser/File/Upload',
             wctx: MODx.ctx || '',
             source: this.getSource(),
         },
@@ -156,7 +156,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,{
                     text: _('update')
                     ,handler: function() {
-                        MODx.loadPage('source/update', 'id=' + node.ownerTree.source);
+                        MODx.loadPage('Source/Update', 'id=' + node.ownerTree.source);
                     }
                 }
             ])
@@ -322,7 +322,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             ui.addClass('haschildren');
             ui.removeClass('icon-resource');
         }
-        if((MODx.request.a == MODx.action['resource/update']) && dropNode.attributes.pk == MODx.request.id){
+        if((MODx.request.a == MODx.action['Resource/Update']) && dropNode.attributes.pk == MODx.request.id){
             var parentFieldCmb = Ext.getCmp('modx-resource-parent');
             var parentFieldHidden = Ext.getCmp('modx-resource-parent-hidden');
             if(parentFieldCmb && parentFieldHidden){
@@ -349,7 +349,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,from: from
                 ,destSource: destSource
                 ,to: to
-                ,action: this.config.sortAction || 'browser/directory/sort'
+                ,action: this.config.sortAction || 'Browser/Directory/Sort'
                 ,point: dropEvent.point
             }
             ,listeners: {
@@ -417,7 +417,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'browser/file/get'
+                action: 'Browser/File/Get'
                 ,file:  node.attributes.id
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
@@ -517,7 +517,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'browser/file/rename'
+                action: 'Browser/File/Rename'
                 ,new_name: nv
                 ,old_name: ov
                 ,file: this.treeEditor.editNode.id
@@ -630,7 +630,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             text: _('file_folder_remove_confirm')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'browser/directory/remove'
+                action: 'Browser/Directory/Remove'
                 ,dir: node.attributes.path
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
@@ -650,7 +650,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             text: _('file_confirm_remove')
             ,url: MODx.config.connector_url
             ,params: {
-                action: 'browser/file/remove'
+                action: 'Browser/File/Remove'
                 ,file: node.attributes.pathRelative
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
@@ -679,7 +679,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             text: _('file_download_unzip') + ' ' + node.attributes.id
             ,url: MODx.config.connectors_url
             ,params: {
-                action: 'browser/file/unpack'
+                action: 'Browser/File/Unpack'
                 ,file: node.attributes.id
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
@@ -696,7 +696,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'browser/file/download'
+                action: 'Browser/File/Download'
                 ,file: node.attributes.pathRelative
                 ,wctx: MODx.ctx || ''
                 ,source: this.getSource()
@@ -704,7 +704,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             ,listeners: {
                 'success':{fn:function(r) {
                     if (!Ext.isEmpty(r.object.url)) {
-                        location.href = MODx.config.connector_url+'?action=browser/file/download&download=1&file='+r.object.url+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.getSource()+'&wctx='+MODx.ctx;
+                        location.href = MODx.config.connector_url+'?action=Browser/File/Download&download=1&file='+r.object.url+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.getSource()+'&wctx='+MODx.ctx;
                     }
                 },scope:this}
             }
@@ -768,7 +768,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         }
 
         this.uploader.setBaseParams({
-            action: 'browser/file/upload'
+            action: 'Browser/File/Upload'
             ,path: path
             ,wctx: MODx.ctx || ''
             ,source: this.getSource()
@@ -794,7 +794,7 @@ MODx.window.CreateDirectory = function(config) {
         // width: 430
         // ,height: 200
         ,url: MODx.config.connector_url
-        ,action: 'browser/directory/create'
+        ,action: 'Browser/Directory/Create'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'wctx'
@@ -834,7 +834,7 @@ MODx.window.SetVisibility = function(config) {
     Ext.applyIf(config,{
         title: _('file_folder_visibility')
         ,url: MODx.config.connector_url
-        ,action: 'browser/visibility'
+        ,action: 'Browser/Visibility'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'wctx'
@@ -882,7 +882,7 @@ MODx.window.RenameDirectory = function(config) {
         // ,width: 430
         // ,height: 200
         ,url: MODx.config.connector_url
-        ,action: 'browser/directory/rename'
+        ,action: 'Browser/Directory/Rename'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'wctx'
@@ -929,7 +929,7 @@ MODx.window.RenameFile = function(config) {
         // ,width: 430
         // ,height: 200
         ,url: MODx.config.connector_url
-        ,action: 'browser/file/rename'
+        ,action: 'Browser/File/Rename'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'wctx'
@@ -981,7 +981,7 @@ MODx.window.QuickUpdateFile = function(config) {
         // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
-        ,action: 'browser/file/update'
+        ,action: 'Browser/File/Update'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'wctx'
@@ -1052,7 +1052,7 @@ MODx.window.QuickCreateFile = function(config) {
         // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
-        ,action: 'browser/file/create'
+        ,action: 'Browser/File/Create'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'wctx'

--- a/manager/assets/modext/widgets/system/modx.tree.menu.js
+++ b/manager/assets/modext/widgets/system/modx.tree.menu.js
@@ -17,8 +17,8 @@ MODx.tree.Menu = function(config) {
         ,enableDrag: true
         ,enableDrop: true
         ,url: MODx.config.connector_url
-        ,action: 'system/menu/getNodes'
-        ,sortAction: 'system/menu/sort'
+        ,action: 'System/Menu/GetNodes'
+        ,sortAction: 'System/Menu/Sort'
         ,primaryKey: 'text'
         ,useDefaultToolbar: true
         ,ddGroup: 'modx-menu'
@@ -78,7 +78,7 @@ Ext.extend(MODx.tree.Menu, MODx.tree.Tree, {
             ,text: _('menu_confirm_remove')
             ,url: this.config.url
             ,params: {
-                action: 'system/menu/remove'
+                action: 'System/Menu/Remove'
                 ,text: this.cm.activeNode.attributes.pk
             }
             ,listeners: {
@@ -136,7 +136,7 @@ MODx.window.CreateMenu = function(config) {
         ,width: 600
         // ,height: 400
         ,url: MODx.config.connector_url
-        ,action: 'system/menu/create'
+        ,action: 'System/Menu/Create'
         ,fields: [{
             xtype: 'modx-combo-menu'
             ,name: 'parent'
@@ -287,7 +287,7 @@ MODx.window.UpdateMenu = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('menu_update')
-        ,action: 'system/menu/update'
+        ,action: 'System/Menu/Update'
     });
     MODx.window.UpdateMenu.superclass.constructor.call(this,config);
 };
@@ -309,7 +309,7 @@ MODx.combo.Menu = function(config) {
         ,hiddenName: 'menu'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'system/menu/getlist'
+            action: 'System/Menu/GetList'
             ,combo: true
             ,limit: 0
             ,showNone: true

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -20,7 +20,7 @@ Ext.extend(MODx.window.DuplicateResource,MODx.Window,{
     _loadForm: function() {
         if (this.checkIfLoaded(this.config.record)) {
             this.fp.getForm().baseParams = {
-                action: 'resource/updateduplicate'
+                action: 'Resource/Updateduplicate'
                 ,prefixDuplicate: true
                 ,id: this.config.resource
             };
@@ -87,7 +87,7 @@ Ext.extend(MODx.window.DuplicateResource,MODx.Window,{
         this.fp = this.createForm({
             url: this.config.url || MODx.config.connector_url
             ,baseParams: this.config.baseParams || {
-                action: 'resource/duplicate'
+                action: 'Resource/Duplicate'
                 ,id: this.config.resource
                 ,prefixDuplicate: true
             }
@@ -208,7 +208,7 @@ Ext.extend(MODx.window.DuplicateElement,MODx.Window, {
                     MODx.Ajax.request({
                         url: MODx.config.connector_url
                         ,params: {
-                            action: 'element/category/getlist'
+                            action: 'Element/Category/GetList'
                             ,id: category
                         }
                         ,listeners: {
@@ -241,7 +241,7 @@ MODx.window.CreateCategory = function(config) {
         // ,height: 150
         // ,width: 350
         ,url: MODx.config.connector_url
-        ,action: 'element/category/create'
+        ,action: 'Element/Category/Create'
         ,fields: [{
             fieldLabel: _('name')
             ,name: 'category'
@@ -284,7 +284,7 @@ MODx.window.RenameCategory = function(config) {
         // ,height: 150
         // ,width: 350
         ,url: MODx.config.connector_url
-        ,action: 'element/category/update'
+        ,action: 'Element/Category/Update'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -321,7 +321,7 @@ MODx.window.CreateNamespace = function(config) {
         ,id: this.ident
         ,width: 600
         ,url: MODx.config.connector_url
-        ,action: 'workspace/packageNamespace/create'
+        ,action: 'Workspace/PackageNamespace/Create'
         ,fields: [{
             xtype: 'textfield'
             ,fieldLabel: _('name')
@@ -374,7 +374,7 @@ MODx.window.UpdateNamespace = function(config) {
 
     Ext.applyIf(config, {
         title: _('namespace_update')
-        ,action: 'workspace/packageNamespace/update'
+        ,action: 'Workspace/PackageNamespace/Update'
         ,isUpdate: true
     });
     MODx.window.UpdateNamespace.superclass.constructor.call(this, config);
@@ -393,7 +393,7 @@ MODx.window.QuickCreateChunk = function(config) {
         // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
-        ,action: 'element/chunk/create'
+        ,action: 'Element/Chunk/Create'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -446,7 +446,7 @@ MODx.window.QuickUpdateChunk = function(config) {
 
     Ext.applyIf(config,{
         title: _('quick_update_chunk')
-        ,action: 'element/chunk/update'
+        ,action: 'Element/Chunk/Update'
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')
             ,scope: this
@@ -476,7 +476,7 @@ MODx.window.QuickCreateTemplate = function(config) {
         // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
-        ,action: 'element/template/create'
+        ,action: 'Element/Template/Create'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -528,7 +528,7 @@ MODx.window.QuickUpdateTemplate = function(config) {
 
     Ext.applyIf(config,{
         title: _('quick_update_template')
-        ,action: 'element/template/update'
+        ,action: 'Element/Template/Update'
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')
             ,scope: this
@@ -559,7 +559,7 @@ MODx.window.QuickCreateSnippet = function(config) {
         // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
-        ,action: 'element/snippet/create'
+        ,action: 'Element/Snippet/Create'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -611,7 +611,7 @@ MODx.window.QuickUpdateSnippet = function(config) {
 
     Ext.applyIf(config,{
         title: _('quick_update_snippet')
-        ,action: 'element/snippet/update'
+        ,action: 'Element/Snippet/Update'
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')
             ,scope: this
@@ -643,7 +643,7 @@ MODx.window.QuickCreatePlugin = function(config) {
         // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
-        ,action: 'element/plugin/create'
+        ,action: 'Element/Plugin/Create'
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -703,7 +703,7 @@ MODx.window.QuickUpdatePlugin = function(config) {
 
     Ext.applyIf(config,{
         title: _('quick_update_plugin')
-        ,action: 'element/plugin/update'
+        ,action: 'Element/Plugin/Update'
         ,buttons: [{
             text: config.cancelBtnText || _('cancel')
             ,scope: this
@@ -861,7 +861,7 @@ MODx.window.DuplicateContext = function(config) {
         title: _('context_duplicate')
         ,id: this.ident
         ,url: MODx.config.connector_url
-        ,action: 'context/duplicate'
+        ,action: 'Context/Duplicate'
         // ,width: 400
         ,fields: [{
             xtype: 'statictextfield'
@@ -928,7 +928,7 @@ MODx.window.Login = function(config) {
         title: _('login')
         ,id: this.ident
         ,url: MODx.config.connectors_url
-        ,action: 'security/login'
+        ,action: 'Security/Login'
         // ,width: 400
         ,fields: [{
             html: '<p>'+_('session_logging_out')+'</p>'

--- a/manager/assets/modext/workspace/combos.js
+++ b/manager/assets/modext/workspace/combos.js
@@ -13,7 +13,7 @@ MODx.combo.Provider = function(config) {
         ,hiddenName: 'provider'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'workspace/providers/getList'
+            action: 'Workspace/Providers/GetList'
             ,combo: true
         }
         ,editable: false

--- a/manager/assets/modext/workspace/lexicon/combos.js
+++ b/manager/assets/modext/workspace/lexicon/combos.js
@@ -22,7 +22,7 @@ MODx.combo.LexiconTopic = function(config) {
         ,displayField: 'name'
         ,valueField: 'name'
         ,baseParams: {
-            action: 'workspace/lexicon/topic/getList'
+            action: 'Workspace/Lexicon/Topic/GetList'
             ,'namespace': 'core'
             ,'language': 'en'
         }

--- a/manager/assets/modext/workspace/lexicon/language.grid.js
+++ b/manager/assets/modext/workspace/lexicon/language.grid.js
@@ -13,7 +13,7 @@ MODx.grid.Language = function(config) {
         ,id: 'modx-grid-language'
         ,url: MODx.config.connector_url+'system/language.php'
         ,baseParams: {
-            action: 'system/language/getlist'
+            action: 'System/Language/GetList'
         }
         ,fields: ['id','name','menu']
         ,width: '97%'

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -13,7 +13,7 @@ MODx.grid.Lexicon = function(config) {
         ,url: MODx.config.connector_url
         ,fields: ['name','value','namespace','topic','language','editedon','overridden']
         ,baseParams: {
-            action: 'workspace/lexicon/getList'
+            action: 'Workspace/Lexicon/GetList'
             ,'namespace': MODx.request['ns'] ? MODx.request['ns'] : 'core'
             ,topic: ''
             ,language: MODx.config.cultureKey || 'en'
@@ -21,7 +21,7 @@ MODx.grid.Lexicon = function(config) {
         ,width: '98%'
         ,paging: true
         ,autosave: true
-        ,save_action: 'workspace/lexicon/updatefromgrid'
+        ,save_action: 'Workspace/Lexicon/UpdateFromGrid'
         ,columns: [{
             header: _('name')
             ,dataIndex: 'name'
@@ -63,7 +63,7 @@ MODx.grid.Lexicon = function(config) {
             ,value: 'default'
             ,width: 120
             ,baseParams: {
-                action: 'workspace/lexicon/topic/getList'
+                action: 'Workspace/Lexicon/Topic/GetList'
                 ,'namespace': MODx.request['ns'] ? MODx.request['ns'] : ''
                 ,'language': 'en'
             }
@@ -81,7 +81,7 @@ MODx.grid.Lexicon = function(config) {
             ,value: MODx.config.cultureKey || 'en'
             ,width: 100
             ,baseParams: {
-                action: 'system/language/getlist'
+                action: 'System/Language/GetList'
                 ,'namespace': MODx.request['ns'] ? MODx.request['ns'] : ''
             }
             ,listeners: {
@@ -217,7 +217,7 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.store.baseParams = {
-            action: 'workspace/lexicon/getList'
+            action: 'Workspace/Lexicon/GetList'
             ,'namespace': 'core'
             ,topic: 'default'
             ,language: 'en'
@@ -318,7 +318,7 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
 
     	MODx.Ajax.request({
     	   url: this.config.url
-    	   ,params: {action: 'workspace/lexicon/reloadFromBase' ,register: 'mgr' ,topic: topic}
+    	   ,params: {action: 'Workspace/Lexicon/ReloadFromBase' ,register: 'mgr' ,topic: topic}
     	   ,listeners: {
                 'success': {fn:function(r) {
                     this.refresh();
@@ -329,7 +329,7 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
 
     ,revertEntry: function() {
         var p = this.menu.record;
-        p.action = 'workspace/lexicon/revert';
+        p.action = 'Workspace/Lexicon/Revert';
 
     	MODx.Ajax.request({
     	   url: this.config.url
@@ -451,7 +451,7 @@ MODx.window.LexiconEntryCreate = function(config) {
     Ext.applyIf(config,{
         title: _('entry_create')
         ,url: MODx.config.connector_url
-        ,action: 'workspace/lexicon/create'
+        ,action: 'Workspace/Lexicon/Create'
         ,fileUpload: true
         ,fields: [{
             xtype: 'textfield'

--- a/manager/assets/modext/workspace/lexicon/lexicon.topic.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.topic.grid.js
@@ -14,7 +14,7 @@ MODx.grid.LexiconTopic = function(config) {
         ,url: MODx.config.connector_url
         ,fields: ['id','name','namespace','menu']
         ,baseParams: {
-            action: 'workspace/lexicon/topic/getList'
+            action: 'Workspace/Lexicon/Topic/GetList'
             ,'namespace': 'core'
         }
         ,saveParams: {

--- a/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
+++ b/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
@@ -48,13 +48,13 @@ MODx.grid.Namespace = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,baseParams: {
-            action: 'workspace/packageNamespace/getlist'
+            action: 'Workspace/PackageNamespace/GetList'
         }
         ,fields: ['id','name','path','assets_path','perm']
         ,anchor: '100%'
         ,paging: true
         ,autosave: true
-        ,save_action: 'workspace/packageNamespace/updatefromgrid'
+        ,save_action: 'Workspace/PackageNamespace/UpdateFromGrid'
         ,primaryKey: 'name'
         ,remoteSort: true
         ,sm: this.sm
@@ -132,7 +132,7 @@ Ext.extend(MODx.grid.Namespace,MODx.grid.Grid,{
             if (p.indexOf('premove') != -1 && this.menu.record.name != 'core') {
                 m.push({
                     text: _('namespace_remove')
-                    ,handler: this.remove.createDelegate(this,['namespace_remove_confirm','workspace/packageNamespace/remove'])
+                    ,handler: this.remove.createDelegate(this,['namespace_remove_confirm','Workspace/PackageNamespace/Remove'])
                 });
             }
         }
@@ -163,7 +163,7 @@ Ext.extend(MODx.grid.Namespace,MODx.grid.Grid,{
     }
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'workspace/packageNamespace/getList'
+            action: 'Workspace/PackageNamespace/GetList'
     	};
         Ext.getCmp('modx-namespace-search').reset();
     	this.getBottomToolbar().changePage(1);
@@ -178,7 +178,7 @@ Ext.extend(MODx.grid.Namespace,MODx.grid.Grid,{
             ,text: _('namespace_remove_multiple_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'workspace/packageNamespace/removeMultiple'
+                action: 'Workspace/PackageNamespace/RemoveMultiple'
                 ,namespaces: cs
             }
             ,listeners: {

--- a/manager/assets/modext/workspace/package.browser.panels.js
+++ b/manager/assets/modext/workspace/package.browser.panels.js
@@ -160,7 +160,7 @@ MODx.grid.PackageBrowserGrid = function(config) {
         ,url: MODx.config.connector_url
         ,baseParams: {
 			provider: MODx.provider
-			,action: 'workspace/packages/rest/getList'
+			,action: 'Workspace/Packages/Rest/GetList'
 		}
         ,paging: true
         ,pageSize: 10
@@ -276,7 +276,7 @@ Ext.extend(MODx.grid.PackageBrowserGrid,MODx.grid.Grid,{
 		Ext.Ajax.request({
 			url : this.config.url
 			,params : {
-				action : 'workspace/packages/rest/download'
+				action : 'Workspace/Packages/Rest/Download'
 				,info : rec.location+'::'+rec.signature
 				,provider : MODx.provider
 			}
@@ -531,7 +531,7 @@ MODx.PackageBrowserThumbsView = function(config) {
                  ,'downloads','releasedon','screenshot','license','supports','location','version-compiled', 'featured'
                  ,'downloaded','dlaction-text','dlaction-icon']
         ,baseParams: {
-            action: 'workspace/packages/rest/getList'
+            action: 'Workspace/Packages/Rest/GetList'
             ,provider: MODx.provider
         }
         ,tpl: this.templates.thumb
@@ -631,7 +631,7 @@ Ext.extend(MODx.PackageBrowserThumbsView,MODx.DataView,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'workspace/packages/rest/download'
+                action: 'Workspace/Packages/Rest/Download'
                 ,info: data.location+'::'+data.signature
                 ,provider: MODx.provider || MODx.config.default_provider
             }
@@ -813,7 +813,7 @@ Ext.extend(MODx.panel.PackageBrowserView,MODx.Panel,{
 		MODx.Ajax.request({
             url: this.url
             ,params: {
-                action: 'workspace/packages/rest/download'
+                action: 'Workspace/Packages/Rest/Download'
                 ,info: record.location+'::'+record.signature
                 ,provider: MODx.provider || MODx.config.default_provider
             }

--- a/manager/assets/modext/workspace/package.browser.tree.js
+++ b/manager/assets/modext/workspace/package.browser.tree.js
@@ -10,7 +10,7 @@ MODx.tree.PackageBrowserTree = function(config) {
     config = config || {};
     Ext.applyIf(config,{
 		url: MODx.config.connector_url
-        ,action: 'workspace/packages/rest/getNodes'
+        ,action: 'Workspace/Packages/Rest/GetNodes'
 		,baseParams: {
 			provider: MODx.provider
 		}
@@ -74,7 +74,7 @@ Ext.extend(MODx.tree.PackageBrowserTree,MODx.tree.Tree,{
 		MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'workspace/packages/rest/getInfo'
+                action: 'Workspace/Packages/Rest/GetInfo'
                 ,provider: pv
             }
             ,listeners: {

--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -107,7 +107,7 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
 
         // Grab the params to send to the install processor
         var params = {
-            action: 'workspace/packages/install'
+            action: 'Workspace/Packages/Install'
             ,signature: r.signature
             ,register: 'mgr'
             ,topic: topic

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -83,7 +83,7 @@ MODx.grid.Package = function(config) {
         title: _('packages')
         ,id: 'modx-package-grid'
         ,url: MODx.config.connector_url
-        ,action: 'workspace/packages/getlist'
+        ,action: 'Workspace/Packages/GetList'
         ,fields: ['signature','name','version','release','created','updated','installed','state','workspace'
                  ,'provider','provider_name','disabled','source','attributes','readme','menu'
                  ,'install','textaction','iconaction','updateable']
@@ -134,7 +134,7 @@ MODx.grid.Package = function(config) {
         this.uploader = new MODx.util.MultiUploadDialog.Upload({
             url: MODx.config.connector_url,
             base_params: {
-                action: 'workspace/packages/upload',
+                action: 'Workspace/Packages/Upload',
                 wctx: MODx.ctx || '',
                 source: MODx.config.default_media_source,
                 path: MODx.config.core_path + 'packages/',
@@ -185,7 +185,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 
     ,clearFilter: function() {
     	this.getStore().baseParams = {
-            action: 'workspace/packages/getList'
+            action: 'Workspace/Packages/GetList'
     	};
         Ext.getCmp('modx-package-search').reset();
     	this.getBottomToolbar().changePage(1);
@@ -267,7 +267,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 		Ext.Ajax.request({
 			url : MODx.config.connector_url
 			,params : {
-				action : 'workspace/packages/getAttribute'
+				action : 'Workspace/Packages/GetAttribute'
 				,attributes: 'license,readme,changelog,setup-options,requires'
 				,signature: record.data.signature
 			}
@@ -329,7 +329,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
            ,text: _('package_search_local_confirm')
            ,url: MODx.config.connector_url
            ,params: {
-                action: 'workspace/packages/scanLocal'
+                action: 'Workspace/Packages/ScanLocal'
            }
            ,listeners: {
                 'success':{fn:function(r) {
@@ -346,7 +346,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'workspace/packages/scanLocal'
+                action: 'Workspace/Packages/ScanLocal'
             }
             ,listeners: {
                 'success':{fn:function(r) {
@@ -369,7 +369,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'workspace/packages/checkforupdates'
+                action: 'Workspace/Packages/CheckForUpdates'
                 ,signature: this.menu.record.signature
             }
             ,listeners: {
@@ -417,7 +417,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
         var topic = '/workspace/package/uninstall/'+r.signature+'/';
         this.loadConsole(btn,topic);
         Ext.apply(va,{
-            action: 'workspace/packages/uninstall'
+            action: 'Workspace/Packages/Uninstall'
             ,signature: r.signature
             ,register: 'mgr'
             ,topic: topic
@@ -460,7 +460,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
 
     /* Purge old packages */
     ,purgePackages: function(btn,e) {
-        var topic = '/workspace/packages/purge/';
+        var topic = '/Workspace/Packages/Purge/';
 
         this.loadWindow(btn,e,{
             xtype: 'modx-window-packages-purge'
@@ -498,7 +498,7 @@ MODx.window.PackageUpdate = function(config) {
     Ext.applyIf(config,{
         title: _('package_update')
         ,url: MODx.config.connector_url
-        ,action: 'workspace/packages/rest/download'
+        ,action: 'Workspace/Packages/Rest/Download'
         // ,height: 400
         // ,width: 400
         ,id: 'modx-window-package-update'

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -315,7 +315,7 @@ MODx.grid.PackageDependencies = function(config) {
     Ext.applyIf(config,{
         id: 'modx-grid-package-dependencies'
         ,baseParams: {
-            action: 'workspace/packages/getdependencies'
+            action: 'Workspace/Packages/GetDependencies'
             ,signature: config.pkgInfo.data.signature
         }
         ,fields: ['name', 'constraints', 'installed', 'parentSignature', 'signature', 'downloaded', 'actions']
@@ -391,7 +391,7 @@ Ext.extend(MODx.grid.PackageDependencies,MODx.grid.Package, {
         Ext.Ajax.request({
             url: MODx.config.connector_url
             ,params: {
-                action: 'workspace/packages/dependency/download'
+                action: 'Workspace/Packages/Dependency/Download'
                 ,signature: rec.data.parentSignature
                 ,name: rec.data.name
                 ,constraints: rec.data.constraints

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -9,7 +9,7 @@ MODx.window.PackageUninstall = function(config) {
     Ext.applyIf(config,{
         title: _('package_uninstall')
         ,url: MODx.config.connector_url
-        ,action: 'workspace/packages/uninstall'
+        ,action: 'Workspace/Packages/Uninstall'
         // ,height: 400
         // ,width: 400
         ,id: 'modx-window-package-uninstall'
@@ -64,7 +64,7 @@ MODx.window.RemovePackage = function(config) {
         title: _('package_remove')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'workspace/packages/uninstall'
+            action: 'Workspace/Packages/Uninstall'
         }
         ,cls: 'modx-confirm'
         ,defaults: { border: false }
@@ -97,7 +97,7 @@ Ext.extend(MODx.window.RemovePackage,MODx.Window,{
         if (this.fp.getForm().isValid()) {
             Ext.getCmp('modx-package-grid').loadConsole(Ext.getBody(),r.topic);
             this.fp.getForm().baseParams = {
-                action: 'workspace/packages/remove'
+                action: 'Workspace/Packages/Remove'
                 ,signature: r.signature
                 ,register: 'mgr'
                 ,topic: r.topic
@@ -141,7 +141,7 @@ MODx.window.PurgePackages = function(config) {
         title: _('packages_purge')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'workspace/packages/purge'
+            action: 'Workspace/Packages/Purge'
         }
         ,cls: 'modx-confirm'
         ,defaults: { border: false }
@@ -163,7 +163,7 @@ Ext.extend(MODx.window.PurgePackages,MODx.Window,{
         if (this.fp.getForm().isValid()) {
             Ext.getCmp('modx-package-grid').loadConsole(Ext.getBody(),r.topic);
             this.fp.getForm().baseParams = {
-                action: 'workspace/packages/purge'
+                action: 'Workspace/Packages/Purge'
                 ,register: 'mgr'
                 ,topic: r.topic
             };
@@ -278,7 +278,7 @@ MODx.window.ChangeProvider = function(config) {
                 ,anchor: '100%'
 				,allowBlank: false
 				,baseParams: {
-                    action: 'workspace/providers/getList'
+                    action: 'Workspace/Providers/GetList'
                     ,showNone: false
                 }
 			}]
@@ -309,7 +309,7 @@ Ext.extend(MODx.window.ChangeProvider,Ext.Window,{ //Using MODx.Window would cre
             if (tree.rendered) {
                 var loader = tree.getLoader();
                 loader.baseParams = {
-                    action: 'workspace/packages/rest/getNodes'
+                    action: 'Workspace/Packages/Rest/GetNodes'
                     ,provider: vs.provider
                 };
                 loader.load(tree.root);

--- a/manager/assets/modext/workspace/package/index.js
+++ b/manager/assets/modext/workspace/package/index.js
@@ -8,7 +8,7 @@ MODx.page.Package = function(config) {
             ,package_name: MODx.request.package_name
         }]
         ,buttons: [{
-            process: 'workspace/packages/update'
+            process: 'Workspace/Packages/Update'
             ,text: _('save')
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'

--- a/manager/assets/modext/workspace/package/package.panel.js
+++ b/manager/assets/modext/workspace/package/package.panel.js
@@ -106,7 +106,7 @@ Ext.extend(MODx.panel.Package,MODx.FormPanel,{
         MODx.Ajax.request({
             url: this.config.url
             ,params: {
-                action: 'workspace/packages/get'
+                action: 'Workspace/Packages/Get'
                 ,signature: this.config.signature
             }
             ,listeners: {

--- a/manager/assets/modext/workspace/package/package.versions.grid.js
+++ b/manager/assets/modext/workspace/package/package.versions.grid.js
@@ -10,7 +10,7 @@ MODx.grid.PackageVersions = function(config) {
         ,id: 'modx-grid-package-versions'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'workspace/packages/version/getList'
+            action: 'Workspace/Packages/Version/GetList'
             ,signature: config.signature
             ,package_name: MODx.request.package_name
         }
@@ -60,7 +60,7 @@ Ext.extend(MODx.grid.PackageVersions,MODx.grid.Grid,{
             ,text: _('package_version_remove_confirm')
             ,url: this.config.url
             ,params: {
-                action: 'workspace/packages/version/remove'
+                action: 'Workspace/Packages/Version/Remove'
                 ,signature: r.signature
             }
             ,listeners: {
@@ -75,7 +75,7 @@ Ext.extend(MODx.grid.PackageVersions,MODx.grid.Grid,{
 
     /* Purge old package versions */
     ,purgePackageVersions: function(btn,e) {
-        var topic = '/workspace/packages/purge/';
+        var topic = '/Workspace/Packages/Purge/';
 
         this.loadWindow(btn,e,{
             xtype: 'modx-window-package-versions-purge'
@@ -120,7 +120,7 @@ MODx.window.PurgePackageVersions = function(config) {
         title: _('package_versions_purge')
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'workspace/packages/purge'
+            action: 'Workspace/Packages/Purge'
         }
         ,cls: 'modx-confirm'
         ,defaults: { border: false }
@@ -142,7 +142,7 @@ Ext.extend(MODx.window.PurgePackageVersions,MODx.Window,{
         if (this.fp.getForm().isValid()) {
             Ext.getCmp('modx-grid-package-versions').loadConsole(Ext.getBody(),r.topic);
             this.fp.getForm().baseParams = {
-                action: 'workspace/packages/purge'
+                action: 'Workspace/Packages/Purge'
                 ,register: 'mgr'
                 ,topic: r.topic
             };

--- a/manager/assets/modext/workspace/provider.grid.js
+++ b/manager/assets/modext/workspace/provider.grid.js
@@ -12,9 +12,9 @@ MODx.grid.Provider = function(config) {
     Ext.applyIf(config,{
         title: _('providers')
         ,url: MODx.config.connector_url
-        ,save_action: 'workspace/providers/updatefromgrid'
+        ,save_action: 'Workspace/Providers/UpdateFromGrid'
         ,baseParams: {
-            action: 'workspace/providers/getlist'
+            action: 'Workspace/Providers/GetList'
         }
         ,fields: ['id','name','description','service_url','username','api_key','menu']
         ,paging: true
@@ -60,7 +60,7 @@ MODx.window.CreateProvider = function(config) {
         title: _('provider_add')
         // ,width: 400
         ,url: MODx.config.connector_url
-        ,action: 'workspace/providers/create'
+        ,action: 'Workspace/Providers/Create'
         ,fields: [{
             name: 'id'
             ,xtype: 'hidden'
@@ -112,7 +112,7 @@ MODx.window.UpdateProvider = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('provider_update')
-        ,action: 'workspace/providers/update'
+        ,action: 'Workspace/Providers/Update'
     });
     MODx.window.UpdateProvider.superclass.constructor.call(this,config);
 };


### PR DESCRIPTION
### What does it do?
This PR renames all actions in ExtJS files to new processors names format.

### Why is it needed?
It will fix problems in manager on all case-sensitive file systems - 99% of GNU\Linux

### Related issue(s)/PR(s)
#14662
#14639


If someone have a questions, how I did it - here is my rename script:
```php
<?php

$base = dirname(__FILE__) . '/';
$processors = $base . 'core/src/Revolution/Processors/';
$manager = $base . 'manager/assets/modext/';

$Directory = new RecursiveDirectoryIterator($processors, FilesystemIterator::SKIP_DOTS);
$Iterator = new RecursiveIteratorIterator($Directory);
$actions = [];
/** @var SplFileInfo $info */
foreach ($Iterator as $info) {
    $actions[] = str_replace($processors, '', str_replace('.php', '', $info->getPathname()));
}

$Directory = new RecursiveDirectoryIterator($manager, FilesystemIterator::SKIP_DOTS);
$Iterator = new RecursiveIteratorIterator($Directory);
/** @var SplFileInfo $info */
foreach ($Iterator as $info) {
    $file = $info->getPathname();
    $replace = str_ireplace($actions, $actions, file_get_contents($file));
    file_put_contents($file, $replace);
}
```