### PR TITLE
Fix processors path for setting an access to namespace

### DIFF
--- a/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/GetList.php
@@ -142,7 +142,7 @@ class GetList extends GetListProcessor
             '-',
             [
                 'text' => $this->modx->lexicon('access_namespace_remove'),
-                'handler' => 'this.confirm.createDelegate(this,["security/access/usergroup/namespace/remove"])',
+                'handler' => 'this.confirm.createDelegate(this,["Security/Access/UserGroup/AccessNamespace/Remove"])',
             ],
         ];
 

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
@@ -10,7 +10,7 @@ MODx.grid.UserGroupNamespace = function(config) {
         id: 'modx-grid-user-group-namespace'
         ,url: MODx.config.connector_url
         ,baseParams: {
-            action: 'security/access/usergroup/namespace/getList'
+            action: 'Security/Access/UserGroup/AccessNamespace/GetList'
             ,usergroup: config.usergroup
         }
         ,paging: true
@@ -143,7 +143,7 @@ MODx.window.CreateUGNamespace = function(config) {
     Ext.applyIf(config,{
         title: _('namespace_add')
         ,url: MODx.config.connector_url
-        ,action: 'security/access/usergroup/namespace/create'
+        ,action: 'Security/Access/UserGroup/AccessNamespace/Create'
         // ,height: 250
         // ,width: 500
         ,fields: [{
@@ -260,7 +260,7 @@ MODx.window.UpdateUGNamespace = function(config) {
     this.ident = config.ident || 'updugsrc'+Ext.id();
     Ext.applyIf(config,{
         title: _('access_namespace_update')
-        ,action: 'security/access/usergroup/namespace/update'
+        ,action: 'Security/Access/UserGroup/AccessNamespace/Update'
     });
     MODx.window.UpdateUGNamespace.superclass.constructor.call(this,config);
 };


### PR DESCRIPTION
### What does it do?
Fix processors path for namespaces grid in user group access.

### Why is it needed?
Listing/Creating/Updating/Deleting namespaces under UserGroup access doesn't work because of the wrong processors path.