### PR TITLE
Fix category actions missing from context menu, and inability to drop elements on categories

### DIFF
--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -332,7 +332,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
     ,_handleDrop: function(e) {
         var target = e.target;
         if (e.point == 'above' || e.point == 'below') {return false;}
-        if (target.attributes.classKey != 'modCategory' && target.attributes.classKey != 'root') { return false; }
+        if (target.attributes.classKey != 'MODX\\Revolution\\modCategory' && target.attributes.classKey != 'root') { return false; }
 
         if (!this.isCorrectType(e.dropNode,target)) {return false;}
         if (target.attributes.type == 'category' && e.point == 'append') {return true;}
@@ -374,7 +374,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                 case 'root':
                     m = this._getRootMenu(n);
                     break;
-                case 'modCategory':
+                case 'MODX\\Revolution\\modCategory':
                     m = this._getCategoryMenu(n);
                     break;
                 default:


### PR DESCRIPTION
### What does it do?

Updates checks in the JS to use the fully qualified class key for categories.

### Why is it needed?

Fixes #14914 - actions in the context menu specific to categories not being available.

Also fixes the inability to drag and drop elements (or categories) onto categories.  

### Related issue(s)/PR(s)
Fixes #14914

**Requires rebuild.**
