### PR TITLE
Header breadcrumbs

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1491,7 +1491,7 @@ iframe[classname="x-hidden"] {
       order: 1;
       font: normal 20px $bodyfonts;
       color: $darkestGray;
-      margin: 0;
+      margin: 0 !important;
       padding-left: 0;
 
       @include grid-media($desktop) {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -593,7 +593,7 @@ a.x-grid-link:focus {
   #modx-content > .x-panel-bwrap > .x-panel-body > .x-panel {
     margin: 0;
 
-    #modx-resource-breadcrumbs {
+    .modx-header-breadcrumbs {
       margin-top: 1.25rem;
       font-weight: bold;
       box-sizing: border-box;
@@ -605,7 +605,7 @@ a.x-grid-link:focus {
       }
     }
 
-    #modx-resource-breadcrumbs {
+    .modx-header-breadcrumbs {
       width: 100% !important;
     }
   }
@@ -1481,13 +1481,13 @@ iframe[classname="x-hidden"] {
 }
 
 /* New Header */
-#modx-resource-breadcrumbs {
+.modx-header-breadcrumbs {
   .breadcrumbs {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
 
-    #modx-resource-header {
+    h2 {
       order: 1;
       font: normal 20px $bodyfonts;
       color: $darkestGray;

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -613,8 +613,7 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
 MODx.LayoutMgr = function() {
     var _activeMenu = 'menu0';
     return {
-        loadPage: function(action, parameters) {
-            // Handles url, passed as first argument
+        getPage: function(action, parameters) {
             var parts = [];
             if (action) {
                 if (isNaN(parseInt(action)) && (action.substr(0,1) == '?' || (action.substr(0, "index.php?".length) == 'index.php?'))) {
@@ -624,9 +623,21 @@ MODx.LayoutMgr = function() {
                 }
             }
             if (parameters) {
-                parts.push(parameters);
+                if (typeof parameters === 'object') {
+                    for (var name in parameters) {
+                        if (parameters.hasOwnProperty(name)) {
+                            parts.push(name + '=' + parameters[name]);
+                        }
+                    }
+                } else {
+                    parts.push(parameters);
+                }
             }
-            var url = parts.join('&');
+            return parts.join('&');
+        },
+        loadPage: function(action, parameters) {
+            // Handles url, passed as first argument
+            var url = MODx.LayoutMgr.getPage(action, parameters);
             if (MODx.fireEvent('beforeLoadPage', url)) {
                 var e = window.event;
 
@@ -655,6 +666,7 @@ MODx.LayoutMgr = function() {
 }();
 
 /* aliases for quicker reference */
+MODx.getPage = MODx.LayoutMgr.getPage;
 MODx.loadPage = MODx.LayoutMgr.loadPage;
 MODx.showDashboard = MODx.LayoutMgr.showDashboard;
 MODx.hideDashboard = MODx.LayoutMgr.hideDashboard;

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -442,6 +442,63 @@ MODx.util.Format = {
     }
 };
 
+MODx.util.getHeaderBreadCrumbs = function(header, trail) {
+    if (typeof header === 'string') {
+        header = {
+            id: header,
+            xtype: 'modx-header'
+        };
+    }
+
+    if (trail === undefined) trail = [];
+    if (!Array.isArray(trail)) trail = [trail];
+
+    return {
+        xtype: 'modx-breadcrumbs-panel',
+        id: 'modx-header-breadcrumbs',
+        cls: 'modx-header-breadcrumbs',
+        desc: '',
+        bdMarkup: '<ul><tpl for="trail"><li>' +
+            '<tpl if="href"><a href="{href}" class="{cls}">{text}</a></tpl>' +
+            '<tpl if="!href">{text}</tpl>' +
+            '</li></tpl></ul>',
+        init: function() {
+            this.tpl = new Ext.XTemplate(this.bdMarkup, {compiled: true});
+        },
+        trail: trail,
+        listeners: {
+            afterrender: function() {
+                this.renderTrail();
+            }
+        },
+        renderTrail: function () {
+            this.tpl.overwrite(this.body.dom.lastElementChild, {trail: this.trail});
+        },
+        updateTrail: function(trail, replace) {
+            if (replace === undefined) replace = false;
+
+            if (replace === true) {
+                this.trail = (Array.isArray(trail)) ? trail : [trail];
+                this.renderTrail();
+                return true;
+            }
+
+            if (Array.isArray(trail)) {
+                for (var i = 0; i < trail.length; i++) {
+                    this.trail.push(trail[i]);
+                }
+
+                this.renderTrail();
+                return true;
+            }
+
+            this.trail.push(trail);
+            this.renderTrail();
+            return true;
+        },
+        items: [header]
+    };
+};
 
 Ext.util.Format.trimCommas = function(s) {
     s = s.replace(',,',',');

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -496,6 +496,14 @@ MODx.util.getHeaderBreadCrumbs = function(header, trail) {
             this.renderTrail();
             return true;
         },
+        updateHeader: function(text) {
+            if (!this.rendered) {
+                Ext.getCmp(header.id).html = text;
+                return;
+            }
+
+            Ext.getCmp(header.id).getEl().update(text);
+        },
         items: [header]
     };
 };

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -215,7 +215,7 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
             ,id: 'modx-resource-header'
             ,xtype: 'modx-header'
         };
-        var items = [];
+
         // Add breadcrumbs with parents
         if (config.record['parents'] && config.record['parents'].length) {
             var parents = config.record['parents'];
@@ -250,28 +250,11 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
                     });
                 }
             }
-            items.push({
-                xtype: 'modx-breadcrumbs-panel'
-                ,id: 'modx-resource-breadcrumbs'
-                ,desc: ''
-                ,bdMarkup: '<ul><tpl for="trail"><li>' +
-                        '<tpl if="href"><a href="{href}" class="{cls}">{text}</a></tpl>' +
-                        '<tpl if="!href">{text}</tpl>' +
-                    '</li></tpl></ul>'
-                ,init: function() {
-                    this.tpl = new Ext.XTemplate(this.bdMarkup, {compiled: true});
-                }
-                ,listeners: {
-                    afterrender: function() {
-                        this.tpl.overwrite(this.body, {trail: trail});
-                    }
-                }, items: [header]
-            });
-        } else {
-            items.push(header);
-        }
 
-        return items;
+            return MODx.util.getHeaderBreadCrumbs(header, trail);
+        } else {
+            return header;
+        }
     }
 });
 Ext.reg('modx-panel-resource-data',MODx.panel.ResourceData);

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -59,7 +59,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 if (MODx.perm.tree_show_resource_ids) {
                     title = title+ ' <small>('+this.config.record.id+')</small>';
                 }
-                Ext.getCmp('modx-resource-header').getEl().update(title);
+                Ext.getCmp('modx-header-breadcrumbs').updateHeader(title);
             }
             // initial check to enable realtime alias
             if (Ext.isEmpty(this.config.record.alias)) {
@@ -633,7 +633,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                                 if (MODx.request.a !== 'Resource/Create' && MODx.perm.tree_show_resource_ids === true) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
-                                Ext.getCmp('modx-resource-header').getEl().update(title);
+                                Ext.getCmp('modx-header-breadcrumbs').updateHeader(title);
 
                                 // check some system settings before doing real time alias transliteration
                                 if (parseInt(MODx.config.friendly_alias_realtime, 10) && parseInt(MODx.config.automatic_alias, 10)) {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -457,11 +457,12 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,id: 'modx-resource-header'
             ,xtype: 'modx-header'
         };
-        var items = [];
+
         // Add breadcrumbs with parents
         if (config.record['parents'] && config.record['parents'].length) {
             var parents = config.record['parents'];
             var trail = [];
+
             for (var i = 0; i < parents.length; i++) {
                 if (parents[i].id) {
                     if (parents[i].parent && i == 1) {
@@ -492,28 +493,11 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     });
                 }
             }
-            items.push({
-                xtype: 'modx-breadcrumbs-panel'
-                ,id: 'modx-resource-breadcrumbs'
-                ,desc: ''
-                ,bdMarkup: '<ul><tpl for="trail"><li>' +
-                        '<tpl if="href"><a href="{href}" class="{cls}">{text}</a></tpl>' +
-                        '<tpl if="!href">{text}</tpl>' +
-                    '</li></tpl></ul>'
-                ,init: function() {
-                    this.tpl = new Ext.XTemplate(this.bdMarkup, {compiled: true});
-                }
-                ,listeners: {
-                    afterrender: function() {
-                        this.tpl.overwrite(this.body, {trail: trail});
-                    }
-                }, items: [header]
-            });
-        } else {
-            items.push(header);
+
+            return MODx.util.getHeaderBreadCrumbs(header, trail);
         }
 
-        return items;
+        return header;
     }
 
     ,getTemplateVariablesPanel: function(config) {

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -64,7 +64,8 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                         var s = g.getStore();
                         if (s) { s.loadData(d); }
                     }
-                    Ext.get('modx-user-header').update(r.object.username);
+
+                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(r.object.username);
                     this.fireEvent('ready',r.object);
                     MODx.fireEvent('ready');
                 },scope:this}
@@ -494,7 +495,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             ,autoCreate: {tag: "input", type: "text", size: "20", autocomplete: "off", msgTarget: "under"}
             ,listeners: {
                 'keyup': {scope:this,fn:function(f,e) {
-                    Ext.getCmp('modx-user-header').getEl().update(Ext.util.Format.htmlEncode(f.getValue()));
+                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getValue()));
                 }}
             }
         },{

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -494,7 +494,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             ,autoCreate: {tag: "input", type: "text", size: "20", autocomplete: "off", msgTarget: "under"}
             ,listeners: {
                 'keyup': {scope:this,fn:function(f,e) {
-                    Ext.getCmp('modx-user-header').getEl().update(_('user')+': '+Ext.util.Format.htmlEncode(f.getValue()));
+                    Ext.getCmp('modx-user-header').getEl().update(Ext.util.Format.htmlEncode(f.getValue()));
                 }}
             }
         },{

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -13,23 +13,22 @@ MODx.panel.User = function(config) {
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,bodyStyle: ''
-        ,items: [{
-            html: _('user_new')
-            ,id: 'modx-user-header'
-            ,xtype: 'modx-header'
-        },{
-            xtype: 'modx-tabs'
-            ,id: 'modx-user-tabs'
-            ,deferredRender: false
-            ,defaults: {
-                autoHeight: true
-                ,layout: 'form'
-                ,labelWidth: 150
-                ,bodyCssClass: 'tab-panel-wrapper'
-                ,layoutOnTabChange: true
+        ,items: [
+            MODx.util.getHeaderBreadCrumbs('modx-user-header', [{text: _('users'), href: MODx.getPage('security/user')}]),
+            {
+                xtype: 'modx-tabs'
+                ,id: 'modx-user-tabs'
+                ,deferredRender: false
+                ,defaults: {
+                    autoHeight: true
+                    ,layout: 'form'
+                    ,labelWidth: 150
+                    ,bodyCssClass: 'tab-panel-wrapper'
+                    ,layoutOnTabChange: true
+                }
+                ,items: this.getFields(config)
             }
-            ,items: this.getFields(config)
-        }]
+        ]
         ,useLoadingMask: true
         ,listeners: {
             'setup': {fn:this.setup,scope:this}
@@ -44,6 +43,7 @@ MODx.panel.User = function(config) {
 Ext.extend(MODx.panel.User,MODx.FormPanel,{
     setup: function() {
         if (this.config.user === '' || this.config.user === 0) {
+            Ext.get('modx-user-header').update(_('user_new'));
             this.fireEvent('ready');
             return false;
         }
@@ -64,7 +64,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                         var s = g.getStore();
                         if (s) { s.loadData(d); }
                     }
-                    Ext.get('modx-user-header').update(_('user')+': '+r.object.username);
+                    Ext.get('modx-user-header').update(r.object.username);
                     this.fireEvent('ready',r.object);
                     MODx.fireEvent('ready');
                 },scope:this}

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -8,11 +8,7 @@ MODx.panel.Source = function(config) {
         }
         ,defaults: { collapsible: false ,autoHeight: true }
 		,cls: 'container form-with-labels'
-        ,items: [{
-             html: _('source')
-            ,id: 'modx-source-header'
-            ,xtype: 'modx-header'
-        },{
+        ,items: [this.getPageHeader(config),{
             xtype: 'modx-tabs'
             ,defaults: {
                 autoHeight: true
@@ -162,7 +158,7 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
         }
         this.getForm().setValues(this.config.record);
 		/* The component rendering is deferred since we are not using renderTo */
-        Ext.getCmp('modx-source-header').html = _('source')+': '+this.config.record.name;
+        Ext.getCmp('modx-source-header').html = this.config.record.name;
 
         var g,d;
         if (!Ext.isEmpty(this.config.record.properties)) {
@@ -210,6 +206,13 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
             var ag = Ext.getCmp('modx-grid-source-access');
             if (ag) { ag.getStore().commitChanges(); }
         }
+    }
+
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-source-header', [{
+            text: _('sources'),
+            href: MODx.getPage('source')
+        }]);
     }
 });
 Ext.reg('modx-panel-source',MODx.panel.Source);

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -64,7 +64,7 @@ MODx.panel.Source = function(config) {
                                 ,anchor: '100%'
                                 ,listeners: {
                                     'keyup': {scope:this,fn:function(f,e) {
-                                        Ext.getCmp('modx-source-header').getEl().update(_('source')+': '+f.getValue());
+                                        Ext.getCmp('modx-source-header').getEl().update(f.getValue());
                                     }}
                                 }
                             },{

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -64,7 +64,7 @@ MODx.panel.Source = function(config) {
                                 ,anchor: '100%'
                                 ,listeners: {
                                     'keyup': {scope:this,fn:function(f,e) {
-                                        Ext.getCmp('modx-source-header').getEl().update(f.getValue());
+                                        Ext.getCmp('modx-source-header').getEl().update(Ext.util.Format.htmlEncode(f.getValue()));
                                     }}
                                 }
                             },{

--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -16,11 +16,7 @@ MODx.panel.Context = function(config) {
         ,class_key: 'modContext'
         ,plugin: ''
         ,bodyStyle: ''
-        ,items: [{
-            html: _('context')+': '+config.context
-            ,id: 'modx-context-name'
-            ,xtype: 'modx-header'
-        },MODx.getPageStructure([{
+        ,items: [this.getPageHeader(config), MODx.getPageStructure([{
             title: _('general_information')
             ,autoHeight: true
             ,layout: 'form'
@@ -122,8 +118,7 @@ Ext.extend(MODx.panel.Context,MODx.FormPanel,{
             ,listeners: {
             	'success': {fn:function(r) {
                     this.getForm().setValues(r.object);
-                    var el = Ext.getCmp('modx-context-name');
-                    if (el) { el.getEl().update(_('context')+': '+r.object.key); }
+                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(r.object.key);
                     this.fireEvent('ready');
                     MODx.fireEvent('ready');
                     this.initialized = true;
@@ -145,6 +140,12 @@ Ext.extend(MODx.panel.Context,MODx.FormPanel,{
 
         var t = parent.Ext.getCmp('modx-resource-tree');
         if (t) { t.refresh(); }
+    }
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-context-name', [{
+            text: _('contexts'),
+            href: MODx.getPage('context')
+        }]);
     }
 });
 Ext.reg('modx-panel-context',MODx.panel.Context);

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -14,11 +14,7 @@ MODx.panel.Dashboard = function(config) {
         }
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
-        ,items: [{
-            html: _('dashboard')
-            ,id: 'modx-dashboard-header'
-            ,xtype: 'modx-header'
-        },{
+        ,items: [this.getPageHeader(config),{
             xtype: 'modx-tabs'
             ,defaults: {
                 autoHeight: true
@@ -69,7 +65,7 @@ MODx.panel.Dashboard = function(config) {
                             ,anchor: '100%'
                             ,listeners: {
                                 'keyup': {scope:this,fn:function(f,e) {
-                                    Ext.getCmp('modx-dashboard-header').getEl().update(_('dashboard')+': '+f.getValue());
+                                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getValue()));
                                 }}
                             }
                         },{
@@ -155,9 +151,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
             return false;
         }
         this.getForm().setValues(this.config.record);
-        Ext.defer(function() {
-            Ext.getCmp('modx-dashboard-header').update(_('dashboard')+': '+this.config.record.name);
-        }, 250, this);
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(this.config.record.name);
 
         /*
         var d = this.config.record.usergroups;
@@ -193,6 +187,12 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
             if (wg) { wg.getStore().commitChanges(); }
 
         }
+    }
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-dashboard-header', [{
+            text: _('dashboards'),
+            href: MODx.getPage('system/dashboards')
+        }]);
     }
 });
 Ext.reg('modx-panel-dashboard',MODx.panel.Dashboard);

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -47,10 +47,7 @@ MODx.panel.DashboardWidget = function(config) {
                         'keyup': {scope:this,fn:function(f,e) {
                             var s = _(f.getValue());
                             if (s == undefined) { s = f.getValue(); }
-                            Ext.getCmp('modx-dashboard-widget-name-trans').setValue(s);
-                            if (!Ext.isEmpty(s)) {
-                                Ext.getCmp('modx-dashboard-widget-header').getEl().update(_('widget')+': '+s);
-                            }
+                                Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(s));
                         }}
                     }
                 },{
@@ -249,11 +246,7 @@ MODx.panel.DashboardWidget = function(config) {
         }
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
-        ,items: [{
-            html: _('widget_new')
-            ,id: 'modx-dashboard-widget-header'
-            ,xtype: 'modx-header'
-        },{
+        ,items: [this.getPageHeader(config),{
             xtype: 'modx-tabs'
             ,defaults: {
                 autoHeight: true
@@ -289,9 +282,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
             return false;
         }
         this.getForm().setValues(this.config.record);
-        Ext.defer(function() {
-            Ext.get('modx-dashboard-widget-header').update(_('widget')+': '+this.config.record.name_trans);
-        }, 250, this);
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(this.config.record.name_trans);
 
         var d = this.config.record.dashboards;
         var g = Ext.getCmp('modx-grid-dashboard-widget-dashboards');
@@ -328,6 +319,15 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
             var g = Ext.getCmp('modx-grid-dashboard-widget-dashboards');
             if (g) { g.getStore().commitChanges(); }
         }
+    }
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-dashboard-widget-header', [{
+            text: _('dashboards'),
+            href: MODx.getPage('system/dashboards')
+        }, {
+            text: _('widget'),
+            href: null
+        }]);
     }
 });
 Ext.reg('modx-panel-dashboard-widget',MODx.panel.DashboardWidget);


### PR DESCRIPTION
### What does it do?
Adds a helper function to generate header breadcrumbs for pages. Implements it for sources & users. There are more places where it can be implemented, but I didn't know if this will be a wanted enhancement or not. So if the idea gets approved I'll add it to other places.

### Why is it needed?
As described in the issue #14769, it seems nice to have breadcrumbs in more places than just in resources.

### Related issue(s)/PR(s)
Resolves #14769
