### PR TITLE
Add actions column to grids

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -537,6 +537,21 @@ a.x-grid-link:focus {
   text-decoration: underline;
 }
 
+.x-grid-buttons {
+  text-align: center;
+}
+.x-grid-buttons li {
+  cursor: pointer;
+  display: inline-block;
+  font-size: 1.1em;
+  line-height: .7;
+  margin-right: 10px;
+}
+
+.x-grid-buttons li:last-child {
+  margin-right: 0;
+}
+
 /* panel stylings */
 .modx-page-header,
 .modx-page-header div {

--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -534,6 +534,7 @@ $_lang['recently_updated'] = 'Recently Updated';
 $_lang['newest'] = 'Newest';
 $_lang['oldest'] = 'Oldest';
 $_lang['constraints'] = 'Constraints';
+$_lang['context_menu'] = 'Context Menu';
 
 $_lang['january'] = 'January';
 $_lang['february'] = 'February';

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -21,6 +21,9 @@ MODx.grid.Grid = function(config) {
         ,preventSaveRefresh: true
         ,showPerPage: true
         ,stateful: false
+        ,showActionsColumn: true
+        ,actionsColumnWidth: 50
+        ,disableContextMenuAction: false
         ,menuConfig: {
             defaultAlign: 'tl-b?'
             ,enableScrolling: false
@@ -91,6 +94,23 @@ MODx.grid.Grid = function(config) {
             if (!itm.scope) { itm.scope = this; }
         }
     }
+
+    if (config.showActionsColumn) {
+        if (config.columns && Array.isArray(config.columns)) {
+            config.columns.push({
+                width: 50
+                ,renderer: this.actionsColumnRenderer.bind(this)
+            });
+        }
+
+        if (config.cm && config.cm.columns && Array.isArray(config.cm.columns)) {
+            config.cm.columns.push({
+                width: 50
+                ,renderer: this.actionsColumnRenderer.bind(this)
+            });
+        }
+    }
+
     MODx.grid.Grid.superclass.constructor.call(this,config);
     this._loadMenu(config);
     this.addEvents('beforeRemoveRow','afterRemoveRow','afterAutoSave');
@@ -574,6 +594,63 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
 
         return plugins[index];
     }
+
+    ,_getActionsColumnTpl: function () {
+        return new Ext.XTemplate('<tpl for=".">'
+            + '<tpl if="actions !== null">'
+            + '<ul class="x-grid-buttons">'
+            + '<tpl for="actions">'
+            + '<li><i class="x-grid-action icon icon-{icon:htmlEncode}" title="{text:htmlEncode}" data-action="{action:htmlEncode}"></i></li>'
+            + '</tpl>'
+            + '</ul>'
+            + '</tpl>'
+            + '</tpl>', {
+            compiled: true
+        });
+    }
+
+    ,actionsColumnRenderer: function(value, metaData, record, rowIndex, colIndex, store) {
+        var actions = this.getActions.apply(this, arguments);
+        if (this.config.disableContextMenuAction !== true) {
+            actions.push({
+                text: _('context_menu'),
+                action: 'contextMenu',
+                icon: 'gear'
+            });
+        }
+
+        return this._getActionsColumnTpl().apply({
+            actions: actions
+        });
+    }
+
+    ,getActions: function(value, metaData, record, rowIndex, colIndex, store) {
+        return [];
+    }
+
+    ,onClick: function(e) {
+        var target = e.getTarget();
+        if (!target.classList.contains('x-grid-action')) return;
+        if (!target.dataset.action) return;
+
+        var actionHandler = 'action' + target.dataset.action.charAt(0).toUpperCase() + target.dataset.action.slice(1);
+        if (!this[actionHandler] || (typeof this[actionHandler] !== 'function')) {
+            actionHandler = target.dataset.action;
+            if (!this[actionHandler] || (typeof this[actionHandler] !== 'function')) {
+                return;
+            }
+        }
+
+        var record = this.getSelectionModel().getSelected();
+        var recordIndex = this.store.indexOf(record);
+        this.menu.record = record.data;
+
+        this[actionHandler](record, recordIndex, e);
+    },
+
+    actionContextMenu: function(record, recordIndex, e) {
+        this._showMenu(this, recordIndex, e);
+    }
 });
 
 /* local grid */
@@ -611,6 +688,9 @@ MODx.grid.LocalGrid = function(config) {
         ,enableColumnMove: true
         ,header: false
         ,cls: 'modx-grid'
+        ,showActionsColumn: true
+        ,actionsColumnWidth: 50
+        ,disableContextMenuAction: false
         ,viewConfig: {
             forceFit: true
             ,enableRowBody: true
@@ -625,6 +705,17 @@ MODx.grid.LocalGrid = function(config) {
     this.menu = new Ext.menu.Menu(config.menuConfig);
     this.config = config;
     this._loadColumnModel();
+
+    if (config.showActionsColumn && config.columns && Array.isArray(config.columns)) {
+        config.columns.push({
+            width: 50
+            ,renderer: {
+                fn: this.actionsColumnRenderer,
+                scope: this
+            }
+        });
+    }
+
     MODx.grid.LocalGrid.superclass.constructor.call(this,config);
     this.addEvents({
         beforeRemoveRow: true
@@ -909,6 +1000,64 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
             z = z+'*';
         }
         return z;
+    }
+
+    ,_getActionsColumnTpl: function () {
+        return new Ext.XTemplate('<tpl for=".">'
+            + '<tpl if="actions !== null">'
+            + '<ul class="x-grid-buttons">'
+            + '<tpl for="actions">'
+            + '<li><i class="x-grid-action icon icon-{icon:htmlEncode}" title="{text:htmlEncode}" data-action="{action:htmlEncode}"></i></li>'
+            + '</tpl>'
+            + '</ul>'
+            + '</tpl>'
+            + '</tpl>', {
+            compiled: true
+        });
+    }
+
+    ,actionsColumnRenderer: function(value, metaData, record, rowIndex, colIndex, store) {
+        var actions = this.getActions.apply(this, arguments);
+
+        if (this.config.disableContextMenuAction !== true) {
+            actions.push({
+                text: _('context_menu'),
+                action: 'contextMenu',
+                icon: 'gear'
+            });
+        }
+
+        return this._getActionsColumnTpl().apply({
+            actions: actions
+        });
+    }
+
+    ,getActions: function(value, metaData, record, rowIndex, colIndex, store) {
+        return [];
+    }
+
+    ,onClick: function(e) {
+        var target = e.getTarget();
+        if (!target.classList.contains('x-grid-action')) return;
+        if (!target.dataset.action) return;
+
+        var actionHandler = 'action' + target.dataset.action.charAt(0).toUpperCase() + target.dataset.action.slice(1);
+        if (!this[actionHandler] || (typeof this[actionHandler] !== 'function')) {
+            actionHandler = target.dataset.action;
+            if (!this[actionHandler] || (typeof this[actionHandler] !== 'function')) {
+                return;
+            }
+        }
+
+        var record = this.getSelectionModel().getSelected();
+        var recordIndex = this.store.indexOf(record);
+        this.menu.record = record.data;
+
+        this[actionHandler](record, recordIndex, e);
+    },
+
+    actionContextMenu: function(record, recordIndex, e) {
+        this._showMenu(this, recordIndex, e);
     }
 });
 Ext.reg('grid-local',MODx.grid.LocalGrid);

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -610,7 +610,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     }
 
     ,actionsColumnRenderer: function(value, metaData, record, rowIndex, colIndex, store) {
-        var actions = this.getActions.apply(this, arguments);
+        var actions = this.getActions.apply(this, [record, rowIndex, colIndex, store]);
         if (this.config.disableContextMenuAction !== true) {
             actions.push({
                 text: _('context_menu'),
@@ -624,7 +624,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         });
     }
 
-    ,getActions: function(value, metaData, record, rowIndex, colIndex, store) {
+    ,getActions: function(record, rowIndex, colIndex, store) {
         return [];
     }
 

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -134,12 +134,14 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
                 ,scope: this
             });
         }
+
         if (p.indexOf('pedit') != -1) {
             m.push({
                 text: _('context_update')
                 ,handler: this.updateContext
             });
         }
+
         if (p.indexOf('premove') != -1) {
             m.push('-');
             m.push({
@@ -235,6 +237,29 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         }
         this.getSelectionModel().clearSelections(true);
         this.refresh();
+    }
+
+    ,getActions: function(value, metaData, record, rowIndex, colIndex, store) {
+        var permissions = record.data.perm;
+        var actions = [];
+
+        if (~permissions.indexOf('pedit')) {
+            actions.push({
+                action: 'updateContext',
+                icon: 'pencil-square-o',
+                text: _('context_update')
+            });
+        }
+
+        if (~permissions.indexOf('premove')) {
+            actions.push({
+                action: 'remove',
+                icon: 'trash-o',
+                text: _('context_remove')
+            });
+        }
+
+        return actions;
     }
 });
 Ext.reg('modx-grid-contexts',MODx.grid.Context);

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -239,7 +239,7 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         this.refresh();
     }
 
-    ,getActions: function(value, metaData, record, rowIndex, colIndex, store) {
+    ,getActions: function(record, rowIndex, colIndex, store) {
         var permissions = record.data.perm;
         var actions = [];
 

--- a/manager/assets/modext/widgets/system/modx.grid.system.event.js
+++ b/manager/assets/modext/widgets/system/modx.grid.system.event.js
@@ -22,6 +22,7 @@ MODx.grid.SystemEvent = function(config) {
         ,groupBy: 'groupname'
         ,singleText: _('system_event')
         ,pluralText: _('system_events')
+        ,showActionsColumn: false
         ,columns: [{
             header: _('name')
             ,dataIndex: 'name'


### PR DESCRIPTION
### What does it do?
Added new properties to `MODx.grid.Grid` and `MODx.grid.LocalGrid`
 - showActionsColumn (default: true) - when set to `true`, shows the new actions column
 - actionsColumnWidth (default: 50) - width of this actions column
 - disableContextMenuAction (default: false) - when set to `true` the `gear` icon won't show up

Added new method that other grids extending `Grid` or `LocalGrid` can implement: `getActions`. It's getting these params: `record`, `rowIndex`, `colIndex`, `store` and should return an array or objects with properties:
- action - name of the function to execute
- icon - fa icon to use
- text - tooltip

Those will get displayed as action buttons in the actions column.

I'm not 100% sure if this should be enabled or disabled by default, when it's enabled by default grids without any actions / items in getMenu will have to disable this. If it's enabled by default, grids with actions / items in getMenu will have to enable this.

### Why is it needed?
Seems like context menus are not intuitive enough for people :)

### Related issue(s)/PR(s)
Improves PR #14581 and #14125
Should resolve #14125

### Screenshots
Contexts grid
![Screenshot 2019-10-22 at 17 58 55](https://user-images.githubusercontent.com/845220/67305545-c9b8b100-f4f5-11e9-917f-fcf961432303.png)

System Settings
![Screenshot 2019-10-22 at 17 59 17](https://user-images.githubusercontent.com/845220/67305547-ca514780-f4f5-11e9-8995-1b0207ae138a.png)

User Groups (Local Grid)
![Screenshot 2019-10-22 at 17 59 32](https://user-images.githubusercontent.com/845220/67305549-ca514780-f4f5-11e9-9edd-8f45e2799565.png)