### PR TITLE
Implement setVisibility handler in modx-browser

### DIFF
--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -268,6 +268,31 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         this.select(0);
     }
 
+    ,setVisibility: function(item,e) {
+        var node = this.cm.activeNode;
+        var data = this.lookup[node.id];
+
+        var r = {
+            path: decodeURIComponent(data.pathRelative)
+            ,visibility: data.visibility
+            ,source: this.config.source
+        };
+        var w = MODx.load({
+            xtype: 'modx-window-set-visibility'
+            ,record: r
+            ,listeners: {
+                'success':{
+                    fn: function() {
+                        this.run();
+                    },
+                    scope:this
+                }
+                ,'hide':{fn:function() {this.destroy();}}
+            }
+        });
+        w.show(e.target);
+    }
+
     ,sortStore: function() {
         var v = MODx.config.modx_browser_default_sort || 'name'
         this.store.sort(v, v == 'name' ? 'ASC' : 'DESC');


### PR DESCRIPTION
### What does it do?
Implements `setVisibility` method in the `modx-browser` component, same way it's in the `modx-tree-directory`.

### Why is it needed?
So users can use Set Visibility on files.

### Related issue(s)/PR(s)
Resolves #14810
