### PR TITLE
Changed resource styles in the tree

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -145,13 +145,14 @@ $treeItemBg: $white;
 $treeItemColor: $mediumGray;
 
 $iconColor: $treeText;
-$unpublished: $treeText;
 
 $deactivatedTextColor: lighten($treeColor, 35%); // do not use 50% here - makes base color nearly invisible
 $disabledTextColor: $deactivatedTextColor;
 
-$hidden: lighten($treeText, 10%) !important;
-$unpubText: italic;
+$unpublished: lighten($treeText, 10%) !important;
+$hidden: $treeText;
+$unpubText: normal;
+$hiddenText: italic;
 /* locked is already signaled with lock-icon, no need to use other semantic style here
    as italic is used for "unpublished" */
 $lockedText: inherit; //italic;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -260,6 +260,7 @@
 
   i.icon,
   i.icon-large {
+    color: $unpublished;
     font-style: normal;
   }
 }
@@ -267,12 +268,7 @@
 .hidemenu,
 .hidemenu a span {
   color: $hidden;
-  font-style: normal;
-
-  &.unpublished,
-  &.unpublished a span {
-    font-style: $unpubText;
-  }
+  font-style: $hiddenText;
 
   i.icon,
   i.icon-large {
@@ -286,7 +282,8 @@
 
   i.icon,
   i.icon-large {
-    color: $delTextColor; // font-style: normal;
+    color: $delTextColor;
+    font-style: normal;
   }
 
   a span {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1487,19 +1487,28 @@ iframe[classname="x-hidden"] {
         font: normal 18px $bodyfonts;
         text-decoration: none;
 
-        &.not_published {
-          font-style: $unpubText;
+        &.menu_hidden {
+          font-style: $hiddenText;
 
           &:hover {
             color: darken($colorSplash, 10%);
           }
         }
 
-        &.menu_hidden {
-          color: $hidden;
+        &.not_published {
+          color: $unpublished;
 
           &:hover {
-            color: darken($colorSplash, 10%) !important;
+            color: darken($colorSplash, 10%);
+          }
+        }
+
+        &.deleted {
+          color: $delTextColor;
+          text-decoration: $delTextDeco;
+
+          &:hover {
+            color: darken($colorSplash, 10%);
           }
         }
       }


### PR DESCRIPTION
### What does it do?
Changed the resource styles in the tree, made them more logical:
- Unpublished - the most faded in the tree;
- Hidden from the menu - font-family: italic;

### Why is it needed?
Unpublished resources look brighter in the resource tree than hidden resources from the menu - which is not logical.
Perhaps this only bothers me, but I'm confusing the current style version.

Now there is no such problem.
![res](https://user-images.githubusercontent.com/12523676/69255604-8d01d780-0bd1-11ea-88fc-e6732b9472dd.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13969#issuecomment-450426844
