### PR TITLE
Added margin for scroll in the tree

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -12,6 +12,8 @@
   background-color: $white;
   z-index: 0;
   min-width: 288px;
+  max-width: 50%;
+
   .x-toolbar {
     padding: 0 !important;
     border: 0;

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -12,7 +12,10 @@
   background-color: $white;
   z-index: 0;
   min-width: 288px;
-  max-width: 50%;
+
+  @include grid-media($gtDesktop) {
+    max-width: 50%;
+  }
 
   .x-toolbar {
     padding: 0 !important;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -5,7 +5,7 @@
 
   /* the main container + bg behind the tabs */
   .x-tab-panel-noborder {
-    margin: 0;
+    margin: 0 12px;
   }
 
   .x-tab-panel-bwrap {
@@ -46,10 +46,6 @@
       width: 100% !important;
       height: auto !important;
     }
-  }
-
-  & .x-tab-panel-noborder {
-    margin: 0;
   }
 
   /* the toolbars just below the tabs */


### PR DESCRIPTION
### What does it do?
In the tree, if a scroll appears, it will overlaps the controls and the trash bin in the tree, **margin fix this**.

Before:
![tree_b](https://user-images.githubusercontent.com/12523676/71119866-9a23dd80-21f4-11ea-924b-417ce09b2509.gif)

After:
![tree_a](https://user-images.githubusercontent.com/12523676/71119865-9a23dd80-21f4-11ea-9bda-b84e03f6454c.gif)

Also limited the width of the tree to 50% on the desktop, otherwise it could be stretched tree to the full width.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14375
