### PR TITLE
Add a DI container and allow namespaces to define a bootstrap.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "erusev/parsedown": "^1.7",
         "inlinestyle/inlinestyle": "^1.2",
         "simplepie/simplepie": "^1.5",
+        "pimple/pimple": "^3.0",
         "ext-curl": "*",
         "ext-dom": "*",
         "ext-gd": "*",

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,3 +1,4 @@
 .htaccess
 /components/
 /vendor/
+/bootstrap.php

--- a/core/src/Revolution/Services/Container.php
+++ b/core/src/Revolution/Services/Container.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace MODX\Revolution\Services;
+
+
+use Psr\Container\ContainerInterface;
+
+class Container extends \Pimple\Container implements ContainerInterface
+{
+    public function add($id, $value)
+    {
+        $this->offsetSet($id, $value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($id)
+    {
+        if ($this->has($id)) {
+            try {
+                return $this->offsetGet($id);
+            } catch (\Exception $e) {
+                throw new ContainerException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
+        throw new NotFoundException("Dependency not found with key {$id}.");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($id)
+    {
+        return $this->offsetExists($id);
+    }
+}

--- a/core/src/Revolution/Services/ContainerException.php
+++ b/core/src/Revolution/Services/ContainerException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace MODX\Revolution\Services;
+
+
+use Exception;
+use Psr\Container\ContainerExceptionInterface;
+
+class ContainerException extends Exception implements ContainerExceptionInterface
+{
+
+}

--- a/core/src/Revolution/Services/NotFoundException.php
+++ b/core/src/Revolution/Services/NotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace MODX\Revolution\Services;
+
+
+use Exception;
+use Psr\Container\NotFoundExceptionInterface;
+
+class NotFoundException extends Exception implements NotFoundExceptionInterface
+{
+
+}

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -26,6 +26,7 @@ if (!file_exists(MODX_CORE_PATH . 'vendor/autoload.php')) {
 require_once MODX_CORE_PATH . 'vendor/autoload.php';
 
 use Exception;
+use MODX\Revolution\Services\Container;
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Error\modErrorHandler;
 use MODX\Revolution\Mail\modMail;
@@ -74,6 +75,10 @@ class modX extends xPDO {
      * @const SESSION_STATE_EXTERNAL
      */
     const SESSION_STATE_EXTERNAL = 2;
+    /**
+     * @var Container The DI services container.
+     */
+    public $services;
     /**
      * @var modContext The Context represents a unique section of the site which
      * this modX instance is controlling.
@@ -490,7 +495,7 @@ class modX extends xPDO {
      * @param array  $data          Data provided to initialize the instance with, overriding config file entries.
      * @param null   $driverOptions Driver options for the primary connection.
      *
-     * @return array The merged config data ready for use by the modX::__construct() method.
+     * @return Container A DI container containing the config data ready for use by the modX::__construct() method.
      * @throws xPDOException
      */
     protected function loadConfig($configPath = '', $data = array(), $driverOptions = null) {
@@ -540,10 +545,14 @@ class modX extends xPDO {
             array_unshift($data[xPDO::OPT_CONNECTIONS], $primaryConnection);
             if (!empty($site_id)) $this->site_id = $site_id;
             if (!empty($uuid)) $this->uuid = $uuid;
+
+            $container = new Container();
+            $container['config'] = $data;
+
+            return $container;
         } else {
             throw new xPDOException("Could not load MODX config file.");
         }
-        return $data;
     }
 
     /**
@@ -566,6 +575,7 @@ class modX extends xPDO {
 
             $this->getCacheManager();
             $this->getConfig();
+            $this->_initNamespaces();
             $this->_initContext($contextKey, false, $options);
             $this->_loadExtensionPackages($options);
             $this->_initSession($options);
@@ -590,6 +600,19 @@ class modX extends xPDO {
             $this->_initialized= true;
         }
         return $this->_initialized;
+    }
+
+    /**
+     * Initialize namespaces.
+     */
+    protected function _initNamespaces() {
+        $namespaces = $this->call(modNamespace::class, 'loadCache', [&$this]);
+        $modx =& $this;
+        foreach ($namespaces as $namespace) {
+            if (is_readable($namespace['path'] . 'bootstrap.php')) {
+                require $namespace['path'] . 'bootstrap.php';
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Adds a DI container extended from Pimple (https://github.com/silexphp/Pimple) for use by MODX components and allows any component which defines a modNamespace to provide a bootstrap.php in the component `path` which is executed on initialization of a modX context.

### Why is it needed?
For 3.x, MODX components need a way to add their paths to the autoloader dynamically. By allowing components to define a bootstrap.php file which is executed when modX is initialized, they can take care of registering their source path(s) with the autoloader, add any custom model packages, add a service class definition to the DI container, and just about anything else they might need to do. This will allow extension packages and the getService() method to be completely deprecated for 3.x in favor of using the DI container and autoloading.

### Related issue(s)/PR(s)
n/a