### PR TITLE
Fix click handler on grid

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -164,6 +164,8 @@ MODx.grid.Grid = function(config) {
     });
     this.getStore().on('exception',this.onStoreException,this);
     this.config = config;
+
+    this.on('click', this.onClickHandler, this);
 };
 Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     windows: {}
@@ -690,7 +692,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         return [];
     }
 
-    ,onClick: function(e) {
+    ,onClickHandler: function(e) {
         var target = e.getTarget();
         if (!target.classList.contains('x-grid-action')) return;
         if (!target.dataset.action) return;


### PR DESCRIPTION
### What does it do?
Register a click listener, instead of overwriting `onClick` function.

### Why is it needed?
When #14806 got merged it messed up click handlers on grids, because someone (me) overwrote the `onClick` function. This approach registers a listener for the click event, which seemed to resolve the issue.


