### PR TITLE
Fix unit tests depending on deprecated classes being loaded

### DIFF
--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -61,8 +61,12 @@ class MODxTestHarness {
             $driver= self::$properties['xpdo_driver'];
             switch ($class) {
                 case 'modX':
+                case modX::class:
                     if (!defined('MODX_REQP')) {
                         define('MODX_REQP',false);
+                    }
+                    if (!defined('MODX_CORE_PATH')) {
+                        define('MODX_CORE_PATH', array_key_exists('core_path', self::$properties) ? self::$properties['core_path'] : dirname(__DIR__, 2) . '/core/');
                     }
                     if (!defined('MODX_CONFIG_KEY')) {
                         define('MODX_CONFIG_KEY', array_key_exists('config_key', self::$properties) ? self::$properties['config_key'] : 'test');
@@ -92,6 +96,7 @@ class MODxTestHarness {
                     }
                     break;
                 case 'xPDO':
+                case xPDO::class:
                     $fixture = new xPDO(
                         self::$properties["{$driver}_string_dsn_test"],
                         self::$properties["{$driver}_string_username"],

--- a/manager/controllers/default/dashboard/widget.updates.php
+++ b/manager/controllers/default/dashboard/widget.updates.php
@@ -5,6 +5,7 @@ use MODX\Revolution\modDashboardWidgetInterface;
 use MODX\Revolution\Processors\Workspace\Packages\GetList;
 use MODX\Revolution\Smarty\modSmarty;
 use MODX\Revolution\Transport\modTransportPackage;
+use xPDO\xPDO;
 
 /**
  * @package modx

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -10,6 +10,8 @@
 
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modMenu;
+use xPDO\xPDO;
+use xPDO\Cache\xPDOCacheManager;
 
 /**
  * Loads the main structure

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -13,6 +13,7 @@ use MODX\Revolution\modFormCustomizationProfile;
 use MODX\Revolution\modFormCustomizationProfileUserGroup;
 use MODX\Revolution\modFormCustomizationSet;
 use MODX\Revolution\modResource;
+use xPDO\Om\xPDOQuery;
 
 require_once dirname(__FILE__) . '/resource.class.php';
 

--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -9,6 +9,8 @@
  */
 
 use MODX\Revolution\modResource;
+use xPDO\xPDO;
+use xPDO\Cache\xPDOCacheManager;
 
 require_once dirname(__FILE__) . '/resource.class.php';
 


### PR DESCRIPTION
### What does it do?
Fixed references to global namespaced classes in unit tests.

### Why is it needed?
Trying to resolve the current problem with unit tests not passing.

### Related issue(s)/PR(s)
n/a