### PR TITLE
Change the value of default_media_source_type system setting

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -436,7 +436,7 @@ $settings['default_media_source']->fromArray(array (
 $settings['default_media_source_type']= $xpdo->newObject(modSystemSetting::class);
 $settings['default_media_source_type']->fromArray(array (
     'key' => 'default_media_source_type',
-    'value' => 'MODX\Revolution\Sources\modFileMediaSource',
+    'value' => MODX\Revolution\Sources\modFileMediaSource::class,
     'xtype' => 'modx-combo-source-type',
     'namespace' => 'core',
     'area' => 'manager',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -436,7 +436,7 @@ $settings['default_media_source']->fromArray(array (
 $settings['default_media_source_type']= $xpdo->newObject(modSystemSetting::class);
 $settings['default_media_source_type']->fromArray(array (
     'key' => 'default_media_source_type',
-    'value' => 'sources.modFileMediaSource',
+    'value' => 'MODX\Revolution\Sources\modFileMediaSource',
     'xtype' => 'modx-combo-source-type',
     'namespace' => 'core',
     'area' => 'manager',

--- a/setup/includes/upgrades/common/3.0.0-update-default-media-source-setting.php
+++ b/setup/includes/upgrades/common/3.0.0-update-default-media-source-setting.php
@@ -10,10 +10,10 @@ $defaultMediaSourceType = $modx->getObject(modSystemSetting::class, [
 if ($defaultMediaSourceType) {
     switch($defaultMediaSourceType->get('value')) {
         case 'sources.modFileMediaSource':
-            $defaultMediaSourceType->set('value', 'MODX\Revolution\Sources\modFileMediaSource');
+            $defaultMediaSourceType->set('value', MODX\Revolution\Sources\modFileMediaSource::class);
             break;
         case 'sources.modS3MediaSource':
-        $defaultMediaSourceType->set('value', 'MODX\Revolution\Sources\modS3MediaSource');
+        $defaultMediaSourceType->set('value', MODX\Revolution\Sources\modS3MediaSource::class);
             break;
     }
 

--- a/setup/includes/upgrades/common/3.0.0-update-default-media-source-setting.php
+++ b/setup/includes/upgrades/common/3.0.0-update-default-media-source-setting.php
@@ -1,0 +1,21 @@
+<?php
+/** Sets the default_media_source_type system setting to a correct class */
+
+use MODX\Revolution\modSystemSetting;
+
+$defaultMediaSourceType = $modx->getObject(modSystemSetting::class, [
+  'key' => 'default_media_source_type'
+]);
+
+if ($defaultMediaSourceType) {
+    switch($defaultMediaSourceType->get('value')) {
+        case 'sources.modFileMediaSource':
+            $defaultMediaSourceType->set('value', 'MODX\Revolution\Sources\modFileMediaSource');
+            break;
+        case 'sources.modS3MediaSource':
+        $defaultMediaSourceType->set('value', 'MODX\Revolution\Sources\modS3MediaSource');
+            break;
+    }
+
+    $defaultMediaSourceType->save();
+}

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -20,3 +20,4 @@ include dirname(__DIR__) . '/common/3.0.0-update-upload_files-upload_images.php'
 include dirname(__DIR__) . '/common/3.0.0-trim-gender-field-size.php';
 include dirname(__DIR__) . '/common/3.0.0-update-legacy-class-references.php';
 include dirname(__DIR__) . '/common/3.0.0-update-menu-entries.php';
+include dirname(__DIR__) . '/common/3.0.0-update-default-media-source-setting.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -19,3 +19,4 @@ include dirname(__DIR__) . '/common/3.0.0-update-xtypes-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-upload_images.php';
 include dirname(__DIR__) . '/common/3.0.0-trim-gender-field-size.php';
 include dirname(__DIR__) . '/common/3.0.0-update-menu-entries.php';
+include dirname(__DIR__) . '/common/3.0.0-update-default-media-source-setting.php';


### PR DESCRIPTION
### What does it do?
Changes the default value of `default_media_source_type` system setting.

### Why is it needed?
When you try and add new media source, the default value is set to `sources.modFileMediaSource` which is an old one from 2.x.

### Related issue(s)/PR(s)
Resolves #14818
