### PR TITLE
Correct deprecation warning in modX::loadClass

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2430,11 +2430,26 @@ class modX extends xPDO {
     }
 
 
+    /**
+     * Load a class by fully qualified name.
+     *
+     * As of MODX 3.0, this is no longer necessary and deprecated. Instead of using loadClass, use the PSR-4 class
+     * references that are available through the autoloader.
+     *
+     * @param string $fqn
+     * @param string $path
+     * @param bool $ignorePkg
+     * @param bool $transient
+     * @return bool|string
+     * @deprecated Since 3.0
+     */
     public function loadClass($fqn, $path = '', $ignorePkg = false, $transient = false)
     {
         if (strpos($fqn, '\\') !== false && class_exists($fqn)) {
             return $fqn;
-        } elseif (empty($path)) {
+        }
+
+        if (empty($path)) {
             $class = $fqn;
             if (strpos($fqn, '.') !== false) {
                 $tmp = explode('.', $fqn);
@@ -2452,12 +2467,12 @@ class modX extends xPDO {
                     class_alias($class, $fqn);
                 }
 
-                $this->deprecated('3.0', "Replace references to class {$fqn} with {$class} to take advantage of PSR-4 autoloading.");
+                $this->deprecated('3.0', "Replace references to class {$fqn} with {$class} to take advantage of PSR-4 autoloading.", $fqn);
 
                 return $class;
-            } else {
-                $this->log(MODX::LOG_LEVEL_WARN, "Could not find legacy class {$fqn} after converting to {$class}");
             }
+
+            $this->log(self::LOG_LEVEL_WARN, "Could not find legacy class {$fqn} after converting to {$class}");
         }
 
         return parent::loadClass($fqn, $path, $ignorePkg, $transient);


### PR DESCRIPTION
### What does it do?

Slightly improves the code style in modX::loadClass (no need for `else` after a return in an `if`), but more importantly this corrects the deprecation warning. 

### Why is it needed?

The `loadClass` method is used a lot, and at the moment when an old class style is encountered it automatically converts it to the new naming and logs a deprecated warning like this:

```
MODX\Revolution\modX::loadClass is deprecated since version 3.0. Replace references to class modx.modNamespace with MODX\Revolution\modNamespace to take advantage of PSR-4 autoloading.
```

However that error incorrectly states that `modX::loadClass` is deprecated. 

With this patch, the error is instead:

```
modx.modNamespace is deprecated since version 3.0. Replace references to class modx.modNamespace with MODX\Revolution\modNamespace to take advantage of PSR-4 autoloading.
```

Also corrects incorrect reference to `MODX` instead of `modX` in the log level. 

### Related issue(s)/PR(s)

Mentioned in #14687