### PR TITLE
Added a link and buttons to the context grid

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -528,13 +528,28 @@ textarea.x-form-field {
 }
 
 a.x-grid-link {
-  color: $mainText;
+  color: $colorSplash;
+  text-decoration: underline;
+}
+
+a.x-grid-link:hover, a.x-grid-link:focus{
   text-decoration: none;
 }
 
-a.x-grid-link:hover,
-a.x-grid-link:focus {
-  text-decoration: underline;
+.x-grid-buttons {
+  text-align: center;
+}
+
+.x-grid-buttons li {
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1.1em;
+  line-height: .7;
+  margin-right: 10px;
+}
+
+.x-grid-buttons li:last-child {
+  margin-right: 0;
 }
 
 /* panel stylings */

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -232,7 +232,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
             ,url: this.config.url
             ,params: p
             ,listeners: {
-            	'success': {fn:this.refresh,scope:this}
+                'success': {fn:this.refresh,scope:this}
             }
         });
     }
@@ -255,7 +255,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,url: this.config.url
                 ,params: p
                 ,listeners: {
-                	'success': {fn:function() {
+                    'success': {fn:function() {
                         this.removeActiveRow(r);
                     },scope:this}
                 }
@@ -314,10 +314,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,groupField: this.config.groupBy || 'name'
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
+                    }
                 }
             });
         } else {
@@ -330,10 +330,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,remoteSort: this.config.remoteSort || false
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
+                    }
                 }
             });
         }
@@ -426,6 +426,20 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         }
     }
 
+    ,getButtonColumnTpl: function () {
+        return new Ext.XTemplate('<tpl for=".">'
+            + '<tpl if="action_buttons !== null">'
+            + '<ul class="x-grid-buttons">'
+            + '<tpl for="action_buttons">'
+            + '<li><i class="icon {className:htmlEncode} icon-{icon:htmlEncode}" title="{text:htmlEncode}"></i></li>'
+            + '</tpl>'
+            + '</ul>'
+            + '</tpl>'
+            + '</tpl>', {
+            compiled: true
+        });
+    }
+
     ,refresh: function() {
         this.getStore().reload();
     }
@@ -472,8 +486,8 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     }
 
     ,editorYesNo: function(r) {
-    	r = r || {};
-    	Ext.applyIf(r,{
+        r = r || {};
+        Ext.applyIf(r,{
             store: new Ext.data.SimpleStore({
                 fields: ['d','v']
                 ,data: [[_('yes'),true],[_('no'),false]]
@@ -582,14 +596,14 @@ MODx.grid.LocalGrid = function(config) {
 
     if (config.grouping) {
         Ext.applyIf(config,{
-          view: new Ext.grid.GroupingView({
-            forceFit: true
-            ,scrollOffset: 0
-            ,hideGroupedColumn: config.hideGroupedColumn ? true : false
-            ,groupTextTpl: config.groupTextTpl || ('{text} ({[values.rs.length]} {[values.rs.length > 1 ? "'
-                +(config.pluralText || _('records')) + '" : "'
-                +(config.singleText || _('record'))+'"]})' )
-          })
+            view: new Ext.grid.GroupingView({
+                forceFit: true
+                ,scrollOffset: 0
+                ,hideGroupedColumn: config.hideGroupedColumn ? true : false
+                ,groupTextTpl: config.groupTextTpl || ('{text} ({[values.rs.length]} {[values.rs.length > 1 ? "'
+                    +(config.pluralText || _('records')) + '" : "'
+                    +(config.singleText || _('record'))+'"]})' )
+            })
         });
     }
     if (config.tbar) {
@@ -787,6 +801,19 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
         }
     }
 
+    ,getButtonColumnTpl: function () {
+        return new Ext.XTemplate('<tpl for=".">'
+            + '<tpl if="action_buttons !== null">'
+            + '<ul class="x-grid-buttons">'
+            + '<tpl for="action_buttons">'
+            + '<li><i class="icon {className:htmlEncode} icon-{icon:htmlEncode}" title="{text:htmlEncode}"></i></li>'
+            + '</tpl>'
+            + '</ul>'
+            + '</tpl>'
+            + '</tpl>', {
+            compiled: true
+        });
+    }
 
     ,remove: function(config) {
         if (this.destroying) {
@@ -812,9 +839,9 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
             r = s.getAt(j).data;
             r.menu = null;
             if (this.config.encodeAssoc) {
-               rs[r[this.config.encodeByPk || 'id']] = r;
+                rs[r[this.config.encodeByPk || 'id']] = r;
             } else {
-               rs.push(r);
+                rs.push(r);
             }
         }
 


### PR DESCRIPTION
It did not work out correctly to rebase, and the discussion in the old PR was not specific :) - had to create another PR.

### What does it do?
Changed the order of functions in a `modx.grid.context.js` file so that in the future it would be easier to edit them.

Added a link and buttons to the context grid. **I figured out how to add a context menu by clicking on the gear.**
In general, it seems to me that the most useful option is the option with the actions "Edit" and "Copy", and all actions will be in the "Gear-menu" (or maybe it’s worth leaving just “Edit” and the "Gear-menu").

What it looks like:

![contexts](https://user-images.githubusercontent.com/12523676/66921458-4fd88180-f036-11e9-9df5-04b362db2825.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14125
Old PR - https://github.com/modxcms/revolution/pull/14581