### PR TITLE
Add hover effect and tooltip for editable grid columns [#14176]

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -540,6 +540,12 @@ a.x-grid-link:focus {
   cursor: pointer;
   &:hover, &:focus {
     color: $colorSplash;
+    > div::after {
+      @include awesome-font;
+      content: fa-content($fa-var-pen);
+      margin-left: 0.5em;
+      color: $colorSplash;
+    }
   }
 }
 

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -536,6 +536,12 @@ a.x-grid-link:hover,
 a.x-grid-link:focus {
   text-decoration: underline;
 }
+.x-editable-column {
+  cursor: pointer;
+  &:hover, &:focus {
+    color: $colorSplash;
+  }
+}
 
 /* panel stylings */
 .modx-page-header,

--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -133,7 +133,6 @@ $_lang['edit_tv'] = 'Edit TV';
 $_lang['editing'] = 'Editing: [[+name]]';
 $_lang['editedon'] = 'Edit Date';
 $_lang['editing_form'] = 'Editing Form';
-$_lang['editable_field'] = 'Double-click to edit this value.';
 $_lang['element_duplicate_values'] = 'Duplicate Resource Values?';
 $_lang['element_name_new'] = 'Name of New Element';
 $_lang['element_caption_new'] = 'Caption of New Element';

--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -133,6 +133,7 @@ $_lang['edit_tv'] = 'Edit TV';
 $_lang['editing'] = 'Editing: [[+name]]';
 $_lang['editedon'] = 'Edit Date';
 $_lang['editing_form'] = 'Editing Form';
+$_lang['editable_field'] = 'Double-click to edit this value.';
 $_lang['element_duplicate_values'] = 'Duplicate Resource Values?';
 $_lang['element_name_new'] = 'Name of New Element';
 $_lang['element_caption_new'] = 'Caption of New Element';

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -379,6 +379,15 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 if (Ext.isEmpty(c[i].renderer)) {
                     c[i].renderer = Ext.util.Format.htmlEncode;
                 }
+
+                /**
+                 * When the field has an editor defined, wrap the (optional) renderer with
+                 * a special renderer that applies a class and tooltip to indicate the
+                 * column is editable.
+                 */
+                if (c[i].editor) {
+                    c[i].renderer = this.renderEditableColumn(c[i].renderer);
+                }
             }
             this.cm = new Ext.grid.ColumnModel(c);
         }
@@ -436,6 +445,18 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
             z = z+'*';
         }
         return z;
+    }
+
+    ,renderEditableColumn: function(renderer) {
+        return function(value, metaData, record, rowIndex, colIndex, store) {
+            if (renderer) {
+                value = renderer(value, metaData, record, rowIndex, colIndex, store);
+            }
+            metaData.css = ['x-editable-column', metaData.css || ''].join(' ');
+            metaData.attr = ['ext:qtip="' + _('editable_field') + '"', metaData.attr || ''].join(' ');
+
+            return value;
+        }
     }
 
     ,rendYesNo: function(v,md) {

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -453,7 +453,6 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 value = renderer(value, metaData, record, rowIndex, colIndex, store);
             }
             metaData.css = ['x-editable-column', metaData.css || ''].join(' ');
-            metaData.attr = ['ext:qtip="' + _('editable_field') + '"', metaData.attr || ''].join(' ');
 
             return value;
         }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -307,13 +307,13 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         var f;
         if (r.xtype == 'combo-boolean' || r.xtype == 'modx-combo-boolean') {
             f = MODx.grid.Grid.prototype.rendYesNo;
-            return f(v,md,rec,ri,ci,s,g);
+            return this.renderEditableColumn(f)(v,md,rec,ri,ci,s,g);
         } else if (r.xtype === 'datefield') {
             f = Ext.util.Format.dateRenderer(MODx.config.manager_date_format);
-            return f(v,md,rec,ri,ci,s,g);
+            return this.renderEditableColumn(f)(v,md,rec,ri,ci,s,g);
         } else if (r.xtype === 'text-password' || r.xtype == 'modx-text-password') {
             f = MODx.grid.Grid.prototype.rendPassword;
-            return f(v,md,rec,ri,ci,s,g);
+            return this.renderEditableColumn(f)(v,md,rec,ri,ci,s,g);
         } else if (r.xtype.substr(0,5) == 'combo' || r.xtype.substr(0,10) == 'modx-combo') {
             var cm = g.getColumnModel();
             var ed = cm.getCellEditor(ci,ri);
@@ -327,9 +327,9 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
                 ed.store.isLoaded = true;
             }
             f = Ext.util.Format.comboRenderer(ed.field,v);
-            return f(v,md,rec,ri,ci,s,g);
+            return this.renderEditableColumn(f)(v,md,rec,ri,ci,s,g);
         }
-        return v;
+        return this.renderEditableColumn()(v,md,rec,ri,ci,s,g);
     }
 
     /**


### PR DESCRIPTION
### What does it do?

Adds a special renderer to all grids (* at least, all grids that define `columns` as a config property; some grids like the settings grid that build a custom ColumnModel need additional work, as shown in this PR as well) that automatically adds a class to grid cells that are editable, as well as a tooltip.

Through the CSS, the cursor is changed, and the color set to the splash color on hover. Open to improvement ideas for the styling.

### Why is it needed?

Make it clear what columns can be edited inline, which is not visible anywhere currently.

This is an enhancement for #14580 which added similar tweaks only to the settings grid. Following on the discussion there, this PR adds it globally to all grids. 

### Related issue(s)/PR(s)

Fixes #14176
Follows up on the discussion in #14580

(Requires rebuild)