### PR TITLE
Revert "Format timestamp to date & time in edit file panel"

### DIFF
--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -110,14 +110,14 @@ MODx.panel.EditFile = function(config) {
                     ,name: 'last_accessed'
                     ,id: 'modx-file-last-accessed'
                     ,anchor: '98%'
-                    ,value: MODx.util.Format.dateFromTimestamp(config.record.last_accessed)
+                    ,value: config.record.last_accessed || ''
                 },{
                     xtype: 'statictextfield'
                     ,fieldLabel: _('file_last_modified')
                     ,name: 'last_modified'
                     ,id: 'modx-file-last-modified'
                     ,anchor: '98%'
-                    ,value: MODx.util.Format.dateFromTimestamp(config.record.last_modified)
+                    ,value: config.record.last_modified || ''
                 },{
                     xtype: 'textarea'
                     ,hideLabel: true

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -1,5 +1,4 @@
 Ext.namespace('MODx.util.Progress');
-Ext.namespace('MODx.util.Format');
 /**
  * A JSON Reader specific to MODExt
  *
@@ -415,28 +414,6 @@ MODx.util.Clipboard = function() {
         }
     };
 }();
-
-MODx.util.Format = {
-    dateFromTimestamp: function(timestamp, date = true, time = true, defaultValue = '') {
-        timestamp = parseInt(timestamp);
-        if (!(timestamp > 0)) return defaultValue;
-
-        if (timestamp.toString().length === 10) {
-            timestamp *= 1000;
-        }
-
-        var format = [];
-
-        if (date === true) format.push(MODx.config.manager_date_format);
-        if (time === true) format.push(MODx.config.manager_time_format);
-
-        if (format.length === 0) return defaultValue;
-
-        format = format.join(' ');
-
-        return (new Date(timestamp).format(format));
-    }
-};
 
 
 Ext.util.Format.trimCommas = function(s) {


### PR DESCRIPTION
Reverts modxcms/revolution#14873

This is being reverted because it broke the `grunt build` due to a syntax error.