### PR TITLE
Deleted unnecessary system settings for "Authentication and Security" section

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1857,15 +1857,6 @@ $settings['tvs_below_content']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
-$settings['udperms_allowroot']= $xpdo->newObject(modSystemSetting::class);
-$settings['udperms_allowroot']->fromArray(array (
-  'key' => 'udperms_allowroot',
-  'value' => false,
-  'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'authentication',
-  'editedon' => null,
-), '', true, true);
 $settings['unauthorized_page']= $xpdo->newObject(modSystemSetting::class);
 $settings['unauthorized_page']->fromArray(array (
   'key' => 'unauthorized_page',
@@ -1954,28 +1945,6 @@ $settings['use_weblink_target']->fromArray(array (
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
-  'editedon' => null,
-), '', true, true);
-$settings['webpwdreminder_message']= $xpdo->newObject(modSystemSetting::class);
-$settings['webpwdreminder_message']->fromArray(array (
-  'key' => 'webpwdreminder_message',
-  'value' => "<p>Hello [[+uid]],</p>
-
-    <p>To activate your new password click the following link:</p>
-
-    <p>[[+surl]]</p>
-
-    <p>If successful you can use the following password to login:</p>
-
-    <p><strong>Password:</strong> [[+pwd]]</p>
-
-    <p>If you did not request this email then please ignore it.</p>
-
-    <p>Regards,<br />
-    Site Administrator</p>",
-  'xtype' => 'textarea',
-  'namespace' => 'core',
-  'area' => 'authentication',
   'editedon' => null,
 ), '', true, true);
 $settings['welcome_screen']= $xpdo->newObject(modSystemSetting::class);

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -761,9 +761,6 @@ $_lang['setting_tvs_below_content_desc'] = 'Set this to Yes to move Template Var
 $_lang['setting_ui_debug_mode'] = 'UI Debug Mode';
 $_lang['setting_ui_debug_mode_desc'] = 'Set this to Yes to output debug messages when using the UI for the default manager theme. You must use a browser that supports console.log.';
 
-$_lang['setting_udperms_allowroot'] = 'Allow root';
-$_lang['setting_udperms_allowroot_desc'] = 'Do you want to allow your users to create new Resources in the root of the site?';
-
 $_lang['setting_unauthorized_page'] = 'Unauthorized page';
 $_lang['setting_unauthorized_page_desc'] = 'Enter the ID of the Resource you want to send users to if they have requested a secured or unauthorized Resource. <strong>NOTE: Make sure the ID you enter belongs to an existing Resource, and that it has been published and is publicly accessible!</strong>';
 $_lang['setting_unauthorized_page_err'] = 'Please specify a Resource ID for the unauthorized page.';
@@ -802,10 +799,6 @@ $_lang['setting_use_weblink_target_desc'] = 'Set to true if you want to have MOD
 
 $_lang['setting_user_nav_parent'] = 'User menu parent';
 $_lang['setting_user_nav_parent_desc'] = 'The container used to pull all records for the user menu.';
-
-$_lang['setting_webpwdreminder_message'] = 'Web Reminder Email';
-$_lang['setting_webpwdreminder_message_desc'] = 'Enter a message to be sent to your web users whenever they request a new password via email. The Content Manager will send an email containing their new password and activation information. <br /><strong>Note:</strong> The following placeholders are replaced by the Content Manager when the message is sent: <br /><br />[[+sname]] - Name of your web site, <br />[[+saddr]] - Your web site email address, <br />[[+surl]] - Your site URL, <br />[[+uid]] - User\'s login name or id, <br />[[+pwd]] - User\'s password, <br />[[+ufn]] - User\'s full name. <br /><br /><strong>Leave the [[+uid]] and [[+pwd]] in the email, or else the username and password won\'t be sent in the mail and your users won\'t know their username or password!</strong>';
-$_lang['setting_webpwdreminder_message_default'] = 'Hello [[+uid]]\n\nTo activate your new password, click the following link:\n\n[[+surl]]\n\nIf successful, you can use the following password to log in:\n\nPassword:[[+pwd]]\n\nIf you did not request this email, then please ignore it.\n\nRegrads,\nSite Administrator';
 
 $_lang['setting_welcome_screen'] = 'Show Welcome Screen';
 $_lang['setting_welcome_screen_desc'] = 'If set to true, the welcome screen will show on the next successful loading of the welcome page, and then not show after that.';

--- a/setup/includes/upgrades/common/3.0.0-cleanup-authentication-security-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-authentication-security-system-settings.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Remove unnecessary system settings for "Authentication and Security" section
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$settings = [
+    'udperms_allowroot',
+    'webpwdreminder_message'
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+foreach ($settings as $key) {
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject(modSystemSetting::class, ['key' => $key]);
+    if ($setting instanceof modSystemSetting) {
+        if ($setting->remove()) {
+            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+                sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])));
+        } else {
+            $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+                sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
+        }
+    }
+}

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -14,6 +14,7 @@ include dirname(__DIR__) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-authentication-security-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';
 include dirname(__DIR__) . '/common/3.0.0-update-xtypes-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-upload_images.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -14,6 +14,7 @@ include dirname(__DIR__) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-authentication-security-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';
 include dirname(__DIR__) . '/common/3.0.0-update-xtypes-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-upload_images.php';


### PR DESCRIPTION
### What does it do?
Deleted unnecessary system settings for **"Authentication and Security"** section.

These settings are found only in the "System Settings", do not participate in the remaining code:
- udperms_allowroot
- webpwdreminder_message

In the future, I will check the settings in other sections.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14539#issuecomment-482059233
