### PR TITLE
Load the setup assets when MODX is inside a subdirectory

### DIFF
--- a/setup/templates/header.tpl
+++ b/setup/templates/header.tpl
@@ -6,7 +6,6 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <base href="/setup/">
     <link rel="shortcut icon" href="favicon.ico" />
     <link href="assets/css/installer.css" type="text/css" rel="stylesheet" />
 


### PR DESCRIPTION
### What does it do?
Don't set a base href for the setup.

### Why is it needed?
It would prevent the assets (CSS/JS) to be loaded if MODX was inside a subdirectory.

### Related issue(s)/PR(s)
Issue #14742