### PR TITLE
Fix pass-by-reference and incompatible declarations for controllers and processors

### DIFF
--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -98,7 +98,7 @@ class Create extends CreateProcessor
      * @param array $properties
      * @return CreateProcessor
      */
-    public static function getInstance(modX &$modx, $className, $properties = [])
+    public static function getInstance(modX $modx, $className, $properties = [])
     {
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : modDocument::class;
         $object = $modx->newObject($classKey);

--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -113,7 +113,7 @@ class Update extends UpdateProcessor
      * @param array $properties
      * @return Processor
      */
-    public static function getInstance(modX &$modx, $className, $properties = [])
+    public static function getInstance(modX $modx, $className, $properties = [])
     {
         /** @var modResource $object */
         $object = $modx->getObject(modResource::class, $properties['id']);

--- a/core/src/Revolution/Processors/Security/User/Create.php
+++ b/core/src/Revolution/Processors/Security/User/Create.php
@@ -54,7 +54,7 @@ class Create extends CreateProcessor {
      * @param array $properties
      * @return Processor
      */
-    public static function getInstance(modX &$modx,$className,$properties = array()) {
+    public static function getInstance(modX $modx,$className,$properties = array()) {
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : modUser::class;
         $object = $modx->newObject($classKey);
 

--- a/core/src/Revolution/Processors/Security/User/Update.php
+++ b/core/src/Revolution/Processors/Security/User/Update.php
@@ -60,7 +60,7 @@ class Update extends UpdateProcessor {
      * @param array $properties
      * @return Processor
      */
-    public static function getInstance(modX &$modx,$className,$properties = array()) {
+    public static function getInstance(modX $modx,$className,$properties = array()) {
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : modUser::class;
         $object = $modx->newObject($classKey);
 

--- a/core/src/Revolution/Processors/System/DatabaseTable/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/GetList.php
@@ -30,7 +30,7 @@ class GetList extends GetListAbstract
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
      */
-    public function __construct(modX &$modx, array $properties = [])
+    public function __construct(modX $modx, array $properties = [])
     {
         parent::__construct($modx, $properties);
 

--- a/core/src/Revolution/Processors/System/DatabaseTable/Optimize.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/Optimize.php
@@ -29,7 +29,7 @@ class Optimize extends OptimizeAbstract
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
      */
-    public function __construct(modX &$modx, array $properties = [])
+    public function __construct(modX $modx, array $properties = [])
     {
         parent::__construct($modx, $properties);
 

--- a/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabase.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/OptimizeDatabase.php
@@ -29,7 +29,7 @@ class OptimizeDatabase extends OptimizeDatabaseAbstract
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
      */
-    public function __construct(modX &$modx, array $properties = [])
+    public function __construct(modX $modx, array $properties = [])
     {
         parent::__construct($modx, $properties);
 

--- a/core/src/Revolution/Processors/System/DatabaseTable/Truncate.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/Truncate.php
@@ -29,7 +29,7 @@ class Truncate extends TruncateAbstract
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
      */
-    public function __construct(modX &$modx, array $properties = [])
+    public function __construct(modX $modx, array $properties = [])
     {
         parent::__construct($modx, $properties);
 

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -95,7 +95,7 @@ abstract class modManagerController
      *
      * @return modManagerController The class specified by $className
      */
-    public static function getInstance(modX &$modx, $className, array $config = [])
+    public static function getInstance(modX $modx, $className, array $config = [])
     {
         /** @var modManagerController $controller */
         $controller = new $className($modx, $config);

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -71,7 +71,7 @@ abstract class ResourceManagerController extends modManagerController
      *
      * @return modManagerController The proper controller class
      */
-    public static function getInstance(modX &$modx, $className, array $config = [])
+    public static function getInstance(modX $modx, $className, array $config = [])
     {
         $resourceClass = modDocument::class;
         $isDerivative = false;


### PR DESCRIPTION
### What does it do?

Removes the `&` indicating pass-by-reference on a variety of processors and 2 controllers.

### Why is it needed?

1) Incompatible definitions for the resource processors as described in #14910 
2) Objects are always passed by reference, so this is totally unnecessary. 

Searching the codebase for `&$modx` finds a lot more similar calls spread across models and services, which should probably also be corrected, but I've focused only on processors and controllers for now.

### Related issue(s)/PR(s)

Fixes #14910 