### PR TITLE
Remove Emogrifier (temporary)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "smarty/smarty": "^3.1",
         "james-heinrich/phpthumb": "^1.7",
         "erusev/parsedown": "^1.7",
-        "pelago/emogrifier": "^2.0",
         "simplepie/simplepie": "^1.5",
         "ext-curl": "*",
         "ext-dom": "*",

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -13,7 +13,6 @@ namespace MODX\Revolution\Mail;
 
 use Exception;
 use MODX\Revolution\modX;
-use Pelago\Emogrifier;
 use PHPMailer\PHPMailer\PHPMailer;
 
 /**
@@ -219,12 +218,6 @@ class modPHPMailer extends modMail
 
         $sent = false;
         try {
-            if (strpos($this->mailer->ContentType, 'html') !== false) {
-                if (!empty($this->mailer->Body)) {
-                    $emogrifier = new Emogrifier($this->mailer->Body);
-                    $this->mailer->Body = $emogrifier->emogrify();
-                }
-            }
             $sent = $this->mailer->send();
         } catch (Exception $e) {
             $this->error = $this->modx->getService('error.modError');


### PR DESCRIPTION
### What does it do?
Remove Emogrifier (temporary)

### Why is it needed?
Emogrifier's platform requirements prevent us from installing MODX using `composer install`.
Travis also fails due to this. Once we can use a version of Emogrifier that allows us to install it under PHP 7.4 we can add it back.

### Related issue(s)/PR(s)
- https://github.com/MyIntervals/emogrifier/issues/819
- PR #14891 