### PR TITLE
Corrected login styles

### DIFF
--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -28,10 +28,6 @@ html {
   outline: 0;
 }
 
-*:focus {
-  box-shadow: 0 0 0 0.125rem $blue;
-}
-
 body,
 h1,
 h2,
@@ -46,7 +42,11 @@ form {
   margin: 0;
   padding: 0;
   font-weight: normal;
-  color: $black;
+  color: $mineShaft;
+}
+
+strong {
+  font-weight: 600;
 }
 
 body {
@@ -160,16 +160,31 @@ a {
 }
 
 input {
+  display: inline-block;
+  width: 100%;
+  background: $lightestGray;
+  border-radius: $borderRadius;
+  outline-color: $green;
   font-size: 1rem;
   padding: 1rem;
   box-shadow: none;
   border: 1px solid $lightGray;
 }
 
+input[type="checkbox"] {
+  width: auto;
+  margin: 0 0.5rem 0 0;
+  position: relative;
+  top: 0;
+}
+
+input:focus {
+  border: 1px solid $blue;
+}
+
 label {
   display: block;
   margin: 1.25rem 0;
-  color: $darkestGray;
   cursor: pointer;
   font-weight: 500;
 
@@ -184,22 +199,8 @@ label#rememberme-checkbox {
   align-items: center;
 }
 
-input {
-  display: inline-block;
-  width: 100%;
-  border-radius: $borderRadius;
-  outline-color: $green;
-}
-
 label > input {
   margin-top: 0.25rem;
-}
-
-input[type="checkbox"] {
-  width: auto;
-  margin: 0 0.5rem 0 0;
-  position: relative;
-  top: 0;
 }
 
 /**
@@ -238,16 +239,6 @@ input[type="checkbox"] {
   cursor: pointer;
 }
 
-.c-button--ghost {
-  color: $blue;
-  background: transparent;
-  border: none;
-
-  .c-arrow {
-    stroke: $blue;
-  }
-}
-
 #modx-login-btn,
 #modx-fl-btn {
   border: 1px solid transparent;
@@ -275,7 +266,6 @@ input[type="checkbox"] {
   margin-bottom: 10px;
   width: 100%;
 }
-
 
 .c-helplink {
   margin-left: 2rem;
@@ -327,7 +317,7 @@ input[type="checkbox"] {
   z-index: 1;
   display: block;
   position: absolute;
-  top: 50%;
+  top: 55%;
   transform: translateY(-50%);
   right: 0;
   width: 0;
@@ -337,15 +327,34 @@ input[type="checkbox"] {
   border-color: $darkestGray transparent transparent transparent;
 }
 
+.c-button--ghost {
+  color: $blue;
+  background: transparent;
+  border: none;
+
+  &:hover {
+    opacity: .8;
+  }
+
+  .c-arrow {
+    stroke: $blue;
+  }
+
+  :hover > & {
+    left: -0.5rem;
+    right: 0;
+  }
+}
+
 .c-arrow {
-  stroke: $black;
+  stroke: $mineShaft;
   vertical-align: middle;
   position: relative;
   top: -2px;
   transition: left .4s ease-in-out, right .4s ease-in-out;
   right: 0;
 
-  a:hover > & {
+  .c-button:hover > & {
     right: -0.5rem;
   }
 
@@ -353,7 +362,7 @@ input[type="checkbox"] {
     transform: rotate(180deg);
     left: 0;
 
-    a:hover > & {
+    .c-button:hover > & {
       left: -0.5rem;
       right: 0;
     }

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -8,11 +8,11 @@
         <meta name="robots" content="noindex, nofollow">
 
         {if $_config.manager_favicon_url}
-            <link rel="shortcut icon" type="image/x-icon" href="{$_config.manager_favicon_url}" />
+            <link rel="shortcut icon" type="image/x-icon" href="{$_config.manager_favicon_url}">
             <link rel="apple-touch-icon" href="{$_config.manager_favicon_url}">
         {/if}
 
-        <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/login{if $_config.compress_css}-min{/if}.css" />
+        <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/login{if $_config.compress_css}-min{/if}.css">
     </head>
     <body id="login">
         {$onManagerLoginFormPrerender}
@@ -117,19 +117,26 @@
                             <form action="" method="post" id="modx-forgot-login-form" class="c-form can-toggle {if NOT $_post.username_reset|default}is-hidden{/if}">
                                 <p class="lead">{$_lang.login_forget_your_login_note}</p>
 
-                                    {if $error_message}
-                                        <p class="is-error">{$error_message|default}</p>
-                                    {elseif $success_message}
-                                        <p class="is-success">{$success_message|default}</p>
-                                    {/if}
+                                {if $error_message}
+                                    <p class="is-error">{$error_message|default}</p>
+                                {elseif $success_message}
+                                    <p class="is-success">{$success_message|default}</p>
+                                {/if}
 
-                                    <label>
-                                        {$_lang.login_username_or_email}
-                                        <input type="text" id="modx-login-username-reset" name="username_reset" value="{$_post.username_reset|default}" required>
-                                    </label>
+                                <label>
+                                    {$_lang.login_username_or_email}
+                                    <input type="text" id="modx-login-username-reset" name="username_reset" value="{$_post.username_reset|default}" required>
+                                </label>
 
-                                    <button class="c-button" name="forgotlogin" type="submit" value="1" id="modx-fl-btn">{$_lang.login_send_activation_email}</button>
-                                    <button name="modx-fl-back-to-login-link" id="modx-fl-back-to-login-link" class="c-button c-button--ghost">{$_lang.login_back_to_login}</button>
+                                <button class="c-button" name="forgotlogin" type="submit" value="1" id="modx-fl-btn">{$_lang.login_send_activation_email}</button>
+                                <button name="modx-fl-back-to-login-link" id="modx-fl-back-to-login-link" class="c-button c-button--ghost">
+                                    <svg class="c-arrow c-arrow--left" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+                                        <g fill="none" stroke-width="1.5" stroke-linejoin="round" stroke-miterlimit="10">
+                                            <path class="arrow-icon--arrow" d="M16.14 9.93L22.21 16l-6.07 6.07M8.23 16h13.98"></path>
+                                        </g>
+                                    </svg>
+                                    {$_lang.login_back_to_login}
+                                </button>
                             </form>
                         {/if}
                     {else}
@@ -155,7 +162,14 @@
                             {$onManagerLoginFormRender}
 
                             <button class="c-button" name="login" type="submit" value="1">{$_lang.login_button}</button>
-                            <a href="{$_config.manager_url}" class="c-button c-button--ghost">{$_lang.login_back_to_login}</a>
+                            <a href="{$_config.manager_url}" class="c-button c-button--ghost">
+                                <svg class="c-arrow c-arrow--left" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+                                    <g fill="none" stroke-width="1.5" stroke-linejoin="round" stroke-miterlimit="10">
+                                        <path class="arrow-icon--arrow" d="M16.14 9.93L22.21 16l-6.07 6.07M8.23 16h13.98"></path>
+                                    </g>
+                                </svg>
+                                {$_lang.login_back_to_login}
+                            </a>
                         </form>
                     {/if}
                 {/if}


### PR DESCRIPTION
### What does it do?
Fixed styles for login:
- Left :focus for input only but without shadow
- Added background to inputs (on gif, background is almost invisible, more noticeable in browser)
- Changed the font color
- Added an arrow to the link "Back to login"

In my opinion, it has become more beautiful, especially without unnecessary :focus.

**After:**
![after](https://user-images.githubusercontent.com/12523676/65802897-00690900-e18e-11e9-89c4-416db4f4d092.gif)

**Before:**
![before](https://user-images.githubusercontent.com/12523676/65802898-00690900-e18e-11e9-9536-e2ec49134b23.gif)

### Related issue(s)/PR(s)
None
