### PR TITLE
Removed unused system settings for "Back-end Manager" section

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -955,33 +955,6 @@ $settings['manager_favicon_url']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
-$settings['manager_js_cache_file_locking']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_js_cache_file_locking']->fromArray(array (
-  'key' => 'manager_js_cache_file_locking',
-  'value' => true,
-  'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'manager',
-  'editedon' => null,
-), '', true, true);
-$settings['manager_js_cache_max_age']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_js_cache_max_age']->fromArray(array (
-  'key' => 'manager_js_cache_max_age',
-  'value' => 3600,
-  'xtype' => 'numberfield',
-  'namespace' => 'core',
-  'area' => 'manager',
-  'editedon' => null,
-), '', true, true);
-$settings['manager_js_document_root']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_js_document_root']->fromArray(array (
-  'key' => 'manager_js_document_root',
-  'value' => '',
-  'xtype' => 'textfield',
-  'namespace' => 'core',
-  'area' => 'manager',
-  'editedon' => null,
-), '', true, true);
 $settings['manager_time_format']= $xpdo->newObject(modSystemSetting::class);
 $settings['manager_time_format']->fromArray(array (
   'key' => 'manager_time_format',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -419,13 +419,6 @@ $_lang['setting_manager_date_format_desc'] = 'The format string, in PHP date() f
 $_lang['setting_manager_favicon_url'] = 'Manager Favicon URL';
 $_lang['setting_manager_favicon_url_desc'] = 'If set, will load this URL as a favicon for the MODX manager. Must be a relative URL to the manager/ directory, or an absolute URL.';
 
-$_lang['setting_manager_js_cache_file_locking'] = 'Enable File Locking for Manager JS/CSS Cache';
-$_lang['setting_manager_js_cache_file_locking_desc'] = 'Cache file locking. Set to No if filesystem is NFS.';
-$_lang['setting_manager_js_cache_max_age'] = 'Manager JS/CSS Compression Cache Age';
-$_lang['setting_manager_js_cache_max_age_desc'] = 'Maximum age of browser cache of manager CSS/JS compression in seconds. After this period, the browser will send another conditional GET. Use a longer period for lower traffic.';
-$_lang['setting_manager_js_document_root'] = 'Manager JS/CSS Compression Document Root';
-$_lang['setting_manager_js_document_root_desc'] = 'If your server does not handle the DOCUMENT_ROOT server variable, set it explicitly here to enable the manager CSS/JS compression. Do not change this unless you know what you are doing.';
-
 $_lang['setting_manager_login_url_alternate'] = 'Alternate Manager Login URL';
 $_lang['setting_manager_login_url_alternate_desc'] = 'An alternate URL to send an unauthenticated user to when they need to login to the manager. The login form there must login the user to the "mgr" context to work.';
 

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -6,15 +6,18 @@
 use MODX\Revolution\modSystemSetting;
 
 $settings = [
+    'allow_tv_eval',
     'compress_js_max_files',
-    'manager_js_zlib_output_compression',
     'editor_css_path',
     'editor_css_selectors',
     'fe_editor_lang',
+    'manager_js_cache_file_locking',
+    'manager_js_cache_max_age',
+    'manager_js_document_root',
+    'manager_js_zlib_output_compression',
     'udperms_allowroot',
-    'webpwdreminder_message',
-    'allow_tv_eval',
     'upload_flash',
+    'webpwdreminder_message',
 ];
 
 $messageTemplate = '<p class="%s">%s</p>';

--- a/setup/includes/upgrades/common/3.0.0-update-xtypes-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-update-xtypes-system-settings.php
@@ -82,11 +82,6 @@ $xtypeSettingsMap = [
         'new_xtype' => 'numberfield',
     ],
     [
-        'key' => 'manager_js_cache_max_age',
-        'old_xtype' => 'textfield',
-        'new_xtype' => 'numberfield',
-    ],
-    [
         'key' => 'manager_week_start',
         'old_xtype' => 'textfield',
         'new_xtype' => 'numberfield',


### PR DESCRIPTION
### What does it do?
Removed unused system settings for "Back-end Manager" section.

These settings are found only in the "System Settings", do not participate in the remaining code:
- manager_js_cache_file_locking
- manager_js_cache_max_age
- manager_js_document_root

These settings are not used in 3.x; they were specified in `min/index.php` of previous versions:
- **manager_js_cache_file_locking** https://github.com/modxcms/revolution/blob/v2.7.2-pl/manager/min/index.php#L52
- **manager_js_cache_max_age** https://github.com/modxcms/revolution/blob/v2.7.2-pl/manager/min/index.php#L55
- **manager_js_document_root** https://github.com/modxcms/revolution/blob/v2.7.2-pl/manager/min/index.php#L47

p.s. I also do not understand what the `inline_help` setting is responsible for - https://github.com/modxcms/revolution/blob/2.x/core/lexicon/en/setting.inc.php#L369.

In the future, I will check the settings in other sections.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14539#issuecomment-482059233