### PR TITLE
Fix listing categories and elements in nested categories

### DIFF
--- a/core/src/Revolution/Processors/Element/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/GetNodes.php
@@ -349,10 +349,10 @@ class GetNodes extends modProcessor
         /* first handle subcategories */
         $c = $this->modx->newQuery(modCategory::class);
         $c->select($this->modx->getSelectColumns(modCategory::class, 'modCategory'));
-        $c->select('COUNT(DISTINCT ' . $elementClassKey . '.id) AS elementCount');
+        $c->select('COUNT(DISTINCT ' . $elementType . '.id) AS elementCount');
         $c->select('COUNT(DISTINCT ' . $this->modx->getSelectColumns(modCategory::class, 'Children', '',
                 ['id']) . ') AS childrenCount');
-        $c->leftJoin($elementClassKey, $elementClassKey, $elementClassKey . '.category = modCategory.id');
+        $c->leftJoin($elementClassKey, $elementType, $elementType . '.category = modCategory.id');
         $c->leftJoin(modCategory::class, 'Children');
         $c->where([
             'parent' => $categoryId,
@@ -577,12 +577,12 @@ class GetNodes extends modProcessor
         $c = $this->modx->newQuery(modCategory::class);
         $c->select($this->modx->getSelectColumns(modCategory::class, 'modCategory'));
         $c->select('
-            COUNT(DISTINCT ' . $this->modx->getSelectColumns($elementClassKey, $elementClassKey, '', ['id']) . ') AS elementCount,
+            COUNT(DISTINCT ' . $this->modx->getSelectColumns($elementClassKey, $elementType, '', ['id']) . ') AS elementCount,
             COUNT(DISTINCT ' . $this->modx->getSelectColumns(modCategory::class, 'Children', '', ['id']) . ') AS childrenCount
         ');
-        $c->leftJoin($elementClassKey, $elementClassKey,
-            $this->modx->getSelectColumns($elementClassKey, $elementClassKey, '',
-                ['category']) . ' = ' . $this->modx->getSelectColumns(modCategory::class, 'modCategory', '', ['id']));
+        $c->leftJoin($elementClassKey, $elementType,
+            $this->modx->getSelectColumns($elementClassKey, $elementType, '', ['category'])
+            . ' = ' . $this->modx->getSelectColumns(modCategory::class, 'modCategory', '', ['id']));
         $c->leftJoin(modCategory::class, 'Children');
         $c->where([
             'modCategory.parent' => 0,
@@ -725,13 +725,15 @@ class GetNodes extends modProcessor
             'parent' => $categoryId,
         ]);
 
+        $elementType = array_search($elementClassKey, $this->typeMap, true);
+
         foreach ($categories as $category) {
             $c = $this->modx->newQuery(modCategory::class);
             $c->select($this->modx->getSelectColumns(modCategory::class, 'modCategory'));
-            $c->select('COUNT(DISTINCT ' . $elementClassKey . '.id) AS elementCount');
+            $c->select('COUNT(DISTINCT ' . $elementType . '.id) AS elementCount');
             $c->select('COUNT(DISTINCT ' . $this->modx->getSelectColumns(modCategory::class, 'Children', '',
                     ['id']) . ') AS childrenCount');
-            $c->leftJoin($elementClassKey, $elementClassKey, $elementClassKey . '.category = modCategory.id');
+            $c->leftJoin($elementClassKey, $elementType, $elementType . '.category = modCategory.id');
             $c->leftJoin(modCategory::class, 'Children');
             $c->where([
                 'id' => $category->get('id'),


### PR DESCRIPTION
### What does it do?

Replaces references of the class key (e.g. `MODX\Revolution\modSnippet`) with a database-friendly alias (e.g. `Snippet`) in the getnodes processor responsible for listing elements.

### Why is it needed?

Elements inside categories, or nested categories, would not get listed in the elements tree, with errors like this getting sent to the log:

```
Error 42000 executing statement: 
Array
(
    [0] => 42000
    [1] => 1064
    [2] => You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '\Revolution\modSnippet.id) AS elementCount, COUNT(DISTINCT `Children`.`id`) AS c' at line 1
)
```

In some cases it would also cause a fatal error because the `getObject` failed on (new) line 742 in `subCategoriesHaveElements()`. 

```
[09-Sep-2019 23:19:15 Europe/Amsterdam] PHP Fatal error:  Uncaught Error: Call to a member function get() on null in core/src/Revolution/Processors/Element/GetNodes.php:742
Stack trace:
#0 core/src/Revolution/Processors/Element/GetNodes.php(619): MODX\Revolution\Processors\Element\GetNodes->subCategoriesHaveElements(2, 'MODX\\Revolution...')
#1 core/src/Revolution/Processors/Element/GetNodes.php(71): MODX\Revolution\Processors\Element\GetNodes->getTypeNodes(Array)
#2 core/src/Revolution/modProcessor.php(178): MODX\Revolution\Processors\Element\GetNodes->process()
#3 core/src/Revolution/modX.php(1742): MODX\Revolution\modProcessor->run()
#4 core/src/Revolution/modConnectorResponse.php(151): MODX\Revolution\modX->runProcessor('Element/GetNode...', Array, Array)
#5 core/src/Revolution/modConnectorRequest.php(93): MODX\Revolution\modCon in core/src/Revolution/Processors/Element/GetNodes.php on line 742
```

Noticed this while testing #14722. 

### Related issue(s)/PR(s)

Surprisingly; I don't see any reports for this issue yet, even though the elements tree was pretty badly broken before. 