### PR TITLE
Fix permission check causing fatal error on dashboard [#14707]

### DIFF
--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -38,6 +38,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface
         }
         $this->modx->getService('smarty', modSmarty::class);
         $this->modx->smarty->assign('data', $data);
+        $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 
         return $this->modx->smarty->fetch('dashboard/onlineusers.tpl');
     }

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -41,6 +41,7 @@ class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterf
         }
         $this->modx->getService('smarty', modSmarty::class);
         $this->modx->smarty->assign('data', $data);
+        $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 
         return $this->modx->smarty->fetch('dashboard/recentlyeditedresources.tpl');
     }

--- a/manager/templates/default/dashboard/onlineusers.tpl
+++ b/manager/templates/default/dashboard/onlineusers.tpl
@@ -40,7 +40,7 @@
     {else}
         <div class="no-results">{$_lang.w_no_data}</div>
     {/if}
-    {if $modx->hasPermission('logs')}
+    {if $can_view_logs}
         <div class="widget-footer">
             <a href="{$_config.manager_url}?a=system/logs">{$_lang.w_view_all} &rarr;</a>
         </div>

--- a/manager/templates/default/dashboard/recentlyeditedresources.tpl
+++ b/manager/templates/default/dashboard/recentlyeditedresources.tpl
@@ -83,7 +83,7 @@
     {else}
         <div class="no-results">{$_lang.w_no_data}</div>
     {/if}
-    {if $modx->hasPermission('logs')}
+    {if $can_view_logs}
         <div class="widget-footer">
             <a href="{$_config.manager_url}?a=system/logs">{$_lang.w_view_all} &rarr;</a>
         </div>


### PR DESCRIPTION
### What does it do?

Moves a permission check from the template to the widget code itself. 

### Why is it needed?

This code appeared to work before when merging #14511, but on a clean installation it breaks the dashboard (#14707). I'm not entirely sure why and would love to hear from anyone who might know why - my guess it it might be related to an extra that's installed (though I didn't have pdotools, which with fenom would've been the main suspect as smarty and fenom syntax look similar).  

By moving the code to the widget controller, it doesn't crash, yay.

### Related issue(s)/PR(s)

Fixes #14707 (along with #14709 to fix the build) 