### PR TITLE
Fixing limit for context settings

### DIFF
--- a/core/model/modx/mysql/modcontextsetting.class.php
+++ b/core/model/modx/mysql/modcontextsetting.class.php
@@ -17,6 +17,7 @@ class modContextSetting_mysql extends modContextSetting {
     public static function listSettings(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
         /* build query */
         $c = $xpdo->newQuery('modContextSetting');
+        $c->distinct();
         $c->select(array(
             $xpdo->getSelectColumns('modContextSetting','modContextSetting'),
         ));


### PR DESCRIPTION
### What does it do?
Add a distinct to the query for context settings

### Why is it needed?
The limit was applied to the wrong (not distinct) results. So i.e. the last elements of the grid mentioned in #14746 were cut off.

### Related issue(s)/PR(s)
#14746
