### PR TITLE
Generate sortable tag signature with serialized array values

### DIFF
--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -268,16 +268,18 @@ class modElement extends modAccessibleSimpleObject
     public function getTag()
     {
         if (empty($this->_tag)) {
-            $propTemp = [];
             if (empty($this->_propertyString) && !empty($this->_properties)) {
+                $propTemp = array();
                 foreach ($this->_properties as $key => $value) {
+                    $key = trim($key);
                     if (is_scalar($value)) {
-                        $propTemp[] = trim($key) . '=`' . $value . '`';
+                        $propTemp[$key] = $key . '=`' . $value . '`';
                     } else {
-                        $propTemp[] = trim($key) . '=`' . md5(uniqid(rand(), true)) . '`';
+                        $propTemp[$key] = $key . '=`' . (is_array($value) ? md5(serialize($value)) : md5(uniqid(rand(), true))) . '`';
                     }
                 }
                 if (!empty($propTemp)) {
+                    ksort($propTemp);
                     $this->_propertyString = '?' . implode('&', $propTemp);
                 }
             }


### PR DESCRIPTION
### What does it do?
Improves the tag signature created by `modElement::getTag()`.

### Why is it needed?
When using non-default template engines in MODX (for example, the Fenom implementation by @bezumkin) arrays can be passed as properties. When a tag is generated for the element in these cases, the array will be replaced with the hash of a random string (as arrays are not scalar values). This means that element output can not be matched from the element cache since the random string will never match.
This also allows properties to be so sorted so that the cached output can be matched when similar element tags have a different property order.

### Related issue(s)/PR(s)
Replaces #14577 targeting 3.x instead of 2.x, and includes changes suggested in my review of that PR.
