### PR TITLE
Regenerate mysql platform classes with explicit InnoDB engine declaration

### DIFF
--- a/core/src/Revolution/Registry/Db/metadata.mysql.php
+++ b/core/src/Revolution/Registry/Db/metadata.mysql.php
@@ -3,14 +3,14 @@ $xpdo_meta_map = array (
     'version' => '3.0',
     'namespace' => 'MODX\\Revolution\\Registry\\Db',
     'namespacePrefix' => 'MODX',
-    'class_map' =>
+    'class_map' => 
     array (
-        'xPDO\\Om\\xPDOSimpleObject' =>
+        'xPDO\\Om\\xPDOSimpleObject' => 
         array (
             0 => 'MODX\\Revolution\\Registry\\Db\\modDbRegisterQueue',
             1 => 'MODX\\Revolution\\Registry\\Db\\modDbRegisterTopic',
         ),
-        'xPDO\\Om\\xPDOObject' =>
+        'xPDO\\Om\\xPDOObject' => 
         array (
             0 => 'MODX\\Revolution\\Registry\\Db\\modDbRegisterMessage',
         ),

--- a/core/src/Revolution/Registry/Db/mysql/modDbRegisterMessage.php
+++ b/core/src/Revolution/Registry/Db/mysql/modDbRegisterMessage.php
@@ -7,12 +7,17 @@ use xPDO\Om\xPDOCriteria;
 
 class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMessage
 {
+
     public static $metaMap = array (
         'package' => 'MODX\\Revolution\\Registry\\Db',
         'version' => '3.0',
         'table' => 'register_messages',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
+        'fields' => 
         array (
             'topic' => NULL,
             'id' => NULL,
@@ -24,9 +29,9 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
             'payload' => NULL,
             'kill' => 0,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'topic' =>
+            'topic' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -35,7 +40,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'null' => false,
                 'index' => 'pk',
             ),
-            'id' =>
+            'id' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -43,28 +48,28 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'null' => false,
                 'index' => 'pk',
             ),
-            'created' =>
+            'created' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'valid' =>
+            'valid' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'accessed' =>
+            'accessed' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
                 'index' => 'index',
             ),
-            'accesses' =>
+            'accesses' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -74,7 +79,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
                 'index' => 'index',
             ),
-            'expires' =>
+            'expires' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '20',
@@ -83,13 +88,13 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
                 'index' => 'index',
             ),
-            'payload' =>
+            'payload' => 
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'string',
                 'null' => false,
             ),
-            'kill' =>
+            'kill' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -99,23 +104,23 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'topic' =>
+                    'topic' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'id' =>
+                    'id' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -123,15 +128,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'created' =>
+            'created' => 
             array (
                 'alias' => 'created',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'created' =>
+                    'created' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -139,15 +144,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'valid' =>
+            'valid' => 
             array (
                 'alias' => 'valid',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'valid' =>
+                    'valid' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -155,15 +160,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accessed' =>
+            'accessed' => 
             array (
                 'alias' => 'accessed',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'accessed' =>
+                    'accessed' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -171,15 +176,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accesses' =>
+            'accesses' => 
             array (
                 'alias' => 'accesses',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'accesses' =>
+                    'accesses' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -187,15 +192,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'expires' =>
+            'expires' => 
             array (
                 'alias' => 'expires',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'expires' =>
+                    'expires' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -204,9 +209,9 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Topic' =>
+            'Topic' => 
             array (
                 'class' => 'MODX\\Revolution\\Registry\\Db\\modDbRegisterTopic',
                 'local' => 'topic',

--- a/core/src/Revolution/Registry/Db/mysql/modDbRegisterQueue.php
+++ b/core/src/Revolution/Registry/Db/mysql/modDbRegisterQueue.php
@@ -11,6 +11,10 @@ class modDbRegisterQueue extends \MODX\Revolution\Registry\Db\modDbRegisterQueue
         'version' => '3.0',
         'table' => 'register_queues',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => NULL,
@@ -63,4 +67,5 @@ class modDbRegisterQueue extends \MODX\Revolution\Registry\Db\modDbRegisterQueue
             ),
         ),
     );
+
 }

--- a/core/src/Revolution/Registry/Db/mysql/modDbRegisterTopic.php
+++ b/core/src/Revolution/Registry/Db/mysql/modDbRegisterTopic.php
@@ -11,6 +11,10 @@ class modDbRegisterTopic extends \MODX\Revolution\Registry\Db\modDbRegisterTopic
         'version' => '3.0',
         'table' => 'register_topics',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'queue' => NULL,
@@ -114,4 +118,5 @@ class modDbRegisterTopic extends \MODX\Revolution\Registry\Db\modDbRegisterTopic
             ),
         ),
     );
+
 }

--- a/core/src/Revolution/Sources/mysql/modAccessMediaSource.php
+++ b/core/src/Revolution/Sources/mysql/modAccessMediaSource.php
@@ -11,6 +11,10 @@ class modAccessMediaSource extends \MODX\Revolution\Sources\modAccessMediaSource
         'version' => '3.0',
         'table' => 'access_media_source',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => '',

--- a/core/src/Revolution/Sources/mysql/modFTPMediaSource.php
+++ b/core/src/Revolution/Sources/mysql/modFTPMediaSource.php
@@ -10,6 +10,10 @@ class modFTPMediaSource extends \MODX\Revolution\Sources\modFTPMediaSource
         'package' => 'MODX\\Revolution\\Sources',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\Sources\\modMediaSource',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/Sources/mysql/modFileMediaSource.php
+++ b/core/src/Revolution/Sources/mysql/modFileMediaSource.php
@@ -10,6 +10,10 @@ class modFileMediaSource extends \MODX\Revolution\Sources\modFileMediaSource
         'package' => 'MODX\\Revolution\\Sources',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\Sources\\modMediaSource',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/Sources/mysql/modMediaSource.php
+++ b/core/src/Revolution/Sources/mysql/modMediaSource.php
@@ -11,6 +11,10 @@ class modMediaSource extends \MODX\Revolution\Sources\modMediaSource
         'version' => '3.0',
         'table' => 'media_sources',
         'extends' => 'MODX\\Revolution\\modAccessibleSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/Sources/mysql/modMediaSourceContext.php
+++ b/core/src/Revolution/Sources/mysql/modMediaSourceContext.php
@@ -11,6 +11,10 @@ class modMediaSourceContext extends \MODX\Revolution\Sources\modMediaSourceConte
         'version' => '3.0',
         'table' => 'media_sources_contexts',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'source' => 0,

--- a/core/src/Revolution/Sources/mysql/modMediaSourceElement.php
+++ b/core/src/Revolution/Sources/mysql/modMediaSourceElement.php
@@ -12,6 +12,10 @@ class modMediaSourceElement extends \MODX\Revolution\Sources\modMediaSourceEleme
         'version' => '3.0',
         'table' => 'media_sources_elements',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'source' => 0,

--- a/core/src/Revolution/Sources/mysql/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/mysql/modS3MediaSource.php
@@ -10,6 +10,10 @@ class modS3MediaSource extends \MODX\Revolution\Sources\modS3MediaSource
         'package' => 'MODX\\Revolution\\Sources',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\Sources\\modMediaSource',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/Transport/metadata.mysql.php
+++ b/core/src/Revolution/Transport/metadata.mysql.php
@@ -3,13 +3,13 @@ $xpdo_meta_map = array (
     'version' => '3.0',
     'namespace' => 'MODX\\Revolution\\Transport',
     'namespacePrefix' => 'MODX',
-    'class_map' =>
+    'class_map' => 
     array (
-        'xPDO\\Om\\xPDOSimpleObject' =>
+        'xPDO\\Om\\xPDOSimpleObject' => 
         array (
             0 => 'MODX\\Revolution\\Transport\\modTransportProvider',
         ),
-        'xPDO\\Om\\xPDOObject' =>
+        'xPDO\\Om\\xPDOObject' => 
         array (
             0 => 'MODX\\Revolution\\Transport\\modTransportPackage',
         ),

--- a/core/src/Revolution/Transport/mysql/modTransportPackage.php
+++ b/core/src/Revolution/Transport/mysql/modTransportPackage.php
@@ -5,12 +5,17 @@ use MODX\Revolution\modX;
 
 class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
 {
+
     public static $metaMap = array (
         'package' => 'MODX\\Revolution\\Transport',
         'version' => '3.0',
         'table' => 'transport_packages',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
+        'fields' => 
         array (
             'signature' => NULL,
             'created' => NULL,
@@ -31,9 +36,9 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
             'release' => '',
             'release_index' => 0,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'signature' =>
+            'signature' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -41,24 +46,24 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'index' => 'pk',
             ),
-            'created' =>
+            'created' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
             ),
-            'updated' =>
+            'updated' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
-            'installed' =>
+            'installed' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
             ),
-            'state' =>
+            'state' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -67,7 +72,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'default' => 1,
             ),
-            'workspace' =>
+            'workspace' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -77,7 +82,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'fk',
             ),
-            'provider' =>
+            'provider' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -87,7 +92,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'fk',
             ),
-            'disabled' =>
+            'disabled' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -97,22 +102,22 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'source' =>
+            'source' => 
             array (
                 'dbtype' => 'tinytext',
                 'phptype' => 'string',
             ),
-            'manifest' =>
+            'manifest' => 
             array (
                 'dbtype' => 'text',
                 'phptype' => 'array',
             ),
-            'attributes' =>
+            'attributes' => 
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'array',
             ),
-            'package_name' =>
+            'package_name' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -120,12 +125,12 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'index' => 'index',
             ),
-            'metadata' =>
+            'metadata' => 
             array (
                 'dbtype' => 'text',
                 'phptype' => 'array',
             ),
-            'version_major' =>
+            'version_major' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -134,7 +139,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'version_minor' =>
+            'version_minor' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -143,7 +148,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'version_patch' =>
+            'version_patch' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -152,7 +157,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'release' =>
+            'release' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
@@ -161,7 +166,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => '',
                 'index' => 'index',
             ),
-            'release_index' =>
+            'release_index' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -171,17 +176,17 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'index' => 'index',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'signature' =>
+                    'signature' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -189,15 +194,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'workspace' =>
+            'workspace' => 
             array (
                 'alias' => 'workspace',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'workspace' =>
+                    'workspace' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -205,15 +210,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'provider' =>
+            'provider' => 
             array (
                 'alias' => 'provider',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'provider' =>
+                    'provider' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -221,15 +226,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'disabled' =>
+            'disabled' => 
             array (
                 'alias' => 'disabled',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'disabled' =>
+                    'disabled' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -237,15 +242,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'package_name' =>
+            'package_name' => 
             array (
                 'alias' => 'package_name',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'package_name' =>
+                    'package_name' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -253,15 +258,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_major' =>
+            'version_major' => 
             array (
                 'alias' => 'version_major',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_major' =>
+                    'version_major' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -269,15 +274,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_minor' =>
+            'version_minor' => 
             array (
                 'alias' => 'version_minor',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_minor' =>
+                    'version_minor' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -285,15 +290,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_patch' =>
+            'version_patch' => 
             array (
                 'alias' => 'version_patch',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_patch' =>
+                    'version_patch' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -301,15 +306,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'release' =>
+            'release' => 
             array (
                 'alias' => 'release',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'release' =>
+                    'release' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -317,15 +322,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'release_index' =>
+            'release_index' => 
             array (
                 'alias' => 'release_index',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'release_index' =>
+                    'release_index' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -334,9 +339,9 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Workspace' =>
+            'Workspace' => 
             array (
                 'class' => 'MODX\\Revolution\\modWorkspace',
                 'local' => 'workspace',
@@ -344,7 +349,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Provider' =>
+            'Provider' => 
             array (
                 'class' => 'MODX\\Revolution\\Transport\\modTransportProvider',
                 'local' => 'provider',

--- a/core/src/Revolution/Transport/mysql/modTransportProvider.php
+++ b/core/src/Revolution/Transport/mysql/modTransportProvider.php
@@ -11,6 +11,10 @@ class modTransportProvider extends \MODX\Revolution\Transport\modTransportProvid
         'version' => '3.0',
         'table' => 'transport_providers',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => NULL,
@@ -195,4 +199,5 @@ class modTransportProvider extends \MODX\Revolution\Transport\modTransportProvid
             ),
         ),
     );
+
 }

--- a/core/src/Revolution/mysql/modAccess.php
+++ b/core/src/Revolution/mysql/modAccess.php
@@ -10,6 +10,10 @@ class modAccess extends \MODX\Revolution\modAccess
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'target' => '',

--- a/core/src/Revolution/mysql/modAccessAction.php
+++ b/core/src/Revolution/mysql/modAccessAction.php
@@ -11,6 +11,10 @@ class modAccessAction extends \MODX\Revolution\modAccessAction
         'version' => '3.0',
         'table' => 'access_actions',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modAccessActionDom.php
+++ b/core/src/Revolution/mysql/modAccessActionDom.php
@@ -11,6 +11,10 @@ class modAccessActionDom extends \MODX\Revolution\modAccessActionDom
         'version' => '3.0',
         'table' => 'access_actiondom',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modAccessCategory.php
+++ b/core/src/Revolution/mysql/modAccessCategory.php
@@ -11,6 +11,10 @@ class modAccessCategory extends \MODX\Revolution\modAccessCategory
         'version' => '3.0',
         'table' => 'access_category',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => '',

--- a/core/src/Revolution/mysql/modAccessContext.php
+++ b/core/src/Revolution/mysql/modAccessContext.php
@@ -11,6 +11,10 @@ class modAccessContext extends \MODX\Revolution\modAccessContext
         'version' => '3.0',
         'table' => 'access_context',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modAccessElement.php
+++ b/core/src/Revolution/mysql/modAccessElement.php
@@ -11,6 +11,10 @@ class modAccessElement extends \MODX\Revolution\modAccessElement
         'version' => '3.0',
         'table' => 'access_elements',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => '',

--- a/core/src/Revolution/mysql/modAccessMenu.php
+++ b/core/src/Revolution/mysql/modAccessMenu.php
@@ -11,6 +11,10 @@ class modAccessMenu extends \MODX\Revolution\modAccessMenu
         'version' => '3.0',
         'table' => 'access_menus',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modAccessNamespace.php
+++ b/core/src/Revolution/mysql/modAccessNamespace.php
@@ -11,6 +11,10 @@ class modAccessNamespace extends \MODX\Revolution\modAccessNamespace
         'version' => '3.0',
         'table' => 'access_namespace',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => '',

--- a/core/src/Revolution/mysql/modAccessPermission.php
+++ b/core/src/Revolution/mysql/modAccessPermission.php
@@ -11,6 +11,10 @@ class modAccessPermission extends \MODX\Revolution\modAccessPermission
         'version' => '3.0',
         'table' => 'access_permissions',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'template' => 0,

--- a/core/src/Revolution/mysql/modAccessPolicy.php
+++ b/core/src/Revolution/mysql/modAccessPolicy.php
@@ -11,6 +11,10 @@ class modAccessPolicy extends \MODX\Revolution\modAccessPolicy
         'version' => '3.0',
         'table' => 'access_policies',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => NULL,

--- a/core/src/Revolution/mysql/modAccessPolicyTemplate.php
+++ b/core/src/Revolution/mysql/modAccessPolicyTemplate.php
@@ -11,6 +11,10 @@ class modAccessPolicyTemplate extends \MODX\Revolution\modAccessPolicyTemplate
         'version' => '3.0',
         'table' => 'access_policy_templates',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'template_group' => 0,

--- a/core/src/Revolution/mysql/modAccessPolicyTemplateGroup.php
+++ b/core/src/Revolution/mysql/modAccessPolicyTemplateGroup.php
@@ -11,6 +11,10 @@ class modAccessPolicyTemplateGroup extends \MODX\Revolution\modAccessPolicyTempl
         'version' => '3.0',
         'table' => 'access_policy_template_groups',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modAccessResource.php
+++ b/core/src/Revolution/mysql/modAccessResource.php
@@ -11,6 +11,10 @@ class modAccessResource extends \MODX\Revolution\modAccessResource
         'version' => '3.0',
         'table' => 'access_resources',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => '',

--- a/core/src/Revolution/mysql/modAccessResourceGroup.php
+++ b/core/src/Revolution/mysql/modAccessResourceGroup.php
@@ -11,6 +11,10 @@ class modAccessResourceGroup extends \MODX\Revolution\modAccessResourceGroup
         'version' => '3.0',
         'table' => 'access_resource_groups',
         'extends' => 'MODX\\Revolution\\modAccess',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => '',

--- a/core/src/Revolution/mysql/modAccessTemplateVar.php
+++ b/core/src/Revolution/mysql/modAccessTemplateVar.php
@@ -11,6 +11,10 @@ class modAccessTemplateVar extends \MODX\Revolution\modAccessTemplateVar
         'version' => '3.0',
         'table' => 'access_templatevars',
         'extends' => 'MODX\\Revolution\\modAccessElement',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modAccessibleObject.php
+++ b/core/src/Revolution/mysql/modAccessibleObject.php
@@ -10,6 +10,10 @@ class modAccessibleObject extends \MODX\Revolution\modAccessibleObject
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modAccessibleSimpleObject.php
+++ b/core/src/Revolution/mysql/modAccessibleSimpleObject.php
@@ -10,6 +10,10 @@ class modAccessibleSimpleObject extends \MODX\Revolution\modAccessibleSimpleObje
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\modAccessibleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'id' => NULL,

--- a/core/src/Revolution/mysql/modAction.php
+++ b/core/src/Revolution/mysql/modAction.php
@@ -11,6 +11,10 @@ class modAction extends \MODX\Revolution\modAction
         'version' => '3.0',
         'table' => 'actions',
         'extends' => 'MODX\\Revolution\\modAccessibleSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'namespace' => 'core',

--- a/core/src/Revolution/mysql/modActionDom.php
+++ b/core/src/Revolution/mysql/modActionDom.php
@@ -11,6 +11,10 @@ class modActionDom extends \MODX\Revolution\modActionDom
         'version' => '3.0',
         'table' => 'actiondom',
         'extends' => 'MODX\\Revolution\\modAccessibleSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'set' => 0,

--- a/core/src/Revolution/mysql/modActionField.php
+++ b/core/src/Revolution/mysql/modActionField.php
@@ -11,6 +11,10 @@ class modActionField extends \MODX\Revolution\modActionField
         'version' => '3.0',
         'table' => 'actions_fields',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'action' => '',

--- a/core/src/Revolution/mysql/modActiveUser.php
+++ b/core/src/Revolution/mysql/modActiveUser.php
@@ -11,6 +11,10 @@ class modActiveUser extends \MODX\Revolution\modActiveUser
         'version' => '3.0',
         'table' => 'active_users',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'internalKey' => 0,

--- a/core/src/Revolution/mysql/modCategory.php
+++ b/core/src/Revolution/mysql/modCategory.php
@@ -11,6 +11,10 @@ class modCategory extends \MODX\Revolution\modCategory
         'version' => '3.0',
         'table' => 'categories',
         'extends' => 'MODX\\Revolution\\modAccessibleSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'parent' => 0,

--- a/core/src/Revolution/mysql/modCategoryClosure.php
+++ b/core/src/Revolution/mysql/modCategoryClosure.php
@@ -11,6 +11,10 @@ class modCategoryClosure extends \MODX\Revolution\modCategoryClosure
         'version' => '3.0',
         'table' => 'categories_closure',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'ancestor' => 0,

--- a/core/src/Revolution/mysql/modChunk.php
+++ b/core/src/Revolution/mysql/modChunk.php
@@ -11,6 +11,10 @@ class modChunk extends \MODX\Revolution\modChunk
         'version' => '3.0',
         'table' => 'site_htmlsnippets',
         'extends' => 'MODX\\Revolution\\modElement',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modClassMap.php
+++ b/core/src/Revolution/mysql/modClassMap.php
@@ -11,6 +11,10 @@ class modClassMap extends \MODX\Revolution\modClassMap
         'version' => '3.0',
         'table' => 'class_map',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'class' => '',

--- a/core/src/Revolution/mysql/modContentType.php
+++ b/core/src/Revolution/mysql/modContentType.php
@@ -11,6 +11,10 @@ class modContentType extends \MODX\Revolution\modContentType
         'version' => '3.0',
         'table' => 'content_type',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => NULL,

--- a/core/src/Revolution/mysql/modContext.php
+++ b/core/src/Revolution/mysql/modContext.php
@@ -12,6 +12,10 @@ class modContext extends \MODX\Revolution\modContext
         'version' => '3.0',
         'table' => 'context',
         'extends' => 'MODX\\Revolution\\modAccessibleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'key' => NULL,

--- a/core/src/Revolution/mysql/modContextResource.php
+++ b/core/src/Revolution/mysql/modContextResource.php
@@ -11,6 +11,10 @@ class modContextResource extends \MODX\Revolution\modContextResource
         'version' => '3.0',
         'table' => 'context_resource',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => NULL,

--- a/core/src/Revolution/mysql/modContextSetting.php
+++ b/core/src/Revolution/mysql/modContextSetting.php
@@ -11,6 +11,10 @@ class modContextSetting extends \MODX\Revolution\modContextSetting
         'version' => '3.0',
         'table' => 'context_setting',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'context_key' => NULL,

--- a/core/src/Revolution/mysql/modDashboard.php
+++ b/core/src/Revolution/mysql/modDashboard.php
@@ -11,6 +11,10 @@ class modDashboard extends \MODX\Revolution\modDashboard
         'version' => '3.0',
         'table' => 'dashboard',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modDashboardWidget.php
+++ b/core/src/Revolution/mysql/modDashboardWidget.php
@@ -11,6 +11,10 @@ class modDashboardWidget extends \MODX\Revolution\modDashboardWidget
         'version' => '3.0',
         'table' => 'dashboard_widget',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modDashboardWidgetPlacement.php
+++ b/core/src/Revolution/mysql/modDashboardWidgetPlacement.php
@@ -11,6 +11,10 @@ class modDashboardWidgetPlacement extends \MODX\Revolution\modDashboardWidgetPla
         'version' => '3.0',
         'table' => 'dashboard_widget_placement',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'user' => 0,

--- a/core/src/Revolution/mysql/modDocument.php
+++ b/core/src/Revolution/mysql/modDocument.php
@@ -10,6 +10,10 @@ class modDocument extends \MODX\Revolution\modDocument
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\modResource',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modElement.php
+++ b/core/src/Revolution/mysql/modElement.php
@@ -11,6 +11,10 @@ class modElement extends \MODX\Revolution\modElement
         'version' => '3.0',
         'table' => 'site_element',
         'extends' => 'MODX\\Revolution\\modAccessibleSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'source' => 0,

--- a/core/src/Revolution/mysql/modElementPropertySet.php
+++ b/core/src/Revolution/mysql/modElementPropertySet.php
@@ -11,6 +11,10 @@ class modElementPropertySet extends \MODX\Revolution\modElementPropertySet
         'version' => '3.0',
         'table' => 'element_property_sets',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'element' => 0,

--- a/core/src/Revolution/mysql/modEvent.php
+++ b/core/src/Revolution/mysql/modEvent.php
@@ -11,15 +11,19 @@ class modEvent extends \MODX\Revolution\modEvent
         'version' => '3.0',
         'table' => 'system_eventnames',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
+        'fields' => 
         array (
             'name' => NULL,
             'service' => 0,
             'groupname' => '',
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'name' =>
+            'name' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '50',
@@ -27,7 +31,7 @@ class modEvent extends \MODX\Revolution\modEvent
                 'null' => false,
                 'index' => 'pk',
             ),
-            'service' =>
+            'service' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '4',
@@ -36,7 +40,7 @@ class modEvent extends \MODX\Revolution\modEvent
                 'null' => false,
                 'default' => 0,
             ),
-            'groupname' =>
+            'groupname' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '20',
@@ -45,17 +49,17 @@ class modEvent extends \MODX\Revolution\modEvent
                 'default' => '',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'name' =>
+                    'name' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -64,9 +68,9 @@ class modEvent extends \MODX\Revolution\modEvent
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'PluginEvents' =>
+            'PluginEvents' => 
             array (
                 'class' => 'MODX\\Revolution\\modPluginEvent',
                 'local' => 'name',

--- a/core/src/Revolution/mysql/modExtensionPackage.php
+++ b/core/src/Revolution/mysql/modExtensionPackage.php
@@ -11,6 +11,10 @@ class modExtensionPackage extends \MODX\Revolution\modExtensionPackage
         'version' => '3.0',
         'table' => 'extension_packages',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'namespace' => 'core',

--- a/core/src/Revolution/mysql/modFormCustomizationProfile.php
+++ b/core/src/Revolution/mysql/modFormCustomizationProfile.php
@@ -11,6 +11,10 @@ class modFormCustomizationProfile extends \MODX\Revolution\modFormCustomizationP
         'version' => '3.0',
         'table' => 'fc_profiles',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modFormCustomizationProfileUserGroup.php
+++ b/core/src/Revolution/mysql/modFormCustomizationProfileUserGroup.php
@@ -11,6 +11,10 @@ class modFormCustomizationProfileUserGroup extends \MODX\Revolution\modFormCusto
         'version' => '3.0',
         'table' => 'fc_profiles_usergroups',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'usergroup' => 0,

--- a/core/src/Revolution/mysql/modFormCustomizationSet.php
+++ b/core/src/Revolution/mysql/modFormCustomizationSet.php
@@ -11,6 +11,10 @@ class modFormCustomizationSet extends \MODX\Revolution\modFormCustomizationSet
         'version' => '3.0',
         'table' => 'fc_sets',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'profile' => 0,

--- a/core/src/Revolution/mysql/modLexiconEntry.php
+++ b/core/src/Revolution/mysql/modLexiconEntry.php
@@ -11,6 +11,10 @@ class modLexiconEntry extends \MODX\Revolution\modLexiconEntry
         'version' => '3.0',
         'table' => 'lexicon_entries',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modManagerLog.php
+++ b/core/src/Revolution/mysql/modManagerLog.php
@@ -11,6 +11,10 @@ class modManagerLog extends \MODX\Revolution\modManagerLog
         'version' => '3.0',
         'table' => 'manager_log',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'user' => 0,

--- a/core/src/Revolution/mysql/modMenu.php
+++ b/core/src/Revolution/mysql/modMenu.php
@@ -11,6 +11,10 @@ class modMenu extends \MODX\Revolution\modMenu
         'version' => '3.0',
         'table' => 'menus',
         'extends' => 'MODX\\Revolution\\modAccessibleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'text' => '',

--- a/core/src/Revolution/mysql/modNamespace.php
+++ b/core/src/Revolution/mysql/modNamespace.php
@@ -11,6 +11,10 @@ class modNamespace extends \MODX\Revolution\modNamespace
         'version' => '3.0',
         'table' => 'namespaces',
         'extends' => 'MODX\\Revolution\\modAccessibleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modPlugin.php
+++ b/core/src/Revolution/mysql/modPlugin.php
@@ -11,6 +11,10 @@ class modPlugin extends \MODX\Revolution\modPlugin
         'version' => '3.0',
         'table' => 'site_plugins',
         'extends' => 'MODX\\Revolution\\modScript',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'cache_type' => 0,

--- a/core/src/Revolution/mysql/modPluginEvent.php
+++ b/core/src/Revolution/mysql/modPluginEvent.php
@@ -11,6 +11,10 @@ class modPluginEvent extends \MODX\Revolution\modPluginEvent
         'version' => '3.0',
         'table' => 'site_plugin_events',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'pluginid' => 0,

--- a/core/src/Revolution/mysql/modPrincipal.php
+++ b/core/src/Revolution/mysql/modPrincipal.php
@@ -10,6 +10,10 @@ class modPrincipal extends \MODX\Revolution\modPrincipal
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modPropertySet.php
+++ b/core/src/Revolution/mysql/modPropertySet.php
@@ -11,6 +11,10 @@ class modPropertySet extends \MODX\Revolution\modPropertySet
         'version' => '3.0',
         'table' => 'property_set',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modResource.php
+++ b/core/src/Revolution/mysql/modResource.php
@@ -12,6 +12,10 @@ class modResource extends \MODX\Revolution\modResource
         'table' => 'site_content',
         'extends' => 'MODX\\Revolution\\modAccessibleSimpleObject',
         'inherit' => 'single',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'type' => 'document',

--- a/core/src/Revolution/mysql/modResourceGroup.php
+++ b/core/src/Revolution/mysql/modResourceGroup.php
@@ -11,6 +11,10 @@ class modResourceGroup extends \MODX\Revolution\modResourceGroup
         'version' => '3.0',
         'table' => 'documentgroup_names',
         'extends' => 'MODX\\Revolution\\modAccessibleSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modResourceGroupResource.php
+++ b/core/src/Revolution/mysql/modResourceGroupResource.php
@@ -11,6 +11,10 @@ class modResourceGroupResource extends \MODX\Revolution\modResourceGroupResource
         'version' => '3.0',
         'table' => 'document_groups',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'document_group' => 0,

--- a/core/src/Revolution/mysql/modScript.php
+++ b/core/src/Revolution/mysql/modScript.php
@@ -11,6 +11,10 @@ class modScript extends \MODX\Revolution\modScript
         'version' => '3.0',
         'table' => 'site_script',
         'extends' => 'MODX\\Revolution\\modElement',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modSession.php
+++ b/core/src/Revolution/mysql/modSession.php
@@ -11,6 +11,10 @@ class modSession extends \MODX\Revolution\modSession
         'version' => '3.0',
         'table' => 'session',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'id' => '',

--- a/core/src/Revolution/mysql/modSnippet.php
+++ b/core/src/Revolution/mysql/modSnippet.php
@@ -11,6 +11,10 @@ class modSnippet extends \MODX\Revolution\modSnippet
         'version' => '3.0',
         'table' => 'site_snippets',
         'extends' => 'MODX\\Revolution\\modScript',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'cache_type' => 0,

--- a/core/src/Revolution/mysql/modStaticResource.php
+++ b/core/src/Revolution/mysql/modStaticResource.php
@@ -10,6 +10,10 @@ class modStaticResource extends \MODX\Revolution\modStaticResource
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\modResource',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modSymLink.php
+++ b/core/src/Revolution/mysql/modSymLink.php
@@ -10,6 +10,10 @@ class modSymLink extends \MODX\Revolution\modSymLink
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\modResource',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modSystemSetting.php
+++ b/core/src/Revolution/mysql/modSystemSetting.php
@@ -11,6 +11,10 @@ class modSystemSetting extends \MODX\Revolution\modSystemSetting
         'version' => '3.0',
         'table' => 'system_settings',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'key' => '',

--- a/core/src/Revolution/mysql/modTemplate.php
+++ b/core/src/Revolution/mysql/modTemplate.php
@@ -9,6 +9,10 @@ class modTemplate extends \MODX\Revolution\modTemplate
         'version' => '3.0',
         'table' => 'site_templates',
         'extends' => 'MODX\\Revolution\\modElement',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'templatename' => '',

--- a/core/src/Revolution/mysql/modTemplateVar.php
+++ b/core/src/Revolution/mysql/modTemplateVar.php
@@ -11,6 +11,10 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
         'version' => '3.0',
         'table' => 'site_tmplvars',
         'extends' => 'MODX\\Revolution\\modElement',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'type' => '',

--- a/core/src/Revolution/mysql/modTemplateVarResource.php
+++ b/core/src/Revolution/mysql/modTemplateVarResource.php
@@ -11,6 +11,10 @@ class modTemplateVarResource extends \MODX\Revolution\modTemplateVarResource
         'version' => '3.0',
         'table' => 'site_tmplvar_contentvalues',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'tmplvarid' => 0,

--- a/core/src/Revolution/mysql/modTemplateVarResourceGroup.php
+++ b/core/src/Revolution/mysql/modTemplateVarResourceGroup.php
@@ -11,6 +11,10 @@ class modTemplateVarResourceGroup extends \MODX\Revolution\modTemplateVarResourc
         'version' => '3.0',
         'table' => 'site_tmplvar_access',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'tmplvarid' => 0,

--- a/core/src/Revolution/mysql/modTemplateVarTemplate.php
+++ b/core/src/Revolution/mysql/modTemplateVarTemplate.php
@@ -11,6 +11,10 @@ class modTemplateVarTemplate extends \MODX\Revolution\modTemplateVarTemplate
         'version' => '3.0',
         'table' => 'site_tmplvar_templates',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'tmplvarid' => 0,

--- a/core/src/Revolution/mysql/modUser.php
+++ b/core/src/Revolution/mysql/modUser.php
@@ -11,6 +11,10 @@ class modUser extends \MODX\Revolution\modUser
         'version' => '3.0',
         'table' => 'users',
         'extends' => 'MODX\\Revolution\\modPrincipal',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'username' => '',

--- a/core/src/Revolution/mysql/modUserGroup.php
+++ b/core/src/Revolution/mysql/modUserGroup.php
@@ -11,6 +11,10 @@ class modUserGroup extends \MODX\Revolution\modUserGroup
         'version' => '3.0',
         'table' => 'membergroup_names',
         'extends' => 'MODX\\Revolution\\modPrincipal',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',

--- a/core/src/Revolution/mysql/modUserGroupMember.php
+++ b/core/src/Revolution/mysql/modUserGroupMember.php
@@ -11,6 +11,10 @@ class modUserGroupMember extends \MODX\Revolution\modUserGroupMember
         'version' => '3.0',
         'table' => 'member_groups',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'user_group' => 0,

--- a/core/src/Revolution/mysql/modUserGroupRole.php
+++ b/core/src/Revolution/mysql/modUserGroupRole.php
@@ -11,6 +11,10 @@ class modUserGroupRole extends \MODX\Revolution\modUserGroupRole
         'version' => '3.0',
         'table' => 'user_group_roles',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => NULL,

--- a/core/src/Revolution/mysql/modUserGroupSetting.php
+++ b/core/src/Revolution/mysql/modUserGroupSetting.php
@@ -11,6 +11,10 @@ class modUserGroupSetting extends \MODX\Revolution\modUserGroupSetting
         'version' => '3.0',
         'table' => 'user_group_settings',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'group' => 0,

--- a/core/src/Revolution/mysql/modUserMessage.php
+++ b/core/src/Revolution/mysql/modUserMessage.php
@@ -11,6 +11,10 @@ class modUserMessage extends \MODX\Revolution\modUserMessage
         'version' => '3.0',
         'table' => 'user_messages',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'type' => '',

--- a/core/src/Revolution/mysql/modUserProfile.php
+++ b/core/src/Revolution/mysql/modUserProfile.php
@@ -11,6 +11,10 @@ class modUserProfile extends \MODX\Revolution\modUserProfile
         'version' => '3.0',
         'table' => 'user_attributes',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'internalKey' => NULL,

--- a/core/src/Revolution/mysql/modUserSetting.php
+++ b/core/src/Revolution/mysql/modUserSetting.php
@@ -11,6 +11,10 @@ class modUserSetting extends \MODX\Revolution\modUserSetting
         'version' => '3.0',
         'table' => 'user_settings',
         'extends' => 'xPDO\\Om\\xPDOObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'user' => 0,

--- a/core/src/Revolution/mysql/modWebLink.php
+++ b/core/src/Revolution/mysql/modWebLink.php
@@ -10,6 +10,10 @@ class modWebLink extends \MODX\Revolution\modWebLink
         'package' => 'MODX\\Revolution\\',
         'version' => '3.0',
         'extends' => 'MODX\\Revolution\\modResource',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
         ),

--- a/core/src/Revolution/mysql/modWorkspace.php
+++ b/core/src/Revolution/mysql/modWorkspace.php
@@ -11,6 +11,10 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
         'version' => '3.0',
         'table' => 'workspaces',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
+        'tableMeta' => 
+        array (
+            'engine' => 'InnoDB',
+        ),
         'fields' => 
         array (
             'name' => '',


### PR DESCRIPTION
### What does it do?
Regenerating the platform classes since xPDO now includes explicit engine declarations for MySQL.

### Why is it needed?
To prevent these changes from showing up when trying to change anything in the model schema.

### Related issue(s)/PR(s)
