### PR TITLE
Reorganized the main menu

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -12,7 +12,7 @@ use MODX\Revolution\modMenu;
 
 $menus = [];
 
-$menus[0]= $xpdo->newObject(modMenu::class);
+$menus[0] = $xpdo->newObject(modMenu::class);
 $menus[0]->fromArray([
     'menuindex' => 0,
     'text' => 'topnav',
@@ -22,9 +22,9 @@ $menus[0]->fromArray([
     'action' => '',
 ], '', true, true);
 
-$menus[1]= $xpdo->newObject(modMenu::class);
+$menus[1] = $xpdo->newObject(modMenu::class);
 $menus[1]->fromArray([
-    'menuindex' => 0,
+    'menuindex' => 1,
     'text' => 'usernav',
     'description' => 'usernav_desc',
     'parent' => '',
@@ -34,7 +34,7 @@ $menus[1]->fromArray([
 
 
 /* ***************** CONTENT MENU ***************** */
-$topNavMenus[0]= $xpdo->newObject(modMenu::class);
+$topNavMenus[0] = $xpdo->newObject(modMenu::class);
 $topNavMenus[0]->fromArray([
   'menuindex' => 0,
   'text' => 'site',
@@ -42,13 +42,13 @@ $topNavMenus[0]->fromArray([
   'parent' => 'topnav',
   'permissions' => 'menu_site',
   'action' => '',
-  'icon' => '<i class="icon-file-text-o icon icon-large"></i>',
+  'icon' => '<i class="icon-file-text-o icon"></i>',
 ], '', true, true);
 
 $children = [];
 
 /* New Resource */
-$children[0]= $xpdo->newObject(modMenu::class);
+$children[0] = $xpdo->newObject(modMenu::class);
 $children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'new_resource',
@@ -58,33 +58,59 @@ $children[0]->fromArray([
   'action' => 'resource/create',
 ], '', true, true);
 
-/* Preview */
-$children[1]= $xpdo->newObject(modMenu::class);
+/* Clear Cache */
+$children[1] = $xpdo->newObject(modMenu::class);
 $children[1]->fromArray([
   'menuindex' => 1,
-  'text' => 'preview',
-  'description' => 'preview_desc',
+  'text' => 'refresh_site',
+  'description' => 'refresh_site_desc',
   'parent' => 'site',
-  'permissions' => '',
+  'permissions' => 'empty_cache',
   'action' => '',
-  'handler' => 'MODx.preview(); return false;',
+  'handler' => 'MODx.clearCache(); return false;',
 ], '', true, true);
 
-/* Manage Resource Groups */
-$children[2]= $xpdo->newObject(modMenu::class);
+/* Refresh URIs */
+$childrenOfClearCache[0] = $xpdo->newObject(modMenu::class);
+$childrenOfClearCache[0]->fromArray([
+  'menuindex' => 0,
+  'text' => 'refreshuris',
+  'description' => 'refreshuris_desc',
+  'parent' => 'refresh_site',
+  'permissions' => 'empty_cache',
+  'action' => '',
+  'handler' => 'MODx.refreshURIs(); return false;',
+], '', true, true);
+
+$children[1]->addMany($childrenOfClearCache, 'Children');
+
+/* Remove Locks */
+$children[2] = $xpdo->newObject(modMenu::class);
 $children[2]->fromArray([
   'menuindex' => 2,
-  'text' => 'resource_groups',
-  'description' => 'resource_groups_desc',
+  'text' => 'remove_locks',
+  'description' => 'remove_locks_desc',
   'parent' => 'site',
-  'permissions' => 'access_permissions',
-  'action' => 'security/resourcegroup',
+  'permissions' => 'remove_locks',
+  'action' => '',
+  'handler' => 'MODx.removeLocks();return false;',
+], '', true, true);
+
+/* Site Schedule */
+$children[3] = $xpdo->newObject(modMenu::class);
+$children[3]->fromArray([
+  'menuindex' => 3,
+  'text' => 'site_schedule',
+  'description' => 'site_schedule_desc',
+  'parent' => 'site',
+  'permissions' => 'view_document',
+  'action' => 'resource/site_schedule',
 ], '', true, true);
 
 /* Content Types */
-$children[3]= $xpdo->newObject(modMenu::class);
-$children[3]->fromArray([
-  'menuindex' => 3,
+$children[4] = $xpdo->newObject(modMenu::class);
+$children[4]->fromArray([
+  'menuindex' => 4,
   'text' => 'content_types',
   'description' => 'content_types_desc',
   'parent' => 'site',
@@ -92,12 +118,12 @@ $children[3]->fromArray([
   'action' => 'system/contenttype',
 ], '', true, true);
 
-$topNavMenus[0]->addMany($children,'Children');
+$topNavMenus[0]->addMany($children, 'Children');
 unset($children);
 
 
 /* ***************** MEDIA MENU ***************** */
-$topNavMenus[1]= $xpdo->newObject(modMenu::class);
+$topNavMenus[1] = $xpdo->newObject(modMenu::class);
 $topNavMenus[1]->fromArray([
   'menuindex' => 1,
   'text' => 'media',
@@ -105,11 +131,11 @@ $topNavMenus[1]->fromArray([
   'parent' => 'topnav',
   'permissions' => 'file_manager',
   'action' => '',
-  'icon' => '<i class="icon-file-image-o icon icon-large"></i>',
+  'icon' => '<i class="icon-file-image-o icon"></i>',
 ], '', true, true);
 
 /* Media Browser */
-$children[0]= $xpdo->newObject(modMenu::class);
+$children[0] = $xpdo->newObject(modMenu::class);
 $children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'file_browser',
@@ -119,23 +145,23 @@ $children[0]->fromArray([
   'action' => 'media/browser',
 ], '', true, true);
 
-/* Media Drivers */
-$children[1]= $xpdo->newObject(modMenu::class);
+/* Media Sources */
+$children[1] = $xpdo->newObject(modMenu::class);
 $children[1]->fromArray([
-  'menuindex'   => 1,
-  'text'        => 'sources',
+  'menuindex' => 1,
+  'text' => 'sources',
   'description' => 'sources_desc',
-  'parent'      => 'media',
+  'parent' => 'media',
   'permissions' => 'sources',
-  'action'      => 'source',
+  'action' => 'source',
 ], '', true, true);
 
-$topNavMenus[1]->addMany($children,'Children');
+$topNavMenus[1]->addMany($children, 'Children');
 unset($children);
 
 
-/* ***************** APPS MENU ***************** */
-$topNavMenus[2]= $xpdo->newObject(modMenu::class);
+/* ***************** COMPONENTS MENU ***************** */
+$topNavMenus[2] = $xpdo->newObject(modMenu::class);
 $topNavMenus[2]->fromArray([
   'menuindex' => 2,
   'text' => 'components',
@@ -143,11 +169,11 @@ $topNavMenus[2]->fromArray([
   'parent' => 'topnav',
   'permissions' => 'components',
   'action' => '',
-  'icon' => '<i class="icon-cube icon icon-large"></i>',
+  'icon' => '<i class="icon-cube icon"></i>',
 ], '', true, true);
 
 /* Installer */
-$children[0]= $xpdo->newObject(modMenu::class);
+$children[0] = $xpdo->newObject(modMenu::class);
 $children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'installer',
@@ -157,79 +183,127 @@ $children[0]->fromArray([
   'action' => 'workspaces',
 ], '', true, true);
 
-$topNavMenus[2]->addMany($children,'Children');
+/* Namespaces */
+$children[1] = $xpdo->newObject(modMenu::class);
+$children[1]->fromArray([
+  'menuindex' => 1,
+  'text' => 'namespaces',
+  'description' => 'namespaces_desc',
+  'parent' => 'components',
+  'permissions' => 'namespaces',
+  'action' => 'workspaces/namespace',
+], '', true, true);
+
+$topNavMenus[2]->addMany($children, 'Children');
 unset($children);
 
 
-/* ***************** ADMIN MENU ***************** */
-$topNavMenus[3]= $xpdo->newObject(modMenu::class);
-$topNavMenus[3]->fromArray([
-  'menuindex' => 3,
-  'text' => 'manage',
+/* ***************** USER MENU ***************** */
+$userNavMenus[0] = $xpdo->newObject(modMenu::class);
+$userNavMenus[0]->fromArray([
+  'menuindex' => 0,
+  'text' => 'user',
   'description' => '',
-  'parent' => 'topnav',
-  'permissions' => 'menu_tools',
+  'parent' => 'usernav',
+  'permissions' => 'menu_user',
   'action' => '',
-  'icon' => '<i class="icon-sliders icon icon-large"></i>',
+  'icon' => '<span id="user-avatar">{$userImage}</span> <span id="user-username">{$username}</span>',
 ], '', true, true);
+
+$children = [];
+
+/* Profile */
+$children[0] = $xpdo->newObject(modMenu::class);
+$children[0]->fromArray([
+  'menuindex' => 0,
+  'text' => '{$username}',
+  'description' => 'profile_desc',
+  'parent' => 'user',
+  'permissions' => 'change_profile',
+  'action' => 'security/profile',
+], '', true, true);
+
+/* Messages */
+$children[1] = $xpdo->newObject(modMenu::class);
+$children[1]->fromArray([
+  'menuindex' => 1,
+  'text' => 'messages',
+  'description' => 'messages_desc',
+  'parent' => 'user',
+  'permissions' => 'messages',
+  'action' => 'security/message',
+], '', true, true);
+
+/* Logout */
+$children[2] = $xpdo->newObject(modMenu::class);
+$children[2]->fromArray([
+  'menuindex' => 2,
+  'text' => 'logout',
+  'description' => 'logout_desc',
+  'parent' => 'user',
+  'permissions' => 'logout',
+  'action' => 'security/logout',
+  'handler' => 'MODx.logout(); return false;',
+], '', true, true);
+
+$userNavMenus[0]->addMany($children, 'Children');
+unset($children);
+
+
+/* ***************** ACCESS MENU ***************** */
+$userNavMenus[1] = $xpdo->newObject(modMenu::class);
+$userNavMenus[1]->fromArray([
+  'menuindex' => 1,
+  'text' => 'access',
+  'description' => '',
+  'parent' => 'usernav',
+  'permissions' => 'access_permissions',
+  'action' => '',
+  'icon' => '<i class="icon-user-lock icon"></i>',
+], '', true, true);
+
 $children = [];
 
 /* Manage Users */
-$children[0]= $xpdo->newObject(modMenu::class);
+$children[0] = $xpdo->newObject(modMenu::class);
 $children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'users',
   'description' => 'user_management_desc',
-  'parent' => 'manage',
+  'parent' => 'access',
   'permissions' => 'view_user',
   'action' => 'security/user',
 ], '', true, true);
 
-/* Clear Cache */
-$children[1]= $xpdo->newObject(modMenu::class);
+/* Manage Resource Groups */
+$children[1] = $xpdo->newObject(modMenu::class);
 $children[1]->fromArray([
   'menuindex' => 1,
-  'text' => 'refresh_site',
-  'description' => 'refresh_site_desc',
-  'parent' => 'manage',
-  'permissions' => 'empty_cache',
-  'action' => '',
-  'handler' => 'MODx.clearCache(); return false;',
+  'text' => 'resource_groups',
+  'description' => 'resource_groups_desc',
+  'parent' => 'access',
+  'permissions' => 'access_permissions',
+  'action' => 'security/resourcegroup',
 ], '', true, true);
 
-/* Refresh URIs */
-$childrenOfClearCache[0]= $xpdo->newObject(modMenu::class);
-$childrenOfClearCache[0]->fromArray([
-  'menuindex' => 0,
-  'text' => 'refreshuris',
-  'description' => 'refreshuris_desc',
-  'parent' => '',
-  'permissions' => 'empty_cache',
-  'action' => '',
-  'handler' => 'MODx.refreshURIs(); return false;',
-], '', true, true);
-
-$children[1]->addMany($childrenOfClearCache, 'Children');
-
-/* Remove Locks */
-$children[2]= $xpdo->newObject(modMenu::class);
+/* ACLs */
+$children[2] = $xpdo->newObject(modMenu::class);
 $children[2]->fromArray([
   'menuindex' => 2,
-  'text' => 'remove_locks',
-  'description' => 'remove_locks_desc',
-  'parent' => 'manage',
-  'permissions' => 'remove_locks',
-  'action' => '',
-  'handler' => 'MODx.removeLocks();return false;',
+  'text' => 'acls',
+  'description' => 'acls_desc',
+  'parent' => 'access',
+  'permissions' => 'access_permissions',
+  'action' => 'security/permission',
 ], '', true, true);
 
 /* Flush Permissions */
-$children[3]= $xpdo->newObject(modMenu::class);
+$children[3] = $xpdo->newObject(modMenu::class);
 $children[3]->fromArray([
   'menuindex' => 3,
   'text' => 'flush_access',
   'description' => 'flush_access_desc',
-  'parent' => 'manage',
+  'parent' => 'access',
   'permissions' => 'access_permissions',
   'action' => '',
   'handler' => 'MODx.msg.confirm({
@@ -247,12 +321,12 @@ $children[3]->fromArray([
 ], '', true, true);
 
 /* Flush Sessions */
-$children[4]= $xpdo->newObject(modMenu::class);
+$children[4] = $xpdo->newObject(modMenu::class);
 $children[4]->fromArray([
   'menuindex' => 4,
   'text' => 'flush_sessions',
   'description' => 'flush_sessions_desc',
-  'parent' => 'manage',
+  'parent' => 'access',
   'permissions' => 'flush_sessions',
   'action' => '',
   'handler' => 'MODx.msg.confirm({
@@ -268,144 +342,26 @@ $children[4]->fromArray([
 });',
 ], '', true, true);
 
-/* Reports */
-$children[5]= $xpdo->newObject(modMenu::class);
-$children[5]->fromArray([
-  'menuindex' => 5,
-  'text' => 'reports',
-  'description' => 'reports_desc',
-  'parent' => 'manage',
-  'permissions' => 'menu_reports',
-  'action' => '',
-], '', true, true);
-
-/* site schedule */
-$childrenOfReports[0]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[0]->fromArray([
-        'menuindex' => 0,
-        'text' => 'site_schedule',
-        'description' => 'site_schedule_desc',
-        'parent' => '',
-        'permissions' => 'view_document',
-        'action' => 'resource/site_schedule',
-], '', true, true);
-
-/* manager actions */
-$childrenOfReports[1]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[1]->fromArray([
-    'menuindex' => 1,
-    'text' => 'view_logging',
-    'description' => 'view_logging_desc',
-    'parent' => '',
-    'permissions' => 'mgr_log_view',
-    'action' => 'system/logs',
-], '', true, true);
-
-/* error log */
-$childrenOfReports[2]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[2]->fromArray([
-    'menuindex' => 2,
-    'text' => 'eventlog_viewer',
-    'description' => 'eventlog_viewer_desc',
-    'parent' => '',
-    'permissions' => 'view_eventlog',
-    'action' => 'system/event',
-], '', true, true);
-
-/* system info */
-$childrenOfReports[3]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[3]->fromArray([
-    'menuindex' => 3,
-    'text' => 'view_sysinfo',
-    'description' => 'view_sysinfo_desc',
-    'parent' => 'reports',
-    'permissions' => 'view_sysinfo',
-    'action' => 'system/info',
-], '', true, true);
-
-$children[5]->addMany($childrenOfReports, 'Children');
-
-
-$topNavMenus[3]->addMany($children,'Children');
-unset($children, $childrenOfReports);
-
-
-/* ***************** USER MENU ***************** */
-$userNavMenus[0]= $xpdo->newObject(modMenu::class);
-$userNavMenus[0]->fromArray([
-  'menuindex' => 5,
-  'text' => 'user',
-  'description' => '',
-  'parent' => 'usernav',
-  'permissions' => 'menu_user',
-  'action' => '',
-  'icon' => '<span id="user-avatar">{$userImage}</span> <span id="user-username">{$username}</span>',
-], '', true, true);
-$children = [];
-
-/* edit account */
-$children[0]= $xpdo->newObject(modMenu::class);
-$children[0]->fromArray([
-  'menuindex' => 0,
-  'text' => '{$username}',
-  'description' => 'profile_desc',
-  'parent' => 'user',
-  'permissions' => 'change_profile',
-  'action' => 'security/profile',
-], '', true, true);
-
-/* messages */
-$children[1]= $xpdo->newObject(modMenu::class);
-$children[1]->fromArray([
-  'menuindex' => 1,
-  'text' => 'messages',
-  'description' => 'messages_desc',
-  'parent' => 'user',
-  'permissions' => 'messages',
-  'action' => 'security/message',
-], '', true, true);
-
-/* language */
-$children[2]= $xpdo->newObject(modMenu::class);
-$children[2]->fromArray([
-    'menuindex' => 2,
-    'text' => 'language',
-    'description' => 'language_desc',
-    'parent' => 'user',
-    'permissions' => 'language',
-    'action' => ''
-], '', true, true);
-
-/* logout */
-$children[3]= $xpdo->newObject(modMenu::class);
-$children[3]->fromArray([
-  'menuindex' => 3,
-  'text' => 'logout',
-  'description' => 'logout_desc',
-  'parent' => 'user',
-  'permissions' => 'logout',
-  'action' => 'security/logout',
-  'handler' => 'MODx.logout(); return false;',
-], '', true, true);
-
-$userNavMenus[0]->addMany($children,'Children');
+$userNavMenus[1]->addMany($children, 'Children');
 unset($children);
 
-/* ***************** ADMIN/SETTINGS MENU ***************** */
-$userNavMenus[1]= $xpdo->newObject(modMenu::class);
-$userNavMenus[1]->fromArray([
-  'menuindex' => 6,
+
+/* ***************** SETTINGS MENU ***************** */
+$userNavMenus[2] = $xpdo->newObject(modMenu::class);
+$userNavMenus[2]->fromArray([
+  'menuindex' => 2,
   'text' => 'admin',
   'description' => '',
   'parent' => 'usernav',
   'permissions' => 'settings',
   'action' => '',
-  'icon' => '<i class="icon-gear icon icon-large"></i>',
+  'icon' => '<i class="icon-gear icon"></i>',
 ], '', true, true);
+
 $children = [];
 
-/* system settings */
-$children[0]= $xpdo->newObject(modMenu::class);
+/* System Settings */
+$children[0] = $xpdo->newObject(modMenu::class);
 $children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'system_settings',
@@ -415,8 +371,8 @@ $children[0]->fromArray([
   'action' => 'system/settings',
 ], '', true, true);
 
-/* customize manager */
-$children[1]= $xpdo->newObject(modMenu::class);
+/* Customize Manager */
+$children[1] = $xpdo->newObject(modMenu::class);
 $children[1]->fromArray([
   'menuindex' => 1,
   'text' => 'form_customization',
@@ -426,8 +382,41 @@ $children[1]->fromArray([
   'action' => 'security/forms',
 ], '', true, true);
 
+/* Property Sets */
+$children[2] = $xpdo->newObject(modMenu::class);
+$children[2]->fromArray([
+  'menuindex' => 2,
+  'text' => 'propertysets',
+  'description' => 'propertysets_desc',
+  'parent' => 'admin',
+  'permissions' => 'property_sets',
+  'action' => 'element/propertyset',
+], '', true, true);
+
+/* Manager Menus */
+$children[3] = $xpdo->newObject(modMenu::class);
+$children[3]->fromArray([
+  'menuindex' => 3,
+  'text' => 'edit_menu',
+  'description' => 'edit_menu_desc',
+  'parent' => 'admin',
+  'permissions' => 'actions',
+  'action' => 'system/action',
+], '', true, true);
+
+/* Contexts */
+$children[4] = $xpdo->newObject(modMenu::class);
+$children[4]->fromArray([
+  'menuindex' => 4,
+  'text' => 'contexts',
+  'description' => 'contexts_desc',
+  'parent' => 'admin',
+  'permissions' => 'view_context',
+  'action' => 'context',
+], '', true, true);
+
 /* Dashboards */
-$children[2]= $xpdo->newObject(modMenu::class);
+$children[2] = $xpdo->newObject(modMenu::class);
 $children[2]->fromArray([
   'menuindex' => 2,
   'text' => 'dashboards',
@@ -437,52 +426,8 @@ $children[2]->fromArray([
   'action' => 'system/dashboards',
 ], '', true, true);
 
-/* Contexts */
-$children[3]= $xpdo->newObject(modMenu::class);
-$children[3]->fromArray([
-  'menuindex' => 3,
-  'text' => 'contexts',
-  'description' => 'contexts_desc',
-  'parent' => 'admin',
-  'permissions' => 'view_context',
-  'action' => 'context',
-], '', true, true);
-
-/* Manager Menus */
-$children[4]= $xpdo->newObject(modMenu::class);
-$children[4]->fromArray([
-  'menuindex' => 4,
-  'text' => 'edit_menu',
-  'description' => 'edit_menu_desc',
-  'parent' => 'admin',
-  'permissions' => 'actions',
-  'action' => 'system/action',
-], '', true, true);
-
-/* ACLs */
-$children[5]= $xpdo->newObject(modMenu::class);
-$children[5]->fromArray([
-  'menuindex' => 5,
-  'text' => 'acls',
-  'description' => 'acls_desc',
-  'parent' => 'admin',
-  'permissions' => 'access_permissions',
-  'action' => 'security/permission',
-], '', true, true);
-
-/* Property Sets */
-$children[6]= $xpdo->newObject(modMenu::class);
-$children[6]->fromArray([
-  'menuindex' => 6,
-  'text' => 'propertysets',
-  'description' => 'propertysets_desc',
-  'parent' => 'admin',
-  'permissions' => 'property_sets',
-  'action' => 'element/propertyset',
-], '', true, true);
-
 /* Lexicons */
-$children[7]= $xpdo->newObject(modMenu::class);
+$children[7] = $xpdo->newObject(modMenu::class);
 $children[7]->fromArray([
   'menuindex' => 7,
   'text' => 'lexicon_management',
@@ -492,30 +437,77 @@ $children[7]->fromArray([
   'action' => 'workspaces/lexicon',
 ], '', true, true);
 
-/* Namespaces */
-$children[8]= $xpdo->newObject(modMenu::class);
+/* Toggle Language */
+$children[8] = $xpdo->newObject(modMenu::class);
 $children[8]->fromArray([
-  'menuindex' => 8,
-  'text' => 'namespaces',
-  'description' => 'namespaces_desc',
-  'parent' => 'admin',
-  'permissions' => 'namespaces',
-  'action' => 'workspaces/namespace',
+    'menuindex' => 8,
+    'text' => 'language',
+    'description' => 'language_desc',
+    'parent' => 'admin',
+    'permissions' => 'language',
+    'action' => ''
 ], '', true, true);
 
-$userNavMenus[1]->addMany($children,'Children');
+/* Reports */
+$children[9] = $xpdo->newObject(modMenu::class);
+$children[9]->fromArray([
+  'menuindex' => 9,
+  'text' => 'reports',
+  'description' => 'reports_desc',
+  'parent' => 'admin',
+  'permissions' => 'menu_reports',
+  'action' => '',
+], '', true, true);
+
+/* Manager Actions */
+$childrenOfReports[0] = $xpdo->newObject(modMenu::class);
+$childrenOfReports[0]->fromArray([
+    'menuindex' => 0,
+    'text' => 'view_logging',
+    'description' => 'view_logging_desc',
+    'parent' => 'reports',
+    'permissions' => 'mgr_log_view',
+    'action' => 'system/logs',
+], '', true, true);
+
+/* Error Log */
+$childrenOfReports[1] = $xpdo->newObject(modMenu::class);
+$childrenOfReports[1]->fromArray([
+    'menuindex' => 1,
+    'text' => 'eventlog_viewer',
+    'description' => 'eventlog_viewer_desc',
+    'parent' => 'reports',
+    'permissions' => 'view_eventlog',
+    'action' => 'system/event',
+], '', true, true);
+
+/* System Info */
+$childrenOfReports[2] = $xpdo->newObject(modMenu::class);
+$childrenOfReports[2]->fromArray([
+    'menuindex' => 2,
+    'text' => 'view_sysinfo',
+    'description' => 'view_sysinfo_desc',
+    'parent' => 'reports',
+    'permissions' => 'view_sysinfo',
+    'action' => 'system/info',
+], '', true, true);
+
+$children[9]->addMany($childrenOfReports, 'Children');
+
+$userNavMenus[2]->addMany($children, 'Children');
 unset($children);
 
-/* ***************** ADMIN/ABOUT MENU ***************** */
-$userNavMenus[2]= $xpdo->newObject(modMenu::class);
-$userNavMenus[2]->fromArray([
-  'menuindex' => 8,
+
+/* ***************** ABOUT MENU ***************** */
+$userNavMenus[3] = $xpdo->newObject(modMenu::class);
+$userNavMenus[3]->fromArray([
+  'menuindex' => 3,
   'text' => 'about',
   'description' => '',
   'parent' => 'usernav',
   'permissions' => 'help',
   'action' => 'help',
-  'icon' => '<i class="icon-question-circle icon icon-large"></i>',
+  'icon' => '<i class="icon-question-circle icon"></i>',
 ], '', true, true);
 
 /* add topnav and usernav menu children */


### PR DESCRIPTION
### What does it do?
Changed the order of the main menu items.
The items from the "Manage" section have moved to other logically related sections and a new "Access" item has been added and that's it.

In principle, we can leave the "Manage" section, where there will be "Clear cache", "Delete Locks", "Manager Action" and "Error log" (the "Site Schedule" item will move to "Content", "Reports -> System Info" item will move to "System").

**BUT the addition of the "Access" item seems to me to be a very useful improvement to the menu.**

### What does it look like now:

**All menu**
![menu](https://user-images.githubusercontent.com/12523676/161322454-ba892133-452c-498b-b6a2-2f62423a53a0.png)

---

**Content**
![content](https://user-images.githubusercontent.com/12523676/161323080-bb139dea-2ead-41b1-9ca0-2f4757276109.png)

---

**Extras**
![extras](https://user-images.githubusercontent.com/12523676/161321477-65587fa2-fce7-40dd-91c7-ea6677000e37.png)

---

**Account**
![user](https://user-images.githubusercontent.com/12523676/69887550-eb7d3300-1300-11ea-84af-fd318e4ddc27.png)
The language switch is now in the system section. The language switch can be left in "Account" section, but it seems to me that this is more about the "System" than the "Account".

---

**Access**
![access](https://user-images.githubusercontent.com/12523676/161321551-f15a2bb8-22b7-48e2-9597-76ad2f96fdc2.png)
All items related to users and access are moved to one section.

---

**System**
![system_1](https://user-images.githubusercontent.com/12523676/161321641-16ca4d9c-dc20-4772-a0d9-6391666dcaea.png)
![system_2](https://user-images.githubusercontent.com/12523676/161321646-8d1ca421-8829-467d-983c-5891041ff89a.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14291