### PR TITLE
Only show the "frame" animation when dragging over visibible elements

### DIFF
--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -43,7 +43,7 @@ Ext.extend(MODx.TreeDrop,Ext.Component,{
             ,notifyEnter: function(ddSource, e, data) {
                 if (ddTarget.getEl) {
                     var el = ddTarget.getEl();
-                    if (el) {
+                    if (el && el.isVisible()) {
                         el.frame();
                         el.focus();
                     }


### PR DESCRIPTION
### What does it do?
Make sure to frame/focus only visible elements when dragging elements from the tree.

### Why is it needed?
After some digging I figured out the root cause of issue #14428. If you enable "freeze uri" for the resource this bug cannot be triggered. 

Resources/Elements can be dragged from the tree straight to Resource Content pane.
If you drag something from the tree to another element it will frame/animate the potential drop target. When triggering the bug you actually drag over an invisible element, therefore showing the animation in this "weird" location.

### Related issue(s)/PR(s)
Fixes issue #14428
Closes PR #14787
