### PR TITLE
Set autocomplete to off on username in user edit form

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -461,6 +461,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,name: 'username'
                     ,fieldLabel: _('username')
                     ,description: _('user_username_desc')
+                    ,autoCreate: {tag: "input", type: "text", size: "20", autocomplete: "off", msgTarget: "under"}
                     ,xtype: 'textfield'
                     ,anchor: '100%'
                 },{


### PR DESCRIPTION
### What does it do?
Set autocomplete to `off` on username field.

### Why is it needed?
To prevent browsers changing username through autocomplete.

### Related issue(s)/PR(s)
Resolves #14699
