### PR TITLE
Move OnResourceDuplicate invoke event

### DIFF
--- a/core/src/Revolution/Processors/Resource/Duplicate.php
+++ b/core/src/Revolution/Processors/Resource/Duplicate.php
@@ -81,7 +81,6 @@ class Duplicate extends Processor
             return $this->failure($this->newResource);
         }
 
-        $this->fireDuplicateEvent();
         $this->logManagerAction();
 
         return $this->success('', [
@@ -102,22 +101,6 @@ class Duplicate extends Processor
             $canAddChildren = false;
         }
         return $canAddChildren;
-    }
-
-    /**
-     * Fire the OnResourceDuplicate event
-     * @return void
-     */
-    public function fireDuplicateEvent()
-    {
-        $this->modx->invokeEvent('OnResourceDuplicate', [
-            'newResource' => &$this->newResource,
-            'oldResource' => &$this->oldResource,
-            'newName' => $this->getProperty('name', ''),
-            'duplicateChildren' => $this->getProperty('duplicate_children', false),
-            'prefixDuplicate' => $this->getProperty('prefixDuplicate', false),
-            'publishedMode' => $this->getProperty('published_mode', 'preserve'),
-        ]);
     }
 
     /**

--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -1252,6 +1252,15 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
             }
         }
 
+        $this->xpdo->invokeEvent('OnResourceDuplicate',array(
+            'newResource' => $newResource,
+            'oldResource' => $this,
+            'newName' => $newName,
+            'duplicateChildren' => $duplicateChildren,
+            'prefixDuplicate' => $prefixDuplicate,
+            'publishedMode' => $publishedMode,
+        ));
+
         return $newResource;
 
     }


### PR DESCRIPTION
### What does it do?
Moved the invokeEvent of the OnResourceDuplicate event to the modResource class where the actual duplication is processed, so the event is invoked every time a resource is duplicated and not only when the processor is used.

### Why is it needed?
Currently there is no way to hook in when duplicating child resources or when resources are duplicated when using the context duplicate functionality.  This is needed so plugins can hook into this process as well when, for instance if you'd like to duplicate custom database values related to a resource.

Also I think it is expected that this event is invoked every time a resource is duplicated and not only when the processor is used (then it only runs for the parent resource).

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/9960
