### PR TITLE
Fix missing use statement in update xtype system settings upgrade script

### DIFF
--- a/setup/includes/upgrades/common/3.0.0-update-xtypes-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-update-xtypes-system-settings.php
@@ -3,6 +3,8 @@
  * Update the xtype's for system settings
  */
 
+use MODX\Revolution\modSystemSetting;
+
 $xtypeSettingsMap = [
     [
         'key' => 'auto_check_pkg_updates_cache_expire',


### PR DESCRIPTION
### What does it do?
Adds a missing use statement in the upgrade script.

### Why is it needed?
To prevent issues when updating MODX.

### Related issue(s)/PR(s)
n/a
