### PR TITLE
Fix saving a form customisation profile, plus fix XSS in profile name

### DIFF
--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -8,6 +8,9 @@ MODx.panel.FCProfile = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         url: MODx.config.connector_url
+        ,baseParams: {
+            action: 'Security/Forms/Profile/Update'
+        }
         ,id: 'modx-panel-fc-profile'
         ,cls: 'container'
         ,class_key: 'MODX\\Revolution\\modFormCustomizationProfile'
@@ -48,7 +51,7 @@ MODx.panel.FCProfile = function(config) {
                     ,value: config.record.name
                     ,listeners: {
                         'keyup': {scope:this,fn:function(f,e) {
-                            Ext.getCmp('modx-fcp-header').getEl().update(_('profile')+': '+f.getValue());
+                            Ext.getCmp('modx-fcp-header').getEl().update(_('profile') + ': ' + Ext.util.Format.htmlEncode(f.getValue()));
                         }}
                     }
                 },{
@@ -108,7 +111,7 @@ Ext.extend(MODx.panel.FCProfile,MODx.FormPanel,{
         if (!this.initialized) { this.getForm().setValues(this.config.record); }
         if (!Ext.isEmpty(this.config.record.name)) {
             Ext.defer(function() {
-                Ext.getCmp('modx-fcp-header').update(_('profile')+': '+this.config.record.name);
+                Ext.getCmp('modx-fcp-header').update(_('profile') + ': ' + Ext.util.Format.htmlEncode(this.config.record.name));
             }, 250, this);
         }
         this.fireEvent('ready',this.config.record);


### PR DESCRIPTION
### What does it do?

Makes sure the processor action is defined for the save request. Theoretically this should already be available in the `actions` definition (in `manager/assets/modext/sections/fc/profile/update.js`, line 13-16), but that does not seem to be used and I don't readily know why not. This does fix it.

While investigating, I also found a XSS vulnerability in the profile name which I've also fixed.

### Why is it needed?

Fixes issue #14887 and enhanced manager security.

Also enhanced manager 

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)
