### PR TITLE
Added item links to grids

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -528,14 +528,15 @@ textarea.x-form-field {
 }
 
 a.x-grid-link {
-  color: $mainText;
-  text-decoration: none;
+  color: $colorSplash;
+  text-decoration: underline;
 }
 
 a.x-grid-link:hover,
 a.x-grid-link:focus {
-  text-decoration: underline;
+  text-decoration: none;
 }
+
 .x-editable-column {
   cursor: pointer;
   &:hover, &:focus {
@@ -552,6 +553,7 @@ a.x-grid-link:focus {
 .x-grid-buttons {
   text-align: center;
 }
+
 .x-grid-buttons li {
   cursor: pointer;
   display: inline-block;

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -644,7 +644,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         });
     }
 
-    ,rendLink: function(v,attr) {
+    ,renderLink: function(v,attr) {
         var el = new Ext.Element(document.createElement('a'));
         el.addClass('x-grid-link');
         el.dom.title = _('edit');
@@ -1063,7 +1063,7 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
         });
     }
 
-    ,rendLink: function(v,attr) {
+    ,renderLink: function(v,attr) {
         var el = new Ext.Element(document.createElement('a'));
         el.addClass('x-grid-link');
         el.dom.title = _('edit');

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -252,7 +252,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
             ,url: this.config.url
             ,params: p
             ,listeners: {
-            	'success': {fn:this.refresh,scope:this}
+                'success': {fn:this.refresh,scope:this}
             }
         });
     }
@@ -275,7 +275,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,url: this.config.url
                 ,params: p
                 ,listeners: {
-                	'success': {fn:function() {
+                    'success': {fn:function() {
                         this.removeActiveRow(r);
                     },scope:this}
                 }
@@ -334,10 +334,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,groupField: this.config.groupBy || 'name'
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
+                    }
                 }
             });
         } else {
@@ -350,10 +350,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                 ,remoteSort: this.config.remoteSort || false
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
-				,listeners:{
+                ,listeners:{
                     load: function(){
-						Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
-					}
+                        Ext.getCmp('modx-content').doLayout(); /* Fix layout bug with absolute positioning */
+                    }
                 }
             });
         }
@@ -512,8 +512,8 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     }
 
     ,editorYesNo: function(r) {
-    	r = r || {};
-    	Ext.applyIf(r,{
+        r = r || {};
+        Ext.applyIf(r,{
             store: new Ext.data.SimpleStore({
                 fields: ['d','v']
                 ,data: [[_('yes'),true],[_('no'),false]]
@@ -644,6 +644,17 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         });
     }
 
+    ,rendLink: function(v,attr) {
+        var el = new Ext.Element(document.createElement('a'));
+        el.addClass('x-grid-link');
+        el.dom.title = _('edit');
+        for (var i in attr) {
+            el.dom[i] = attr[i];
+        }
+        el.dom.innerHTML = Ext.util.Format.htmlEncode(v);
+        return el.dom.outerHTML;
+    }
+
     ,getActions: function(record, rowIndex, colIndex, store) {
         return [];
     }
@@ -679,14 +690,14 @@ MODx.grid.LocalGrid = function(config) {
 
     if (config.grouping) {
         Ext.applyIf(config,{
-          view: new Ext.grid.GroupingView({
-            forceFit: true
-            ,scrollOffset: 0
-            ,hideGroupedColumn: config.hideGroupedColumn ? true : false
-            ,groupTextTpl: config.groupTextTpl || ('{text} ({[values.rs.length]} {[values.rs.length > 1 ? "'
-                +(config.pluralText || _('records')) + '" : "'
-                +(config.singleText || _('record'))+'"]})' )
-          })
+            view: new Ext.grid.GroupingView({
+                forceFit: true
+                ,scrollOffset: 0
+                ,hideGroupedColumn: config.hideGroupedColumn ? true : false
+                ,groupTextTpl: config.groupTextTpl || ('{text} ({[values.rs.length]} {[values.rs.length > 1 ? "'
+                    +(config.pluralText || _('records')) + '" : "'
+                    +(config.singleText || _('record'))+'"]})' )
+            })
         });
     }
     if (config.tbar) {
@@ -1050,6 +1061,17 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
         return this._getActionsColumnTpl().apply({
             actions: actions
         });
+    }
+
+    ,rendLink: function(v,attr) {
+        var el = new Ext.Element(document.createElement('a'));
+        el.addClass('x-grid-link');
+        el.dom.title = _('edit');
+        for (var i in attr) {
+            el.dom[i] = attr[i];
+        }
+        el.dom.innerHTML = Ext.util.Format.htmlEncode(v);
+        return el.dom.outerHTML;
     }
 
     ,getActions: function(value, metaData, record, rowIndex, colIndex, store) {

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -50,8 +50,13 @@ MODx.grid.TemplateTV = function(config) {
             header: _('name')
             ,dataIndex: 'name'
             ,width: 150
-            ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=element/tv/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('category')
             ,dataIndex: 'category_name'
@@ -61,7 +66,6 @@ MODx.grid.TemplateTV = function(config) {
             header: _('description')
             ,dataIndex: 'description'
             ,width: 350
-            ,editor: { xtype: 'textfield' }
             ,sortable: false
         },tt,{
             header: _('rank')
@@ -129,14 +133,43 @@ Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
         }
         return m;
     }
+
     ,updateTV: function(itm,e) {
-        MODx.loadPage('Element/TemplateVar/Update', 'id='+this.menu.record.id);
+        MODx.loadPage('element/tv/update', 'id='+this.menu.record.id);
     }
+
+    ,sortTVs: function(sourceNode, targetNode) {
+        var store = this.getStore();
+        var sourceIdx = store.indexOf(sourceNode);
+        var targetIdx = store.indexOf(targetNode);
+
+        // Insert the selection to the target (and remove original selection)
+        store.removeAt(sourceIdx);
+        store.insert(targetIdx, sourceNode);
+
+        // Extract the store items with the same category_name as the sourceNode to start the index at 0 for each category
+        var filteredStore = store.queryBy(function(rec, id) {
+            if (rec.get('category_name') === sourceNode.get('category_name')) {
+                return true;
+            }
+            return false;
+        }, this);
+
+        // Loop trough the filtered store and re-apply the re-calculated ranks to the store records
+        Ext.each(filteredStore.items, function(item, index, allItems) {
+            if (sourceNode.get('category_name') === item.get('category_name')) {
+                var record = store.getById(item.id);
+                record.set('tv_rank', index);
+            }
+        }, this);
+    }
+
     ,filterByCategory: function(cb,rec,ri) {
         this.getStore().baseParams['category'] = cb.getValue();
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
@@ -145,16 +178,18 @@ Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
         //this.refresh();
         return true;
     }
+
     ,clearFilter: function() {
-    	this.getStore().baseParams = {
+        this.getStore().baseParams = {
             action: 'Element/Template/TemplateVar/GetList'
             ,template: this.config.template
-    	};
+        };
         Ext.getCmp('modx-temptv-filter-category').reset();
         Ext.getCmp('modx-temptv-search').setValue('');
-    	this.getBottomToolbar().changePage(1);
+        this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,prepareDDSort: function(grid) {
         this.dropTarget = new Ext.dd.DropTarget(grid.getView().mainBody, {
             ddGroup: 'template-tvs-ddsort'
@@ -190,31 +225,6 @@ Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
                 }
             }
         });
-    }
-    ,sortTVs: function(sourceNode, targetNode) {
-        var store = this.getStore();
-        var sourceIdx = store.indexOf(sourceNode);
-        var targetIdx = store.indexOf(targetNode);
-
-        // Insert the selection to the target (and remove original selection)
-        store.removeAt(sourceIdx);
-        store.insert(targetIdx, sourceNode);
-
-        // Extract the store items with the same category_name as the sourceNode to start the index at 0 for each category
-        var filteredStore = store.queryBy(function(rec, id) {
-            if (rec.get('category_name') === sourceNode.get('category_name')) {
-                return true;
-            }
-            return false;
-        }, this);
-
-        // Loop trough the filtered store and re-apply the re-calculated ranks to the store records
-        Ext.each(filteredStore.items, function(item, index, allItems) {
-            if (sourceNode.get('category_name') === item.get('category_name')) {
-                var record = store.getById(item.id);
-                record.set('tv_rank', index);
-            }
-        }, this);
     }
 });
 Ext.reg('modx-grid-template-tv',MODx.grid.TemplateTV);

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -52,7 +52,7 @@ MODx.grid.TemplateTV = function(config) {
             ,width: 150
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=element/tv/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/element/modx.grid.tv.security.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.security.js
@@ -35,7 +35,7 @@ MODx.grid.TVSecurity = function(config) {
             ,width: 200
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/resourcegroup'
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/element/modx.grid.tv.security.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.security.js
@@ -1,6 +1,6 @@
 /**
- * Loads a grid of resource groups assigned to a resource. 
- * 
+ * Loads a grid of resource groups assigned to a resource.
+ *
  * @class MODx.grid.TVSecurity
  * @extends MODx.grid.Grid
  * @param {Object} config An object of options.
@@ -34,8 +34,13 @@ MODx.grid.TVSecurity = function(config) {
             ,dataIndex: 'name'
             ,width: 200
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/resourcegroup'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },tt]
-        
     });
     MODx.grid.TVSecurity.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -34,6 +34,12 @@ MODx.grid.TemplateVarTemplate = function(config) {
             ,dataIndex: 'templatename'
             ,width: 150
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=element/template/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('category')
             ,dataIndex: 'category_name'
@@ -91,6 +97,7 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
@@ -99,13 +106,14 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
         //this.refresh();
         return true;
     }
+
     ,clearFilter: function() {
-    	this.getStore().baseParams = {
+        this.getStore().baseParams = {
             action: 'Element/TemplateVar/Template/GetList'
-    	};
+        };
         Ext.getCmp('modx-tvtemp-filter-category').reset();
         Ext.getCmp('modx-tvtemp-search').setValue('');
-    	this.getBottomToolbar().changePage(1);
+        this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
 });

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -35,7 +35,7 @@ MODx.grid.TemplateVarTemplate = function(config) {
             ,width: 150
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=element/template/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -17,7 +17,7 @@ MODx.panel.TV = function(config) {
             action: 'Element/TemplateVar/Get'
         }
         ,id: 'modx-panel-tv'
-		,cls: 'container form-with-labels'
+        ,cls: 'container form-with-labels'
         ,class_key: 'modTemplateVar'
         ,tv: ''
         ,bodyStyle: ''
@@ -194,7 +194,6 @@ MODx.panel.TV = function(config) {
                         ,id: 'modx-tv-clear-cache'
                         ,inputValue: 1
                         ,checked: Ext.isDefined(config.record.clearCache) || true
-
                     },{border: false, html: '<br style="line-height: 25px;"/>'},{
                         xtype: 'xcheckbox'
                         ,hideLabel: true
@@ -241,9 +240,8 @@ MODx.panel.TV = function(config) {
                         ,hidden: !config.record['static']
                         ,hideMode: 'offsets'
                     }]
-
                 }]
-			}]
+            }]
         },{
             xtype: 'modx-panel-tv-input-properties'
             ,record: config.record
@@ -255,14 +253,14 @@ MODx.panel.TV = function(config) {
             ,itemId: 'form-template'
             ,hideMode: 'offsets'
             ,defaults: {autoHeight: true}
-			,layout: 'form'
+            ,layout: 'form'
             ,items: [{
                 html: '<p>'+_('tv_tmpl_access_msg')+'</p>'
                 ,xtype: 'modx-description'
             },{
                 xtype: 'modx-grid-tv-template'
                 ,itemId: 'grid-template'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,tv: config.tv
                 ,preventRender: true
                 ,anchor: '100%'
@@ -277,8 +275,8 @@ MODx.panel.TV = function(config) {
             ,id: 'modx-tv-sources-form'
             ,itemId: 'form-sources'
             ,defaults: {autoHeight: true}
-			,layout: 'form'
-			,hideMode: 'offsets'
+            ,layout: 'form'
+            ,hideMode: 'offsets'
             ,items: [{
                 html: '<p>'+_('tv_sources.intro_msg')+'</p>'
                 ,id: 'modx-tv-sources-msg'
@@ -286,7 +284,7 @@ MODx.panel.TV = function(config) {
             },{
                 xtype: 'modx-grid-element-sources'
                 ,itemId: 'grid-sources'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,id: 'modx-grid-element-sources'
                 ,tv: config.tv
                 ,preventRender: true
@@ -360,6 +358,7 @@ MODx.panel.TV = function(config) {
 };
 Ext.extend(MODx.panel.TV,MODx.FormPanel,{
     initialized: false
+
     ,setup: function() {
         if (this.initialized) { this.clearDirty(); return true; }
         this.getForm().setValues(this.config.record);
@@ -421,6 +420,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
             ,stay: MODx.config.stay
         });
     }
+
     ,success: function(r) {
         Ext.getCmp('modx-grid-tv-template').getStore().commitChanges();
         Ext.getCmp('modx-grid-tv-security').getStore().commitChanges();
@@ -437,16 +437,19 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
             t.refreshNode(u,true);
         }
     }
+
     ,changeEditor: function() {
         this.cleanupEditor();
         this.submit();
     }
+
     ,cleanupEditor: function() {
         if (MODx.onSaveEditor) {
             var fld = Ext.getCmp('modx-tv-default-text');
             MODx.onSaveEditor(fld);
         }
     }
+
     ,toggleStaticFile: function(cb) {
         var flds = ['modx-tv-static-file','modx-tv-static-file-help','modx-tv-static-source','modx-tv-static-source-help'];
         var fld,i;
@@ -465,15 +468,19 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
 });
 Ext.reg('modx-panel-tv',MODx.panel.TV);
 
-
-
+/**
+ * @class MODx.panel.TVInputProperties
+ * @extends MODx.Panel
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-panel-tv-input-properties
+ */
 MODx.panel.TVInputProperties = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-tv-input-properties'
         ,title: _('tv_input_options')
         ,header: false
-		,border: false
+        ,border: false
         ,defaults: { border: false }
         ,cls: 'form-with-labels'
         ,items: [{
@@ -482,70 +489,70 @@ MODx.panel.TVInputProperties = function(config) {
             ,xtype: 'modx-description'
         },{
             layout: 'form'
-			,border: false
-			,cls:'main-wrapper'
+            ,border: false
+            ,cls:'main-wrapper'
             ,labelAlign: 'top'
             ,labelSeparator: ''
-			,items: [{
-				xtype: 'modx-combo-tv-input-type'
-				,fieldLabel: _('tv_type')
-				,description: MODx.expandHelp ? '' : _('tv_type_desc')
-				,name: 'type'
-				,id: 'modx-tv-type'
-				,itemid: 'fld-type'
-				,anchor: '100%'
-				,value: config.record.type || 'text'
-				,listeners: {
-					'select': {fn:this.showInputProperties,scope:this}
-				}
-			},{
+            ,items: [{
+                xtype: 'modx-combo-tv-input-type'
+                ,fieldLabel: _('tv_type')
+                ,description: MODx.expandHelp ? '' : _('tv_type_desc')
+                ,name: 'type'
+                ,id: 'modx-tv-type'
+                ,itemid: 'fld-type'
+                ,anchor: '100%'
+                ,value: config.record.type || 'text'
+                ,listeners: {
+                    'select': {fn:this.showInputProperties,scope:this}
+                }
+            },{
                 xtype: 'label'
                 ,forId: 'modx-tv-type'
                 ,html: _('tv_type_desc')
                 ,cls: 'desc-under'
             },{
-				xtype: 'textarea'
-				,fieldLabel: _('tv_elements')
-				,description: MODx.expandHelp ? '' : _('tv_elements_desc')
-				,name: 'els'
-				,id: 'modx-tv-elements'
-				,itemId: 'fld-els'
-				,anchor: '100%'
-				,grow: true
-				,maxHeight: 160
-				,value: config.record.elements || ''
-				,listeners: {
-					'change': {fn:this.markPanelDirty,scope:this}
-				}
-			},{
+                xtype: 'textarea'
+                ,fieldLabel: _('tv_elements')
+                ,description: MODx.expandHelp ? '' : _('tv_elements_desc')
+                ,name: 'els'
+                ,id: 'modx-tv-elements'
+                ,itemId: 'fld-els'
+                ,anchor: '100%'
+                ,grow: true
+                ,maxHeight: 160
+                ,value: config.record.elements || ''
+                ,listeners: {
+                    'change': {fn:this.markPanelDirty,scope:this}
+                }
+            },{
                 xtype: MODx.expandHelp ? 'label' : 'hidden'
                 ,forId: 'modx-tv-elements'
                 ,html: _('tv_elements_desc')
                 ,cls: 'desc-under'
             },{
-				xtype: 'textarea'
-				,fieldLabel: _('tv_default')
-				,description: MODx.expandHelp ? '' : _('tv_default_desc')
-				,name: 'default_text'
-				,id: 'modx-tv-default-text'
-				,itemId: 'fld-default_text'
-				,anchor: '100%'
-				,grow: true
-				,maxHeight: 250
-				,value: config.record.default_text || ''
-				,listeners: {
-					'change': {fn:this.markPanelDirty,scope:this}
-				}
-			},{
+                xtype: 'textarea'
+                ,fieldLabel: _('tv_default')
+                ,description: MODx.expandHelp ? '' : _('tv_default_desc')
+                ,name: 'default_text'
+                ,id: 'modx-tv-default-text'
+                ,itemId: 'fld-default_text'
+                ,anchor: '100%'
+                ,grow: true
+                ,maxHeight: 250
+                ,value: config.record.default_text || ''
+                ,listeners: {
+                    'change': {fn:this.markPanelDirty,scope:this}
+                }
+            },{
                 xtype: MODx.expandHelp ? 'label' : 'hidden'
                 ,forId: 'modx-tv-default-text'
                 ,html: _('tv_default_desc')
                 ,cls: 'desc-under'
             },{
-				id: 'modx-input-props'
-				,autoHeight: true
-			}]
-		}]
+                id: 'modx-input-props'
+                ,autoHeight: true
+            }]
+        }]
     });
     MODx.panel.TVInputProperties.superclass.constructor.call(this,config);
 };
@@ -553,6 +560,7 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
     markPanelDirty: function() {
         Ext.getCmp('modx-panel-tv').markDirty();
     }
+
     ,showInputProperties: function(cb,rc,i) {
         var element = Ext.getCmp('modx-tv-elements');
         if (element) {
@@ -580,8 +588,12 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
 });
 Ext.reg('modx-panel-tv-input-properties',MODx.panel.TVInputProperties);
 
-
-
+/**
+ * @class MODx.panel.TVOutputProperties
+ * @extends MODx.Panel
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-panel-tv-output-properties
+ */
 MODx.panel.TVOutputProperties = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -597,8 +609,8 @@ MODx.panel.TVOutputProperties = function(config) {
             ,xtype: 'modx-description'
         },{
             layout: 'form'
-			,border: false
-			,cls:'main-wrapper'
+            ,border: false
+            ,cls:'main-wrapper'
             ,labelAlign: 'top'
             ,items: [{
                 xtype: 'modx-combo-tv-widget'
@@ -619,10 +631,10 @@ MODx.panel.TVOutputProperties = function(config) {
                 ,html: _('tv_output_type_desc')
                 ,cls: 'desc-under'
             },{
-				id: 'modx-widget-props'
-				,autoHeight: true
-			}]
-		}]
+                id: 'modx-widget-props'
+                ,autoHeight: true
+            }]
+        }]
     });
     MODx.panel.TVOutputProperties.superclass.constructor.call(this,config);
 };
@@ -649,7 +661,12 @@ Ext.extend(MODx.panel.TVOutputProperties,MODx.Panel,{
 });
 Ext.reg('modx-panel-tv-output-properties',MODx.panel.TVOutputProperties);
 
-
+/**
+ * @class MODx.grid.ElementSources
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-element-sources
+ */
 MODx.grid.ElementSources = function(config) {
     var src = new MODx.combo.MediaSource();
     src.getStore().load();
@@ -663,6 +680,12 @@ MODx.grid.ElementSources = function(config) {
         ,columns: [{
             header: _('context')
             ,dataIndex: 'context_key'
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=context/update&key=' + v
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('source')
             ,dataIndex: 'source'

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -681,7 +681,7 @@ MODx.grid.ElementSources = function(config) {
             header: _('context')
             ,dataIndex: 'context_key'
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=context/update&key=' + v
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -1,17 +1,23 @@
+/**
+ * @class MODx.panel.FCProfiles
+ * @extends MODx.FormPanel
+ * @param {Object} config An object of configuration options
+ * @xtype modx-panel-fc-profiles
+ */
 MODx.panel.FCProfiles = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-fc-profiles'
-		,cls: 'container'
+        ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
-             html: _('form_customization')
+            html: _('form_customization')
             ,id: 'modx-fcp-header'
             ,xtype: 'modx-header'
         },MODx.getPageStructure([{
             title: _('profiles')
             ,autoHeight: true
-			,layout: "form"
+            ,layout: "form"
             ,items: [{
                 html: '<p>'+_('form_customization_msg')+'</p>'
                 ,xtype: 'modx-description'
@@ -19,7 +25,7 @@ MODx.panel.FCProfiles = function(config) {
                 title: ''
                 ,preventRender: true
                 ,xtype: 'modx-grid-fc-profile'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
             }]
         }],{
             id: 'modx-form-customization-tabs'
@@ -30,6 +36,12 @@ MODx.panel.FCProfiles = function(config) {
 Ext.extend(MODx.panel.FCProfiles,MODx.FormPanel);
 Ext.reg('modx-panel-fc-profiles',MODx.panel.FCProfiles);
 
+/**
+ * @class MODx.grid.FCProfile
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-fc-profile
+ */
 MODx.grid.FCProfile = function(config) {
     config = config || {};
     this.sm = new Ext.grid.CheckboxSelectionModel();
@@ -56,6 +68,11 @@ MODx.grid.FCProfile = function(config) {
             ,width: 200
             ,sortable: true
             ,editor: { xtype: 'textfield' }
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/forms/profile/update&id=' + record.data.id
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -187,21 +204,6 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         }
     }
 
-    ,search: function(tf,newValue,oldValue) {
-        var nv = newValue || tf;
-        this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
-        this.getBottomToolbar().changePage(1);
-        //this.refresh();
-        return true;
-    }
-    ,clearFilter: function() {
-    	this.getStore().baseParams = {
-            action: 'Security/Forms/Profile/GetList'
-    	};
-        Ext.getCmp('modx-fcp-search').reset();
-    	this.getBottomToolbar().changePage(1);
-    }
-
     ,createProfile: function(btn,e) {
         if (!this.windows.cpro) {
             this.windows.cpro = MODx.load({
@@ -221,6 +223,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         var r = this.menu.record;
         location.href = '?a=Security/Forms/Profile/Update&id='+r.id;
     }
+
     ,duplicateProfile: function(btn,e) {
         MODx.Ajax.request({
             url: this.config.url
@@ -266,6 +269,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         });
         return true;
     }
+
     ,deactivateProfile: function(btn,e) {
         MODx.Ajax.request({
             url: this.config.url
@@ -278,6 +282,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
             }
         });
     }
+
     ,deactivateSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -297,6 +302,7 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         });
         return true;
     }
+
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -318,10 +324,31 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         });
         return true;
     }
+
+    ,search: function(tf,newValue,oldValue) {
+        var nv = newValue || tf;
+        this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
+        this.getBottomToolbar().changePage(1);
+        //this.refresh();
+        return true;
+    }
+
+    ,clearFilter: function() {
+        this.getStore().baseParams = {
+            action: 'Security/Forms/Profile/GetList'
+        };
+        Ext.getCmp('modx-fcp-search').reset();
+        this.getBottomToolbar().changePage(1);
+    }
 });
 Ext.reg('modx-grid-fc-profile',MODx.grid.FCProfile);
 
-
+/**
+ * @class MODx.window.CreateFCProfile
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-fc-profile-create
+ */
 MODx.window.CreateFCProfile = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -69,7 +69,7 @@ MODx.grid.FCProfile = function(config) {
             ,sortable: true
             ,editor: { xtype: 'textfield' }
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/forms/profile/update&id=' + record.data.id
                 });
             }, scope: this }

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -9,7 +9,7 @@ MODx.panel.FCProfile = function(config) {
     Ext.applyIf(config,{
         url: MODx.config.connector_url
         ,id: 'modx-panel-fc-profile'
-		,cls: 'container'
+        ,cls: 'container'
         ,class_key: 'MODX\\Revolution\\modFormCustomizationProfile'
         ,bodyStyle: ''
         ,items: [{
@@ -27,52 +27,52 @@ MODx.panel.FCProfile = function(config) {
                 ,id: 'modx-fcp-msg'
                 ,xtype: 'modx-description'
             },{
-				xtype: 'panel'
-				,border: false
-				,cls:'main-wrapper'
-				,layout: 'form'
-				,items: [{
-					xtype: 'hidden'
-					,name: 'id'
-					,id: 'modx-fcp-id'
-					,value: config.record.id || MODx.request.id
-				},{
-					xtype: 'textfield'
-					,fieldLabel: _('name')
-					,name: 'name'
-					,id: 'modx-fcp-name'
-					,anchor: '100%'
-					,maxLength: 255
-					,enableKeyEvents: true
-					,allowBlank: false
-					,value: config.record.name
-					,listeners: {
-						'keyup': {scope:this,fn:function(f,e) {
-							Ext.getCmp('modx-fcp-header').getEl().update(_('profile')+': '+f.getValue());
-						}}
-					}
-				},{
-					xtype: 'textarea'
-					,fieldLabel: _('description')
-					,name: 'description'
-					,id: 'modx-fcp-description'
-					,anchor: '100%'
-					,maxLength: 255
-					,grow: false
-					,value: config.record.description
-				},{
-					xtype: 'xcheckbox'
-					,fieldLabel: _('active')
-					,name: 'active'
-					,id: 'modx-fcp-active'
-					,inputValue: true
-					,value: config.record.active ? true : false
-					,anchor: '100%'
-					,allowBlank: true
-				}]
+                xtype: 'panel'
+                ,border: false
+                ,cls:'main-wrapper'
+                ,layout: 'form'
+                ,items: [{
+                    xtype: 'hidden'
+                    ,name: 'id'
+                    ,id: 'modx-fcp-id'
+                    ,value: config.record.id || MODx.request.id
+                },{
+                    xtype: 'textfield'
+                    ,fieldLabel: _('name')
+                    ,name: 'name'
+                    ,id: 'modx-fcp-name'
+                    ,anchor: '100%'
+                    ,maxLength: 255
+                    ,enableKeyEvents: true
+                    ,allowBlank: false
+                    ,value: config.record.name
+                    ,listeners: {
+                        'keyup': {scope:this,fn:function(f,e) {
+                            Ext.getCmp('modx-fcp-header').getEl().update(_('profile')+': '+f.getValue());
+                        }}
+                    }
+                },{
+                    xtype: 'textarea'
+                    ,fieldLabel: _('description')
+                    ,name: 'description'
+                    ,id: 'modx-fcp-description'
+                    ,anchor: '100%'
+                    ,maxLength: 255
+                    ,grow: false
+                    ,value: config.record.description
+                },{
+                    xtype: 'xcheckbox'
+                    ,fieldLabel: _('active')
+                    ,name: 'active'
+                    ,id: 'modx-fcp-active'
+                    ,inputValue: true
+                    ,value: config.record.active ? true : false
+                    ,anchor: '100%'
+                    ,allowBlank: true
+                }]
             },{
                 xtype: 'modx-grid-fc-set'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,baseParams: {
                     action: 'Security/Forms/Set/GetList'
                     ,profile: config.record.id
@@ -87,7 +87,7 @@ MODx.panel.FCProfile = function(config) {
                 ,xtype: 'modx-description'
             },{
                 xtype: 'modx-grid-fc-profile-usergroups'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,data: config.record.usergroups || []
                 ,preventRender: true
             }]
@@ -132,6 +132,12 @@ Ext.extend(MODx.panel.FCProfile,MODx.FormPanel,{
 });
 Ext.reg('modx-panel-fc-profile',MODx.panel.FCProfile);
 
+/**
+ * @class MODx.grid.FCProfileUserGroups
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-fc-profile-usergroups
+ */
 MODx.grid.FCProfileUserGroups = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -142,6 +148,12 @@ MODx.grid.FCProfileUserGroups = function(config) {
         ,columns: [{
             header: _('name')
             ,dataIndex: 'name'
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/usergroup/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
         }]
         ,tbar: [{
             text: _('usergroup_create')
@@ -186,8 +198,12 @@ Ext.extend(MODx.grid.FCProfileUserGroups,MODx.grid.LocalGrid,{
 });
 Ext.reg('modx-grid-fc-profile-usergroups',MODx.grid.FCProfileUserGroups);
 
-
-
+/**
+ * @class MODx.window.AddGroupToProfile
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-fc-profile-add-usergroup
+ */
 MODx.window.AddGroupToProfile = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -149,7 +149,7 @@ MODx.grid.FCProfileUserGroups = function(config) {
             header: _('name')
             ,dataIndex: 'name'
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/usergroup/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -406,7 +406,7 @@ MODx.grid.FCSetTVs = function(config) {
             ,dataIndex: 'name'
             ,width: 200
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=element/tv/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -164,6 +164,7 @@ MODx.panel.FCSet = function(config) {
 };
 Ext.extend(MODx.panel.FCSet,MODx.FormPanel,{
     initialized: false
+
     ,setup: function() {
         if (!this.initialized) {this.getForm().setValues(this.config.record);}
         if (!Ext.isEmpty(this.config.record.controller)) {
@@ -176,6 +177,7 @@ Ext.extend(MODx.panel.FCSet,MODx.FormPanel,{
         MODx.fireEvent('ready');
         return true;
     }
+
     ,beforeSubmit: function(o) {
         Ext.apply(o.form.baseParams,{
             fields: Ext.getCmp('modx-grid-fc-set-fields').encode()
@@ -186,6 +188,7 @@ Ext.extend(MODx.panel.FCSet,MODx.FormPanel,{
             values: this.getForm().getValues()
         });
     }
+
     ,success: function(r) {
         this.getForm().setValues(r.result.object);
 
@@ -212,7 +215,12 @@ Ext.extend(MODx.panel.FCSet,MODx.FormPanel,{
 });
 Ext.reg('modx-panel-fc-set',MODx.panel.FCSet);
 
-
+/**
+ * @class MODx.grid.FCSetFields
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-fc-set-fields
+ */
 MODx.grid.FCSetFields = function(config) {
     config = config || {};
     this.vcb = new Ext.ux.grid.CheckColumn({
@@ -274,7 +282,12 @@ MODx.grid.FCSetFields = function(config) {
 Ext.extend(MODx.grid.FCSetFields,MODx.grid.LocalGrid);
 Ext.reg('modx-grid-fc-set-fields',MODx.grid.FCSetFields);
 
-
+/**
+ * @class MODx.grid.FCSetTabs
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-fc-set-tabs
+ */
 MODx.grid.FCSetTabs = function(config) {
     config = config || {};
     this.vcb = new Ext.ux.grid.CheckColumn({
@@ -319,7 +332,19 @@ MODx.grid.FCSetTabs = function(config) {
     this.propRecord = Ext.data.Record.create(config.fields);
 };
 Ext.extend(MODx.grid.FCSetTabs,MODx.grid.LocalGrid,{
-    createTab: function(btn,e) {
+    getMenu: function(g,ri) {
+        var rec = this.getStore().getAt(ri);
+        if (rec.data.type == 'new') {
+            return [{
+                text: _('tab_remove')
+                ,handler: this.removeTab
+                ,scope: this
+            }];
+        }
+        return [];
+    }
+
+    ,createTab: function(btn,e) {
         if (!this.windows.ctab) {
             this.windows.ctab = MODx.load({
                 xtype: 'modx-window-fc-set-add-tab'
@@ -335,17 +360,6 @@ Ext.extend(MODx.grid.FCSetTabs,MODx.grid.LocalGrid,{
         this.windows.ctab.reset();
         this.windows.ctab.show(e.target);
     }
-    ,getMenu: function(g,ri) {
-        var rec = this.getStore().getAt(ri);
-        if (rec.data.type == 'new') {
-            return [{
-                text: _('tab_remove')
-                ,handler: this.removeTab
-                ,scope: this
-            }];
-        }
-        return [];
-    }
 
     ,removeTab: function(btn,e) {
         var rec = this.getSelectionModel().getSelected();
@@ -358,7 +372,93 @@ Ext.extend(MODx.grid.FCSetTabs,MODx.grid.LocalGrid,{
 });
 Ext.reg('modx-grid-fc-set-tabs',MODx.grid.FCSetTabs);
 
+/**
+ * @class MODx.grid.FCSetTVs
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-fc-set-tvs
+ */
+MODx.grid.FCSetTVs = function(config) {
+    config = config || {};
+    this.vcb = new Ext.ux.grid.CheckColumn({
+        header: _('visible')
+        ,dataIndex: 'visible'
+        ,width: 40
+        ,sortable: false
+    });
+    Ext.applyIf(config,{
+        id: 'modx-grid-fc-set-tvs'
+        ,fields: ['id','name','tab','rank','visible','label','default_value','category','default_text']
+        ,autoHeight: true
+        ,grouping: true
+        ,groupBy: 'category'
+        ,sortBy: 'rank'
+        ,sortDir: 'ASC'
+        ,stateful: false
+        ,groupTextTpl: '{group} ({[values.rs.length]} {[values.rs.length > 1 ? "'+_('tvs')+'" : "'+_('tv')+'"]})'
+        ,plugins: [this.vcb]
+        ,hideGroupedColumn: true
+        ,columns: [{
+            header: _('category')
+            ,dataIndex: 'category'
+        },{
+            header: _('tv_name')
+            ,dataIndex: 'name'
+            ,width: 200
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=element/tv/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
+        },this.vcb,{
+            header: _('label')
+            ,dataIndex: 'label'
+            ,editor: { xtype: 'textfield' }
+        },{
+            header: _('default_value')
+            ,dataIndex: 'default_value'
+            ,editor: { xtype: 'textfield' }
+            ,renderer: function(v) { return Ext.util.Format.htmlEncode(v); }
+        },{
+            header: _('original_value')
+            ,dataIndex: 'default_text'
+            ,editable: false
+        },{
+            header: _('region')
+            ,dataIndex: 'tab'
+            ,width: 100
+            ,editor: { xtype: 'textfield' }
+        },{
+            header: _('tab_rank')
+            ,dataIndex: 'rank'
+            ,width: 70
+            ,editor: { xtype: 'textfield' }
+        }]
+        ,viewConfig: {
+            forceFit:true
+            ,enableRowBody:true
+            ,scrollOffset: 0
+            ,autoFill: true
+            ,showPreview: true
+            ,getRowClass : function(rec, ri, p){
+                return rec.data.visible ? 'grid-row-active' : 'grid-row-inactive';
+            }
+        }
+    });
+    MODx.grid.FCSetTVs.superclass.constructor.call(this,config);
+    this.propRecord = Ext.data.Record.create(config.fields);
+};
+Ext.extend(MODx.grid.FCSetTVs,MODx.grid.LocalGrid,{
+});
+Ext.reg('modx-grid-fc-set-tvs',MODx.grid.FCSetTVs);
 
+/**
+ * @class MODx.window.AddTabToSet
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-fc-set-add-tab
+ */
 MODx.window.AddTabToSet = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -416,72 +516,3 @@ Ext.extend(MODx.window.AddTabToSet,MODx.Window,{
     }
 });
 Ext.reg('modx-window-fc-set-add-tab',MODx.window.AddTabToSet);
-
-MODx.grid.FCSetTVs = function(config) {
-    config = config || {};
-    this.vcb = new Ext.ux.grid.CheckColumn({
-        header: _('visible')
-        ,dataIndex: 'visible'
-        ,width: 40
-        ,sortable: false
-    });
-    Ext.applyIf(config,{
-        id: 'modx-grid-fc-set-tvs'
-        ,fields: ['id','name','tab','rank','visible','label','default_value','category','default_text']
-        ,autoHeight: true
-        ,grouping: true
-        ,groupBy: 'category'
-        ,sortBy: 'rank'
-        ,sortDir: 'ASC'
-        ,stateful: false
-        ,groupTextTpl: '{group} ({[values.rs.length]} {[values.rs.length > 1 ? "'+_('tvs')+'" : "'+_('tv')+'"]})'
-        ,plugins: [this.vcb]
-        ,hideGroupedColumn: true
-        ,columns: [{
-            header: _('category')
-            ,dataIndex: 'category'
-        },{
-            header: _('tv_name')
-            ,dataIndex: 'name'
-            ,width: 200
-        },this.vcb,{
-            header: _('label')
-            ,dataIndex: 'label'
-            ,editor: { xtype: 'textfield' }
-        },{
-            header: _('default_value')
-            ,dataIndex: 'default_value'
-            ,editor: { xtype: 'textfield' }
-            ,renderer: function(v) { return Ext.util.Format.htmlEncode(v); }
-        },{
-            header: _('original_value')
-            ,dataIndex: 'default_text'
-            ,editable: false
-        },{
-            header: _('region')
-            ,dataIndex: 'tab'
-            ,width: 100
-            ,editor: { xtype: 'textfield' }
-        },{
-            header: _('tab_rank')
-            ,dataIndex: 'rank'
-            ,width: 70
-            ,editor: { xtype: 'textfield' }
-        }]
-        ,viewConfig: {
-            forceFit:true
-            ,enableRowBody:true
-            ,scrollOffset: 0
-            ,autoFill: true
-            ,showPreview: true
-            ,getRowClass : function(rec, ri, p){
-                return rec.data.visible ? 'grid-row-active' : 'grid-row-inactive';
-            }
-        }
-    });
-    MODx.grid.FCSetTVs.superclass.constructor.call(this,config);
-    this.propRecord = Ext.data.Record.create(config.fields);
-};
-Ext.extend(MODx.grid.FCSetTVs,MODx.grid.LocalGrid,{
-});
-Ext.reg('modx-grid-fc-set-tvs',MODx.grid.FCSetTVs);

--- a/manager/assets/modext/widgets/modx.panel.search.js
+++ b/manager/assets/modext/widgets/modx.panel.search.js
@@ -266,7 +266,7 @@ MODx.grid.Search = function(config) {
             ,dataIndex: 'pagetitle'
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=resource/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/modx.panel.search.js
+++ b/manager/assets/modext/widgets/modx.panel.search.js
@@ -10,7 +10,7 @@ MODx.panel.Search = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-search'
-		,cls: 'container form-with-labels'
+        ,cls: 'container form-with-labels'
         ,labelAlign: 'top'
         ,autoHeight: true
         ,items: [{
@@ -265,6 +265,12 @@ MODx.grid.Search = function(config) {
             header: _('pagetitle')
             ,dataIndex: 'pagetitle'
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=resource/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'

--- a/manager/assets/modext/widgets/resource/modx.grid.resource.security.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.resource.security.js
@@ -1,3 +1,9 @@
+/**
+ * @class MODx.grid.ResourceSecurity
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-resource-security
+ */
 MODx.grid.ResourceSecurity = function(config) {
     config = config || {};
     var ac = new Ext.ux.grid.CheckColumn({
@@ -31,6 +37,12 @@ MODx.grid.ResourceSecurity = function(config) {
             ,dataIndex: 'name'
             ,width: 200
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/resourcegroup'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },ac]
     });
     MODx.grid.ResourceSecurity.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/resource/modx.grid.resource.security.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.resource.security.js
@@ -38,7 +38,7 @@ MODx.grid.ResourceSecurity = function(config) {
             ,width: 200
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/resourcegroup'
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/resource/modx.grid.resource.security.local.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.resource.security.local.js
@@ -1,3 +1,9 @@
+/**
+ * @class MODx.grid.ResourceSecurity
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-resource-security
+ */
 MODx.grid.ResourceSecurity = function(config) {
     config = config || {};
     var ac = new Ext.ux.grid.CheckColumn({
@@ -19,6 +25,12 @@ MODx.grid.ResourceSecurity = function(config) {
             ,dataIndex: 'name'
             ,width: 200
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/resourcegroup'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },ac]
     });
     MODx.grid.ResourceSecurity.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/resource/modx.grid.resource.security.local.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.resource.security.local.js
@@ -26,7 +26,7 @@ MODx.grid.ResourceSecurity = function(config) {
             ,width: 200
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/resourcegroup'
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
@@ -52,40 +52,54 @@ MODx.grid.ResourceSchedule = function(config) {
             action: 'Resource/Event/GetList'
             ,mode: 'pub_date'
         }
-        ,fields: ['id','pagetitle','class_key'
+        ,fields: [
+            'id'
+            ,'pagetitle'
+            ,'class_key'
             ,{name: 'pub_date', type: 'date'}
             ,{name: 'unpub_date', type:'date'}
-            ,'menu']
+            ,'menu'
+        ]
         ,paging: true
         ,save_action: 'Resource/Event/UpdateFromGrid'
         ,autosave: true
-        ,columns: [
-            { header: _('id') ,dataIndex: 'id' ,width: 40 }
-            ,{ header: _('pagetitle') ,dataIndex: 'pagetitle' ,width: 40 }
-            ,{
-                header: _('publish_date')
-                ,dataIndex: 'pub_date'
-                ,width: 150
-                ,editor: {
-                    xtype: 'xdatetime'
-                    ,dateFormat: MODx.config.manager_date_format
-                    ,timeFormat: MODx.config.manager_time_format
-                    ,ctCls: 'x-datetime-inline-editor'
-                }
-                ,renderer: Ext.util.Format.dateRenderer(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)
-            },{
-                header: _('unpublish_date')
-                ,dataIndex: 'unpub_date'
-                ,width: 150
-                ,editor: {
-                    xtype: 'xdatetime'
-                    ,dateFormat: MODx.config.manager_date_format
-                    ,timeFormat: MODx.config.manager_time_format
-                    ,ctCls: 'x-datetime-inline-editor'
-                }
-                ,renderer: Ext.util.Format.dateRenderer(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)
+        ,columns: [{
+            header: _('id')
+            ,dataIndex: 'id'
+            ,width: 40
+        },{
+            header: _('pagetitle')
+            ,dataIndex: 'pagetitle'
+            ,width: 40
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=resource/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
+        },{
+            header: _('publish_date')
+            ,dataIndex: 'pub_date'
+            ,width: 150
+            ,editor: {
+                xtype: 'xdatetime'
+                ,dateFormat: MODx.config.manager_date_format
+                ,timeFormat: MODx.config.manager_time_format
+                ,ctCls: 'x-datetime-inline-editor'
             }
-        ]
+            ,renderer: Ext.util.Format.dateRenderer(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)
+        },{
+            header: _('unpublish_date')
+            ,dataIndex: 'unpub_date'
+            ,width: 150
+            ,editor: {
+                xtype: 'xdatetime'
+                ,dateFormat: MODx.config.manager_date_format
+                ,timeFormat: MODx.config.manager_time_format
+                ,ctCls: 'x-datetime-inline-editor'
+            }
+            ,renderer: Ext.util.Format.dateRenderer(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)
+        }]
         ,tbar: [{
             text: _('showing_pub')
             ,scope: this

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
@@ -72,7 +72,7 @@ MODx.grid.ResourceSchedule = function(config) {
             ,dataIndex: 'pagetitle'
             ,width: 40
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=resource/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.access.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.context.js
@@ -28,7 +28,7 @@ MODx.grid.AccessContext = function(config) {
             ,dataIndex: 'principal_name'
             ,width: 120
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/usergroup/update&id=' + record.data.principal
                     ,target: '_blank'
                 });
@@ -42,7 +42,7 @@ MODx.grid.AccessContext = function(config) {
             ,dataIndex: 'policy_name'
             ,width: 175
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.policy
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.access.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.context.js
@@ -19,12 +19,35 @@ MODx.grid.AccessContext = function(config) {
         ,fields: ['id','target','target_name','principal_class','principal','principal_name','authority','policy','policy_name','cls']
         ,type: 'modAccessContext'
         ,paging: true
-        ,columns: [
-            { header: _('context') ,dataIndex: 'target_name' ,width: 100 }
-            ,{ header: _('user_group') ,dataIndex: 'principal_name' ,width: 120 }
-            ,{ header: _('authority') ,dataIndex: 'authority' ,width: 50 }
-            ,{ header: _('policy') ,dataIndex: 'policy_name' ,width: 175 }
-        ]
+        ,columns: [{
+            header: _('context')
+            ,dataIndex: 'target_name'
+            ,width: 100
+        },{
+            header: _('user_group')
+            ,dataIndex: 'principal_name'
+            ,width: 120
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/usergroup/update&id=' + record.data.principal
+                    ,target: '_blank'
+                });
+            }, scope: this }
+        },{
+            header: _('authority')
+            ,dataIndex: 'authority'
+            ,width: 50
+        },{
+            header: _('policy')
+            ,dataIndex: 'policy_name'
+            ,width: 175
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.policy
+                    ,target: '_blank'
+                });
+            }, scope: this }
+        }]
         ,tbar: [{
             text: _('acl_add')
             ,cls: 'primary-button'
@@ -119,15 +142,19 @@ Ext.extend(MODx.grid.AccessContext,MODx.grid.Grid,{
                 ,type: this.config.type || 'modAccessContext'
             }
             ,listeners: {
-            	'success': {fn:this.refresh,scope:this}
+                'success': {fn:this.refresh,scope:this}
             }
         });
     }
-
 });
 Ext.reg('modx-grid-access-context',MODx.grid.AccessContext);
 
-
+/**
+ * @class MODx.window.CreateAccessContext
+ * @extends MODx.window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-access-context-create
+ */
 MODx.window.CreateAccessContext = function(config) {
     config = config || {};
     var r = config.record;
@@ -187,6 +214,12 @@ MODx.window.CreateAccessContext = function(config) {
 Ext.extend(MODx.window.CreateAccessContext,MODx.Window);
 Ext.reg('modx-window-access-context-create',MODx.window.CreateAccessContext);
 
+/**
+ * @class MODx.window.UpdateAccessContext
+ * @extends MODx.window.CreateAccessContext
+ * @param {Object} config An object of options.
+ * @xtype modx-window-access-context-update
+ */
 MODx.window.UpdateAccessContext = function(config) {
     config = config || {};
     var r = config.record;

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -62,6 +62,11 @@ MODx.grid.AccessPolicy = function(config) {
             ,width: 200
             ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.id
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -71,6 +76,12 @@ MODx.grid.AccessPolicy = function(config) {
             header: _('policy_template')
             ,dataIndex: 'template_name'
             ,width: 375
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/template/update&id=' + record.data.template
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('active_permissions')
             ,dataIndex: 'active_of'
@@ -137,11 +148,11 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
         return true;
     }
     ,clearFilter: function() {
-    	this.getStore().baseParams = {
+        this.getStore().baseParams = {
             action: 'Security/Access/Policy/GetList'
-    	};
+        };
         Ext.getCmp('modx-policy-search').reset();
-    	this.getBottomToolbar().changePage(1);
+        this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
 
@@ -335,7 +346,12 @@ MODx.window.CreateAccessPolicy = function(config) {
 Ext.extend(MODx.window.CreateAccessPolicy,MODx.Window);
 Ext.reg('modx-window-access-policy-create',MODx.window.CreateAccessPolicy);
 
-
+/**
+ * @class MODx.window.AccessPolicyTemplate
+ * @extends MODx.combo.ComboBox
+ * @param {Object} config An object of options.
+ * @xtype modx-combo-access-policy-template
+ */
 MODx.combo.AccessPolicyTemplate = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -360,6 +376,12 @@ MODx.combo.AccessPolicyTemplate = function(config) {
 Ext.extend(MODx.combo.AccessPolicyTemplate,MODx.combo.ComboBox);
 Ext.reg('modx-combo-access-policy-template',MODx.combo.AccessPolicyTemplate);
 
+/**
+ * @class MODx.window.ImportPolicy
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-policy-import
+ */
 MODx.window.ImportPolicy = function(config) {
     config = config || {};
     this.ident = config.ident || 'imppol-'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -63,7 +63,7 @@ MODx.grid.AccessPolicy = function(config) {
             ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.id
                 });
             }, scope: this }
@@ -77,7 +77,7 @@ MODx.grid.AccessPolicy = function(config) {
             ,dataIndex: 'template_name'
             ,width: 375
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/template/update&id=' + record.data.template
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -62,6 +62,11 @@ MODx.grid.AccessPolicyTemplate = function(config) {
             ,width: 200
             ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/template/update&id=' + record.data.id
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -132,78 +137,7 @@ MODx.grid.AccessPolicyTemplate = function(config) {
     MODx.grid.AccessPolicyTemplate.superclass.constructor.call(this,config);
 };
 Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
-    search: function(tf,newValue,oldValue) {
-        var nv = newValue || tf;
-        this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
-        this.getBottomToolbar().changePage(1);
-       // this.refresh();
-        return true;
-    }
-    ,clearFilter: function() {
-    	this.getStore().baseParams = {
-            action: 'Security/Access/Policy/Template/GetList'
-    	};
-        Ext.getCmp('modx-policy-template-search').reset();
-    	this.getBottomToolbar().changePage(1);
-       // this.refresh();
-    }
-    ,editPolicyTemplate: function(itm,e) {
-        MODx.loadPage('Security/Access/Policy/Template/Update', 'id='+this.menu.record.id);
-    }
-
-    ,createPolicyTemplate: function(btn,e) {
-        var r = this.menu.record;
-        if (!this.windows.aptc) {
-            this.windows.aptc = MODx.load({
-                xtype: 'modx-window-access-policy-template-create'
-                ,record: r
-                ,plugin: this.config.plugin
-                ,listeners: {
-                    'success': {fn:function(r) {
-                        this.refresh();
-                    },scope:this}
-                }
-            });
-        }
-        this.windows.aptc.reset();
-        this.windows.aptc.show(e.target);
-    }
-    ,exportPolicyTemplate: function(btn,e) {
-        var id = this.menu.record.id;
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
-                action: 'Security/Access/Policy/Template/Export'
-                ,id: id
-            }
-            ,listeners: {
-                'success': {fn:function(r) {
-                    location.href = this.config.url+'?action=Security/Access/Policy/Template/Export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
-                },scope:this}
-            }
-        });
-    }
-
-    ,importPolicyTemplate: function(btn,e) {
-        var r = {};
-        if (!this.windows.importPolicyTemplate) {
-            this.windows.importPolicyTemplate = MODx.load({
-                xtype: 'modx-window-policy-template-import'
-                ,record: r
-                ,listeners: {
-                    'success': {fn:function(o) {
-                        this.refresh();
-                    },scope:this}
-                }
-            });
-        }
-        this.windows.importPolicyTemplate.reset();
-        this.windows.importPolicyTemplate.setValues(r);
-        this.windows.importPolicyTemplate.show(e.target);
-    }
-
-
-    ,getMenu: function() {
+    getMenu: function() {
         var r = this.getSelectionModel().getSelected();
         var p = r.data.cls;
 
@@ -244,6 +178,63 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
             this.addContextMenuItem(m);
         }
     }
+
+    ,createPolicyTemplate: function(btn,e) {
+        var r = this.menu.record;
+        if (!this.windows.aptc) {
+            this.windows.aptc = MODx.load({
+                xtype: 'modx-window-access-policy-template-create'
+                ,record: r
+                ,plugin: this.config.plugin
+                ,listeners: {
+                    'success': {fn:function(r) {
+                        this.refresh();
+                    },scope:this}
+                }
+            });
+        }
+        this.windows.aptc.reset();
+        this.windows.aptc.show(e.target);
+    }
+
+    ,importPolicyTemplate: function(btn,e) {
+        var r = {};
+        if (!this.windows.importPolicyTemplate) {
+            this.windows.importPolicyTemplate = MODx.load({
+                xtype: 'modx-window-policy-template-import'
+                ,record: r
+                ,listeners: {
+                    'success': {fn:function(o) {
+                        this.refresh();
+                    },scope:this}
+                }
+            });
+        }
+        this.windows.importPolicyTemplate.reset();
+        this.windows.importPolicyTemplate.setValues(r);
+        this.windows.importPolicyTemplate.show(e.target);
+    }
+
+    ,exportPolicyTemplate: function(btn,e) {
+        var id = this.menu.record.id;
+        MODx.Ajax.request({
+            url: this.config.url
+            ,params: {
+                action: 'Security/Access/Policy/Template/Export'
+                ,id: id
+            }
+            ,listeners: {
+                'success': {fn:function(r) {
+                    location.href = this.config.url+'?action=Security/Access/Policy/Template/Export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
+                },scope:this}
+            }
+        });
+    }
+
+    ,editPolicyTemplate: function(itm,e) {
+        MODx.loadPage('Security/Access/Policy/Template/Update', 'id='+this.menu.record.id);
+    }
+
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -265,8 +256,54 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
         });
         return true;
     }
+
+    ,search: function(tf,newValue,oldValue) {
+        var nv = newValue || tf;
+        this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
+        this.getBottomToolbar().changePage(1);
+       // this.refresh();
+        return true;
+    }
+
+    ,clearFilter: function() {
+        this.getStore().baseParams = {
+            action: 'Security/Access/Policy/Template/GetList'
+        };
+        Ext.getCmp('modx-policy-template-search').reset();
+        this.getBottomToolbar().changePage(1);
+       // this.refresh();
+    }
 });
 Ext.reg('modx-grid-access-policy-templates',MODx.grid.AccessPolicyTemplate);
+
+/**
+ * @class MODx.combo.AccessPolicyTemplateGroups
+ * @extends MODx.combo.ComboBox
+ * @param {Object} config An object of options.
+ * @xtype modx-combo-access-policy-template-group
+ */
+MODx.combo.AccessPolicyTemplateGroups = function(config) {
+    config = config || {};
+    Ext.applyIf(config,{
+        name: 'template_group'
+        ,hiddenName: 'template_group'
+        ,fields: ['id','name','description']
+        ,forceSelection: true
+        ,typeAhead: false
+        ,editable: false
+        ,allowBlank: false
+        // ,listWidth: 300
+        ,url: MODx.config.connector_url
+        ,baseParams: {
+            action: 'Security/Access/Policy/Template/Group/GetList'
+        }
+        ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{name:htmlEncode}</span>'
+            ,'<p style="margin: 0; font-size: 11px; color: gray;">{description:htmlEncode}</p></div></tpl>')
+    });
+    MODx.combo.AccessPolicyTemplateGroups.superclass.constructor.call(this,config);
+};
+Ext.extend(MODx.combo.AccessPolicyTemplateGroups,MODx.combo.ComboBox);
+Ext.reg('modx-combo-access-policy-template-group',MODx.combo.AccessPolicyTemplateGroups);
 
 /**
  * Generates a window for creating Access Policies.
@@ -327,31 +364,12 @@ MODx.window.CreateAccessPolicyTemplate = function(config) {
 Ext.extend(MODx.window.CreateAccessPolicyTemplate,MODx.Window);
 Ext.reg('modx-window-access-policy-template-create',MODx.window.CreateAccessPolicyTemplate);
 
-
-MODx.combo.AccessPolicyTemplateGroups = function(config) {
-    config = config || {};
-    Ext.applyIf(config,{
-        name: 'template_group'
-        ,hiddenName: 'template_group'
-        ,fields: ['id','name','description']
-        ,forceSelection: true
-        ,typeAhead: false
-        ,editable: false
-        ,allowBlank: false
-        // ,listWidth: 300
-        ,url: MODx.config.connector_url
-        ,baseParams: {
-            action: 'Security/Access/Policy/Template/Group/GetList'
-        }
-        ,tpl: new Ext.XTemplate('<tpl for="."><div class="x-combo-list-item"><span style="font-weight: bold">{name:htmlEncode}</span>'
-            ,'<p style="margin: 0; font-size: 11px; color: gray;">{description:htmlEncode}</p></div></tpl>')
-    });
-    MODx.combo.AccessPolicyTemplateGroups.superclass.constructor.call(this,config);
-};
-Ext.extend(MODx.combo.AccessPolicyTemplateGroups,MODx.combo.ComboBox);
-Ext.reg('modx-combo-access-policy-template-group',MODx.combo.AccessPolicyTemplateGroups);
-
-
+/**
+ * @class MODx.window.ImportPolicyTemplate
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-policy-template-import
+ */
 MODx.window.ImportPolicyTemplate = function(config) {
     config = config || {};
     this.ident = config.ident || 'imppt-'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -63,7 +63,7 @@ MODx.grid.AccessPolicyTemplate = function(config) {
             ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/template/update&id=' + record.data.id
                 });
             }, scope: this }

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
@@ -39,7 +39,7 @@ MODx.grid.UserGroupCategory = function(config) {
             ,dataIndex: 'authority_name'
             ,width: 100
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });
@@ -49,7 +49,7 @@ MODx.grid.UserGroupCategory = function(config) {
             ,dataIndex: 'policy_name'
             ,width: 200
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.policy
                     ,target: '_blank'
                 });
@@ -60,7 +60,7 @@ MODx.grid.UserGroupCategory = function(config) {
             ,width: 150
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=context/update&key=' + record.data.context_key
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
@@ -1,4 +1,9 @@
-
+/**
+ * @class MODx.grid.UserGroupCategory
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-user-group-categories
+ */
 MODx.grid.UserGroupCategory = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -33,15 +38,33 @@ MODx.grid.UserGroupCategory = function(config) {
             header: _('minimum_role')
             ,dataIndex: 'authority_name'
             ,width: 100
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('policy')
             ,dataIndex: 'policy_name'
             ,width: 200
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.policy
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('context')
             ,dataIndex: 'context_key'
             ,width: 150
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=context/update&key=' + record.data.context_key
+                    ,target: '_blank'
+                });
+            }, scope: this }
         }]
         ,tbar: [{
             text: _('category_add')
@@ -88,6 +111,7 @@ Ext.extend(MODx.grid.UserGroupCategory,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         this.refresh();
     }
+
     ,filterPolicy: function(cb,rec,ri) {
         this.getStore().baseParams['policy'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
@@ -102,6 +126,7 @@ Ext.extend(MODx.grid.UserGroupCategory,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,createAcl: function(itm,e) {
         var r = {
             principal: this.config.usergroup
@@ -121,6 +146,7 @@ Ext.extend(MODx.grid.UserGroupCategory,MODx.grid.Grid,{
         this.windows.createAcl.setValues(r);
         this.windows.createAcl.show(e.target);
     }
+
     ,updateAcl: function(itm,e) {
         var r = this.menu.record;
 
@@ -142,7 +168,12 @@ Ext.extend(MODx.grid.UserGroupCategory,MODx.grid.Grid,{
 });
 Ext.reg('modx-grid-user-group-category',MODx.grid.UserGroupCategory);
 
-
+/**
+ * @class MODx.window.CreateUGCat
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-category-create
+ */
 MODx.window.CreateUGCat = function(config) {
     config = config || {};
     this.ident = config.ident || 'cugcat'+Ext.id();
@@ -270,7 +301,12 @@ Ext.extend(MODx.window.CreateUGCat,MODx.Window,{
 });
 Ext.reg('modx-window-user-group-category-create',MODx.window.CreateUGCat);
 
-
+/**
+ * @class MODx.window.UpdateUGCat
+ * @extends MODx.window.CreateUGCat
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-category-update
+ */
 MODx.window.UpdateUGCat = function(config) {
     config = config || {};
     this.ident = config.ident || 'updugcat'+Ext.id();
@@ -281,5 +317,5 @@ MODx.window.UpdateUGCat = function(config) {
     });
     MODx.window.UpdateUGCat.superclass.constructor.call(this,config);
 };
-Ext.extend(MODx.window.UpdateUGCat, MODx.window.CreateUGCat);
+Ext.extend(MODx.window.UpdateUGCat,MODx.window.CreateUGCat);
 Ext.reg('modx-window-user-group-category-update',MODx.window.UpdateUGCat);

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -35,7 +35,7 @@ MODx.grid.UserGroupContext = function(config) {
             ,width: 120
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=context/update&key=' + record.data.target
                     ,target: '_blank'
                 });
@@ -46,7 +46,7 @@ MODx.grid.UserGroupContext = function(config) {
             ,width: 100
             ,sortable: false
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });
@@ -57,7 +57,7 @@ MODx.grid.UserGroupContext = function(config) {
             ,width: 200
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.policy
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -1,4 +1,9 @@
-
+/**
+ * @class MODx.grid.UserGroupContext
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-user-group-contexts
+ */
 MODx.grid.UserGroupContext = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -29,16 +34,34 @@ MODx.grid.UserGroupContext = function(config) {
             ,dataIndex: 'target'
             ,width: 120
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=context/update&key=' + record.data.target
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('minimum_role')
             ,dataIndex: 'authority_name'
             ,width: 100
             ,sortable: false
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('policy')
             ,dataIndex: 'policy_name'
             ,width: 200
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.policy
+                    ,target: '_blank'
+                });
+            }, scope: this }
         }]
         ,tbar: [{
             text: _('context_add')
@@ -112,6 +135,7 @@ Ext.extend(MODx.grid.UserGroupContext,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,filterPolicy: function(cb,rec,ri) {
         this.getStore().baseParams['policy'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
@@ -146,6 +170,7 @@ Ext.extend(MODx.grid.UserGroupContext,MODx.grid.Grid,{
         this.windows.createAcl.setValues(r);
         this.windows.createAcl.show(e.target);
     }
+
     ,updateAcl: function(itm,e) {
         var r = this.menu.record;
 
@@ -167,7 +192,12 @@ Ext.extend(MODx.grid.UserGroupContext,MODx.grid.Grid,{
 });
 Ext.reg('modx-grid-user-group-context',MODx.grid.UserGroupContext);
 
-
+/**
+ * @class MODx.window.CreateUGAccessContext
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-context-create
+ */
 MODx.window.CreateUGAccessContext = function(config) {
     config = config || {};
     this.ident = config.ident || 'cugactx'+Ext.id();
@@ -277,7 +307,12 @@ Ext.extend(MODx.window.CreateUGAccessContext,MODx.Window,{
 });
 Ext.reg('modx-window-user-group-context-create',MODx.window.CreateUGAccessContext);
 
-
+/**
+ * @class MODx.window.UpdateUGAccessContext
+ * @extends MODx.window.CreateUGAccessContext
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-context-update
+ */
 MODx.window.UpdateUGAccessContext = function(config) {
     config = config || {};
     this.ident = config.ident || 'uugactx'+Ext.id();
@@ -289,4 +324,3 @@ MODx.window.UpdateUGAccessContext = function(config) {
 };
 Ext.extend(MODx.window.UpdateUGAccessContext,MODx.window.CreateUGAccessContext);
 Ext.reg('modx-window-user-group-context-update',MODx.window.UpdateUGAccessContext);
-

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -27,10 +27,22 @@ MODx.grid.UserGroups = function(config) {
             header: _('user_group')
             ,dataIndex: 'name'
             ,width: 175
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/usergroup/update&id=' + record.data.usergroup
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('role')
             ,dataIndex: 'rolename'
             ,width: 175
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('rank')
             ,dataIndex: 'rank'
@@ -58,8 +70,29 @@ MODx.grid.UserGroups = function(config) {
     this.addEvents('beforeUpdateRole','afterUpdateRole','beforeAddGroup','afterAddGroup','beforeReorderGroup','afterReorderGroup');
 };
 Ext.extend(MODx.grid.UserGroups,MODx.grid.LocalGrid,{
+    _showMenu: function(g,ri,e) {
+        e.stopEvent();
+        e.preventDefault();
+        var m = this.menu;
+        m.recordIndex = ri;
+        m.record = this.getStore().getAt(ri).data;
+        if (!this.getSelectionModel().isSelected(ri)) {
+            this.getSelectionModel().selectRow(ri);
+        }
+        m.removeAll();
+        m.add({
+            text: _('user_role_update')
+            ,handler: this.updateRole
+            ,scope: this
+        },'-',{
+            text: _('user_group_user_remove')
+            ,handler: this.remove.createDelegate(this,[{text: _('user_group_remove_confirm')}])
+            ,scope: this
+        });
+        m.showAt(e.xy);
+    }
 
-    onBeforeRowMove: function(dt,sri,ri,sels) {
+    ,onBeforeRowMove: function(dt,sri,ri,sels) {
         if (!this.fireEvent('beforeReorderGroup',{dt:dt,sri:sri,ri:ri,sels:sels})) {
             return false;
         }
@@ -87,6 +120,7 @@ Ext.extend(MODx.grid.UserGroups,MODx.grid.LocalGrid,{
         this.fireEvent('afterReorderGroup');
         return true;
     }
+
     ,updateRole: function(btn,e) {
         var r = this.menu.record;
         r.user = this.config.user;
@@ -107,6 +141,7 @@ Ext.extend(MODx.grid.UserGroups,MODx.grid.LocalGrid,{
             }
         });
     }
+
     ,addGroup: function(btn,e) {
         var r = {member:this.config.user};
         this.fireEvent('beforeUpdateRole',r);
@@ -124,33 +159,15 @@ Ext.extend(MODx.grid.UserGroups,MODx.grid.LocalGrid,{
             }
         });
     }
-
-    ,_showMenu: function(g,ri,e) {
-        e.stopEvent();
-        e.preventDefault();
-        var m = this.menu;
-        m.recordIndex = ri;
-        m.record = this.getStore().getAt(ri).data;
-        if (!this.getSelectionModel().isSelected(ri)) {
-            this.getSelectionModel().selectRow(ri);
-        }
-        m.removeAll();
-        m.add({
-            text: _('user_role_update')
-            ,handler: this.updateRole
-            ,scope: this
-        },'-',{
-            text: _('user_group_user_remove')
-            ,handler: this.remove.createDelegate(this,[{text: _('user_group_remove_confirm')}])
-            ,scope: this
-        });
-        m.showAt(e.xy);
-    }
 });
 Ext.reg('modx-grid-user-groups',MODx.grid.UserGroups);
 
-
-
+/**
+ * @class MODx.window.AddGroupToUser
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-addgroup
+ */
 MODx.window.AddGroupToUser = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -208,8 +225,12 @@ Ext.extend(MODx.window.AddGroupToUser,MODx.Window,{
 });
 Ext.reg('modx-window-user-addgroup',MODx.window.AddGroupToUser);
 
-
-
+/**
+ * @class MODx.window.UpdateUserGroupsRole
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-groups-role-update
+ */
 MODx.window.UpdateUserGroupsRole = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -28,7 +28,7 @@ MODx.grid.UserGroups = function(config) {
             ,dataIndex: 'name'
             ,width: 175
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/usergroup/update&id=' + record.data.usergroup
                     ,target: '_blank'
                 });
@@ -38,7 +38,7 @@ MODx.grid.UserGroups = function(config) {
             ,dataIndex: 'rolename'
             ,width: 175
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
@@ -35,7 +35,7 @@ MODx.grid.UserGroupNamespace = function(config) {
             ,width: 120
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=workspaces/namespace'
                     ,target: '_blank'
                 });
@@ -45,7 +45,7 @@ MODx.grid.UserGroupNamespace = function(config) {
             ,dataIndex: 'authority_name'
             ,width: 100
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });
@@ -55,7 +55,7 @@ MODx.grid.UserGroupNamespace = function(config) {
             ,dataIndex: 'policy_name'
             ,width: 200
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.policy
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
@@ -1,4 +1,9 @@
-
+/**
+ * @class MODx.grid.UserGroupNamespace
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-user-group-namespace
+ */
 MODx.grid.UserGroupNamespace = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -29,14 +34,32 @@ MODx.grid.UserGroupNamespace = function(config) {
             ,dataIndex: 'name'
             ,width: 120
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=workspaces/namespace'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('minimum_role')
             ,dataIndex: 'authority_name'
             ,width: 100
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('policy')
             ,dataIndex: 'policy_name'
             ,width: 200
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.policy
+                    ,target: '_blank'
+                });
+            }, scope: this }
         }]
         ,tbar: [{
             text: _('namespace_add')
@@ -96,6 +119,7 @@ Ext.extend(MODx.grid.UserGroupNamespace,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,createAcl: function(itm,e) {
         var r = {
             principal: this.config.usergroup
@@ -115,6 +139,7 @@ Ext.extend(MODx.grid.UserGroupNamespace,MODx.grid.Grid,{
         this.windows.createAcl.setValues(r);
         this.windows.createAcl.show(e.target);
     }
+
     ,updateAcl: function(itm,e) {
         var r = this.menu.record;
 
@@ -136,7 +161,12 @@ Ext.extend(MODx.grid.UserGroupNamespace,MODx.grid.Grid,{
 });
 Ext.reg('modx-grid-user-group-namespace',MODx.grid.UserGroupNamespace);
 
-
+/**
+ * @class MODx.window.CreateUGNamespace
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-namespace-create
+ */
 MODx.window.CreateUGNamespace = function(config) {
     config = config || {};
     this.ident = config.ident || 'cugnamespace'+Ext.id();
@@ -254,7 +284,12 @@ Ext.extend(MODx.window.CreateUGNamespace,MODx.Window,{
 });
 Ext.reg('modx-window-user-group-namespace-create',MODx.window.CreateUGNamespace);
 
-
+/**
+ * @class MODx.window.UpdateUGNamespace
+ * @extends MODx.window.CreateUGNamespace
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-namespace-update
+ */
 MODx.window.UpdateUGNamespace = function(config) {
     config = config || {};
     this.ident = config.ident || 'updugsrc'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
@@ -1,4 +1,9 @@
-
+/**
+ * @class MODx.grid.UserGroupResourceGroup
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-user-group-resource-groups
+ */
 MODx.grid.UserGroupResourceGroup = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -29,19 +34,43 @@ MODx.grid.UserGroupResourceGroup = function(config) {
             ,dataIndex: 'name'
             ,width: 120
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/resourcegroup'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('minimum_role')
             ,dataIndex: 'authority_name'
             ,width: 100
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('policy')
             ,dataIndex: 'policy_name'
             ,width: 200
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.policy
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('context')
             ,dataIndex: 'context_key'
             ,width: 150
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=context/update&key=' + record.data.context_key
+                    ,target: '_blank'
+                });
+            }, scope: this }
         }]
         ,tbar: [{
             text: _('resource_group_add')
@@ -102,6 +131,7 @@ Ext.extend(MODx.grid.UserGroupResourceGroup,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,createAcl: function(itm,e) {
         var r = {
             principal: this.config.usergroup
@@ -121,6 +151,7 @@ Ext.extend(MODx.grid.UserGroupResourceGroup,MODx.grid.Grid,{
         this.windows.createAcl.setValues(r);
         this.windows.createAcl.show(e.target);
     }
+
     ,updateAcl: function(itm,e) {
         var r = this.menu.record;
 
@@ -142,7 +173,12 @@ Ext.extend(MODx.grid.UserGroupResourceGroup,MODx.grid.Grid,{
 });
 Ext.reg('modx-grid-user-group-resource-group',MODx.grid.UserGroupResourceGroup);
 
-
+/**
+ * @class MODx.window.CreateUGRG
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-resourcegroup-create
+ */
 MODx.window.CreateUGRG = function(config) {
     config = config || {};
     this.ident = config.ident || 'crgactx'+Ext.id();
@@ -269,7 +305,12 @@ Ext.extend(MODx.window.CreateUGRG,MODx.Window,{
 });
 Ext.reg('modx-window-user-group-resourcegroup-create',MODx.window.CreateUGRG);
 
-
+/**
+ * @class MODx.window.UpdateUGRG
+ * @extends MODx.window.CreateUGRG
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-resourcegroup-update
+ */
 MODx.window.UpdateUGRG = function(config) {
     config = config || {};
     this.ident = config.ident || 'ugrgactx'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
@@ -35,7 +35,7 @@ MODx.grid.UserGroupResourceGroup = function(config) {
             ,width: 120
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/resourcegroup'
                     ,target: '_blank'
                 });
@@ -45,7 +45,7 @@ MODx.grid.UserGroupResourceGroup = function(config) {
             ,dataIndex: 'authority_name'
             ,width: 100
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });
@@ -55,7 +55,7 @@ MODx.grid.UserGroupResourceGroup = function(config) {
             ,dataIndex: 'policy_name'
             ,width: 200
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.policy
                     ,target: '_blank'
                 });
@@ -66,7 +66,7 @@ MODx.grid.UserGroupResourceGroup = function(config) {
             ,width: 150
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=context/update&key=' + record.data.context_key
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
@@ -1,4 +1,9 @@
-
+/**
+ * @class MODx.grid.UserGroupSource
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-user-group-sources
+ */
 MODx.grid.UserGroupSource = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -29,14 +34,32 @@ MODx.grid.UserGroupSource = function(config) {
             ,dataIndex: 'name'
             ,width: 120
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=source/update&id=' + record.data.target
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('minimum_role')
             ,dataIndex: 'authority_name'
             ,width: 100
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('policy')
             ,dataIndex: 'policy_name'
             ,width: 200
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.policy
+                    ,target: '_blank'
+                });
+            }, scope: this }
         }]
         ,tbar: [{
             text: _('source_add')
@@ -83,6 +106,7 @@ Ext.extend(MODx.grid.UserGroupSource,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,filterPolicy: function(cb,rec,ri) {
         this.getStore().baseParams['policy'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
@@ -97,6 +121,7 @@ Ext.extend(MODx.grid.UserGroupSource,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
+
     ,createAcl: function(itm,e) {
         var r = {
             principal: this.config.usergroup
@@ -116,6 +141,7 @@ Ext.extend(MODx.grid.UserGroupSource,MODx.grid.Grid,{
         this.windows.createAcl.setValues(r);
         this.windows.createAcl.show(e.target);
     }
+
     ,updateAcl: function(itm,e) {
         var r = this.menu.record;
 
@@ -137,7 +163,12 @@ Ext.extend(MODx.grid.UserGroupSource,MODx.grid.Grid,{
 });
 Ext.reg('modx-grid-user-group-source',MODx.grid.UserGroupSource);
 
-
+/**
+ * @class MODx.window.CreateUGSource
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-source-create
+ */
 MODx.window.CreateUGSource = function(config) {
     config = config || {};
     this.ident = config.ident || 'cugsrc'+Ext.id();
@@ -255,7 +286,12 @@ Ext.extend(MODx.window.CreateUGSource,MODx.Window,{
 });
 Ext.reg('modx-window-user-group-source-create',MODx.window.CreateUGSource);
 
-
+/**
+ * @class MODx.window.UpdateUGSource
+ * @extends MODx.window.CreateUGSource
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-source-update
+ */
 MODx.window.UpdateUGSource = function(config) {
     config = config || {};
     this.ident = config.ident || 'updugsrc'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
@@ -35,7 +35,7 @@ MODx.grid.UserGroupSource = function(config) {
             ,width: 120
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=source/update&id=' + record.data.target
                     ,target: '_blank'
                 });
@@ -45,7 +45,7 @@ MODx.grid.UserGroupSource = function(config) {
             ,dataIndex: 'authority_name'
             ,width: 100
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });
@@ -55,7 +55,7 @@ MODx.grid.UserGroupSource = function(config) {
             ,dataIndex: 'policy_name'
             ,width: 200
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.policy
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -80,9 +80,11 @@ MODx.grid.User = function(config) {
             ,dataIndex: 'username'
             ,width: 150
             ,sortable: true
-            ,renderer: function(value, p, record){
-                return String.format('<a href="?a=Security/User/Update&id={0}" title="{1}" class="x-grid-link">{2}</a>', record.id, _('user_update'), Ext.util.Format.htmlEncode( value ) );
-            }
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/user/update&id=' + record.data.id
+                });
+            }, scope: this }
         },{
             header: _('user_full_name')
             ,dataIndex: 'fullname'
@@ -230,6 +232,38 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         MODx.loadPage('Security/User/Create');
     }
 
+    ,updateUser: function() {
+        MODx.loadPage('Security/User/Update', 'id='+this.menu.record.id);
+    }
+
+    ,duplicateUser: function() {
+        MODx.Ajax.request({
+            url: this.config.url
+            ,params: {
+                action: 'Security/User/Duplicate'
+                ,id: this.menu.record.id
+            }
+            ,listeners: {
+                'success': {fn:this.refresh,scope:this}
+            }
+        });
+    }
+
+    ,removeUser: function() {
+        MODx.msg.confirm({
+            title: _('user_remove')
+            ,text: _('user_confirm_remove')
+            ,url: this.config.url
+            ,params: {
+                action: 'Security/User/Delete'
+                ,id: this.menu.record.id
+            }
+            ,listeners: {
+                'success': {fn:this.refresh,scope:this}
+            }
+        });
+    }
+
     ,activateSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -249,6 +283,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         });
         return true;
     }
+
     ,deactivateSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -268,6 +303,7 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         });
         return true;
     }
+
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -290,38 +326,6 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         return true;
     }
 
-    ,removeUser: function() {
-        MODx.msg.confirm({
-            title: _('user_remove')
-            ,text: _('user_confirm_remove')
-            ,url: this.config.url
-            ,params: {
-                action: 'Security/User/Delete'
-                ,id: this.menu.record.id
-            }
-            ,listeners: {
-                'success': {fn:this.refresh,scope:this}
-            }
-        });
-    }
-
-    ,duplicateUser: function() {
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
-                action: 'Security/User/Duplicate'
-                ,id: this.menu.record.id
-            }
-            ,listeners: {
-                'success': {fn:this.refresh,scope:this}
-            }
-        });
-    }
-
-    ,updateUser: function() {
-        MODx.loadPage('Security/User/Update', 'id='+this.menu.record.id);
-    }
-
     ,rendGender: function(d,c) {
         switch(d.toString()) {
             case '0':
@@ -338,12 +342,14 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
         this.getBottomToolbar().changePage(1);
         return true;
     }
+
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
         return true;
     }
+
     ,clearFilter: function() {
         this.getStore().baseParams = {
             action: 'Security/User/GetList'

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -81,7 +81,7 @@ MODx.grid.User = function(config) {
             ,width: 150
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/user/update&id=' + record.data.id
                 });
             }, scope: this }

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -29,7 +29,7 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
             header: _('pagetitle')
             ,dataIndex: 'pagetitle'
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=resource/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -28,6 +28,12 @@ MODx.grid.RecentlyEditedResourcesByUser = function(config) {
         },{
             header: _('pagetitle')
             ,dataIndex: 'pagetitle'
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=resource/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('editedon')
             ,dataIndex: 'occurred'

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -357,7 +357,7 @@ MODx.grid.UserGroupUsers = function(config) {
             ,width: 175
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/user/update&id=' + record.data.id
                     ,target: '_blank'
                 });
@@ -368,7 +368,7 @@ MODx.grid.UserGroupUsers = function(config) {
             ,width: 175
             ,sortable: true
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -1,3 +1,9 @@
+/**
+ * @class MODx.panel.UserGroup
+ * @extends MODx.FormPanel
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-panel-user-group
+ */
 MODx.panel.UserGroup = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -320,6 +326,12 @@ Ext.extend(MODx.panel.UserGroup,MODx.FormPanel,{
 });
 Ext.reg('modx-panel-user-group',MODx.panel.UserGroup);
 
+/**
+ * @class MODx.grid.FCProfileUserGroups
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-user-group-users
+ */
 MODx.grid.UserGroupUsers = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -344,11 +356,23 @@ MODx.grid.UserGroupUsers = function(config) {
             ,dataIndex: 'username'
             ,width: 175
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/user/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('role')
             ,dataIndex: 'role_name'
             ,width: 175
             ,sortable: true
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
         }]
         ,tbar: [{
             text: _('user_group_user_add')
@@ -386,7 +410,6 @@ MODx.grid.UserGroupUsers = function(config) {
     this.addEvents('updateRole','addMember');
 };
 Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
-
     getMenu: function() {
         var m = [];
         if (MODx.perm.usergroup_user_edit) {
@@ -402,6 +425,7 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
         }
         return m;
     }
+
     ,searchUser: function(tf,nv,ov) {
         this.getStore().baseParams['username'] = Ext.getCmp('modx-ugu-filter-username').getValue();
         this.getBottomToolbar().changePage(1);
@@ -431,6 +455,7 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
             }
         });
     }
+
     ,addMember: function(btn,e) {
         var r = {usergroup:this.config.usergroup};
 
@@ -450,8 +475,8 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
 
         this.windows['modx-window-user-group-adduser'].setValues(r);
         this.windows['modx-window-user-group-adduser'].show(e.target);
-
     }
+
     ,removeUser: function(btn,e) {
         var r = this.menu.record;
         MODx.msg.confirm({
@@ -471,6 +496,12 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
 });
 Ext.reg('modx-grid-user-group-users',MODx.grid.UserGroupUsers);
 
+/**
+ * @class MODx.window.UpdateUserGroupRole
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-role-update
+ */
 MODx.window.UpdateUserGroupRole = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -498,7 +529,12 @@ MODx.window.UpdateUserGroupRole = function(config) {
 Ext.extend(MODx.window.UpdateUserGroupRole,MODx.Window);
 Ext.reg('modx-window-user-group-role-update',MODx.window.UpdateUserGroupRole);
 
-
+/**
+ * @class MODx.window.AddUserToUserGroup
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-user-group-adduser
+ */
 MODx.window.AddUserToUserGroup = function(config) {
     config = config || {};
     this.ident = config.ident || 'auug'+Ext.id();

--- a/manager/assets/modext/widgets/source/modx.grid.source.access.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.access.js
@@ -18,7 +18,7 @@ MODx.grid.MediaSourceAccess = function(config) {
             ,dataIndex: 'principal_name'
             ,width: 120
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/usergroup/update&id=' + record.data.principal
                     ,target: '_blank'
                 });
@@ -28,7 +28,7 @@ MODx.grid.MediaSourceAccess = function(config) {
             ,dataIndex: 'authority_name'
             ,width: 50
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/permission'
                     ,target: '_blank'
                 });
@@ -38,7 +38,7 @@ MODx.grid.MediaSourceAccess = function(config) {
             ,dataIndex: 'policy_name'
             ,width: 175
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=security/access/policy/update&id=' + record.data.policy
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/source/modx.grid.source.access.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.access.js
@@ -11,13 +11,39 @@ MODx.grid.MediaSourceAccess = function(config) {
     Ext.applyIf(config,{
         id: 'modx-grid-source-access'
         ,fields: ['id','target','target_name','principal_class','principal','principal_name','authority','authority_name','policy','policy_name','context_key']
-		,type: 'modAccessMediaSource'
-		,paging: true
-        ,columns: [
-            { header: _('user_group') ,dataIndex: 'principal_name' ,width: 120 }
-            ,{ header: _('minimum_role') ,dataIndex: 'authority_name' ,width: 50 }
-            ,{ header: _('policy') ,dataIndex: 'policy_name' ,width: 175 }
-        ]
+        ,type: 'modAccessMediaSource'
+        ,paging: true
+        ,columns: [{
+            header: _('user_group')
+            ,dataIndex: 'principal_name'
+            ,width: 120
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/usergroup/update&id=' + record.data.principal
+                    ,target: '_blank'
+                });
+            }, scope: this }
+        },{
+            header: _('minimum_role')
+            ,dataIndex: 'authority_name'
+            ,width: 50
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/permission'
+                    ,target: '_blank'
+                });
+            }, scope: this }
+        },{
+            header: _('policy')
+            ,dataIndex: 'policy_name'
+            ,width: 175
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=security/access/policy/update&id=' + record.data.policy
+                    ,target: '_blank'
+                });
+            }, scope: this }
+        }]
         ,tbar: [{
             text: _('source_access_add')
             ,cls: 'primary-button'
@@ -31,6 +57,25 @@ MODx.grid.MediaSourceAccess = function(config) {
 Ext.extend(MODx.grid.MediaSourceAccess,MODx.grid.LocalGrid,{
     combos: {}
     ,windows: {}
+
+    ,getMenu: function() {
+        var menu = [];
+        if (this.menu.record.id) {
+            menu.push({
+                text: _('source_access_update')
+                ,handler: this.editAcl
+            });
+        }
+        menu.push({
+            text: _('source_access_remove')
+            ,handler: this.remove.createDelegate(this,[{
+                title: _('source_access_remove')
+                ,text: _('source_access_remove_confirm')
+            }])
+        });
+
+        return menu;
+    }
 
     ,createAcl: function(itm,e) {
         var r = {
@@ -98,33 +143,19 @@ Ext.extend(MODx.grid.MediaSourceAccess,MODx.grid.LocalGrid,{
                 ,type: this.config.type || 'modAccessMediaSource'
             }
             ,listeners: {
-            	'success': {fn:this.refresh,scope:this}
+                'success': {fn:this.refresh,scope:this}
             }
         });
     }
-    ,getMenu: function() {
-        var menu = [];
-        if (this.menu.record.id) {
-            menu.push({
-                text: _('source_access_update')
-                ,handler: this.editAcl
-            });
-        }
-        menu.push({
-            text: _('source_access_remove')
-            ,handler: this.remove.createDelegate(this,[{
-                title: _('source_access_remove')
-                ,text: _('source_access_remove_confirm')
-            }])
-        });
-
-        return menu;
-    }
-
 });
 Ext.reg('modx-grid-source-access',MODx.grid.MediaSourceAccess);
 
-
+/**
+ * @class MODx.window.CreateSourceAccess
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-source-access-create
+ */
 MODx.window.CreateSourceAccess = function(config) {
     config = config || {};
     var r = config.record;
@@ -210,6 +241,12 @@ Ext.extend(MODx.window.CreateSourceAccess,MODx.Window,{
 });
 Ext.reg('modx-window-source-access-create',MODx.window.CreateSourceAccess);
 
+/**
+ * @class MODx.window.UpdateSourceAccess
+ * @extends MODx.window.CreateSourceAccess
+ * @param {Object} config An object of options.
+ * @xtype modx-window-source-access-update
+ */
 MODx.window.UpdateSourceAccess = function(config) {
     config = config || {};
     var r = config.record;

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -88,7 +88,7 @@ MODx.grid.Sources = function(config) {
             ,sortable: true
             ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=source/update&id=' + record.data.id
                 });
             }, scope: this }

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -10,7 +10,7 @@ MODx.panel.Sources = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-sources'
-		,cls: 'container'
+        ,cls: 'container'
         ,bodyStyle: ''
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
@@ -25,7 +25,7 @@ MODx.panel.Sources = function(config) {
                 ,xtype: 'modx-description'
             },{
                 xtype: 'modx-grid-sources'
-				,cls: 'main-wrapper'
+                ,cls: 'main-wrapper'
                 ,preventRender: true
             }]
         },{
@@ -36,7 +36,7 @@ MODx.panel.Sources = function(config) {
                 ,xtype: 'modx-description'
             },{
                 xtype: 'modx-grid-source-types'
-				,cls: 'main-wrapper'
+                ,cls: 'main-wrapper'
                 ,preventRender: true
             }]
         }],{
@@ -87,7 +87,11 @@ MODx.grid.Sources = function(config) {
             ,width: 150
             ,sortable: true
             ,editor: { xtype: 'textfield' ,allowBlank: false }
-            ,renderer: Ext.util.Format.htmlEncode
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=source/update&id=' + record.data.id
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -177,6 +181,14 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         }
     }
 
+    ,createSource: function() {
+        MODx.loadPage('system/Source/Create');
+    }
+
+    ,updateSource: function() {
+        MODx.loadPage('Source/Update', 'id='+this.menu.record.id);
+    }
+
     ,duplicateSource: function(btn,e) {
         MODx.Ajax.request({
             url: this.config.url
@@ -190,8 +202,19 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         });
     }
 
-    ,createSource: function() {
-        MODx.loadPage('system/Source/Create');
+    ,removeSource: function() {
+        MODx.msg.confirm({
+            title: _('source_remove')
+            ,text: _('source_remove_confirm')
+            ,url: this.config.url
+            ,params: {
+                action: 'Source/Remove'
+                ,id: this.menu.record.id
+            }
+            ,listeners: {
+                'success': {fn:this.refresh,scope:this}
+            }
+        });
     }
 
     ,removeSelected: function() {
@@ -216,24 +239,6 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         return true;
     }
 
-    ,removeSource: function() {
-        MODx.msg.confirm({
-            title: _('source_remove')
-            ,text: _('source_remove_confirm')
-            ,url: this.config.url
-            ,params: {
-                action: 'Source/Remove'
-                ,id: this.menu.record.id
-            }
-            ,listeners: {
-                'success': {fn:this.refresh,scope:this}
-            }
-        });
-    }
-
-    ,updateSource: function() {
-        MODx.loadPage('Source/Update', 'id='+this.menu.record.id);
-    }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
@@ -241,6 +246,7 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         //this.refresh();
         return true;
     }
+
     ,clearFilter: function() {
         this.getStore().baseParams = {
             action: 'Source/GetList'

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -70,7 +70,7 @@ MODx.grid.Context = function(config) {
             ,sortable: true
             ,editor: { xtype: 'textfield' }
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=context/update&key=' + record.data.key
                 });
             }, scope: this }

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -69,6 +69,11 @@ MODx.grid.Context = function(config) {
             ,width: 150
             ,sortable: true
             ,editor: { xtype: 'textfield' }
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=context/update&key=' + record.data.key
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -120,10 +125,7 @@ MODx.grid.Context = function(config) {
     MODx.grid.Context.superclass.constructor.call(this,config);
 };
 Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
-    updateContext: function(itm,e) {
-        MODx.loadPage('Context/Update', 'key='+this.menu.record.key);
-    }
-    ,getMenu: function() {
+    getMenu: function() {
         var r = this.getSelectionModel().getSelected();
         var p = r.data.perm;
         var m = [];
@@ -153,6 +155,29 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         return m;
     }
 
+    ,create: function(btn, e) {
+        if (this.createWindow) {
+            this.createWindow.destroy();
+        }
+        this.createWindow = MODx.load({
+            xtype		: 'modx-window-context-create',
+            closeAction	:'close',
+            listeners	: {
+                'success'	: {
+                    fn			: function() {
+                        this.afterAction();
+                    },
+                    scope		: this
+                }
+            }
+        });
+        this.createWindow.show(e.target);
+    }
+
+    ,updateContext: function(itm,e) {
+        MODx.loadPage('Context/Update', 'key='+this.menu.record.key);
+    }
+
     ,duplicateContext: function() {
         var r = {
             key: this.menu.record.key
@@ -174,42 +199,6 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         w.show();
     }
 
-    ,search: function(tf,newValue,oldValue) {
-        var nv = newValue || tf;
-        this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
-        this.getBottomToolbar().changePage(1);
-        //this.refresh();
-        return true;
-    }
-
-    ,clearFilter: function() {
-        this.getStore().baseParams = {
-            action: 'Context/GetList'
-        };
-        Ext.getCmp('modx-ctx-search').reset();
-        this.getBottomToolbar().changePage(1);
-        //this.refresh();
-    }
-
-    ,create: function(btn, e) {
-        if (this.createWindow) {
-            this.createWindow.destroy();
-        }
-        this.createWindow = MODx.load({
-            xtype		: 'modx-window-context-create',
-            closeAction	:'close',
-            listeners	: {
-                'success'	: {
-                    fn			: function() {
-                        this.afterAction();
-                    },
-                    scope		: this
-                }
-            }
-        });
-        this.createWindow.show(e.target);
-    }
-
     ,remove: function(btn, e) {
         MODx.msg.confirm({
             title 		: _('warning'),
@@ -228,6 +217,23 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
                 }
             }
         });
+    }
+
+    ,search: function(tf,newValue,oldValue) {
+        var nv = newValue || tf;
+        this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
+        this.getBottomToolbar().changePage(1);
+        //this.refresh();
+        return true;
+    }
+
+    ,clearFilter: function() {
+        this.getStore().baseParams = {
+            action: 'Context/GetList'
+        };
+        Ext.getCmp('modx-ctx-search').reset();
+        this.getBottomToolbar().changePage(1);
+        //this.refresh();
     }
 
     ,afterAction: function() {

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -1,4 +1,9 @@
-
+/**
+ * @class MODx.grid.DashboardWidgets
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-dashboard-widgets
+ */
 MODx.grid.DashboardWidgets = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -29,6 +34,11 @@ MODx.grid.DashboardWidgets = function(config) {
             ,width: 150
             ,sortable: true
             ,editable: false
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=system/dashboards/widget/update&id=' + record.data.id
+                });
+            }, scope: this }
         },{
             header: _('widget_type')
             ,dataIndex: 'type'
@@ -119,6 +129,26 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
     ,createDashboard: function() {
         MODx.loadPage('system/dashboards/widget/create');
     }
+
+    ,updateWidget: function() {
+        MODx.loadPage('system/dashboards/widget/update', 'id='+this.menu.record.id);
+    }
+
+    ,removeWidget: function() {
+        MODx.msg.confirm({
+            title: _('widget_remove')
+            ,text: _('widget_remove_confirm')
+            ,url: this.config.url
+            ,params: {
+                action: 'System/Dashboard/Widget/Remove'
+                ,id: this.menu.record.id
+            }
+            ,listeners: {
+                'success': {fn:this.refresh,scope:this}
+            }
+        });
+    }
+
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -141,24 +171,6 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
         return true;
     }
 
-    ,removeWidget: function() {
-        MODx.msg.confirm({
-            title: _('widget_remove')
-            ,text: _('widget_remove_confirm')
-            ,url: this.config.url
-            ,params: {
-                action: 'System/Dashboard/Widget/Remove'
-                ,id: this.menu.record.id
-            }
-            ,listeners: {
-            	'success': {fn:this.refresh,scope:this}
-            }
-        });
-    }
-
-    ,updateWidget: function() {
-        MODx.loadPage('system/dashboards/widget/update', 'id='+this.menu.record.id);
-    }
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
@@ -166,12 +178,13 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
         //this.refresh();
         return true;
     }
+
     ,clearFilter: function() {
-    	this.getStore().baseParams = {
+        this.getStore().baseParams = {
             action: 'System/Dashboard/Widget/GetList'
-    	};
+        };
         Ext.getCmp('modx-dashboard-widget-search').reset();
-    	this.getBottomToolbar().changePage(1);
+        this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
 });

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -35,7 +35,7 @@ MODx.grid.DashboardWidgets = function(config) {
             ,sortable: true
             ,editable: false
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=system/dashboards/widget/update&id=' + record.data.id
                 });
             }, scope: this }

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -231,7 +231,7 @@ MODx.grid.DashboardWidgetPlacements = function(config) {
             ,dataIndex: 'name_trans'
             ,width: 600
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=system/dashboards/widget/update&id=' + record.data.widget
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -1,3 +1,9 @@
+/**
+ * @class MODx.panel.Dashboard
+ * @extends MODx.FormPanel
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-panel-dashboard
+ */
 MODx.panel.Dashboard = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -9,7 +15,7 @@ MODx.panel.Dashboard = function(config) {
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
-             html: _('dashboard')
+            html: _('dashboard')
             ,id: 'modx-dashboard-header'
             ,xtype: 'modx-header'
         },{
@@ -191,6 +197,12 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
 });
 Ext.reg('modx-panel-dashboard',MODx.panel.Dashboard);
 
+/**
+ * @class MODx.grid.DashboardWidgetPlacements
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-dashboard-widget-placements
+ */
 MODx.grid.DashboardWidgetPlacements = function(config) {
     config = config || {};
     this.exp = new Ext.grid.RowExpander({
@@ -218,6 +230,12 @@ MODx.grid.DashboardWidgetPlacements = function(config) {
             header: _('widget')
             ,dataIndex: 'name_trans'
             ,width: 600
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=system/dashboards/widget/update&id=' + record.data.widget
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('rank')
             ,dataIndex: 'rank'
@@ -300,8 +318,12 @@ Ext.extend(MODx.grid.DashboardWidgetPlacements,MODx.grid.LocalGrid,{
 });
 Ext.reg('modx-grid-dashboard-widget-placements',MODx.grid.DashboardWidgetPlacements);
 
-
-
+/**
+ * @class MODx.window.DashboardWidgetPlace
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-dashboard-widget-place
+ */
 MODx.window.DashboardWidgetPlace = function(config) {
     config = config || {};
     this.ident = config.ident || 'dbugadd'+Ext.id();
@@ -365,7 +387,6 @@ Ext.extend(MODx.window.DashboardWidgetPlace,MODx.Window,{
 });
 Ext.reg('modx-window-dashboard-widget-place',MODx.window.DashboardWidgetPlace);
 
-
 /*
 MODx.grid.DashboardUserGroups = function(config) {
     config = config || {};
@@ -404,13 +425,13 @@ Ext.extend(MODx.grid.DashboardUserGroups,MODx.grid.LocalGrid,{
 
     ,addUserGroup: function(btn,e) {
         this.loadWindow(btn,e,{
-           xtype: 'modx-window-dashboard-usergroup-add'
-           ,listeners: {
+            xtype: 'modx-window-dashboard-usergroup-add'
+            ,listeners: {
                 'success': {fn:function(vs) {
                     var rec = new this.propRecord(vs);
                     this.getStore().add(rec);
                 },scope:this}
-           }
+            }
         });
         var w = Ext.getCmp('modx-window-dashboard-usergroup-add');
         w.reset();
@@ -421,7 +442,6 @@ Ext.extend(MODx.grid.DashboardUserGroups,MODx.grid.LocalGrid,{
     }
 });
 Ext.reg('modx-grid-dashboard-usergroups',MODx.grid.DashboardUserGroups);
-
 
 MODx.window.DashboardUserGroupAdd = function(config) {
     config = config || {};
@@ -464,7 +484,12 @@ Ext.extend(MODx.window.DashboardUserGroupAdd,MODx.Window,{
 Ext.reg('modx-window-dashboard-usergroup-add',MODx.window.DashboardUserGroupAdd);
 */
 
-
+/**
+ * @class MODx.combo.DashboardWidgets
+ * @extends MODx.combo.ComboBox
+ * @param {Object} config An object of options.
+ * @xtype modx-combo-dashboard-widgets
+ */
 MODx.combo.DashboardWidgets = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -1,3 +1,9 @@
+/**
+ * @class MODx.grid.DashboardWidget
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-dashboard-widget-form
+ */
 MODx.panel.DashboardWidget = function(config) {
     config = config || {};
 
@@ -170,7 +176,7 @@ MODx.panel.DashboardWidget = function(config) {
                 html: '<h4>'+_('widget_content')+'</h4>'
                 ,border: false
                 ,anchor: '100%'
-             },*/{
+            },*/{
                 xtype: 'textarea'
                 ,name: 'content'
                 ,fieldLabel: _('widget_content')
@@ -244,7 +250,7 @@ MODx.panel.DashboardWidget = function(config) {
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
-             html: _('widget_new')
+            html: _('widget_new')
             ,id: 'modx-dashboard-widget-header'
             ,xtype: 'modx-header'
         },{
@@ -275,6 +281,7 @@ MODx.panel.DashboardWidget = function(config) {
 };
 Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
     initialized: false
+
     ,setup: function() {
         if (this.initialized) { return false; }
         if (Ext.isEmpty(this.config.record.id)) {
@@ -296,6 +303,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
         MODx.fireEvent('ready');
         this.initialized = true;
     }
+
     ,beforeSubmit: function(o) {
         var g = Ext.getCmp('modx-grid-dashboard-widget-dashboards');
         if (g) {
@@ -311,6 +319,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
             });
         }
     }
+
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
             MODx.loadPage('system/dashboards/widget/update', 'id='+o.result.object.id);
@@ -323,7 +332,12 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
 });
 Ext.reg('modx-panel-dashboard-widget',MODx.panel.DashboardWidget);
 
-
+/**
+ * @class MODx.grid.DashboardWidgetDashboards
+ * @extends MODx.grid.LocalGrid
+ * @param {Object} config An object of options.
+ * @xtype modx-grid-dashboard-widget-dashboards
+ */
 MODx.grid.DashboardWidgetDashboards = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -337,6 +351,12 @@ MODx.grid.DashboardWidgetDashboards = function(config) {
             header: _('dashboard')
             ,dataIndex: 'name'
             ,width: 200
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=system/dashboards/update&id=' + record.data.id
+                    ,target: '_blank'
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -349,8 +369,13 @@ MODx.grid.DashboardWidgetDashboards = function(config) {
 Ext.extend(MODx.grid.DashboardWidgetDashboards,MODx.grid.LocalGrid);
 Ext.reg('modx-grid-dashboard-widget-dashboards',MODx.grid.DashboardWidgetDashboards);
 
-
-/* seems unused */
+/**
+ * SEEMS UNUSED
+ * @class MODx.window.WidgetAddDashboard
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-widget-add-dashboard
+ */
 MODx.window.WidgetAddDashboard = function(config) {
     config = config || {};
     this.ident = config.ident || 'dbugadd'+Ext.id();
@@ -402,6 +427,12 @@ Ext.extend(MODx.window.WidgetAddDashboard,MODx.Window,{
 });
 Ext.reg('modx-window-widget-add-dashboard',MODx.window.WidgetAddDashboard);
 
+/**
+ * @class MODx.combo.DashboardWidgetType
+ * @extends MODx.combo.ComboBox
+ * @param {Object} config An object of options.
+ * @xtype modx-combo-dashboard-widget-type
+ */
 MODx.combo.DashboardWidgetType = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -431,7 +462,12 @@ MODx.combo.DashboardWidgetType = function(config) {
 Ext.extend(MODx.combo.DashboardWidgetType,MODx.combo.ComboBox);
 Ext.reg('modx-combo-dashboard-widget-type',MODx.combo.DashboardWidgetType);
 
-
+/**
+ * @class MODx.combo.DashboardWidgetSize
+ * @extends MODx.combo.ComboBox
+ * @param {Object} config An object of options.
+ * @xtype modx-combo-dashboard-widget-size
+ */
 MODx.combo.DashboardWidgetSize = function(config) {
     config = config || {};
     Ext.applyIf(config,{

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -352,7 +352,7 @@ MODx.grid.DashboardWidgetDashboards = function(config) {
             ,dataIndex: 'name'
             ,width: 200
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=system/dashboards/update&id=' + record.data.id
                     ,target: '_blank'
                 });

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -1,3 +1,9 @@
+/**
+ * @class MODx.panel.Dashboards
+ * @extends MODx.FormPanel
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-panel-dashboards
+ */
 MODx.panel.Dashboards = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -44,6 +50,12 @@ MODx.panel.Dashboards = function(config) {
 Ext.extend(MODx.panel.Dashboards,MODx.FormPanel);
 Ext.reg('modx-panel-dashboards',MODx.panel.Dashboards);
 
+/**
+ * @class MODx.grid.Dashboards
+ * @extends MODx.grid.Grid
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-grid-dashboards
+ */
 MODx.grid.Dashboards = function(config) {
     config = config || {};
 
@@ -70,6 +82,11 @@ MODx.grid.Dashboards = function(config) {
             ,width: 150
             ,sortable: true
             ,editor: { xtype: 'textfield' ,allowBlank: false }
+            ,renderer: { fn: function(v,md,record) {
+                return this.rendLink(v, {
+                    href: '?a=system/dashboards/update&id=' + record.data.id
+                });
+            }, scope: this }
         },{
             header: _('description')
             ,dataIndex: 'description'
@@ -180,6 +197,39 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
     ,createDashboard: function() {
         MODx.loadPage('system/dashboards/create');
     }
+
+    ,updateDashboard: function() {
+        MODx.loadPage('system/dashboards/update', 'id='+this.menu.record.id);
+    }
+
+    ,duplicateDashboard: function(btn,e) {
+        MODx.Ajax.request({
+            url: this.config.url
+            ,params: {
+                action: 'System/Dashboard/Duplicate'
+                ,id: this.menu.record.id
+            }
+            ,listeners: {
+                'success': {fn:this.refresh,scope:this}
+            }
+        });
+    }
+
+    ,removeDashboard: function() {
+        MODx.msg.confirm({
+            title: _('dashboard_remove')
+            ,text: _('dashboard_remove_confirm')
+            ,url: this.config.url
+            ,params: {
+                action: 'System/Dashboard/Remove'
+                ,id: this.menu.record.id
+            }
+            ,listeners: {
+                'success': {fn:this.refresh,scope:this}
+            }
+        });
+    }
+
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();
         if (cs === false) return false;
@@ -202,44 +252,13 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
         return true;
     }
 
-    ,removeDashboard: function() {
-        MODx.msg.confirm({
-            title: _('dashboard_remove')
-            ,text: _('dashboard_remove_confirm')
-            ,url: this.config.url
-            ,params: {
-                action: 'System/Dashboard/Remove'
-                ,id: this.menu.record.id
-            }
-            ,listeners: {
-            	'success': {fn:this.refresh,scope:this}
-            }
-        });
-    }
-
-    ,duplicateDashboard: function(btn,e) {
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
-                action: 'System/Dashboard/Duplicate'
-                ,id: this.menu.record.id
-            }
-            ,listeners: {
-                'success': {fn:this.refresh,scope:this}
-            }
-        });
-    }
-
-    ,updateDashboard: function() {
-        MODx.loadPage('system/dashboards/update', 'id='+this.menu.record.id);
-    }
-
     ,filterUsergroup: function(cb,nv,ov) {
         this.getStore().baseParams.usergroup = Ext.isEmpty(nv) || Ext.isObject(nv) ? cb.getValue() : nv;
         this.getBottomToolbar().changePage(1);
         //this.refresh();
         return true;
     }
+
     ,search: function(tf,newValue,oldValue) {
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
@@ -247,13 +266,14 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
         //this.refresh();
         return true;
     }
+
     ,clearFilter: function() {
-    	this.getStore().baseParams = {
+        this.getStore().baseParams = {
             action: 'System/Dashboard/GetList'
-    	};
+        };
         Ext.getCmp('modx-dashboard-search').reset();
         Ext.getCmp('modx-user-filter-usergroup').reset();
-    	this.getBottomToolbar().changePage(1);
+        this.getBottomToolbar().changePage(1);
         //this.refresh();
     }
 });

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -83,7 +83,7 @@ MODx.grid.Dashboards = function(config) {
             ,sortable: true
             ,editor: { xtype: 'textfield' ,allowBlank: false }
             ,renderer: { fn: function(v,md,record) {
-                return this.rendLink(v, {
+                return this.renderLink(v, {
                     href: '?a=system/dashboards/update&id=' + record.data.id
                 });
             }, scope: this }


### PR DESCRIPTION
### What does it do?
- Added links to the item in the list, in grids.
Now you can go inside the element without calling the context menu.
- Also linked items with links in grids that are not directly related (opens in new tab).
- Cleaned the code: fixed tabs, removed extra spaces, added comments.
In some grids, I changed the order of functions to a more logical one (for example, **before:** createContext, filter, search, updateContext, deleteContext, ... **after:** createContext, updateContext, deleteContext, filter, search, ...)

### What does it look like:
![link_grids](https://user-images.githubusercontent.com/12523676/69976226-11dde100-1542-11ea-88e5-2d8e778d7ea2.gif)

The changes are very useful for UX, they reduce the number of clicks and it becomes more convenient to work: now it’s easy to open non-directly related elements, but before you had to look for an element by navigating through sections in the manager panel.

Thanks a lot to @GulomovCreative for help in PR!

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14125 (paragraph 1)
