### PR TITLE
Returned #modx-leftbar-trigger for mobile screens

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -345,10 +345,6 @@
       }
     }
 
-    #modx-leftbar-trigger {
-      display: none;
-    }
-
     #modx-topnav {
       width: 100%;
       order: 0;


### PR DESCRIPTION
### What does it do?
Returned #modx-leftbar-trigger for small (mobile) screens. While testing responsive styles on a desktop browser, but with a small width, the #modx-leftbar-trigger button worked strangely (sometimes it doesn’t work at all, sometimes with bugs), see gif below.

![tree](https://user-images.githubusercontent.com/12523676/66553783-d257d180-eb5c-11e9-9b46-bdfca17fd3fe.gif)

But, apparently, this behavior is not relevant for mobile devices (but this is not accurate).
**We need more tests on mobile devices.**

### Why is it needed?
However, for mobile devices without this button #modx-leftbar-trigger, you can ensure that the tree disappears and cannot be returned (after visiting installer or file manager).

In general, the tree disappear functionality in the file manager and installer is not clear to me. **In my opinion, it is superfluous and should be removed:**
- There is enough space on modern monitors without tree collapse
- The element tree is an important navigation block, almost always work goes through it, do not need to hide it
- Hiding some elements without explicit user action is bad for UX
- There are bugs described above

### Related issue(s)/PR(s)
Not directly https://github.com/modxcms/revolution/issues/14736
