### PR TITLE
Add permissions to the languages list array for Language Toggle

### DIFF
--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -106,6 +106,7 @@ class modMenu extends modAccessibleObject
                 'action' => 'language',
                 'params' => '&switch=' . $code,
                 'namespace' => 'core',
+                'permissions' => ''
             ];
         }
 


### PR DESCRIPTION
### What does it do?
Adds `'permissions' => ''` to the languages sub menu when generating it.

### Why is it needed?
The menu handler is expecting `permissions` item in the menu entry to work properly. The generated language toggle submenu is missing this `permissions` item and throwing a warning.

### Related issue(s)/PR(s)
Resolves #14755
