### PR TITLE
Rename and move the base Object-related processors

### DIFF
--- a/_build/test/MODxTestCase.php
+++ b/_build/test/MODxTestCase.php
@@ -11,6 +11,7 @@
 */
 namespace MODX\Revolution;
 
+use MODX\Revolution\Processors\ProcessorResponse;
 use PHPUnit\Framework\TestCase;
 use xPDO\xPDOException;
 
@@ -54,18 +55,18 @@ abstract class MODxTestCase extends TestCase {
     /**
      * Check a MODX return result for a success flag
      *
-     * @param modProcessorResponse $result The result response
+     * @param ProcessorResponse $result The result response
      * @return boolean
      */
     public function checkForSuccess(&$result) {
-        if (empty($result) || !($result instanceof modProcessorResponse)) return false;
+        if (empty($result) || !($result instanceof ProcessorResponse)) return false;
         return !$result->isError();
     }
 
     /**
      * Check a MODX processor response and return results
      *
-     * @param modProcessorResponse $result The response
+     * @param ProcessorResponse $result The response
      * @return array
      */
     public function getResults(&$result) {

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Tests\Processors\Browser;
 
 
 use Exception;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Processors\Browser\Directory\Create;
@@ -169,7 +169,7 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
      * @param boolean $shouldWork True if the directory list should not be empty.
      */
     public function testGetDirectoryList($dir,$shouldWork = true) {
-        /** @var modProcessorResponse $response */
+        /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(GetList::class,array(
             'id' => $dir,
         ));

--- a/_build/test/Tests/Processors/Context/ContextTest.php
+++ b/_build/test/Tests/Processors/Context/ContextTest.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Tests\Processors\Context;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Processors\Context\Create;
 use MODX\Revolution\Processors\Context\Duplicate;
@@ -68,7 +68,7 @@ class ContextProcessorsTest extends MODxTestCase {
      */
     public function testContextCreate($ctx,$description = '') {
         if (empty($ctx)) return;
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Create::class,array(
             'key' => $ctx,
             'description' => $description,
@@ -167,7 +167,7 @@ class ContextProcessorsTest extends MODxTestCase {
     public function testContextUpdate($ctx,$description = '') {
         if (empty($ctx)) return;
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Update::class,array(
             'key' => $ctx,
             'description' => $description,
@@ -200,7 +200,7 @@ class ContextProcessorsTest extends MODxTestCase {
     public function testContextGet($ctx) {
         if (empty($ctx)) return false;
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Get::class,array(
             'key' => $ctx,
         ));
@@ -233,7 +233,7 @@ class ContextProcessorsTest extends MODxTestCase {
     public function testContextGetInvalid($ctx,$description = '') {
         if (empty($ctx)) return false;
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Get::class,array(
             'key' => $ctx,
         ));

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Tests\Processors\Element;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Processors\Element\Category\Create;
 use MODX\Revolution\Processors\Element\Category\Get;
@@ -66,7 +66,7 @@ class CategoryProcessorsTest extends MODxTestCase {
      * @dataProvider providerCategoryCreate
      */
     public function testCategoryCreate($shouldPass,$categoryPk) {
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Create::class,array(
             'category' => $categoryPk,
         ));
@@ -110,7 +110,7 @@ class CategoryProcessorsTest extends MODxTestCase {
             return false;
         }
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Get::class,array(
             'id' => $category ? $category->get('id') : $categoryPk,
         ));
@@ -146,7 +146,7 @@ class CategoryProcessorsTest extends MODxTestCase {
      * @dataProvider providerCategoryGetList
      */
     public function testCategoryGetList($shouldPass,$sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(GetList::class,array(
             'sort' => $sort,
             'dir' => $dir,
@@ -188,7 +188,7 @@ class CategoryProcessorsTest extends MODxTestCase {
             return false;
         }
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Remove::class,array(
             'id' => $category ? $category->get('id') : $categoryPk,
         ));

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -14,7 +14,7 @@ namespace MODX\Revolution\Tests\Processors\Element;
 
 use MODX\Revolution\modCategory;
 use MODX\Revolution\modChunk;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Processors\Element\Chunk\Create;
 use MODX\Revolution\Processors\Element\Chunk\Duplicate;
@@ -133,7 +133,7 @@ class ChunkProcessorsTest extends MODxTestCase {
         }
         $this->modx->lexicon->load('default');
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Duplicate::class,array(
             'id' => $chunk ? $chunk->get('id') : $chunkPk,
             'name' => $newName,
@@ -189,7 +189,7 @@ class ChunkProcessorsTest extends MODxTestCase {
         $data['id'] = $chunk ? $chunk->get('id') : $chunkPk;
         $data['name'] = $chunkPk;
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Update::class,$data);
         $passed = $this->checkForSuccess($result);
         if ($passed) {

--- a/_build/test/Tests/Processors/Element/PropertySetTest.php
+++ b/_build/test/Tests/Processors/Element/PropertySetTest.php
@@ -12,7 +12,7 @@
 namespace MODX\Revolution\Tests\Processors\Element;
 
 
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modPropertySet;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Processors\Element\PropertySet\Create;
@@ -61,7 +61,7 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @dataProvider providerPropertySetCreate
      */
     public function testPropertySetCreate($shouldPass,$propertySetPk) {
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Create::class,array(
             'name' => $propertySetPk,
         ));

--- a/_build/test/Tests/Processors/Element/TemplateTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateTest.php
@@ -12,7 +12,7 @@
 namespace MODX\Revolution\Tests\Processors\Element;
 
 
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Processors\Element\Template\Create;
@@ -168,7 +168,7 @@ class TemplateProcessorsTest extends MODxTestCase {
             $this->fail('No Template found "'.$templatePk.'" as specified in test provider.');
             return;
         }
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Remove::class,array(
             'id' => $template ? $template->get('id') : $templatePk,
         ));

--- a/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
+++ b/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
@@ -12,7 +12,7 @@
 namespace MODX\Revolution\Tests\Processors\Resource;
 
 
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
@@ -81,7 +81,7 @@ class ResourceCreateProcessorTest extends MODxTestCase {
             $this->modx->setOption($k,$v);
         }
 
-        /** @var modProcessorResponse $result */
+        /** @var ProcessorResponse $result */
         $result = $this->modx->runProcessor(Create::class,$fields);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');

--- a/core/include/deprecated.php
+++ b/core/include/deprecated.php
@@ -21,18 +21,21 @@ class_alias(\xPDO\Transport\xPDOObjectVehicle::class, \xPDOObjectVehicle::class)
 class_alias(\MODX\Revolution\modX::class, \modX::class);
 
 // Processors
-class_alias(\MODX\Revolution\modProcessor::class, \modProcessor::class);
-class_alias(\MODX\Revolution\modObjectProcessor::class, \modObjectProcessor::class);
-class_alias(\MODX\Revolution\modObjectCreateProcessor::class, \modObjectCreateProcessor::class);
-class_alias(\MODX\Revolution\modObjectExportProcessor::class, \modObjectExportProcessor::class);
-class_alias(\MODX\Revolution\modObjectGetListProcessor::class, \modObjectGetListProcessor::class);
-class_alias(\MODX\Revolution\modObjectGetProcessor::class, \modObjectGetProcessor::class);
-class_alias(\MODX\Revolution\modObjectImportProcessor::class, \modObjectImportProcessor::class);
-class_alias(\MODX\Revolution\modObjectRemoveProcessor::class, \modObjectRemoveProcessor::class);
-class_alias(\MODX\Revolution\modObjectSoftRemoveProcessor::class, \modObjectSoftRemoveProcessor::class);
-class_alias(\MODX\Revolution\modObjectUpdateProcessor::class, \modObjectUpdateProcessor::class);
+class_alias(\MODX\Revolution\Processors\Processor::class, \modProcessor::class);
+class_alias(\MODX\Revolution\Processors\ModelProcessor::class, \modObjectProcessor::class);
+class_alias(\MODX\Revolution\Processors\DriverSpecificProcessor::class, \modDriverSpecificProcessor::class);
+class_alias(\MODX\Revolution\Processors\ProcessorResponse::class, \modProcessorResponse::class);
+class_alias(\MODX\Revolution\Processors\ProcessorResponseError::class, \modProcessorResponseError::class);
+class_alias(\MODX\Revolution\Processors\Model\CreateProcessor::class, \modObjectCreateProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\DuplicateProcessor::class, \modObjectDuplicateProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\ExportProcessor::class, \modObjectExportProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\GetListProcessor::class, \modObjectGetListProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\GetProcessor::class, \modObjectGetProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\ImportProcessor::class, \modObjectImportProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\RemoveProcessor::class, \modObjectRemoveProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\SoftRemoveProcessor::class, \modObjectSoftRemoveProcessor::class);
+class_alias(\MODX\Revolution\Processors\Model\UpdateProcessor::class, \modObjectUpdateProcessor::class);
 class_alias(\MODX\Revolution\modParsedManagerController::class, \modParsedManagerController::class);
-class_alias(\MODX\Revolution\modObjectDuplicateProcessor::class, \modObjectDuplicateProcessor::class);
 
 class_alias(\MODX\Revolution\modExtraManagerController::class, \modExtraManagerController::class);
 class_alias(\MODX\Revolution\modResource::class, \modResource::class);

--- a/core/src/Revolution/Processors/Browser/Browser.php
+++ b/core/src/Revolution/Processors/Browser/Browser.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Browser;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Sources\modMediaSource;
 
 /**
@@ -21,7 +21,7 @@ use MODX\Revolution\Sources\modMediaSource;
  *
  * @package MODX\Revolution\Processors\Browser
  */
-abstract class Browser extends modProcessor
+abstract class Browser extends Processor
 {
     /** @var modMediaSource $source */
     public $source;

--- a/core/src/Revolution/Processors/Context/Create.php
+++ b/core/src/Revolution/Processors/Context/Create.php
@@ -14,7 +14,7 @@ namespace MODX\Revolution\Processors\Context;
 use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
@@ -24,7 +24,7 @@ use MODX\Revolution\modUserGroup;
  *
  * @package MODX\Revolution\Processors\Context
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modContext::class;
     public $languageTopics = ['context'];

--- a/core/src/Revolution/Processors/Context/Duplicate.php
+++ b/core/src/Revolution/Processors/Context/Duplicate.php
@@ -14,7 +14,7 @@ namespace MODX\Revolution\Processors\Context;
 use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modContextSetting;
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\Sources\modMediaSourceElement;
 
@@ -26,7 +26,7 @@ use MODX\Revolution\Sources\modMediaSourceElement;
  *
  * @package MODX\Revolution\Processors\Context
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modContext::class;
     public $languageTopics = ['context'];

--- a/core/src/Revolution/Processors/Context/Get.php
+++ b/core/src/Revolution/Processors/Context/Get.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Context;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 
 /**
  * Grabs a context
@@ -21,7 +21,7 @@ use MODX\Revolution\modObjectGetProcessor;
  *
  * @package MODX\Revolution\Processors\Context
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modContext::class;
     public $languageTopics = ['context'];

--- a/core/src/Revolution/Processors/Context/GetList.php
+++ b/core/src/Revolution/Processors/Context/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Context;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -27,7 +27,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @package MODX\Revolution\Processors\Context
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modContext::class;
     public $permission = 'view_context';

--- a/core/src/Revolution/Processors/Context/Remove.php
+++ b/core/src/Revolution/Processors/Context/Remove.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Context;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modTemplateVarResource;
 
@@ -23,7 +23,7 @@ use MODX\Revolution\modTemplateVarResource;
  *
  * @package MODX\Revolution\Processors\Context
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modContext::class;
     public $languageTopics = ['context'];

--- a/core/src/Revolution/Processors/Context/Setting/Create.php
+++ b/core/src/Revolution/Processors/Context/Setting/Create.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modContext;
 use MODX\Revolution\modContextSetting;
 use MODX\Revolution\modLexiconEntry;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modResource;
 
 /**
@@ -33,7 +33,7 @@ use MODX\Revolution\modResource;
  *
  * @package MODX\Revolution\Processors\Context\Setting
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modContextSetting::class;
     public $languageTopics = ['setting', 'namespace'];

--- a/core/src/Revolution/Processors/Context/Setting/Get.php
+++ b/core/src/Revolution/Processors/Context/Setting/Get.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Context\Setting;
 
 use MODX\Revolution\modContext;
 use MODX\Revolution\modContextSetting;
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 
 /**
  * Gets a context setting
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectGetProcessor;
  *
  * @package MODX\Revolution\Processors\Context\Setting
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modContextSetting::class;
     public $languageTopics = ['setting'];

--- a/core/src/Revolution/Processors/Context/Setting/GetList.php
+++ b/core/src/Revolution/Processors/Context/Setting/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Context\Setting;
 
 
 use MODX\Revolution\modContextSetting;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modX;
 use xPDO\Om\xPDOObject;
 
@@ -28,7 +28,7 @@ use xPDO\Om\xPDOObject;
  *
  * @package MODX\Revolution\Processors\Context\Setting
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modContextSetting::class;
     public $languageTopics = ['setting', 'namespace'];

--- a/core/src/Revolution/Processors/Context/Update.php
+++ b/core/src/Revolution/Processors/Context/Update.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Context;
 
 use MODX\Revolution\modContextSetting;
 use MODX\Revolution\modLexiconEntry;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Updates a context.
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectUpdateProcessor;
  *
  * @package MODX\Revolution\Processors\Context
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = 'modContext';
     public $languageTopics = ['context'];

--- a/core/src/Revolution/Processors/Context/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Context/UpdateFromGrid.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Context;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Update a context from a grid. Passed as JSON data.
  *
  * @package MODX\Revolution\Processors\Context
  */
-class UpdateFromGrid extends modProcessor
+class UpdateFromGrid extends Processor
 {
     /** @var modContext $context */
     public $context;

--- a/core/src/Revolution/Processors/DeprecatedProcessor.php
+++ b/core/src/Revolution/Processors/DeprecatedProcessor.php
@@ -8,8 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
-
+namespace MODX\Revolution\Processors;
 
 /**
  * A utility class for pre-2.2-style, or flat file, processors.
@@ -18,7 +17,7 @@ namespace MODX\Revolution;
  *
  * @package MODX\Revolution
  */
-class modDeprecatedProcessor extends modProcessor
+class DeprecatedProcessor extends Processor
 {
     /**
      * Rather than load a class for processing, include the processor file directly.

--- a/core/src/Revolution/Processors/DriverSpecificProcessor.php
+++ b/core/src/Revolution/Processors/DriverSpecificProcessor.php
@@ -8,30 +8,31 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors;
 
+use MODX\Revolution\modX;
 use ReflectionClass;
 
 /**
  * A utility class used for defining driver-specific processors
  * @package MODX\Revolution
  */
-abstract class modDriverSpecificProcessor extends modProcessor
+abstract class DriverSpecificProcessor extends Processor
 {
     /**
      * @param modX $modx
      * @param string $className
      * @param array $properties
-     * @return modProcessor
+     * @return Processor
      * @throws \ReflectionException
      */
-    public static function getInstance(modX &$modx, $className, $properties = [])
+    public static function getInstance(modX $modx, $className, $properties = [])
     {
         $class = new ReflectionClass($className);
         $namespace = $class->getNamespaceName();
         $className = implode('\\', [$namespace, $modx->getOption('dbtype'), $class->getShortName()]);
 
-        /** @var modProcessor $processor */
+        /** @var Processor $processor */
         $processor = new $className($modx, $properties);
 
         return $processor;

--- a/core/src/Revolution/Processors/Element/Category/Create.php
+++ b/core/src/Revolution/Processors/Element/Category/Create.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Category;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Create a category.
@@ -21,7 +21,7 @@ use MODX\Revolution\modObjectCreateProcessor;
  *
  * @package MODX\Revolution\Processors\Element\Category
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modCategory::class;
     public $languageTopics = ['category'];

--- a/core/src/Revolution/Processors/Element/Category/Get.php
+++ b/core/src/Revolution/Processors/Element/Category/Get.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Category;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 
 /**
  * Gets a category.
@@ -21,7 +21,7 @@ use MODX\Revolution\modObjectGetProcessor;
  *
  * @package MODX\Revolution\Processors\Element\Category
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modCategory::class;
     public $languageTopics = ['category'];

--- a/core/src/Revolution/Processors/Element/Category/GetList.php
+++ b/core/src/Revolution/Processors/Element/Category/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Category;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -27,7 +27,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @package MODX\Revolution\Processors\Element\Category
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modCategory::class;
     public $languageTopics = ['category'];

--- a/core/src/Revolution/Processors/Element/Category/Remove.php
+++ b/core/src/Revolution/Processors/Element/Category/Remove.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Category;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Deletes a category. Resets all elements with that category to 0.
@@ -21,7 +21,7 @@ use MODX\Revolution\modObjectRemoveProcessor;
  *
  * @package MODX\Revolution\Processors\Element\Category
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modCategory::class;
     public $languageTopics = ['category'];

--- a/core/src/Revolution/Processors/Element/Category/Update.php
+++ b/core/src/Revolution/Processors/Element/Category/Update.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Category;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Update a category.
@@ -22,7 +22,7 @@ use MODX\Revolution\modObjectUpdateProcessor;
  *
  * @package MODX\Revolution\Processors\Element\Category
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modCategory::class;
     public $languageTopics = ['category'];

--- a/core/src/Revolution/Processors/Element/Create.php
+++ b/core/src/Revolution/Processors/Element/Create.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Element;
 
 use MODX\Revolution\modCategory;
 use MODX\Revolution\modElement;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\Validation\modValidator;
 
@@ -24,7 +24,7 @@ use MODX\Revolution\Validation\modValidator;
  *
  * @package MODX\Revolution\Processors\Element
  */
-abstract class Create extends modObjectCreateProcessor
+abstract class Create extends CreateProcessor
 {
     /** @var modElement $object */
     public $object;

--- a/core/src/Revolution/Processors/Element/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/Duplicate.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element;
 
 
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 
 /**
  * Abstract class for Duplicate Element processors. To be extended for each derivative element type.
@@ -20,7 +20,7 @@ use MODX\Revolution\modObjectDuplicateProcessor;
  *
  * @package MODX\Revolution\Processors\Element
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public function cleanup()
     {

--- a/core/src/Revolution/Processors/Element/ExportProperties.php
+++ b/core/src/Revolution/Processors/Element/ExportProperties.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Element;
 
 
 use MODX\Revolution\File\modFileHandler;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Export properties and output url to download to browser
  *
  * @package MODX\Revolution\Processors\Element
  */
-class ExportProperties extends modProcessor
+class ExportProperties extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Element/Get.php
+++ b/core/src/Revolution/Processors/Element/Get.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element;
 
 
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 
 /**
  * Abstract class for Get Element processors. To be extended for each derivative element type.
@@ -20,7 +20,7 @@ use MODX\Revolution\modObjectGetProcessor;
  *
  * @package MODX\Revolution\Processors\Element
  */
-abstract class Get extends modObjectGetProcessor
+abstract class Get extends GetProcessor
 {
     /**
      * Used for adding custom data in derivative types

--- a/core/src/Revolution/Processors/Element/GetClasses.php
+++ b/core/src/Revolution/Processors/Element/GetClasses.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element;
 
 
 use MODX\Revolution\modClassMap;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Outputs a list of Element subclasses
@@ -21,7 +21,7 @@ use MODX\Revolution\modProcessor;
  *
  * @package    MODX\Revolution\Processors\Element
  */
-class GetClasses extends modProcessor
+class GetClasses extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Element/GetInsertProperties.php
+++ b/core/src/Revolution/Processors/Element/GetInsertProperties.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element;
 
 
 use MODX\Revolution\modElement;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modPropertySet;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modSnippet;
@@ -23,7 +23,7 @@ use MODX\Revolution\modTemplateVar;
  *
  * @package MODX\Revolution\Processors\Element
  */
-class GetInsertProperties extends modProcessor
+class GetInsertProperties extends Processor
 {
     /** @var modElement $element */
     public $element;

--- a/core/src/Revolution/Processors/Element/GetList.php
+++ b/core/src/Revolution/Processors/Element/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOQuery;
 
 /**
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @package MODX\Revolution\Processors\Element
  */
-abstract class GetList extends modObjectGetListProcessor
+abstract class GetList extends GetListProcessor
 {
     public function prepareQueryBeforeCount(xPDOQuery $c)
     {

--- a/core/src/Revolution/Processors/Element/GetListByClass.php
+++ b/core/src/Revolution/Processors/Element/GetListByClass.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element;
 
 
 use MODX\Revolution\modElement;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modTemplate;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modTemplate;
  *
  * @package MODX\Revolution\Processors\Element
  */
-class GetListByClass extends modProcessor
+class GetListByClass extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Element/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/GetNodes.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modCategory;
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modElement;
 use MODX\Revolution\modPlugin;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVar;
@@ -27,7 +27,7 @@ use MODX\Revolution\modTemplateVar;
  *
  * @package MODX\Revolution\Processors\Element
  */
-class GetNodes extends modProcessor
+class GetNodes extends Processor
 {
     public $typeMap = [
         'template' => modTemplate::class,

--- a/core/src/Revolution/Processors/Element/ImportProperties.php
+++ b/core/src/Revolution/Processors/Element/ImportProperties.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modX;
  *
  * @package MODX\Revolution\Processors\Element
  */
-class ImportProperties extends modProcessor
+class ImportProperties extends Processor
 {
     public $file = [];
 

--- a/core/src/Revolution/Processors/Element/Plugin/Activate.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Activate.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\Plugin;
 
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modPlugin;
 
 /**
@@ -21,7 +21,7 @@ use MODX\Revolution\modPlugin;
  *
  * @package MODX\Revolution\Processors\Element\Plugin
  */
-class Activate extends modObjectUpdateProcessor
+class Activate extends UpdateProcessor
 {
     public $classKey = modPlugin::class;
     public $languageTopics = ['plugin', 'category', 'element'];

--- a/core/src/Revolution/Processors/Element/Plugin/Create.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Create.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Plugin;
 
 
 use MODX\Revolution\modPlugin;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modX;
 use MODX\Revolution\Processors\Element\Plugin\Event\Update;
 
@@ -78,7 +78,7 @@ class Create extends \MODX\Revolution\Processors\Element\Create
                     'plugin' => $this->object->get('id'),
                     'event' => $event['name'],
                 ]);
-                /** @var modProcessorResponse $response */
+                /** @var ProcessorResponse $response */
                 $response = $this->modx->runProcessor(Update::class, $properties);
                 if ($response->isError()) {
                     $this->modx->log(modX::LOG_LEVEL_ERROR, $response->getMessage() . print_r($properties, true));

--- a/core/src/Revolution/Processors/Element/Plugin/Deactivate.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Deactivate.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\Plugin;
 
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modPlugin;
 
 /**
@@ -21,7 +21,7 @@ use MODX\Revolution\modPlugin;
  *
  * @package MODX\Revolution\Processors\Element\Plugin
  */
-class Deactivate extends modObjectUpdateProcessor
+class Deactivate extends UpdateProcessor
 {
     public $classKey = modPlugin::class;
     public $languageTopics = ['plugin', 'category', 'element'];

--- a/core/src/Revolution/Processors/Element/Plugin/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Duplicate.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Element\Plugin;
 
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\modPluginEvent;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\Element\Plugin\Event\Update;
 
 /**
@@ -47,7 +47,7 @@ class Duplicate extends \MODX\Revolution\Processors\Element\Duplicate
                 $properties = $event->toArray();
                 $properties['plugin'] = $this->newObject->get('id');
                 $properties['enabled'] = 1;
-                /** @var modProcessorResponse $response */
+                /** @var ProcessorResponse $response */
                 $response = $this->modx->runProcessor(Update::class, $properties);
                 if ($response->isError()) {
                     $this->newObject->remove();

--- a/core/src/Revolution/Processors/Element/Plugin/Event/Associate.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Event/Associate.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Plugin\Event;
 
 
 use MODX\Revolution\modEvent;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modPluginEvent;
 
 /**
@@ -23,7 +23,7 @@ use MODX\Revolution\modPluginEvent;
  *
  * @package MODX\Revolution\Processors\Element\Plugin\Event
  */
-class Associate extends modObjectUpdateProcessor
+class Associate extends UpdateProcessor
 {
     public $classKey = modEvent::class;
     public $primaryKeyField = 'name';

--- a/core/src/Revolution/Processors/Element/Plugin/Event/Get.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Event/Get.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\Plugin\Event;
 
 
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 use MODX\Revolution\modPluginEvent;
 
 /**
@@ -22,7 +22,7 @@ use MODX\Revolution\modPluginEvent;
  *
  * @package MODX\Revolution\Processors\Element\Plugin\Event
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modPluginEvent::class;
     public $objectType = 'plugin_event';

--- a/core/src/Revolution/Processors/Element/Plugin/Event/GetAssoc.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Event/GetAssoc.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\Plugin\Event;
 
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\modPluginEvent;
 use xPDO\Om\xPDOObject;
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @package MODX\Revolution\Processors\Element\Plugin\Event
  */
-class GetAssoc extends modObjectGetListProcessor
+class GetAssoc extends GetListProcessor
 {
     public $classKey = modPlugin::class;
     public $languageTopics = ['plugin'];

--- a/core/src/Revolution/Processors/Element/Plugin/Event/GetList.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Event/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Plugin\Event;
 
 
 use MODX\Revolution\modEvent;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modPluginEvent;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modPluginEvent;
  *
  * @package MODX\Revolution\Processors\Element\Plugin\Event
  */
-class GetList extends modObjectProcessor
+class GetList extends ModelProcessor
 {
     public $classKey = modPluginEvent::class;
     public $languageTopics = ['plugin', 'system_events'];

--- a/core/src/Revolution/Processors/Element/Plugin/Event/Remove.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Event/Remove.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\Plugin\Event;
 
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modPluginEvent;
 
 /**
@@ -22,7 +22,7 @@ use MODX\Revolution\modPluginEvent;
  *
  * @package MODX\Revolution\Processors\Element\Plugin\Event
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modPluginEvent::class;
     public $objectType = 'plugin_event';

--- a/core/src/Revolution/Processors/Element/Plugin/Event/Update.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Event/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\Plugin\Event;
 
 
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modPluginEvent;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modPluginEvent;
  *
  * @package MODX\Revolution\Processors\Element\Plugin\Event
  */
-class Update extends modObjectProcessor
+class Update extends ModelProcessor
 {
     public $classKey = modPluginEvent::class;
     public $objectType = 'plugin_event';

--- a/core/src/Revolution/Processors/Element/Plugin/Update.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Update.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\Plugin;
 
 
 use MODX\Revolution\modPlugin;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modX;
 
 /**
@@ -80,7 +80,7 @@ class Update extends \MODX\Revolution\Processors\Element\Update
                     'plugin' => $this->object->get('id'),
                     'event' => $event['name'],
                 ]);
-                /** @var modProcessorResponse $response */
+                /** @var ProcessorResponse $response */
                 $response = $this->modx->runProcessor(Event\Update::class, $properties);
                 if ($response->isError()) {
                     $this->modx->log(modX::LOG_LEVEL_ERROR, $response->getMessage() . print_r($properties, true));

--- a/core/src/Revolution/Processors/Element/PropertySet/AddElement.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/AddElement.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\PropertySet;
 
 
 use MODX\Revolution\modElementPropertySet;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modPropertySet;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modPropertySet;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class AddElement extends modObjectProcessor
+class AddElement extends ModelProcessor
 {
     public $classKey = modElementPropertySet::class;
     public $objectType = 'propertyset';

--- a/core/src/Revolution/Processors/Element/PropertySet/Create.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/Create.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\PropertySet;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modPropertySet;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modPropertySet;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modPropertySet::class;
     public $languageTopics = ['propertyset'];

--- a/core/src/Revolution/Processors/Element/PropertySet/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/Duplicate.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Element\PropertySet;
 
 use MODX\Revolution\modElement;
 use MODX\Revolution\modElementPropertySet;
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 use MODX\Revolution\modPropertySet;
 
 /**
@@ -21,7 +21,7 @@ use MODX\Revolution\modPropertySet;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modPropertySet::class;
     public $objectType = 'propertyset';

--- a/core/src/Revolution/Processors/Element/PropertySet/Get.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/Get.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\PropertySet;
 
 
 use MODX\Revolution\modElement;
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 use MODX\Revolution\modPropertySet;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modPropertySet;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modPropertySet::class;
     public $objectType = 'propertyset';

--- a/core/src/Revolution/Processors/Element/PropertySet/GetList.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\PropertySet;
 
 
 use MODX\Revolution\modElementPropertySet;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modPropertySet;
 use xPDO\Om\xPDOQuery;
 
@@ -32,7 +32,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modPropertySet::class;
     public $objectType = 'propertyset';

--- a/core/src/Revolution/Processors/Element/PropertySet/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/GetNodes.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modCategory;
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modElement;
 use MODX\Revolution\modElementPropertySet;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\modPropertySet;
 use MODX\Revolution\modSnippet;
@@ -29,7 +29,7 @@ use MODX\Revolution\modTemplateVar;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class GetNodes extends modObjectProcessor
+class GetNodes extends ModelProcessor
 {
     public $classKey = modPropertySet::class;
     public $objectType = 'propertyset';

--- a/core/src/Revolution/Processors/Element/PropertySet/Remove.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/Remove.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\PropertySet;
 
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modPropertySet;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modPropertySet;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modPropertySet::class;
     public $objectType = 'propertyset';

--- a/core/src/Revolution/Processors/Element/PropertySet/RemoveElement.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/RemoveElement.php
@@ -13,14 +13,14 @@ namespace MODX\Revolution\Processors\Element\PropertySet;
 
 use MODX\Revolution\modAccessibleObject;
 use MODX\Revolution\modElementPropertySet;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Removes an element from a Property Set
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class RemoveElement extends modObjectRemoveProcessor
+class RemoveElement extends RemoveProcessor
 {
     public $classKey = modElementPropertySet::class;
     public $objectType = 'propertyset';

--- a/core/src/Revolution/Processors/Element/PropertySet/Update.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/Update.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\PropertySet;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modPropertySet;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modPropertySet;
  *
  * @package MODX\Revolution\Processors\Element\PropertySet
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modPropertySet::class;
     public $languageTopics = ['propertyset', 'category'];

--- a/core/src/Revolution/Processors/Element/Remove.php
+++ b/core/src/Revolution/Processors/Element/Remove.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element;
 
 
 use MODX\Revolution\modChunk;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
@@ -25,7 +25,7 @@ use MODX\Revolution\modTemplateVar;
  *
  * @package MODX\Revolution\Processors\Element
  */
-abstract class Remove extends modObjectRemoveProcessor
+abstract class Remove extends RemoveProcessor
 {
     public $staticFilePath;
     public $staticFile;

--- a/core/src/Revolution/Processors/Element/Sort.php
+++ b/core/src/Revolution/Processors/Element/Sort.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modCategory;
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modElement;
 use MODX\Revolution\modPlugin;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVar;
@@ -27,7 +27,7 @@ use MODX\Revolution\modTemplateVar;
  *
  * @package MODX\Revolution\Processors\Element
  */
-class Sort extends modProcessor
+class Sort extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Element/Template/TemplateVar/GetList.php
+++ b/core/src/Revolution/Processors/Element/Template/TemplateVar/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\Template\TemplateVar;
 
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modTemplate;
 use xPDO\Om\xPDOObject;
 
@@ -28,7 +28,7 @@ use xPDO\Om\xPDOObject;
  *
  * @package MODX\Revolution\Processors\Element\Template\TemplateVar
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modTemplate::class;
     public $primaryKeyField = 'template';

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\TemplateVar\Renders;
 
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\Processors\Element\TemplateVar\Renders\Controllers\TvInputPropertiesManagerController;
 
@@ -27,7 +27,7 @@ use MODX\Revolution\Processors\Element\TemplateVar\Renders\Controllers\TvInputPr
  *
  * @package MODX\Revolution\Processors\Element\TemplateVar\Renders
  */
-class GetInputProperties extends modProcessor {
+class GetInputProperties extends Processor {
 
     public $propertiesKey = 'input_properties';
     public $renderDirectory = 'inputproperties';

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Element\TemplateVar\Renders;
 
 use DirectoryIterator;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Processors\Element\TemplateVar\Renders\Controllers\TvInputManagerController;
 use UnexpectedValueException;
 
@@ -25,7 +25,7 @@ use UnexpectedValueException;
  *
  * @package MODX\Revolution\Processors\Element\TemplateVar\Renders
  */
-class GetInputs extends modProcessor {
+class GetInputs extends Processor {
     public function checkPermissions() {
         return $this->modx->hasPermission('view_tv');
     }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetOutputs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetOutputs.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Element\TemplateVar\Renders;
 
 use DirectoryIterator;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use UnexpectedValueException;
 
 /**
@@ -23,7 +23,7 @@ use UnexpectedValueException;
  *
  * @package MODX\Revolution\Processors\Element\TemplateVar\Renders
  */
-class GetOutputs extends modProcessor {
+class GetOutputs extends Processor {
 
     /**
      * Check permissions to view TV

--- a/core/src/Revolution/Processors/Element/TemplateVar/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/ResourceGroup/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\TemplateVar\ResourceGroup;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modTemplateVarResourceGroup;
 
@@ -28,7 +28,7 @@ use MODX\Revolution\modTemplateVarResourceGroup;
  *
  * @package MODX\Revolution\Processors\Element\TemplateVar\ResourceGroup
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Element/TemplateVar/Template/GetList.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Template/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Element\TemplateVar\Template;
 
 
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVarTemplate;
 
@@ -28,7 +28,7 @@ use MODX\Revolution\modTemplateVarTemplate;
  *
  * @package MODX\Revolution\Processors\Element\TemplateVar\Template
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Element/TemplateVar/Template/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Template/UpdateFromGrid.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Element\TemplateVar\Template;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modTemplateVarTemplate;
 
 /**
@@ -24,7 +24,7 @@ use MODX\Revolution\modTemplateVarTemplate;
  *
  * @package MODX\Revolution\Processors\Element\TemplateVar\Template
  */
-class UpdateFromGrid extends modProcessor
+class UpdateFromGrid extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Element/Update.php
+++ b/core/src/Revolution/Processors/Element/Update.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Element;
 
 use MODX\Revolution\modCategory;
 use MODX\Revolution\modElement;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modTemplate;
 
 /**
@@ -23,7 +23,7 @@ use MODX\Revolution\modTemplate;
  *
  * @package MODX\Revolution\Processors\Element
  */
-abstract class Update extends modObjectUpdateProcessor
+abstract class Update extends UpdateProcessor
 {
     public $previousCategory;
     /** @var modElement $object */

--- a/core/src/Revolution/Processors/Model/CreateProcessor.php
+++ b/core/src/Revolution/Processors/Model/CreateProcessor.php
@@ -8,9 +8,11 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
 
+use MODX\Revolution\modSystemEvent;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\Validation\modValidator;
 
 /**
@@ -20,7 +22,7 @@ use MODX\Revolution\Validation\modValidator;
  *
  * @package MODX\Revolution
  */
-abstract class modObjectCreateProcessor extends modObjectProcessor
+abstract class CreateProcessor extends ModelProcessor
 {
     /** @var string $beforeSaveEvent The name of the event to fire before saving */
     public $beforeSaveEvent = '';
@@ -77,7 +79,7 @@ abstract class modObjectCreateProcessor extends modObjectProcessor
         }
 
         /* save element */
-        if ($this->saveObject() == false) {
+        if ($this->saveObject() === false) {
             $this->modx->error->checkValidation($this->object);
 
             return $this->failure($this->modx->lexicon($this->objectType . '_err_save'));

--- a/core/src/Revolution/Processors/Model/DuplicateProcessor.php
+++ b/core/src/Revolution/Processors/Model/DuplicateProcessor.php
@@ -8,9 +8,11 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
 
+use MODX\Revolution\modAccessibleObject;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\Sources\modFileMediaSource;
 use xPDO\Om\xPDOObject;
 
@@ -21,7 +23,7 @@ use xPDO\Om\xPDOObject;
  *
  * @package MODX\Revolution
  */
-class modObjectDuplicateProcessor extends modObjectProcessor
+abstract class DuplicateProcessor extends ModelProcessor
 {
     /** @var boolean $checkSavePermission Whether or not to check the save permission on modAccessibleObjects */
     public $checkSavePermission = true;
@@ -29,7 +31,8 @@ class modObjectDuplicateProcessor extends modObjectProcessor
     public $newObject;
     public $nameField = 'name';
     public $staticfileField = 'static_file';
-    /** @var string $newNameField The name of field that used for filling new name of object.
+    /**
+     * @var string $newNameField The name of field that used for filling new name of object.
      * If defined, duplication error will be attached to field with this name
      */
     public $newNameField;

--- a/core/src/Revolution/Processors/Model/ExportProcessor.php
+++ b/core/src/Revolution/Processors/Model/ExportProcessor.php
@@ -8,10 +8,11 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
 
 use MODX\Revolution\File\modFileHandler;
+use MODX\Revolution\modCacheManager;
 use XMLWriter;
 
 /**
@@ -21,7 +22,7 @@ use XMLWriter;
  *
  * @package MODX\Revolution
  */
-abstract class modObjectExportProcessor extends modObjectGetProcessor
+abstract class ExportProcessor extends GetProcessor
 {
     /** @var string $downloadProperty */
     public $downloadProperty = 'download';

--- a/core/src/Revolution/Processors/Model/GetListProcessor.php
+++ b/core/src/Revolution/Processors/Model/GetListProcessor.php
@@ -8,9 +8,11 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
 
+use MODX\Revolution\modAccessibleObject;
+use MODX\Revolution\Processors\ModelProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -21,7 +23,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @package MODX\Revolution
  */
-abstract class modObjectGetListProcessor extends modObjectProcessor
+abstract class GetListProcessor extends ModelProcessor
 {
     /** @var string $defaultSortField The default field to sort by */
     public $defaultSortField = 'name';
@@ -136,8 +138,8 @@ abstract class modObjectGetListProcessor extends modObjectProcessor
     public function getData()
     {
         $data = [];
-        $limit = intval($this->getProperty('limit'));
-        $start = intval($this->getProperty('start'));
+        $limit = (int)$this->getProperty('limit');
+        $start = (int)$this->getProperty('start');
 
         /* query for chunks */
         $c = $this->modx->newQuery($this->classKey);

--- a/core/src/Revolution/Processors/Model/GetProcessor.php
+++ b/core/src/Revolution/Processors/Model/GetProcessor.php
@@ -8,8 +8,11 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
+
+use MODX\Revolution\modAccessibleObject;
+use MODX\Revolution\Processors\ModelProcessor;
 
 /**
  * A utility abstract class for defining get-based processors
@@ -18,7 +21,7 @@ namespace MODX\Revolution;
  *
  * @package MODX\Revolution
  */
-abstract class modObjectGetProcessor extends modObjectProcessor
+abstract class GetProcessor extends ModelProcessor
 {
     /** @var boolean $checkViewPermission If set to true, will check the view permission on modAccessibleObjects */
     public $checkViewPermission = true;

--- a/core/src/Revolution/Processors/Model/ImportProcessor.php
+++ b/core/src/Revolution/Processors/Model/ImportProcessor.php
@@ -8,9 +8,10 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
 
+use MODX\Revolution\Processors\ModelProcessor;
 use SimpleXMLElement;
 
 /**
@@ -20,7 +21,7 @@ use SimpleXMLElement;
  *
  * @package MODX\Revolution
  */
-abstract class modObjectImportProcessor extends modObjectProcessor
+abstract class ImportProcessor extends ModelProcessor
 {
     /** @var string $nameField The name, or unique, field for the object */
     public $nameField = 'name';
@@ -37,7 +38,7 @@ abstract class modObjectImportProcessor extends modObjectProcessor
         if (empty($file) || !isset($file['tmp_name'])) {
             return $this->modx->lexicon('import_err_upload');
         }
-        if ($file['error'] != 0) {
+        if ($file['error'] !== 0) {
             return $this->modx->lexicon('import_err_upload');
         }
         if (!file_exists($file['tmp_name'])) {

--- a/core/src/Revolution/Processors/Model/RemoveProcessor.php
+++ b/core/src/Revolution/Processors/Model/RemoveProcessor.php
@@ -8,17 +8,20 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
+
+use MODX\Revolution\modAccessibleObject;
+use MODX\Revolution\Processors\ModelProcessor;
 
 /**
- * A utility abstract class for defining soft remove-based processors
+ * A utility abstract class for defining remove-based processors
  *
  * @abstract
  *
  * @package MODX\Revolution
  */
-abstract class modObjectSoftRemoveProcessor extends modObjectProcessor
+abstract class RemoveProcessor extends ModelProcessor
 {
     /** @var boolean $checkRemovePermission If set to true, will check the remove permission on modAccessibleObjects */
     public $checkRemovePermission = true;
@@ -26,18 +29,6 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor
     public $beforeRemoveEvent = '';
     /** @var string $afterRemoveEvent The name of the event to fire after removal */
     public $afterRemoveEvent = '';
-    /** @var bool $userDeletedOn To use or not deleted on field */
-    public $useDeletedOn = true;
-    /** @var string $deletedOnField Name of deleted on field */
-    public $deletedOnField = 'deletedon';
-    /** @var bool $userDeleted To use or not deleted field */
-    public $useDeleted = true;
-    /** @var string $deletedField Name of deleted field */
-    public $deletedField = 'deleted';
-    /** @var bool $userDeletedBy To use or not deleted by field */
-    public $useDeletedBy = true;
-    /** @var string $deletedByField Name of deleted by field */
-    public $deletedByField = 'deletedby';
 
     public function initialize()
     {
@@ -54,23 +45,6 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor
             return $this->modx->lexicon('access_denied');
         }
 
-        if (!$this->useDeleted && !$this->useDeletedOn && !$this->useDeletedBy) {
-            return $this->modx->lexicon($this->objectType . '_err_dt_ns');
-        }
-
-        if ($this->useDeleted && ($this->deletedField == null)) {
-            return $this->modx->lexicon($this->objectType . '_err_df_ns');
-        }
-
-        if ($this->useDeletedOn && ($this->deletedOnField == null)) {
-            return $this->modx->lexicon($this->objectType . '_err_dof_ns');
-        }
-
-        if ($this->useDeletedBy && ($this->deletedByField == null)) {
-            return $this->modx->lexicon($this->objectType . '_err_dbf_ns');
-        }
-
-
         return parent::initialize();
     }
 
@@ -85,23 +59,9 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor
             return $this->failure($preventRemoval);
         }
 
-
-        if ($this->useDeleted) {
-            $this->object->set($this->deletedField, true);
+        if ($this->removeObject() === false) {
+            return $this->failure($this->modx->lexicon($this->objectType . '_err_remove'));
         }
-
-        if ($this->useDeletedOn) {
-            $this->object->set($this->deletedOnField, time());
-        }
-
-        if ($this->useDeletedBy) {
-            $this->object->set($this->deletedByField, $this->modx->user->id);
-        }
-
-        if ($this->saveObject() == false) {
-            return $this->failure($this->modx->lexicon($this->objectType . '_err_soft_remove'));
-        }
-
         $this->afterRemove();
         $this->fireAfterRemoveEvent();
         $this->logManagerAction();
@@ -111,14 +71,14 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor
     }
 
     /**
-     * Abstract the saving of the object out to allow for transient and non-persistent object updating in derivative
+     * Abstract the removing of the object out to allow for transient and non-persistent object updating in derivative
      * classes
      *
      * @return boolean
      */
-    public function saveObject()
+    public function removeObject()
     {
-        return $this->object->save();
+        return $this->object->remove();
     }
 
     /**
@@ -148,7 +108,7 @@ abstract class modObjectSoftRemoveProcessor extends modObjectProcessor
      */
     public function logManagerAction()
     {
-        $this->modx->logManagerAction($this->objectType . '_soft_delete', $this->classKey,
+        $this->modx->logManagerAction($this->objectType . '_delete', $this->classKey,
             $this->object->get($this->primaryKeyField));
     }
 

--- a/core/src/Revolution/Processors/Model/UpdateProcessor.php
+++ b/core/src/Revolution/Processors/Model/UpdateProcessor.php
@@ -8,9 +8,12 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors\Model;
 
 
+use MODX\Revolution\modAccessibleObject;
+use MODX\Revolution\modSystemEvent;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\Validation\modValidator;
 
 /**
@@ -20,7 +23,7 @@ use MODX\Revolution\Validation\modValidator;
  *
  * @package MODX\Revolution
  */
-abstract class modObjectUpdateProcessor extends modObjectProcessor
+abstract class UpdateProcessor extends ModelProcessor
 {
     public $checkSavePermission = true;
     /** @var string $beforeSaveEvent The name of the event to fire before saving */
@@ -83,7 +86,7 @@ abstract class modObjectUpdateProcessor extends modObjectProcessor
             return $this->failure($preventSave);
         }
 
-        if ($this->saveObject() == false) {
+        if ($this->saveObject() === false) {
             return $this->failure($this->modx->lexicon($this->objectType . '_err_save'));
         }
         $this->afterSave();

--- a/core/src/Revolution/Processors/ModelProcessor.php
+++ b/core/src/Revolution/Processors/ModelProcessor.php
@@ -8,19 +8,20 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors;
 
 
+use MODX\Revolution\modAccessibleObject;
 use xPDO\Om\xPDOObject;
 
 /**
- * Base class for object-specific processors
+ * Base class for model-specific processors, simplifying any interactions with your xPDO model objects.
  *
  * @abstract
  *
  * @package MODX\Revolution
  */
-abstract class modObjectProcessor extends modProcessor
+abstract class ModelProcessor extends Processor
 {
     /** @var xPDOObject|modAccessibleObject $object The object being grabbed */
     public $object;

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -8,15 +8,16 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors;
 
+use MODX\Revolution\modX;
 
 /**
  * Abstracts a MODX processor, handling its response and error formatting.
  *
  * @package MODX\Revolution
  */
-abstract class modProcessor {
+abstract class Processor {
     /**
      * A reference to the modX object.
      * @var modX $modx
@@ -39,7 +40,7 @@ abstract class modProcessor {
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
      */
-    function __construct(modX & $modx,array $properties = array()) {
+    public function __construct(modX $modx,array $properties = array()) {
         $this->modx =& $modx;
         $this->setProperties($properties);
     }
@@ -142,10 +143,10 @@ abstract class modProcessor {
      * @param modX $modx A reference to the modX object.
      * @param string $className The name of the class that is being requested.
      * @param array $properties An array of properties being run with the processor
-     * @return modProcessor The class specified by $className
+     * @return Processor The class specified by $className
      */
-    public static function getInstance(modX &$modx,$className,$properties = array()) {
-        /** @var modProcessor $processor */
+    public static function getInstance(modX $modx,$className,$properties = array()) {
+        /** @var Processor $processor */
         $processor = new $className($modx,$properties);
         return $processor;
     }
@@ -159,8 +160,8 @@ abstract class modProcessor {
     abstract public function process();
 
     /**
-     * Run the processor, returning a modProcessorResponse object.
-     * @return modProcessorResponse
+     * Run the processor, returning a ProcessorResponse object.
+     * @return ProcessorResponse
      */
     public function run() {
         if (!$this->checkPermissions()) {
@@ -178,7 +179,7 @@ abstract class modProcessor {
                 $o = $this->process();
             }
         }
-        $response = new modProcessorResponse($this->modx,$o);
+        $response = new ProcessorResponse($this->modx,$o);
         return $response;
     }
 

--- a/core/src/Revolution/Processors/ProcessorResponse.php
+++ b/core/src/Revolution/Processors/ProcessorResponse.php
@@ -8,15 +8,16 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors;
 
+use MODX\Revolution\modX;
 
 /**
  * Response class for Processor executions
  *
  * @package MODX\Revolution
  */
-class modProcessorResponse
+class ProcessorResponse
 {
     /**
      * When there is only a general error
@@ -66,22 +67,22 @@ class modProcessorResponse
      * @param modX  $modx     A reference to the modX object.
      * @param array $response The array response from the modX.runProcessor method
      */
-    function __construct(modX &$modx, $response = [])
+    public function __construct(modX $modx, $response = [])
     {
         $this->modx =& $modx;
         $this->response = $response;
         if ($this->isError()) {
             if (!empty($response['errors']) && is_array($response['errors'])) {
                 foreach ($response['errors'] as $error) {
-                    $this->errors[] = new modProcessorResponseError($error);
+                    $this->errors[] = new ProcessorResponseError($error);
                 }
                 if (!empty($response['message'])) {
-                    $this->error_type = modProcessorResponse::ERROR_BOTH;
+                    $this->error_type = self::ERROR_BOTH;
                 } else {
-                    $this->error_type = modProcessorResponse::ERROR_FIELD;
+                    $this->error_type = self::ERROR_FIELD;
                 }
             } else {
-                $this->error_type = modProcessorResponse::ERROR_GENERAL;
+                $this->error_type = self::ERROR_GENERAL;
             }
         }
     }

--- a/core/src/Revolution/Processors/ProcessorResponseError.php
+++ b/core/src/Revolution/Processors/ProcessorResponseError.php
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace MODX\Revolution;
+namespace MODX\Revolution\Processors;
 
 
 /**
@@ -16,7 +16,7 @@ namespace MODX\Revolution;
  *
  * @package MODX\Revolution
  */
-class modProcessorResponseError
+class ProcessorResponseError
 {
     /**
      * @var array The error data itself
@@ -36,7 +36,7 @@ class modProcessorResponseError
      *
      * @param array $error An array error response
      */
-    function __construct($error = [])
+    public function __construct($error = [])
     {
         $this->error = $error;
         if (isset($error['id']) && !empty($error['id'])) {

--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -59,7 +59,7 @@ namespace MODX\Revolution\Processors\Resource;
 
 use MODX\Revolution\modContext;
 use MODX\Revolution\modDocument;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modResourceGroupResource;
@@ -71,7 +71,7 @@ use MODX\Revolution\modTemplateVarResource;
 use MODX\Revolution\modWebLink;
 use MODX\Revolution\modX;
 
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modResource::class;
     public $languageTopics = ['resource'];
@@ -96,7 +96,7 @@ class Create extends modObjectCreateProcessor
      * @param modX $modx
      * @param $className
      * @param array $properties
-     * @return modObjectCreateProcessor
+     * @return CreateProcessor
      */
     public static function getInstance(modX &$modx, $className, $properties = [])
     {
@@ -109,7 +109,7 @@ class Create extends modObjectCreateProcessor
                 $className = Create::class;
             }
         }
-        /** @var modObjectCreateProcessor $processor */
+        /** @var CreateProcessor $processor */
         $processor = new $className($modx, $properties);
         return $processor;
     }

--- a/core/src/Revolution/Processors/Resource/Data.php
+++ b/core/src/Revolution/Processors/Resource/Data.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modUser;
@@ -23,7 +23,7 @@ use xPDO\xPDO;
  * @param integer $id The ID of the resource
  * @return array
  */
-class Data extends modProcessor
+class Data extends Processor
 {
     /** @var modResource $resource */
     public $resource;

--- a/core/src/Revolution/Processors/Resource/Delete.php
+++ b/core/src/Revolution/Processors/Resource/Delete.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modX;
@@ -20,7 +20,7 @@ use MODX\Revolution\modX;
  *
  * @param integer $id The ID of the resource
  */
-class Delete extends modProcessor
+class Delete extends Processor
 {
     /** @var modResource $resource */
     public $resource;

--- a/core/src/Revolution/Processors/Resource/Duplicate.php
+++ b/core/src/Revolution/Processors/Resource/Duplicate.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modX;
 
@@ -26,7 +26,7 @@ use MODX\Revolution\modX;
  * @var modX $this ->modx
  * @var array $scriptProperties
  */
-class Duplicate extends modProcessor
+class Duplicate extends Processor
 {
     /** @var modResource $oldResource */
     public $oldResource;

--- a/core/src/Revolution/Processors/Resource/EmptyRecycleBin.php
+++ b/core/src/Revolution/Processors/Resource/EmptyRecycleBin.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroupResource;
 use MODX\Revolution\modTemplateVarResource;
@@ -20,7 +20,7 @@ use MODX\Revolution\modTemplateVarResource;
  *
  * @return boolean
  */
-class EmptyRecycleBin extends modProcessor
+class EmptyRecycleBin extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Resource/Event/GetList.php
+++ b/core/src/Revolution/Processors/Resource/Event/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource\Event;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use xPDO\Om\xPDOObject;
 
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOObject;
  * to 10.
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Resource/Event/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Resource/Event/UpdateFromGrid.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource\Event;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\modResource;
  *
  * @param json $data A JSON array of data to update with.
  */
-class UpdateFromGrid extends modProcessor
+class UpdateFromGrid extends Processor
 {
     /** @var modResource $resource */
     public $resource;

--- a/core/src/Revolution/Processors/Resource/Get.php
+++ b/core/src/Revolution/Processors/Resource/Get.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 use MODX\Revolution\modResource;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modResource;
  * @param integer $id The ID of the resource to grab
  * @return modResource
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modResource::class;
     public $languageTopics = ['resource'];

--- a/core/src/Revolution/Processors/Resource/GetList.php
+++ b/core/src/Revolution/Processors/Resource/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modResource;
 use xPDO\Om\xPDOObject;
 
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOObject;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @return array An array of modResources
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modResource::class;
     public $languageTopics = ['resource'];

--- a/core/src/Revolution/Processors/Resource/GetNodes.php
+++ b/core/src/Revolution/Processors/Resource/GetNodes.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Resource;
 
 use MODX\Revolution\modContext;
 use MODX\Revolution\modContextSetting;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 use ReflectionClass;
@@ -21,7 +21,7 @@ use xPDO\Om\xPDOQuery;
 /**
  * Get nodes for the resource tree
  */
-class GetNodes extends modProcessor
+class GetNodes extends Processor
 {
     /** @var int $defaultRootId */
     public $defaultRootId;

--- a/core/src/Revolution/Processors/Resource/GetToolbar.php
+++ b/core/src/Revolution/Processors/Resource/GetToolbar.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
  * Gets a dynamic toolbar for the Resource tree.
  */
-class GetToolbar extends modProcessor
+class GetToolbar extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Resource/Locks/Release.php
+++ b/core/src/Revolution/Processors/Resource/Locks/Release.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\Resource\Locks;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
  * Release a lock on a resource
  */
-class Release extends modProcessor
+class Release extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Resource/Locks/Steal.php
+++ b/core/src/Revolution/Processors/Resource/Locks/Steal.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Resource\Locks;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
  * Steal a lock on a resource
  */
-class Steal extends modProcessor
+class Steal extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Resource/Publish.php
+++ b/core/src/Revolution/Processors/Resource/Publish.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 
@@ -19,7 +19,7 @@ use MODX\Revolution\modUser;
  *
  * @param integer $id The ID of the resource
  */
-class Publish extends modProcessor
+class Publish extends Processor
 {
     /** @var modResource $resource */
     public $resource;

--- a/core/src/Revolution/Processors/Resource/Reload.php
+++ b/core/src/Revolution/Processors/Resource/Reload.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Resource;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\Registry\modRegister;
 
 /**
  * save resource form data for reload
  */
-class Reload extends modProcessor
+class Reload extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Resource/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Resource/ResourceGroup/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource\ResourceGroup;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modResourceGroupResource;
@@ -25,7 +25,7 @@ use MODX\Revolution\modResourceGroupResource;
  * @param string $sort (optional) The column to sort by. Defaults to name.
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /** @var modResource $resource */
     public $resource;

--- a/core/src/Revolution/Processors/Resource/ResourceGroup/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Resource/ResourceGroup/UpdateFromGrid.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource\ResourceGroup;
 
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modResourceGroupResource;
@@ -23,7 +23,7 @@ use MODX\Revolution\modResourceGroupResource;
  * @param boolean $access Either true or false whether the resource has access
  * to the group specified.
  */
-class UpdateFromGrid extends modObjectProcessor
+class UpdateFromGrid extends ModelProcessor
 {
     /** @var array $languageTopics */
     public $languageTopics = ['save_document'];
@@ -111,7 +111,7 @@ class UpdateFromGrid extends modObjectProcessor
             return $this->modx->lexicon('resource_err_ns');
         }
         $this->resource = $this->modx->getObject(modResource::class, $resource_id);
-        if (empty($resourcegroup)) {
+        if (!$this->resource) {
             return $this->modx->lexicon('resource_err_nf');
         }
         /* check access */

--- a/core/src/Revolution/Processors/Resource/Search.php
+++ b/core/src/Revolution/Processors/Resource/Search.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Resource;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modResource;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -26,7 +26,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir The direction to sort
  * @return array An array of modResources
  */
-class Search extends modObjectGetListProcessor
+class Search extends GetListProcessor
 {
     public $classKey = modResource::class;
     public $languageTopics = ['resource'];

--- a/core/src/Revolution/Processors/Resource/Sort.php
+++ b/core/src/Revolution/Processors/Resource/Sort.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Resource;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modResource;
  *
  * @param string $data The encoded tree data
  */
-class Sort extends modProcessor
+class Sort extends Processor
 {
     public $nodes = [];
     public $nodesAffected = [];

--- a/core/src/Revolution/Processors/Resource/Translit.php
+++ b/core/src/Revolution/Processors/Resource/Translit.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modResource;
  * @param string $string The string to transliterate
  * @return string
  */
-class Translit extends modProcessor
+class Translit extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Resource/Trash/GetList.php
+++ b/core/src/Revolution/Processors/Resource/Trash/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Resource\Trash;
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 use PDO;
@@ -28,7 +28,7 @@ use xPDO\Om\xPDOQuery;
  *
  * @return array An array of modResources
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modResource::class;
 

--- a/core/src/Revolution/Processors/Resource/Trash/Purge.php
+++ b/core/src/Revolution/Processors/Resource/Trash/Purge.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource\Trash;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroupResource;
 use MODX\Revolution\modTemplateVarResource;
@@ -21,7 +21,7 @@ use MODX\Revolution\modX;
  *
  * @return boolean
  */
-class Purge extends modProcessor
+class Purge extends Processor
 {
 
     /** @var modResource[] $resources */

--- a/core/src/Revolution/Processors/Resource/Trash/Restore.php
+++ b/core/src/Revolution/Processors/Resource/Trash/Restore.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource\Trash;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 
@@ -21,7 +21,7 @@ use MODX\Revolution\modUser;
  * @package    modx
  * @subpackage processors.resource
  */
-class Restore extends modProcessor
+class Restore extends Processor
 {
     /** @var modResource[] $resources */
     private $resources;

--- a/core/src/Revolution/Processors/Resource/Undelete.php
+++ b/core/src/Revolution/Processors/Resource/Undelete.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 
@@ -20,7 +20,7 @@ use MODX\Revolution\modUser;
  * @param integer $id The ID of the resource
  * @return array An array with the ID of the undeleted resource
  */
-class Undelete extends modProcessor
+class Undelete extends Processor
 {
     /** @var modResource $resource */
     public $resource;

--- a/core/src/Revolution/Processors/Resource/Unpublish.php
+++ b/core/src/Revolution/Processors/Resource/Unpublish.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Resource;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 
@@ -20,7 +20,7 @@ use MODX\Revolution\modUser;
  * @param integer $id The ID of the resource
  * @return array An array with the ID of the unpublished resource
  */
-class Unpublish extends modProcessor
+class Unpublish extends Processor
 {
     /** @var modResource $resource */
     public $resource;

--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -12,8 +12,8 @@ namespace MODX\Revolution\Processors\Resource;
 
 use MODX\Revolution\modContext;
 use MODX\Revolution\modDocument;
-use MODX\Revolution\modObjectUpdateProcessor;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modResourceGroupResource;
@@ -70,7 +70,7 @@ use MODX\Revolution\modX;
  * save.
  * @return array
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modResource::class;
     public $languageTopics = ['resource'];
@@ -111,7 +111,7 @@ class Update extends modObjectUpdateProcessor
      * @param modX $modx
      * @param string $className
      * @param array $properties
-     * @return modProcessor
+     * @return Processor
      */
     public static function getInstance(modX &$modx, $className, $properties = [])
     {
@@ -125,7 +125,7 @@ class Update extends modObjectUpdateProcessor
                 $className = Update::class;
             }
         }
-        /** @var modProcessor $processor */
+        /** @var Processor $processor */
         $processor = new $className($modx, $properties);
         return $processor;
     }

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modChunk;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modElement;
 use MODX\Revolution\modPlugin;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
@@ -26,7 +26,7 @@ use MODX\Revolution\modUserProfile;
 /**
  * Searches for elements, resources and users
  **/
-class Search extends modProcessor
+class Search extends Processor
 {
     const TYPE_TEMPLATE = 'template';
     const TYPE_TV = 'tv';

--- a/core/src/Revolution/Processors/Security/Access/AddAcl.php
+++ b/core/src/Revolution/Processors/Security/Access/AddAcl.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Access;
 
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
@@ -24,7 +24,7 @@ use MODX\Revolution\modUserGroup;
  * @param string $context_key (optional) The context to assign this ACL to.
  * @package MODX\Revolution\Processors\Security\Access
  */
-class AddAcl extends modObjectCreateProcessor
+class AddAcl extends CreateProcessor
 {
     public $objectType = 'access';
     public $permission = 'access_permissions';

--- a/core/src/Revolution/Processors/Security/Access/Flush.php
+++ b/core/src/Revolution/Processors/Security/Access/Flush.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\Security\Access;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Flushes permissions for the logged in user.
  * @package MODX\Revolution\Processors\Security\Access
  */
-class Flush extends modProcessor
+class Flush extends Processor
 {
     /**
      * @return array

--- a/core/src/Revolution/Processors/Security/Access/GetAcl.php
+++ b/core/src/Revolution/Processors/Security/Access/GetAcl.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Access;
 
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 
 /**
  * Gets an ACL.
@@ -18,7 +18,7 @@ use MODX\Revolution\modObjectGetProcessor;
  * @param string $id The ID of the ACL.
  * @package MODX\Revolution\Processors\Security\Access
  */
-class GetAcl extends modObjectGetProcessor
+class GetAcl extends GetProcessor
 {
     public $objectType = 'access';
     public $permission = 'access_permissions';

--- a/core/src/Revolution/Processors/Security/Access/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access;
 
 use MODX\Revolution\modAccessContext;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroup;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -29,7 +29,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Access
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $permission = 'access_permissions';
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/Access/GetNodes.php
+++ b/core/src/Revolution/Processors/Security/Access/GetNodes.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Security\Access;
 
 use MODX\Revolution\modAccess;
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modResourceGroup;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\modResourceGroup;
  * @param string $id The parent ID.
  * @package MODX\Revolution\Processors\Security\Access
  */
-class GetNodes extends modObjectProcessor
+class GetNodes extends ModelProcessor
 {
     public $permission = 'access_permissions';
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Security\Access\Permission;
 
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
 /**
  * @package MODX\Revolution\Processors\Security\Access\Permission
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessPermission::class;
     public $checkListPermission = false;

--- a/core/src/Revolution/Processors/Security/Access/Policy/Create.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Create.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Security\Access\Policy;
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Create an access policy.
@@ -24,7 +24,7 @@ use MODX\Revolution\modObjectCreateProcessor;
  * @param string $data The JSON-encoded policy data
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modAccessPolicy::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/Policy/Duplicate.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Duplicate.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy;
 
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 
 /**
  * Duplicates a policy
  * @param integer $id The ID of the policy
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modAccessPolicy::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/Policy/Export.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Export.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\Security\Access\Policy;
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectExportProcessor;
+use MODX\Revolution\Processors\Model\ExportProcessor;
 
 /**
  * Export a policy template.
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class Export extends modObjectExportProcessor
+class Export extends ExportProcessor
 {
     public $classKey = modAccessPolicy::class;
     public $objectType = 'policy';

--- a/core/src/Revolution/Processors/Security/Access/Policy/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/GetList.php
@@ -14,7 +14,7 @@ use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessPolicyTemplate;
 use MODX\Revolution\modAccessPolicyTemplateGroup;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -27,7 +27,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessPolicy::class;
     public $checkListPermission = false;

--- a/core/src/Revolution/Processors/Security/Access/Policy/Import.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Import.php
@@ -14,13 +14,13 @@ use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessPolicyTemplate;
 use MODX\Revolution\modAccessPolicyTemplateGroup;
-use MODX\Revolution\modObjectImportProcessor;
+use MODX\Revolution\Processors\Model\ImportProcessor;
 
 /**
  * Import a policy template.
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class Import extends modObjectImportProcessor
+class Import extends ImportProcessor
 {
     public $classKey = modAccessPolicy::class;
     public $objectType = 'policy';

--- a/core/src/Revolution/Processors/Security/Access/Policy/Remove.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy;
 
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Removes a policy
  * @param integer $id The ID of the policy
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modAccessPolicy::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/Policy/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/RemoveMultiple.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy;
 
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modX;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modX;
  * @param integer $policies A comma-separated list of policies
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class RemoveMultiple extends modObjectProcessor
+class RemoveMultiple extends ModelProcessor
 {
     public $languageTopics = ['policy'];
     public $permission = 'policy_delete';

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/Create.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/Create.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Create an access policy template
@@ -19,7 +19,7 @@ use MODX\Revolution\modObjectCreateProcessor;
  * @param string $description (optional) A short description
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modAccessPolicyTemplate::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/Duplicate.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/Duplicate.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 
 /**
  * Duplicates a policy template
  * @param integer $id The ID of the policy template
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modAccessPolicyTemplate::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/Export.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/Export.php
@@ -12,13 +12,13 @@ namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectExportProcessor;
+use MODX\Revolution\Processors\Model\ExportProcessor;
 
 /**
  * Export a policy template.
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class Export extends modObjectExportProcessor
+class Export extends ExportProcessor
 {
     public $classKey = modAccessPolicyTemplate::class;
     public $objectType = 'policy_template';

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/GetList.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicyTemplate;
 use MODX\Revolution\modAccessPolicyTemplateGroup;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -26,7 +26,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Default
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessPolicyTemplate::class;
     public $checkListPermission = false;

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/Group/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/Group/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy\Template\Group;
 
 use MODX\Revolution\modAccessPolicyTemplateGroup;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 
 /**
@@ -23,7 +23,7 @@ use xPDO\Om\xPDOObject;
  * @param string $dir (optional) The direction of the sort. Default
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template\Group
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessPolicyTemplateGroup::class;
     public $checkListPermission = false;

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/Import.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/Import.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicyTemplate;
 use MODX\Revolution\modAccessPolicyTemplateGroup;
-use MODX\Revolution\modObjectImportProcessor;
+use MODX\Revolution\Processors\Model\ImportProcessor;
 
 /**
  * Import a policy template.
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class Import extends modObjectImportProcessor
+class Import extends ImportProcessor
 {
     public $classKey = modAccessPolicyTemplate::class;
     public $objectType = 'policy_template';

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/Remove.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Removes a policy template
  * @param integer $id The ID of the policy template
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modAccessPolicyTemplate::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/RemoveMultiple.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modX;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modX;
  * @param integer $templates A comma-separated list of policy templates
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class RemoveMultiple extends modObjectProcessor
+class RemoveMultiple extends ModelProcessor
 {
     public $languageTopics = ['policy'];
     public $permission = 'policy_template_delete';

--- a/core/src/Revolution/Processors/Security/Access/Policy/Template/Update.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Template/Update.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Security\Access\Policy\Template;
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Updates a policy template
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectUpdateProcessor;
  * @param string $data The JSON-encoded policy permissions
  * @package MODX\Revolution\Processors\Security\Access\Policy\Template
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modAccessPolicyTemplate::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/Policy/Update.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access\Policy;
 
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Updates a policy
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectUpdateProcessor;
  * @param string $data The JSON-encoded policy data
  * @package MODX\Revolution\Processors\Security\Access\Policy
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modAccessPolicy::class;
     public $languageTopics = ['policy'];

--- a/core/src/Revolution/Processors/Security/Access/RemoveAcl.php
+++ b/core/src/Revolution/Processors/Security/Access/RemoveAcl.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Access;
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove an ACL.
@@ -18,7 +18,7 @@ use MODX\Revolution\modObjectRemoveProcessor;
  * @param string $id The ID of the ACL.
  * @package MODX\Revolution\Processors\Security\Access
  */
-class RemoveAcl extends modObjectRemoveProcessor
+class RemoveAcl extends RemoveProcessor
 {
     public $objectType = 'access';
     public $permission = 'access_permissions';

--- a/core/src/Revolution/Processors/Security/Access/UpdateAcl.php
+++ b/core/src/Revolution/Processors/Security/Access/UpdateAcl.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Access;
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Update an ACL.
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectUpdateProcessor;
  * @param string $context_key (optional) The context to assign this ACL to.
  * @package MODX\Revolution\Processors\Security\Access
  */
-class UpdateAcl extends modObjectUpdateProcessor
+class UpdateAcl extends UpdateProcessor
 {
     public $objectType = 'access';
     public $permission = 'access_permissions';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/Create.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/Create.php
@@ -14,13 +14,13 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace;
 use MODX\Revolution\modAccessNamespace;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modAccessNamespace::class;
     public $objectType = 'access_namespace';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/GetList.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace;
 use MODX\Revolution\modAccessNamespace;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupRole;
 use xPDO\Om\xPDOObject;
@@ -31,7 +31,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessNamespace::class;
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/Remove.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace;
 
 use MODX\Revolution\modAccessNamespace;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove a Resource Group ACL for a user group
  * @param integer $id The ID of the ACL
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modAccessNamespace::class;
     public $objectType = 'access_namespace';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/Update.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/Update.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace;
 use MODX\Revolution\modAccessNamespace;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\AccessNamespace
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modAccessNamespace::class;
     public $objectType = 'access_namespace';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Category/Create.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Category/Create.php
@@ -13,14 +13,14 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\Category;
 use MODX\Revolution\modAccessCategory;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
  * Class Create
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Category
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modAccessCategory::class;
     public $objectType = 'access_category';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Category/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Category/GetList.php
@@ -14,7 +14,7 @@ use MODX\Revolution\modAccessCategory;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessResourceGroup;
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupRole;
 use xPDO\Om\xPDOObject;
@@ -32,7 +32,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Category
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessCategory::class;
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Category/Remove.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Category/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Access\UserGroup\Category;
 
 use MODX\Revolution\modAccessCategory;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove a Resource Group ACL for a user group
  * @param integer $id The ID of the ACL
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Category
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modAccessCategory::class;
     public $objectType = 'access_category';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Category/Update.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Category/Update.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\Category;
 use MODX\Revolution\modAccessCategory;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Category
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modAccessCategory::class;
     public $objectType = 'access_category';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Context/Create.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Context/Create.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\Context;
 use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Context
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modAccessContext::class;
     public $objectType = 'access_context';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Context/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Context/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\Context;
 
 use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupRole;
 use xPDO\Om\xPDOObject;
@@ -30,7 +30,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Context
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessContext::class;
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Context/Remove.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Context/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Access\UserGroup\Context;
 
 use MODX\Revolution\modAccessContext;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove a context ACL for a user group
  * @param integer $id The ID of the ACL
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Context
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modAccessContext::class;
     public $objectType = 'access_context';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Context/Update.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Context/Update.php
@@ -13,14 +13,14 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\Context;
 use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
  * Update ACL for Context
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Context
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modAccessContext::class;
     public $objectType = 'access_context';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/Create.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/Create.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup;
 
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessResourceGroup;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modUserGroup;
 
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modAccessResourceGroup::class;
     public $objectType = 'access_rgroup';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/GetList.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup;
 
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessResourceGroup;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupRole;
@@ -32,7 +32,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessResourceGroup::class;
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/Remove.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup;
 
 use MODX\Revolution\modAccessResourceGroup;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove a Resource Group ACL for a user group
  * @param integer $id The ID of the ACL
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modAccessResourceGroup::class;
     public $objectType = 'access_rgroup';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/Update.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/Update.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup;
 
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessResourceGroup;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modUserGroup;
 
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modAccessResourceGroup::class;
     public $objectType = 'access_rgroup';

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Source/Create.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Source/Create.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access\UserGroup\Source;
 
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\Sources\modAccessMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
@@ -19,7 +19,7 @@ use MODX\Revolution\Sources\modMediaSource;
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Source
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modAccessMediaSource::class;
     public $languageTopics = ['source', 'access', 'user'];

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Source/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Source/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Access\UserGroup\Source;
 
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupRole;
 use MODX\Revolution\Sources\modAccessMediaSource;
@@ -31,7 +31,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Source
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modAccessMediaSource::class;
     public $languageTopics = ['access', 'source'];

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Source/Remove.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Source/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Access\UserGroup\Source;
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\Sources\modAccessMediaSource;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\Sources\modAccessMediaSource;
  * @param integer $id The ID of the ACL
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Source
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modAccessMediaSource::class;
     public $languageTopics = ['source', 'access', 'user'];

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Source/Update.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Source/Update.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Security\Access\UserGroup\Source;
 
 use MODX\Revolution\modAccessCategory;
 use MODX\Revolution\modAccessPolicy;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\Sources\modAccessMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
@@ -20,7 +20,7 @@ use MODX\Revolution\Sources\modMediaSource;
 /**
  * @package MODX\Revolution\Processors\Security\Access\UserGroup\Source
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modAccessMediaSource::class;
     public $languageTopics = ['source', 'access', 'user'];

--- a/core/src/Revolution/Processors/Security/Flush.php
+++ b/core/src/Revolution/Processors/Security/Flush.php
@@ -10,14 +10,14 @@
 
 namespace MODX\Revolution\Processors\Security;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modSession;
 use MODX\Revolution\modSessionHandler;
 
 /**
  * Flush all sessions
  */
-class Flush extends modProcessor
+class Flush extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Security/Forms/Profile/Activate.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/Activate.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Profile;
 
 use MODX\Revolution\modFormCustomizationProfile;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Activate a FC Profile
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class Activate extends modObjectUpdateProcessor
+class Activate extends UpdateProcessor
 {
     public $classKey = modFormCustomizationProfile::class;
     public $objectType = 'profile';

--- a/core/src/Revolution/Processors/Security/Forms/Profile/Create.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/Create.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Profile;
 
 use MODX\Revolution\modFormCustomizationProfile;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Create a FC Profile
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modFormCustomizationProfile::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Profile/Deactivate.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/Deactivate.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Profile;
 
 use MODX\Revolution\modFormCustomizationProfile;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Deactivate a FC Profile
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class Deactivate extends modObjectUpdateProcessor
+class Deactivate extends UpdateProcessor
 {
     public $classKey = modFormCustomizationProfile::class;
     public $objectType = 'profile';

--- a/core/src/Revolution/Processors/Security/Forms/Profile/Duplicate.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/Duplicate.php
@@ -14,13 +14,13 @@ use MODX\Revolution\modActionDom;
 use MODX\Revolution\modFormCustomizationProfile;
 use MODX\Revolution\modFormCustomizationProfileUserGroup;
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 
 /**
  * Duplicate a FC Profile
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modFormCustomizationProfile::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Profile/GetList.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Forms\Profile;
 
 use MODX\Revolution\modFormCustomizationProfile;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 
 /**
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOObject;
  * @param string $dir (optional) The direction of the sort. Default action.
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modFormCustomizationProfile::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Profile/Remove.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/Remove.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Profile;
 
 use MODX\Revolution\modFormCustomizationProfile;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove FC Profile
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modFormCustomizationProfile::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Profile/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/RemoveMultiple.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Forms\Profile;
 
 use MODX\Revolution\modFormCustomizationProfile;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 
 /**
  * Remove multiple FC profiles
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class RemoveMultiple extends modProcessor
+class RemoveMultiple extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Security/Forms/Profile/Update.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/Update.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Security\Forms\Profile;
 
 use MODX\Revolution\modFormCustomizationProfile;
 use MODX\Revolution\modFormCustomizationProfileUserGroup;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
  * Update a FC Profile
  * @package MODX\Revolution\Processors\Security\Forms\Profile
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modFormCustomizationProfile::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Set/Activate.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Activate.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Activate a FC Set
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Activate extends modObjectUpdateProcessor
+class Activate extends UpdateProcessor
 {
     public $classKey = modFormCustomizationSet::class;
     public $objectType = 'set';

--- a/core/src/Revolution/Processors/Security/Forms/Set/Create.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Create.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modResource;
 
 /**
  * Create a FC Set
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modFormCustomizationSet::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Set/Deactivate.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Deactivate.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Deactivate a FC Set
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Deactivate extends modObjectUpdateProcessor
+class Deactivate extends UpdateProcessor
 {
     public $classKey = modFormCustomizationSet::class;
     public $objectType = 'set';

--- a/core/src/Revolution/Processors/Security/Forms/Set/Duplicate.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Duplicate.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modActionDom;
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 use MODX\Revolution\modResource;
 
 /**
  * Duplicate a FC Set
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modFormCustomizationSet::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Set/Export.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Export.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectExportProcessor;
+use MODX\Revolution\Processors\Model\ExportProcessor;
 
 /**
  * Export a form customization set.
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Export extends modObjectExportProcessor
+class Export extends ExportProcessor
 {
     public $objectType = 'set';
     public $classKey = modFormCustomizationSet::class;

--- a/core/src/Revolution/Processors/Security/Forms/Set/GetList.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modTemplate;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Default action.
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modFormCustomizationSet::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Set/Import.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Import.php
@@ -14,7 +14,7 @@ use MODX\Revolution\modActionDom;
 use MODX\Revolution\modActionField;
 use MODX\Revolution\modFormCustomizationProfile;
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectImportProcessor;
+use MODX\Revolution\Processors\Model\ImportProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVar;
@@ -24,7 +24,7 @@ use MODX\Revolution\modX;
  * Import a Form Customization Set from an XML file
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Import extends modObjectImportProcessor
+class Import extends ImportProcessor
 {
     public $objectType = 'set';
     public $classKey = modFormCustomizationSet::class;

--- a/core/src/Revolution/Processors/Security/Forms/Set/Remove.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Remove.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove a FC Set
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modFormCustomizationSet::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Forms/Set/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/RemoveMultiple.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 
 /**
  * Remove multiple FC sets
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class RemoveMultiple extends modProcessor
+class RemoveMultiple extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Security/Forms/Set/Update.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/Update.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Security\Forms\Set;
 use MODX\Revolution\modActionDom;
 use MODX\Revolution\modActionField;
 use MODX\Revolution\modFormCustomizationSet;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modTemplateVar;
 
@@ -25,7 +25,7 @@ use MODX\Revolution\modTemplateVar;
  * @param string $dir (optional) The direction of the sort. Default action.
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modFormCustomizationSet::class;
     public $languageTopics = ['formcustomization'];

--- a/core/src/Revolution/Processors/Security/Group/Create.php
+++ b/core/src/Revolution/Processors/Security/Group/Create.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessResourceGroup;
 use MODX\Revolution\modCategory;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
@@ -28,7 +28,7 @@ use MODX\Revolution\modUserGroupRole;
  * @param integer $parent (optional) The ID of the parent user group. Defaults to 0.
  * @package MODX\Revolution\Processors\Security\Group
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modUserGroup::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/Group/GetList.php
+++ b/core/src/Revolution/Processors/Security/Group/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroup;
 use xPDO\Om\xPDOQuery;
 
@@ -23,7 +23,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Group
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modUserGroup::class;
     public $languageTopics = ['user', 'access', 'messages'];

--- a/core/src/Revolution/Processors/Security/Group/GetNodes.php
+++ b/core/src/Revolution/Processors/Security/Group/GetNodes.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUserGroup;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\modUserGroup;
  * @param string $id The parent ID
  * @package MODX\Revolution\Processors\Security\Group
  */
-class GetNodes extends modProcessor
+class GetNodes extends Processor
 {
     /** @var string $id */
     public $id;

--- a/core/src/Revolution/Processors/Security/Group/Remove.php
+++ b/core/src/Revolution/Processors/Security/Group/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group;
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modUserGroup;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\modUserGroup;
  * @param integer $id The ID of the user group
  * @package MODX\Revolution\Processors\Security\Group
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modUserGroup::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/Group/Sort.php
+++ b/core/src/Revolution/Processors/Security/Group/Sort.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -21,7 +21,7 @@ use MODX\Revolution\modX;
  * @param string $data The encoded in JSON tree data
  * @package MODX\Revolution\Processors\Security\Group
  */
-class Sort extends modProcessor
+class Sort extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Security/Group/Update.php
+++ b/core/src/Revolution/Processors/Security/Group/Update.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group;
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -21,7 +21,7 @@ use MODX\Revolution\modUserGroupMember;
  * @param string $name The new name of the user group
  * @package MODX\Revolution\Processors\Security\Group
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modUserGroup::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/Group/User/Create.php
+++ b/core/src/Revolution/Processors/Security/Group/User/Create.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group\User;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -23,7 +23,7 @@ use MODX\Revolution\modUserGroupRole;
  * @param integer $role The ID of the role
  * @package MODX\Revolution\Processors\Security\Group\User
  */
-class Create extends modProcessor
+class Create extends Processor
 {
     /** @var modUser $user */
     public $user;

--- a/core/src/Revolution/Processors/Security/Group/User/GetList.php
+++ b/core/src/Revolution/Processors/Security/Group/User/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group\User;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -27,7 +27,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Group\User
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modUser::class;
     public $defaultSortField = 'username';

--- a/core/src/Revolution/Processors/Security/Group/User/Remove.php
+++ b/core/src/Revolution/Processors/Security/Group/User/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group\User;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -21,7 +21,7 @@ use MODX\Revolution\modUserGroupMember;
  * @param integer $user The ID of the user
  * @package MODX\Revolution\Processors\Security\Group\User
  */
-class Remove extends modProcessor
+class Remove extends Processor
 {
     /** @var modUserGroupMember $membership */
     public $membership;

--- a/core/src/Revolution/Processors/Security/Group/User/Update.php
+++ b/core/src/Revolution/Processors/Security/Group/User/Update.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Group\User;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUserGroupMember;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modUserGroupMember;
  * @param integer $user The ID of the user
  * @package MODX\Revolution\Processors\Security\Group\User
  */
-class Update extends modProcessor
+class Update extends Processor
 {
     /** @var modUserGroupMember $membership */
     public $membership;

--- a/core/src/Revolution/Processors/Security/Login.php
+++ b/core/src/Revolution/Processors/Security/Login.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\Security;
 
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
 use MODX\Revolution\modUserSetting;
@@ -20,7 +20,7 @@ use MODX\Revolution\modUserSetting;
 /**
  * Properly log in the user and set up the session.
  */
-class Login extends modProcessor
+class Login extends Processor
 {
 
     /** @var modUser */

--- a/core/src/Revolution/Processors/Security/Logout.php
+++ b/core/src/Revolution/Processors/Security/Logout.php
@@ -10,12 +10,12 @@
 
 namespace MODX\Revolution\Processors\Security;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Properly log out the user, running any events and flushing the session.
  */
-class Logout extends modProcessor
+class Logout extends Processor
 {
     public $loginContext;
 

--- a/core/src/Revolution/Processors/Security/Message/Create.php
+++ b/core/src/Revolution/Processors/Security/Message/Create.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Message;
 
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -30,7 +30,7 @@ use xPDO\xPDOIterator;
  * @param integer $group (optional)
  * @package MODX\Revolution\Processors\Security\Message
  */
-class Create extends modObjectProcessor
+class Create extends ModelProcessor
 {
     public $classKey = modUserMessage::class;
     public $objectType = 'message';

--- a/core/src/Revolution/Processors/Security/Message/GetList.php
+++ b/core/src/Revolution/Processors/Security/Message/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Message;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserMessage;
 use MODX\Revolution\modUserProfile;
@@ -25,7 +25,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Message
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modUserMessage::class;
     public $languageTopics = ['messages', 'user'];

--- a/core/src/Revolution/Processors/Security/Message/Read.php
+++ b/core/src/Revolution/Processors/Security/Message/Read.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Message;
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserMessage;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\modUserMessage;
  * @param integer $id The ID of the message
  * @package MODX\Revolution\Processors\Security\Message
  */
-class Read extends modObjectUpdateProcessor
+class Read extends UpdateProcessor
 {
     public $classKey = modUserMessage::class;
     public $objectType = 'message';

--- a/core/src/Revolution/Processors/Security/Message/Remove.php
+++ b/core/src/Revolution/Processors/Security/Message/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Message;
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modUserMessage;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\modUserMessage;
  * @param integer $id The ID of the message
  * @package MODX\Revolution\Processors\Security\Message
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modUserMessage::class;
     public $objectType = 'message';

--- a/core/src/Revolution/Processors/Security/Message/Unread.php
+++ b/core/src/Revolution/Processors/Security/Message/Unread.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Message;
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserMessage;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\modUserMessage;
  * @param integer $id The ID of the message
  * @package MODX\Revolution\Processors\Security\Message
  */
-class Unread extends modObjectUpdateProcessor
+class Unread extends UpdateProcessor
 {
     public $classKey = modUserMessage::class;
     public $objectType = 'message';

--- a/core/src/Revolution/Processors/Security/Profile/ChangePassword.php
+++ b/core/src/Revolution/Processors/Security/Profile/ChangePassword.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Profile;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 
 /**
@@ -22,7 +22,7 @@ use MODX\Revolution\modUser;
  * @param string $password_confirm A confirmed version of the new password
  * @package MODX\Revolution\Processors\Security\Profile
  */
-class ChangePassword extends modProcessor
+class ChangePassword extends Processor
 {
     public function checkPermissions()
     {

--- a/core/src/Revolution/Processors/Security/Profile/Get.php
+++ b/core/src/Revolution/Processors/Security/Profile/Get.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\Profile;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -21,7 +21,7 @@ use MODX\Revolution\modUserGroupRole;
  * @param integer $id The ID of the user
  * @package MODX\Revolution\Processors\Security\Profile
  */
-class Get extends modProcessor
+class Get extends Processor
 {
     /** @var modUser $user */
     public $user;

--- a/core/src/Revolution/Processors/Security/Profile/Update.php
+++ b/core/src/Revolution/Processors/Security/Profile/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Profile;
 
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
 
@@ -19,7 +19,7 @@ use MODX\Revolution\modUserProfile;
  * Update a user profile
  * @package MODX\Revolution\Processors\Security\Profile
  */
-class Update extends modProcessor
+class Update extends Processor
 {
     /** @var modUserProfile $profile */
     public $profile;

--- a/core/src/Revolution/Processors/Security/ResourceGroup/Create.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/Create.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Security\ResourceGroup;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessResourceGroup;
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
@@ -24,7 +24,7 @@ use PDO;
  * @param string $name The name of the new resource group
  * @package MODX\Revolution\Processors\Security\ResourceGroup
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modResourceGroup::class;
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\ResourceGroup;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modResourceGroup;
 use xPDO\Om\xPDOQuery;
 
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\ResourceGroup
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modResourceGroup::class;
     public $languageTopics = ['access'];

--- a/core/src/Revolution/Processors/Security/ResourceGroup/GetNodes.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/GetNodes.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\ResourceGroup;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
 
@@ -19,7 +19,7 @@ use MODX\Revolution\modResourceGroup;
  * @param string $id The ID of the parent node
  * @package MODX\Revolution\Processors\Security\ResourceGroup
  */
-class GetNodes extends modProcessor
+class GetNodes extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Security/ResourceGroup/Remove.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\ResourceGroup;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResourceGroup;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\modResourceGroup;
  * @param integer $id The ID of the resource group
  * @package MODX\Revolution\Processors\Security\ResourceGroup
  */
-class Remove extends modProcessor
+class Remove extends Processor
 {
     /** @var modResourceGroup $resourceGroup */
     public $resourceGroup;

--- a/core/src/Revolution/Processors/Security/ResourceGroup/RemoveResource.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/RemoveResource.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\ResourceGroup;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modResourceGroupResource;
@@ -21,7 +21,7 @@ use MODX\Revolution\modResourceGroupResource;
  * @param integer $resource The ID of the resource
  * @package MODX\Revolution\Processors\Security\ResourceGroup
  */
-class RemoveResource extends modProcessor
+class RemoveResource extends Processor
 {
     /** @var modResourceGroup $resourceGroup */
     public $resourceGroup;

--- a/core/src/Revolution/Processors/Security/ResourceGroup/Update.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/Update.php
@@ -10,14 +10,14 @@
 
 namespace MODX\Revolution\Processors\Security\ResourceGroup;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResourceGroup;
 
 /**
  * Update a resource group
  * @package MODX\Revolution\Processors\Security\ResourceGroup
  */
-class Update extends modProcessor
+class Update extends Processor
 {
     /** @var modResourceGroup $resourceGroup */
     public $resourceGroup;

--- a/core/src/Revolution/Processors/Security/ResourceGroup/UpdateResourcesIn.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/UpdateResourcesIn.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\ResourceGroup;
 
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
 use MODX\Revolution\modResourceGroupResource;
@@ -19,7 +19,7 @@ use MODX\Revolution\modResourceGroupResource;
  * Update documents in a resource group
  * @package MODX\Revolution\Processors\Security\ResourceGroup
  */
-class UpdateResourcesIn extends modObjectCreateProcessor
+class UpdateResourcesIn extends CreateProcessor
 {
     public $classKey = modResourceGroupResource::class;
     public $objectType = 'resource_group_resource';

--- a/core/src/Revolution/Processors/Security/Role/Create.php
+++ b/core/src/Revolution/Processors/Security/Role/Create.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Security\Role;
 
 
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroupRole;
 
 /**
  * Creates a role from a POST request.
  * @package MODX\Revolution\Processors\Security\Role
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modUserGroupRole::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/Role/Get.php
+++ b/core/src/Revolution/Processors/Security/Role/Get.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Role;
 
 
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 use MODX\Revolution\modUserGroupRole;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modUserGroupRole;
  * @param integer $id The ID of the role
  * @package MODX\Revolution\Processors\Security\Role
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modUserGroupRole::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/Role/GetList.php
+++ b/core/src/Revolution/Processors/Security/Role/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Role;
 
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroupRole;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -26,7 +26,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\Role
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modUserGroupRole::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/Role/Remove.php
+++ b/core/src/Revolution/Processors/Security/Role/Remove.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Role;
 
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modUserGroupMember;
 use MODX\Revolution\modUserGroupRole;
 
@@ -20,7 +20,7 @@ use MODX\Revolution\modUserGroupRole;
  * @param integer $id The ID of the role
  * @package MODX\Revolution\Processors\Security\Role
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modUserGroupRole::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/Role/Update.php
+++ b/core/src/Revolution/Processors/Security/Role/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\Role;
 
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserGroupRole;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modUserGroupRole;
  * @param integer $id The ID of the role
  * @package MODX\Revolution\Processors\Security\Role
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modUserGroupRole::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/User/ActivateMultiple.php
+++ b/core/src/Revolution/Processors/Security/User/ActivateMultiple.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\User;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modX;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\modX;
  * Activate multiple users
  * @package MODX\Revolution\Processors\Security\User
  */
-class ActivateMultiple extends modProcessor
+class ActivateMultiple extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Security/User/Create.php
+++ b/core/src/Revolution/Processors/Security/User/Create.php
@@ -12,8 +12,8 @@ namespace MODX\Revolution\Processors\Security\User;
 
 
 use Exception;
-use MODX\Revolution\modObjectCreateProcessor;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -29,7 +29,7 @@ use MODX\Revolution\Smarty\modSmarty;
  *
  * @package MODX\Revolution\Processors\Security\User
  */
-class Create extends modObjectCreateProcessor {
+class Create extends CreateProcessor {
     public $classKey = modUser::class;
     public $languageTopics = array('user', 'login');
     public $permission = 'new_user';
@@ -52,7 +52,7 @@ class Create extends modObjectCreateProcessor {
      * @param modX $modx
      * @param $className
      * @param array $properties
-     * @return modProcessor
+     * @return Processor
      */
     public static function getInstance(modX &$modx,$className,$properties = array()) {
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : modUser::class;
@@ -64,7 +64,7 @@ class Create extends modObjectCreateProcessor {
                 $className = static::class;
             }
         }
-        /** @var modProcessor $processor */
+        /** @var Processor $processor */
         $processor = new $className($modx,$properties);
         return $processor;
     }

--- a/core/src/Revolution/Processors/Security/User/DeactivateMultiple.php
+++ b/core/src/Revolution/Processors/Security/User/DeactivateMultiple.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\User;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modX;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\modX;
  * Deactivate multiple users
  * @package MODX\Revolution\Processors\Security\User
  */
-class DeactivateMultiple extends modProcessor
+class DeactivateMultiple extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Security/User/Delete.php
+++ b/core/src/Revolution/Processors/Security/User/Delete.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\User;
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -20,7 +20,7 @@ use MODX\Revolution\modUserGroupMember;
  * @param integer $id The ID of the user
  * @package MODX\Revolution\Processors\Security\User
  */
-class Delete extends modObjectRemoveProcessor
+class Delete extends RemoveProcessor
 {
     public $classKey = modUser::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/User/Duplicate.php
+++ b/core/src/Revolution/Processors/Security/User/Duplicate.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\User;
 
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroupMember;
 use MODX\Revolution\modUserProfile;
@@ -22,7 +22,7 @@ use MODX\Revolution\modUserSetting;
  * @param string $new_username The name of the new user.
  * @package MODX\Revolution\Processors\Security\User
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modUser::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/User/Get.php
+++ b/core/src/Revolution/Processors/Security/User/Get.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\User;
 
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -21,7 +21,7 @@ use MODX\Revolution\modUserGroupRole;
  * @param integer $id The ID of the user
  * @package MODX\Revolution\Processors\Security\User
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modUser::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/User/GetList.php
+++ b/core/src/Revolution/Processors/Security/User/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\User;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroupMember;
 use MODX\Revolution\modUserProfile;
@@ -26,7 +26,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\User
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modUser::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/User/GetOnline.php
+++ b/core/src/Revolution/Processors/Security/User/GetOnline.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\Security\User;
 use DateInterval;
 use DateTime;
 use MODX\Revolution\modManagerLog;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use PDO;
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOObject;
  * Gets a list of all users who are online
  * @package MODX\Revolution\Processors\Security\User
  */
-class GetOnline extends modObjectGetListProcessor
+class GetOnline extends GetListProcessor
 {
     public $classKey = modManagerLog::class;
     public $defaultSortField = 'occurred';

--- a/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
+++ b/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\User;
 
 use MODX\Revolution\modManagerLog;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
@@ -28,7 +28,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Security\User
  */
-class GetRecentlyEditedResources extends modObjectGetListProcessor
+class GetRecentlyEditedResources extends GetListProcessor
 {
     public $classKey = modManagerLog::class;
     public $permission = 'view_document';

--- a/core/src/Revolution/Processors/Security/User/Group/GetList.php
+++ b/core/src/Revolution/Processors/Security/User/Group/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Security\User\Group;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\modUserGroupMember;
@@ -21,7 +21,7 @@ use xPDO\Om\xPDOQuery;
  * Gets a list of groups for a user
  * @package MODX\Revolution\Processors\Security\User\Group
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modUserGroupMember::class;
     public $languageTopics = ['user'];

--- a/core/src/Revolution/Processors/Security/User/Update.php
+++ b/core/src/Revolution/Processors/Security/User/Update.php
@@ -11,8 +11,8 @@
 namespace MODX\Revolution\Processors\Security\User;
 
 
-use MODX\Revolution\modObjectUpdateProcessor;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modSystemEvent;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
@@ -28,7 +28,7 @@ use MODX\Revolution\modX;
  * @package modx
  * @subpackage processors.security.user
  */
-class Update extends modObjectUpdateProcessor {
+class Update extends UpdateProcessor {
     public $classKey = modUser::class;
     public $languageTopics = array('user');
     public $permission = 'save_user';
@@ -58,7 +58,7 @@ class Update extends modObjectUpdateProcessor {
      * @param modX $modx
      * @param string $className
      * @param array $properties
-     * @return modProcessor
+     * @return Processor
      */
     public static function getInstance(modX &$modx,$className,$properties = array()) {
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : modUser::class;
@@ -70,7 +70,7 @@ class Update extends modObjectUpdateProcessor {
                 $className = static::class;
             }
         }
-        /** @var modProcessor $processor */
+        /** @var Processor $processor */
         $processor = new $className($modx,$properties);
         return $processor;
     }

--- a/core/src/Revolution/Processors/Security/User/Validation.php
+++ b/core/src/Revolution/Processors/Security/User/Validation.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Security\User;
 
 
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
 use MODX\Revolution\modX;
@@ -31,7 +31,7 @@ class Validation {
     /** @var modUserProfile $profile */
     public $profile;
 
-    function __construct(modObjectProcessor &$processor,modUser &$user,modUserProfile &$profile) {
+    function __construct(ModelProcessor &$processor,modUser &$user,modUserProfile &$profile) {
         $this->processor =& $processor;
         $this->modx =& $processor->modx;
         $this->user =& $user;

--- a/core/src/Revolution/Processors/Source/Create.php
+++ b/core/src/Revolution/Processors/Source/Create.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Source;
 
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\Sources\modFileMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\Sources\modMediaSource;
  * Creates a Media Source
  * @package MODX\Revolution\Processors\Source
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modMediaSource::class;
     public $languageTopics = ['source'];

--- a/core/src/Revolution/Processors/Source/Duplicate.php
+++ b/core/src/Revolution/Processors/Source/Duplicate.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Source;
 
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 use MODX\Revolution\Sources\modMediaSource;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\Sources\modMediaSource;
  * @param string $name The name of the new source.
  * @package MODX\Revolution\Processors\Source
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modMediaSource::class;
     public $languageTopics = ['source'];

--- a/core/src/Revolution/Processors/Source/GetList.php
+++ b/core/src/Revolution/Processors/Source/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Source;
 
 use MODX\Revolution\modAccessibleObject;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\Sources\modMediaSource;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Source
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modMediaSource::class;
     public $languageTopics = ['source'];

--- a/core/src/Revolution/Processors/Source/Remove.php
+++ b/core/src/Revolution/Processors/Source/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Source;
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\Sources\modMediaSource;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\Sources\modMediaSource;
  * @param integer $id The ID of the source
  * @package MODX\Revolution\Processors\Source
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modMediaSource::class;
     public $languageTopics = ['source'];

--- a/core/src/Revolution/Processors/Source/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/Source/RemoveMultiple.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Source;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Sources\modMediaSource;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\Sources\modMediaSource;
  * Removes multiple Media Sources
  * @package MODX\Revolution\Processors\Source
  */
-class RemoveMultiple extends modProcessor
+class RemoveMultiple extends Processor
 {
     /** @var modMediaSource $source */
     public $source;

--- a/core/src/Revolution/Processors/Source/Type/GetList.php
+++ b/core/src/Revolution/Processors/Source/Type/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Source\Type;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Sources\modMediaSource;
 use xPDO\Om\xPDOObject;
 
@@ -18,7 +18,7 @@ use xPDO\Om\xPDOObject;
  * Gets a list of media source types
  * @package MODX\Revolution\Processors\Source\Type
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Source/Update.php
+++ b/core/src/Revolution/Processors/Source/Update.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Source;
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\Sources\modAccessMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
 
@@ -19,7 +19,7 @@ use MODX\Revolution\Sources\modMediaSource;
  * @param integer $id The ID of the Source
  * @package MODX\Revolution\Processors\Source
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modMediaSource::class;
     public $languageTopics = ['source'];

--- a/core/src/Revolution/Processors/System/ActiveResource/GetList.php
+++ b/core/src/Revolution/Processors/System/ActiveResource/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System\ActiveResource;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modUser;
 use xPDO\Om\xPDOObject;
@@ -26,7 +26,7 @@ use xPDO\Om\xPDOQuery;
  * editedon date to. Defaults to: %b %d, %Y %I:%M %p
  * @package MODX\Revolution\Processors\System\ActiveResource
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modResource::class;
     public $languageTopics = ['resource'];

--- a/core/src/Revolution/Processors/System/Charset/GetList.php
+++ b/core/src/Revolution/Processors/System/Charset/GetList.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\System\Charset;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Gets a list of charsets
  * @package MODX\Revolution\Processors\System\Charset
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/ClassMap/GetList.php
+++ b/core/src/Revolution/Processors/System/ClassMap/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\ClassMap;
 
 use MODX\Revolution\modClassMap;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOQuery;
 
 /**
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\ClassMap
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modClassMap::class;
     public $permission = 'class_map';

--- a/core/src/Revolution/Processors/System/ClearCache.php
+++ b/core/src/Revolution/Processors/System/ClearCache.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System;
 
 use MODX\Revolution\modContext;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use PDO;
 
@@ -19,7 +19,7 @@ use PDO;
  * Refreshes the site cache
  * @package MODX\Revolution\Processors\System
  */
-class ClearCache extends modProcessor
+class ClearCache extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/ConfigCheck.php
+++ b/core/src/Revolution/Processors/System/ConfigCheck.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System;
 
 use MODX\Revolution\modContextSetting;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modSystemSetting;
 use PDO;
@@ -20,7 +20,7 @@ use PDO;
  * Runs a config check
  * @package MODX\Revolution\Processors\System
  */
-class ConfigCheck extends modProcessor
+class ConfigCheck extends Processor
 {
     protected $warnings = [];
 

--- a/core/src/Revolution/Processors/System/ConfigJs.php
+++ b/core/src/Revolution/Processors/System/ConfigJs.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\System;
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
@@ -24,7 +24,7 @@ use MODX\Revolution\modResource;
  * custom context by its action
  * @package MODX\Revolution\Processors\System
  */
-class ConfigJs extends modProcessor
+class ConfigJs extends Processor
 {
     /**
      * @return mixed|string

--- a/core/src/Revolution/Processors/System/Console.php
+++ b/core/src/Revolution/Processors/System/Console.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Registry\modFileRegister;
 use MODX\Revolution\Registry\modRegistry;
 
@@ -28,7 +28,7 @@ use MODX\Revolution\Registry\modRegistry;
  * @param boolean $show_filename (optional) If true, will show the filename in the message. Defaults to false.
  * @package MODX\Revolution\Processors\System
  */
-class Console extends modProcessor
+class Console extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/ContentType/Create.php
+++ b/core/src/Revolution/Processors/System/ContentType/Create.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\ContentType;
 
 use MODX\Revolution\modContentType;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Create a content type
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectCreateProcessor;
  * @param boolean $binary If true, will be sent as binary data
  * @package MODX\Revolution\Processors\System\ContentType
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modContentType::class;
     public $languageTopics = ['content_type'];

--- a/core/src/Revolution/Processors/System/ContentType/GetList.php
+++ b/core/src/Revolution/Processors/System/ContentType/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\ContentType;
 
 use MODX\Revolution\modContentType;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOQuery;
 
 /**
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\ContentType
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modContentType::class;
     public $languageTopics = ['content_type'];

--- a/core/src/Revolution/Processors/System/ContentType/Remove.php
+++ b/core/src/Revolution/Processors/System/ContentType/Remove.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\ContentType;
 
 use MODX\Revolution\modContentType;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modResource;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modResource;
  * @param integer $id The ID of the content type
  * @package MODX\Revolution\Processors\System\ContentType
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modContentType::class;
     public $languageTopics = ['content_type'];

--- a/core/src/Revolution/Processors/System/ContentType/Update.php
+++ b/core/src/Revolution/Processors/System/ContentType/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\ContentType;
 
 use MODX\Revolution\modContentType;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modResource;
 
 /**
@@ -26,7 +26,7 @@ use MODX\Revolution\modResource;
  * @param boolean $binary If true, will be sent as binary data
  * @package MODX\Revolution\Processors\System\ContentType
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modContentType::class;
     public $languageTopics = ['content_type'];

--- a/core/src/Revolution/Processors/System/ContentType/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/System/ContentType/UpdateFromGrid.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\ContentType;
 
 use MODX\Revolution\modContentType;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 
 /**
@@ -26,7 +26,7 @@ use MODX\Revolution\modResource;
  * @param boolean $binary If true, will be sent as binary data
  * @package MODX\Revolution\Processors\System\ContentType
  */
-class UpdateFromGrid extends modProcessor
+class UpdateFromGrid extends Processor
 {
     /** @var array $records */
     public $records;

--- a/core/src/Revolution/Processors/System/Country/GetList.php
+++ b/core/src/Revolution/Processors/System/Country/GetList.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\System\Country;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Gets a list of country codes
  * @package MODX\Revolution\Processors\System\Country
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/System/Dashboard/Create.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Create.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\System\Dashboard;
 
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Creates a Dashboard
  * @param integer $id The ID of the dashboard
  * @package MODX\Revolution\Processors\System\Dashboard
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modDashboard::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/Duplicate.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Duplicate.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\System\Dashboard;
 
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectDuplicateProcessor;
+use MODX\Revolution\Processors\Model\DuplicateProcessor;
 
 /**
  * Duplicates a dashboard.
@@ -20,7 +20,7 @@ use MODX\Revolution\modObjectDuplicateProcessor;
  * @param string $name The name of the new chunk.
  * @package MODX\Revolution\Processors\System\Dashboard
  */
-class Duplicate extends modObjectDuplicateProcessor
+class Duplicate extends DuplicateProcessor
 {
     public $classKey = modDashboard::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/GetList.php
+++ b/core/src/Revolution/Processors/System/Dashboard/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Dashboard;
 
 use MODX\Revolution\modDashboard;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modUserGroup;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -25,7 +25,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\Dashboard
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modDashboard::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/Remove.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Dashboard;
 
 use MODX\Revolution\modDashboard;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Removes a Dashboard
  * @param integer $id The ID of the dashboard
  * @package MODX\Revolution\Processors\System\Dashboard
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modDashboard::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/System/Dashboard/RemoveMultiple.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Dashboard;
 
 use MODX\Revolution\modDashboard;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 
 /**
  * Removes multiple Dashboards
  * @package MODX\Revolution\Processors\System\Dashboard
  */
-class RemoveMultiple extends modProcessor
+class RemoveMultiple extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Dashboard/Update.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Update.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\System\Dashboard;
 
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Updates a Dashboard
  * @param integer $id The ID of the dashboard
  * @package MODX\Revolution\Processors\System\Dashboard
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modDashboard::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/User/Create.php
+++ b/core/src/Revolution/Processors/System/Dashboard/User/Create.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\System\Dashboard\User;
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidget;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Class Create
  * @package MODX\Revolution\Processors\System\Dashboard\User
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modDashboardWidgetPlacement::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/User/GetList.php
+++ b/core/src/Revolution/Processors/System/Dashboard/User/GetList.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\System\Dashboard\User;
 use MODX\Revolution\modAccessibleObject;
 use MODX\Revolution\modDashboardWidget;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use PDO;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  * Class GetList
  * @package MODX\Revolution\Processors\System\Dashboard\User
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modDashboardWidget::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/User/Remove.php
+++ b/core/src/Revolution/Processors/System/Dashboard/User/Remove.php
@@ -13,14 +13,14 @@ namespace MODX\Revolution\Processors\System\Dashboard\User;
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidget;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectRemoveProcessor;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
+use MODX\Revolution\Processors\ProcessorResponse;
 
 /**
  * Class Remove
  * @package MODX\Revolution\Processors\System\Dashboard\User
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modDashboardWidgetPlacement::class;
     public $languageTopics = ['dashboards'];
@@ -61,7 +61,7 @@ class Remove extends modObjectRemoveProcessor
 
         $new_widgets = 0;
         $this->modx->error->reset();
-        /** @var modProcessorResponse $res */
+        /** @var ProcessorResponse $res */
         $res = $this->modx->runProcessor(GetList::class, [
             'dashboard' => $this->object->get('dashboard'),
             'combo' => true,

--- a/core/src/Revolution/Processors/System/Dashboard/User/Resize.php
+++ b/core/src/Revolution/Processors/System/Dashboard/User/Resize.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\System\Dashboard\User;
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidget;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Class Resize
  * @package MODX\Revolution\Processors\System\Dashboard\User
  */
-class Resize extends modObjectUpdateProcessor
+class Resize extends UpdateProcessor
 {
     public $classKey = modDashboardWidgetPlacement::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/User/Sort.php
+++ b/core/src/Revolution/Processors/System/Dashboard/User/Sort.php
@@ -13,13 +13,13 @@ namespace MODX\Revolution\Processors\System\Dashboard\User;
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidget;
 use MODX\Revolution\modDashboardWidgetPlacement;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Class Sort
  * @package MODX\Revolution\Processors\System\Dashboard\User
  */
-class Sort extends modObjectUpdateProcessor
+class Sort extends UpdateProcessor
 {
     public $classKey = modDashboardWidgetPlacement::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Create.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Create.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\System\Dashboard\Widget;
 
 use MODX\Revolution\modDashboardWidget;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Creates a new Dashboard Widget
  * @package MODX\Revolution\Processors\System\Dashboard\Widget
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modDashboardWidget::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Dashboard\Widget;
 
 use MODX\Revolution\modChunk;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use SimplePie_Item;
 use xPDO\xPDO;
@@ -22,7 +22,7 @@ use xPDO\xPDO;
  * (i.e. HTML) is returned in object->html.
  * @package MODX\Revolution\Processors\System\Dashboard\Widget
  */
-class Feed extends modProcessor
+class Feed extends Processor
 {
     /**
      * @return array|mixed|string

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/GetList.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Dashboard\Widget;
 
 use MODX\Revolution\modDashboardWidget;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\Dashboard\Widget
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modDashboardWidget::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Remove.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Dashboard\Widget;
 
 use MODX\Revolution\modDashboardWidget;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Removes a Dashboard Widget
  * @param integer $id The ID of the dashboard widget
  * @package MODX\Revolution\Processors\System\Dashboard\Widget
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modDashboardWidget::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/RemoveMultiple.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Dashboard\Widget;
 
 use MODX\Revolution\modDashboardWidget;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 
 /**
  * Removes multiple Dashboard Widgets
  * @package MODX\Revolution\Processors\System\Dashboard\Widget
  */
-class RemoveMultiple extends modProcessor
+class RemoveMultiple extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Update.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Update.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Dashboard\Widget;
 
 use MODX\Revolution\modDashboardWidget;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Updates a Dashboard Widget
  * @param integer $id The ID of the dashboard widget
  * @package MODX\Revolution\Processors\System\Dashboard\Widget
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modDashboardWidget::class;
     public $languageTopics = ['dashboards'];

--- a/core/src/Revolution/Processors/System/DatabaseTable/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/GetList.php
@@ -25,7 +25,7 @@ class GetList extends GetListAbstract
     protected $concreteProcessor;
 
     /**
-     * Creates a modProcessor object.
+     * Creates a Processor object.
      *
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties

--- a/core/src/Revolution/Processors/System/DatabaseTable/GetListAbstract.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/GetListAbstract.php
@@ -10,14 +10,14 @@
 
 namespace MODX\Revolution\Processors\System\DatabaseTable;
 
-use MODX\Revolution\modDriverSpecificProcessor;
+use MODX\Revolution\Processors\DriverSpecificProcessor;
 
 /**
  * Gets a list of database tables
  * @package modx
  * @subpackage processors.system.databasetable
  */
-abstract class GetListAbstract extends modDriverSpecificProcessor
+abstract class GetListAbstract extends DriverSpecificProcessor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/DatabaseTable/Optimize.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/Optimize.php
@@ -24,7 +24,7 @@ class Optimize extends OptimizeAbstract
     protected $concreteProcessor;
 
     /**
-     * Creates a modProcessor object.
+     * Creates a Processor object.
      *
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
@@ -33,7 +33,7 @@ class Optimize extends OptimizeAbstract
     {
         parent::__construct($modx, $properties);
 
-        $this->concreteProcessor = self::getInstance($modx, GetList::class, $properties);
+        $this->concreteProcessor = self::getInstance($modx, Optimize::class, $properties);
 
         return $this->concreteProcessor;
     }

--- a/core/src/Revolution/Processors/System/DatabaseTable/OptimizeAbstract.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/OptimizeAbstract.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\System\DatabaseTable;
 
-use MODX\Revolution\modDriverSpecificProcessor;
+use MODX\Revolution\Processors\DriverSpecificProcessor;
 
 /**
  * Optimize a database table
  * @package MODX\Revolution\Processors\System\DatabaseTable
  */
-abstract class OptimizeAbstract extends modDriverSpecificProcessor
+abstract class OptimizeAbstract extends DriverSpecificProcessor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabase.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabase.php
@@ -24,7 +24,7 @@ class OptimizeDatabase extends OptimizeDatabaseAbstract
     protected $concreteProcessor;
 
     /**
-     * Creates a modProcessor object.
+     * Creates a Processor object.
      *
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
@@ -33,7 +33,7 @@ class OptimizeDatabase extends OptimizeDatabaseAbstract
     {
         parent::__construct($modx, $properties);
 
-        $this->concreteProcessor = self::getInstance($modx, GetList::class, $properties);
+        $this->concreteProcessor = self::getInstance($modx, OptimizeDatabase::class, $properties);
 
         return $this->concreteProcessor;
     }

--- a/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabaseAbstract.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabaseAbstract.php
@@ -10,12 +10,12 @@
 
 namespace MODX\Revolution\Processors\System\DatabaseTable;
 
-use MODX\Revolution\modDriverSpecificProcessor;
+use MODX\Revolution\Processors\DriverSpecificProcessor;
 
 /**
  * @package MODX\Revolution\Processors\System\DatabaseTable
  */
-abstract class OptimizeDatabaseAbstract extends modDriverSpecificProcessor
+abstract class OptimizeDatabaseAbstract extends DriverSpecificProcessor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/DatabaseTable/Truncate.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/Truncate.php
@@ -24,7 +24,7 @@ class Truncate extends TruncateAbstract
     protected $concreteProcessor;
 
     /**
-     * Creates a modProcessor object.
+     * Creates a Processor object.
      *
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
@@ -33,7 +33,7 @@ class Truncate extends TruncateAbstract
     {
         parent::__construct($modx, $properties);
 
-        $this->concreteProcessor = self::getInstance($modx, GetList::class, $properties);
+        $this->concreteProcessor = self::getInstance($modx, Truncate::class, $properties);
 
         return $this->concreteProcessor;
     }

--- a/core/src/Revolution/Processors/System/DatabaseTable/TruncateAbstract.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/TruncateAbstract.php
@@ -10,12 +10,12 @@
 
 namespace MODX\Revolution\Processors\System\DatabaseTable;
 
-use MODX\Revolution\modDriverSpecificProcessor;
+use MODX\Revolution\Processors\DriverSpecificProcessor;
 
 /**
  * @package MODX\Revolution\Processors\System\DatabaseTable
  */
-abstract class TruncateAbstract extends modDriverSpecificProcessor
+abstract class TruncateAbstract extends DriverSpecificProcessor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Derivatives/GetList.php
+++ b/core/src/Revolution/Processors/System/Derivatives/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System\Derivatives;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use xPDO\Om\xPDOObject;
 
@@ -18,7 +18,7 @@ use xPDO\Om\xPDOObject;
  * Gets a list of derivative classes for a class
  * @package MODX\Revolution\Processors\System\Derivatives
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/DownloadOutput.php
+++ b/core/src/Revolution/Processors/System/DownloadOutput.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\System;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Output data to a file for downloading
  * @package MODX\Revolution\Processors\System
  */
-class DownloadOutput extends modProcessor
+class DownloadOutput extends Processor
 {
     /**
      * @return array|string

--- a/core/src/Revolution/Processors/System/ErrorLog/Clear.php
+++ b/core/src/Revolution/Processors/System/ErrorLog/Clear.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\ErrorLog;
 
 use MODX\Revolution\modCacheManager;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use xPDO\Cache\xPDOCacheManager;
 
 /**
  * Clear the error log
  * @package MODX\Revolution\Processors\System\ErrorLog
  */
-class Clear extends modProcessor
+class Clear extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/System/ErrorLog/Download.php
+++ b/core/src/Revolution/Processors/System/ErrorLog/Download.php
@@ -10,14 +10,14 @@
 
 namespace MODX\Revolution\Processors\System\ErrorLog;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use xPDO\Cache\xPDOCacheManager;
 
 /**
  * Grab and download the error log
  * @package MODX\Revolution\Processors\System\ErrorLog
  */
-class Download extends modProcessor
+class Download extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/System/ErrorLog/Get.php
+++ b/core/src/Revolution/Processors/System/ErrorLog/Get.php
@@ -10,14 +10,14 @@
 
 namespace MODX\Revolution\Processors\System\ErrorLog;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use xPDO\Cache\xPDOCacheManager;
 
 /**
  * Grab and output the error log
  * @package MODX\Revolution\Processors\System\ErrorLog
  */
-class Get extends modProcessor
+class Get extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Event/Create.php
+++ b/core/src/Revolution/Processors/System/Event/Create.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\System\Event;
 
 use MODX\Revolution\modEvent;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Create a system event
  * @package MODX\Revolution\Processors\System\Event
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modEvent::class;
     public $languageTopics = ['events'];

--- a/core/src/Revolution/Processors/System/Event/GetList.php
+++ b/core/src/Revolution/Processors/System/Event/GetList.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Processors\System\Event;
 use MODX\Revolution\modEvent;
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\modPluginEvent;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Gets a list of system events
@@ -23,7 +23,7 @@ use MODX\Revolution\modProcessor;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\Event
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Event/GroupList.php
+++ b/core/src/Revolution/Processors/System/Event/GroupList.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Event;
 
 use MODX\Revolution\modEvent;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use PDO;
 
 /**
  * Create a system setting
  * @package MODX\Revolution\Processors\System\Event
  */
-class GroupList extends modProcessor
+class GroupList extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Event/Remove.php
+++ b/core/src/Revolution/Processors/System/Event/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Event;
 
 use MODX\Revolution\modEvent;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove a system even
  * @param string $name The name of the event
  * @package MODX\Revolution\Processors\System\Event
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modEvent::class;
     public $languageTopics = ['events'];

--- a/core/src/Revolution/Processors/System/Import/Index.php
+++ b/core/src/Revolution/Processors/System/Import/Index.php
@@ -12,14 +12,14 @@ namespace MODX\Revolution\Processors\System\Import;
 
 use MODX\Revolution\Import\modStaticImport;
 use MODX\Revolution\modContext;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modStaticResource;
 
 /**
  * @package MODX\Revolution\Processors\System\Import
  */
-class Index extends modObjectProcessor
+class Index extends ModelProcessor
 {
     public $permission = 'import_static';
     public $languageTopics = ['import'];

--- a/core/src/Revolution/Processors/System/Info.php
+++ b/core/src/Revolution/Processors/System/Info.php
@@ -10,14 +10,14 @@
 
 namespace MODX\Revolution\Processors\System;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use PDO;
 
 /**
  * Removes locks on all objects
  * @package MODX\Revolution\Processors\System
  */
-class Info extends modProcessor
+class Info extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/System/Language/GetList.php
+++ b/core/src/Revolution/Processors/System/Language/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System\Language;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Grabs a list of lexicon languages
@@ -18,7 +18,7 @@ use MODX\Revolution\modProcessor;
  * @param integer $limit (optional) The number of records to limit to. Defaults to 10.
  * @package MODX\Revolution\Processors\System\Language
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/System/Log/GetList.php
+++ b/core/src/Revolution/Processors/System/Log/GetList.php
@@ -16,7 +16,7 @@ use MODX\Revolution\modContext;
 use MODX\Revolution\modContextSetting;
 use MODX\Revolution\modDocument;
 use MODX\Revolution\modMenu;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modManagerLog;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modStaticResource;
@@ -38,7 +38,7 @@ use xPDO\Om\xPDOObject;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\Log
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Log/Truncate.php
+++ b/core/src/Revolution/Processors/System/Log/Truncate.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\System\Log;
 
 use MODX\Revolution\modManagerLog;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Clears the manager log actions
  * @package MODX\Revolution\Processors\System\Log
  */
-class Truncate extends modProcessor
+class Truncate extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Menu/Create.php
+++ b/core/src/Revolution/Processors/System/Menu/Create.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Menu;
 
 use MODX\Revolution\modMenu;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Creates a menu item
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectCreateProcessor;
  * @param integer $parent (optional) The parent menu to create from. Defaults to 0.
  * @package MODX\Revolution\Processors\System\Menu
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modMenu::class;
     public $languageTopics = ['action', 'menu'];

--- a/core/src/Revolution/Processors/System/Menu/GetList.php
+++ b/core/src/Revolution/Processors/System/Menu/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Menu;
 
 use MODX\Revolution\modMenu;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 
 /**
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOObject;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\Menu
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modMenu::class;
     public $objectType = 'menu';

--- a/core/src/Revolution/Processors/System/Menu/GetNodes.php
+++ b/core/src/Revolution/Processors/System/Menu/GetNodes.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Menu;
 
 use MODX\Revolution\modMenu;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  * @param integer $limit (optional) The number of records to limit to. Defaults to 10.
  * @package MODX\Revolution\Processors\System\Menu
  */
-class GetNodes extends modObjectGetListProcessor
+class GetNodes extends GetListProcessor
 {
     public $classKey = modMenu::class;
     public $objectType = 'menu';

--- a/core/src/Revolution/Processors/System/Menu/Remove.php
+++ b/core/src/Revolution/Processors/System/Menu/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Menu;
 
 use MODX\Revolution\modMenu;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Remove a menu item
  * @param string $text The ID of the menu item
  * @package MODX\Revolution\Processors\System\Menu
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modMenu::class;
     public $languageTopics = ['action', 'menu'];

--- a/core/src/Revolution/Processors/System/Menu/Sort.php
+++ b/core/src/Revolution/Processors/System/Menu/Sort.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\System\Menu;
 
 use MODX\Revolution\modMenu;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Sort menu items for a tree
  * @param string $data
  * @package MODX\Revolution\Processors\System\Menu
  */
-class Sort extends modProcessor
+class Sort extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Menu/Update.php
+++ b/core/src/Revolution/Processors/System/Menu/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Menu;
 
 use MODX\Revolution\modMenu;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Update a menu item
@@ -23,7 +23,7 @@ use MODX\Revolution\modObjectUpdateProcessor;
  * @param integer $parent (optional) The parent menu to create from. Defaults to 0.
  * @package MODX\Revolution\Processors\System\Menu
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modMenu::class;
     public $objectType = 'menu';

--- a/core/src/Revolution/Processors/System/PhpInfo.php
+++ b/core/src/Revolution/Processors/System/PhpInfo.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\System;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Display phpinfo()
  * @package MODX\Revolution\Processors\System
  */
-class PhpInfo extends modProcessor
+class PhpInfo extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/System/PhpThumb.php
+++ b/core/src/Revolution/Processors/System/PhpThumb.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\System;
 
 use MODX\Revolution\File\modFileHandler;
 use MODX\Revolution\modPhpThumb;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Sources\modFileMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
@@ -21,7 +21,7 @@ use MODX\Revolution\Sources\modMediaSource;
  * Generate a thumbnail
  * @package MODX\Revolution\Processors\System
  */
-class PhpThumb extends modProcessor
+class PhpThumb extends Processor
 {
     /** @var modPhpThumb $phpThumb */
     public $phpThumb;

--- a/core/src/Revolution/Processors/System/RefreshUris.php
+++ b/core/src/Revolution/Processors/System/RefreshUris.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modX;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\modX;
  * Regenerate the system's Resource URIs in the database
  * @package MODX\Revolution\Processors\System
  */
-class RefreshUris extends modProcessor
+class RefreshUris extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Registry/Register/Read.php
+++ b/core/src/Revolution/Processors/System/Registry/Register/Read.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System\Registry\Register;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Registry\modFileRegister;
 use MODX\Revolution\Registry\modRegister;
 use MODX\Revolution\Registry\modRegistry;
@@ -29,7 +29,7 @@ use MODX\Revolution\Registry\modRegistry;
  * @param boolean $show_filename (optional) If true, will show the filename in the message. Defaults to false.
  * @package MODX\Revolution\Processors\System\Registry\Register
  */
-class Read extends modProcessor
+class Read extends Processor
 {
     /** @var  modRegister */
     public $register;

--- a/core/src/Revolution/Processors/System/Registry/Register/Send.php
+++ b/core/src/Revolution/Processors/System/Registry/Register/Send.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System\Registry\Register;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Registry\modFileRegister;
 use MODX\Revolution\Registry\modRegister;
 use MODX\Revolution\Registry\modRegistry;
@@ -29,7 +29,7 @@ use MODX\Revolution\Registry\modRegistry;
  * @param integer $kill (optional) Defaults to false.
  * @package MODX\Revolution\Processors\System\Registry\Register
  */
-class Send extends modProcessor
+class Send extends Processor
 {
     /** @var modRegister */
     public $register;

--- a/core/src/Revolution/Processors/System/RemoveLocks.php
+++ b/core/src/Revolution/Processors/System/RemoveLocks.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Registry\modDbRegister;
 use MODX\Revolution\Registry\modRegistry;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\Registry\modRegistry;
  * Removes locks on all objects
  * @package MODX\Revolution\Processors\System
  */
-class RemoveLocks extends modProcessor
+class RemoveLocks extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/System/Rte/GetList.php
+++ b/core/src/Revolution/Processors/System/Rte/GetList.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\System\Rte;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Get a list of registered RTEs
  * @package MODX\Revolution\Processors\System\Rte
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     public function process()
     {

--- a/core/src/Revolution/Processors/System/Settings/Create.php
+++ b/core/src/Revolution/Processors/System/Settings/Create.php
@@ -12,7 +12,7 @@ namespace MODX\Revolution\Processors\System\Settings;
 
 use MODX\Revolution\modLexiconEntry;
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modSystemSetting;
 
 /**
@@ -26,7 +26,7 @@ use MODX\Revolution\modSystemSetting;
  * @param string $description The lexicon description for the setting
  * @package MODX\Revolution\Processors\System\Settings
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modSystemSetting::class;
     public $languageTopics = ['setting', 'namespace'];

--- a/core/src/Revolution/Processors/System/Settings/GetAreas.php
+++ b/core/src/Revolution/Processors/System/Settings/GetAreas.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\System\Settings;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modSystemSetting;
 use PDO;
 use xPDO\Om\xPDOQuery;
@@ -22,7 +22,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\System\Settings
  */
-class GetAreas extends modProcessor
+class GetAreas extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/System/Settings/GetList.php
+++ b/core/src/Revolution/Processors/System/Settings/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Settings;
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\modSystemSetting;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -26,7 +26,7 @@ use xPDO\Om\xPDOQuery;
  * @package modx
  * @subpackage processors.system.settings
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modSystemSetting::class;
     public $languageTopics = ['setting', 'namespace'];

--- a/core/src/Revolution/Processors/System/Settings/Remove.php
+++ b/core/src/Revolution/Processors/System/Settings/Remove.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Settings;
 
 use MODX\Revolution\modLexiconEntry;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\modSystemSetting;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modSystemSetting;
  * @property string $key The key of the setting
  * @package MODX\Revolution\Processors\System\Settings
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modSystemSetting::class;
     public $languageTopics = ['setting', 'namespace'];

--- a/core/src/Revolution/Processors/System/Settings/Update.php
+++ b/core/src/Revolution/Processors/System/Settings/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\System\Settings;
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modSystemSetting;
 
@@ -26,7 +26,7 @@ use MODX\Revolution\modSystemSetting;
  * @property string $description The lexicon description for the setting
  * @package MODX\Revolution\Processors\Context\Setting
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modSystemSetting::class;
     public $languageTopics = ['setting', 'namespace'];

--- a/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Workspace\Lexicon;
 
 use MODX\Revolution\modLexiconEntry;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Updates a lexicon entry from a grid
  * @package MODX\Revolution\Processors\Workspace\Lexicon
  */
-class Create extends modProcessor
+class Create extends Processor
 {
     /** @var modLexiconEntry $entry */
     public $entry;

--- a/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Workspace\Lexicon;
 
 use MODX\Revolution\modLexiconEntry;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Gets a list of lexicon entries
@@ -22,7 +22,7 @@ use MODX\Revolution\modProcessor;
  * @param integer $limit (optional) The number of records to limit to. Defaults to 10.
  * @package MODX\Revolution\Processors\Workspace\Lexicon
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Workspace/Lexicon/ReloadFromBase.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/ReloadFromBase.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Workspace\Lexicon;
 
 use MODX\Revolution\modLexiconEntry;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 
 /**
  * Regenerates strings from the base lexicon files, resetting any customizations.
  * @package MODX\Revolution\Processors\Workspace\Lexicon
  */
-class ReloadFromBase extends modProcessor
+class ReloadFromBase extends Processor
 {
     /**
      * @return bool

--- a/core/src/Revolution/Processors/Workspace/Lexicon/Revert.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/Revert.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Workspace\Lexicon;
 
 use MODX\Revolution\modLexiconEntry;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Updates a lexicon entry from a grid
  * @package MODX\Revolution\Processors\Workspace\Lexicon
  */
-class Revert extends modProcessor
+class Revert extends Processor
 {
     /** @var modLexiconEntry $entry */
     public $entry;

--- a/core/src/Revolution/Processors/Workspace/Lexicon/Topic/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/Topic/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Lexicon\Topic;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Gets a list of lexicon topics
@@ -20,7 +20,7 @@ use MODX\Revolution\modProcessor;
  * @param integer $limit (optional) The number of records to limit to. Defaults to 10.
  * @package MODX\Revolution\Processors\Workspace\Lexicon\Topic
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /**
      * @return mixed

--- a/core/src/Revolution/Processors/Workspace/Lexicon/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/UpdateFromGrid.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Workspace\Lexicon;
 
 use MODX\Revolution\modLexiconEntry;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 
 /**
  * Updates a lexicon entry from a grid
  * @package MODX\Revolution\Processors\Workspace\Lexicon
  */
-class UpdateFromGrid extends modProcessor
+class UpdateFromGrid extends Processor
 {
     /** @var modLexiconEntry $entry */
     public $entry;

--- a/core/src/Revolution/Processors/Workspace/PackageNamespace/Create.php
+++ b/core/src/Revolution/Processors/Workspace/PackageNamespace/Create.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Workspace\PackageNamespace;
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 
 /**
  * Creates a namespace
@@ -19,7 +19,7 @@ use MODX\Revolution\modObjectCreateProcessor;
  * @param string $path (optional) The path of the namespace
  * @package MODX\Revolution\Processors\Workspace\PackageNamespace
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modNamespace::class;
     public $languageTopics = ['namespace'];

--- a/core/src/Revolution/Processors/Workspace/PackageNamespace/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/PackageNamespace/GetList.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Workspace\PackageNamespace;
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
 
@@ -24,7 +24,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Workspace\PackageNamespace
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modNamespace::class;
     public $languageTopics = ['namespace', 'workspace'];

--- a/core/src/Revolution/Processors/Workspace/PackageNamespace/Remove.php
+++ b/core/src/Revolution/Processors/Workspace/PackageNamespace/Remove.php
@@ -11,14 +11,14 @@
 namespace MODX\Revolution\Processors\Workspace\PackageNamespace;
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 
 /**
  * Removes a namespace.
  * @param string $name The name of the namespace.
  * @package MODX\Revolution\Processors\Workspace\PackageNamespace
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modNamespace::class;
     public $languageTopics = ['namespace', 'workspace', 'lexicon'];

--- a/core/src/Revolution/Processors/Workspace/PackageNamespace/RemoveMultiple.php
+++ b/core/src/Revolution/Processors/Workspace/PackageNamespace/RemoveMultiple.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Workspace\PackageNamespace;
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 
 /**
@@ -19,7 +19,7 @@ use MODX\Revolution\modX;
  * @param string $name The name of the namespace.
  * @package MODX\Revolution\Processors\Workspace\PackageNamespace
  */
-class RemoveMultiple extends modProcessor
+class RemoveMultiple extends Processor
 {
     /** @var modNamespace $namespace */
     public $namespace;

--- a/core/src/Revolution/Processors/Workspace/PackageNamespace/Update.php
+++ b/core/src/Revolution/Processors/Workspace/PackageNamespace/Update.php
@@ -11,7 +11,7 @@
 namespace MODX\Revolution\Processors\Workspace\PackageNamespace;
 
 use MODX\Revolution\modNamespace;
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 
 /**
  * Updates a namespace from a grid
@@ -19,7 +19,7 @@ use MODX\Revolution\modObjectUpdateProcessor;
  * @param string $path An absolute path
  * @package MODX\Revolution\Processors\Workspace\PackageNamespace
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modNamespace::class;
     public $languageTopics = ['workspace', 'namespace', 'lexicon'];

--- a/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Transport\modTransportPackage;
 use MODX\Revolution\Transport\modTransportProvider;
@@ -21,7 +21,7 @@ use SimpleXMLElement;
  * @param string $signature The signature of the package.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class CheckForUpdates extends modProcessor
+class CheckForUpdates extends Processor
 {
     /** @var modTransportPackage $package */
     public $package;

--- a/core/src/Revolution/Processors/Workspace/Packages/Dependency/Download.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Dependency/Download.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages\Dependency;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Transport\modTransportPackage;
 use MODX\Revolution\Transport\modTransportProvider;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\Transport\modTransportProvider;
  * Download a package by resolving dependent package constraints
  * @package MODX\Revolution\Processors\Workspace\Packages\Dependency
  */
-class Download extends modProcessor
+class Download extends Processor
 {
     /** @var modTransportProvider $provider */
     public $provider;

--- a/core/src/Revolution/Processors/Workspace/Packages/Get.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Get.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modObjectGetProcessor;
+use MODX\Revolution\Processors\Model\GetProcessor;
 use MODX\Revolution\Transport\modTransportPackage;
 use MODX\Revolution\Transport\modTransportProvider;
 use xPDO\Transport\xPDOTransport;
@@ -20,7 +20,7 @@ use xPDO\Transport\xPDOTransport;
  * @param integer $id The ID of the chunk.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class Get extends modObjectGetProcessor
+class Get extends GetProcessor
 {
     public $classKey = modTransportPackage::class;
     public $languageTopics = ['workspace'];

--- a/core/src/Revolution/Processors/Workspace/Packages/GetAttribute.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetAttribute.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Transport\modTransportPackage;
 use Parsedown;
 use xPDO\Transport\xPDOTransport;
@@ -21,7 +21,7 @@ use xPDO\Transport\xPDOTransport;
  * @param string $attr The attribute to select
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class GetAttribute extends modProcessor
+class GetAttribute extends Processor
 {
     /** @var modTransportPackage $package */
     public $package;

--- a/core/src/Revolution/Processors/Workspace/Packages/GetDependencies.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetDependencies.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\Transport\modTransportPackage;
 use xPDO\Transport\xPDOTransport;
 
@@ -23,7 +23,7 @@ use xPDO\Transport\xPDOTransport;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class GetDependencies extends modObjectGetListProcessor
+class GetDependencies extends GetListProcessor
 {
     public $classKey = modTransportPackage::class;
     public $checkListPermission = false;

--- a/core/src/Revolution/Processors/Workspace/Packages/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\Transport\modTransportPackage;
 use MODX\Revolution\Transport\modTransportProvider;
 use xPDO\Om\xPDOObject;
@@ -26,7 +26,7 @@ use xPDO\xPDO;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modTransportPackage::class;
     public $checkListPermission = false;

--- a/core/src/Revolution/Processors/Workspace/Packages/Install.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Install.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Transport\modTransportPackage;
 use xPDO\Transport\xPDOTransport;
@@ -21,7 +21,7 @@ use xPDO\xPDO;
  * @param string $signature The signature of the package.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class Install extends modProcessor
+class Install extends Processor
 {
     /** @var modTransportPackage $package */
     public $package;

--- a/core/src/Revolution/Processors/Workspace/Packages/Purge.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Purge.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Transport\modTransportPackage;
 use xPDO\xPDO;
@@ -20,7 +20,7 @@ use xPDO\xPDO;
  * @param string $package_name The name of the package, could be set to * to purge all old packages
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class Purge extends modProcessor
+class Purge extends Processor
 {
     /** @var modTransportPackage[] $package */
     public $packages;

--- a/core/src/Revolution/Processors/Workspace/Packages/Remove.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Transport\modTransportPackage;
 use xPDO\xPDO;
@@ -22,7 +22,7 @@ use xPDO\xPDO;
  * uninstall fails. Defaults to false.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class Remove extends modProcessor
+class Remove extends Processor
 {
     /** @var modTransportPackage $package */
     public $package;

--- a/core/src/Revolution/Processors/Workspace/Packages/Rest/Download.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Rest/Download.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages\Rest;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Transport\modTransportPackage;
 use MODX\Revolution\Transport\modTransportProvider;
 
@@ -18,7 +18,7 @@ use MODX\Revolution\Transport\modTransportProvider;
  * Download a package by passing in its location
  * @package MODX\Revolution\Processors\Workspace\Packages\Rest
  */
-class Download extends modProcessor
+class Download extends Processor
 {
     /** @var modTransportProvider $provider */
     public $provider;

--- a/core/src/Revolution/Processors/Workspace/Packages/Rest/GetInfo.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Rest/GetInfo.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages\Rest;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Transport\modTransportProvider;
 
 /**
  * @package MODX\Revolution\Processors\Workspace\Packages\Rest
  */
-class GetInfo extends modProcessor
+class GetInfo extends Processor
 {
     /** @var modTransportProvider $provider */
     public $provider;

--- a/core/src/Revolution/Processors/Workspace/Packages/Rest/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Rest/GetList.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages\Rest;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Transport\modTransportProvider;
 
 /**
  * @package MODX\Revolution\Processors\Workspace\Packages\Rest
  */
-class GetList extends modProcessor
+class GetList extends Processor
 {
     /** @var modTransportProvider $provider */
     public $provider;

--- a/core/src/Revolution/Processors/Workspace/Packages/Rest/GetNodes.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Rest/GetNodes.php
@@ -10,13 +10,13 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages\Rest;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Transport\modTransportProvider;
 
 /**
  * @package MODX\Revolution\Processors\Workspace\Packages\Rest
  */
-class GetNodes extends modProcessor
+class GetNodes extends Processor
 {
     /** @var modTransportProvider $provider */
     public $provider;

--- a/core/src/Revolution/Processors/Workspace/Packages/ScanLocal.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/ScanLocal.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modWorkspace;
 use MODX\Revolution\Transport\modTransportPackage;
 
@@ -19,7 +19,7 @@ use MODX\Revolution\Transport\modTransportPackage;
  * @param integer $workspace The workspace to add to. Defaults to 1.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class ScanLocal extends modProcessor
+class ScanLocal extends Processor
 {
     /** @var modWorkspace $workspace */
     public $workspace;

--- a/core/src/Revolution/Processors/Workspace/Packages/Uninstall.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Uninstall.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Transport\modTransportPackage;
 use xPDO\Transport\xPDOTransport;
@@ -20,7 +20,7 @@ use xPDO\Transport\xPDOTransport;
  * @param string $signature The signature of the package.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class Uninstall extends modProcessor
+class Uninstall extends Processor
 {
     /** @var modTransportPackage $package */
     public $package;

--- a/core/src/Revolution/Processors/Workspace/Packages/Update.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Update.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Transport\modTransportPackage;
 
@@ -19,7 +19,7 @@ use MODX\Revolution\Transport\modTransportPackage;
  * @param integer $id The ID of the chunk.
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class Update extends modProcessor
+class Update extends Processor
 {
     /** @var modTransportPackage $package */
     public $package;

--- a/core/src/Revolution/Processors/Workspace/Packages/Upload.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Upload.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Sources\modMediaSource;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\Sources\modMediaSource;
  * @param string $file The transport package to upload
  * @package MODX\Revolution\Processors\Workspace\Packages
  */
-class Upload extends modProcessor
+class Upload extends Processor
 {
     /** @var modMediaSource $source */
     public $source;

--- a/core/src/Revolution/Processors/Workspace/Packages/Version/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Version/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages\Version;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\Transport\modTransportPackage;
 use xPDO\Om\xPDOObject;
 use xPDO\Transport\xPDOTransport;
@@ -19,7 +19,7 @@ use xPDO\Transport\xPDOTransport;
  * Gets a list of package versions for a package
  * @package MODX\Revolution\Processors\Workspace\Packages\Version
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $primaryKeyField = 'signature';
     public $classKey = modTransportPackage::class;

--- a/core/src/Revolution/Processors/Workspace/Packages/Version/Remove.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Version/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Packages\Version;
 
-use MODX\Revolution\modProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modX;
 use MODX\Revolution\Transport\modTransportPackage;
 use xPDO\xPDO;
@@ -22,7 +22,7 @@ use xPDO\xPDO;
  * uninstall fails. Defaults to false.
  * @package MODX\Revolution\Processors\Workspace\Packages\Version
  */
-class Remove extends modProcessor
+class Remove extends Processor
 {
     /** @var modTransportPackage $package */
     public $package;

--- a/core/src/Revolution/Processors/Workspace/Providers/Create.php
+++ b/core/src/Revolution/Processors/Workspace/Providers/Create.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Providers;
 
-use MODX\Revolution\modObjectCreateProcessor;
+use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\Transport\modTransportProvider;
 
 /**
@@ -20,7 +20,7 @@ use MODX\Revolution\Transport\modTransportProvider;
  * @param string $service_url The URL the provider is hosted under
  * @package MODX\Revolution\Processors\Workspace\Providers
  */
-class Create extends modObjectCreateProcessor
+class Create extends CreateProcessor
 {
     public $classKey = modTransportProvider::class;
     public $languageTopics = ['workspace'];

--- a/core/src/Revolution/Processors/Workspace/Providers/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Providers/GetList.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Providers;
 
-use MODX\Revolution\modObjectGetListProcessor;
+use MODX\Revolution\Processors\Model\GetListProcessor;
 use MODX\Revolution\Transport\modTransportProvider;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -23,7 +23,7 @@ use xPDO\Om\xPDOQuery;
  * @param string $dir (optional) The direction of the sort. Defaults to ASC.
  * @package MODX\Revolution\Processors\Workspace\Providers
  */
-class GetList extends modObjectGetListProcessor
+class GetList extends GetListProcessor
 {
     public $classKey = modTransportProvider::class;
     public $languageTopics = ['workspace'];

--- a/core/src/Revolution/Processors/Workspace/Providers/Remove.php
+++ b/core/src/Revolution/Processors/Workspace/Providers/Remove.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Providers;
 
-use MODX\Revolution\modObjectRemoveProcessor;
+use MODX\Revolution\Processors\Model\RemoveProcessor;
 use MODX\Revolution\Transport\modTransportProvider;
 
 /**
@@ -18,7 +18,7 @@ use MODX\Revolution\Transport\modTransportProvider;
  * @param integer $id The provider ID
  * @package MODX\Revolution\Processors\Workspace\Providers
  */
-class Remove extends modObjectRemoveProcessor
+class Remove extends RemoveProcessor
 {
     public $classKey = modTransportProvider::class;
     public $languageTopics = ['workspace'];

--- a/core/src/Revolution/Processors/Workspace/Providers/Update.php
+++ b/core/src/Revolution/Processors/Workspace/Providers/Update.php
@@ -10,7 +10,7 @@
 
 namespace MODX\Revolution\Processors\Workspace\Providers;
 
-use MODX\Revolution\modObjectUpdateProcessor;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\Transport\modTransportProvider;
 
 /**
@@ -21,7 +21,7 @@ use MODX\Revolution\Transport\modTransportProvider;
  * @param string $service_url The URL which the provider is hosted under
  * @package MODX\Revolution\Processors\Workspace\Providers
  */
-class Update extends modObjectUpdateProcessor
+class Update extends UpdateProcessor
 {
     public $classKey = modTransportProvider::class;
     public $languageTopics = ['workspace'];

--- a/core/src/Revolution/Processors/Workspace/Theme/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Theme/GetList.php
@@ -11,13 +11,13 @@
 namespace MODX\Revolution\Processors\Workspace\Theme;
 
 use DirectoryIterator;
-use MODX\Revolution\modObjectProcessor;
+use MODX\Revolution\Processors\ModelProcessor;
 
 /**
  * Grabs a list of manager themes
  * @package MODX\Revolution\Processors\Workspace\Theme
  */
-class GetList extends modObjectProcessor
+class GetList extends ModelProcessor
 {
     public $permission = 'settings';
 

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -10,6 +10,7 @@
 
 namespace MODX\Revolution;
 
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\System\Registry\Register\Read;
 use MODX\Revolution\Sources\modMediaSource;
 use xPDO\Om\xPDOObject;
@@ -683,7 +684,7 @@ abstract class modManagerController
      */
     public function getDefaultState()
     {
-        /** @var modProcessorResponse $response */
+        /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(Read::class, [
             'register' => 'state',
             'topic' => '/ys/user-' . $this->modx->user->get('id') . '/',

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -29,6 +29,8 @@ use Exception;
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Error\modErrorHandler;
 use MODX\Revolution\Mail\modMail;
+use MODX\Revolution\Processors\DeprecatedProcessor;
+use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Registry\modRegister;
 use MODX\Revolution\Registry\modRegistry;
 use MODX\Revolution\Rest\modRestClient;
@@ -1715,7 +1717,7 @@ class modX extends xPDO {
         $result = null;
 
         if (class_exists($action)) {
-            /** @var modProcessor $processor */
+            /** @var Processor $processor */
             $processor = new $action($this, $scriptProperties);
 
             return $processor->run();
@@ -1726,7 +1728,7 @@ class modX extends xPDO {
             $legacyAction = str_replace('\\Tv\\', '\\TemplateVar\\', $legacyAction);
         }
         if (class_exists($legacyAction)) {
-            /** @var modProcessor $processor */
+            /** @var Processor $processor */
             $processor = new $legacyAction($this, $scriptProperties);
 
             return $processor->run();
@@ -1775,7 +1777,7 @@ class modX extends xPDO {
                 }
             }
             if (empty($processor)) {
-                $processor = new modDeprecatedProcessor($this, $scriptProperties);
+                $processor = new DeprecatedProcessor($this, $scriptProperties);
             }
             $processor->setPath($processorFile);
             $response = $processor->run();

--- a/manager/controllers/default/dashboard/widget.configcheck.php
+++ b/manager/controllers/default/dashboard/widget.configcheck.php
@@ -9,7 +9,7 @@
  */
 
 use MODX\Revolution\modDashboardWidgetInterface;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\System\ConfigCheck;
 use MODX\Revolution\Smarty\modSmarty;
 
@@ -29,7 +29,7 @@ class modDashboardWidgetConfigCheck extends modDashboardWidgetInterface
      */
     public function render()
     {
-        /** @var modProcessorResponse $response */
+        /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(ConfigCheck::class);
 
         $this->modx->getService('smarty', modSmarty::class);

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -9,7 +9,7 @@
  */
 
 use MODX\Revolution\modDashboardWidgetInterface;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\Security\User\GetOnline;
 use MODX\Revolution\Smarty\modSmarty;
 
@@ -25,7 +25,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface
      */
     public function render()
     {
-        /** @var modProcessorResponse $res */
+        /** @var ProcessorResponse $res */
         $res = $this->modx->runProcessor(GetOnline::class, [
             'limit' => 10,
         ]);

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -9,7 +9,7 @@
  */
 
 use MODX\Revolution\modDashboardWidgetInterface;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\Security\User\GetRecentlyEditedResources;
 use MODX\Revolution\Smarty\modSmarty;
 
@@ -27,7 +27,7 @@ class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterf
      */
     public function render()
     {
-        /** @var modProcessorResponse $res */
+        /** @var ProcessorResponse $res */
         $res = $this->modx->runProcessor(GetRecentlyEditedResources::class, [
             'limit' => 10,
             'user' => $this->modx->user->get('id'),

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -9,7 +9,7 @@
  */
 
 use MODX\Revolution\modManagerController;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
 use MODX\Revolution\Processors\Security\User\Update;
@@ -323,9 +323,9 @@ class SecurityLoginManagerController extends modManagerController
             $this->scriptProperties['password'] = $password;
             $registry->read(['poll_limit' => 1, 'remove_read' => true]);
 
-            /** @var modProcessorResponse $response */
+            /** @var ProcessorResponse $response */
             $response = $this->modx->runProcessor('security/login', $this->scriptProperties);
-            if (($response instanceof modProcessorResponse)) {
+            if (($response instanceof ProcessorResponse)) {
                 if (!$response->isError()) {
                     $url = !empty($this->scriptProperties['returnUrl'])
                         ? $this->scriptProperties['returnUrl']
@@ -444,9 +444,9 @@ class SecurityLoginManagerController extends modManagerController
             $registry->read(['poll_limit' => 1, 'remove_read' => true]);
         }
 
-        /** @var modProcessorResponse $response */
+        /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(\MODX\Revolution\Processors\Security\Login::class, $this->scriptProperties);
-        if (($response instanceof modProcessorResponse)) {
+        if (($response instanceof ProcessorResponse)) {
             if (!$response->isError()) {
                 $url = !empty($this->scriptProperties['returnUrl'])
                     ? $this->scriptProperties['returnUrl']

--- a/manager/controllers/default/welcome.class.php
+++ b/manager/controllers/default/welcome.class.php
@@ -10,7 +10,7 @@
 
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modManagerController;
-use MODX\Revolution\modProcessorResponse;
+use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\modSystemSetting;
 use MODX\Revolution\modUserSetting;
 use MODX\Revolution\Processors\System\Dashboard\User\GetList;
@@ -64,7 +64,7 @@ class WelcomeManagerController extends modManagerController
 
         $new_widgets = 0;
         if ($this->dashboard->get('customizable')) {
-            /** @var modProcessorResponse $res */
+            /** @var ProcessorResponse $res */
             $res = $this->modx->runProcessor(GetList::class, [
                 'dashboard' => $this->dashboard->get('id'),
                 'combo' => true,


### PR DESCRIPTION
### What does it do?

This modernises the structure and naming of the base processors, inline with the earlier massive refactor of all implementing processors. While this commit technically breaks all third party processor compatibility - that has already been broken anyway. 

By doing this refactor now, we can prepare the documentation _before_ the first alpha appropriately and benefit from the simplified naming in the future without adding another set of breaking changes down the road.

Also some minor/code style issues have been resolved (objects always passed by reference, strict bool checks, base DuplicateProcessor not marked as abstract, wrong classes being called in database table processors).

Brought you by PhpStorm's a-bloody-mazing refactoring capabilities.

### Why is it needed?

While great strides have been made, I think we can do even better with modernising the codebase further. This is one of the things that can help bring greater clarity and code separation to the core, by making sure all processor related classes are in one specific, logical, place. 

### Related issue(s)/PR(s)

N/a.