### PR TITLE
Modify core class references in modContextSettings

### DIFF
--- a/setup/includes/upgrades/common/3.0.0-update-legacy-class-references.php
+++ b/setup/includes/upgrades/common/3.0.0-update-legacy-class-references.php
@@ -17,7 +17,9 @@ use MODX\Revolution\Hashing\modMD5;
 use MODX\Revolution\Hashing\modNative;
 use MODX\Revolution\Hashing\modPBKDF2;
 use MODX\Revolution\modAccess;
+use MODX\Revolution\modContextSetting;
 use MODX\Revolution\modDocument;
+use MODX\Revolution\modManagerRequest;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modStaticResource;
 use MODX\Revolution\modSymLink;
@@ -78,3 +80,9 @@ $this->processResults($class, $classKey, [$modx->manager, 'alterField'], [$class
 $modx->updateCollection($class, ['class_key' => modFileMediaSource::class], ['class_key' => 'sources.modFileMediaSource']);
 $modx->updateCollection($class, ['class_key' => modFTPMediaSource::class], ['class_key' => 'sources.modFTPMediaSource']);
 $modx->updateCollection($class, ['class_key' => modS3MediaSource::class], ['class_key' => 'sources.modS3MediaSource']);
+
+/* modify core class references in modContextSettings */
+$class = modContextSetting::class;
+$table = $modx->getTableName($class);
+
+$modx->updateCollection($class, ['value' => modManagerRequest::class], ['key' => 'modRequest.class']);

--- a/setup/includes/upgrades/common/3.0.0-update-legacy-class-references.php
+++ b/setup/includes/upgrades/common/3.0.0-update-legacy-class-references.php
@@ -85,4 +85,7 @@ $modx->updateCollection($class, ['class_key' => modS3MediaSource::class], ['clas
 $class = modContextSetting::class;
 $table = $modx->getTableName($class);
 
-$modx->updateCollection($class, ['value' => modManagerRequest::class], ['key' => 'modRequest.class']);
+$modx->updateCollection($class, ['value' => modManagerRequest::class], [
+    'key' => 'modRequest.class',
+    'value' => 'modManagerRequest'
+]);


### PR DESCRIPTION
### What does it do?
Modify core class references in modContextSettings

### Why is it needed?
This solves the error "Class 'modManagerRequest' not found" after upgrading to MODX 3

### Related issue(s)/PR(s)
Resolves issue #14822 
