### PR TITLE
Dark dashboard theme

### DIFF
--- a/_build/templates/default/sass/dark-theme.scss
+++ b/_build/templates/default/sass/dark-theme.scss
@@ -1,7 +1,14 @@
 @media (prefers-color-scheme: dark) {
   body {
+    color: #b1b1b5 !important;
+
     a {
       color: #4d83ff !important;
+    }
+
+    h2,
+    h3 {
+      color: #b1b1b5 !important;
     }
   }
 
@@ -16,6 +23,62 @@
       background: #1c1e2f !important;
       color: #b1b1b5 !important
     }
+
+    &.x-tab-strip-active {
+      background: #1c1e2f !important;
+    }
+  }
+
+  #modx-user-tabs {
+    ul.x-tab-strip li.x-tab-strip-active {
+      background: #26293b !important;
+    }
+  }
+
+  .panel-desc {
+    color: #b1b1b5 !important;
+    border-bottom: 1px solid #313452 !important;
+  }
+
+  .x-grid3 {
+    background-color: transparent;
+    border: 1px solid #313452 !important;
+  }
+
+  .x-grid3-header {
+    background: #26293b !important;
+    border-bottom: 1px solid #313452 !important;
+
+    .x-grid3-hd-row {
+      td {
+        color: #b1b1b5 !important;
+        font-weight: 400 !important;
+      }
+
+      td {
+        border-left: 1px solid #313452 !important;
+      }
+    }
+  }
+
+  td.x-grid3-hd-over .x-grid3-hd-inner,
+  td.sort-desc .x-grid3-hd-inner,
+  td.sort-asc .x-grid3-hd-inner,
+  td.x-grid3-hd-menu-open .x-grid3-hd-inner {
+    background: #26293b !important;
+    color: #b1b1b5 !important;
+  }
+
+  .x-grid3-hd-btn:hover {
+    background-color: #26293b !important;
+  }
+
+  .x-panel-body-noheader .x-grid3-body {
+    background-color: #26293b !important;
+  }
+
+  .x-toolbar .x-form-field-trigger-wrap {
+    box-shadow: 0 0 0 1px #313452 !important;
   }
 
   .modx-tree-node-tool-ct .x-btn:hover,
@@ -52,7 +115,7 @@
   }
 
   .modx-page-header {
-    color: white !important;
+    color: #b1b1b5 !important;
   }
 
   #modx-leftbar {
@@ -82,14 +145,14 @@
 
   #modx-leftbar-header {
     background-color: #313452 !important;
-    color: white !important;
+    color: #b1b1b5 !important;
 
     a {
-      color: white !important;
+      color: #b1b1b5 !important;
 
       &:hover,
       &:focus {
-        color: white !important;
+        color: #b1b1b5 !important;
       }
     }
   }
@@ -97,7 +160,7 @@
   #modx-header {
     background-color: #313452 !important;
     border-right: 1px solid rgba(151, 151, 151, 0.18) !important;
-    color: white !important;
+    color: #b1b1b5 !important;
   }
 
   #modx-footer {
@@ -123,6 +186,10 @@
     .modx-subnav-arrow {
       border-right-color: #1c1e2f !important;
     }
+  }
+
+  #modx-action-buttons {
+    background: #313452 !important;
   }
 
   .x-tab-panel-noborder .x-tab-panel-body-noborder {
@@ -158,7 +225,7 @@
 
     .dashboard-button {
       background-color: #313452 !important;
-      color: white !important;
+      color: #b1b1b5 !important;
     }
   }
 
@@ -182,13 +249,13 @@
       }
 
       h4 {
-        color: white !important;
+        color: #b1b1b5 !important;
       }
 
       &:not(.headless),
       .title-wrapper .title {
         background-color: #313452 !important;
-        color: white !important;
+        color: #b1b1b5 !important;
       }
     }
   }
@@ -219,5 +286,155 @@
 
   .news_article .content {
     color: #b1b1b5 !important
+  }
+
+  // Forms
+  .x-form-field-wrap {
+    background: #1d1e2f !important;
+    border-color: #313452 !important;
+  }
+
+  .x-form-item label.x-form-item-label {
+    color: #b1b1b5 !important;
+    font-weight: 400 !important;
+  }
+
+  .x-form-text,
+  textarea.x-form-field {
+    background-color: #1d1e2f !important;
+    border-color: #313452 !important;
+    color: #b1b1b5 !important;
+  }
+
+  .x-form-text,
+  textarea.x-form-field,
+  .x-form-textarea {}
+
+  .x-form-check-wrap .x-form-cb-label,
+  .x-form-check-wrap .x-fieldset-header-text,
+  .x-fieldset-checkbox-toggle legend .x-form-cb-label,
+  .x-fieldset-checkbox-toggle legend .x-fieldset-header-text {
+    color: #b1b1b5 !important;
+  }
+
+  .x-form-check-wrap .x-form-checkbox:checked+.x-form-cb-label:before,
+  .x-form-check-wrap input[type="checkbox"]:checked+.x-fieldset-header-text:before,
+  .x-fieldset-checkbox-toggle legend .x-form-checkbox:checked+.x-form-cb-label:before,
+  .x-fieldset-checkbox-toggle legend input[type="checkbox"]:checked+.x-fieldset-header-text:before {
+    color: #b1b1b5 !important;
+  }
+
+  .x-fieldset {
+    border: 1px solid #1d1e2f !important;
+
+    .x-fieldset-header {
+      color: #b1b1b5 !important;
+    }
+
+    .x-form-text,
+    textarea.x-form-field,
+    .x-form-textarea {
+      border: #313452 !important;
+    }
+  }
+
+  .x-btn-over.x-btn,
+  .actions button.x-btn-over,
+  .x-btn-over.inline-button,
+  .x-btn-over.x-superboxselect-item,
+  .x-btn-over.x-form-trigger,
+  .x-btn-over.x-date-mp-ok,
+  .x-btn-over.x-date-mp-cancel,
+  .x-btn:hover,
+  .actions button:hover,
+  .inline-button:hover,
+  .x-superboxselect-item:hover,
+  .x-form-trigger:hover,
+  .x-date-mp-ok:hover,
+  .x-date-mp-cancel:hover,
+  .x-btn-focus.x-btn,
+  .actions button.x-btn-focus,
+  .x-btn-focus.inline-button,
+  .x-btn-focus.x-superboxselect-item,
+  .x-btn-focus.x-form-trigger,
+  .x-btn-focus.x-date-mp-ok,
+  .x-btn-focus.x-date-mp-cancel,
+  .x-btn:focus,
+  .actions button:focus,
+  .inline-button:focus,
+  .x-superboxselect-item:focus,
+  .x-form-trigger:focus,
+  .x-date-mp-ok:focus,
+  .x-date-mp-cancel:focus {
+    background-color: #26293b !important;
+    color: #b1b1b5 !important;
+  }
+
+  .x-btn,
+  .actions button,
+  .inline-button,
+  .x-superboxselect-item,
+  .x-form-trigger,
+  .x-date-picker .x-btn,
+  .x-date-mp-ok,
+  .x-date-mp-cancel {
+    background-color: #26293b !important;
+    color: #b1b1b5 !important;
+    box-shadow: 0 0 0 1px #313452 !important;
+  }
+
+  .x-btn button,
+  .actions button button,
+  .inline-button button,
+  .x-superboxselect-item button,
+  .x-form-trigger button,
+  .x-date-picker .x-btn button,
+  .x-date-mp-ok button,
+  .x-date-mp-cancel button {
+    color: white !important;
+  }
+
+  .x-combo-list {
+    .x-combo-list-inner {
+      background-color: #26293b !important;
+      border: 1px solid #313452;
+    }
+
+    .x-combo-list-item {
+      color: #b1b1b5 !important;
+
+      &.x-combo-selected {
+        background-color: #26293b;
+      }
+    }
+  }
+
+  .x-date-picker,
+  .x-date-mp {
+    background-color: #26293b !important;
+    border: 1px solid #313452;
+
+  }
+
+  .x-date-inner {
+    th {
+      color: #b1b1b5 !important;
+    }
+
+    th {
+      background-color: #26293b !important;
+      border-bottom-color: #313452 !important;
+    }
+  }
+
+  .x-date-inner td,
+  .x-date-mp td {
+    background-color: #26293b !important;
+    color: #b1b1b5 !important;
+  }
+
+  .x-date-bottom,
+  .x-date-mp-btns {
+    border-top: 1px solid #313452 !important;
   }
 }

--- a/_build/templates/default/sass/dark-theme.scss
+++ b/_build/templates/default/sass/dark-theme.scss
@@ -40,6 +40,14 @@
     border-bottom: 1px solid #313452 !important;
   }
 
+  .desc-under {
+    color: #b1b1b5 !important;
+  }
+
+  .x-grid-empty {
+    color: #b1b1b5 !important;
+  }
+
   .x-grid3 {
     background-color: transparent;
     border: 1px solid #313452 !important;
@@ -61,6 +69,11 @@
     }
   }
 
+  .x-grid3-row-checker:before,
+  .x-grid3-hd-checker:not(.x-grid3-hd-inner):before {
+    color: #b1b1b5 !important;
+  }
+
   td.x-grid3-hd-over .x-grid3-hd-inner,
   td.sort-desc .x-grid3-hd-inner,
   td.sort-asc .x-grid3-hd-inner,
@@ -73,8 +86,33 @@
     background-color: #26293b !important;
   }
 
-  .x-panel-body-noheader .x-grid3-body {
-    background-color: #26293b !important;
+  .x-grid3-check-col:before,
+  .x-grid3-check-col-on:before {
+    color: #b1b1b5 !important;
+  }
+
+  .x-panel-body-noheader {
+    .x-grid3-row-alt {
+      background: transparent !important;
+      border-bottom: 1px solid #313452 !important;
+      border-top: 1px solid #313452 !important;
+    }
+
+    .x-grid3-body {
+      background-color: #26293b !important;
+    }
+  }
+
+  .x-menu-list {
+    background: #26293b !important;
+
+    li.x-menu-item-active {
+      background-color: transparent;
+    }
+  }
+
+  .x-menu-floating {
+    border-color: #313452 !important;
   }
 
   .x-toolbar .x-form-field-trigger-wrap {
@@ -108,6 +146,14 @@
   .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded span,
   .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded>.icon {
     color: #b1b1b5 !important
+  }
+
+  .tree-pseudoroot-node.x-tree-node-el.x-tree-node-collapsed {
+    border-bottom: 1px solid #313452 !important;
+  }
+
+  .tree-pseudoroot-node.x-tree-node-el>.icon {
+    color: #b1b1b5 !important;
   }
 
   #modx-container {
@@ -452,7 +498,7 @@
       color: #b1b1b5 !important;
     }
 
-    .x-window .x-window-bc .x-window-footer {
+    .x-window-bc .x-window-footer {
       background-color: #26293b !important;
       border-top: 1px solid #313452 !important;
     }
@@ -474,10 +520,6 @@
   }
 
   #modx-resource-tabs {
-    ul.x-tab-strip li.x-tab-strip-active {
-      background: #313452 !important;
-    }
-
     .x-panel-header {
       border-bottom: 1px solid #313452 !important;
       color: #b1b1b5 !important;
@@ -495,5 +537,16 @@
       height: 1.6em;
       background: #b1b1b5;
     }
+  }
+
+  // Elements
+  #modx-content {
+    ul.x-tab-strip li.x-tab-strip-active {
+      background: #313452 !important;
+    }
+  }
+
+  .ext-el-mask {
+    background-color: transparent !important;
   }
 }

--- a/_build/templates/default/sass/dark-theme.scss
+++ b/_build/templates/default/sass/dark-theme.scss
@@ -306,10 +306,6 @@
     color: #b1b1b5 !important;
   }
 
-  .x-form-text,
-  textarea.x-form-field,
-  .x-form-textarea {}
-
   .x-form-check-wrap .x-form-cb-label,
   .x-form-check-wrap .x-fieldset-header-text,
   .x-fieldset-checkbox-toggle legend .x-form-cb-label,
@@ -436,5 +432,68 @@
   .x-date-bottom,
   .x-date-mp-btns {
     border-top: 1px solid #313452 !important;
+  }
+
+  // Modal
+  .x-window {
+    .x-window-body {
+      background-color: #26293b !important;
+      color: #b1b1b5 !important;
+    }
+
+    .x-panel-bwrap {
+      background-color: #26293b !important;
+      color: #b1b1b5 !important;
+    }
+
+    .x-window-tc .x-window-header {
+      background-color: #26293b !important;
+      border-bottom: 1px solid #313452 !important;
+      color: #b1b1b5 !important;
+    }
+
+    .x-window .x-window-bc .x-window-footer {
+      background-color: #26293b !important;
+      border-top: 1px solid #313452 !important;
+    }
+  }
+
+  .x-tool {
+    color: #b1b1b5 !important;
+  }
+
+  // Resources
+  #modx-resource-settings {
+    #modx-resource-main-left {
+      background: #26293b !important;
+    }
+
+    #modx-resource-main-right .modx-resource-panel {
+      background: #26293b !important;
+    }
+  }
+
+  #modx-resource-tabs {
+    ul.x-tab-strip li.x-tab-strip-active {
+      background: #313452 !important;
+    }
+
+    .x-panel-header {
+      border-bottom: 1px solid #313452 !important;
+      color: #b1b1b5 !important;
+    }
+
+    .x-form-check-wrap [type="checkbox"]+.x-form-cb-label:before,
+    .x-form-check-wrap [type="checkbox"]+.x-fieldset-header-text:before,
+    .x-fieldset-checkbox-toggle legend [type="checkbox"]+.x-form-cb-label:before,
+    .x-fieldset-checkbox-toggle legend [type="checkbox"]+.x-fieldset-header-text:before,
+    .x-fieldset legend [type="checkbox"]+.x-form-cb-label:before,
+    .x-fieldset legend [type="checkbox"]+.x-fieldset-header-text:before {
+      left: 0;
+      top: 0;
+      width: 3em;
+      height: 1.6em;
+      background: #b1b1b5;
+    }
   }
 }

--- a/_build/templates/default/sass/dark-theme.scss
+++ b/_build/templates/default/sass/dark-theme.scss
@@ -1,0 +1,223 @@
+@media (prefers-color-scheme: dark) {
+  body {
+    a {
+      color: #4d83ff !important;
+    }
+  }
+
+  #modx-navbar #modx-topnav .top:not(#modx-manager-search-icon) {
+    border-top: 0 !important;
+  }
+
+  ul.x-tab-strip li {
+    color: #b1b1b5 !important;
+
+    &:hover {
+      background: #1c1e2f !important;
+      color: #b1b1b5 !important
+    }
+  }
+
+  .modx-tree-node-tool-ct .x-btn:hover,
+  .modx-tree-node-tool-ct .x-btn:focus {
+    color: #23af47 !important;
+  }
+
+  .x-tree-node {
+    background: transparent !important;
+
+    a span {
+      color: #b1b1b5 !important;
+    }
+  }
+
+  .tree-pseudoroot-node.x-tree-node-el {
+    background-color: rgba(151, 151, 151, 0.18) !important;
+  }
+
+  .tree-pseudoroot-node.x-tree-node-el+.x-tree-node-ct,
+  .tree-pseudoroot-node.x-tree-node-el+div>.x-tree-node-ct {
+    background: #1c1e2f !important;
+    color: #b1b1b5 !important
+  }
+
+  .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded,
+  .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded span,
+  .tree-pseudoroot-node.x-tree-node-el.x-tree-node-expanded>.icon {
+    color: #b1b1b5 !important
+  }
+
+  #modx-container {
+    background: #1c1e2f !important;
+  }
+
+  .modx-page-header {
+    color: white !important;
+  }
+
+  #modx-leftbar {
+    background-color: #313452 !important;
+    border-right: 1px solid rgba(151, 151, 151, 0.18) !important;
+
+    .x-tab-panel-bwrap .x-tab-panel-body-noborder {
+      border-radius: 0 !important;
+    }
+
+    .x-tree .x-panel-body {
+      background: #26293b !important;
+    }
+  }
+
+  #modx-leftbar-tabpanel .x-tab-panel-header .x-tab-strip {
+    li.x-tab-strip-active {
+      background: #1c1e2f !important;
+      border: 0 !important;
+      border-radius: 0 !important;
+    }
+
+    li:hover {
+      border-radius: 0 !important;
+    }
+  }
+
+  #modx-leftbar-header {
+    background-color: #313452 !important;
+    color: white !important;
+
+    a {
+      color: white !important;
+
+      &:hover,
+      &:focus {
+        color: white !important;
+      }
+    }
+  }
+
+  #modx-header {
+    background-color: #313452 !important;
+    border-right: 1px solid rgba(151, 151, 151, 0.18) !important;
+    color: white !important;
+  }
+
+  #modx-footer {
+    .modx-subnav {
+      background: #1c1e2f !important;
+
+      li,
+      li a {
+        background: #1c1e2f !important;
+      }
+
+      li:not(:first-child) {
+        border-top: 1px solid #313452 !important;
+      }
+
+      .modx-subsubnav {
+        border: 1px solid #313452 !important;
+        border-radius: 0 !important;
+        background: #1c1e2f !important;
+      }
+    }
+
+    .modx-subnav-arrow {
+      border-right-color: #1c1e2f !important;
+    }
+  }
+
+  .x-tab-panel-noborder .x-tab-panel-body-noborder {
+    background-color: #313452 !important;
+  }
+
+  .crumb_wrapper {
+    background: #313452 !important;
+  }
+
+  .main-wrapper {
+    background-color: #222437 !important;
+  }
+
+  .primary-button.x-btn,
+  .actions button.primary-button,
+  .primary-button.inline-button,
+  .primary-button.x-superboxselect-item,
+  .primary-button.x-form-trigger,
+  .primary-button.x-date-mp-ok,
+  .primary-button.x-date-mp-cancel {
+    background: #23af47 !important;
+  }
+
+  .dashboard-buttons {
+    .dashboard-button-icon {
+      border: 1px solid #23af47 !important;
+
+      .icon {
+        color: #23af47 !important;
+      }
+    }
+
+    .dashboard-button {
+      background-color: #313452 !important;
+      color: white !important;
+    }
+  }
+
+  .dashboard {
+    ul.configcheck li {
+      background-color: #313452 !important;
+      border: 1px solid rgba(151, 151, 151, 0.18) !important;
+
+      h5 {
+        color: #ff4747 !important;
+      }
+
+      p {
+        color: #b1b1b5 !important;
+      }
+    }
+
+    .dashboard-block {
+      .body {
+        color: #b1b1b5 !important
+      }
+
+      h4 {
+        color: white !important;
+      }
+
+      &:not(.headless),
+      .title-wrapper .title {
+        background-color: #313452 !important;
+        color: white !important;
+      }
+    }
+  }
+
+  .dashboard table {
+    border-radius: 0 !important;
+    border: 1px solid rgba(151, 151, 151, 0.18) !important;
+
+    th,
+    td {
+      border-bottom: 2px solid rgba(151, 151, 151, 0.18) !important;
+    }
+
+    tr:last-child td {
+      border: none !important;
+    }
+  }
+
+  .updates-widget {
+    .updates-ok {
+      background: #23af47 !important;
+    }
+
+    .updates-title {
+      color: #4d83ff !important;
+    }
+  }
+
+  .news_article .content {
+    color: #b1b1b5 !important
+  }
+}

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -47,6 +47,7 @@ $fa-css-prefix: fa;
 @import "dashboard";
 @import "help";
 @import "trash";
+@import "dark-theme";
 
 .icon {
   @extend %pseudo-font;


### PR DESCRIPTION
### What does it do?
Adds a native dark control panel theme. It turns on automatically if the operating system has a dark appearance.

**A few screenshots of the start page**
![Dashboard _ MODX Revolution - Google Chrome 2019-1 (5)](https://user-images.githubusercontent.com/2138260/70859907-ada91d00-1f44-11ea-8ad5-f42fa3ef11e4.jpg)
![Dashboard _ MODX Revolution - Google Chrome 2019-1](https://user-images.githubusercontent.com/2138260/70859903-ad108680-1f44-11ea-81eb-d9038fbe253d.jpg)
![Dashboard _ MODX Revolution - Google Chrome 2019-1 (1)](https://user-images.githubusercontent.com/2138260/70859904-ad108680-1f44-11ea-8686-8a3c4b83600d.jpg)
![Dashboard _ MODX Revolution - Google Chrome 2019-1 (2)](https://user-images.githubusercontent.com/2138260/70859905-ada91d00-1f44-11ea-9809-b93a80c550cb.jpg)
![Dashboard _ MODX Revolution - Google Chrome 2019-1 (3)](https://user-images.githubusercontent.com/2138260/70859906-ada91d00-1f44-11ea-8c94-b95b3052be9d.jpg)


### Why is it needed?
For fans of dark themes =)

### Related issue(s)/PR(s)
NA
