### PR TITLE
Added check for multiple and single space instead of pagetitle

### DIFF
--- a/core/lexicon/en/resource.inc.php
+++ b/core/lexicon/en/resource.inc.php
@@ -156,7 +156,6 @@ $_lang['symlink_help'] = 'The address of the object you wish to reference with t
 $_lang['symlink_message'] = 'A symlink is a symbolic link to another resource in your site which is forwarded to without changing the URL.';
 $_lang['symlink_new'] = 'New Symlink';
 $_lang['template_variables'] = 'Template Variables';
-$_lang['untitled_resource'] = 'Untitled Resource';
 $_lang['weblink'] = 'Weblink';
 $_lang['weblink_create'] = 'Create Weblink';
 $_lang['weblink_create_here'] = 'Weblink';

--- a/core/model/modx/processors/resource/create.class.php
+++ b/core/model/modx/processors/resource/create.class.php
@@ -335,9 +335,7 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
      */
     public function preparePageTitle() {
         $pageTitle = $this->getProperty('pagetitle','');
-        if (!empty($pageTitle)) {
-            $pageTitle = trim($pageTitle);
-        }
+        $pageTitle = trim($pageTitle);
 
         /* default pagetitle if not reloading template */
         if (!$this->getProperty('reloadOnly',false)) {

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -153,7 +153,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         }
         $this->checkDeletedStatus();
 
-        // If we are changing an existing modResource that is not already a symlink/weblink, it does not make 
+        // If we are changing an existing modResource that is not already a symlink/weblink, it does not make
         // much sense to run this check, as it would attempt to validate the existing content of the content field
         if ($properties['class_key'] === 'modSymLink' && $this->object->get('class_key') === 'modSymLink') {
             $this->checkSymLinkTarget();
@@ -216,8 +216,10 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
      */
     public function trimPageTitle() {
         $pageTitle = $this->getProperty('pagetitle',null);
+        $pageTitle = preg_replace('|\s+|', ' ', $pageTitle);
+
         if ($pageTitle != null && !$this->getProperty('reloadOnly',false)) {
-            if ($pageTitle === '') {
+            if ($pageTitle === '' || $pageTitle == ' ') {
                 $pageTitle = $this->modx->lexicon('resource_untitled');
             }
             $pageTitle = trim($pageTitle);


### PR DESCRIPTION
### What does it do?
In the current version, you can save a resource with one or several spaces instead of a pagetitle.
This PR fixes this if there are only spaces in the pagetitle - the pagetitle will become "Untitled Resource".

Deleted an unnecessary `$_lang['untitled_resource']` line (found only in the lexicon file), the rest of the code uses `$_lang['resource_untitled']`.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14564
