### PR TITLE
Removed unused system settings for "System and Server" section

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1434,15 +1434,6 @@ $settings['request_param_id']->fromArray(array (
   'area' => 'gateway',
   'editedon' => null,
 ), '', true, true);
-$settings['resolve_hostnames']= $xpdo->newObject(modSystemSetting::class);
-$settings['resolve_hostnames']->fromArray(array (
-  'key' => 'resolve_hostnames',
-  'value' => false,
-  'xtype' => 'combo-boolean',
-  'namespace' => 'core',
-  'area' => 'system',
-  'editedon' => null,
-), '', true, true);
 $settings['resource_tree_node_name']= $xpdo->newObject(modSystemSetting::class);
 $settings['resource_tree_node_name']->fromArray(array (
   'key' => 'resource_tree_node_name',
@@ -1493,15 +1484,6 @@ $settings['server_offset_time']->fromArray(array (
   'key' => 'server_offset_time',
   'value' => 0,
   'xtype' => 'numberfield',
-  'namespace' => 'core',
-  'area' => 'system',
-  'editedon' => null,
-), '', true, true);
-$settings['server_protocol']= $xpdo->newObject(modSystemSetting::class);
-$settings['server_protocol']->fromArray(array (
-  'key' => 'server_protocol',
-  'value' => 'http',
-  'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -84,9 +84,6 @@ $_lang['setting_login_homepage'] = 'Login Home Page';
 $_lang['setting_login_homepage_desc'] = 'Enter the ID of the document you want to send the user to after he/she has logged in. <strong>NOTE: Make sure the ID you enter belongs to an existing document, and that it has been published and is accessible by this user!</strong>';
 
 // system settings
-$_lang['setting_access_policies_version'] = 'Access Policy Schema Version';
-$_lang['setting_access_policies_version_desc'] = 'The version of the Access Policy system. DO NOT CHANGE.';
-
 $_lang['setting_allow_forward_across_contexts'] = 'Allow Forwarding Across Contexts';
 $_lang['setting_allow_forward_across_contexts_desc'] = 'When true, Symlinks and modX::sendForward() API calls can forward requests to Resources in other Contexts.';
 
@@ -606,9 +603,6 @@ $_lang['setting_request_param_alias_desc'] = 'The name of the GET parameter to i
 $_lang['setting_request_param_id'] = 'Request ID Parameter';
 $_lang['setting_request_param_id_desc'] = 'The name of the GET parameter to identify Resource IDs when not using FURLs.';
 
-$_lang['setting_resolve_hostnames'] = 'Resolve hostnames';
-$_lang['setting_resolve_hostnames_desc'] = 'Do you want MODX to try to resolve your visitors\' hostnames when they visit your site? Resolving hostnames may create some extra server load, although your visitors won\'t notice this in any way.';
-
 $_lang['setting_resource_tree_node_name'] = 'Resource Tree Node Field';
 $_lang['setting_resource_tree_node_name_desc'] = 'Specify the Resource field to use when rendering the nodes in the Resource Tree. Defaults to pagetitle, although any Resource field can be used, such as menutitle, alias, longtitle, etc.';
 
@@ -627,12 +621,6 @@ $_lang['setting_search_default_err'] = 'Please specify whether or not you want d
 
 $_lang['setting_server_offset_time'] = 'Server offset time';
 $_lang['setting_server_offset_time_desc'] = 'Select the number of hours time difference between where you are and where the server is.';
-
-$_lang['setting_server_protocol'] = 'Server type';
-$_lang['setting_server_protocol_desc'] = 'If your site is on a https connection, please specify so here.';
-$_lang['setting_server_protocol_err'] = 'Please specify whether or not your site is a secure site.';
-$_lang['setting_server_protocol_http'] = 'http';
-$_lang['setting_server_protocol_https'] = 'https';
 
 $_lang['setting_session_cookie_domain'] = 'Session Cookie Domain';
 $_lang['setting_session_cookie_domain_desc'] = 'Use this setting to customize the session cookie domain. Leave blank to use the current domain.';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -84,6 +84,9 @@ $_lang['setting_login_homepage'] = 'Login Home Page';
 $_lang['setting_login_homepage_desc'] = 'Enter the ID of the document you want to send the user to after he/she has logged in. <strong>NOTE: Make sure the ID you enter belongs to an existing document, and that it has been published and is accessible by this user!</strong>';
 
 // system settings
+$_lang['setting_access_policies_version'] = 'Access Policy Schema Version';
+$_lang['setting_access_policies_version_desc'] = 'The version of the Access Policy system. DO NOT CHANGE.';
+
 $_lang['setting_allow_forward_across_contexts'] = 'Allow Forwarding Across Contexts';
 $_lang['setting_allow_forward_across_contexts_desc'] = 'When true, Symlinks and modX::sendForward() API calls can forward requests to Resources in other Contexts.';
 

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -15,6 +15,8 @@ $settings = [
     'manager_js_cache_max_age',
     'manager_js_document_root',
     'manager_js_zlib_output_compression',
+    'resolve_hostnames',
+    'server_protocol',
     'udperms_allowroot',
     'upload_flash',
     'webpwdreminder_message',


### PR DESCRIPTION
### What does it do?
Removed unused system settings for "System and Server" section.

These settings are found only in the "System Settings", do not participate in the remaining code:
- `resolve_hostnames`
- `server_protocol` (https://github.com/modxcms/revolution/issues/13269)
The server_protocol setting is confusing, I saw posts, for example, when setting up redirects, people are looking for the cause of the problem, including in this setting, not knowing that it does not work at all :)

These settings are not used in 3.x; they were specified in Evolution:
- **resolve_hostnames** https://github.com/modxcms/evolution/blob/v1.0.0/install/setup.sql#L847
- **server_protocol** https://github.com/modxcms/evolution/blob/v1.0.0/install/setup.sql#L837

In the future, I will check the settings in other sections.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14539#issuecomment-482059233