### PR TITLE
Use fully qualified class names for modTemplate

### DIFF
--- a/_build/test/Tests/Model/Element/modTemplateTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateTest.php
@@ -31,7 +31,7 @@ class modTemplateTest extends MODxTestCase {
 
     public function setUp() {
         parent::setUp();
-        $this->template = $this->modx->newObject('modTemplate');
+        $this->template = $this->modx->newObject(modTemplate::class);
         $this->template->fromArray(array(
             'id' => 12345,
             'templatename' => 'Unit Test Template',

--- a/core/src/Revolution/modTemplate.php
+++ b/core/src/Revolution/modTemplate.php
@@ -221,7 +221,7 @@ class modTemplate extends modElement
      */
     public function getTemplateVarList(array $sort = ['name' => 'ASC'], $limit = 0, $offset = 0, array $conditions = [])
     {
-        return $this->xpdo->call('modTemplate', 'listTemplateVars', [&$this, $sort, $limit, $offset, $conditions]);
+        return $this->xpdo->call(modTemplate::class, 'listTemplateVars', [&$this, $sort, $limit, $offset, $conditions]);
     }
 
     /**

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -1162,7 +1162,7 @@ class modTemplateVar extends modElement
     public function hasTemplate($templatePk)
     {
         if (!is_int($templatePk) && !is_object($templatePk)) {
-            $template = $this->xpdo->getObject('modTemplate', ['templatename' => $templatePk]);
+            $template = $this->xpdo->getObject(modTemplate::class, ['templatename' => $templatePk]);
             if (empty($template) || !is_object($template) || !($template instanceof modTemplate)) {
                 $this->xpdo->log(modX::LOG_LEVEL_ERROR, 'modTemplateVar::hasTemplate - No template: ' . $templatePk);
 


### PR DESCRIPTION
### What does it do?
Use the fully qualified class names for modTemplate when possible

### Why is it needed?
To make sure we have the right class names.

### Related issue(s)/PR(s)
Related PR #14720