### PR TITLE
Fixed transparency in .png for TV

### DIFF
--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,69 +1,71 @@
 <div id="tv-image-{$tv->id}"></div>
+
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&src={$tv->value}&source={$source}" alt="" />{/if}
+    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}" alt="" />{/if}
 </div>
+
 {if $disabled}
-<script type="text/javascript">
-// <![CDATA[
-{literal}
-Ext.onReady(function() {
-    var fld{/literal}{$tv->id}{literal} = MODx.load({
-    {/literal}
-        xtype: 'displayfield'
-        ,tv: '{$tv->id}'
-        ,renderTo: 'tv-image-{$tv->id}'
-        ,value: '{$tv->value|escape:'javascript'}'
-        ,width: 400
-        ,msgTarget: 'under'
+    <script type="text/javascript">
+    // <![CDATA[
     {literal}
+    Ext.onReady(function() {
+        var fld{/literal}{$tv->id}{literal} = MODx.load({
+        {/literal}
+            xtype: 'displayfield'
+            ,tv: '{$tv->id}'
+            ,renderTo: 'tv-image-{$tv->id}'
+            ,value: '{$tv->value|escape:'javascript'}'
+            ,width: 400
+            ,msgTarget: 'under'
+        {literal}
+        });
     });
-});
-{/literal}
-// ]]>
-</script>
+    {/literal}
+    // ]]>
+    </script>
 {else}
-<script type="text/javascript">
-// <![CDATA[
-{literal}
-Ext.onReady(function() {
-    var fld{/literal}{$tv->id}{literal} = MODx.load({
-    {/literal}
-        xtype: 'modx-panel-tv-image'
-        ,renderTo: 'tv-image-{$tv->id}'
-        ,tv: '{$tv->id}'
-        ,value: '{$tv->value|escape:'javascript'}'
-        ,relativeValue: '{$tv->value|escape:'javascript'}'
-        ,width: 400
-        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
-        ,wctx: '{if $params.wctx|default}{$params.wctx}{else}web{/if}'
-        {if $params.openTo|default},openTo: '{$params.openTo|replace:"'":"\\'"}'{/if}
-        ,source: '{$source}'
+    <script type="text/javascript">
+    // <![CDATA[
     {literal}
-        ,msgTarget: 'under'
-        ,listeners: {
-            'select': {fn:function(data) {
-                MODx.fireResourceFormChange();
-                var d = Ext.get('tv-image-preview-{/literal}{$tv->id}{literal}');
-                if (Ext.isEmpty(data.url)) {
-                    d.update('');
-                } else {
-                    {/literal}
-                    d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
-                    {literal}
-                }
-            }}
-        }
+    Ext.onReady(function() {
+        var fld{/literal}{$tv->id}{literal} = MODx.load({
+        {/literal}
+            xtype: 'modx-panel-tv-image'
+            ,renderTo: 'tv-image-{$tv->id}'
+            ,tv: '{$tv->id}'
+            ,value: '{$tv->value|escape:'javascript'}'
+            ,relativeValue: '{$tv->value|escape:'javascript'}'
+            ,width: 400
+            ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
+            ,wctx: '{if $params.wctx|default}{$params.wctx}{else}web{/if}'
+            {if $params.openTo|default},openTo: '{$params.openTo|replace:"'":"\\'"}'{/if}
+            ,source: '{$source}'
+        {literal}
+            ,msgTarget: 'under'
+            ,listeners: {
+                'select': {fn:function(data) {
+                    MODx.fireResourceFormChange();
+                    var d = Ext.get('tv-image-preview-{/literal}{$tv->id}{literal}');
+                    if (Ext.isEmpty(data.url)) {
+                        d.update('');
+                    } else {
+                        {/literal}
+                        d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src='+data.url+'&wctx={$ctx}&source={$source}" alt="" />');
+                        {literal}
+                    }
+                }}
+            }
+        });
+        MODx.makeDroppable(Ext.get('tv-image-{/literal}{$tv->id}{literal}'),function(v) {
+            var cb = Ext.getCmp('tvbrowser{/literal}{$tv->id}{literal}');
+            if (cb) {
+                cb.setValue(v);
+                cb.fireEvent('select',{relativeUrl:v});
+            }
+            return '';
+        });
     });
-    MODx.makeDroppable(Ext.get('tv-image-{/literal}{$tv->id}{literal}'),function(v) {
-        var cb = Ext.getCmp('tvbrowser{/literal}{$tv->id}{literal}');
-        if (cb) {
-            cb.setValue(v);
-            cb.fireEvent('select',{relativeUrl:v});
-        }
-        return '';
-    });
-});
-{/literal}
-// ]]>
-</script>
+    {/literal}
+    // ]]>
+    </script>
 {/if}


### PR DESCRIPTION
### What does it do?
This PR is for 3.x. For branch 2.x, corrections were applied in MODX 2.7.2.

Pretty old bug with transparency in .png for TV. In general, png with white edges is not noticeable in the standard manager area, because the background is white, but sometimes artifacts appear on the png background.

Also made the code a little clearer.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/14664
