### PR TITLE
Prevent users without edit_locked permission from editing locked elements

### DIFF
--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -75,10 +75,6 @@ class ElementChunkUpdateManagerController extends modManagerController {
         if (empty($this->chunk)) return $this->failure($this->modx->lexicon('chunk_err_nfs',array('id' => $scriptProperties['id'])));
         if (!$this->chunk->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
-        if ($this->chunk->get('locked') && !$this->modx->hasPermission('edit_locked')) {
-            return $this->failure($this->modx->lexicon('chunk_err_locked'));
-        }
-
         /* grab category for chunk, assign to parser */
         $placeholders['chunk'] = $this->chunk;
 


### PR DESCRIPTION
### What does it do?

Makes sure that the locked status of an element, and the `edit_locked` permission, is checked **before** the `locked` value is set on the object being edited. 

### Why is it needed?

The current situation allows users without edit_locked permission from editing locked elements by unchecking the `locked` checkbox. 

This was [identified in PR #14723](https://github.com/modxcms/revolution/pull/14723#pullrequestreview-285737349), which attempted to resolve the problem by preventing the manager controller from loading for affected elements. However that solution does not prevent directly submitting to the processor, which was still affected, and the `edit_locked` permission is _not_ meant to block _accessing_ an elements view. 

Now when trying to save a locked element, an error pops up saying it is locked.

This PR also removes a check in the Chunk update controller which prevented accessing the chunk view when it was locked. If the intention is to disable access to elements completely; that can be accomplished with element category access ACLs. 

### Related issue(s)/PR(s)

Fixes #14702, replaces #14723. 