### PR TITLE
Fix user edit page

### DIFF
--- a/manager/controllers/default/security/user/update.class.php
+++ b/manager/controllers/default/security/user/update.class.php
@@ -10,6 +10,7 @@
 
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
+use MODX\Revolution\modUser;
 
 /**
  * Loads update user page
@@ -81,7 +82,7 @@ Ext.onReady(function() {
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('user_err_ns'));
         }
-        $this->user = $this->modx->getObject(modUse::class, array('id' => $scriptProperties['id']));
+        $this->user = $this->modx->getObject(modUser::class, array('id' => $scriptProperties['id']));
         if ($this->user == null) return $this->failure($this->modx->lexicon('user_err_nf'));
 
         /* process remote data, if existent */


### PR DESCRIPTION
### What does it do?
Add missing import statement for modUser and correct a typo `modUse` -> `modUser`

### Why is it needed?
ATM you can't edit a user, it'll always show user not found error.
