### PR TITLE
Fix grid's renderEditableColumn

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -470,7 +470,14 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     ,renderEditableColumn: function(renderer) {
         return function(value, metaData, record, rowIndex, colIndex, store) {
             if (renderer) {
-                value = renderer(value, metaData, record, rowIndex, colIndex, store);
+                if (typeof renderer.fn === 'function') {
+                    var scope = (renderer.scope) ? renderer.scope : false;
+                    renderer = renderer.fn.bind(scope);
+                }
+
+                if (typeof renderer === 'function') {
+                    value = renderer(value, metaData, record, rowIndex, colIndex, store);
+                }
             }
             metaData.css = ['x-editable-column', metaData.css || ''].join(' ');
 


### PR DESCRIPTION
### What does it do?
Check if renderer is a function before executing it. Renderer can also be an object in a form `{fn, scope}` so it also checks if the `fn` is callable and applies the scope.

### Why is it needed?
After #14748 and #14864 got merged, grids with links stopped working.
