### PR TITLE
Reduce buttons and TV category headers for mobile devices

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -292,6 +292,11 @@ button {
     }
   }
 
+  .x-toolbar-left {
+    width: auto !important;
+    zoom: 1;
+  }
+
   @include grid-media($desktop) {
     background: transparent;
     padding: 0 15px;
@@ -310,11 +315,11 @@ button {
     #modx-panel-welcome & {
       display: none;
     }
-  }
 
-  .x-toolbar-left {
-    width: auto !important;
-    zoom: 1;
+    .x-toolbar-cell {
+      width: auto;
+      margin: 5px;
+    }
   }
 }
 

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -180,7 +180,7 @@ ul.x-tab-strip-bottom {
     color: $treeColor;
     content: '';
     font-size: 28px;
-    margin-top: -14px; /* half of the height to center vertically with top 50% */
+    margin-top: -20px; /* half of the height to center vertically with top 50% */
     opacity: 1;
     filter: alpha(opacity=100); /* for IE <= 8 */
     position: absolute;
@@ -255,6 +255,10 @@ ul.x-tab-strip-bottom {
     padding-bottom: 10000px !important; /* dirty hack to make vertical tabs container stretch to bottom */
     width: 168px !important; /* aligns the vertical tabs with the TVs tab left edge, will not work that nicely with non-english langs */
 
+    @include grid-media($desktop) {
+      width: 80px !important;
+    }
+
     .x-tab-strip-wrap {
       background-color: transparent; /* as vertical tab panels are nested ones too, do not apply the background color for nested tab panels */
       display: inline-block;
@@ -280,6 +284,11 @@ ul.x-tab-strip-bottom {
           padding: 10px 15px 10px 15px;
           transition: background-color .25s, color .25s;
 
+          @include grid-media($desktop) {
+            font-size: 12px;
+            padding: 8px;
+          }
+
           &:hover {
             background: $white;
           }
@@ -291,6 +300,12 @@ ul.x-tab-strip-bottom {
             box-shadow: none; /* removes the active tab strip on top */
             color: $tabActiveText;
             width: 168px; /* make the active li 1px more wide to cover the containers right border, this makes the right border on inactive tabs necessary as the whole tab-strip wrap gets wider */
+          }
+
+          @include grid-media($desktop) {
+            &.x-tab-strip-active {
+              width: 80px !important;
+            }
           }
 
           &.x-tab-edge {

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -240,6 +240,7 @@
 
 /* the progress bar (ex. saving a resource), usually in a window too */
 .x-progress-wrap {
+  width: 100% !important;
   border: 1px solid $green;
 
   .x-progress-inner {


### PR DESCRIPTION
### What does it do?

- Reduce action buttons in #modx-action-buttons
- Reduce TV category tab headers

to save space.

**Before:**
![b](https://user-images.githubusercontent.com/12523676/65960077-ace40d00-e464-11e9-9bb2-b62d08d95332.png)

**After:**
![a](https://user-images.githubusercontent.com/12523676/65960076-ac4b7680-e464-11e9-9120-44f59a317318.png)

### Related issue(s)/PR(s)
None