### PR TITLE
Escape usage of reserved name rank in sortby and groupby statements 

### DIFF
--- a/core/src/Revolution/Processors/Element/PropertySet/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/GetNodes.php
@@ -87,7 +87,7 @@ class GetNodes extends modObjectProcessor
         $list = [];
 
         $c = $this->modx->newQuery(modCategory::class);
-        $c->sortby('rank', 'ASC');
+        $c->sortby($this->modx->escape('rank'), 'ASC');
         $c->sortby('category', 'ASC');
         $categories = $this->modx->getIterator('modCategory', $c);
 

--- a/core/src/Revolution/Processors/Element/Template/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/Template/Duplicate.php
@@ -45,7 +45,7 @@ class Duplicate extends \MODX\Revolution\Processors\Element\Duplicate
         $c->where([
             'templateid' => $this->object->get('id'),
         ]);
-        $c->sortby('rank', 'ASC');
+        $c->sortby($this->modx->escape('rank'), 'ASC');
         $templateVarTemplates = $this->modx->getCollection(modTemplateVarTemplate::class, $c);
         /** @var modTemplateVarTemplate $templateVarTemplate */
         foreach ($templateVarTemplates as $templateVarTemplate) {

--- a/core/src/Revolution/Processors/Resource/Sort.php
+++ b/core/src/Revolution/Processors/Resource/Sort.php
@@ -399,7 +399,7 @@ class Sort extends modProcessor
             'key:NOT IN' => ['mgr', $this->source->key, $this->target->key],
             'rank:>=' => $lastRank,
         ]);
-        $c->sortby('rank', 'ASC');
+        $c->sortby($this->modx->escape('rank'), 'ASC');
 
         $contextsToSort = $this->modx->getIterator(modContext::class, $c);
         $lastRank = $lastRank + 2;

--- a/core/src/Revolution/modDashboard.php
+++ b/core/src/Revolution/modDashboard.php
@@ -104,7 +104,7 @@ class modDashboard extends xPDOSimpleObject
 
         // Get widgets
         $c = $this->xpdo->newQuery(modDashboardWidgetPlacement::class, $where);
-        $c->sortby('rank', 'ASC');
+        $c->sortby($this->xpdo->escape('rank'), 'ASC');
         if ($placements = $this->xpdo->getIterator(modDashboardWidgetPlacement::class, $c)) {
             /** @var modDashboardWidgetPlacement $placement */
             foreach ($placements as $placement) {
@@ -142,7 +142,7 @@ class modDashboard extends xPDOSimpleObject
                 'dashboard' => $this->id,
                 'user' => $user,
             ]);
-            $c->groupby('rank');
+            $c->groupby($this->xpdo->escape('rank'));
             $c->select('COUNT(rank) as idx');
             $c->sortby('idx', 'DESC');
             $c->limit(1);

--- a/core/src/Revolution/modFormCustomizationSet.php
+++ b/core/src/Revolution/modFormCustomizationSet.php
@@ -168,7 +168,7 @@ class modFormCustomizationSet extends xPDOSimpleObject
             'action' => $baseAction,
             'type' => 'tab',
         ]);
-        $c->sortby('rank', 'ASC');
+        $c->sortby($this->xpdo->escape('rank'), 'ASC');
         $tabs = $this->xpdo->getCollection('modActionField', $c);
 
         /** @var modActionField $tab */

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -315,8 +315,8 @@ abstract class ResourceManagerController extends modManagerController
 
         /* get categories */
         $c = $this->modx->newQuery(modCategory::class);
-        $c->sortby('rank', 'ASC');
-        $c->sortby('category', 'ASC');
+        $c->sortby($this->modx->escape('rank'), 'ASC');
+        $c->sortby($this->modx->escape('category'), 'ASC');
         $cats = $this->modx->getCollection(modCategory::class, $c);
         $categories = [];
         /** @var modCategory $cat */


### PR DESCRIPTION
### What does it do?

Escapes the usage of `rank` on sortby() and groupby() statements. 

### Why is it needed?

`rank` is reserved on MySQL 8. See #13894 for more details and #14701 for an earlier merged variation of this for 2.x.

### Related issue(s)/PR(s)
Fixes #13894 for 3.x; based roughly on #14701 for 2.x