### PR TITLE
Use fully qualified class names for modTemplateVar

### DIFF
--- a/core/model/schema/modx.sources.mysql.schema.xml
+++ b/core/model/schema/modx.sources.mysql.schema.xml
@@ -66,7 +66,7 @@
 
     <object class="modMediaSourceElement" table="media_sources_elements" extends="xPDO\Om\xPDOObject">
         <field key="source" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
-        <field key="object_class" dbtype="varchar" precision="100" phptype="string" null="false" default="modTemplateVar" index="pk" />
+        <field key="object_class" dbtype="varchar" precision="100" phptype="string" null="false" default="MODX\Revolution\modTemplateVar" index="pk" />
         <field key="object" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
         <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="web" index="pk" />
 

--- a/core/model/schema/modx.sources.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sources.sqlsrv.schema.xml
@@ -67,7 +67,7 @@
     <object class="modMediaSourceElement" table="media_sources_tvs" extends="xPDO\Om\xPDOObject">
         <field key="source" dbtype="int" phptype="integer" null="false" default="0" index="pk" />
         <field key="object" dbtype="int" phptype="integer" null="false" default="0" index="pk" />
-        <field key="object_class" dbtype="nvarchar" precision="100" phptype="string" null="false" default="modTemplateVar" index="pk" />
+        <field key="object_class" dbtype="nvarchar" precision="100" phptype="string" null="false" default="MODX\Revolution\modTemplateVar" index="pk" />
         <field key="context_key" dbtype="nvarchar" precision="100" phptype="string" null="false" default="web" index="pk" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -14,6 +14,7 @@ namespace MODX\Revolution\Filters;
 use Exception;
 use MODX\Revolution\modElement;
 use MODX\Revolution\modTag;
+use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modX;
 
@@ -710,7 +711,7 @@ class modOutputFilter
                             if (!empty($m_val) && strpos($name, $m_val) === 0) {
                                 $name = substr($name, strlen($m_val));
                             }
-                            $tv = $this->modx->getObject('modTemplateVar', ['name' => $name]);
+                            $tv = $this->modx->getObject(modTemplateVar::class, ['name' => $name]);
                             if (!$tv) {
                                 break;
                             }

--- a/core/src/Revolution/Import/modStaticImport.php
+++ b/core/src/Revolution/Import/modStaticImport.php
@@ -19,6 +19,7 @@ use MODX\Revolution\modContentType;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modDocument;
 use MODX\Revolution\modResource;
+use MODX\Revolution\modTemplateVar;
 use PDO;
 
 /**
@@ -369,7 +370,7 @@ class modStaticImport extends modImport
                 }
 
             } else {
-                $tv = $this->modx->getObject('modTemplateVar', ['name' => $field]);
+                $tv = $this->modx->getObject(modTemplateVar::class, ['name' => $field]);
                 if ($tv) {
                     $tvs[$field] = $this->getFieldValue($selector, $body, $xpath);
                 }

--- a/core/src/Revolution/Processors/Element/Sort.php
+++ b/core/src/Revolution/Processors/Element/Sort.php
@@ -110,7 +110,7 @@ class Sort extends modProcessor
 
                 $className = 'mod' . ucfirst($elKey[1]);
                 if ($className == 'modTv') {
-                    $className = 'modTemplateVar';
+                    $className = modTemplateVar::class;
                 }
 
                 /** @var modElement $element */

--- a/core/src/Revolution/Processors/Element/TemplateVar/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Duplicate.php
@@ -114,7 +114,7 @@ class Duplicate extends \MODX\Revolution\Processors\Element\Duplicate
     {
         $sourceElements = $this->modx->getCollection(modMediaSourceElement::class, [
             'object' => $this->object->get('id'),
-            'object_class' => 'modTemplateVar',
+            'object_class' => modTemplateVar::class,
         ]);
         if (is_array($sourceElements) && !empty($sourceElements)) {
             /** @var modMediaSourceElement $sourceElement */
@@ -123,7 +123,7 @@ class Duplicate extends \MODX\Revolution\Processors\Element\Duplicate
                 $newSourceElement = $this->modx->newObject(modMediaSourceElement::class);
                 $newSourceElement->fromArray([
                     'object' => $this->newObject->get('id'),
-                    'object_class' => 'modTemplateVar',
+                    'object_class' => modTemplateVar::class,
                     'context_key' => $sourceElement->get('context_key'),
                     'source' => $sourceElement->get('source'),
                 ], '', true, true);

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
@@ -103,7 +103,7 @@ class GetInputProperties extends modProcessor {
         $tvId = $this->getProperty('tv');
         if (!empty($tvId)) {
             /** @var modTemplateVar $tv */
-            $tv = $this->modx->getObject('modTemplateVar',$tvId);
+            $tv = $this->modx->getObject(modTemplateVar::class,$tvId);
             if (is_object($tv) && $tv instanceof modTemplateVar) {
                 $settings = $tv->get($this->propertiesKey);
 

--- a/core/src/Revolution/Processors/Element/TemplateVar/Update.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Update.php
@@ -212,7 +212,7 @@ class Update extends \MODX\Revolution\Processors\Element\Update
             if (is_array($sources)) {
                 $sourceElements = $this->modx->getCollection(modMediaSourceElement::class, [
                     'object' => $this->object->get('id'),
-                    'object_class' => 'modTemplateVar',
+                    'object_class' => modTemplateVar::class,
                 ]);
                 /** @var modMediaSourceElement $sourceElement */
                 foreach ($sourceElements as $sourceElement) {

--- a/core/src/Revolution/Sources/mysql/modMediaSourceElement.php
+++ b/core/src/Revolution/Sources/mysql/modMediaSourceElement.php
@@ -12,16 +12,16 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
         'version' => '3.0',
         'table' => 'media_sources_elements',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'fields' => 
         array (
             'source' => 0,
             'object_class' => 'MODX\\Revolution\\modTemplateVar',
             'object' => 0,
             'context_key' => 'web',
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'source' =>
+            'source' => 
             array (
                 'dbtype' => 'int',
                 'precision' => '11',
@@ -31,7 +31,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'object_class' =>
+            'object_class' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
@@ -40,7 +40,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 'MODX\\Revolution\\modTemplateVar',
                 'index' => 'pk',
             ),
-            'object' =>
+            'object' => 
             array (
                 'dbtype' => 'int',
                 'precision' => '11',
@@ -50,7 +50,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'context_key' =>
+            'context_key' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
@@ -60,35 +60,35 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'index' => 'pk',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'source' =>
+                    'source' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object' =>
+                    'object' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object_class' =>
+                    'object_class' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'context_key' =>
+                    'context_key' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -97,9 +97,9 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Source' =>
+            'Source' => 
             array (
                 'class' => 'MODX\\Revolution\\Sources\\modMediaSource',
                 'local' => 'source',
@@ -107,7 +107,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Element' =>
+            'Element' => 
             array (
                 'class' => 'MODX\\Revolution\\modElement',
                 'local' => 'object',
@@ -115,7 +115,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Context' =>
+            'Context' => 
             array (
                 'class' => 'MODX\\Revolution\\modContext',
                 'local' => 'context_key',

--- a/core/src/Revolution/Sources/mysql/modMediaSourceElement.php
+++ b/core/src/Revolution/Sources/mysql/modMediaSourceElement.php
@@ -1,6 +1,7 @@
 <?php
 namespace MODX\Revolution\Sources\mysql;
 
+use MODX\Revolution\modTemplateVar;
 use xPDO\xPDO;
 
 class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceElement
@@ -11,16 +12,16 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
         'version' => '3.0',
         'table' => 'media_sources_elements',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' => 
+        'fields' =>
         array (
             'source' => 0,
-            'object_class' => 'modTemplateVar',
+            'object_class' => 'MODX\\Revolution\\modTemplateVar',
             'object' => 0,
             'context_key' => 'web',
         ),
-        'fieldMeta' => 
+        'fieldMeta' =>
         array (
-            'source' => 
+            'source' =>
             array (
                 'dbtype' => 'int',
                 'precision' => '11',
@@ -30,16 +31,16 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'object_class' => 
+            'object_class' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
                 'phptype' => 'string',
                 'null' => false,
-                'default' => 'modTemplateVar',
+                'default' => 'MODX\\Revolution\\modTemplateVar',
                 'index' => 'pk',
             ),
-            'object' => 
+            'object' =>
             array (
                 'dbtype' => 'int',
                 'precision' => '11',
@@ -49,7 +50,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'context_key' => 
+            'context_key' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
@@ -59,35 +60,35 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'index' => 'pk',
             ),
         ),
-        'indexes' => 
+        'indexes' =>
         array (
-            'PRIMARY' => 
+            'PRIMARY' =>
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'source' => 
+                    'source' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object' => 
+                    'object' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object_class' => 
+                    'object_class' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'context_key' => 
+                    'context_key' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -96,9 +97,9 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 ),
             ),
         ),
-        'aggregates' => 
+        'aggregates' =>
         array (
-            'Source' => 
+            'Source' =>
             array (
                 'class' => 'MODX\\Revolution\\Sources\\modMediaSource',
                 'local' => 'source',
@@ -106,7 +107,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Element' => 
+            'Element' =>
             array (
                 'class' => 'MODX\\Revolution\\modElement',
                 'local' => 'object',
@@ -114,7 +115,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Context' => 
+            'Context' =>
             array (
                 'class' => 'MODX\\Revolution\\modContext',
                 'local' => 'context_key',

--- a/core/src/Revolution/Sources/sqlsrv/modMediaSourceElement.php
+++ b/core/src/Revolution/Sources/sqlsrv/modMediaSourceElement.php
@@ -11,16 +11,16 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
         'version' => '3.0',
         'table' => 'media_sources_tvs',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' => 
+        'fields' =>
         array (
             'source' => 0,
             'object' => 0,
-            'object_class' => 'modTemplateVar',
+            'object_class' => 'MODX\\Revolution\\modTemplateVar',
             'context_key' => 'web',
         ),
-        'fieldMeta' => 
+        'fieldMeta' =>
         array (
-            'source' => 
+            'source' =>
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
@@ -28,7 +28,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'object' => 
+            'object' =>
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
@@ -36,16 +36,16 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'object_class' => 
+            'object_class' =>
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '100',
                 'phptype' => 'string',
                 'null' => false,
-                'default' => 'modTemplateVar',
+                'default' => 'MODX\\Revolution\\modTemplateVar',
                 'index' => 'pk',
             ),
-            'context_key' => 
+            'context_key' =>
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '100',
@@ -55,35 +55,35 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'index' => 'pk',
             ),
         ),
-        'indexes' => 
+        'indexes' =>
         array (
-            'PRIMARY' => 
+            'PRIMARY' =>
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'source' => 
+                    'source' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object' => 
+                    'object' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object_class' => 
+                    'object_class' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'context_key' => 
+                    'context_key' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -92,9 +92,9 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 ),
             ),
         ),
-        'aggregates' => 
+        'aggregates' =>
         array (
-            'Source' => 
+            'Source' =>
             array (
                 'class' => 'MODX\\Revolution\\Sources\\modMediaSource',
                 'local' => 'source',
@@ -102,7 +102,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Element' => 
+            'Element' =>
             array (
                 'class' => 'MODX\\Revolution\\modElement',
                 'local' => 'object',
@@ -110,7 +110,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Context' => 
+            'Context' =>
             array (
                 'class' => 'MODX\\Revolution\\modContext',
                 'local' => 'context_key',

--- a/core/src/Revolution/Sources/sqlsrv/modMediaSourceElement.php
+++ b/core/src/Revolution/Sources/sqlsrv/modMediaSourceElement.php
@@ -11,16 +11,16 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
         'version' => '3.0',
         'table' => 'media_sources_tvs',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'fields' => 
         array (
             'source' => 0,
             'object' => 0,
             'object_class' => 'MODX\\Revolution\\modTemplateVar',
             'context_key' => 'web',
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'source' =>
+            'source' => 
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
@@ -28,7 +28,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'object' =>
+            'object' => 
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
@@ -36,7 +36,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'object_class' =>
+            'object_class' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '100',
@@ -45,7 +45,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'default' => 'MODX\\Revolution\\modTemplateVar',
                 'index' => 'pk',
             ),
-            'context_key' =>
+            'context_key' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '100',
@@ -55,35 +55,35 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'index' => 'pk',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'source' =>
+                    'source' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object' =>
+                    'object' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'object_class' =>
+                    'object_class' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'context_key' =>
+                    'context_key' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -92,9 +92,9 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Source' =>
+            'Source' => 
             array (
                 'class' => 'MODX\\Revolution\\Sources\\modMediaSource',
                 'local' => 'source',
@@ -102,7 +102,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Element' =>
+            'Element' => 
             array (
                 'class' => 'MODX\\Revolution\\modElement',
                 'local' => 'object',
@@ -110,7 +110,7 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Context' =>
+            'Context' => 
             array (
                 'class' => 'MODX\\Revolution\\modContext',
                 'local' => 'context_key',

--- a/core/src/Revolution/modFormCustomizationSet.php
+++ b/core/src/Revolution/modFormCustomizationSet.php
@@ -92,7 +92,7 @@ class modFormCustomizationSet extends xPDOSimpleObject
             $c = $this->xpdo->newQuery('modTemplateVar');
             $c->leftJoin('modCategory', 'Category');
             $c->innerJoin('modTemplateVarTemplate', 'TemplateVarTemplates');
-            $c->select($this->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar'));
+            $c->select($this->xpdo->getSelectColumns(modTemplateVar::class, 'modTemplateVar'));
             $c->select([
                 'Category.category AS category_name',
             ]);
@@ -101,18 +101,18 @@ class modFormCustomizationSet extends xPDOSimpleObject
             ]);
             $c->sortby('Category.category', 'ASC');
             $c->sortby('TemplateVarTemplates.rank', 'ASC');
-            $tvs = $this->xpdo->getCollection('modTemplateVar', $c);
+            $tvs = $this->xpdo->getCollection(modTemplateVar::class, $c);
 
         } else {
-            $c = $this->xpdo->newQuery('modTemplateVar');
+            $c = $this->xpdo->newQuery(modTemplateVar::class);
             $c->leftJoin('modCategory', 'Category');
-            $c->select($this->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar'));
+            $c->select($this->xpdo->getSelectColumns(modTemplateVar::class, 'modTemplateVar'));
             $c->select([
                 'Category.category AS category_name',
             ]);
             $c->sortby('Category.category', 'ASC');
             $c->sortby('modTemplateVar.name', 'ASC');
-            $tvs = $this->xpdo->getCollection('modTemplateVar', $c);
+            $tvs = $this->xpdo->getCollection(modTemplateVar::class, $c);
         }
         /** @var modTemplateVar $tv */
         foreach ($tvs as $tv) {

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -480,7 +480,7 @@ class modParser
                         $elementOutput= $element->process($tagPropString);
                     }
                     else {
-                        $element = $this->getElement('modTemplateVar', $tagName);
+                        $element = $this->getElement(modTemplateVar::class, $tagName);
 
                         // If our element tag was not found (e.i. not an existing TV), create a new instance of
                         // modFieldTag. We do this to make it possible to use output modifiers such as default. This

--- a/core/src/Revolution/modTemplate.php
+++ b/core/src/Revolution/modTemplate.php
@@ -167,12 +167,12 @@ class modTemplate extends modElement
     public function & getMany($alias, $criteria = null, $cacheFlag = true)
     {
         if (($alias === 'TemplateVars' || $alias === 'modTemplateVar') && ($criteria === null || strtolower($criteria) === 'all')) {
-            $c = $this->xpdo->newQuery('modTemplateVar');
+            $c = $this->xpdo->newQuery(modTemplateVar::class);
             $c->query['distinct'] = 'DISTINCT';
-            $c->select($this->xpdo->getSelectColumns('modTemplateVar'));
+            $c->select($this->xpdo->getSelectColumns(modTemplateVar::class));
             $c->select($this->xpdo->getSelectColumns('modTemplateVarTemplate', 'tvtpl', '', ['rank']));
             $c->select([
-                'value' => $this->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar', '', ['default_text']),
+                'value' => $this->xpdo->getSelectColumns(modTemplateVar::class, 'modTemplateVar', '', ['default_text']),
             ]);
             $c->innerJoin('modTemplateVarTemplate', 'tvtpl', [
                 'tvtpl.tmplvarid = modTemplateVar.id',
@@ -180,7 +180,7 @@ class modTemplate extends modElement
             ]);
             $c->sortby('tvtpl.rank,modTemplateVar.rank');
 
-            $collection = $this->xpdo->getCollection('modTemplateVar', $c, $cacheFlag);
+            $collection = $this->xpdo->getCollection(modTemplateVar::class, $c, $cacheFlag);
         } else {
             $collection = parent:: getMany($alias, $criteria, $cacheFlag);
         }
@@ -197,7 +197,7 @@ class modTemplate extends modElement
      */
     public function getTemplateVars()
     {
-        $c = $this->xpdo->newQuery('modTemplateVar');
+        $c = $this->xpdo->newQuery(modTemplateVar::class);
         $c->innerJoin('modTemplateVarTemplate', 'TemplateVarTemplates');
         $c->where([
             'TemplateVarTemplates.templateid' => $this->get('id'),
@@ -234,7 +234,7 @@ class modTemplate extends modElement
     public function hasTemplateVar($tvPk)
     {
         if (!is_int($tvPk) && !is_object($tvPk)) {
-            $tv = $this->xpdo->getObject('modTemplateVar', ['name' => $tvPk]);
+            $tv = $this->xpdo->getObject(modTemplateVar::class, ['name' => $tvPk]);
             if (empty($tv) || !is_object($tv) || !($tv instanceof modTemplateVar)) {
                 $this->xpdo->log(modX::LOG_LEVEL_ERROR, 'modTemplate::hasTemplateVar - No TV: ' . $tvPk);
 


### PR DESCRIPTION
### What does it do?
Use the fully qualified class names for modTemplateVar when possible

### Why is it needed?
To make sure we have the right class names.

### Related issue(s)/PR(s)
Fixes #14714
