### PR TITLE
Fixed display of icons in the tree

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -164,48 +164,6 @@
   width: 12px;
 }
 
-/* icons for the various tree elements */
-.tree-context:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-globe);
-}
-
-.x-tree-node-expanded .tree-folder:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-folder-open);
-}
-
-.x-tree-node-collapsed .tree-folder:before,
-.x-tree-node .tree-folder:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-folder);
-}
-
-.x-tree-node .locked-resource:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-lock);
-}
-
-.tree-resource:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-file);
-}
-
-.tree-static-resource:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-file-alt);
-}
-
-.tree-weblink:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-link);
-}
-
-.tree-symlink:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-copy);
-}
-
 /* tree states */
 .x-tree-node-el {
   color: $treeColor;
@@ -430,7 +388,6 @@
     }
   }
 }
-
 
 .x-tree-elbow,
 .x-tree-elbow-end {
@@ -810,6 +767,49 @@
 .x-tree-node-loading a span {
   color: $tundora;
   font-style: italic;
+}
+
+/* icons for the various tree elements */
+.tree-context:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-globe);
+}
+
+.tree-resource:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-file);
+}
+
+.tree-static-resource:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-file-alt);
+}
+
+.tree-weblink:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-link);
+}
+
+.tree-symlink:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-copy);
+}
+
+.parent-resource:before,
+.icon-folder:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-folder);
+}
+
+.x-tree-node-expanded .parent-resource:before,
+.x-tree-node-expanded .icon-folder:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-folder-open);
+}
+
+.locked-resource:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-lock) !important;
 }
 
 .ext-ie .x-tree-node-el input {


### PR DESCRIPTION
![nodes](https://user-images.githubusercontent.com/12523676/66669966-ad04b980-ec69-11e9-848e-271a4fa5b95b.png)

Moved styles below **styles for file types**, as otherwise they were in charge - https://github.com/modxcms/revolution/blob/4b0cf0a9f93cb9e708fde6877f42b5655265db86/_build/templates/default/sass/_tree.scss#L675

For example, a resource with a file type of **.pdf** would always have a pdf icon, even if this resource is a symbolic link or folder. Now there is no such problem.

And I changed the classes from `.tree-folder` to` .parent-resource`, `.icon-folder`. Because currently there is no `.tree-folder` class in the tree.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14597
