### PR TITLE
Set autocomplete to off on username in user edit form (for 3.x)

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -491,6 +491,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             ,description: _('user_username_desc')
             ,xtype: 'textfield'
             ,anchor: '100%'
+            ,autoCreate: {tag: "input", type: "text", size: "20", autocomplete: "off", msgTarget: "under"}
             ,listeners: {
                 'keyup': {scope:this,fn:function(f,e) {
                     Ext.getCmp('modx-user-header').getEl().update(_('user')+': '+Ext.util.Format.htmlEncode(f.getValue()));


### PR DESCRIPTION
### What does it do?
Set autocomplete to `off` on username field.

### Why is it needed?
To prevent browsers changing username through autocomplete.

### Related issue(s)/PR(s)
Resolves #14699
