### PR TITLE
Fix the bug with copying TVs when caption is empty

### DIFF
--- a/core/src/Revolution/Processors/Element/TemplateVar/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Duplicate.php
@@ -139,12 +139,7 @@ class Duplicate extends \MODX\Revolution\Processors\Element\Duplicate
      */
     public function getNewCaption()
     {
-        $caption = $this->getProperty($this->captionField);
-        $newCaption = !empty($caption)
-            ? $caption
-            : $this->modx->lexicon('duplicate_of', ['name' => $this->object->get($this->captionField)]);
-
-        return $newCaption;
+        return $this->getProperty($this->captionField);
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Cherry-picked the changes from PR #14386

### Why is it needed?
To make sure they get into 3.x

### Related issue(s)/PR(s)
PR #14386
Issue #14381 