### PR TITLE
Check if component is rendered before using it's dom

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -170,13 +170,19 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
     }
     ,fixPanelHeight: function() {
         // fixing border layout's height regarding to tree panel's
-        var treeEl = Ext.getCmp('modx-tree-usergroup').getEl();
-        var treeH = treeEl.getHeight();
-        var cHeight = Ext.getCmp('modx-usergroup-users').getHeight(); // .main-wrapper
-        var maxH = (treeH > cHeight) ? treeH : cHeight;
-        maxH = maxH > 500 ? maxH : 500;
-        Ext.getCmp('modx-tree-panel-usergroup').setHeight(maxH);
-        Ext.getCmp('modx-content').doLayout();
+        var tree = Ext.getCmp('modx-tree-usergroup');
+        var groupUsers = Ext.getCmp('modx-usergroup-users');
+        var userGroupPanel = Ext.getCmp('modx-tree-panel-usergroup');
+
+        if (tree && groupUsers && userGroupPanel) {
+            var treeEl = tree.getEl();
+            var treeH = treeEl.getHeight();
+            var cHeight = groupUsers.getHeight(); // .main-wrapper
+            var maxH = (treeH > cHeight) ? treeH : cHeight;
+            maxH = maxH > 500 ? maxH : 500;
+            userGroupPanel.setHeight(maxH);
+            Ext.getCmp('modx-content').doLayout();
+        }
     }
 });
 Ext.reg('modx-panel-groups-roles',MODx.panel.GroupsRoles);

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -174,7 +174,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
         var groupUsers = Ext.getCmp('modx-usergroup-users');
         var userGroupPanel = Ext.getCmp('modx-tree-panel-usergroup');
 
-        if (tree && groupUsers && userGroupPanel) {
+        if (tree.rendered && groupUsers.rendered && userGroupPanel.rendered) {
             var treeEl = tree.getEl();
             var treeH = treeEl.getHeight();
             var cHeight = groupUsers.getHeight(); // .main-wrapper


### PR DESCRIPTION
### What does it do?
Checks if components `modx-tree-usergroup`, `modx-usergroup-users` and `modx-tree-panel-usergroup` are rendered before trying to access their dom.

### Why is it needed?
When you reload the ACL page and you are on other than the first tab, the component `modx-tree-usergroup` won't be rendered, `getEl()` will return `undefined` and calling another functions on the el will cause an error.

### Related issue(s)/PR(s)
Resolves #14805