### PR TITLE
fix php7.4 compatibility. Remove curly braces syntax

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -286,7 +286,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         /* replace one or more instances of word delimiters with word delimiter */
         $delimiterTokens = array();
         for ($d = 0; $d < strlen($delimiters); $d++) {
-            $delimiterTokens[] = preg_quote($delimiters{$d}, '/');
+            $delimiterTokens[] = preg_quote($delimiters[$d], '/');
         }
         if (!empty($delimiterTokens)) {
             $delimiterPattern = '/[' . implode('|', $delimiterTokens) . ']+/';
@@ -462,7 +462,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         # 3. Parse uncacheable elements.
         $this->parseContent();
     }
-    
+
     /**
      * Process a resource, transforming source content to output.
      *
@@ -524,7 +524,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $this->_jscripts       = $this->xpdo->jscripts;
         $this->_sjscripts      = $this->xpdo->sjscripts;
         $this->_loadedjscripts = $this->xpdo->loadedjscripts;
-    }    
+    }
     /**
      * Gets the raw, unprocessed source content for a resource.
      *

--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -203,7 +203,7 @@ class modStaticResource extends modResource implements modResourceInterface {
      */
     protected function _bytes($value) {
         $value = trim($value);
-        $modifier = strtolower($value{strlen($value)-1});
+        $modifier = strtolower($value[strlen($value)-1]);
         switch($modifier) {
             case 'g':
                 $value *= 1024;

--- a/core/xpdo/cache/xpdocachemanager.class.php
+++ b/core/xpdo/cache/xpdocachemanager.class.php
@@ -163,7 +163,7 @@ class xPDOCacheManager {
                     break;
                 }
                 if ($cachePath) {
-                    if ($cachePath{strlen($cachePath) - 1} != '/') $cachePath .= '/';
+                    if ($cachePath[strlen($cachePath) - 1] != '/') $cachePath .= '/';
                     $cachePath .= '.xpdo-cache';
                 }
             }
@@ -177,7 +177,7 @@ class xPDOCacheManager {
             $perms = $this->getOption('new_folder_permissions', null, $this->getFolderPermissions());
             if (is_string($perms)) $perms = octdec($perms);
             if (@ $this->writeTree($cachePath, $perms)) {
-                if ($cachePath{strlen($cachePath) - 1} != '/') $cachePath .= '/';
+                if ($cachePath[strlen($cachePath) - 1] != '/') $cachePath .= '/';
                 if (!is_writeable($cachePath)) {
                     @ chmod($cachePath, $perms);
                 }
@@ -331,7 +331,7 @@ class xPDOCacheManager {
             $mode = $this->getOption('new_folder_permissions', $options, $this->getFolderPermissions());
             if (is_string($mode)) $mode = octdec($mode);
             $dirname= strtr(trim($dirname), '\\', '/');
-            if ($dirname{strlen($dirname) - 1} == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
+            if ($dirname[strlen($dirname) - 1] == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
             if (is_dir($dirname) || (is_writable(dirname($dirname)) && @mkdir($dirname, $mode))) {
                 $written= true;
             } elseif (!$this->writeTree(dirname($dirname), $options)) {
@@ -404,8 +404,8 @@ class xPDOCacheManager {
         $copied= false;
         $source= strtr($source, '\\', '/');
         $target= strtr($target, '\\', '/');
-        if ($source{strlen($source) - 1} == '/') $source = substr($source, 0, strlen($source) - 1);
-        if ($target{strlen($target) - 1} == '/') $target = substr($target, 0, strlen($target) - 1);
+        if ($source[strlen($source) - 1] == '/') $source = substr($source, 0, strlen($source) - 1);
+        if ($target[strlen($target) - 1] == '/') $target = substr($target, 0, strlen($target) - 1);
         if (is_dir($source . '/')) {
             if (!is_array($options)) $options = is_scalar($options) && !is_bool($options) ? array('new_folder_permissions' => $options) : array();
             if (func_num_args() === 4) $options['new_file_permissions'] = func_get_arg(3);


### PR DESCRIPTION
In php7.4 Deprecated: Array and string offset access syntax with curly braces is deprecated.

Modx on php7.4 send errors:
Deprecated: Array and string offset access syntax with curly braces is deprecated in /core/model/modx/modresource.class.php on line 289
/core/xpdo/cache/xpdocachemanager.class.php on line 166
/core/xpdo/cache/xpdocachemanager.class.php on line 180
/core/xpdo/cache/xpdocachemanager.class.php on line 334
/core/xpdo/cache/xpdocachemanager.class.php on line 407
/core/xpdo/cache/xpdocachemanager.class.php on line 408
/core/model/modx/modstaticresource.class.php on line 206

### What does it do?
change {} to []

### Why is it needed?
for compatibility with php7.4.