### PR TITLE
Removed unused system settings for "Lexicon and Language" section

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -532,15 +532,6 @@ $settings['failed_login_attempts']->fromArray(array (
   'area' => 'authentication',
   'editedon' => null,
 ), '', true, true);
-$settings['fe_editor_lang']= $xpdo->newObject(modSystemSetting::class);
-$settings['fe_editor_lang']->fromArray(array (
-  'key' => 'fe_editor_lang',
-  'value' => 'en',
-  'xtype' => 'modx-combo-language',
-  'namespace' => 'core',
-  'area' => 'language',
-  'editedon' => null,
-), '', true, true);
 $settings['feed_modx_news']= $xpdo->newObject(modSystemSetting::class);
 $settings['feed_modx_news']->fromArray(array (
   'key' => 'feed_modx_news',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -274,9 +274,6 @@ $_lang['setting_enable_gravatar_desc'] = 'If enabled, Gravatar will be used as a
 $_lang['setting_failed_login_attempts'] = 'Failed Login Attempts';
 $_lang['setting_failed_login_attempts_desc'] = 'The number of failed login attempts a User is allowed before becoming \'blocked\'.';
 
-$_lang['setting_fe_editor_lang'] = 'Front-end Editor Language';
-$_lang['setting_fe_editor_lang_desc'] = 'Choose a language for the editor to use when used as a front-end editor.';
-
 $_lang['setting_feed_modx_news'] = 'MODX News Feed URL';
 $_lang['setting_feed_modx_news_desc'] = 'Set the URL for the RSS feed for the MODX News panel in the manager.';
 

--- a/setup/includes/upgrades/common/3.0.0-cleanup-lexicon-language-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-lexicon-language-system-settings.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Remove unnecessary system settings for "Lexicon and Language" section
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$settings = [
+    'fe_editor_lang'
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+foreach ($settings as $key) {
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject(modSystemSetting::class, ['key' => $key]);
+    if ($setting instanceof modSystemSetting) {
+        if ($setting->remove()) {
+            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+                sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])));
+        } else {
+            $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+                sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_cleanup_failure', ['key' => $key])));
+        }
+    }
+}

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -15,6 +15,7 @@ include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-cleanup-authentication-security-system-settings.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-lexicon-language-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';
 include dirname(__DIR__) . '/common/3.0.0-update-xtypes-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-upload_images.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -15,6 +15,7 @@ include dirname(__DIR__) . '/common/3.0.0-cleanup-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-tv-eval-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-upload-flash-system-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-cleanup-authentication-security-system-settings.php';
+include dirname(__DIR__) . '/common/3.0.0-cleanup-lexicon-language-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';
 include dirname(__DIR__) . '/common/3.0.0-update-xtypes-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-upload_images.php';


### PR DESCRIPTION
### What does it do?
Removed unused system settings for "Lexicon and Language" section.

These settings are found only in the "System Settings", do not participate in the remaining code:
- fe_editor_lang

In the future, I will check the settings in other sections.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14539#issuecomment-482059233