### PR TITLE
Fix deprecation warnings on curly brace string offset access syntax

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -4,6 +4,7 @@ development release, and is only shown to give an idea of what's currently in th
 
 MODX Revolution 3.0.0-beta1  (TBD)
 ====================================
+- Fix deprecation warnings on curly brace string offset access syntax for PHP 7.4 compatibility [#14863]
 - Format timestamp to date & time in edit file panel [#14883]
 - Add links to grid items in manager [#14864]
 - Fix stretched user avatars in dashboard widgets [#14840]

--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -274,7 +274,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         /* replace one or more instances of word delimiters with word delimiter */
         $delimiterTokens = [];
         for ($d = 0; $d < strlen($delimiters); $d++) {
-            $delimiterTokens[] = preg_quote($delimiters{$d}, '/');
+            $delimiterTokens[] = preg_quote($delimiters[$d], '/');
         }
         if (!empty($delimiterTokens)) {
             $delimiterPattern = '/[' . implode('|', $delimiterTokens) . ']+/';

--- a/core/src/Revolution/modStaticResource.php
+++ b/core/src/Revolution/modStaticResource.php
@@ -221,8 +221,8 @@ class modStaticResource extends modResource implements modResourceInterface
     protected function _bytes($value)
     {
         $value = trim($value);
-        $modifier = strtolower($value{strlen($value) - 1});
-        switch ($modifier) {
+        $modifier = strtolower($value[strlen($value) - 1]);
+        switch($modifier) {
             case 'g':
                 $value *= 1024;
             case 'm':


### PR DESCRIPTION
In PHP 7.4, array or string offset access using curly braces is deprecated. This adopts the changes from a PR submitted against the 2.x branch to solve this issue.

### What does it do?
Improves PHP 7.4 compatibility

### Why is it needed?
Deprecation warnings in PHP 7.4

### Related issue(s)/PR(s)
#14863