### PR TITLE
Added a 3.0.0-update-legacy-class-references.php script to the list

### DIFF
--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -19,5 +19,6 @@ include dirname(__DIR__) . '/common/3.0.0-content-type-icon.php';
 include dirname(__DIR__) . '/common/3.0.0-update-xtypes-system-settings.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-upload_images.php';
 include dirname(__DIR__) . '/common/3.0.0-trim-gender-field-size.php';
+include dirname(__DIR__) . '/common/3.0.0-update-legacy-class-references.php';
 include dirname(__DIR__) . '/common/3.0.0-update-menu-entries.php';
 include dirname(__DIR__) . '/common/3.0.0-update-default-media-source-setting.php';


### PR DESCRIPTION
### What does it do?
Added a `3.0.0-update-legacy-class-references.php` script to the list of scripts when updating.

In the https://github.com/modxcms/revolution/blob/3.x/setup/includes/upgrades/sqlsrv/3.0.0-pl.php file, the 3.0.0-update-legacy-class-references.php script was missing, although this script was specified in the https://github.com/modxcms/revolution/blob/3.x/setup/includes/upgrades/mysql/3.0.0-pl.php#L22 file.

### Related issue(s)/PR(s)
None
