### PR TITLE
Decode relativeURL

### DIFF
--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -143,7 +143,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
                     var r = {
                         file: data.pathRelative
                         ,name: data.name
-                        ,path: data.pathRelative
+                        ,path: decodeURIComponent(data.pathRelative)
                         ,source: this.config.source
                         ,content: response.object.content
                     };


### PR DESCRIPTION
### What does it do?
Uses `decodeURIComponent` on `data.pathRelative` which is url encoded in JS and shows that way also in the quick edit window.

### Why is it needed?
So user can see decoded relative path to the file, instead of encoded one.

### Related issue(s)/PR(s)
Resolves #14811
