### PR TITLE
Add missing alias_visible field definition to model schemas

### DIFF
--- a/core/model/modx/mysql/modresource.map.inc.php
+++ b/core/model/modx/mysql/modresource.map.inc.php
@@ -9,11 +9,11 @@ $xpdo_meta_map['modResource']= array (
   'table' => 'site_content',
   'extends' => 'modAccessibleSimpleObject',
   'inherit' => 'single',
-  'tableMeta' =>
+  'tableMeta' => 
   array (
     'engine' => 'InnoDB',
   ),
-  'fields' =>
+  'fields' => 
   array (
     'type' => 'document',
     'contentType' => 'text/html',
@@ -59,9 +59,9 @@ $xpdo_meta_map['modResource']= array (
     'show_in_tree' => 1,
     'properties' => NULL,
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'type' =>
+    'type' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '20',
@@ -69,7 +69,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 'document',
     ),
-    'contentType' =>
+    'contentType' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '50',
@@ -77,7 +77,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 'text/html',
     ),
-    'pagetitle' =>
+    'pagetitle' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -87,7 +87,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'longtitle' =>
+    'longtitle' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -97,7 +97,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'description' =>
+    'description' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'string',
@@ -106,7 +106,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'alias' =>
+    'alias' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -115,7 +115,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => '',
       'index' => 'index',
     ),
-    'alias_visible' =>
+    'alias_visible' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -124,7 +124,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 1,
     ),
-    'link_attributes' =>
+    'link_attributes' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -132,7 +132,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => '',
     ),
-    'published' =>
+    'published' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -142,7 +142,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'pub_date' =>
+    'pub_date' => 
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -151,7 +151,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'unpub_date' =>
+    'unpub_date' => 
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -160,7 +160,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'parent' =>
+    'parent' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -169,7 +169,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'isfolder' =>
+    'isfolder' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -179,21 +179,21 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'introtext' =>
+    'introtext' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'string',
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'content' =>
+    'content' => 
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'string',
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'richtext' =>
+    'richtext' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -202,7 +202,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 1,
     ),
-    'template' =>
+    'template' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -211,7 +211,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'menuindex' =>
+    'menuindex' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -220,17 +220,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'searchable' =>
-    array (
-      'dbtype' => 'tinyint',
-      'precision' => '1',
-      'attributes' => 'unsigned',
-      'phptype' => 'boolean',
-      'null' => false,
-      'default' => 1,
-      'index' => 'index',
-    ),
-    'cacheable' =>
+    'searchable' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -240,7 +230,17 @@ $xpdo_meta_map['modResource']= array (
       'default' => 1,
       'index' => 'index',
     ),
-    'createdby' =>
+    'cacheable' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'attributes' => 'unsigned',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'createdby' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -248,7 +248,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'createdon' =>
+    'createdon' => 
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -256,7 +256,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'editedby' =>
+    'editedby' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -264,7 +264,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'editedon' =>
+    'editedon' => 
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -272,7 +272,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'deleted' =>
+    'deleted' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -281,7 +281,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'deletedon' =>
+    'deletedon' => 
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -289,7 +289,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'deletedby' =>
+    'deletedby' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -297,7 +297,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'publishedon' =>
+    'publishedon' => 
     array (
       'dbtype' => 'int',
       'precision' => '20',
@@ -305,7 +305,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'publishedby' =>
+    'publishedby' => 
     array (
       'dbtype' => 'int',
       'precision' => '10',
@@ -313,7 +313,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'menutitle' =>
+    'menutitle' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -321,7 +321,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => '',
     ),
-    'donthit' =>
+    'donthit' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -330,7 +330,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'privateweb' =>
+    'privateweb' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -339,7 +339,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'privatemgr' =>
+    'privatemgr' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -348,7 +348,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'content_dispo' =>
+    'content_dispo' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -356,7 +356,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'hidemenu' =>
+    'hidemenu' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -366,7 +366,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'class_key' =>
+    'class_key' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '100',
@@ -375,7 +375,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 'modDocument',
       'index' => 'index',
     ),
-    'context_key' =>
+    'context_key' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '100',
@@ -384,7 +384,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 'web',
       'index' => 'index',
     ),
-    'content_type' =>
+    'content_type' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -393,14 +393,14 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 1,
     ),
-    'uri' =>
+    'uri' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'string',
       'null' => true,
       'index' => 'index',
     ),
-    'uri_override' =>
+    'uri_override' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -409,7 +409,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'hide_children_in_tree' =>
+    'hide_children_in_tree' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -418,7 +418,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'show_in_tree' =>
+    'show_in_tree' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -427,24 +427,24 @@ $xpdo_meta_map['modResource']= array (
       'default' => 1,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'json',
       'null' => true,
     ),
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'alias' =>
+    'alias' => 
     array (
       'alias' => 'alias',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'alias' =>
+        'alias' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -452,15 +452,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'published' =>
+    'published' => 
     array (
       'alias' => 'published',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'published' =>
+        'published' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -468,15 +468,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'pub_date' =>
+    'pub_date' => 
     array (
       'alias' => 'pub_date',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'pub_date' =>
+        'pub_date' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -484,15 +484,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'unpub_date' =>
+    'unpub_date' => 
     array (
       'alias' => 'unpub_date',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'unpub_date' =>
+        'unpub_date' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -500,15 +500,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'parent' =>
+    'parent' => 
     array (
       'alias' => 'parent',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'parent' =>
+        'parent' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -516,15 +516,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'isfolder' =>
+    'isfolder' => 
     array (
       'alias' => 'isfolder',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'isfolder' =>
+        'isfolder' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -532,15 +532,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'template' =>
+    'template' => 
     array (
       'alias' => 'template',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'template' =>
+        'template' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -548,15 +548,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'menuindex' =>
+    'menuindex' => 
     array (
       'alias' => 'menuindex',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'menuindex' =>
+        'menuindex' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -564,15 +564,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'searchable' =>
+    'searchable' => 
     array (
       'alias' => 'searchable',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'searchable' =>
+        'searchable' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -580,15 +580,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'cacheable' =>
+    'cacheable' => 
     array (
       'alias' => 'cacheable',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'cacheable' =>
+        'cacheable' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -596,15 +596,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'hidemenu' =>
+    'hidemenu' => 
     array (
       'alias' => 'hidemenu',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'hidemenu' =>
+        'hidemenu' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -612,15 +612,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'class_key' =>
+    'class_key' => 
     array (
       'alias' => 'class_key',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'class_key' =>
+        'class_key' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -628,15 +628,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'context_key' =>
+    'context_key' => 
     array (
       'alias' => 'context_key',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'context_key' =>
+        'context_key' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -644,15 +644,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'uri' =>
+    'uri' => 
     array (
       'alias' => 'uri',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'uri' =>
+        'uri' => 
         array (
           'length' => '191',
           'collation' => 'A',
@@ -660,15 +660,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'uri_override' =>
+    'uri_override' => 
     array (
       'alias' => 'uri_override',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'uri_override' =>
+        'uri_override' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -676,15 +676,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'hide_children_in_tree' =>
+    'hide_children_in_tree' => 
     array (
       'alias' => 'hide_children_in_tree',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'hide_children_in_tree' =>
+        'hide_children_in_tree' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -692,15 +692,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'show_in_tree' =>
+    'show_in_tree' => 
     array (
       'alias' => 'show_in_tree',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'show_in_tree' =>
+        'show_in_tree' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -708,39 +708,39 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'content_ft_idx' =>
+    'content_ft_idx' => 
     array (
       'alias' => 'content_ft_idx',
       'primary' => false,
       'unique' => false,
       'type' => 'FULLTEXT',
-      'columns' =>
+      'columns' => 
       array (
-        'pagetitle' =>
+        'pagetitle' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'longtitle' =>
+        'longtitle' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'description' =>
+        'description' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'introtext' =>
+        'introtext' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => true,
         ),
-        'content' =>
+        'content' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -748,27 +748,27 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'cache_refresh_idx' =>
+    'cache_refresh_idx' => 
     array (
       'alias' => 'cache_refresh_index',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'parent' =>
+        'parent' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'menuindex' =>
+        'menuindex' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'id' =>
+        'id' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -777,9 +777,9 @@ $xpdo_meta_map['modResource']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'Children' =>
+    'Children' => 
     array (
       'class' => 'modResource',
       'local' => 'id',
@@ -787,7 +787,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarResources' =>
+    'TemplateVarResources' => 
     array (
       'class' => 'modTemplateVarResource',
       'local' => 'id',
@@ -795,7 +795,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'ResourceGroupResources' =>
+    'ResourceGroupResources' => 
     array (
       'class' => 'modResourceGroupResource',
       'local' => 'id',
@@ -803,7 +803,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'Acls' =>
+    'Acls' => 
     array (
       'class' => 'modAccessResource',
       'local' => 'id',
@@ -811,7 +811,7 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'local',
       'cardinality' => 'many',
     ),
-    'ContextResources' =>
+    'ContextResources' => 
     array (
       'class' => 'modContextResource',
       'local' => 'id',
@@ -820,9 +820,9 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'local',
     ),
   ),
-  'aggregates' =>
+  'aggregates' => 
   array (
-    'Parent' =>
+    'Parent' => 
     array (
       'class' => 'modResource',
       'local' => 'parent',
@@ -830,7 +830,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'CreatedBy' =>
+    'CreatedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'createdby',
@@ -838,7 +838,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'EditedBy' =>
+    'EditedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'editedby',
@@ -846,7 +846,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'DeletedBy' =>
+    'DeletedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'deletedby',
@@ -854,7 +854,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'PublishedBy' =>
+    'PublishedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'publishedby',
@@ -862,7 +862,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'Template' =>
+    'Template' => 
     array (
       'class' => 'modTemplate',
       'local' => 'template',
@@ -870,7 +870,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'TemplateVars' =>
+    'TemplateVars' => 
     array (
       'class' => 'modTemplateVar',
       'local' => 'id:template',
@@ -878,7 +878,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarTemplates' =>
+    'TemplateVarTemplates' => 
     array (
       'class' => 'modTemplateVarTemplate',
       'local' => 'template',
@@ -886,7 +886,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'ContentType' =>
+    'ContentType' => 
     array (
       'class' => 'modContentType',
       'local' => 'content_type',
@@ -894,7 +894,7 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'foreign',
       'cardinality' => 'one',
     ),
-    'Context' =>
+    'Context' => 
     array (
       'class' => 'modContext',
       'local' => 'context_key',

--- a/core/model/modx/sqlsrv/modresource.map.inc.php
+++ b/core/model/modx/sqlsrv/modresource.map.inc.php
@@ -9,7 +9,7 @@ $xpdo_meta_map['modResource']= array (
   'table' => 'site_content',
   'extends' => 'modAccessibleSimpleObject',
   'inherit' => 'single',
-  'fields' =>
+  'fields' => 
   array (
     'type' => 'document',
     'contentType' => 'text/html',
@@ -55,9 +55,9 @@ $xpdo_meta_map['modResource']= array (
     'show_in_tree' => 1,
     'properties' => NULL,
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'type' =>
+    'type' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '20',
@@ -65,7 +65,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 'document',
     ),
-    'contentType' =>
+    'contentType' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '50',
@@ -73,7 +73,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 'text/html',
     ),
-    'pagetitle' =>
+    'pagetitle' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -83,7 +83,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'longtitle' =>
+    'longtitle' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -93,7 +93,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'description' =>
+    'description' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
@@ -103,7 +103,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'alias' =>
+    'alias' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -112,14 +112,14 @@ $xpdo_meta_map['modResource']= array (
       'default' => '',
       'index' => 'index',
     ),
-    'alias_visible' =>
+    'alias_visible' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
       'null' => false,
       'default' => 1,
     ),
-    'link_attributes' =>
+    'link_attributes' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -127,7 +127,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => '',
     ),
-    'published' =>
+    'published' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -135,7 +135,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'pub_date' =>
+    'pub_date' => 
     array (
       'dbtype' => 'bigint',
       'phptype' => 'timestamp',
@@ -143,7 +143,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'unpub_date' =>
+    'unpub_date' => 
     array (
       'dbtype' => 'bigint',
       'phptype' => 'timestamp',
@@ -151,7 +151,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'parent' =>
+    'parent' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
@@ -159,7 +159,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'isfolder' =>
+    'isfolder' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -167,7 +167,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'introtext' =>
+    'introtext' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
@@ -175,7 +175,7 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'content' =>
+    'content' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
@@ -183,14 +183,14 @@ $xpdo_meta_map['modResource']= array (
       'index' => 'fulltext',
       'indexgrp' => 'content_ft_idx',
     ),
-    'richtext' =>
+    'richtext' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
       'null' => false,
       'default' => 1,
     ),
-    'template' =>
+    'template' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
@@ -198,7 +198,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'menuindex' =>
+    'menuindex' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
@@ -206,15 +206,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'searchable' =>
-    array (
-      'dbtype' => 'bit',
-      'phptype' => 'boolean',
-      'null' => false,
-      'default' => 1,
-      'index' => 'index',
-    ),
-    'cacheable' =>
+    'searchable' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -222,70 +214,78 @@ $xpdo_meta_map['modResource']= array (
       'default' => 1,
       'index' => 'index',
     ),
-    'createdby' =>
+    'cacheable' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'createdby' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 0,
     ),
-    'createdon' =>
+    'createdon' => 
     array (
       'dbtype' => 'bigint',
       'phptype' => 'timestamp',
       'null' => false,
       'default' => 0,
     ),
-    'editedby' =>
+    'editedby' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 0,
     ),
-    'editedon' =>
+    'editedon' => 
     array (
       'dbtype' => 'bigint',
       'phptype' => 'timestamp',
       'null' => false,
       'default' => 0,
     ),
-    'deleted' =>
+    'deleted' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
       'null' => false,
       'default' => 0,
     ),
-    'deletedon' =>
+    'deletedon' => 
     array (
       'dbtype' => 'bigint',
       'phptype' => 'timestamp',
       'null' => false,
       'default' => 0,
     ),
-    'deletedby' =>
+    'deletedby' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 0,
     ),
-    'publishedon' =>
+    'publishedon' => 
     array (
       'dbtype' => 'bigint',
       'phptype' => 'timestamp',
       'null' => false,
       'default' => 0,
     ),
-    'publishedby' =>
+    'publishedby' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 0,
     ),
-    'menutitle' =>
+    'menutitle' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -293,28 +293,28 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => '',
     ),
-    'donthit' =>
+    'donthit' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
       'null' => false,
       'default' => 0,
     ),
-    'privateweb' =>
+    'privateweb' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
       'null' => false,
       'default' => 0,
     ),
-    'privatemgr' =>
+    'privatemgr' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
       'null' => false,
       'default' => 0,
     ),
-    'content_dispo' =>
+    'content_dispo' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -322,7 +322,7 @@ $xpdo_meta_map['modResource']= array (
       'null' => false,
       'default' => 0,
     ),
-    'hidemenu' =>
+    'hidemenu' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -330,7 +330,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'class_key' =>
+    'class_key' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '100',
@@ -339,7 +339,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 'modDocument',
       'index' => 'index',
     ),
-    'context_key' =>
+    'context_key' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '100',
@@ -348,14 +348,14 @@ $xpdo_meta_map['modResource']= array (
       'default' => 'web',
       'index' => 'index',
     ),
-    'content_type' =>
+    'content_type' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 1,
     ),
-    'uri' =>
+    'uri' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '1000',
@@ -364,7 +364,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => '',
       'index' => 'index',
     ),
-    'uri_override' =>
+    'uri_override' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -372,7 +372,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'hide_children_in_tree' =>
+    'hide_children_in_tree' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -380,7 +380,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'show_in_tree' =>
+    'show_in_tree' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -388,7 +388,7 @@ $xpdo_meta_map['modResource']= array (
       'default' => 1,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
@@ -396,17 +396,17 @@ $xpdo_meta_map['modResource']= array (
       'null' => true,
     ),
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'alias' =>
+    'alias' => 
     array (
       'alias' => 'alias',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'alias' =>
+        'alias' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -414,15 +414,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'published' =>
+    'published' => 
     array (
       'alias' => 'published',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'published' =>
+        'published' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -430,15 +430,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'pub_date' =>
+    'pub_date' => 
     array (
       'alias' => 'pub_date',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'pub_date' =>
+        'pub_date' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -446,15 +446,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'unpub_date' =>
+    'unpub_date' => 
     array (
       'alias' => 'unpub_date',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'unpub_date' =>
+        'unpub_date' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -462,15 +462,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'parent' =>
+    'parent' => 
     array (
       'alias' => 'parent',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'parent' =>
+        'parent' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -478,15 +478,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'isfolder' =>
+    'isfolder' => 
     array (
       'alias' => 'isfolder',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'isfolder' =>
+        'isfolder' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -494,15 +494,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'template' =>
+    'template' => 
     array (
       'alias' => 'template',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'template' =>
+        'template' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -510,15 +510,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'menuindex' =>
+    'menuindex' => 
     array (
       'alias' => 'menuindex',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'menuindex' =>
+        'menuindex' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -526,15 +526,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'searchable' =>
+    'searchable' => 
     array (
       'alias' => 'searchable',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'searchable' =>
+        'searchable' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -542,15 +542,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'cacheable' =>
+    'cacheable' => 
     array (
       'alias' => 'cacheable',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'cacheable' =>
+        'cacheable' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -558,15 +558,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'hidemenu' =>
+    'hidemenu' => 
     array (
       'alias' => 'hidemenu',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'hidemenu' =>
+        'hidemenu' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -574,15 +574,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'class_key' =>
+    'class_key' => 
     array (
       'alias' => 'class_key',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'class_key' =>
+        'class_key' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -590,15 +590,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'context_key' =>
+    'context_key' => 
     array (
       'alias' => 'context_key',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'context_key' =>
+        'context_key' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -606,15 +606,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'uri' =>
+    'uri' => 
     array (
       'alias' => 'uri',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'uri' =>
+        'uri' => 
         array (
           'length' => '1000',
           'collation' => 'A',
@@ -622,15 +622,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'uri_override' =>
+    'uri_override' => 
     array (
       'alias' => 'uri_override',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'uri_override' =>
+        'uri_override' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -638,15 +638,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'hide_children_in_tree' =>
+    'hide_children_in_tree' => 
     array (
       'alias' => 'hide_children_in_tree',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'hide_children_in_tree' =>
+        'hide_children_in_tree' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -654,15 +654,15 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'show_in_tree' =>
+    'show_in_tree' => 
     array (
       'alias' => 'show_in_tree',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'show_in_tree' =>
+        'show_in_tree' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -670,39 +670,39 @@ $xpdo_meta_map['modResource']= array (
         ),
       ),
     ),
-    'content_ft_idx' =>
+    'content_ft_idx' => 
     array (
       'alias' => 'content_ft_idx',
       'primary' => false,
       'unique' => false,
       'type' => 'FULLTEXT',
-      'columns' =>
+      'columns' => 
       array (
-        'pagetitle' =>
+        'pagetitle' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'longtitle' =>
+        'longtitle' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'description' =>
+        'description' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => false,
         ),
-        'introtext' =>
+        'introtext' => 
         array (
           'length' => '',
           'collation' => 'A',
           'null' => true,
         ),
-        'content' =>
+        'content' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -711,9 +711,9 @@ $xpdo_meta_map['modResource']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'Children' =>
+    'Children' => 
     array (
       'class' => 'modResource',
       'local' => 'id',
@@ -721,7 +721,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarResources' =>
+    'TemplateVarResources' => 
     array (
       'class' => 'modTemplateVarResource',
       'local' => 'id',
@@ -729,7 +729,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'ResourceGroupResources' =>
+    'ResourceGroupResources' => 
     array (
       'class' => 'modResourceGroupResource',
       'local' => 'id',
@@ -737,7 +737,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'Acls' =>
+    'Acls' => 
     array (
       'class' => 'modAccessResource',
       'local' => 'id',
@@ -745,7 +745,7 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'local',
       'cardinality' => 'many',
     ),
-    'ContextResources' =>
+    'ContextResources' => 
     array (
       'class' => 'modContextResource',
       'local' => 'id',
@@ -754,9 +754,9 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'local',
     ),
   ),
-  'aggregates' =>
+  'aggregates' => 
   array (
-    'Parent' =>
+    'Parent' => 
     array (
       'class' => 'modResource',
       'local' => 'parent',
@@ -764,7 +764,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'CreatedBy' =>
+    'CreatedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'createdby',
@@ -772,7 +772,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'EditedBy' =>
+    'EditedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'editedby',
@@ -780,7 +780,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'DeletedBy' =>
+    'DeletedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'deletedby',
@@ -788,7 +788,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'PublishedBy' =>
+    'PublishedBy' => 
     array (
       'class' => 'modUser',
       'local' => 'publishedby',
@@ -796,7 +796,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'Template' =>
+    'Template' => 
     array (
       'class' => 'modTemplate',
       'local' => 'template',
@@ -804,7 +804,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'TemplateVars' =>
+    'TemplateVars' => 
     array (
       'class' => 'modTemplateVar',
       'local' => 'id:template',
@@ -812,7 +812,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarTemplates' =>
+    'TemplateVarTemplates' => 
     array (
       'class' => 'modTemplateVarTemplate',
       'local' => 'template',
@@ -820,7 +820,7 @@ $xpdo_meta_map['modResource']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'ContentType' =>
+    'ContentType' => 
     array (
       'class' => 'modContentType',
       'local' => 'content_type',
@@ -828,7 +828,7 @@ $xpdo_meta_map['modResource']= array (
       'owner' => 'foreign',
       'cardinality' => 'one',
     ),
-    'Context' =>
+    'Context' => 
     array (
       'class' => 'modContext',
       'local' => 'context_key',

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -863,6 +863,7 @@
         <field key="longtitle" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="description" dbtype="text" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="alias" dbtype="varchar" precision="191" phptype="string" null="true" default="" index="index" />
+        <field key="alias_visible" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" />
         <field key="link_attributes" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
         <field key="published" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="pub_date" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" index="index" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -816,6 +816,7 @@
         <field key="longtitle" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="description" dbtype="nvarchar" precision="max" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="alias" dbtype="nvarchar" precision="255" phptype="string" null="true" default="" index="index" />
+        <field key="alias_visible" dbtype="bit" phptype="boolean" null="false" default="1" />
         <field key="link_attributes" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" />
         <field key="published" dbtype="bit" phptype="boolean" null="false" default="0" index="index" />
         <field key="pub_date" dbtype="bigint" phptype="timestamp" null="false" default="0" index="index" />


### PR DESCRIPTION
### What does it do?
Added missing alias_visible field definition to mysql and sqlsrv model schemas.

### Why is it needed?
The field was added to the map files and upgrade scripts but was never added to the schema so that regeneration of the model from the schema files removed them from the map files.

### Related issue(s)/PR(s)
Fixes #14599 