### PR TITLE
Removed unused system settings for "Caching" section

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -190,15 +190,6 @@ $settings['cache_db']->fromArray(array (
   'area' => 'caching',
   'editedon' => null,
 ), '', true, true);
-$settings['cache_db_expires']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_db_expires']->fromArray(array (
-  'key' => 'cache_db_expires',
-  'value' => 0,
-  'xtype' => 'numberfield',
-  'namespace' => 'core',
-  'area' => 'caching',
-  'editedon' => null,
-), '', true, true);
 $settings['cache_db_session']= $xpdo->newObject(modSystemSetting::class);
 $settings['cache_db_session']->fromArray(array (
   'key' => 'cache_db_session',
@@ -222,24 +213,6 @@ $settings['cache_default']->fromArray(array (
   'key' => 'cache_default',
   'value' => true,
   'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'caching',
-  'editedon' => null,
-), '', true, true);
-$settings['cache_expires']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_expires']->fromArray(array (
-  'key' => 'cache_expires',
-  'value' => 0,
-  'xtype' => 'numberfield',
-  'namespace' => 'core',
-  'area' => 'caching',
-  'editedon' => null,
-), '', true, true);
-$settings['cache_format']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_format']->fromArray(array (
-  'key' => 'cache_format',
-  'value' => 0,
-  'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -144,9 +144,6 @@ $_lang['setting_cache_context_settings_desc'] = 'When enabled, context settings 
 $_lang['setting_cache_db'] = 'Enable Database Cache';
 $_lang['setting_cache_db_desc'] = 'When enabled, objects and raw result sets from SQL queries are cached to significantly reduce database loads.';
 
-$_lang['setting_cache_db_expires'] = 'Expiration Time for DB Cache';
-$_lang['setting_cache_db_expires_desc'] = 'This value (in seconds) sets the amount of time cache files last for DB result-set caching.';
-
 $_lang['setting_cache_db_session'] = 'Enable Database Session Cache';
 $_lang['setting_cache_db_session_desc'] = 'When enabled, and cache_db is enabled, database sessions will be cached in the DB result-set cache.';
 
@@ -157,14 +154,8 @@ $_lang['setting_cache_default'] = 'Cacheable default';
 $_lang['setting_cache_default_desc'] = 'Select \'Yes\' to make all new Resources cacheable by default.';
 $_lang['setting_cache_default_err'] = 'Please state whether or not you want documents to be cached by default.';
 
-$_lang['setting_cache_expires'] = 'Expiration Time for Default Cache';
-$_lang['setting_cache_expires_desc'] = 'This value (in seconds) sets the amount of time cache files last for default caching.';
-
 $_lang['setting_cache_resource_clear_partial'] = 'Clear Partial Resource Cache for provided contexts';
 $_lang['setting_cache_resource_clear_partial_desc'] = 'When enabled, MODX refresh will only clear resource cache for the provided contexts.';
-
-$_lang['setting_cache_format'] = 'Caching Format to Use';
-$_lang['setting_cache_format_desc'] = '0 = PHP, 1 = JSON, 2 = serialize. One of the formats';
 
 $_lang['setting_cache_handler'] = 'Caching Handler Class';
 $_lang['setting_cache_handler_desc'] = 'The class name of the type handler to use for caching.';

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -6,15 +6,18 @@
 use MODX\Revolution\modSystemSetting;
 
 $settings = [
+    'allow_tv_eval',
+    'cache_db_expires',
+    'cache_expires',
+    'cache_format',
     'compress_js_max_files',
-    'manager_js_zlib_output_compression',
     'editor_css_path',
     'editor_css_selectors',
     'fe_editor_lang',
+    'manager_js_zlib_output_compression',
     'udperms_allowroot',
-    'webpwdreminder_message',
-    'allow_tv_eval',
     'upload_flash',
+    'webpwdreminder_message',
 ];
 
 $messageTemplate = '<p class="%s">%s</p>';

--- a/setup/includes/upgrades/common/3.0.0-update-xtypes-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-update-xtypes-system-settings.php
@@ -17,22 +17,7 @@ $xtypeSettingsMap = [
         'new_xtype' => 'numberfield',
     ],
     [
-        'key' => 'cache_db_expires',
-        'old_xtype' => 'textfield',
-        'new_xtype' => 'numberfield',
-    ],
-    [
         'key' => 'cache_db_session_lifetime',
-        'old_xtype' => 'textfield',
-        'new_xtype' => 'numberfield',
-    ],
-    [
-        'key' => 'cache_expires',
-        'old_xtype' => 'textfield',
-        'new_xtype' => 'numberfield',
-    ],
-    [
-        'key' => 'cache_format',
         'old_xtype' => 'textfield',
         'new_xtype' => 'numberfield',
     ],


### PR DESCRIPTION
### What does it do?
Removed unused system settings for "Caching" section.

These settings are found only in the "System Settings", do not participate in the remaining code:
- cache_db_expires
- cache_expires
- cache_format

In the future, I will check the settings in other sections.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14539#issuecomment-482059233