### PR TITLE
Add league/container and allow namespaces to define a bootstrap.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "require": {
         "php": ">=7.0",
         "xpdo/xpdo": "^3.0@dev",
+        "league/container": "^3.3",
         "league/flysystem": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0",
         "league/flysystem-cached-adapter": "^1.0",

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,3 +1,4 @@
 .htaccess
 /components/
 /vendor/
+/bootstrap.php


### PR DESCRIPTION
### What does it do?
Adds league/container as a DI container for use by MODX components and allows any component which defines a modNamespace to provide a bootstrap.php in the component `path` which is executed on initialization of a modX context.

### Why is it needed?
For 3.x, MODX components need a way to add their paths to the autoloader dynamically. By allowing components to define a bootstrap.php file which is executed when modX is initialized, they can take care of registering their source path(s) with the autoloader, add any custom model packages, add a service class definition to the DI container, and just about anything else they might need to do. This will allow extension packages and the getService() method to be completely deprecated for 3.x in favor of using the DI container and autoloading.

### Related issue(s)/PR(s)
n/a