### PR TITLE
Fix height of content in resource

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -1133,7 +1133,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 ,id: 'ta'
                 ,fieldLabel: _('resource_content')
                 ,anchor: '100%'
-                ,height: 451
+                ,height: 468
                 ,grow: false
                 ,value: (config.record.content || config.record.ta) || ''
             },{


### PR DESCRIPTION
### What does it do?
Corrected the height of the content in the resource.

Before:
![before](https://user-images.githubusercontent.com/12523676/65376300-423a1100-dcaf-11e9-9f65-be1fe78873ed.png)

After:
![after](https://user-images.githubusercontent.com/12523676/65376299-423a1100-dcaf-11e9-9a59-5d7d769e1339.png)

### Related issue(s)/PR(s)
None
