### PR TITLE
Move deprecated class_aliases out of composer and clean up entry points

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,10 +75,7 @@
     "autoload": {
         "psr-4": {
             "MODX\\": "core/src/"
-        },
-        "files": [
-          "core/include/deprecated.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/connectors/index.php
+++ b/connectors/index.php
@@ -8,10 +8,6 @@
  * files found in the top-level directory of this distribution.
  */
 
-use MODX\Revolution\modConnectorRequest;
-use MODX\Revolution\modX;
-use xPDO\xPDO;
-
 /**
  * @package modx
  * @subpackage connectors
@@ -24,6 +20,7 @@ if (!defined('MODX_CORE_PATH')) {
         include dirname(__FILE__) . '/config.core.php';
     } else {
         define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
+        define('MODX_CONFIG_KEY', 'config');
     }
 
     /* anonymous access for security/login action */
@@ -44,7 +41,7 @@ if (!require_once(MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* load modX instance */
-$modx = new modX('', array(xPDO::OPT_CONN_INIT => array(xPDO::OPT_CONN_MUTABLE => true)));
+$modx = new \MODX\Revolution\modX('', array(\xPDO\xPDO::OPT_CONN_INIT => array(\xPDO\xPDO::OPT_CONN_MUTABLE => true)));
 
 /* initialize the proper context */
 $ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) && is_string($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';
@@ -73,7 +70,7 @@ if ($ctx == 'mgr') {
 }
 
 /* handle the request */
-$connectorRequestClass = $modx->getOption('modConnectorRequest.class', null, modConnectorRequest::class);
+$connectorRequestClass = $modx->getOption('modConnectorRequest.class', null, \MODX\Revolution\modConnectorRequest::class);
 $modx->config['modRequest.class'] = $connectorRequestClass;
 $modx->getRequest();
 $modx->request->sanitizeRequest();

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -10,21 +10,6 @@
 
 namespace MODX\Revolution;
 
-/**
- * This is the main file to include in your scripts to use MODX.
- */
-if (!defined('MODX_CORE_PATH')) {
-    define('MODX_CORE_PATH', dirname(__DIR__, 2) . DIRECTORY_SEPARATOR);
-}
-
-if (!file_exists(MODX_CORE_PATH . 'vendor/autoload.php')) {
-    $errorMessage = 'Site temporarily unavailable; missing dependencies.';
-    @include(MODX_CORE_PATH . 'error/unavailable.include.php');
-    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
-    exit();
-}
-require_once MODX_CORE_PATH . 'vendor/autoload.php';
-
 use Exception;
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Error\modErrorHandler;
@@ -472,10 +457,10 @@ class modX extends xPDO {
             if (!is_null($debug) && $debug !== '') {
                 $this->setDebug($debug);
             }
-            $this->setPackage('Revolution', MODX_CORE_PATH . 'src/');
-            $this->addPackage('Revolution\Registry\Db', MODX_CORE_PATH . 'src/');
-            $this->addPackage('Revolution\Sources', MODX_CORE_PATH . 'src/');
-            $this->addPackage('Revolution\Transport', MODX_CORE_PATH . 'src/');
+            $this->setPackage('MODX\Revolution', MODX_CORE_PATH . 'src/', null, 'MODX\\');
+            $this->addPackage('MODX\Revolution\Registry\Db', MODX_CORE_PATH . 'src/', null, 'MODX\\');
+            $this->addPackage('MODX\Revolution\Sources', MODX_CORE_PATH . 'src/', null, 'MODX\\');
+            $this->addPackage('MODX\Revolution\Transport', MODX_CORE_PATH . 'src/', null, 'MODX\\');
         } catch (xPDOException $xe) {
             $this->sendError('unavailable', array('error_message' => $xe->getMessage()));
         } catch (Exception $e) {
@@ -521,6 +506,7 @@ class modX extends xPDO {
                     xPDO::OPT_VALIDATE_ON_SAVE => true,
                     'cache_system_settings' => true,
                     'cache_system_settings_key' => 'system_settings',
+                    'load_deprecated_global_class_aliases' => true,
                 ),
                 $config_options,
                 $data
@@ -540,6 +526,9 @@ class modX extends xPDO {
             array_unshift($data[xPDO::OPT_CONNECTIONS], $primaryConnection);
             if (!empty($site_id)) $this->site_id = $site_id;
             if (!empty($uuid)) $this->uuid = $uuid;
+            if ((boolean)$data['load_deprecated_global_class_aliases']) {
+                include MODX_CORE_PATH . 'include/deprecated.php';
+            }
         } else {
             throw new xPDOException("Could not load MODX config file.");
         }

--- a/index.php
+++ b/index.php
@@ -19,6 +19,7 @@ if (!defined('MODX_API_MODE')) {
 /* include custom core config and define core path */
 @include(dirname(__FILE__) . '/config.core.php');
 if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__FILE__) . '/core/');
+if (!defined('MODX_CONFIG_KEY')) define('MODX_CONFIG_KEY', 'config');
 
 /* include the autoloader */
 if (!@require_once (MODX_CORE_PATH . "vendor/autoload.php")) {

--- a/manager/index.php
+++ b/manager/index.php
@@ -8,17 +8,15 @@
  * files found in the top-level directory of this distribution.
  */
 
-use MODX\Revolution\modX;
-use xPDO\xPDO;
-
 /**
  * Initializes the modx manager
  *
  * @package modx
  * @subpackage manager
  */
-@include dirname(__FILE__) . '/config.core.php';
+@include(dirname(__FILE__) . '/config.core.php');
 if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
+if (!defined('MODX_CONFIG_KEY')) define('MODX_CONFIG_KEY', 'config');
 
 /* define this as true in another entry file, then include this file to simply access the API
  * without executing the MODX request handler */
@@ -43,9 +41,9 @@ if (!(require_once MODX_CORE_PATH . 'vendor/autoload.php')) {
     die('Site temporarily unavailable!');
 }
 
-/* @var modX $modx create the modX object */
-$modx= new modX('', array(xPDO::OPT_CONN_INIT => array(xPDO::OPT_CONN_MUTABLE => true)));
-if (!is_object($modx) || !($modx instanceof modX)) {
+/* @var \MODX\Revolution\modX $modx create the modX object */
+$modx= new \MODX\Revolution\modX('', array(\xPDO\xPDO::OPT_CONN_INIT => array(\xPDO\xPDO::OPT_CONN_MUTABLE => true)));
+if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     $errorMessage = '<a href="../setup/">MODX not installed. Install now?</a>';
     include MODX_CORE_PATH . 'error/unavailable.include.php';
     header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');


### PR DESCRIPTION
### What does it do?
Having core/includes/deprecated.php loaded via composer was breaking any use of core/vendor/bin/xpdo because it was forcing the loading of modX before a core.config.php was loaded. This should never be allowed. To make the process more strict, I am moving MODX_CORE_PATH and autoloading out of modX class. Autoloading and loading config.core.php MUST always come first.

### Why is it needed?
To fix problems regenerating the model classes and make entry points more consistent.

### Related issue(s)/PR(s)
