### PR TITLE
Show installation errors in a red block (Fixes #14654)

### DIFF
--- a/_build/templates/default/sass/installer.scss
+++ b/_build/templates/default/sass/installer.scss
@@ -713,6 +713,13 @@ header {
                 font-weight: 500;
             }
 
+            &.testWarn {
+                background-color: $lighterRed;
+                padding: 5px 15px;
+                margin: 0 -15px 0 -18px;
+                border-left: 3px solid darken($red, 25%);
+            }
+
         }
 
         &.failed {

--- a/setup/includes/test/modinstalltest.class.php
+++ b/setup/includes/test/modinstalltest.class.php
@@ -425,7 +425,7 @@ abstract class modInstallTest {
      */
     protected function warn($key,$title,$message = '',$messageTitle = '') {
         if (empty($title)) $title = $this->install->lexicon('warning');
-        $msg = '<span class="notok">'.$title.'</span></p>';
+        $msg = '<p class="notok">'.$title.'</p>';
         if (!empty($message)) {
             $msg .= '<div class="notes">';
             if (!empty($messageTitle)) $msg .= '<h3>'.$messageTitle.'</h3>';
@@ -457,7 +457,7 @@ abstract class modInstallTest {
      */
     protected function fail($key,$title = '',$message = '') {
         if (empty($title)) $title = $this->install->lexicon('failed');
-        $msg = '<span class="notok">'.$title.'</span></p>';
+        $msg = '<p class="notok">'.$title.'</p>';
         if (!empty($message)) {
             $msg .= '<p><strong>'.$message.'</strong></p>';
         }


### PR DESCRIPTION
### What does it do?

Add some nice red styling to installation check errors. 

### Why is it needed?

Errors do not stand out now. 

### Related issue(s)/PR(s)

Fixes #14654