### PR TITLE
Create the RSS cache directory if it doesn't exist

### DIFF
--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -56,7 +56,12 @@ class Feed extends modProcessor
     {
         $feed = new \SimplePie();
 
-        $feed->set_cache_location($this->modx->getOption('core_path') . 'cache/rss/');
+        $cachePath = $this->modx->getOption('core_path') . 'cache/rss/';
+        if (!is_dir($cachePath)) {
+            $this->modx->cacheManager->writeTree($cachePath);
+        }
+
+        $feed->set_cache_location($cachePath);
         $feed->set_useragent($this->modx->getVersionData()['full_version']);
         $feed->set_feed_url($url);
         $feed->init();

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -14,6 +14,7 @@ use MODX\Revolution\modChunk;
 use MODX\Revolution\modProcessor;
 use MODX\Revolution\modX;
 use SimplePie_Item;
+use xPDO\xPDO;
 
 /**
  * Class modDashboardWidgetFeedProcessor
@@ -56,7 +57,7 @@ class Feed extends modProcessor
     {
         $feed = new \SimplePie();
 
-        $cachePath = $this->modx->getOption('core_path') . 'cache/rss/';
+        $cachePath = $this->modx->getOption(xPDO::OPT_CACHE_PATH) . 'rss/';
         if (!is_dir($cachePath)) {
             $this->modx->cacheManager->writeTree($cachePath);
         }


### PR DESCRIPTION
### What does it do?
When loading the RSS feed, check if the RSS cache directory exists, if not: create it.

### Why is it needed?
Prevent the error log to be filled with errors

### Related issue(s)/PR(s)
Fixes issue #14669