### PR TITLE
Call getInstance instead of creating directly new instance of processor

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1724,7 +1724,7 @@ class modX extends xPDO {
         // We're limiting to subclasses of Processor to prevent instantiating arbitrary classes
         if (static::isProcessorClass($action)) {
             /** @var Processor $processor */
-            $processor = new $action($this, $scriptProperties);
+            $processor = call_user_func_array([$action, 'getInstance'], [&$this, $action, $scriptProperties]);
 
             return $processor->run();
         }
@@ -1738,7 +1738,7 @@ class modX extends xPDO {
         }
         if (static::isProcessorClass($legacyAction)) {
             /** @var Processor $processor */
-            $processor = new $legacyAction($this, $scriptProperties);
+            $processor = call_user_func_array([$legacyAction, 'getInstance'], [&$this, $legacyAction, $scriptProperties]);
 
             return $processor->run();
         }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1724,7 +1724,7 @@ class modX extends xPDO {
         // We're limiting to subclasses of Processor to prevent instantiating arbitrary classes
         if (static::isProcessorClass($action)) {
             /** @var Processor $processor */
-            $processor = call_user_func_array([$action, 'getInstance'], [&$this, $action, $scriptProperties]);
+            $processor = $action::getInstance($this, $action, $scriptProperties);
 
             return $processor->run();
         }
@@ -1738,7 +1738,7 @@ class modX extends xPDO {
         }
         if (static::isProcessorClass($legacyAction)) {
             /** @var Processor $processor */
-            $processor = call_user_func_array([$legacyAction, 'getInstance'], [&$this, $legacyAction, $scriptProperties]);
+            $processor = $legacyAction::getInstance($this, $legacyAction, $scriptProperties);
 
             return $processor->run();
         }


### PR DESCRIPTION
### What does it do?
Replaces creating a direct instance of a processor class with calling `getInstance` method. As that's how instance of processor should be created :)

### Why is it needed?
CRCs for example Collections have own Update/Create processors that extend those core ones. MODX know about them only through the `getInstance` implementation on the `MODX\Revolution\Processors\Resource\Update(/Create)` class, that tries to check if there's a different processor for the `class_key`. This doesn't work atm.

