### PR TITLE
Added missing indent in package update window

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -379,6 +379,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
                 'success': {fn:function(r) {
                     this.loadWindow(btn,e,{
                         xtype: 'modx-window-package-update'
+                        ,cls: 'modx-alert'
                         ,packages: r.object
                         ,record: this.menu.record
                         ,force: true


### PR DESCRIPTION
### What does it do?
Added missing indent in package update window.

Before
![before](https://user-images.githubusercontent.com/12523676/55347103-058e1980-54c5-11e9-8d01-b5ece6d9fdc4.png)

After
![after](https://user-images.githubusercontent.com/12523676/55347102-058e1980-54c5-11e9-95ce-ba0885ae8b2f.png)

Because for branch 2.x, global style changes are no longer expected, solved the problem in a simpler way and closed old branch. See discussion here - https://github.com/modxcms/revolution/pull/14518