### PR TITLE
Replace Pelago/Emogrifier to InlineStyle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "smarty/smarty": "^3.1",
         "james-heinrich/phpthumb": "^1.7",
         "erusev/parsedown": "^1.7",
-        "pelago/emogrifier": "^2.0",
+        "inlinestyle/inlinestyle": "^1.2",
         "simplepie/simplepie": "^1.5",
         "ext-curl": "*",
         "ext-dom": "*",

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -13,7 +13,7 @@ namespace MODX\Revolution\Mail;
 
 use Exception;
 use MODX\Revolution\modX;
-use Pelago\Emogrifier;
+use InlineStyle\InlineStyle;
 use PHPMailer\PHPMailer\PHPMailer;
 
 /**
@@ -221,8 +221,10 @@ class modPHPMailer extends modMail
         try {
             if (strpos($this->mailer->ContentType, 'html') !== false) {
                 if (!empty($this->mailer->Body)) {
-                    $emogrifier = new Emogrifier($this->mailer->Body);
-                    $this->mailer->Body = $emogrifier->emogrify();
+                    $html = new InlineStyle($this->mailer->Body);
+                    /** @noinspection PhpParamsInspection */
+                    $html->applyStylesheet($html->extractStylesheets());
+                    $this->mailer->Body = $html->getHTML();
                 }
             }
             $sent = $this->mailer->send();


### PR DESCRIPTION
### What does it do?
Replaces Pelago/Emogrifier to InlineStyle

### Why is it needed?
While Emogrifier block us from use PHP 7.4 we need to replace it

### Related issue(s)/PR(s)
#14899
