### PR TITLE
Added adaptive styles for MODX browser

### DIFF
--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -292,9 +292,9 @@
     background-color: $white !important;
   }
 
-  .modx-browser-tree, .modx-browser-view-ct, .modx-browser-details-ct {
-    width: 30% !important;
-    max-width: 30% !important;
+  .modx-browser-tree, .modx-browser-view-ct {
+    width: 35% !important;
+    max-width: 35% !important;
     padding: 0 5px;
     display: inline-block !important;
     position: relative !important;
@@ -302,7 +302,25 @@
     left: 0 !important;
   }
 
-  .modx-browser .x-toolbar-ct tbody tr td {
+  .modx-browser-details-ct {
+    width: 20% !important;
+    max-width: 20% !important;
+    padding: 0 5px;
+    display: inline-block !important;
+    position: relative !important;
+    float: left;
+    left: 0 !important;
+  }
+
+  .modx-browser-tree *, .modx-browser-view-ct *, .modx-browser-details-ct * {
+    font-size: 12px !important;
+  }
+
+  .modx-browser-tree input, .modx-browser-view-ct input, .modx-browser-details-ct input {
+    padding: 5px !important;
+  }
+
+  .modx-browser-tree .x-toolbar-ct tbody tr td {
     display: table-cell;
   }
 
@@ -330,5 +348,13 @@
 
   .modx-browser-thumb img {
     max-width: 100%;
+  }
+
+  .modx-browser-placeholder {
+    height: 50px;
+  }
+
+  .modx-browser-details-info {
+    padding: 5px;
   }
 }

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -277,3 +277,58 @@
     background-image: url($imgPath + 'modx-theme/transparency-pattern.png');
   }
 }
+
+@include grid-media($desktop) {
+  .modx-browser {
+    top: 15px !important;
+    max-height: 100% !important;
+    overflow-y: scroll;
+  }
+
+  .modx-browser-panel {
+    width: 100% !important;
+    min-height: 700px;
+    margin: 15px 0 !important;
+    background-color: $white !important;
+  }
+
+  .modx-browser-tree, .modx-browser-view-ct, .modx-browser-details-ct {
+    width: 30% !important;
+    max-width: 30% !important;
+    padding: 0 5px;
+    display: inline-block !important;
+    position: relative !important;
+    float: left;
+    left: 0 !important;
+  }
+
+  .modx-browser .x-toolbar-ct tbody tr td {
+    display: table-cell;
+  }
+
+  .modx-browser .x-panel-tbar-noheader, .modx-browser .x-toolbar, .modx-browser-view-ct .x-panel-tbar-noheader, .modx-browser-view-ct .x-panel-tbar, .modx-browser-view-ct .x-panel-tbar .x-toolbar, .modx-browser-view-ct .x-panel-body {
+    width: 100% !important;
+  }
+
+  .modx-browser-view-ct .x-panel-tbar .x-toolbar-cell label {
+    line-height: 2.2;
+  }
+
+  .modx-browser-thumb-wrap {
+    width: 24%;
+    margin: 5px;
+    padding: 5px;
+  }
+
+  .modx-browser-thumb {
+    max-width: 100%;
+    height: 25px;
+    line-height: 25px;
+    overflow: hidden;
+    padding: 0;
+  }
+
+  .modx-browser-thumb img {
+    max-width: 100%;
+  }
+}

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -351,7 +351,7 @@ textarea.x-form-field {
 .x-window {
   @include grid-media($desktop) {
     width: auto !important;
-    max-width: 100vh !important;
+    max-width: 100% !important;
     left: 0.5em !important;
     right: 0.5em !important;
 
@@ -637,7 +637,9 @@ a.x-grid-link:focus {
   .x-panel-body {
     @include grid-media($desktop) {
       height: auto !important;
+      max-height: 100% !important;
       width: auto !important;
+      max-width: 100% !important;
     }
   }
 }


### PR DESCRIPTION
### What does it do?
In the previous version of adaptive styles, the MODX browser did not work at all, this PR fixes this.

By the way, for **MODX 2.7 the browser also does not work**, we can copy these styles for MODX 2.7.2

![browser](https://user-images.githubusercontent.com/12523676/64718975-5d9b6400-d4d8-11e9-8115-4013455933c2.png)

### Related issue(s)/PR(s)
None
