### PR TITLE
delete copies of the lexicon

### DIFF
--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -847,6 +847,3 @@ $_lang['setting_passwordless_activated_desc'] = 'When enabled, users will enter 
 
 $_lang['setting_passwordless_expiration'] = 'Passwordless login expiration';
 $_lang['setting_passwordless_expiration_desc'] = 'How long a one-time login link is valid in seconds.';
-
-$_lang['setting_passwordless_expiration'] = 'Passwordless login expiration';
-$_lang['setting_passwordless_expiration_desc'] = 'How long a one-time login link is valid in seconds.';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -848,8 +848,5 @@ $_lang['setting_passwordless_activated_desc'] = 'When enabled, users will enter 
 $_lang['setting_passwordless_expiration'] = 'Passwordless login expiration';
 $_lang['setting_passwordless_expiration_desc'] = 'How long a one-time login link is valid in seconds.';
 
-$_lang['setting_passwordless_activated'] = 'Activate passwordless login';
-$_lang['setting_passwordless_activated_desc'] = 'When enabled, users will enter their email address to receive a one-time login link, rather than entering a username and password.';
-
 $_lang['setting_passwordless_expiration'] = 'Passwordless login expiration';
 $_lang['setting_passwordless_expiration_desc'] = 'How long a one-time login link is valid in seconds.';


### PR DESCRIPTION
### What does it do?
delete copies of the lexicon key setting_passwordless_activated and setting_passwordless_activated_desc

### Why is it needed?
https://github.com/modxcms/revolution/blob/3.x/core/lexicon/en/setting.inc.php#L845-L846

https://github.com/modxcms/revolution/blob/3.x/core/lexicon/en/setting.inc.php#L851-L852
