### PR TITLE
Fixed a bug with appearance of save animation over logo

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -22,7 +22,7 @@
   background: $colorSplash;
   max-width: $navbarWidth;
   position: absolute;
-  z-index: 2;
+  z-index: 99999;
   height: 100%;
 }
 


### PR DESCRIPTION
### What does it do?
If you edit a resource and drag the same resource in the tree, a save animation appears next to the logo.

![save-anim](https://user-images.githubusercontent.com/12523676/66673838-85661f00-ec72-11e9-920d-0dccc5b0d920.gif)

This PR fixes this bug through increasing `z-index`.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14428
