### PR TITLE
Prevent users without edit_locked permission from editing locked elements (3.x)

### DIFF
--- a/core/src/Revolution/Processors/Element/Update.php
+++ b/core/src/Revolution/Processors/Element/Update.php
@@ -29,6 +29,15 @@ abstract class Update extends modObjectUpdateProcessor
     /** @var modElement $object */
     public $object;
 
+    public function beforeSet()
+    {
+        // Make sure the element isn't locked
+        if ($this->object->get('locked') && !$this->modx->hasPermission('edit_locked')) {
+            return $this->modx->lexicon($this->objectType.'_err_locked');
+        }
+        return parent::beforeSet();
+    }
+
     public function beforeSave()
     {
         $locked = $this->getProperty('locked');
@@ -37,7 +46,7 @@ abstract class Update extends modObjectUpdateProcessor
         }
 
         /* make sure a name was specified */
-        $nameField = $this->classKey == modTemplate::class ? 'templatename' : 'name';
+        $nameField = $this->classKey === modTemplate::class ? 'templatename' : 'name';
         $name = $this->getProperty($nameField, '');
         if (empty($name)) {
             $this->addFieldError($nameField, $this->modx->lexicon($this->objectType . '_err_ns_name'));
@@ -47,11 +56,6 @@ abstract class Update extends modObjectUpdateProcessor
                 $this->modx->error->addField($nameField,
                     $this->modx->lexicon($this->objectType . '_err_ae', ['name' => $name]));
             }
-        }
-
-        /* if element is locked */
-        if ($this->object->get('locked') && $this->modx->hasPermission('edit_locked') == false) {
-            $this->addFieldError($nameField, $this->modx->lexicon($this->objectType . '_err_locked'));
         }
 
         /* category */
@@ -86,7 +90,7 @@ abstract class Update extends modObjectUpdateProcessor
 
     public function alreadyExists($name)
     {
-        $nameField = $this->classKey == modTemplate::class ? 'templatename' : 'name';
+        $nameField = $this->classKey === modTemplate::class ? 'templatename' : 'name';
 
         return $this->modx->getCount($this->classKey, [
                 'id:!=' => $this->object->get('id'),

--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -77,10 +77,6 @@ class ElementChunkUpdateManagerController extends modManagerController {
         if (empty($this->chunk)) return $this->failure($this->modx->lexicon('chunk_err_nfs',array('id' => $scriptProperties['id'])));
         if (!$this->chunk->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
-        if ($this->chunk->get('locked') && !$this->modx->hasPermission('edit_locked')) {
-            return $this->failure($this->modx->lexicon('chunk_err_locked'));
-        }
-
         /* grab category for chunk, assign to parser */
         $placeholders['chunk'] = $this->chunk;
 


### PR DESCRIPTION
Exact replica of #14739 for 3.x; in case a cherry-pick does not apply cleanly due to the refactored processors. 