### PR TITLE
Add back support for deprecated actions

### DIFF
--- a/core/src/Revolution/Processors/System/ConfigJs.php
+++ b/core/src/Revolution/Processors/System/ConfigJs.php
@@ -113,6 +113,10 @@ class ConfigJs extends modProcessor
         $o .= $this->modx->toJSON($c);
         $o .= '; MODx.perm = {};';
 
+        // Load actions for backwards compatibility (DEPRECATED)
+        $actions = $this->modx->request->getAllActionIDs();
+        $o .= 'MODx.action = ' . $this->modx->toJSON($actions) . ';';
+
         if ($this->modx->user) {
             $accessPermissionsQuery = $this->modx->newQuery(modAccessPermission::class);
             $accessPermissionsQuery->select('name');


### PR DESCRIPTION
### What does it do?
Add back support for deprecated actions

### Why is it needed?
We are already changing enough in 3.x, we want to maintain some backwards compatibility.
This fixes an issue where moving resources didn't work in 3.x

### Related issue(s)/PR(s)
~Fixes issue #14638~
