### PR TITLE
Deleting resource with new switch (checkbox) shows duplicate in tree

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -148,7 +148,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             if (deleteChk) {
                 deleteChk.setValue(deleted);
             }
-            this.updateTree();
         }
     }
 
@@ -211,7 +210,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         var g = Ext.getCmp('modx-grid-resource-security');
         if (g) { g.getStore().commitChanges(); }
 
-        this.updateTree();
         var object = o.result.object;
         // object.parent is undefined on template changing.
         if (this.config.resource && object.parent !== undefined && (object.class_key != this.defaultClassKey || object.parent != this.defaultValues.parent)) {
@@ -226,6 +224,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 this.handlePreview(object.deleted);
                 this.handleDeleted(object.deleted);
             }
+
+            this.updateTree();
+
             this.record = object;
             this.getForm().setValues(object);
             Ext.getCmp('modx-page-update-resource').config.preview_url = object.preview_url;


### PR DESCRIPTION
### What does it do?
IMHO the `updateTree` function is called twice too soon, the tree doesn't refresh the node fast enough so on the second call it'll add it once more. I moved the call of `updateTree` function, so it's called just once.

### Why is it needed?
ATM when you delete/undelete a resource through the resource edit panel, the tree refreshes and the current resource will appear twice.

### Related issue(s)/PR(s)
#14893
