### PR TITLE
Escape instances of new MySQL reserved word rank

### DIFF
--- a/core/model/modx/moddashboard.class.php
+++ b/core/model/modx/moddashboard.class.php
@@ -72,7 +72,7 @@ class modDashboard extends xPDOSimpleObject {
         $c->where(array(
             'dashboard' => $this->get('id'),
         ));
-        $c->sortby('rank', 'ASC');
+        $c->sortby($this->xpdo->escape('rank'), 'ASC');
         $placements = $this->getMany('Placements', $c);
         $output = array();
         /** @var modDashboardWidgetPlacement $placement */

--- a/core/model/modx/modformcustomizationset.class.php
+++ b/core/model/modx/modformcustomizationset.class.php
@@ -167,7 +167,7 @@ class modFormCustomizationSet extends xPDOSimpleObject {
             'action' => $baseAction,
             'type' => 'tab',
         ));
-        $c->sortby('rank','ASC');
+        $c->sortby($this->xpdo->escape('rank'), 'ASC');
         $tabs = $this->xpdo->getCollection('modActionField',$c);
 
         /** @var modActionField $tab */

--- a/core/model/modx/processors/element/propertyset/getnodes.class.php
+++ b/core/model/modx/processors/element/propertyset/getnodes.class.php
@@ -68,8 +68,8 @@ class modPropertySetGetNodesProcessor extends modObjectProcessor {
         $list = array();
 
         $c = $this->modx->newQuery('modCategory');
-        $c->sortby('rank', 'ASC');
-        $c->sortby('category', 'ASC');
+        $c->sortby($this->modx->escape('rank'), 'ASC');
+        $c->sortby($this->modx->escape('category'), 'ASC');
         $categories = $this->modx->getIterator('modCategory', $c);
 
         /** @var modCategory $category */

--- a/core/model/modx/processors/element/template/duplicate.class.php
+++ b/core/model/modx/processors/element/template/duplicate.class.php
@@ -37,7 +37,7 @@ class modTemplateDuplicateProcessor extends modElementDuplicateProcessor {
         $c->where(array(
             'templateid' => $this->object->get('id'),
         ));
-        $c->sortby('rank','ASC');
+        $c->sortby($this->modx->escape('rank'),'ASC');
         $templateVarTemplates = $this->modx->getCollection('modTemplateVarTemplate',$c);
         /** @var modTemplateVarTemplate $templateVarTemplate */
         foreach ($templateVarTemplates as $templateVarTemplate) {

--- a/core/model/modx/processors/resource/sort.class.php
+++ b/core/model/modx/processors/resource/sort.class.php
@@ -363,7 +363,7 @@ class modResourceSortProcessor extends modProcessor {
             'key:NOT IN' => array('mgr', $this->source->key, $this->target->key),
             'rank:>=' => $lastRank,
         ));
-        $c->sortby('rank', 'ASC');
+        $c->sortby($this->modx->escape('rank'), 'ASC');
 
         $contextsToSort = $this->modx->getIterator('modContext', $c);
         $lastRank = $lastRank + 2;

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -259,8 +259,8 @@ abstract class ResourceManagerController extends modManagerController {
 
         /* get categories */
         $c = $this->modx->newQuery('modCategory');
-        $c->sortby('rank', 'ASC');
-        $c->sortby('category','ASC');
+        $c->sortby($this->modx->escape('rank'), 'ASC');
+        $c->sortby($this->modx->escape('category'),'ASC');
         $cats = $this->modx->getCollection('modCategory',$c);
         $categories = array();
         /** @var modCategory $cat */


### PR DESCRIPTION
### What does it do?
Make sure any sortby() and groupby() method calls sending the column name `rank` are escaped properly.

### Why is it needed?
MySQL 8.0.2 made the word `rank` a new reserved word and it must now be escaped in any SQL sent to that database engine. There were several places where a column named rank was being sent to a sortby() method call without being escaped.

### Related issue(s)/PR(s)
Fixes #13894