### PR TITLE
Edited resource date and time from system settings, after refactor

### DIFF
--- a/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
+++ b/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
@@ -92,6 +92,14 @@ class GetRecentlyEditedResources extends modObjectGetListProcessor
         $resourceArray = $resource->get(['id','pagetitle','description','published','deleted','context_key', 'editedon']);
         $resourceArray['pagetitle'] = htmlspecialchars($resourceArray['pagetitle'], ENT_QUOTES, $this->modx->getOption('modx_charset', null, 'UTF-8'));
 
+        $dateFormat = $this->modx->getOption('manager_date_format');
+        $timeFormat = $this->modx->getOption('manager_time_format');
+
+        $resourceArray['editedon_date'] = date($dateFormat, strtotime($resourceArray['editedon']));
+        $resourceArray['editedon_time'] = date($timeFormat, strtotime($resourceArray['editedon']));
+        $resourceArray['createdon_date'] = date($dateFormat, strtotime($resourceArray['createdon']));
+        $resourceArray['createdon_time'] = date($timeFormat, strtotime($resourceArray['createdon']));
+
         $row = array_merge($row, $resourceArray);
 
         /** @var modUser $user */

--- a/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
+++ b/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
@@ -95,10 +95,13 @@ class GetRecentlyEditedResources extends modObjectGetListProcessor
         $dateFormat = $this->modx->getOption('manager_date_format');
         $timeFormat = $this->modx->getOption('manager_time_format');
 
-        $resourceArray['editedon_date'] = date($dateFormat, strtotime($resourceArray['editedon']));
-        $resourceArray['editedon_time'] = date($timeFormat, strtotime($resourceArray['editedon']));
-        $resourceArray['createdon_date'] = date($dateFormat, strtotime($resourceArray['createdon']));
-        $resourceArray['createdon_time'] = date($timeFormat, strtotime($resourceArray['createdon']));
+        $editedon = new \DateTimeImmutable($resourceArray['editedon']);
+        $createdon = new \DateTimeImmutable($resourceArray['createdon']);
+
+        $resourceArray['editedon_date'] = $editedon->format($dateFormat);
+        $resourceArray['editedon_time'] = $editedon->format($timeFormat);
+        $resourceArray['createdon_date'] = $createdon->format($dateFormat);
+        $resourceArray['createdon_time'] = $createdon->format($timeFormat);
 
         $row = array_merge($row, $resourceArray);
 

--- a/manager/templates/default/dashboard/recentlyeditedresources.tpl
+++ b/manager/templates/default/dashboard/recentlyeditedresources.tpl
@@ -27,11 +27,11 @@
                         </td>
                         <td class="occurred">
                             {if $record.editedon}
-                                <div class="occurred-date">{$record.editedon|date_format:'%B %d, %Y'}</div>
-                                <div class="occurred-time">{$record.editedon|date_format:'%H:%M'}</div>
+                                <div class="occurred-date">{$record.editedon_date}</div>
+                                <div class="occurred-time">{$record.editedon_time}</div>
                             {elseif $record.createdon}
-                                <div class="occurred-date">{$record.createdon|date_format:'%B %d, %Y'}</div>
-                                <div class="occurred-time">{$record.createdon|date_format:'%H:%M'}</div>
+                                <div class="occurred-date">{$record.createdon_date}</div>
+                                <div class="occurred-time">{$record.createdon_time}</div>
                             {/if}
                         </td>
                         <td class="user-with-avatar">


### PR DESCRIPTION
### What does it do?
Dashboard widget: 'Recently edited resources'. It takes the date and time format from the system settings:

- manager_date_format
- manager_time_format

Instead of using a fixed format, '%B %d, %Y' which is defined in recentlyeditedresources.tpl.


### Why is it needed?
Date and time formatting should be in line with the system settings as preferences differ per geographical area.


### Related issue(s)/PR(s)
This PR is based on https://github.com/modxcms/revolution/pull/14608. That needed changes because of the massive refactor.
