### PR TITLE
Call the right manager controller when saving a Template Variable 

### DIFF
--- a/manager/assets/modext/sections/element/tv/create.js
+++ b/manager/assets/modext/sections/element/tv/create.js
@@ -40,7 +40,7 @@ MODx.page.CreateTV = function(config) {
                 }]
             }
         },{
-            process: 'Element/TemplateVar/Create'
+            process: 'Element/Tv/Create'
             ,reload: true
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -112,7 +112,7 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             text: _('cancel') + ' <i class="icon icon-times"></i>'
             ,id: 'modx-abtn-cancel'
         },{
-            process: 'Element/TemplateVar/Update'
+            process: 'Element/Tv/Update'
             ,text: _('save') + ' <i class="icon icon-check"></i>'
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'


### PR DESCRIPTION
### What does it do?
Use the "legacy" process names for the Template Variable save button so it loads the right "manager controller".

### Why is it needed?
Fix an incorrect redirect when creating a new Template Variable 

### Related issue(s)/PR(s)
[Related comment in PR #14687](https://github.com/modxcms/revolution/issues/14687#issuecomment-527492897)