### PR TITLE
Removed fixed sizes for .user-avatar img in widgets

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -262,12 +262,9 @@
       display: block;
       padding-bottom: 5px;
       padding-top: 5px;
-      color: $blue;
       font-size: 14px;
-      font-weight: bold;
       text-decoration: none;
       text-align: center;
-      text-transform: uppercase;
     }
   }
 

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -308,10 +308,11 @@
     align-items: center;
 
     .user-avatar {
-      margin-right: 5px;
+      margin-right: 10px;
 
       img {
-        border-radius: 30px;
+        width: 35px;
+        border-radius: 50%;
       }
     }
 

--- a/manager/templates/default/dashboard/onlineusers.tpl
+++ b/manager/templates/default/dashboard/onlineusers.tpl
@@ -17,7 +17,7 @@
                     <td class="user-with-avatar">
                         <div class="user-avatar">
                             {if $record.photo}
-                                <img src="{$record.photo}" width="32" height="32">
+                                <img src="{$record.photo}">
                             {else}
                                 <i class="icon icon-user icon-2x"></i>
                             {/if}

--- a/manager/templates/default/dashboard/recentlyeditedresources.tpl
+++ b/manager/templates/default/dashboard/recentlyeditedresources.tpl
@@ -37,7 +37,7 @@
                         <td class="user-with-avatar">
                             <div class="user-avatar">
                                 {if $record.photo}
-                                    <img src="{$record.photo}" width="32" height="32">
+                                    <img src="{$record.photo}">
                                 {else}
                                     <i class="icon icon-user icon-2x"></i>
                                 {/if}


### PR DESCRIPTION
### What does it do?
Removed fixed sizes for `.user-avatar img` in widgets

Before:
![before](https://user-images.githubusercontent.com/12523676/69012048-8fbebb80-098a-11ea-8039-9b7ae6ae7889.png)

After:
![after](https://user-images.githubusercontent.com/12523676/69498818-79be7700-0f05-11ea-9ded-28d834d8170f.png)

Fixed styles for links in widgets:
![link](https://user-images.githubusercontent.com/12523676/69564510-92de2b00-0fcc-11ea-8979-5f0c62cd054c.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14828