### PR TITLE
Fixed .sub menu triangle

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -241,7 +241,8 @@
           content: fa-content($fa-var-caret-right);
           font-size: 14px;
           margin-top: 0;
-          top: 20px;
+          top: 50%;
+          transform: translateY(-50%);
           right: 10px;
         }
       }


### PR DESCRIPTION
### What does it do?
For MODX3, the bug was also relevant. Changed styles to %:

![before](https://user-images.githubusercontent.com/12523676/69885411-67be4900-12f6-11ea-89c8-c633e7f04ca1.png)

![after](https://user-images.githubusercontent.com/12523676/69885408-67be4900-12f6-11ea-8395-a070efde9f10.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14777