### PR TITLE
Check permissions for locked elements

### DIFF
--- a/core/lexicon/en/plugin.inc.php
+++ b/core/lexicon/en/plugin.inc.php
@@ -25,6 +25,7 @@ $_lang['plugin_err_create'] = 'An error occurred while creating the plugin.';
 $_lang['plugin_err_ae'] = 'A plugin already exists with the name "[[+name]]".';
 $_lang['plugin_err_invalid_name'] = 'Plugin name is invalid.';
 $_lang['plugin_err_duplicate'] = 'An error occurred while trying to duplicate the plugin.';
+$_lang['plugin_err_locked'] = 'Plugin is locked.';
 $_lang['plugin_err_nf'] = 'Plugin not found!';
 $_lang['plugin_err_ns'] = 'Plugin not specified.';
 $_lang['plugin_err_ns_name'] = 'Please specify a name for the plugin.';

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -78,6 +78,10 @@ class ElementPluginUpdateManagerController extends modManagerController {
         if ($this->plugin == null) return $this->failure($this->modx->lexicon('plugin_err_nf'));
         if (!$this->plugin->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
+        if ($this->plugin->get('locked') && !$this->modx->hasPermission('edit_locked')) {
+            return $this->failure($this->modx->lexicon('plugin_err_locked'));
+        }
+
         /* get properties */
         $properties = $this->plugin->get('properties');
         if (!is_array($properties)) $properties = array();

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -77,6 +77,10 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         if ($this->snippet == null) return $this->failure($this->modx->lexicon('snippet_err_nf'));
         if (!$this->snippet->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
+        if ($this->snippet->get('locked') && !$this->modx->hasPermission('edit_locked')) {
+            return $this->failure($this->modx->lexicon('snippet_err_locked'));
+        }
+
         /* get properties */
         $properties = $this->snippet->get('properties');
         if (!is_array($properties)) $properties = array();

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -78,6 +78,10 @@ class ElementTemplateUpdateManagerController extends modManagerController {
         if ($this->template == null) return $this->failure($this->modx->lexicon('template_err_nf'));
         if (!$this->template->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
+        if ($this->template->get('locked') && !$this->modx->hasPermission('edit_locked')) {
+            return $this->failure($this->modx->lexicon('template_err_locked'));
+        }
+
         /* get properties */
         $properties = $this->template->get('properties');
         if (!is_array($properties)) $properties = array();

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -79,6 +79,10 @@ class ElementTVUpdateManagerController extends modManagerController {
         if ($this->tv == null) return $this->failure($this->modx->lexicon('tv_err_nf'));
         if (!$this->tv->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
+        if ($this->tv->get('locked') && !$this->modx->hasPermission('edit_locked')) {
+            return $this->failure($this->modx->lexicon('tv_err_locked'));
+        }
+
         /* get properties */
         $properties = $this->tv->get('properties');
         if (!is_array($properties)) $properties = array();


### PR DESCRIPTION
### What does it do?
When editing a locked snippets, templates, template variables, and plugins make sure the user has the right permissions to do so

### Why is it needed?
To make sure only users with the `edit_locked` permissions can edit locked elements.

### Related issue(s)/PR(s)
Fixes issue #14702