### PR TITLE
Format timestamp to date & time in edit file panel

### DIFF
--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -110,14 +110,14 @@ MODx.panel.EditFile = function(config) {
                     ,name: 'last_accessed'
                     ,id: 'modx-file-last-accessed'
                     ,anchor: '98%'
-                    ,value: config.record.last_accessed || ''
+                    ,value: ((new Date(parseInt(config.record.last_accessed) * 1000)).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)) || ''
                 },{
                     xtype: 'statictextfield'
                     ,fieldLabel: _('file_last_modified')
                     ,name: 'last_modified'
                     ,id: 'modx-file-last-modified'
                     ,anchor: '98%'
-                    ,value: config.record.last_modified || ''
+                    ,value: ((new Date(parseInt(config.record.last_modified) * 1000)).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)) || ''
                 },{
                     xtype: 'textarea'
                     ,hideLabel: true

--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -110,14 +110,14 @@ MODx.panel.EditFile = function(config) {
                     ,name: 'last_accessed'
                     ,id: 'modx-file-last-accessed'
                     ,anchor: '98%'
-                    ,value: ((new Date(parseInt(config.record.last_accessed) * 1000)).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)) || ''
+                    ,value: MODx.util.Format.dateFromTimestamp(config.record.last_accessed)
                 },{
                     xtype: 'statictextfield'
                     ,fieldLabel: _('file_last_modified')
                     ,name: 'last_modified'
                     ,id: 'modx-file-last-modified'
                     ,anchor: '98%'
-                    ,value: ((new Date(parseInt(config.record.last_modified) * 1000)).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)) || ''
+                    ,value: MODx.util.Format.dateFromTimestamp(config.record.last_modified)
                 },{
                     xtype: 'textarea'
                     ,hideLabel: true

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -1,4 +1,5 @@
 Ext.namespace('MODx.util.Progress');
+Ext.namespace('MODx.util.Format');
 /**
  * A JSON Reader specific to MODExt
  *
@@ -414,6 +415,28 @@ MODx.util.Clipboard = function() {
         }
     };
 }();
+
+MODx.util.Format = {
+    dateFromTimestamp: function(timestamp, date = true, time = true, defaultValue = '') {
+        timestamp = parseInt(timestamp);
+        if (!(timestamp > 0)) return defaultValue;
+
+        if (timestamp.toString().length === 10) {
+            timestamp *= 1000;
+        }
+
+        var format = [];
+
+        if (date === true) format.push(MODx.config.manager_date_format);
+        if (time === true) format.push(MODx.config.manager_time_format);
+
+        if (format.length === 0) return defaultValue;
+
+        format = format.join(' ');
+
+        return (new Date(timestamp).format(format));
+    }
+};
 
 
 Ext.util.Format.trimCommas = function(s) {


### PR DESCRIPTION
### What does it do?
Format timestamp using system settings (`manager_date_format` & `manager_time_format`) into a friendlier format.

### Why is it needed?
In the edit file panel, last accessed & last modified dates are displayed as a timestamp.

### Related issue(s)/PR(s)
Resolves #14750
