### PR TITLE
Added element name to browser title

### DIFF
--- a/manager/controllers/default/security/forms/profile/update.class.php
+++ b/manager/controllers/default/security/forms/profile/update.class.php
@@ -96,7 +96,7 @@ class SecurityFormsProfileUpdateManagerController extends modManagerController {
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('form_customization');
+        return $this->modx->lexicon('form_customization').': '.$this->profileArray['name'];
     }
 
     /**

--- a/manager/controllers/default/source/update.class.php
+++ b/manager/controllers/default/source/update.class.php
@@ -159,7 +159,7 @@ class SourceUpdateManagerController extends modManagerController {
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('source_update');
+        return $this->modx->lexicon('source').': '.$this->sourceArray['name'];
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/update.class.php
+++ b/manager/controllers/default/system/dashboards/update.class.php
@@ -137,7 +137,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('dashboards');
+        return $this->modx->lexicon('dashboards').': '.$this->dashboardArray['name'];
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/widget/create.class.php
+++ b/manager/controllers/default/system/dashboards/widget/create.class.php
@@ -58,7 +58,7 @@ class SystemDashboardsWidgetCreateManagerController extends modManagerController
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('dashboards');
+        return $this->modx->lexicon('widget');
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/widget/update.class.php
+++ b/manager/controllers/default/system/dashboards/widget/update.class.php
@@ -120,7 +120,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('dashboards');
+        return $this->modx->lexicon('widget').': '.$this->widgetArray['name'];
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Added element name in  browser title for:
- Media sources;
- Dashboard widgets and widgets themselves;
- Profiles customization forms.

In the remaining sections, the names are in the title.
And with titles in title it’s easier to navigate in browser tabs.

Before
![before](https://user-images.githubusercontent.com/12523676/69177798-b06d4980-0b21-11ea-8e54-383af9f49a04.png)

After
![after](https://user-images.githubusercontent.com/12523676/69177797-b06d4980-0b21-11ea-92cd-91fe09ea0c86.png)

### Related issue(s)/PR(s)
None
