### PR TITLE
Fix several access-related processors (fixes #14696)

### DIFF
--- a/core/src/Revolution/Processors/Security/Access/Policy/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/GetList.php
@@ -42,7 +42,7 @@ class GetList extends modObjectGetListProcessor
     {
         $initialized = parent::initialize();
         $this->setDefaultProperties([
-            'sortAlias' => modAccessPolicy::class,
+            'sortAlias' => 'modAccessPolicy',
             'group' => false,
             'combo' => false,
             'query' => '',

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/GetList.php
@@ -41,7 +41,7 @@ class GetList extends modObjectGetListProcessor
     {
         $initialized = parent::initialize();
         $this->setDefaultProperties([
-            'sortAlias' => modAccessPolicyTemplate::class,
+            'sortAlias' => 'modAccessPolicyTemplate',
             'query' => '',
         ]);
         return $initialized;

--- a/core/src/Revolution/Processors/Security/Role/GetAuthorityList.php
+++ b/core/src/Revolution/Processors/Security/Role/GetAuthorityList.php
@@ -11,7 +11,6 @@
 namespace MODX\Revolution\Processors\Security\Role;
 
 
-use modUserGroupRoleGetListProcessor;
 use xPDO\Om\xPDOObject;
 
 /**
@@ -25,7 +24,7 @@ use xPDO\Om\xPDOObject;
  *
  * @package MODX\Revolution\Processors\Security\Role
  */
-class GetAuthorityList extends modUserGroupRoleGetListProcessor
+class GetAuthorityList extends GetList
 {
     /**
      * @param xPDOObject $object


### PR DESCRIPTION
### What does it do?

Fixes incorrect processor references. Details in #14696 + the roles selection when adding access which was broken since the refactor. 

### Why is it needed?

Make access management work.

### Related issue(s)/PR(s)

Fix #14696