### PR TITLE
Removed unused system settings for "Rich-Text Editor" section

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -478,24 +478,6 @@ $settings['default_content_type']->fromArray(array (
   'area' => 'site',
   'editedon' => null,
 ), '', true, true);
-$settings['editor_css_path']= $xpdo->newObject(modSystemSetting::class);
-$settings['editor_css_path']->fromArray(array (
-  'key' => 'editor_css_path',
-  'value' => '',
-  'xtype' => 'textfield',
-  'namespace' => 'core',
-  'area' => 'editor',
-  'editedon' => null,
-), '', true, true);
-$settings['editor_css_selectors']= $xpdo->newObject(modSystemSetting::class);
-$settings['editor_css_selectors']->fromArray(array (
-  'key' => 'editor_css_selectors',
-  'value' => '',
-  'xtype' => 'textfield',
-  'namespace' => 'core',
-  'area' => 'editor',
-  'editedon' => null,
-), '', true, true);
 $settings['emailsender']= $xpdo->newObject(modSystemSetting::class);
 $settings['emailsender']->fromArray(array (
   'key' => 'emailsender',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -245,12 +245,6 @@ $_lang['setting_default_template_desc'] = 'Select the default Template you wish 
 $_lang['setting_default_per_page'] = 'Default Per Page';
 $_lang['setting_default_per_page_desc'] = 'The default number of results to show in grids throughout the manager.';
 
-$_lang['setting_editor_css_path'] = 'Path to CSS file';
-$_lang['setting_editor_css_path_desc'] = 'Enter the path to your CSS file that you wish to use within a richtext editor. The best way to enter the path is to enter the path from the root of your server, for example: /assets/site/style.css. If you do not wish to load a style sheet into a richtext editor, leave this field blank.';
-
-$_lang['setting_editor_css_selectors'] = 'CSS Selectors for Editor';
-$_lang['setting_editor_css_selectors_desc'] = 'A comma-separated list of CSS selectors for a richtext editor.';
-
 $_lang['setting_emailsender'] = 'Registration Email From Address';
 $_lang['setting_emailsender_desc'] = 'Here you can specify the email address used when sending Users their usernames and passwords.';
 $_lang['setting_emailsender_err'] = 'Please state the administration email address.';

--- a/setup/includes/upgrades/common/3.0.0-cleanup-richtext-editor-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-richtext-editor-system-settings.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Remove unused system settings for "Rich-Text Editor" section
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$settings = [
+    'editor_css_path',
+    'editor_css_selectors'
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+foreach ($settings as $key) {
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject(modSystemSetting::class, ['key' => $key]);
+    if ($setting instanceof modSystemSetting) {
+        if ($setting->remove()) {
+            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+                sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])));
+        } else {
+            $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+                sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
+        }
+    }
+}

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -12,6 +12,7 @@ include dirname(__DIR__) . '/common/3.0-cleanup-files.php';
 include dirname(__DIR__) . '/common/3.0.0-dashboard-widgets.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-richtext-editor-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -12,6 +12,7 @@ include dirname(__DIR__) . '/common/3.0-cleanup-files.php';
 include dirname(__DIR__) . '/common/3.0.0-dashboard-widgets.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-copy-to-clipboard.php';
 include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-richtext-editor-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';


### PR DESCRIPTION
### What does it do?
Removed unused system settings for "Rich-Text Editor" section.

These settings are found only in the "System Settings", do not participate in the remaining code:
- editor_css_path
- editor_css_selectors

In the future, I will check the settings in other sections.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14539#issuecomment-482059233