### PR TITLE
Update travis CI configuration to include php 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
-dist: trusty
-sudo: required
 language: php
 script:
-  - phpunit --version
-  - "phpunit -c ./phpunit.xml"
+  - "../../core/vendor/bin/phpunit --version"
+  - "../../core/vendor/bin/phpunit -c ./phpunit.xml"
 
 # Set php versions
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1
   - 7.0
   - nightly
+
+services: mysql
 
 matrix:
   allow_failures:
@@ -23,7 +24,6 @@ mysql:
   username: root
   encoding: utf8
 
-before_script: 'composer install -n && cd _build/test && ./generateConfigs.sh'
-
-before_install:
-  -  if [[ "(7.0 7.1 7.2 7.3 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-6.5.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+before_script:
+  - 'composer install -n && cd _build/test && ./generateConfigs.sh'
+  - phpenv config-add test.ini

--- a/_build/test/test.ini
+++ b/_build/test/test.ini
@@ -1,0 +1,1 @@
+error_reporting = E_ALL & ~E_DEPRECATED


### PR DESCRIPTION
### What does it do?
Adds PHP 7.4 to the TravisCI configuration.

### Why is it needed?
To include PHP 7.4 in the unit test coverage.

### Related issue(s)/PR(s)
n/a