### PR TITLE
Use fully qualified class names for modCategory

### DIFF
--- a/core/src/Revolution/Processors/Element/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/GetNodes.php
@@ -325,7 +325,7 @@ class GetNodes extends modProcessor
                 'cls' => $class,
                 'iconCls' => $this->getNodeIcon('category'),
                 'page' => '',
-                'classKey' => 'modCategory',
+                'classKey' => 'MODX\\Revolution\\modCategory',
                 'type' => 'category',
             ];
         }

--- a/core/src/Revolution/Processors/Element/PropertySet/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/GetNodes.php
@@ -89,7 +89,7 @@ class GetNodes extends modObjectProcessor
         $c = $this->modx->newQuery(modCategory::class);
         $c->sortby($this->modx->escape('rank'), 'ASC');
         $c->sortby('category', 'ASC');
-        $categories = $this->modx->getIterator('modCategory', $c);
+        $categories = $this->modx->getIterator(modCategory::class, $c);
 
         /** @var modCategory $category */
         foreach ($categories as $category) {
@@ -108,7 +108,7 @@ class GetNodes extends modObjectProcessor
                 'cls' => 'icon-category',
                 'iconCls' => $this->getNodeIcon('category'),
                 'href' => '',
-                'class_key' => 'modCategory',
+                'class_key' => 'MODX\\Revolution\\modCategory',
                 'menu' => [],
             ];
 

--- a/core/src/Revolution/Processors/Element/Sort.php
+++ b/core/src/Revolution/Processors/Element/Sort.php
@@ -166,7 +166,7 @@ class Sort extends modProcessor
                 continue;
             }
 
-            if ($item['class'] == 'modCategory') {
+            if ($item['class'] == modCategory::class) {
                 /** @var modCategory $category */
                 $category = $this->modx->getObject(modCategory::class, $item['pk']);
                 if ($category) {

--- a/core/src/Revolution/modFormCustomizationSet.php
+++ b/core/src/Revolution/modFormCustomizationSet.php
@@ -90,7 +90,7 @@ class modFormCustomizationSet extends xPDOSimpleObject
         /* get TVs */
         if ($this->get('template')) {
             $c = $this->xpdo->newQuery('modTemplateVar');
-            $c->leftJoin('modCategory', 'Category');
+            $c->leftJoin(modCategory::class, 'Category');
             $c->innerJoin('modTemplateVarTemplate', 'TemplateVarTemplates');
             $c->select($this->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar'));
             $c->select([
@@ -105,7 +105,7 @@ class modFormCustomizationSet extends xPDOSimpleObject
 
         } else {
             $c = $this->xpdo->newQuery('modTemplateVar');
-            $c->leftJoin('modCategory', 'Category');
+            $c->leftJoin(modCategory::class, 'Category');
             $c->select($this->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar'));
             $c->select([
                 'Category.category AS category_name',


### PR DESCRIPTION
### What does it do?
Use the fully qualified class names for modCategory when possible

### Why is it needed?
To make sure we have the right class names.

### Related issue(s)/PR(s)
Related PR #14720
Related PR #14721