### PR TITLE
Added an additional .sub class in the menu for nested li

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -121,6 +121,17 @@
   }
 }
 
+#modx-navbar .sub {
+  &:after {
+    border: 5px solid transparent;
+    border-left: 5px solid rgb(96,114,124);
+    position: absolute;
+    content: ' ';
+    right: 12px;
+    top: 24px;
+  }
+}
+
 #modx-user-menu li.top > a,
 #modx-topnav li.top > a {
   cursor: default;

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -311,6 +311,7 @@ class TopMenu
             if (!$this->hasPermission($menu['permissions'])) {
                 continue;
             }
+            $sub = (!empty($menu['children'])) ? ' class="sub"' : '';
             $smTpl = '<li id="'.$menu['id'].'">'."\n";
 
             $description = '';

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -312,7 +312,7 @@ class TopMenu
                 continue;
             }
             $sub = (!empty($menu['children'])) ? ' class="sub"' : '';
-            $smTpl = '<li id="'.$menu['id'].'">'."\n";
+            $smTpl = '<li id="'.$menu['id'].'"'.$sub.'>'."\n";
 
             $description = '';
             if ($this->showDescriptions && !empty($menu['description'])) {


### PR DESCRIPTION
### What does it do?
Added an additional .sub class in the menu for nested li which have child items. 
Added an extra icon to the .sub class.

Because there is already a branch in 3.0, I don’t see the point of why this function is not added for 2.7.2 either.

![sub_info](https://user-images.githubusercontent.com/12523676/51253930-2ca27800-19b9-11e9-9762-61a283e35416.png)

Because commits were from the old version of the branch, I recreated PR

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/11579