### PR TITLE
Fixed display #modx-site-info depending on width

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -199,8 +199,8 @@ $cinema: new-breakpoint(max-width 1400px 12);
 
 $gtMobile: new-breakpoint(min-width 641px 12);
 $gtTabletP: new-breakpoint(min-width 769px 12);
-$gtTabletL: new-breakpoint(min-width 1025px 12);
 $gtDesktop: new-breakpoint(min-width 961px 12);
+$gtTabletL: new-breakpoint(min-width 1025px 12);
 $gtCinema: new-breakpoint(min-width 1401px 12);
 
 // Path for background-images

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -4,7 +4,7 @@
   height: 55px;
   max-height: 55px;
   @include media($mobile) {
-	  height:auto !important;
+    height:auto !important;
   }
 }
 #modx-navbar {
@@ -14,7 +14,7 @@
   position: relative;
   z-index: 20;
   @include media($mobile) {
-	  box-shadow:none;
+    box-shadow:none;
   }
 }
 
@@ -35,7 +35,7 @@
   margin: 0;
   padding: 0;
   @include media($mobile) {
-	  float:none;
+    float:none;
   }
   li {
     border-right: 1px solid $navbarBorder;
@@ -343,13 +343,10 @@
 #modx-site-info {
   padding: 12px 5px 0 !important;
   border-right: 0 !important;
-
-  @include media($gtTabletL) {
-    width: 175px;
-  }
+  width: 175px;
 
   @include media($tabletL) {
-    display: none
+    display: none;
   }
 
   .site_name { color:#fff }

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -341,11 +341,14 @@
 }
 
 #modx-site-info {
-  padding: 13px 5px 0 5px !important;
+  padding: 12px 5px 0 !important;
   border-right: 0 !important;
-  width: 175px;
 
-  @include media($desktop) {
+  @include media($gtTabletL) {
+    width: 175px;
+  }
+
+  @include media($tabletL) {
     display: none
   }
 

--- a/_build/templates/default/sass/_uberbar.scss
+++ b/_build/templates/default/sass/_uberbar.scss
@@ -2,7 +2,7 @@
 #modx-manager-search-icon{
   a{
     padding-left: 0;
-    @include media($desktop) {
+    @include media($tabletL) {
       padding-left:10px; padding-right: 10px;
     }
   }
@@ -27,40 +27,40 @@
   position: absolute;
   top: 55px;
   left: 26px;
-  
+
   &.visible {
-  	visibility: visible;
+    visibility: visible;
   }
-  
+
   @include media($mobile) {
-	  padding-right:25px;
-	  top:auto;
-	  left:0;
-	  right:0;
-	  min-width:0;
-	  &.visible {
-	  	position: relative;
-	  }
+    padding-right:25px;
+    top:auto;
+    left:0;
+    right:0;
+    min-width:0;
+    &.visible {
+      position: relative;
+    }
   }
-  
+
   .x-form-field-wrap {
-	  @include media($mobile) {
-		  width:auto !important;
-		  @include display(flex);
-		  #modx-uberbar {
-			  @include flex-grow(1);
-		  }
-		  .x-form-arrow-trigger {
-			  position:relative;
-			  top:auto;
-			  &:before {
-				  position: relative;
-				  margin-top:0;
-				  top:auto;
-				  line-height:30px;
-			  }
-		  }
-	  }
+    @include media($mobile) {
+      width:auto !important;
+      @include display(flex);
+      #modx-uberbar {
+        @include flex-grow(1);
+      }
+      .x-form-arrow-trigger {
+        position:relative;
+        top:auto;
+        &:before {
+          position: relative;
+          margin-top:0;
+          top:auto;
+          line-height:30px;
+        }
+      }
+    }
   }
 
   /* up arrow connecting modx-manager-search-icon to the search field */
@@ -70,7 +70,7 @@
     position: absolute;
     top: -20px;
     left: 235px;
-    @include media($desktop) {
+    @include media($tabletL) {
       left: 60px;
     }
     @include media($mobile) {
@@ -93,9 +93,9 @@
   }*/
   .x-form-text {
     background: none; /* prevent white searchfield background */
-	@include media($mobile) {
-		width:auto !important;
-	}
+  @include media($mobile) {
+    width:auto !important;
+  }
   }
 }
 
@@ -167,7 +167,7 @@
   z-index: 15 !important; /* show beneath subnav and modals */
 
   @include media($mobile) {
-	  left:0 !important;
+    left:0 !important;
   }
   .loading-indicator{
     background: none;
@@ -191,16 +191,16 @@
     margin: 12px 0 0;
     overflow: auto;
     width: 100% !important;
-	@include media($mobile) {
-		height:auto !important;
-		line-height:4em;
-		.section {
-			> * {
-				padding-top:1em;
-				padding-bottom:1em;
-			}
-		}
-	}
+  @include media($mobile) {
+    height:auto !important;
+    line-height:4em;
+    .section {
+      > * {
+        padding-top:1em;
+        padding-bottom:1em;
+      }
+    }
+  }
   }
 
     .section {


### PR DESCRIPTION
### What does it do?
Depending on the language, the text may not fit in the width and the top menu shifts beyond the boundaries of the block.
Now the `#modx-site-info` block is hidden at a width of 1024 instead of 960.

Fixed styles for `#modx-site-info` and search `#modx-manager-search` (`#modx-manager-search-icon`):

![site-info](https://user-images.githubusercontent.com/12523676/67145293-56af0080-f291-11e9-9f8f-94a33b72bd54.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14770
