### PR TITLE
Convert traditional array syntax to short array syntax

### DIFF
--- a/_build/build.properties.sample.php
+++ b/_build/build.properties.sample.php
@@ -10,13 +10,13 @@ $properties['mysql_string_dsn_nodb']= 'mysql:host=localhost;charset=utf8';
 $properties['mysql_string_dsn_error']= 'mysql:host= nonesuchhost;dbname=nonesuchdb';
 $properties['mysql_string_username']= '';
 $properties['mysql_string_password']= '';
-$properties['mysql_array_options']= array(
+$properties['mysql_array_options']= [
     xPDO::OPT_CACHE_PATH => $properties['cache_path'],
     xPDO::OPT_HYDRATE_FIELDS => true,
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
-);
-$properties['mysql_array_driverOptions']= array();
+];
+$properties['mysql_array_driverOptions']= [];
 
 /* sqlsrv */
 $properties['sqlsrv_string_dsn_test']= 'sqlsrv:server=(local);database=revo_test';
@@ -24,13 +24,13 @@ $properties['sqlsrv_string_dsn_nodb']= 'sqlsrv:server=(local)';
 $properties['sqlsrv_string_dsn_error']= 'sqlsrv:server=xyz;123';
 $properties['sqlsrv_string_username']= '';
 $properties['sqlsrv_string_password']= '';
-$properties['sqlsrv_array_options']= array(
+$properties['sqlsrv_array_options']= [
     xPDO::OPT_CACHE_PATH => $properties['cache_path'],
     xPDO::OPT_HYDRATE_FIELDS => true,
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
-);
-$properties['sqlsrv_array_driverOptions']= array(/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/);
+];
+$properties['sqlsrv_array_driverOptions']= [/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/];
 
 /* PHPUnit test config */
 $properties['xpdo_driver']= 'mysql';

--- a/_build/data/permissions/transport.policy.tpl.administrator.php
+++ b/_build/data/permissions/transport.policy.tpl.administrator.php
@@ -6,891 +6,891 @@
  */
 use MODX\Revolution\modAccessPermission;
 
-$permissions = array();
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+$permissions = [];
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'about',
     'description' => 'perm.about_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'access_permissions',
     'description' => 'perm.access_permissions_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'actions',
     'description' => 'perm.actions_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'change_password',
     'description' => 'perm.change_password_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'change_profile',
     'description' => 'perm.change_profile_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'charsets',
     'description' => 'perm.charsets_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'class_map',
     'description' => 'perm.class_map_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'components',
     'description' => 'perm.components_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'content_types',
     'description' => 'perm.content_types_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'countries',
     'description' => 'perm.countries_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'create',
     'description' => 'perm.create_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'credits',
     'description' => 'perm.credits_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'customize_forms',
     'description' => 'perm.customize_forms_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'dashboards',
     'description' => 'perm.dashboards_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'database',
     'description' => 'perm.database_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'database_truncate',
     'description' => 'perm.database_truncate_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_category',
     'description' => 'perm.delete_category_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_chunk',
     'description' => 'perm.delete_chunk_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_context',
     'description' => 'perm.delete_context_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_document',
     'description' => 'perm.delete_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_eventlog',
     'description' => 'perm.delete_eventlog_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_plugin',
     'description' => 'perm.delete_plugin_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_propertyset',
     'description' => 'perm.delete_propertyset_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_snippet',
     'description' => 'perm.delete_snippet_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_template',
     'description' => 'perm.delete_template_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_tv',
     'description' => 'perm.delete_tv_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_role',
     'description' => 'perm.delete_role_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete_user',
     'description' => 'perm.delete_user_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'directory_chmod',
     'description' => 'perm.directory_chmod_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'directory_create',
     'description' => 'perm.directory_create_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'directory_list',
     'description' => 'perm.directory_list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'directory_remove',
     'description' => 'perm.directory_remove_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'directory_update',
     'description' => 'perm.directory_update_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_category',
     'description' => 'perm.edit_category_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_chunk',
     'description' => 'perm.edit_chunk_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_context',
     'description' => 'perm.edit_context_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_document',
     'description' => 'perm.edit_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_locked',
     'description' => 'perm.edit_locked_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_plugin',
     'description' => 'perm.edit_plugin_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_propertyset',
     'description' => 'perm.edit_propertyset_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_role',
     'description' => 'perm.edit_role_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_snippet',
     'description' => 'perm.edit_snippet_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_template',
     'description' => 'perm.edit_template_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_tv',
     'description' => 'perm.edit_tv_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'edit_user',
     'description' => 'perm.edit_user_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'element_tree',
     'description' => 'perm.element_tree_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'empty_cache',
     'description' => 'perm.empty_cache_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'error_log_erase',
     'description' => 'perm.error_log_erase_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'error_log_view',
     'description' => 'perm.error_log_view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'export_static',
     'description' => 'perm.export_static_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_create',
     'description' => 'perm.file_create_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_list',
     'description' => 'perm.file_list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_manager',
     'description' => 'perm.file_manager_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_remove',
     'description' => 'perm.file_remove_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_tree',
     'description' => 'perm.file_tree_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_update',
     'description' => 'perm.file_update_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_upload',
     'description' => 'perm.file_upload_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_unpack',
     'description' => 'perm.file_unpack_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'file_view',
     'description' => 'perm.file_view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'flush_sessions',
     'description' => 'perm.flush_sessions_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'frames',
     'description' => 'perm.frames_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'help',
     'description' => 'perm.help_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'home',
     'description' => 'perm.home_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'import_static',
     'description' => 'perm.import_static_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'language',
     'description' => 'perm.language_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'languages',
     'description' => 'perm.languages_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'lexicons',
     'description' => 'perm.lexicons_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'list',
     'description' => 'perm.list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'load',
     'description' => 'perm.load_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'logout',
     'description' => 'perm.logout_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'logs',
     'description' => 'perm.logs_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_reports',
     'description' => 'perm.menu_reports_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_security',
     'description' => 'perm.menu_security_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_site',
     'description' => 'perm.menu_site_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_support',
     'description' => 'perm.menu_support_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_system',
     'description' => 'perm.menu_system_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_tools',
     'description' => 'perm.menu_tools_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_trash',
     'description' => 'perm.menu_trash_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menu_user',
     'description' => 'perm.menu_user_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'menus',
     'description' => 'perm.menus_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'messages',
     'description' => 'perm.messages_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'namespaces',
     'description' => 'perm.namespaces_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_category',
     'description' => 'perm.new_category_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_chunk',
     'description' => 'perm.new_chunk_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_context',
     'description' => 'perm.new_context_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_document',
     'description' => 'perm.new_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_static_resource',
     'description' => 'perm.new_static_resource_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_symlink',
     'description' => 'perm.new_symlink_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_weblink',
     'description' => 'perm.new_weblink_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_document_in_root',
     'description' => 'perm.new_document_in_root_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_plugin',
     'description' => 'perm.new_plugin_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_propertyset',
     'description' => 'perm.new_propertyset_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_role',
     'description' => 'perm.new_role_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_snippet',
     'description' => 'perm.new_snippet_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_template',
     'description' => 'perm.new_template_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_tv',
     'description' => 'perm.new_tv_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'new_user',
     'description' => 'perm.new_user_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'packages',
     'description' => 'perm.packages_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_delete',
     'description' => 'perm.policy_delete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_edit',
     'description' => 'perm.policy_edit_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_new',
     'description' => 'perm.policy_new_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_save',
     'description' => 'perm.policy_save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_view',
     'description' => 'perm.policy_view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_template_delete',
     'description' => 'perm.policy_template_delete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_template_edit',
     'description' => 'perm.policy_template_edit_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_template_new',
     'description' => 'perm.policy_template_new_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_template_save',
     'description' => 'perm.policy_template_save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'policy_template_view',
     'description' => 'perm.policy_template_view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'property_sets',
     'description' => 'perm.property_sets_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'providers',
     'description' => 'perm.providers_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'publish_document',
     'description' => 'perm.publish_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'purge_deleted',
     'description' => 'perm.purge_deleted_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'remove',
     'description' => 'perm.remove_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'remove_locks',
     'description' => 'perm.remove_locks_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resource_duplicate',
     'description' => 'perm.resource_duplicate_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resourcegroup_delete',
     'description' => 'perm.resourcegroup_delete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resourcegroup_edit',
     'description' => 'perm.resourcegroup_edit_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resourcegroup_new',
     'description' => 'perm.resourcegroup_new_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resourcegroup_resource_edit',
     'description' => 'perm.resourcegroup_resource_edit_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resourcegroup_resource_list',
     'description' => 'perm.resourcegroup_resource_list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resourcegroup_save',
     'description' => 'perm.resourcegroup_save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resourcegroup_view',
     'description' => 'perm.resourcegroup_view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resource_quick_create',
     'description' => 'perm.resource_quick_create_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resource_quick_update',
     'description' => 'perm.resource_quick_update_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'resource_tree',
     'description' => 'perm.resource_tree_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save',
     'description' => 'perm.save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_category',
     'description' => 'perm.save_category_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_chunk',
     'description' => 'perm.save_chunk_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_context',
     'description' => 'perm.save_context_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_document',
     'description' => 'perm.save_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_plugin',
     'description' => 'perm.save_plugin_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_propertyset',
     'description' => 'perm.save_propertyset_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_role',
     'description' => 'perm.save_role_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_snippet',
     'description' => 'perm.save_snippet_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_template',
     'description' => 'perm.save_template_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_tv',
     'description' => 'perm.save_tv_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save_user',
     'description' => 'perm.save_user_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'search',
     'description' => 'perm.search_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'set_sudo',
     'description' => 'perm.set_sudo_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'settings',
     'description' => 'perm.settings_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'events',
     'description' => 'perm.events_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'source_save',
     'description' => 'perm.source_save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'source_delete',
     'description' => 'perm.source_delete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'source_edit',
     'description' => 'perm.source_edit_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'source_view',
     'description' => 'perm.source_view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'sources',
     'description' => 'perm.sources_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'steal_locks',
     'description' => 'perm.steal_locks_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'tree_show_element_ids',
     'description' => 'perm.tree_show_element_ids_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'tree_show_resource_ids',
     'description' => 'perm.tree_show_resource_ids_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'undelete_document',
     'description' => 'perm.undelete_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'unpublish_document',
     'description' => 'perm.unpublish_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'unlock_element_properties',
     'description' => 'perm.unlock_element_properties_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'usergroup_delete',
     'description' => 'perm.usergroup_delete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'usergroup_edit',
     'description' => 'perm.usergroup_edit_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'usergroup_new',
     'description' => 'perm.usergroup_new_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'usergroup_save',
     'description' => 'perm.usergroup_save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'usergroup_user_edit',
     'description' => 'perm.usergroup_user_edit_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'usergroup_user_list',
     'description' => 'perm.usergroup_user_list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'usergroup_view',
     'description' => 'perm.usergroup_view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view',
     'description' => 'perm.view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_category',
     'description' => 'perm.view_category_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_chunk',
     'description' => 'perm.view_chunk_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_context',
     'description' => 'perm.view_context_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_document',
     'description' => 'perm.view_document_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_element',
     'description' => 'perm.view_element_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_eventlog',
     'description' => 'perm.view_eventlog_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_offline',
     'description' => 'perm.view_offline_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_plugin',
     'description' => 'perm.view_plugin_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_propertyset',
     'description' => 'perm.view_propertyset_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_role',
     'description' => 'perm.view_role_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_snippet',
     'description' => 'perm.view_snippet_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_sysinfo',
     'description' => 'perm.view_sysinfo_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_template',
     'description' => 'perm.view_template_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_tv',
     'description' => 'perm.view_tv_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_user',
     'description' => 'perm.view_user_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_unpublished',
     'description' => 'perm.view_unpublished_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'workspaces',
     'description' => 'perm.workspaces_desc',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/permissions/transport.policy.tpl.context.php
+++ b/_build/data/permissions/transport.policy.tpl.context.php
@@ -7,41 +7,41 @@
  */
 use MODX\Revolution\modAccessPermission;
 
-$permissions = array();
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+$permissions = [];
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'load',
     'description' => 'perm.load_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'list',
     'description' => 'perm.list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view',
     'description' => 'perm.view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save',
     'description' => 'perm.save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'remove',
     'description' => 'perm.remove_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view_unpublished',
     'description' => 'perm.view_unpublished_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'copy',
     'description' => 'perm.copy_desc',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/permissions/transport.policy.tpl.element.php
+++ b/_build/data/permissions/transport.policy.tpl.element.php
@@ -6,51 +6,51 @@
  */
 use MODX\Revolution\modAccessPermission;
 
-$permissions = array();
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+$permissions = [];
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'add_children',
     'description' => 'perm.add_children_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'create',
     'description' => 'perm.create_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'copy',
     'description' => 'perm.copy_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete',
     'description' => 'perm.delete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'list',
     'description' => 'perm.list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'load',
     'description' => 'perm.load_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'remove',
     'description' => 'perm.remove_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save',
     'description' => 'perm.save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view',
     'description' => 'perm.view_desc',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/permissions/transport.policy.tpl.media_source.php
+++ b/_build/data/permissions/transport.policy.tpl.media_source.php
@@ -6,41 +6,41 @@
  */
 use MODX\Revolution\modAccessPermission;
 
-$permissions = array();
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+$permissions = [];
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'create',
     'description' => 'perm.create_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'copy',
     'description' => 'perm.copy_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'list',
     'description' => 'perm.list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'load',
     'description' => 'perm.load_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'remove',
     'description' => 'perm.remove_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save',
     'description' => 'perm.save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view',
     'description' => 'perm.view_desc',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/permissions/transport.policy.tpl.namespace.php
+++ b/_build/data/permissions/transport.policy.tpl.namespace.php
@@ -6,21 +6,21 @@
  */
 use MODX\Revolution\modAccessPermission;
 
-$permissions = array();
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+$permissions = [];
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'list',
     'description' => 'perm.list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'load',
     'description' => 'perm.load_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view',
     'description' => 'perm.view_desc',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/permissions/transport.policy.tpl.object.php
+++ b/_build/data/permissions/transport.policy.tpl.object.php
@@ -6,31 +6,31 @@
  */
 use MODX\Revolution\modAccessPermission;
 
-$permissions = array();
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+$permissions = [];
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'load',
     'description' => 'perm.load_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'list',
     'description' => 'perm.list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view',
     'description' => 'perm.view_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save',
     'description' => 'perm.save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'remove',
     'description' => 'perm.remove_desc',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/permissions/transport.policy.tpl.resource.php
+++ b/_build/data/permissions/transport.policy.tpl.resource.php
@@ -6,76 +6,76 @@
  */
 use MODX\Revolution\modAccessPermission;
 
-$permissions = array();
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+$permissions = [];
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'add_children',
     'description' => 'perm.add_children_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'copy',
     'description' => 'perm.copy_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'create',
     'description' => 'perm.create_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'delete',
     'description' => 'perm.delete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'list',
     'description' => 'perm.list_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'load',
     'description' => 'perm.load_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'move',
     'description' => 'perm.move_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'publish',
     'description' => 'perm.publish_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'remove',
     'description' => 'perm.remove_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'save',
     'description' => 'perm.save_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'steal_lock',
     'description' => 'perm.steal_lock_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'undelete',
     'description' => 'perm.undelete_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'unpublish',
     'description' => 'perm.unpublish_desc',
     'value' => true,
-));
-$permissions[] = $xpdo->newObject(modAccessPermission::class,array(
+]);
+$permissions[] = $xpdo->newObject(modAccessPermission::class, [
     'name' => 'view',
     'description' => 'perm.view_desc',
     'value' => true,
-));
+]);
 
 return $permissions;

--- a/_build/data/transport.core.accesspolicies.php
+++ b/_build/data/transport.core.accesspolicies.php
@@ -7,10 +7,10 @@
  */
 use MODX\Revolution\modAccessPolicy;
 
-$policies = array();
+$policies = [];
 
 $policies['1']= $xpdo->newObject(modAccessPolicy::class);
-$policies['1']->fromArray(array (
+$policies['1']->fromArray([
   'id' => 1,
   'name' => 'Resource',
   'description' => 'MODX Resource Policy with all attributes.',
@@ -18,10 +18,10 @@ $policies['1']->fromArray(array (
   'class' => '',
   'data' => '{"add_children":true,"create":true,"copy":true,"delete":true,"list":true,"load":true,"move":true,"publish":true,"remove":true,"save":true,"steal_lock":true,"undelete":true,"unpublish":true,"view":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['2']= $xpdo->newObject(modAccessPolicy::class);
-$policies['2']->fromArray(array (
+$policies['2']->fromArray([
   'id' => 2,
   'name' => 'Administrator',
   'description' => 'Context administration policy with all permissions.',
@@ -29,10 +29,10 @@ $policies['2']->fromArray(array (
   'class' => '',
   'data' => '{"about":true,"access_permissions":true,"actions":true,"change_password":true,"change_profile":true,"charsets":true,"class_map":true,"components":true,"content_types":true,"countries":true,"create":true,"credits":true,"customize_forms":true,"dashboards":true,"database":true,"database_truncate":true,"delete_category":true,"delete_chunk":true,"delete_context":true,"delete_document":true,"delete_eventlog":true,"delete_plugin":true,"delete_propertyset":true,"delete_role":true,"delete_snippet":true,"delete_template":true,"delete_tv":true,"delete_user":true,"directory_chmod":true,"directory_create":true,"directory_list":true,"directory_remove":true,"directory_update":true,"edit_category":true,"edit_chunk":true,"edit_context":true,"edit_document":true,"edit_locked":true,"edit_plugin":true,"edit_propertyset":true,"edit_role":true,"edit_snippet":true,"edit_template":true,"edit_tv":true,"edit_user":true,"element_tree":true,"empty_cache":true,"error_log_erase":true,"error_log_view":true,"events":true,"export_static":true,"file_create":true,"file_list":true,"file_manager":true,"file_remove":true,"file_tree":true,"file_update":true,"file_upload":true,"file_unpack":true,"file_view":true,"flush_sessions":true,"frames":true,"help":true,"home":true,"import_static":true,"languages":true,"lexicons":true,"list":true,"load":true,"logout":true,"logs":true,"menus":true,"menu_reports":true,"menu_security":true,"menu_site":true,"menu_support":true,"menu_system":true,"menu_tools":true,"menu_user":true,"messages":true,"namespaces":true,"new_category":true,"new_chunk":true,"new_context":true,"new_document":true,"new_document_in_root":true,"new_plugin":true,"new_propertyset":true,"new_role":true,"new_snippet":true,"new_static_resource":true,"new_symlink":true,"new_template":true,"new_tv":true,"new_user":true,"new_weblink":true,"packages":true,"policy_delete":true,"policy_edit":true,"policy_new":true,"policy_save":true,"policy_template_delete":true,"policy_template_edit":true,"policy_template_new":true,"policy_template_save":true,"policy_template_view":true,"policy_view":true,"property_sets":true,"providers":true,"publish_document":true,"purge_deleted":true,"remove":true,"remove_locks":true,"resource_duplicate":true,"resourcegroup_delete":true,"resourcegroup_edit":true,"resourcegroup_new":true,"resourcegroup_resource_edit":true,"resourcegroup_resource_list":true,"resourcegroup_save":true,"resourcegroup_view":true,"resource_quick_create":true,"resource_quick_update":true,"resource_tree":true,"save":true,"save_category":true,"save_chunk":true,"save_context":true,"save_document":true,"save_plugin":true,"save_propertyset":true,"save_role":true,"save_snippet":true,"save_template":true,"save_tv":true,"save_user":true,"search":true,"set_sudo":true,"settings":true,"sources":true,"source_delete":true,"source_edit":true,"source_save":true,"source_view":true,"steal_locks":true,"tree_show_element_ids":true,"tree_show_resource_ids":true,"undelete_document":true,"unlock_element_properties":true,"unpublish_document":true,"usergroup_delete":true,"usergroup_edit":true,"usergroup_new":true,"usergroup_save":true,"usergroup_user_edit":true,"usergroup_user_list":true,"usergroup_view":true,"view":true,"view_category":true,"view_chunk":true,"view_context":true,"view_document":true,"view_element":true,"view_eventlog":true,"view_offline":true,"view_plugin":true,"view_propertyset":true,"view_role":true,"view_snippet":true,"view_sysinfo":true,"view_template":true,"view_tv":true,"view_unpublished":true,"view_user":true,"workspaces":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['3']= $xpdo->newObject(modAccessPolicy::class);
-$policies['3']->fromArray(array (
+$policies['3']->fromArray([
   'id' => 3,
   'name' => 'Load Only',
   'description' => 'A minimal policy with permission to load an object.',
@@ -40,10 +40,10 @@ $policies['3']->fromArray(array (
   'class' => '',
   'data' => '{"load":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['4']= $xpdo->newObject(modAccessPolicy::class);
-$policies['4']->fromArray(array (
+$policies['4']->fromArray([
   'id' => 4,
   'name' => 'Load, List and View',
   'description' => 'Provides load, list and view permissions only.',
@@ -51,10 +51,10 @@ $policies['4']->fromArray(array (
   'class' => '',
   'data' => '{"load":true,"list":true,"view":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['5']= $xpdo->newObject(modAccessPolicy::class);
-$policies['5']->fromArray(array (
+$policies['5']->fromArray([
   'id' => 5,
   'name' => 'Object',
   'description' => 'An Object policy with all permissions.',
@@ -62,10 +62,10 @@ $policies['5']->fromArray(array (
   'class' => '',
   'data' => '{"load":true,"list":true,"view":true,"save":true,"remove":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['6']= $xpdo->newObject(modAccessPolicy::class);
-$policies['6']->fromArray(array (
+$policies['6']->fromArray([
   'id' => 6,
   'name' => 'Element',
   'description' => 'MODX Element policy with all attributes.',
@@ -73,10 +73,10 @@ $policies['6']->fromArray(array (
   'class' => '',
   'data' => '{"add_children":true,"create":true,"delete":true,"list":true,"load":true,"remove":true,"save":true,"view":true,"copy":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['7']= $xpdo->newObject(modAccessPolicy::class);
-$policies['7']->fromArray(array (
+$policies['7']->fromArray([
   'id' => 7,
   'name' => 'Content Editor',
   'description' => 'Context administration policy with limited, content-editing related Permissions, but no publishing.',
@@ -84,10 +84,10 @@ $policies['7']->fromArray(array (
   'class' => '',
   'data' => '{"change_profile":true,"class_map":true,"countries":true,"edit_document":true,"frames":true,"help":true,"home":true,"load":true,"list":true,"logout":true,"menu_reports":true,"menu_site":true,"menu_support":true,"menu_tools":true,"menu_user":true,"resource_duplicate":true,"resource_tree":true,"save_document":true,"source_view":true,"tree_show_resource_ids":true,"view":true,"view_document":true,"view_template":true,"new_document":true,"delete_document":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['8']= $xpdo->newObject(modAccessPolicy::class);
-$policies['8']->fromArray(array (
+$policies['8']->fromArray([
   'id' => 8,
   'name' => 'Media Source Admin',
   'description' => 'Media Source administration policy.',
@@ -95,10 +95,10 @@ $policies['8']->fromArray(array (
   'class' => '',
   'data' => '{"create":true,"copy":true,"load":true,"list":true,"save":true,"remove":true,"view":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['9']= $xpdo->newObject(modAccessPolicy::class);
-$policies['9']->fromArray(array (
+$policies['9']->fromArray([
   'id' => 9,
   'name' => 'Media Source User',
   'description' => 'Media Source user policy, with basic viewing and using - but no editing - of Media Sources.',
@@ -106,10 +106,10 @@ $policies['9']->fromArray(array (
   'class' => '',
   'data' => '{"load":true,"list":true,"view":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['10']= $xpdo->newObject(modAccessPolicy::class);
-$policies['10']->fromArray(array (
+$policies['10']->fromArray([
   'id' => 10,
   'name' => 'Developer',
   'description' => 'Context administration policy with most Permissions except Administrator and Security functions.',
@@ -117,10 +117,10 @@ $policies['10']->fromArray(array (
   'class' => '',
   'data' => '{"about":true,"change_password":true,"change_profile":true,"charsets":true,"class_map":true,"components":true,"content_types":true,"countries":true,"create":true,"credits":true,"customize_forms":true,"dashboards":true,"database":true,"delete_category":true,"delete_chunk":true,"delete_context":true,"delete_document":true,"delete_eventlog":true,"delete_plugin":true,"delete_propertyset":true,"delete_snippet":true,"delete_template":true,"delete_tv":true,"delete_role":true,"delete_user":true,"directory_chmod":true,"directory_create":true,"directory_list":true,"directory_remove":true,"directory_update":true,"edit_category":true,"edit_chunk":true,"edit_context":true,"edit_document":true,"edit_locked":true,"edit_plugin":true,"edit_propertyset":true,"edit_role":true,"edit_snippet":true,"edit_template":true,"edit_tv":true,"edit_user":true,"element_tree":true,"empty_cache":true,"error_log_erase":true,"error_log_view":true,"export_static":true,"file_create":true,"file_list":true,"file_manager":true,"file_remove":true,"file_tree":true,"file_update":true,"file_upload":true,"file_unpack":true,"file_view":true,"frames":true,"help":true,"home":true,"import_static":true,"languages":true,"lexicons":true,"list":true,"load":true,"logout":true,"logs":true,"menu_reports":true,"menu_site":true,"menu_support":true,"menu_system":true,"menu_tools":true,"menu_user":true,"menus":true,"messages":true,"namespaces":true,"new_category":true,"new_chunk":true,"new_context":true,"new_document":true,"new_static_resource":true,"new_symlink":true,"new_weblink":true,"new_document_in_root":true,"new_plugin":true,"new_propertyset":true,"new_role":true,"new_snippet":true,"new_template":true,"new_tv":true,"new_user":true,"packages":true,"property_sets":true,"providers":true,"publish_document":true,"purge_deleted":true,"remove":true,"resource_duplicate":true,"resource_quick_create":true,"resource_quick_update":true,"resource_tree":true,"save":true,"save_category":true,"save_chunk":true,"save_context":true,"save_document":true,"save_plugin":true,"save_propertyset":true,"save_snippet":true,"save_template":true,"save_tv":true,"save_user":true,"search":true,"settings":true,"source_delete":true,"source_edit":true,"source_save":true,"source_view":true,"sources":true,"tree_show_element_ids":true,"tree_show_resource_ids":true,"undelete_document":true,"unpublish_document":true,"unlock_element_properties":true,"view":true,"view_category":true,"view_chunk":true,"view_context":true,"view_document":true,"view_element":true,"view_eventlog":true,"view_offline":true,"view_plugin":true,"view_propertyset":true,"view_role":true,"view_snippet":true,"view_sysinfo":true,"view_template":true,"view_tv":true,"view_user":true,"view_unpublished":true,"workspaces":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['11']= $xpdo->newObject(modAccessPolicy::class);
-$policies['11']->fromArray(array (
+$policies['11']->fromArray([
   'id' => 11,
   'name' => 'Context',
   'description' => 'A standard Context policy that you can apply when creating Context ACLs for basic read/write and view_unpublished access within a Context.',
@@ -128,10 +128,10 @@ $policies['11']->fromArray(array (
   'class' => '',
   'data' => '{"load":true,"list":true,"view":true,"save":true,"remove":true,"copy":true,"view_unpublished":true}',
   'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 $policies['12']= $xpdo->newObject(modAccessPolicy::class);
-$policies['12']->fromArray(array (
+$policies['12']->fromArray([
     'id' => 12,
     'name' => 'Hidden Namespace',
     'description' => 'Hidden Namespace policy, will not show Namespace in lists.',
@@ -139,6 +139,6 @@ $policies['12']->fromArray(array (
     'class' => '',
     'data' => '{"load":false,"list":false,"view":true}',
     'lexicon' => 'permissions',
-), '', true, true);
+], '', true, true);
 
 return $policies;

--- a/_build/data/transport.core.accesspolicytemplategroups.php
+++ b/_build/data/transport.core.accesspolicytemplategroups.php
@@ -9,54 +9,54 @@
  */
 use MODX\Revolution\modAccessPolicyTemplateGroup;
 
-$templateGroups = array();
+$templateGroups = [];
 
 /* administrator group templates */
 $templateGroups['1']= $xpdo->newObject(modAccessPolicyTemplateGroup::class);
-$templateGroups['1']->fromArray(array(
+$templateGroups['1']->fromArray([
     'id' => 1,
     'name' => 'Admin',
     'description' => 'All admin policy templates.',
-));
+]);
 
 /* Object group templates */
 $templateGroups['2']= $xpdo->newObject(modAccessPolicyTemplateGroup::class);
-$templateGroups['2']->fromArray(array(
+$templateGroups['2']->fromArray([
     'id' => 2,
     'name' => 'Object',
     'description' => 'All Object-based policy templates.',
-));
+]);
 
 /* Resource group templates */
 $templateGroups['3']= $xpdo->newObject(modAccessPolicyTemplateGroup::class);
-$templateGroups['3']->fromArray(array(
+$templateGroups['3']->fromArray([
     'id' => 3,
     'name' => 'Resource',
     'description' => 'All Resource-based policy templates.',
-));
+]);
 
 /* Element group templates */
 $templateGroups['4']= $xpdo->newObject(modAccessPolicyTemplateGroup::class);
-$templateGroups['4']->fromArray(array(
+$templateGroups['4']->fromArray([
     'id' => 4,
     'name' => 'Element',
     'description' => 'All Element-based policy templates.',
-));
+]);
 
 /* Media Source group templates */
 $templateGroups['5']= $xpdo->newObject(modAccessPolicyTemplateGroup::class);
-$templateGroups['5']->fromArray(array(
+$templateGroups['5']->fromArray([
     'id' => 5,
     'name' => 'MediaSource',
     'description' => 'All Media Source-based policy templates.',
-));
+]);
 
 /* Namespace group templates */
 $templateGroups['6']= $xpdo->newObject(modAccessPolicyTemplateGroup::class);
-$templateGroups['6']->fromArray(array(
+$templateGroups['6']->fromArray([
     'id' => 6,
     'name' => 'Namespace',
     'description' => 'All Namespace based policy templates.',
-));
+]);
 
 return $templateGroups;

--- a/_build/data/transport.core.accesspolicytemplates.php
+++ b/_build/data/transport.core.accesspolicytemplates.php
@@ -9,16 +9,16 @@
  */
 use MODX\Revolution\modAccessPolicyTemplate;
 
-$templates = array();
+$templates = [];
 
 /* administrator template/policy */
 $templates['1']= $xpdo->newObject(modAccessPolicyTemplate::class);
-$templates['1']->fromArray(array(
+$templates['1']->fromArray([
     'id' => 1,
     'name' => 'AdministratorTemplate',
     'description' => 'Context administration policy template with all permissions.',
     'lexicon' => 'permissions',
-));
+]);
 $permissions = include dirname(__FILE__).'/permissions/transport.policy.tpl.administrator.php';
 if (is_array($permissions)) {
     $templates['1']->addMany($permissions);
@@ -26,12 +26,12 @@ if (is_array($permissions)) {
 
 /* resource template/policy */
 $templates['2']= $xpdo->newObject(modAccessPolicyTemplate::class);
-$templates['2']->fromArray(array(
+$templates['2']->fromArray([
     'id' => 2,
     'name' => 'ResourceTemplate',
     'description' => 'Resource Policy Template with all attributes.',
     'lexicon' => 'permissions',
-));
+]);
 $permissions = include dirname(__FILE__).'/permissions/transport.policy.tpl.resource.php';
 if (is_array($permissions)) {
     $templates['2']->addMany($permissions);
@@ -39,12 +39,12 @@ if (is_array($permissions)) {
 
 /* object template and policies */
 $templates['3']= $xpdo->newObject(modAccessPolicyTemplate::class);
-$templates['3']->fromArray(array(
+$templates['3']->fromArray([
     'id' => 3,
     'name' => 'ObjectTemplate',
     'description' => 'Object Policy Template with all attributes.',
     'lexicon' => 'permissions',
-));
+]);
 $permissions = include dirname(__FILE__).'/permissions/transport.policy.tpl.object.php';
 if (is_array($permissions)) {
     $templates['3']->addMany($permissions);
@@ -52,12 +52,12 @@ if (is_array($permissions)) {
 
 /* element template/policy */
 $templates['4']= $xpdo->newObject(modAccessPolicyTemplate::class);
-$templates['4']->fromArray(array(
+$templates['4']->fromArray([
     'id' => 4,
     'name' => 'ElementTemplate',
     'description' => 'Element Policy Template with all attributes.',
     'lexicon' => 'permissions',
-));
+]);
 $permissions = include dirname(__FILE__).'/permissions/transport.policy.tpl.element.php';
 if (is_array($permissions)) {
     $templates['4']->addMany($permissions);
@@ -65,12 +65,12 @@ if (is_array($permissions)) {
 
 /* media source template/policy */
 $templates['5']= $xpdo->newObject(modAccessPolicyTemplate::class);
-$templates['5']->fromArray(array(
+$templates['5']->fromArray([
     'id' => 5,
     'name' => 'MediaSourceTemplate',
     'description' => 'Media Source Policy Template with all attributes.',
     'lexicon' => 'permissions',
-));
+]);
 $permissions = include dirname(__FILE__).'/permissions/transport.policy.tpl.media_source.php';
 if (is_array($permissions)) {
     $templates['5']->addMany($permissions);
@@ -78,12 +78,12 @@ if (is_array($permissions)) {
 
 /* context template policies */
 $templates['6']= $xpdo->newObject(modAccessPolicyTemplate::class);
-$templates['6']->fromArray(array(
+$templates['6']->fromArray([
     'id' => 6,
     'name' => 'ContextTemplate',
     'description' => 'Context Policy Template with all attributes.',
     'lexicon' => 'permissions',
-));
+]);
 $permissions = include dirname(__FILE__).'/permissions/transport.policy.tpl.context.php';
 if (is_array($permissions)) {
     $templates['6']->addMany($permissions);
@@ -91,12 +91,12 @@ if (is_array($permissions)) {
 
 /* namespace template/policy */
 $templates['7']= $xpdo->newObject(modAccessPolicyTemplate::class);
-$templates['7']->fromArray(array(
+$templates['7']->fromArray([
     'id' => 7,
     'name' => 'NamespaceTemplate',
     'description' => 'Namespace Policy Template with all attributes.',
     'lexicon' => 'permissions',
-));
+]);
 $permissions = include dirname(__FILE__).'/permissions/transport.policy.tpl.namespace.php';
 if (is_array($permissions)) {
     $templates['7']->addMany($permissions);

--- a/_build/data/transport.core.actions.php
+++ b/_build/data/transport.core.actions.php
@@ -6,36 +6,36 @@
  */
 use MODX\Revolution\modAction;
 
-$collection = array();
+$collection = [];
 $collection['1']= $xpdo->newObject(modAction::class);
-$collection['1']->fromArray(array (
+$collection['1']->fromArray([
   'id' => 1,
   'namespace' => 'core',
   'controller' => 'welcome',
   'haslayout' => 1,
   'lang_topics' => 'welcome,configcheck',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['3']= $xpdo->newObject(modAction::class);
-$collection['3']->fromArray(array (
+$collection['3']->fromArray([
   'id' => 3,
   'namespace' => 'core',
   'controller' => 'system',
   'haslayout' => 0,
   'lang_topics' => '',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['5']= $xpdo->newObject(modAction::class);
-$collection['5']->fromArray(array (
+$collection['5']->fromArray([
   'id' => 5,
   'namespace' => 'core',
   'controller' => 'browser',
   'haslayout' => 0,
   'lang_topics' => 'file',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['7']= $xpdo->newObject(modAction::class);
-$collection['7']->fromArray(array (
+$collection['7']->fromArray([
   'id' => 7,
   'namespace' => 'core',
   'controller' => 'context/create',
@@ -43,9 +43,9 @@ $collection['7']->fromArray(array (
   'lang_topics' => 'context,setting,access,policy,user',
   'assets' => '',
   'help_url' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $collection['8']= $xpdo->newObject(modAction::class);
-$collection['8']->fromArray(array (
+$collection['8']->fromArray([
   'id' => 8,
   'namespace' => 'core',
   'controller' => 'context/update',
@@ -53,9 +53,9 @@ $collection['8']->fromArray(array (
   'lang_topics' => 'context,setting,access,policy,user',
   'assets' => '',
   'help_url' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $collection['9']= $xpdo->newObject(modAction::class);
-$collection['9']->fromArray(array (
+$collection['9']->fromArray([
   'id' => 9,
   'namespace' => 'core',
   'controller' => 'context/view',
@@ -63,18 +63,18 @@ $collection['9']->fromArray(array (
   'lang_topics' => 'context',
   'assets' => '',
   'help_url' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $collection['10']= $xpdo->newObject(modAction::class);
-$collection['10']->fromArray(array (
+$collection['10']->fromArray([
   'id' => 10,
   'namespace' => 'core',
   'controller' => 'element',
   'haslayout' => 1,
   'lang_topics' => 'element',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['11']= $xpdo->newObject(modAction::class);
-$collection['11']->fromArray(array (
+$collection['11']->fromArray([
   'id' => 11,
   'namespace' => 'core',
   'controller' => 'element/chunk',
@@ -82,9 +82,9 @@ $collection['11']->fromArray(array (
   'lang_topics' => 'chunk,category,propertyset,element',
   'assets' => '',
   'help_url' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $collection['12']= $xpdo->newObject(modAction::class);
-$collection['12']->fromArray(array (
+$collection['12']->fromArray([
   'id' => 12,
   'namespace' => 'core',
   'controller' => 'element/chunk/create',
@@ -92,9 +92,9 @@ $collection['12']->fromArray(array (
   'lang_topics' => 'chunk,category,propertyset,element',
   'assets' => '',
   'help_url' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $collection['13']= $xpdo->newObject(modAction::class);
-$collection['13']->fromArray(array (
+$collection['13']->fromArray([
   'id' => 13,
   'namespace' => 'core',
   'controller' => 'element/chunk/update',
@@ -102,9 +102,9 @@ $collection['13']->fromArray(array (
   'lang_topics' => 'chunk,category,propertyset,element',
   'assets' => '',
   'help_url' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $collection['20']= $xpdo->newObject(modAction::class);
-$collection['20']->fromArray(array (
+$collection['20']->fromArray([
   'id' => 20,
   'namespace' => 'core',
   'controller' => 'element/plugin',
@@ -112,9 +112,9 @@ $collection['20']->fromArray(array (
   'lang_topics' => 'plugin,category,system_events,propertyset,element',
   'assets' => '',
   'help_url' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $collection['21']= $xpdo->newObject(modAction::class);
-$collection['21']->fromArray(array (
+$collection['21']->fromArray([
   'id' => 21,
   'namespace' => 'core',
   'controller' => 'element/plugin/create',
@@ -122,9 +122,9 @@ $collection['21']->fromArray(array (
   'lang_topics' => 'plugin,category,system_events,propertyset,element',
   'assets' => '',
   'help_url' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $collection['22']= $xpdo->newObject(modAction::class);
-$collection['22']->fromArray(array (
+$collection['22']->fromArray([
   'id' => 22,
   'namespace' => 'core',
   'controller' => 'element/plugin/update',
@@ -132,9 +132,9 @@ $collection['22']->fromArray(array (
   'lang_topics' => 'plugin,category,system_events,propertyset,element',
   'assets' => '',
   'help_url' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $collection['25']= $xpdo->newObject(modAction::class);
-$collection['25']->fromArray(array (
+$collection['25']->fromArray([
   'id' => 25,
   'namespace' => 'core',
   'controller' => 'element/snippet',
@@ -142,9 +142,9 @@ $collection['25']->fromArray(array (
   'lang_topics' => 'snippet,propertyset,element',
   'assets' => '',
   'help_url' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $collection['26']= $xpdo->newObject(modAction::class);
-$collection['26']->fromArray(array (
+$collection['26']->fromArray([
   'id' => 26,
   'namespace' => 'core',
   'controller' => 'element/snippet/create',
@@ -152,9 +152,9 @@ $collection['26']->fromArray(array (
   'lang_topics' => 'snippet,propertyset,element',
   'assets' => '',
   'help_url' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $collection['27']= $xpdo->newObject(modAction::class);
-$collection['27']->fromArray(array (
+$collection['27']->fromArray([
   'id' => 27,
   'namespace' => 'core',
   'controller' => 'element/snippet/update',
@@ -162,9 +162,9 @@ $collection['27']->fromArray(array (
   'lang_topics' => 'snippet,propertyset,element',
   'assets' => '',
   'help_url' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $collection['28']= $xpdo->newObject(modAction::class);
-$collection['28']->fromArray(array (
+$collection['28']->fromArray([
   'id' => 28,
   'namespace' => 'core',
   'controller' => 'element/template',
@@ -172,9 +172,9 @@ $collection['28']->fromArray(array (
   'lang_topics' => 'template,propertyset,element',
   'assets' => '',
   'help_url' => 'Templates',
-), '', true, true);
+], '', true, true);
 $collection['29']= $xpdo->newObject(modAction::class);
-$collection['29']->fromArray(array (
+$collection['29']->fromArray([
   'id' => 29,
   'namespace' => 'core',
   'controller' => 'element/template/create',
@@ -182,9 +182,9 @@ $collection['29']->fromArray(array (
   'lang_topics' => 'template,propertyset,element',
   'assets' => '',
   'help_url' => 'Templates',
-), '', true, true);
+], '', true, true);
 $collection['30']= $xpdo->newObject(modAction::class);
-$collection['30']->fromArray(array (
+$collection['30']->fromArray([
   'id' => 30,
   'namespace' => 'core',
   'controller' => 'element/template/update',
@@ -192,18 +192,18 @@ $collection['30']->fromArray(array (
   'lang_topics' => 'template,propertyset,element',
   'assets' => '',
   'help_url' => 'Templates',
-), '', true, true);
+], '', true, true);
 $collection['31']= $xpdo->newObject(modAction::class);
-$collection['31']->fromArray(array (
+$collection['31']->fromArray([
   'id' => 31,
   'namespace' => 'core',
   'controller' => 'element/template/tvsort',
   'haslayout' => 1,
   'lang_topics' => 'template,tv,propertyset,element',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['32']= $xpdo->newObject(modAction::class);
-$collection['32']->fromArray(array (
+$collection['32']->fromArray([
   'id' => 32,
   'namespace' => 'core',
   'controller' => 'element/tv',
@@ -211,9 +211,9 @@ $collection['32']->fromArray(array (
   'lang_topics' => 'tv,propertyset,element',
   'assets' => '',
   'help_url' => 'Template+Variables',
-), '', true, true);
+], '', true, true);
 $collection['33']= $xpdo->newObject(modAction::class);
-$collection['33']->fromArray(array (
+$collection['33']->fromArray([
   'id' => 33,
   'namespace' => 'core',
   'controller' => 'element/tv/create',
@@ -221,9 +221,9 @@ $collection['33']->fromArray(array (
   'lang_topics' => 'tv,tv_widget,propertyset,element',
   'assets' => '',
   'help_url' => 'Template+Variables',
-), '', true, true);
+], '', true, true);
 $collection['34']= $xpdo->newObject(modAction::class);
-$collection['34']->fromArray(array (
+$collection['34']->fromArray([
   'id' => 34,
   'namespace' => 'core',
   'controller' => 'element/tv/update',
@@ -231,27 +231,27 @@ $collection['34']->fromArray(array (
   'lang_topics' => 'tv,tv_widget,propertyset,element',
   'assets' => '',
   'help_url' => 'Template+Variables',
-), '', true, true);
+], '', true, true);
 $collection['35']= $xpdo->newObject(modAction::class);
-$collection['35']->fromArray(array (
+$collection['35']->fromArray([
   'id' => 35,
   'namespace' => 'core',
   'controller' => 'element/view',
   'haslayout' => 1,
   'lang_topics' => 'element',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['36']= $xpdo->newObject(modAction::class);
-$collection['36']->fromArray(array (
+$collection['36']->fromArray([
   'id' => 36,
   'namespace' => 'core',
   'controller' => 'resource',
   'haslayout' => 1,
   'lang_topics' => '',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['38']= $xpdo->newObject(modAction::class);
-$collection['38']->fromArray(array (
+$collection['38']->fromArray([
   'id' => 38,
   'namespace' => 'core',
   'controller' => 'security/usergroup/create',
@@ -259,9 +259,9 @@ $collection['38']->fromArray(array (
   'lang_topics' => 'user,access,policy,context',
   'assets' => '',
   'help_url' => 'User+Groups',
-), '', true, true);
+], '', true, true);
 $collection['39']= $xpdo->newObject(modAction::class);
-$collection['39']->fromArray(array (
+$collection['39']->fromArray([
   'id' => 39,
   'namespace' => 'core',
   'controller' => 'security/usergroup/update',
@@ -269,9 +269,9 @@ $collection['39']->fromArray(array (
   'lang_topics' => 'user,access,policy,context',
   'assets' => '',
   'help_url' => 'User+Groups',
-), '', true, true);
+], '', true, true);
 $collection['40']= $xpdo->newObject(modAction::class);
-$collection['40']->fromArray(array (
+$collection['40']->fromArray([
   'id' => 40,
   'namespace' => 'core',
   'controller' => 'resource/data',
@@ -279,18 +279,18 @@ $collection['40']->fromArray(array (
   'lang_topics' => 'resource',
   'assets' => '',
   'help_url' => 'Resource',
-), '', true, true);
+], '', true, true);
 $collection['41']= $xpdo->newObject(modAction::class);
-$collection['41']->fromArray(array (
+$collection['41']->fromArray([
   'id' => 41,
   'namespace' => 'core',
   'controller' => 'resource/empty_recycle_bin',
   'haslayout' => 1,
   'lang_topics' => 'resource',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['43']= $xpdo->newObject(modAction::class);
-$collection['43']->fromArray(array (
+$collection['43']->fromArray([
   'id' => 43,
   'namespace' => 'core',
   'controller' => 'resource/update',
@@ -298,18 +298,18 @@ $collection['43']->fromArray(array (
   'lang_topics' => 'resource',
   'assets' => '',
   'help_url' => 'Resource',
-), '', true, true);
+], '', true, true);
 $collection['46']= $xpdo->newObject(modAction::class);
-$collection['46']->fromArray(array (
+$collection['46']->fromArray([
   'id' => 46,
   'namespace' => 'core',
   'controller' => 'security',
   'haslayout' => 1,
   'lang_topics' => 'user',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['50']= $xpdo->newObject(modAction::class);
-$collection['50']->fromArray(array (
+$collection['50']->fromArray([
   'id' => 50,
   'namespace' => 'core',
   'controller' => 'security/role',
@@ -317,9 +317,9 @@ $collection['50']->fromArray(array (
   'lang_topics' => 'user',
   'assets' => '',
   'help_url' => 'Roles',
-), '', true, true);
+], '', true, true);
 $collection['54']= $xpdo->newObject(modAction::class);
-$collection['54']->fromArray(array (
+$collection['54']->fromArray([
   'id' => 54,
   'namespace' => 'core',
   'controller' => 'security/user/create',
@@ -327,9 +327,9 @@ $collection['54']->fromArray(array (
   'lang_topics' => 'user,setting,access',
   'assets' => '',
   'help_url' => 'Users',
-), '', true, true);
+], '', true, true);
 $collection['55']= $xpdo->newObject(modAction::class);
-$collection['55']->fromArray(array (
+$collection['55']->fromArray([
   'id' => 55,
   'namespace' => 'core',
   'controller' => 'security/user/update',
@@ -337,63 +337,63 @@ $collection['55']->fromArray(array (
   'lang_topics' => 'user,setting,access',
   'assets' => '',
   'help_url' => 'Users',
-), '', true, true);
+], '', true, true);
 $collection['56']= $xpdo->newObject(modAction::class);
-$collection['56']->fromArray(array (
+$collection['56']->fromArray([
   'id' => 56,
   'namespace' => 'core',
   'controller' => 'security/login',
   'haslayout' => 1,
   'lang_topics' => 'login',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['62']= $xpdo->newObject(modAction::class);
-$collection['62']->fromArray(array (
+$collection['62']->fromArray([
   'id' => 62,
   'namespace' => 'core',
   'controller' => 'system/refresh_site',
   'haslayout' => 1,
   'lang_topics' => '',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['64']= $xpdo->newObject(modAction::class);
-$collection['64']->fromArray(array (
+$collection['64']->fromArray([
   'id' => 64,
   'namespace' => 'core',
   'controller' => 'system/phpinfo',
   'haslayout' => 1,
   'lang_topics' => '',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['67']= $xpdo->newObject(modAction::class);
-$collection['67']->fromArray(array (
+$collection['67']->fromArray([
   'id' => 67,
   'namespace' => 'core',
   'controller' => 'resource/tvs',
   'haslayout' => 0,
   'lang_topics' => '',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['70']= $xpdo->newObject(modAction::class);
-$collection['70']->fromArray(array (
+$collection['70']->fromArray([
   'id' => 70,
   'namespace' => 'core',
   'controller' => 'system/file',
   'haslayout' => 1,
   'lang_topics' => 'file',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['71']= $xpdo->newObject(modAction::class);
-$collection['71']->fromArray(array (
+$collection['71']->fromArray([
   'id' => 71,
   'namespace' => 'core',
   'controller' => 'system/file/edit',
   'haslayout' => 1,
   'lang_topics' => 'file',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 $collection['75']= $xpdo->newObject(modAction::class);
-$collection['75']->fromArray(array (
+$collection['75']->fromArray([
   'id' => 75,
   'namespace' => 'core',
   'controller' => 'security/access/policy/update',
@@ -401,9 +401,9 @@ $collection['75']->fromArray(array (
   'lang_topics' => 'user,policy',
   'assets' => '',
   'help_url' => 'Policies',
-), '', true, true);
+], '', true, true);
 $collection['82']= $xpdo->newObject(modAction::class);
-$collection['82']->fromArray(array (
+$collection['82']->fromArray([
   'id' => 82,
   'namespace' => 'core',
   'controller' => 'workspaces/package/view',
@@ -411,9 +411,9 @@ $collection['82']->fromArray(array (
   'lang_topics' => 'workspace,namespace',
   'assets' => '',
   'help_url' => 'Package+Management',
-), '', true, true);
+], '', true, true);
 $collection['83']= $xpdo->newObject(modAction::class);
-$collection['83']->fromArray(array (
+$collection['83']->fromArray([
   'id' => 83,
   'namespace' => 'core',
   'controller' => 'security/access/policy/template/update',
@@ -421,9 +421,9 @@ $collection['83']->fromArray(array (
   'lang_topics' => 'user,policy',
   'assets' => '',
   'help_url' => 'PolicyTemplates',
-), '', true, true);
+], '', true, true);
 $collection['84']= $xpdo->newObject(modAction::class);
-$collection['84']->fromArray(array (
+$collection['84']->fromArray([
   'id' => 84,
   'namespace' => 'core',
   'controller' => 'security/forms/profile/update',
@@ -431,9 +431,9 @@ $collection['84']->fromArray(array (
   'lang_topics' => 'formcustomization,user,access,policy',
   'assets' => '',
   'help_url' => 'Form+Customization+Profiles',
-), '', true, true);
+], '', true, true);
 $collection['85']= $xpdo->newObject(modAction::class);
-$collection['85']->fromArray(array (
+$collection['85']->fromArray([
   'id' => 85,
   'namespace' => 'core',
   'controller' => 'security/forms/set/update',
@@ -441,9 +441,9 @@ $collection['85']->fromArray(array (
   'lang_topics' => 'formcustomization,user,access,policy',
   'assets' => '',
   'help_url' => 'Form+Customization+Sets',
-), '', true, true);
+], '', true, true);
 $collection['101']= $xpdo->newObject(modAction::class);
-$collection['101']->fromArray(array (
+$collection['101']->fromArray([
   'id' => 101,
   'namespace' => 'core',
   'controller' => 'system/dashboards/update',
@@ -451,9 +451,9 @@ $collection['101']->fromArray(array (
   'lang_topics' => 'dashboards,user',
   'assets' => '',
   'help_url' => 'Dashboards',
-), '', true, true);
+], '', true, true);
 $collection['102']= $xpdo->newObject(modAction::class);
-$collection['102']->fromArray(array (
+$collection['102']->fromArray([
   'id' => 102,
   'namespace' => 'core',
   'controller' => 'system/dashboards/create',
@@ -461,9 +461,9 @@ $collection['102']->fromArray(array (
   'lang_topics' => 'dashboards,user',
   'assets' => '',
   'help_url' => 'Dashboards',
-), '', true, true);
+], '', true, true);
 $collection['103']= $xpdo->newObject(modAction::class);
-$collection['103']->fromArray(array (
+$collection['103']->fromArray([
   'id' => 103,
   'namespace' => 'core',
   'controller' => 'system/dashboards/widget/update',
@@ -471,9 +471,9 @@ $collection['103']->fromArray(array (
   'lang_topics' => 'dashboards,user',
   'assets' => '',
   'help_url' => 'Dashboard+Widgets',
-), '', true, true);
+], '', true, true);
 $collection['104']= $xpdo->newObject(modAction::class);
-$collection['104']->fromArray(array (
+$collection['104']->fromArray([
   'id' => 104,
   'namespace' => 'core',
   'controller' => 'system/dashboards/widget/create',
@@ -481,9 +481,9 @@ $collection['104']->fromArray(array (
   'lang_topics' => 'dashboards,user',
   'assets' => '',
   'help_url' => 'Dashboard+Widgets',
-), '', true, true);
+], '', true, true);
 $collection['105']= $xpdo->newObject(modAction::class);
-$collection['105']->fromArray(array (
+$collection['105']->fromArray([
   'id' => 105,
   'namespace' => 'core',
   'controller' => 'source/create',
@@ -491,9 +491,9 @@ $collection['105']->fromArray(array (
   'lang_topics' => 'sources,namespace',
   'assets' => '',
   'help_url' => 'Media+Sources',
-), '', true, true);
+], '', true, true);
 $collection['106']= $xpdo->newObject(modAction::class);
-$collection['106']->fromArray(array (
+$collection['106']->fromArray([
   'id' => 106,
   'namespace' => 'core',
   'controller' => 'source/update',
@@ -501,15 +501,15 @@ $collection['106']->fromArray(array (
   'lang_topics' => 'sources,namespace',
   'assets' => '',
   'help_url' => 'Media+Sources',
-), '', true, true);
+], '', true, true);
 $collection['107']= $xpdo->newObject(modAction::class);
-$collection['107']->fromArray(array (
+$collection['107']->fromArray([
   'id' => 107,
   'namespace' => 'core',
   'controller' => 'system/file/create',
   'haslayout' => 1,
   'lang_topics' => 'file',
   'assets' => '',
-), '', true, true);
+], '', true, true);
 
 return $collection;

--- a/_build/data/transport.core.content_types.php
+++ b/_build/data/transport.core.content_types.php
@@ -2,7 +2,7 @@
 use MODX\Revolution\modContentType;
 
 $collection['1']= $xpdo->newObject(modContentType::class);
-$collection['1']->fromArray(array (
+$collection['1']->fromArray([
   'id' => 1,
   'name' => 'HTML',
   'description' => 'HTML content',
@@ -11,9 +11,9 @@ $collection['1']->fromArray(array (
   'icon' => '',
   'headers' => 'NULL',
   'binary' => 0,
-), '', true, true);
+], '', true, true);
 $collection['2']= $xpdo->newObject(modContentType::class);
-$collection['2']->fromArray(array (
+$collection['2']->fromArray([
   'id' => 2,
   'name' => 'XML',
   'description' => 'XML content',
@@ -22,9 +22,9 @@ $collection['2']->fromArray(array (
   'icon' => 'icon-xml',
   'headers' => 'NULL',
   'binary' => 0,
-), '', true, true);
+], '', true, true);
 $collection['3']= $xpdo->newObject(modContentType::class);
-$collection['3']->fromArray(array (
+$collection['3']->fromArray([
   'id' => 3,
   'name' => 'Text',
   'description' => 'Plain text content',
@@ -33,9 +33,9 @@ $collection['3']->fromArray(array (
   'icon' => 'icon-txt',
   'headers' => 'NULL',
   'binary' => 0,
-), '', true, true);
+], '', true, true);
 $collection['4']= $xpdo->newObject(modContentType::class);
-$collection['4']->fromArray(array (
+$collection['4']->fromArray([
   'id' => 4,
   'name' => 'CSS',
   'description' => 'CSS content',
@@ -44,9 +44,9 @@ $collection['4']->fromArray(array (
   'icon' => 'icon-css',
   'headers' => 'NULL',
   'binary' => 0,
-), '', true, true);
+], '', true, true);
 $collection['5']= $xpdo->newObject(modContentType::class);
-$collection['5']->fromArray(array (
+$collection['5']->fromArray([
   'id' => 5,
   'name' => 'JavaScript',
   'description' => 'JavaScript content',
@@ -55,9 +55,9 @@ $collection['5']->fromArray(array (
   'icon' => 'icon-js',
   'headers' => 'NULL',
   'binary' => 0,
-), '', true, true);
+], '', true, true);
 $collection['6']= $xpdo->newObject(modContentType::class);
-$collection['6']->fromArray(array (
+$collection['6']->fromArray([
   'id' => 6,
   'name' => 'RSS',
   'description' => 'For RSS feeds',
@@ -66,9 +66,9 @@ $collection['6']->fromArray(array (
   'icon' => 'icon-rss',
   'headers' => 'NULL',
   'binary' => 0,
-), '', true, true);
+], '', true, true);
 $collection['7']= $xpdo->newObject(modContentType::class);
-$collection['7']->fromArray(array (
+$collection['7']->fromArray([
   'id' => 7,
   'name' => 'JSON',
   'description' => 'JSON',
@@ -77,9 +77,9 @@ $collection['7']->fromArray(array (
   'icon' => 'icon-json',
   'headers' => 'NULL',
   'binary' => 0,
-), '', true, true);
+], '', true, true);
 $collection['8']= $xpdo->newObject(modContentType::class);
-$collection['8']->fromArray(array (
+$collection['8']->fromArray([
   'id' => 8,
   'name' => 'PDF',
   'description' => 'PDF Files',
@@ -88,4 +88,4 @@ $collection['8']->fromArray(array (
   'icon' => 'icon-pdf',
   'headers' => 'NULL',
   'binary' => 1,
-), '', true, true);
+], '', true, true);

--- a/_build/data/transport.core.context_settings.php
+++ b/_build/data/transport.core.context_settings.php
@@ -2,7 +2,7 @@
 use MODX\Revolution\modContextSetting;
 
 $collection['0']= $xpdo->newObject(modContextSetting::class);
-$collection['0']->fromArray(array (
+$collection['0']->fromArray([
   'context_key' => 'mgr',
   'key' => 'allow_tags_in_post',
   'value' => true,
@@ -10,9 +10,9 @@ $collection['0']->fromArray(array (
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => NULL,
-), '', true, true);
+], '', true, true);
 $collection['1']= $xpdo->newObject(modContextSetting::class);
-$collection['1']->fromArray(array (
+$collection['1']->fromArray([
   'context_key' => 'mgr',
   'key' => 'modRequest.class',
   'value' => 'MODX\Revolution\modManagerRequest',
@@ -20,4 +20,4 @@ $collection['1']->fromArray(array (
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => NULL,
-), '', true, true);
+], '', true, true);

--- a/_build/data/transport.core.dashboard_widgets.php
+++ b/_build/data/transport.core.dashboard_widgets.php
@@ -5,9 +5,9 @@
 
 use MODX\Revolution\modDashboardWidget;
 
-$widgets = array();
+$widgets = [];
 $widgets[1]= $xpdo->newObject(modDashboardWidget::class);
-$widgets[1]->fromArray(array (
+$widgets[1]->fromArray([
   'name' => 'w_newsfeed',
   'description' => 'w_newsfeed_desc',
   'type' => 'file',
@@ -15,10 +15,10 @@ $widgets[1]->fromArray(array (
   'content' => '[[++manager_path]]controllers/default/dashboard/widget.modx-news.php',
   'namespace' => 'core',
   'lexicon' => 'core:dashboards',
-), '', true, true);
+], '', true, true);
 
 $widgets[2]= $xpdo->newObject(modDashboardWidget::class);
-$widgets[2]->fromArray(array (
+$widgets[2]->fromArray([
   'name' => 'w_securityfeed',
   'description' => 'w_securityfeed_desc',
   'type' => 'file',
@@ -26,10 +26,10 @@ $widgets[2]->fromArray(array (
   'content' => '[[++manager_path]]controllers/default/dashboard/widget.modx-security.php',
   'namespace' => 'core',
   'lexicon' => 'core:dashboards',
-), '', true, true);
+], '', true, true);
 
 $widgets[3]= $xpdo->newObject(modDashboardWidget::class);
-$widgets[3]->fromArray(array (
+$widgets[3]->fromArray([
   'name' => 'w_whosonline',
   'description' => 'w_whosonline_desc',
   'type' => 'file',
@@ -37,10 +37,10 @@ $widgets[3]->fromArray(array (
   'content' => '[[++manager_path]]controllers/default/dashboard/widget.grid-online.php',
   'namespace' => 'core',
   'lexicon' => 'core:dashboards',
-), '', true, true);
+], '', true, true);
 
 $widgets[4]= $xpdo->newObject(modDashboardWidget::class);
-$widgets[4]->fromArray(array (
+$widgets[4]->fromArray([
   'name' => 'w_recentlyeditedresources',
   'description' => 'w_recentlyeditedresources_desc',
   'type' => 'file',
@@ -49,10 +49,10 @@ $widgets[4]->fromArray(array (
   'content' => '[[++manager_path]]controllers/default/dashboard/widget.grid-rer.php',
   'namespace' => 'core',
   'lexicon' => 'core:dashboards',
-), '', true, true);
+], '', true, true);
 
 $widgets[5]= $xpdo->newObject(modDashboardWidget::class);
-$widgets[5]->fromArray(array (
+$widgets[5]->fromArray([
   'name' => 'w_configcheck',
   'description' => 'w_configcheck_desc',
   'type' => 'file',
@@ -60,10 +60,10 @@ $widgets[5]->fromArray(array (
   'content' => '[[++manager_path]]controllers/default/dashboard/widget.configcheck.php',
   'namespace' => 'core',
   'lexicon' => 'core:dashboards',
-), '', true, true);
+], '', true, true);
 
 $widgets[6]= $xpdo->newObject(modDashboardWidget::class);
-$widgets[6]->fromArray(array (
+$widgets[6]->fromArray([
   'name' => 'w_buttons',
   'description' => 'w_buttons_desc',
   'type' => 'file',
@@ -98,10 +98,10 @@ $widgets[6]->fromArray(array (
   'content' => '[[++manager_path]]controllers/default/dashboard/widget.buttons.php',
   'namespace' => 'core',
   'lexicon' => 'core:dashboards',
-), '', true, true);
+], '', true, true);
 
 $widgets[7]= $xpdo->newObject(modDashboardWidget::class);
-$widgets[7]->fromArray(array (
+$widgets[7]->fromArray([
   'name' => 'w_updates',
   'description' => 'w_updates_desc',
   'type' => 'file',
@@ -110,6 +110,6 @@ $widgets[7]->fromArray(array (
   'content' => '[[++manager_path]]controllers/default/dashboard/widget.updates.php',
   'namespace' => 'core',
   'lexicon' => 'core:dashboards',
-), '', true, true);
+], '', true, true);
 
 return $widgets;

--- a/_build/data/transport.core.dashboards.php
+++ b/_build/data/transport.core.dashboards.php
@@ -5,8 +5,8 @@
 use MODX\Revolution\modDashboard;
 
 $collection[1]= $xpdo->newObject(modDashboard::class);
-$collection[1]->fromArray(array (
+$collection[1]->fromArray([
   'id' => 1,
   'name' => 'Default',
   'description' => '',
-), '', true, true);
+], '', true, true);

--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -6,1209 +6,1209 @@
 
 use MODX\Revolution\modEvent;
 
-$events = array();
+$events = [];
 
 
 /* Plugin Events */
 $events['OnPluginEventBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnPluginEventBeforeSave']->fromArray(array (
+$events['OnPluginEventBeforeSave']->fromArray([
     'name' => 'OnPluginEventBeforeSave',
     'service' => 1,
     'groupname' => 'Plugin Events',
-), '', true, true);
+], '', true, true);
 $events['OnPluginEventSave']= $xpdo->newObject(modEvent::class);
-$events['OnPluginEventSave']->fromArray(array (
+$events['OnPluginEventSave']->fromArray([
     'name' => 'OnPluginEventSave',
     'service' => 1,
     'groupname' => 'Plugin Events',
-), '', true, true);
+], '', true, true);
 $events['OnPluginEventBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnPluginEventBeforeRemove']->fromArray(array (
+$events['OnPluginEventBeforeRemove']->fromArray([
     'name' => 'OnPluginEventBeforeRemove',
     'service' => 1,
     'groupname' => 'Plugin Events',
-), '', true, true);
+], '', true, true);
 $events['OnPluginEventRemove']= $xpdo->newObject(modEvent::class);
-$events['OnPluginEventRemove']->fromArray(array (
+$events['OnPluginEventRemove']->fromArray([
     'name' => 'OnPluginEventRemove',
     'service' => 1,
     'groupname' => 'Plugin Events',
-), '', true, true);
+], '', true, true);
 
 
 /* Resource Groups */
 $events['OnResourceGroupSave']= $xpdo->newObject(modEvent::class);
-$events['OnResourceGroupSave']->fromArray(array (
+$events['OnResourceGroupSave']->fromArray([
     'name' => 'OnResourceGroupSave',
     'service' => 1,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnResourceGroupBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnResourceGroupBeforeSave']->fromArray(array (
+$events['OnResourceGroupBeforeSave']->fromArray([
     'name' => 'OnResourceGroupBeforeSave',
     'service' => 1,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnResourceGroupRemove']= $xpdo->newObject(modEvent::class);
-$events['OnResourceGroupRemove']->fromArray(array (
+$events['OnResourceGroupRemove']->fromArray([
     'name' => 'OnResourceGroupRemove',
     'service' => 1,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnResourceGroupBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnResourceGroupBeforeRemove']->fromArray(array (
+$events['OnResourceGroupBeforeRemove']->fromArray([
     'name' => 'OnResourceGroupBeforeRemove',
     'service' => 1,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 
 
 /* Snippets */
 $events['OnSnippetBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnSnippetBeforeSave']->fromArray(array (
+$events['OnSnippetBeforeSave']->fromArray([
     'name' => 'OnSnippetBeforeSave',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnSnippetSave']= $xpdo->newObject(modEvent::class);
-$events['OnSnippetSave']->fromArray(array (
+$events['OnSnippetSave']->fromArray([
     'name' => 'OnSnippetSave',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnSnippetBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnSnippetBeforeRemove']->fromArray(array (
+$events['OnSnippetBeforeRemove']->fromArray([
     'name' => 'OnSnippetBeforeRemove',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnSnippetRemove']= $xpdo->newObject(modEvent::class);
-$events['OnSnippetRemove']->fromArray(array (
+$events['OnSnippetRemove']->fromArray([
     'name' => 'OnSnippetRemove',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnSnipFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnSnipFormPrerender']->fromArray(array (
+$events['OnSnipFormPrerender']->fromArray([
     'name' => 'OnSnipFormPrerender',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnSnipFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnSnipFormRender']->fromArray(array (
+$events['OnSnipFormRender']->fromArray([
     'name' => 'OnSnipFormRender',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeSnipFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeSnipFormSave']->fromArray(array (
+$events['OnBeforeSnipFormSave']->fromArray([
     'name' => 'OnBeforeSnipFormSave',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnSnipFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnSnipFormSave']->fromArray(array (
+$events['OnSnipFormSave']->fromArray([
     'name' => 'OnSnipFormSave',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeSnipFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeSnipFormDelete']->fromArray(array (
+$events['OnBeforeSnipFormDelete']->fromArray([
     'name' => 'OnBeforeSnipFormDelete',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 $events['OnSnipFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnSnipFormDelete']->fromArray(array (
+$events['OnSnipFormDelete']->fromArray([
     'name' => 'OnSnipFormDelete',
     'service' => 1,
     'groupname' => 'Snippets',
-), '', true, true);
+], '', true, true);
 
 
 /* Templates */
 $events['OnTemplateBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateBeforeSave']->fromArray(array (
+$events['OnTemplateBeforeSave']->fromArray([
     'name' => 'OnTemplateBeforeSave',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnTemplateSave']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateSave']->fromArray(array (
+$events['OnTemplateSave']->fromArray([
     'name' => 'OnTemplateSave',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnTemplateBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateBeforeRemove']->fromArray(array (
+$events['OnTemplateBeforeRemove']->fromArray([
     'name' => 'OnTemplateBeforeRemove',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnTemplateRemove']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateRemove']->fromArray(array (
+$events['OnTemplateRemove']->fromArray([
     'name' => 'OnTemplateRemove',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnTempFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnTempFormPrerender']->fromArray(array (
+$events['OnTempFormPrerender']->fromArray([
     'name' => 'OnTempFormPrerender',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnTempFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnTempFormRender']->fromArray(array (
+$events['OnTempFormRender']->fromArray([
     'name' => 'OnTempFormRender',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeTempFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeTempFormSave']->fromArray(array (
+$events['OnBeforeTempFormSave']->fromArray([
     'name' => 'OnBeforeTempFormSave',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnTempFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnTempFormSave']->fromArray(array (
+$events['OnTempFormSave']->fromArray([
     'name' => 'OnTempFormSave',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeTempFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeTempFormDelete']->fromArray(array (
+$events['OnBeforeTempFormDelete']->fromArray([
     'name' => 'OnBeforeTempFormDelete',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 $events['OnTempFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnTempFormDelete']->fromArray(array (
+$events['OnTempFormDelete']->fromArray([
     'name' => 'OnTempFormDelete',
     'service' => 1,
     'groupname' => 'Templates',
-), '', true, true);
+], '', true, true);
 
 
 /* Template Variables */
 $events['OnTemplateVarBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateVarBeforeSave']->fromArray(array (
+$events['OnTemplateVarBeforeSave']->fromArray([
     'name' => 'OnTemplateVarBeforeSave',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTemplateVarSave']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateVarSave']->fromArray(array (
+$events['OnTemplateVarSave']->fromArray([
     'name' => 'OnTemplateVarSave',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTemplateVarBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateVarBeforeRemove']->fromArray(array (
+$events['OnTemplateVarBeforeRemove']->fromArray([
     'name' => 'OnTemplateVarBeforeRemove',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTemplateVarRemove']= $xpdo->newObject(modEvent::class);
-$events['OnTemplateVarRemove']->fromArray(array (
+$events['OnTemplateVarRemove']->fromArray([
     'name' => 'OnTemplateVarRemove',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTVFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnTVFormPrerender']->fromArray(array (
+$events['OnTVFormPrerender']->fromArray([
     'name' => 'OnTVFormPrerender',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTVFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnTVFormRender']->fromArray(array (
+$events['OnTVFormRender']->fromArray([
     'name' => 'OnTVFormRender',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeTVFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeTVFormSave']->fromArray(array (
+$events['OnBeforeTVFormSave']->fromArray([
     'name' => 'OnBeforeTVFormSave',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTVFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnTVFormSave']->fromArray(array (
+$events['OnTVFormSave']->fromArray([
     'name' => 'OnTVFormSave',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeTVFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeTVFormDelete']->fromArray(array (
+$events['OnBeforeTVFormDelete']->fromArray([
     'name' => 'OnBeforeTVFormDelete',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTVFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnTVFormDelete']->fromArray(array (
+$events['OnTVFormDelete']->fromArray([
     'name' => 'OnTVFormDelete',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 
 
 /* TV Renders */
 $events['OnTVInputRenderList']= $xpdo->newObject(modEvent::class);
-$events['OnTVInputRenderList']->fromArray(array (
+$events['OnTVInputRenderList']->fromArray([
     'name' => 'OnTVInputRenderList',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTVInputPropertiesList']= $xpdo->newObject(modEvent::class);
-$events['OnTVInputPropertiesList']->fromArray(array (
+$events['OnTVInputPropertiesList']->fromArray([
     'name' => 'OnTVInputPropertiesList',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTVOutputRenderList']= $xpdo->newObject(modEvent::class);
-$events['OnTVOutputRenderList']->fromArray(array (
+$events['OnTVOutputRenderList']->fromArray([
     'name' => 'OnTVOutputRenderList',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 $events['OnTVOutputRenderPropertiesList']= $xpdo->newObject(modEvent::class);
-$events['OnTVOutputRenderPropertiesList']->fromArray(array (
+$events['OnTVOutputRenderPropertiesList']->fromArray([
     'name' => 'OnTVOutputRenderPropertiesList',
     'service' => 1,
     'groupname' => 'Template Variables',
-), '', true, true);
+], '', true, true);
 
 
 /* User Groups */
 $events['OnUserGroupBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupBeforeSave']->fromArray(array (
+$events['OnUserGroupBeforeSave']->fromArray([
     'name' => 'OnUserGroupBeforeSave',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserGroupSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupSave']->fromArray(array (
+$events['OnUserGroupSave']->fromArray([
     'name' => 'OnUserGroupSave',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserGroupBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupBeforeRemove']->fromArray(array (
+$events['OnUserGroupBeforeRemove']->fromArray([
     'name' => 'OnUserGroupBeforeRemove',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserGroupRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupRemove']->fromArray(array (
+$events['OnUserGroupRemove']->fromArray([
     'name' => 'OnUserGroupRemove',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserGroupBeforeFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupBeforeFormSave']->fromArray(array (
+$events['OnUserGroupBeforeFormSave']->fromArray([
     'name' => 'OnBeforeUserGroupFormSave',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserGroupFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupFormSave']->fromArray(array (
+$events['OnUserGroupFormSave']->fromArray([
     'name' => 'OnUserGroupFormSave',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserGroupBeforeFormRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupBeforeFormRemove']->fromArray(array (
+$events['OnUserGroupBeforeFormRemove']->fromArray([
     'name' => 'OnBeforeUserGroupFormRemove',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserGroupFormRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserGroupFormRemove']->fromArray(array (
+$events['OnUserGroupFormRemove']->fromArray([
     'name' => 'OnBeforeUserGroupFormRemove',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 
 /* User Profiles */
 $events['OnUserProfileBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserProfileBeforeSave']->fromArray(array (
+$events['OnUserProfileBeforeSave']->fromArray([
     'name' => 'OnUserProfileBeforeSave',
     'service' => 1,
     'groupname' => 'User Profiles',
-), '', true, true);
+], '', true, true);
 $events['OnUserProfileSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserProfileSave']->fromArray(array (
+$events['OnUserProfileSave']->fromArray([
     'name' => 'OnUserProfileSave',
     'service' => 1,
     'groupname' => 'User Profiles',
-), '', true, true);
+], '', true, true);
 $events['OnUserProfileBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserProfileBeforeRemove']->fromArray(array (
+$events['OnUserProfileBeforeRemove']->fromArray([
     'name' => 'OnUserProfileBeforeRemove',
     'service' => 1,
     'groupname' => 'User Profiles',
-), '', true, true);
+], '', true, true);
 $events['OnUserProfileRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserProfileRemove']->fromArray(array (
+$events['OnUserProfileRemove']->fromArray([
     'name' => 'OnUserProfileRemove',
     'service' => 1,
     'groupname' => 'User Profiles',
-), '', true, true);
+], '', true, true);
 
 /* Resources */
 $events['OnDocFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnDocFormPrerender']->fromArray(array (
+$events['OnDocFormPrerender']->fromArray([
     'name' => 'OnDocFormPrerender',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnDocFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnDocFormRender']->fromArray(array (
+$events['OnDocFormRender']->fromArray([
     'name' => 'OnDocFormRender',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeDocFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeDocFormSave']->fromArray(array (
+$events['OnBeforeDocFormSave']->fromArray([
     'name' => 'OnBeforeDocFormSave',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnDocFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnDocFormSave']->fromArray(array (
+$events['OnDocFormSave']->fromArray([
     'name' => 'OnDocFormSave',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeDocFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeDocFormDelete']->fromArray(array (
+$events['OnBeforeDocFormDelete']->fromArray([
     'name' => 'OnBeforeDocFormDelete',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnDocFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnDocFormDelete']->fromArray(array (
+$events['OnDocFormDelete']->fromArray([
     'name' => 'OnDocFormDelete',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnDocPublished']= $xpdo->newObject(modEvent::class);
-$events['OnDocPublished']->fromArray(array (
+$events['OnDocPublished']->fromArray([
     'name' => 'OnDocPublished',
     'service' => 5,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnDocUnPublished']= $xpdo->newObject(modEvent::class);
-$events['OnDocUnPublished']->fromArray(array (
+$events['OnDocUnPublished']->fromArray([
     'name' => 'OnDocUnPublished',
     'service' => 5,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeEmptyTrash']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeEmptyTrash']->fromArray(array (
+$events['OnBeforeEmptyTrash']->fromArray([
     'name' => 'OnBeforeEmptyTrash',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnEmptyTrash']= $xpdo->newObject(modEvent::class);
-$events['OnEmptyTrash']->fromArray(array (
+$events['OnEmptyTrash']->fromArray([
     'name' => 'OnEmptyTrash',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceTVFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnResourceTVFormPrerender']->fromArray(array (
+$events['OnResourceTVFormPrerender']->fromArray([
     'name' => 'OnResourceTVFormPrerender',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceTVFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnResourceTVFormRender']->fromArray(array (
+$events['OnResourceTVFormRender']->fromArray([
     'name' => 'OnResourceTVFormRender',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceAutoPublish']= $xpdo->newObject(modEvent::class);
-$events['OnResourceAutoPublish']->fromArray(array (
+$events['OnResourceAutoPublish']->fromArray([
     'name' => 'OnResourceAutoPublish',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceDelete']= $xpdo->newObject(modEvent::class);
-$events['OnResourceDelete']->fromArray(array (
+$events['OnResourceDelete']->fromArray([
     'name' => 'OnResourceDelete',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceUndelete']= $xpdo->newObject(modEvent::class);
-$events['OnResourceUndelete']->fromArray(array (
+$events['OnResourceUndelete']->fromArray([
     'name' => 'OnResourceUndelete',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceBeforeSort']= $xpdo->newObject(modEvent::class);
-$events['OnResourceBeforeSort']->fromArray(array (
+$events['OnResourceBeforeSort']->fromArray([
     'name' => 'OnResourceBeforeSort',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceSort']= $xpdo->newObject(modEvent::class);
-$events['OnResourceSort']->fromArray(array (
+$events['OnResourceSort']->fromArray([
     'name' => 'OnResourceSort',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceDuplicate']= $xpdo->newObject(modEvent::class);
-$events['OnResourceDuplicate']->fromArray(array (
+$events['OnResourceDuplicate']->fromArray([
     'name' => 'OnResourceDuplicate',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceToolbarLoad']= $xpdo->newObject(modEvent::class);
-$events['OnResourceToolbarLoad']->fromArray(array (
+$events['OnResourceToolbarLoad']->fromArray([
     'name' => 'OnResourceToolbarLoad',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceRemoveFromResourceGroup']= $xpdo->newObject(modEvent::class);
-$events['OnResourceRemoveFromResourceGroup']->fromArray(array (
+$events['OnResourceRemoveFromResourceGroup']->fromArray([
     'name' => 'OnResourceRemoveFromResourceGroup',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceAddToResourceGroup']= $xpdo->newObject(modEvent::class);
-$events['OnResourceAddToResourceGroup']->fromArray(array (
+$events['OnResourceAddToResourceGroup']->fromArray([
     'name' => 'OnResourceAddToResourceGroup',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 $events['OnResourceCacheUpdate']= $xpdo->newObject(modEvent::class);
-$events['OnResourceCacheUpdate']->fromArray(array (
+$events['OnResourceCacheUpdate']->fromArray([
     'name' => 'OnResourceCacheUpdate',
     'service' => 1,
     'groupname' => 'Resources',
-), '', true, true);
+], '', true, true);
 
 
 /* Richtext Editor */
 $events['OnRichTextEditorRegister']= $xpdo->newObject(modEvent::class);
-$events['OnRichTextEditorRegister']->fromArray(array (
+$events['OnRichTextEditorRegister']->fromArray([
     'name' => 'OnRichTextEditorRegister',
     'service' => 1,
     'groupname' => 'RichText Editor',
-), '', true, true);
+], '', true, true);
 $events['OnRichTextEditorInit']= $xpdo->newObject(modEvent::class);
-$events['OnRichTextEditorInit']->fromArray(array (
+$events['OnRichTextEditorInit']->fromArray([
     'name' => 'OnRichTextEditorInit',
     'service' => 1,
     'groupname' => 'RichText Editor',
-), '', true, true);
+], '', true, true);
 $events['OnRichTextBrowserInit']= $xpdo->newObject(modEvent::class);
-$events['OnRichTextBrowserInit']->fromArray(array (
+$events['OnRichTextBrowserInit']->fromArray([
     'name' => 'OnRichTextBrowserInit',
     'service' => 1,
     'groupname' => 'RichText Editor',
-), '', true, true);
+], '', true, true);
 
 
 /* Security */
 $events['OnWebLogin']= $xpdo->newObject(modEvent::class);
-$events['OnWebLogin']->fromArray(array (
+$events['OnWebLogin']->fromArray([
     'name' => 'OnWebLogin',
     'service' => 3,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeWebLogout']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeWebLogout']->fromArray(array (
+$events['OnBeforeWebLogout']->fromArray([
     'name' => 'OnBeforeWebLogout',
     'service' => 3,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnWebLogout']= $xpdo->newObject(modEvent::class);
-$events['OnWebLogout']->fromArray(array (
+$events['OnWebLogout']->fromArray([
     'name' => 'OnWebLogout',
     'service' => 3,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnManagerLogin']= $xpdo->newObject(modEvent::class);
-$events['OnManagerLogin']->fromArray(array (
+$events['OnManagerLogin']->fromArray([
     'name' => 'OnManagerLogin',
     'service' => 2,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeManagerLogout']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeManagerLogout']->fromArray(array (
+$events['OnBeforeManagerLogout']->fromArray([
     'name' => 'OnBeforeManagerLogout',
     'service' => 2,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnManagerLogout']= $xpdo->newObject(modEvent::class);
-$events['OnManagerLogout']->fromArray(array (
+$events['OnManagerLogout']->fromArray([
     'name' => 'OnManagerLogout',
     'service' => 2,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeWebLogin']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeWebLogin']->fromArray(array (
+$events['OnBeforeWebLogin']->fromArray([
     'name' => 'OnBeforeWebLogin',
     'service' => 3,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnWebAuthentication']= $xpdo->newObject(modEvent::class);
-$events['OnWebAuthentication']->fromArray(array (
+$events['OnWebAuthentication']->fromArray([
     'name' => 'OnWebAuthentication',
     'service' => 3,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeManagerLogin']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeManagerLogin']->fromArray(array (
+$events['OnBeforeManagerLogin']->fromArray([
     'name' => 'OnBeforeManagerLogin',
     'service' => 2,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnManagerAuthentication']= $xpdo->newObject(modEvent::class);
-$events['OnManagerAuthentication']->fromArray(array (
+$events['OnManagerAuthentication']->fromArray([
     'name' => 'OnManagerAuthentication',
     'service' => 2,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnManagerLoginFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnManagerLoginFormRender']->fromArray(array (
+$events['OnManagerLoginFormRender']->fromArray([
     'name' => 'OnManagerLoginFormRender',
     'service' => 2,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnManagerLoginFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnManagerLoginFormPrerender']->fromArray(array (
+$events['OnManagerLoginFormPrerender']->fromArray([
     'name' => 'OnManagerLoginFormPrerender',
     'service' => 2,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 $events['OnPageUnauthorized']= $xpdo->newObject(modEvent::class);
-$events['OnPageUnauthorized']->fromArray(array (
+$events['OnPageUnauthorized']->fromArray([
     'name' => 'OnPageUnauthorized',
     'service' => 1,
     'groupname' => 'Security',
-), '', true, true);
+], '', true, true);
 
 
 /* Users */
 $events['OnUserFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnUserFormPrerender']->fromArray(array (
+$events['OnUserFormPrerender']->fromArray([
     'name' => 'OnUserFormPrerender',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnUserFormRender']->fromArray(array (
+$events['OnUserFormRender']->fromArray([
     'name' => 'OnUserFormRender',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeUserFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeUserFormSave']->fromArray(array (
+$events['OnBeforeUserFormSave']->fromArray([
     'name' => 'OnBeforeUserFormSave',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserFormSave']->fromArray(array (
+$events['OnUserFormSave']->fromArray([
     'name' => 'OnUserFormSave',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeUserFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeUserFormDelete']->fromArray(array (
+$events['OnBeforeUserFormDelete']->fromArray([
     'name' => 'OnBeforeUserFormDelete',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnUserFormDelete']->fromArray(array (
+$events['OnUserFormDelete']->fromArray([
     'name' => 'OnUserFormDelete',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserNotFound']= $xpdo->newObject(modEvent::class);
-$events['OnUserNotFound']->fromArray(array (
+$events['OnUserNotFound']->fromArray([
     'name' => 'OnUserNotFound',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeUserActivate']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeUserActivate']->fromArray(array (
+$events['OnBeforeUserActivate']->fromArray([
     'name' => 'OnBeforeUserActivate',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserActivate']= $xpdo->newObject(modEvent::class);
-$events['OnUserActivate']->fromArray(array (
+$events['OnUserActivate']->fromArray([
     'name' => 'OnUserActivate',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeUserDeactivate']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeUserDeactivate']->fromArray(array (
+$events['OnBeforeUserDeactivate']->fromArray([
     'name' => 'OnBeforeUserDeactivate',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserDeactivate']= $xpdo->newObject(modEvent::class);
-$events['OnUserDeactivate']->fromArray(array (
+$events['OnUserDeactivate']->fromArray([
     'name' => 'OnUserDeactivate',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeUserDuplicate']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeUserDuplicate']->fromArray(array (
+$events['OnBeforeUserDuplicate']->fromArray([
     'name' => 'OnBeforeUserDuplicate',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserDuplicate']= $xpdo->newObject(modEvent::class);
-$events['OnUserDuplicate']->fromArray(array (
+$events['OnUserDuplicate']->fromArray([
     'name' => 'OnUserDuplicate',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserChangePassword']= $xpdo->newObject(modEvent::class);
-$events['OnUserChangePassword']->fromArray(array (
+$events['OnUserChangePassword']->fromArray([
     'name' => 'OnUserChangePassword',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserBeforeRemove']->fromArray(array (
+$events['OnUserBeforeRemove']->fromArray([
     'name' => 'OnUserBeforeRemove',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserBeforeSave']->fromArray(array (
+$events['OnUserBeforeSave']->fromArray([
     'name' => 'OnUserBeforeSave',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserSave']= $xpdo->newObject(modEvent::class);
-$events['OnUserSave']->fromArray(array (
+$events['OnUserSave']->fromArray([
     'name' => 'OnUserSave',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserRemove']= $xpdo->newObject(modEvent::class);
-$events['OnUserRemove']->fromArray(array (
+$events['OnUserRemove']->fromArray([
     'name' => 'OnUserRemove',
     'service' => 1,
     'groupname' => 'Users',
-), '', true, true);
+], '', true, true);
 $events['OnUserBeforeAddToGroup']= $xpdo->newObject(modEvent::class);
-$events['OnUserBeforeAddToGroup']->fromArray(array (
+$events['OnUserBeforeAddToGroup']->fromArray([
     'name' => 'OnUserBeforeAddToGroup',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserAddToGroup']= $xpdo->newObject(modEvent::class);
-$events['OnUserAddToGroup']->fromArray(array (
+$events['OnUserAddToGroup']->fromArray([
     'name' => 'OnUserAddToGroup',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserBeforeRemoveFromGroup']= $xpdo->newObject(modEvent::class);
-$events['OnUserBeforeRemoveFromGroup']->fromArray(array (
+$events['OnUserBeforeRemoveFromGroup']->fromArray([
     'name' => 'OnUserBeforeRemoveFromGroup',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 $events['OnUserRemoveFromGroup']= $xpdo->newObject(modEvent::class);
-$events['OnUserRemoveFromGroup']->fromArray(array (
+$events['OnUserRemoveFromGroup']->fromArray([
     'name' => 'OnUserRemoveFromGroup',
     'service' => 1,
     'groupname' => 'User Groups',
-), '', true, true);
+], '', true, true);
 
 
 /* System */
 $events['OnBeforeRegisterClientScripts']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeRegisterClientScripts']->fromArray(array (
+$events['OnBeforeRegisterClientScripts']->fromArray([
     'name' => 'OnBeforeRegisterClientScripts',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnWebPagePrerender']= $xpdo->newObject(modEvent::class);
-$events['OnWebPagePrerender']->fromArray(array (
+$events['OnWebPagePrerender']->fromArray([
     'name' => 'OnWebPagePrerender',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeCacheUpdate']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeCacheUpdate']->fromArray(array (
+$events['OnBeforeCacheUpdate']->fromArray([
     'name' => 'OnBeforeCacheUpdate',
     'service' => 4,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnCacheUpdate']= $xpdo->newObject(modEvent::class);
-$events['OnCacheUpdate']->fromArray(array (
+$events['OnCacheUpdate']->fromArray([
     'name' => 'OnCacheUpdate',
     'service' => 4,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnLoadWebPageCache']= $xpdo->newObject(modEvent::class);
-$events['OnLoadWebPageCache']->fromArray(array (
+$events['OnLoadWebPageCache']->fromArray([
     'name' => 'OnLoadWebPageCache',
     'service' => 4,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeSaveWebPageCache']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeSaveWebPageCache']->fromArray(array (
+$events['OnBeforeSaveWebPageCache']->fromArray([
     'name' => 'OnBeforeSaveWebPageCache',
     'service' => 4,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnSiteRefresh']= $xpdo->newObject(modEvent::class);
-$events['OnSiteRefresh']->fromArray(array (
+$events['OnSiteRefresh']->fromArray([
     'name' => 'OnSiteRefresh',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerDirCreate']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerDirCreate']->fromArray(array (
+$events['OnFileManagerDirCreate']->fromArray([
     'name' => 'OnFileManagerDirCreate',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerDirRemove']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerDirRemove']->fromArray(array (
+$events['OnFileManagerDirRemove']->fromArray([
     'name' => 'OnFileManagerDirRemove',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerDirRename']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerDirRename']->fromArray(array (
+$events['OnFileManagerDirRename']->fromArray([
     'name' => 'OnFileManagerDirRename',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerFileRename']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerFileRename']->fromArray(array (
+$events['OnFileManagerFileRename']->fromArray([
     'name' => 'OnFileManagerFileRename',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerFileRemove']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerFileRemove']->fromArray(array (
+$events['OnFileManagerFileRemove']->fromArray([
     'name' => 'OnFileManagerFileRemove',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerFileUpdate']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerFileUpdate']->fromArray(array (
+$events['OnFileManagerFileUpdate']->fromArray([
     'name' => 'OnFileManagerFileUpdate',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerFileCreate']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerFileCreate']->fromArray(array (
+$events['OnFileManagerFileCreate']->fromArray([
     'name' => 'OnFileManagerFileCreate',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerBeforeUpload']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerBeforeUpload']->fromArray(array (
+$events['OnFileManagerBeforeUpload']->fromArray([
     'name' => 'OnFileManagerBeforeUpload',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerUpload']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerUpload']->fromArray(array (
+$events['OnFileManagerUpload']->fromArray([
     'name' => 'OnFileManagerUpload',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileManagerMoveObject']= $xpdo->newObject(modEvent::class);
-$events['OnFileManagerMoveObject']->fromArray(array (
+$events['OnFileManagerMoveObject']->fromArray([
     'name' => 'OnFileManagerMoveObject',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileCreateFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnFileCreateFormPrerender']->fromArray(array (
+$events['OnFileCreateFormPrerender']->fromArray([
     'name' => 'OnFileCreateFormPrerender',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnFileEditFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnFileEditFormPrerender']->fromArray(array (
+$events['OnFileEditFormPrerender']->fromArray([
     'name' => 'OnFileEditFormPrerender',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnManagerPageInit']= $xpdo->newObject(modEvent::class);
-$events['OnManagerPageInit']->fromArray(array (
+$events['OnManagerPageInit']->fromArray([
     'name' => 'OnManagerPageInit',
     'service' => 2,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnManagerPageBeforeRender']= $xpdo->newObject(modEvent::class);
-$events['OnManagerPageBeforeRender']->fromArray(array (
+$events['OnManagerPageBeforeRender']->fromArray([
     'name' => 'OnManagerPageBeforeRender',
     'service' => 2,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnManagerPageAfterRender']= $xpdo->newObject(modEvent::class);
-$events['OnManagerPageAfterRender']->fromArray(array (
+$events['OnManagerPageAfterRender']->fromArray([
     'name' => 'OnManagerPageAfterRender',
     'service' => 2,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnWebPageInit']= $xpdo->newObject(modEvent::class);
-$events['OnWebPageInit']->fromArray(array (
+$events['OnWebPageInit']->fromArray([
     'name' => 'OnWebPageInit',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnLoadWebDocument']= $xpdo->newObject(modEvent::class);
-$events['OnLoadWebDocument']->fromArray(array (
+$events['OnLoadWebDocument']->fromArray([
     'name' => 'OnLoadWebDocument',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnParseDocument']= $xpdo->newObject(modEvent::class);
-$events['OnParseDocument']->fromArray(array (
+$events['OnParseDocument']->fromArray([
     'name' => 'OnParseDocument',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnWebPageComplete']= $xpdo->newObject(modEvent::class);
-$events['OnWebPageComplete']->fromArray(array (
+$events['OnWebPageComplete']->fromArray([
     'name' => 'OnWebPageComplete',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeManagerPageInit']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeManagerPageInit']->fromArray(array (
+$events['OnBeforeManagerPageInit']->fromArray([
     'name' => 'OnBeforeManagerPageInit',
     'service' => 2,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnPageNotFound']= $xpdo->newObject(modEvent::class);
-$events['OnPageNotFound']->fromArray(array (
+$events['OnPageNotFound']->fromArray([
     'name' => 'OnPageNotFound',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnHandleRequest']= $xpdo->newObject(modEvent::class);
-$events['OnHandleRequest']->fromArray(array (
+$events['OnHandleRequest']->fromArray([
     'name' => 'OnHandleRequest',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnMODXInit']= $xpdo->newObject(modEvent::class);
-$events['OnMODXInit']->fromArray(array (
+$events['OnMODXInit']->fromArray([
     'name' => 'OnMODXInit',
     'service' => 5,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 $events['OnElementNotFound']= $xpdo->newObject(modEvent::class);
-$events['OnElementNotFound']->fromArray(array (
+$events['OnElementNotFound']->fromArray([
     'name' => 'OnElementNotFound',
     'service' => 1,
     'groupname' => 'System',
-), '', true, true);
+], '', true, true);
 
 
 /* Settings */
 $events['OnSiteSettingsRender']= $xpdo->newObject(modEvent::class);
-$events['OnSiteSettingsRender']->fromArray(array (
+$events['OnSiteSettingsRender']->fromArray([
     'name' => 'OnSiteSettingsRender',
     'service' => 1,
     'groupname' => 'Settings',
-), '', true, true);
+], '', true, true);
 
 
 /* Internationalization */
 $events['OnInitCulture']= $xpdo->newObject(modEvent::class);
-$events['OnInitCulture']->fromArray(array (
+$events['OnInitCulture']->fromArray([
     'name' => 'OnInitCulture',
     'service' => 1,
     'groupname' => 'Internationalization',
-), '', true, true);
+], '', true, true);
 
 
 /* Categories */
 $events['OnCategorySave']= $xpdo->newObject(modEvent::class);
-$events['OnCategorySave']->fromArray(array (
+$events['OnCategorySave']->fromArray([
     'name' => 'OnCategorySave',
     'service' => 1,
     'groupname' => 'Categories',
-), '', true, true);
+], '', true, true);
 $events['OnCategoryBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnCategoryBeforeSave']->fromArray(array (
+$events['OnCategoryBeforeSave']->fromArray([
     'name' => 'OnCategoryBeforeSave',
     'service' => 1,
     'groupname' => 'Categories',
-), '', true, true);
+], '', true, true);
 $events['OnCategoryRemove']= $xpdo->newObject(modEvent::class);
-$events['OnCategoryRemove']->fromArray(array (
+$events['OnCategoryRemove']->fromArray([
     'name' => 'OnCategoryRemove',
     'service' => 1,
     'groupname' => 'Categories',
-), '', true, true);
+], '', true, true);
 $events['OnCategoryBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnCategoryBeforeRemove']->fromArray(array (
+$events['OnCategoryBeforeRemove']->fromArray([
     'name' => 'OnCategoryBeforeRemove',
     'service' => 1,
     'groupname' => 'Categories',
-), '', true, true);
+], '', true, true);
 
 
 /* Chunks */
 $events['OnChunkSave']= $xpdo->newObject(modEvent::class);
-$events['OnChunkSave']->fromArray(array (
+$events['OnChunkSave']->fromArray([
     'name' => 'OnChunkSave',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnChunkBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnChunkBeforeSave']->fromArray(array (
+$events['OnChunkBeforeSave']->fromArray([
     'name' => 'OnChunkBeforeSave',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnChunkRemove']= $xpdo->newObject(modEvent::class);
-$events['OnChunkRemove']->fromArray(array (
+$events['OnChunkRemove']->fromArray([
     'name' => 'OnChunkRemove',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnChunkBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnChunkBeforeRemove']->fromArray(array (
+$events['OnChunkBeforeRemove']->fromArray([
     'name' => 'OnChunkBeforeRemove',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnChunkFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnChunkFormPrerender']->fromArray(array (
+$events['OnChunkFormPrerender']->fromArray([
     'name' => 'OnChunkFormPrerender',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnChunkFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnChunkFormRender']->fromArray(array (
+$events['OnChunkFormRender']->fromArray([
     'name' => 'OnChunkFormRender',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeChunkFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeChunkFormSave']->fromArray(array (
+$events['OnBeforeChunkFormSave']->fromArray([
     'name' => 'OnBeforeChunkFormSave',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnChunkFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnChunkFormSave']->fromArray(array (
+$events['OnChunkFormSave']->fromArray([
     'name' => 'OnChunkFormSave',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnBeforeChunkFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnBeforeChunkFormDelete']->fromArray(array (
+$events['OnBeforeChunkFormDelete']->fromArray([
     'name' => 'OnBeforeChunkFormDelete',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 $events['OnChunkFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnChunkFormDelete']->fromArray(array (
+$events['OnChunkFormDelete']->fromArray([
     'name' => 'OnChunkFormDelete',
     'service' => 1,
     'groupname' => 'Chunks',
-), '', true, true);
+], '', true, true);
 
 
 /* Contexts */
 $events['OnContextSave']= $xpdo->newObject(modEvent::class);
-$events['OnContextSave']->fromArray(array (
+$events['OnContextSave']->fromArray([
     'name' => 'OnContextSave',
     'service' => 1,
     'groupname' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $events['OnContextBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnContextBeforeSave']->fromArray(array (
+$events['OnContextBeforeSave']->fromArray([
     'name' => 'OnContextBeforeSave',
     'service' => 1,
     'groupname' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $events['OnContextRemove']= $xpdo->newObject(modEvent::class);
-$events['OnContextRemove']->fromArray(array (
+$events['OnContextRemove']->fromArray([
     'name' => 'OnContextRemove',
     'service' => 1,
     'groupname' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $events['OnContextBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnContextBeforeRemove']->fromArray(array (
+$events['OnContextBeforeRemove']->fromArray([
     'name' => 'OnContextBeforeRemove',
     'service' => 1,
     'groupname' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $events['OnContextFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnContextFormPrerender']->fromArray(array (
+$events['OnContextFormPrerender']->fromArray([
     'name' => 'OnContextFormPrerender',
     'service' => 2,
     'groupname' => 'Contexts',
-), '', true, true);
+], '', true, true);
 $events['OnContextFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnContextFormRender']->fromArray(array (
+$events['OnContextFormRender']->fromArray([
     'name' => 'OnContextFormRender',
     'service' => 2,
     'groupname' => 'Contexts',
-), '', true, true);
+], '', true, true);
 
 
 /* Plugins */
 $events['OnPluginSave']= $xpdo->newObject(modEvent::class);
-$events['OnPluginSave']->fromArray(array (
+$events['OnPluginSave']->fromArray([
     'name' => 'OnPluginSave',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnPluginBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnPluginBeforeSave']->fromArray(array (
+$events['OnPluginBeforeSave']->fromArray([
     'name' => 'OnPluginBeforeSave',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnPluginRemove']= $xpdo->newObject(modEvent::class);
-$events['OnPluginRemove']->fromArray(array (
+$events['OnPluginRemove']->fromArray([
     'name' => 'OnPluginRemove',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnPluginBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnPluginBeforeRemove']->fromArray(array (
+$events['OnPluginBeforeRemove']->fromArray([
     'name' => 'OnPluginBeforeRemove',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnPluginFormPrerender']= $xpdo->newObject(modEvent::class);
-$events['OnPluginFormPrerender']->fromArray(array (
+$events['OnPluginFormPrerender']->fromArray([
     'name' => 'OnPluginFormPrerender',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnPluginFormRender']= $xpdo->newObject(modEvent::class);
-$events['OnPluginFormRender']->fromArray(array (
+$events['OnPluginFormRender']->fromArray([
     'name' => 'OnPluginFormRender',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnBeforePluginFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnBeforePluginFormSave']->fromArray(array (
+$events['OnBeforePluginFormSave']->fromArray([
     'name' => 'OnBeforePluginFormSave',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnPluginFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnPluginFormSave']->fromArray(array (
+$events['OnPluginFormSave']->fromArray([
     'name' => 'OnPluginFormSave',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnBeforePluginFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnBeforePluginFormDelete']->fromArray(array (
+$events['OnBeforePluginFormDelete']->fromArray([
     'name' => 'OnBeforePluginFormDelete',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 $events['OnPluginFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnPluginFormDelete']->fromArray(array (
+$events['OnPluginFormDelete']->fromArray([
     'name' => 'OnPluginFormDelete',
     'service' => 1,
     'groupname' => 'Plugins',
-), '', true, true);
+], '', true, true);
 
 
 /* Property Sets */
 $events['OnPropertySetSave']= $xpdo->newObject(modEvent::class);
-$events['OnPropertySetSave']->fromArray(array (
+$events['OnPropertySetSave']->fromArray([
     'name' => 'OnPropertySetSave',
     'service' => 1,
     'groupname' => 'Property Sets',
-), '', true, true);
+], '', true, true);
 $events['OnPropertySetBeforeSave']= $xpdo->newObject(modEvent::class);
-$events['OnPropertySetBeforeSave']->fromArray(array (
+$events['OnPropertySetBeforeSave']->fromArray([
     'name' => 'OnPropertySetBeforeSave',
     'service' => 1,
     'groupname' => 'Property Sets',
-), '', true, true);
+], '', true, true);
 $events['OnPropertySetRemove']= $xpdo->newObject(modEvent::class);
-$events['OnPropertySetRemove']->fromArray(array (
+$events['OnPropertySetRemove']->fromArray([
     'name' => 'OnPropertySetRemove',
     'service' => 1,
     'groupname' => 'Property Sets',
-), '', true, true);
+], '', true, true);
 $events['OnPropertySetBeforeRemove']= $xpdo->newObject(modEvent::class);
-$events['OnPropertySetBeforeRemove']->fromArray(array (
+$events['OnPropertySetBeforeRemove']->fromArray([
     'name' => 'OnPropertySetBeforeRemove',
     'service' => 1,
     'groupname' => 'Property Sets',
-), '', true, true);
+], '', true, true);
 
 
 /* Media Source */
 $events['OnMediaSourceBeforeFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnMediaSourceBeforeFormDelete']->fromArray(array (
+$events['OnMediaSourceBeforeFormDelete']->fromArray([
     'name' => 'OnMediaSourceBeforeFormDelete',
     'service' => 1,
     'groupname' => 'Media Sources',
-), '', true, true);
+], '', true, true);
 $events['OnMediaSourceBeforeFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnMediaSourceBeforeFormSave']->fromArray(array (
+$events['OnMediaSourceBeforeFormSave']->fromArray([
     'name' => 'OnMediaSourceBeforeFormSave',
     'service' => 1,
     'groupname' => 'Media Sources',
-), '', true, true);
+], '', true, true);
 $events['OnMediaSourceGetProperties']= $xpdo->newObject(modEvent::class);
-$events['OnMediaSourceGetProperties']->fromArray(array (
+$events['OnMediaSourceGetProperties']->fromArray([
     'name' => 'OnMediaSourceGetProperties',
     'service' => 1,
     'groupname' => 'Media Sources',
-), '', true, true);
+], '', true, true);
 $events['OnMediaSourceFormDelete']= $xpdo->newObject(modEvent::class);
-$events['OnMediaSourceFormDelete']->fromArray(array (
+$events['OnMediaSourceFormDelete']->fromArray([
     'name' => 'OnMediaSourceFormDelete',
     'service' => 1,
     'groupname' => 'Media Sources',
-), '', true, true);
+], '', true, true);
 $events['OnMediaSourceFormSave']= $xpdo->newObject(modEvent::class);
-$events['OnMediaSourceFormSave']->fromArray(array (
+$events['OnMediaSourceFormSave']->fromArray([
     'name' => 'OnMediaSourceFormSave',
     'service' => 1,
     'groupname' => 'Media Sources',
-), '', true, true);
+], '', true, true);
 $events['OnMediaSourceDuplicate']= $xpdo->newObject(modEvent::class);
-$events['OnMediaSourceDuplicate']->fromArray(array (
+$events['OnMediaSourceDuplicate']->fromArray([
     'name' => 'OnMediaSourceDuplicate',
     'service' => 1,
     'groupname' => 'Media Sources',
-), '', true, true);
+], '', true, true);
 
 /* Package Manager */
 $events['OnPackageInstall']= $xpdo->newObject(modEvent::class);
-$events['OnPackageInstall']->fromArray(array (
+$events['OnPackageInstall']->fromArray([
   'name' => 'OnPackageInstall',
   'service' => 2,
   'groupname' => 'Package Manager',
-), '', true, true);
+], '', true, true);
 $events['OnPackageUninstall']= $xpdo->newObject(modEvent::class);
-$events['OnPackageUninstall']->fromArray(array (
+$events['OnPackageUninstall']->fromArray([
   'name' => 'OnPackageUninstall',
   'service' => 2,
   'groupname' => 'Package Manager',
-), '', true, true);
+], '', true, true);
 $events['OnPackageRemove']= $xpdo->newObject(modEvent::class);
-$events['OnPackageRemove']->fromArray(array (
+$events['OnPackageRemove']->fromArray([
   'name' => 'OnPackageRemove',
   'service' => 2,
   'groupname' => 'Package Manager',
-), '', true, true);
+], '', true, true);
 
 return $events;

--- a/_build/data/transport.core.media_sources.php
+++ b/_build/data/transport.core.media_sources.php
@@ -7,10 +7,10 @@
 use MODX\Revolution\Sources\modMediaSource;
 
 $collection[1]= $xpdo->newObject(modMediaSource::class);
-$collection[1]->fromArray(array (
+$collection[1]->fromArray([
   'id' => 1,
   'name' => 'Filesystem',
   'description' => '',
   'class_key' => 'MODX\Revolution\Sources\modFileMediaSource',
-  'properties' => array(),
-), '', true, true);
+  'properties' => [],
+], '', true, true);

--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -10,56 +10,56 @@
 
 use MODX\Revolution\modMenu;
 
-$menus = array();
+$menus = [];
 
 $menus[0]= $xpdo->newObject(modMenu::class);
-$menus[0]->fromArray(array (
+$menus[0]->fromArray([
     'menuindex' => 0,
     'text' => 'topnav',
     'description' => 'topnav_desc',
     'parent' => '',
     'permissions' => '',
     'action' => '',
-), '', true, true);
+], '', true, true);
 
 $menus[1]= $xpdo->newObject(modMenu::class);
-$menus[1]->fromArray(array (
+$menus[1]->fromArray([
     'menuindex' => 0,
     'text' => 'usernav',
     'description' => 'usernav_desc',
     'parent' => '',
     'permissions' => '',
     'action' => '',
-), '', true, true);
+], '', true, true);
 
 
 /* ***************** CONTENT MENU ***************** */
 $topNavMenus[0]= $xpdo->newObject(modMenu::class);
-$topNavMenus[0]->fromArray(array (
+$topNavMenus[0]->fromArray([
   'menuindex' => 0,
   'text' => 'site',
   'description' => '',
   'parent' => 'topnav',
   'permissions' => 'menu_site',
   'action' => '',
-), '', true, true);
+], '', true, true);
 
-$children = array();
+$children = [];
 
 /* New Resource */
 $children[0]= $xpdo->newObject(modMenu::class);
-$children[0]->fromArray(array (
+$children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'new_resource',
   'description' => 'new_resource_desc',
   'parent' => 'site',
   'permissions' => 'new_document',
   'action' => 'resource/create',
-), '', true, true);
+], '', true, true);
 
 /* Preview */
 $children[4]= $xpdo->newObject(modMenu::class);
-$children[4]->fromArray(array (
+$children[4]->fromArray([
   'menuindex' => 4,
   'text' => 'preview',
   'description' => 'preview_desc',
@@ -67,51 +67,51 @@ $children[4]->fromArray(array (
   'permissions' => '',
   'action' => '',
   'handler' => 'MODx.preview(); return false;',
-), '', true, true);
+], '', true, true);
 
 /* Import HTML */
 $children[5]= $xpdo->newObject(modMenu::class);
-$children[5]->fromArray(array (
+$children[5]->fromArray([
   'menuindex' => 5,
   'text' => 'import_site',
   'description' => 'import_site_desc',
   'parent' => 'site',
   'permissions' => 'import_static',
   'action' => 'system/import/html',
-), '', true, true);
+], '', true, true);
 
 /* Import Static Resources */
 $children[6]= $xpdo->newObject(modMenu::class);
-$children[6]->fromArray(array (
+$children[6]->fromArray([
   'menuindex' => 6,
   'text' => 'import_resources',
   'description' => 'import_resources_desc',
   'parent' => 'site',
   'permissions' => 'import_static',
   'action' => 'system/import',
-), '', true, true);
+], '', true, true);
 
 /* Manage Resource Groups */
 $children[7]= $xpdo->newObject(modMenu::class);
-$children[7]->fromArray(array (
+$children[7]->fromArray([
   'menuindex' => 7,
   'text' => 'resource_groups',
   'description' => 'resource_groups_desc',
   'parent' => 'site',
   'permissions' => 'access_permissions',
   'action' => 'security/resourcegroup',
-), '', true, true);
+], '', true, true);
 
 /* Content Types */
 $children[8]= $xpdo->newObject(modMenu::class);
-$children[8]->fromArray(array (
+$children[8]->fromArray([
   'menuindex' => 8,
   'text' => 'content_types',
   'description' => 'content_types_desc',
   'parent' => 'site',
   'permissions' => 'content_types',
   'action' => 'system/contenttype',
-), '', true, true);
+], '', true, true);
 
 $topNavMenus[0]->addMany($children,'Children');
 unset($children);
@@ -119,36 +119,36 @@ unset($children);
 
 /* ***************** MEDIA MENU ***************** */
 $topNavMenus[1]= $xpdo->newObject(modMenu::class);
-$topNavMenus[1]->fromArray(array (
+$topNavMenus[1]->fromArray([
   'menuindex' => 1,
   'text' => 'media',
   'description' => 'media_desc',
   'parent' => 'topnav',
   'permissions' => 'file_manager',
   'action' => '',
-), '', true, true);
+], '', true, true);
 
 /* Media Browser */
 $children[0]= $xpdo->newObject(modMenu::class);
-$children[0]->fromArray(array (
+$children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'file_browser',
   'description' => 'file_browser_desc',
   'parent' => 'media',
   'permissions' => 'file_manager',
   'action' => 'media/browser',
-), '', true, true);
+], '', true, true);
 
 /* Media Drivers */
 $children[1]= $xpdo->newObject(modMenu::class);
-$children[1]->fromArray(array(
+$children[1]->fromArray([
   'menuindex'   => 1,
   'text'        => 'sources',
   'description' => 'sources_desc',
   'parent'      => 'media',
   'permissions' => 'sources',
   'action'      => 'source',
-), '', true, true);
+], '', true, true);
 
 $topNavMenus[1]->addMany($children,'Children');
 unset($children);
@@ -156,25 +156,25 @@ unset($children);
 
 /* ***************** APPS MENU ***************** */
 $topNavMenus[2]= $xpdo->newObject(modMenu::class);
-$topNavMenus[2]->fromArray(array (
+$topNavMenus[2]->fromArray([
   'menuindex' => 2,
   'text' => 'components',
   'description' => '',
   'parent' => 'topnav',
   'permissions' => 'components',
   'action' => '',
-), '', true, true);
+], '', true, true);
 
 /* Installer */
 $children[0]= $xpdo->newObject(modMenu::class);
-$children[0]->fromArray(array (
+$children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'installer',
   'description' => 'installer_desc',
   'parent' => 'components',
   'permissions' => 'packages',
   'action' => 'workspaces',
-), '', true, true);
+], '', true, true);
 
 $topNavMenus[2]->addMany($children,'Children');
 unset($children);
@@ -182,30 +182,30 @@ unset($children);
 
 /* ***************** ADMIN MENU ***************** */
 $topNavMenus[3]= $xpdo->newObject(modMenu::class);
-$topNavMenus[3]->fromArray(array (
+$topNavMenus[3]->fromArray([
   'menuindex' => 3,
   'text' => 'manage',
   'description' => '',
   'parent' => 'topnav',
   'permissions' => 'menu_tools',
   'action' => '',
-), '', true, true);
-$children = array();
+], '', true, true);
+$children = [];
 
 /* Manage Users */
 $children[0]= $xpdo->newObject(modMenu::class);
-$children[0]->fromArray(array (
+$children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'users',
   'description' => 'user_management_desc',
   'parent' => 'manage',
   'permissions' => 'view_user',
   'action' => 'security/user',
-), '', true, true);
+], '', true, true);
 
 /* Clear Cache */
 $children[1]= $xpdo->newObject(modMenu::class);
-$children[1]->fromArray(array (
+$children[1]->fromArray([
   'menuindex' => 1,
   'text' => 'refresh_site',
   'description' => 'refresh_site_desc',
@@ -213,11 +213,11 @@ $children[1]->fromArray(array (
   'permissions' => 'empty_cache',
   'action' => '',
   'handler' => 'MODx.clearCache(); return false;',
-), '', true, true);
+], '', true, true);
 
 /* Refresh URIs */
 $childrenOfClearCache[0]= $xpdo->newObject(modMenu::class);
-$childrenOfClearCache[0]->fromArray(array (
+$childrenOfClearCache[0]->fromArray([
   'menuindex' => 0,
   'text' => 'refreshuris',
   'description' => 'refreshuris_desc',
@@ -225,13 +225,13 @@ $childrenOfClearCache[0]->fromArray(array (
   'permissions' => 'empty_cache',
   'action' => '',
   'handler' => 'MODx.refreshURIs(); return false;',
-), '', true, true);
+], '', true, true);
 
 $children[1]->addMany($childrenOfClearCache, 'Children');
 
 /* Remove Locks */
 $children[2]= $xpdo->newObject(modMenu::class);
-$children[2]->fromArray(array (
+$children[2]->fromArray([
   'menuindex' => 2,
   'text' => 'remove_locks',
   'description' => 'remove_locks_desc',
@@ -239,11 +239,11 @@ $children[2]->fromArray(array (
   'permissions' => 'remove_locks',
   'action' => '',
   'handler' => 'MODx.removeLocks();return false;',
-), '', true, true);
+], '', true, true);
 
 /* Flush Permissions */
 $children[3]= $xpdo->newObject(modMenu::class);
-$children[3]->fromArray(array (
+$children[3]->fromArray([
   'menuindex' => 3,
   'text' => 'flush_access',
   'description' => 'flush_access_desc',
@@ -262,11 +262,11 @@ $children[3]->fromArray(array (
         \'failure\': {fn:function(response) { Ext.MessageBox.alert(\'failure\', response.responseText); },scope:this},
     }
 });',
-), '', true, true);
+], '', true, true);
 
 /* Flush Sessions */
 $children[4]= $xpdo->newObject(modMenu::class);
-$children[4]->fromArray(array (
+$children[4]->fromArray([
   'menuindex' => 4,
   'text' => 'flush_sessions',
   'description' => 'flush_sessions_desc',
@@ -284,62 +284,62 @@ $children[4]->fromArray(array (
         \'success\': {fn:function() { location.href = \'./\'; },scope:this}
     }
 });',
-), '', true, true);
+], '', true, true);
 
 /* Reports */
 $children[5]= $xpdo->newObject(modMenu::class);
-$children[5]->fromArray(array (
+$children[5]->fromArray([
   'menuindex' => 5,
   'text' => 'reports',
   'description' => 'reports_desc',
   'parent' => 'manage',
   'permissions' => 'menu_reports',
   'action' => '',
-), '', true, true);
+], '', true, true);
 
 /* site schedule */
 $childrenOfReports[0]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[0]->fromArray(array (
+$childrenOfReports[0]->fromArray([
         'menuindex' => 0,
         'text' => 'site_schedule',
         'description' => 'site_schedule_desc',
         'parent' => '',
         'permissions' => 'view_document',
         'action' => 'resource/site_schedule',
-    ), '', true, true);
+], '', true, true);
 
 /* manager actions */
 $childrenOfReports[1]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[1]->fromArray(array (
+$childrenOfReports[1]->fromArray([
     'menuindex' => 1,
     'text' => 'view_logging',
     'description' => 'view_logging_desc',
     'parent' => '',
     'permissions' => 'logs',
     'action' => 'system/logs',
-), '', true, true);
+], '', true, true);
 
 /* error log */
 $childrenOfReports[2]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[2]->fromArray(array (
+$childrenOfReports[2]->fromArray([
     'menuindex' => 2,
     'text' => 'eventlog_viewer',
     'description' => 'eventlog_viewer_desc',
     'parent' => '',
     'permissions' => 'view_eventlog',
     'action' => 'system/event',
-), '', true, true);
+], '', true, true);
 
 /* system info */
 $childrenOfReports[3]= $xpdo->newObject(modMenu::class);
-$childrenOfReports[3]->fromArray(array (
+$childrenOfReports[3]->fromArray([
     'menuindex' => 3,
     'text' => 'view_sysinfo',
     'description' => 'view_sysinfo_desc',
     'parent' => 'reports',
     'permissions' => 'view_sysinfo',
     'action' => 'system/info',
-), '', true, true);
+], '', true, true);
 
 $children[5]->addMany($childrenOfReports, 'Children');
 
@@ -350,7 +350,7 @@ unset($children, $childrenOfReports);
 
 /* ***************** USER MENU ***************** */
 $userNavMenus[0]= $xpdo->newObject(modMenu::class);
-$userNavMenus[0]->fromArray(array(
+$userNavMenus[0]->fromArray([
   'menuindex' => 5,
   'text' => 'user',
   'description' => '',
@@ -358,45 +358,45 @@ $userNavMenus[0]->fromArray(array(
   'permissions' => 'menu_user',
   'action' => '',
   'icon' => '<span id="user-avatar">{$userImage}</span> <span id="user-username">{$username}</span>',
-), '', true, true);
-$children = array();
+], '', true, true);
+$children = [];
 
 /* edit account */
 $children[0]= $xpdo->newObject(modMenu::class);
-$children[0]->fromArray(array (
+$children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'profile',
   'description' => 'profile_desc',
   'parent' => 'user',
   'permissions' => 'change_profile',
   'action' => 'security/profile',
-), '', true, true);
+], '', true, true);
 
 /* messages */
 $children[1]= $xpdo->newObject(modMenu::class);
-$children[1]->fromArray(array (
+$children[1]->fromArray([
   'menuindex' => 1,
   'text' => 'messages',
   'description' => 'messages_desc',
   'parent' => 'user',
   'permissions' => 'messages',
   'action' => 'security/message',
-), '', true, true);
+], '', true, true);
 
 /* language */
 $children[2]= $xpdo->newObject(modMenu::class);
-$children[2]->fromArray(array(
+$children[2]->fromArray([
     'menuindex' => 2,
     'text' => 'language',
     'description' => 'language_desc',
     'parent' => 'user',
     'permissions' => 'language',
     'action' => ''
-), '', true, true);
+], '', true, true);
 
 /* logout */
 $children[3]= $xpdo->newObject(modMenu::class);
-$children[3]->fromArray(array (
+$children[3]->fromArray([
   'menuindex' => 3,
   'text' => 'logout',
   'description' => 'logout_desc',
@@ -404,14 +404,14 @@ $children[3]->fromArray(array (
   'permissions' => 'logout',
   'action' => 'security/logout',
   'handler' => 'MODx.logout(); return false;',
-), '', true, true);
+], '', true, true);
 
 $userNavMenus[0]->addMany($children,'Children');
 unset($children);
 
 /* ***************** ADMIN/SETTINGS MENU ***************** */
 $userNavMenus[1]= $xpdo->newObject(modMenu::class);
-$userNavMenus[1]->fromArray(array(
+$userNavMenus[1]->fromArray([
   'menuindex' => 6,
   'text' => 'admin',
   'description' => '',
@@ -419,114 +419,114 @@ $userNavMenus[1]->fromArray(array(
   'permissions' => 'settings',
   'action' => '',
   'icon' => '<i class="icon-gear icon icon-large"></i>',
-), '', true, true);
-$children = array();
+], '', true, true);
+$children = [];
 
 /* system settings */
 $children[0]= $xpdo->newObject(modMenu::class);
-$children[0]->fromArray(array (
+$children[0]->fromArray([
   'menuindex' => 0,
   'text' => 'system_settings',
   'description' => 'system_settings_desc',
   'parent' => 'admin',
   'permissions' => 'settings',
   'action' => 'system/settings',
-), '', true, true);
+], '', true, true);
 
 /* customize manager */
 $children[1]= $xpdo->newObject(modMenu::class);
-$children[1]->fromArray(array (
+$children[1]->fromArray([
   'menuindex' => 1,
   'text' => 'form_customization',
   'description' => 'form_customization_desc',
   'parent' => 'admin',
   'permissions' => 'customize_forms',
   'action' => 'security/forms',
-), '', true, true);
+], '', true, true);
 
 /* Dashboards */
 $children[2]= $xpdo->newObject(modMenu::class);
-$children[2]->fromArray(array (
+$children[2]->fromArray([
   'menuindex' => 2,
   'text' => 'dashboards',
   'description' => 'dashboards_desc',
   'parent' => 'admin',
   'permissions' => 'dashboards',
   'action' => 'system/dashboards',
-), '', true, true);
+], '', true, true);
 
 /* Contexts */
 $children[3]= $xpdo->newObject(modMenu::class);
-$children[3]->fromArray(array (
+$children[3]->fromArray([
   'menuindex' => 3,
   'text' => 'contexts',
   'description' => 'contexts_desc',
   'parent' => 'admin',
   'permissions' => 'view_context',
   'action' => 'context',
-), '', true, true);
+], '', true, true);
 
 /* Manager Menus */
 $children[4]= $xpdo->newObject(modMenu::class);
-$children[4]->fromArray(array (
+$children[4]->fromArray([
   'menuindex' => 4,
   'text' => 'edit_menu',
   'description' => 'edit_menu_desc',
   'parent' => 'admin',
   'permissions' => 'actions',
   'action' => 'system/action',
-), '', true, true);
+], '', true, true);
 
 /* ACLs */
 $children[5]= $xpdo->newObject(modMenu::class);
-$children[5]->fromArray(array (
+$children[5]->fromArray([
   'menuindex' => 5,
   'text' => 'acls',
   'description' => 'acls_desc',
   'parent' => 'admin',
   'permissions' => 'access_permissions',
   'action' => 'security/permission',
-), '', true, true);
+], '', true, true);
 
 /* Property Sets */
 $children[6]= $xpdo->newObject(modMenu::class);
-$children[6]->fromArray(array (
+$children[6]->fromArray([
   'menuindex' => 6,
   'text' => 'propertysets',
   'description' => 'propertysets_desc',
   'parent' => 'admin',
   'permissions' => 'property_sets',
   'action' => 'element/propertyset',
-), '', true, true);
+], '', true, true);
 
 /* Lexicons */
 $children[7]= $xpdo->newObject(modMenu::class);
-$children[7]->fromArray(array (
+$children[7]->fromArray([
   'menuindex' => 7,
   'text' => 'lexicon_management',
   'description' => 'lexicon_management_desc',
   'parent' => 'admin',
   'permissions' => 'lexicons',
   'action' => 'workspaces/lexicon',
-), '', true, true);
+], '', true, true);
 
 /* Namespaces */
 $children[8]= $xpdo->newObject(modMenu::class);
-$children[8]->fromArray(array (
+$children[8]->fromArray([
   'menuindex' => 8,
   'text' => 'namespaces',
   'description' => 'namespaces_desc',
   'parent' => 'admin',
   'permissions' => 'namespaces',
   'action' => 'workspaces/namespace',
-), '', true, true);
+], '', true, true);
 
 $userNavMenus[1]->addMany($children,'Children');
 unset($children);
 
 /* ***************** ADMIN/ABOUT MENU ***************** */
 $userNavMenus[2]= $xpdo->newObject(modMenu::class);
-$userNavMenus[2]->fromArray(array(
+$userNavMenus[2]->fromArray([
   'menuindex' => 8,
   'text' => 'about',
   'description' => '',
@@ -534,7 +534,7 @@ $userNavMenus[2]->fromArray(array(
   'permissions' => 'help',
   'action' => 'help',
   'icon' => '<i class="icon-question-circle icon icon-large"></i>',
-), '', true, true);
+], '', true, true);
 
 /* add topnav and usernav menu children */
 $menus[0]->addMany($topNavMenus, 'Children');

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -9,2078 +9,2078 @@
 use MODX\Revolution\modSessionHandler;
 use MODX\Revolution\modSystemSetting;
 
-$settings = array();
+$settings = [];
 $settings['access_category_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['access_category_enabled']->fromArray(array (
+$settings['access_category_enabled']->fromArray([
   'key' => 'access_category_enabled',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['access_context_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['access_context_enabled']->fromArray(array (
+$settings['access_context_enabled']->fromArray([
   'key' => 'access_context_enabled',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['access_resource_group_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['access_resource_group_enabled']->fromArray(array (
+$settings['access_resource_group_enabled']->fromArray([
   'key' => 'access_resource_group_enabled',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['allow_forward_across_contexts']= $xpdo->newObject(modSystemSetting::class);
-$settings['allow_forward_across_contexts']->fromArray(array (
+$settings['allow_forward_across_contexts']->fromArray([
   'key' => 'allow_forward_across_contexts',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['allow_manager_login_forgot_password']= $xpdo->newObject(modSystemSetting::class);
-$settings['allow_manager_login_forgot_password']->fromArray(array (
+$settings['allow_manager_login_forgot_password']->fromArray([
   'key' => 'allow_manager_login_forgot_password',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['allow_multiple_emails']= $xpdo->newObject(modSystemSetting::class);
-$settings['allow_multiple_emails']->fromArray(array (
+$settings['allow_multiple_emails']->fromArray([
   'key' => 'allow_multiple_emails',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['allow_tags_in_post']= $xpdo->newObject(modSystemSetting::class);
-$settings['allow_tags_in_post']->fromArray(array (
+$settings['allow_tags_in_post']->fromArray([
   'key' => 'allow_tags_in_post',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['archive_with']= $xpdo->newObject(modSystemSetting::class);
-$settings['archive_with']->fromArray(array (
+$settings['archive_with']->fromArray([
   'key' => 'archive_with',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['auto_menuindex']= $xpdo->newObject(modSystemSetting::class);
-$settings['auto_menuindex']->fromArray(array (
+$settings['auto_menuindex']->fromArray([
   'key' => 'auto_menuindex',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['auto_check_pkg_updates']= $xpdo->newObject(modSystemSetting::class);
-$settings['auto_check_pkg_updates']->fromArray(array (
+$settings['auto_check_pkg_updates']->fromArray([
   'key' => 'auto_check_pkg_updates',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['auto_check_pkg_updates_cache_expire']= $xpdo->newObject(modSystemSetting::class);
-$settings['auto_check_pkg_updates_cache_expire']->fromArray(array (
+$settings['auto_check_pkg_updates_cache_expire']->fromArray([
   'key' => 'auto_check_pkg_updates_cache_expire',
   'value' => 15,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['automatic_alias']= $xpdo->newObject(modSystemSetting::class);
-$settings['automatic_alias']->fromArray(array (
+$settings['automatic_alias']->fromArray([
   'key' => 'automatic_alias',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['automatic_template_assignment']= $xpdo->newObject(modSystemSetting::class);
-$settings['automatic_template_assignment']->fromArray(array (
+$settings['automatic_template_assignment']->fromArray([
     'key' => 'automatic_template_assignment',
     'value' => 'sibling',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'site',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['base_help_url']= $xpdo->newObject(modSystemSetting::class);
-$settings['base_help_url']->fromArray(array (
+$settings['base_help_url']->fromArray([
   'key' => 'base_help_url',
   'value' => '//docs.modx.com/display/revolution20/',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['blocked_minutes']= $xpdo->newObject(modSystemSetting::class);
-$settings['blocked_minutes']->fromArray(array (
+$settings['blocked_minutes']->fromArray([
   'key' => 'blocked_minutes',
   'value' => 60,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_action_map']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_action_map']->fromArray(array (
+$settings['cache_action_map']->fromArray([
   'key' => 'cache_action_map',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_alias_map']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_alias_map']->fromArray(array (
+$settings['cache_alias_map']->fromArray([
     'key' => 'cache_alias_map',
     'value' => true,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'caching',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['use_context_resource_table']= $xpdo->newObject(modSystemSetting::class);
-$settings['use_context_resource_table']->fromArray(array (
+$settings['use_context_resource_table']->fromArray([
     'key' => 'use_context_resource_table',
     'value' => true,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'caching',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_context_settings']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_context_settings']->fromArray(array (
+$settings['cache_context_settings']->fromArray([
   'key' => 'cache_context_settings',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_db']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_db']->fromArray(array (
+$settings['cache_db']->fromArray([
   'key' => 'cache_db',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_db_expires']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_db_expires']->fromArray(array (
+$settings['cache_db_expires']->fromArray([
   'key' => 'cache_db_expires',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_db_session']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_db_session']->fromArray(array (
+$settings['cache_db_session']->fromArray([
   'key' => 'cache_db_session',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_db_session_lifetime']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_db_session_lifetime']->fromArray(array (
+$settings['cache_db_session_lifetime']->fromArray([
   'key' => 'cache_db_session_lifetime',
   'value' => '',
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_default']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_default']->fromArray(array (
+$settings['cache_default']->fromArray([
   'key' => 'cache_default',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_expires']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_expires']->fromArray(array (
+$settings['cache_expires']->fromArray([
   'key' => 'cache_expires',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_format']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_format']->fromArray(array (
+$settings['cache_format']->fromArray([
   'key' => 'cache_format',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_handler']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_handler']->fromArray(array (
+$settings['cache_handler']->fromArray([
   'key' => 'cache_handler',
   'value' => 'xPDO\Cache\xPDOFileCache',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_lang_js']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_lang_js']->fromArray(array (
+$settings['cache_lang_js']->fromArray([
   'key' => 'cache_lang_js',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_lexicon_topics']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_lexicon_topics']->fromArray(array (
+$settings['cache_lexicon_topics']->fromArray([
   'key' => 'cache_lexicon_topics',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_noncore_lexicon_topics']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_noncore_lexicon_topics']->fromArray(array (
+$settings['cache_noncore_lexicon_topics']->fromArray([
   'key' => 'cache_noncore_lexicon_topics',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_resource']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_resource']->fromArray(array (
+$settings['cache_resource']->fromArray([
   'key' => 'cache_resource',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_resource_expires']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_resource_expires']->fromArray(array (
+$settings['cache_resource_expires']->fromArray([
   'key' => 'cache_resource_expires',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_resource_clear_partial']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_resource_clear_partial']->fromArray(array (
+$settings['cache_resource_clear_partial']->fromArray([
     'key' => 'cache_resource_clear_partial',
     'value' => false,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'caching',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cache_scripts']= $xpdo->newObject(modSystemSetting::class);
-$settings['cache_scripts']->fromArray(array (
+$settings['cache_scripts']->fromArray([
   'key' => 'cache_scripts',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['clear_cache_refresh_trees']= $xpdo->newObject(modSystemSetting::class);
-$settings['clear_cache_refresh_trees']->fromArray(array (
+$settings['clear_cache_refresh_trees']->fromArray([
   'key' => 'clear_cache_refresh_trees',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'caching',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['compress_css']= $xpdo->newObject(modSystemSetting::class);
-$settings['compress_css']->fromArray(array (
+$settings['compress_css']->fromArray([
   'key' => 'compress_css',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['compress_js']= $xpdo->newObject(modSystemSetting::class);
-$settings['compress_js']->fromArray(array (
+$settings['compress_js']->fromArray([
   'key' => 'compress_js',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['confirm_navigation']= $xpdo->newObject(modSystemSetting::class);
-$settings['confirm_navigation']->fromArray(array (
+$settings['confirm_navigation']->fromArray([
   'key' => 'confirm_navigation',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['container_suffix']= $xpdo->newObject(modSystemSetting::class);
-$settings['container_suffix']->fromArray(array (
+$settings['container_suffix']->fromArray([
   'key' => 'container_suffix',
   'value' => '/',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['context_tree_sort']= $xpdo->newObject(modSystemSetting::class);
-$settings['context_tree_sort']->fromArray(array (
+$settings['context_tree_sort']->fromArray([
   'key' => 'context_tree_sort',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['context_tree_sortby']= $xpdo->newObject(modSystemSetting::class);
-$settings['context_tree_sortby']->fromArray(array (
+$settings['context_tree_sortby']->fromArray([
   'key' => 'context_tree_sortby',
   'value' => 'rank',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['context_tree_sortdir']= $xpdo->newObject(modSystemSetting::class);
-$settings['context_tree_sortdir']->fromArray(array (
+$settings['context_tree_sortdir']->fromArray([
   'key' => 'context_tree_sortdir',
   'value' => 'ASC',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['cultureKey']= $xpdo->newObject(modSystemSetting::class);
-$settings['cultureKey']->fromArray(array (
+$settings['cultureKey']->fromArray([
   'key' => 'cultureKey',
   'value' => 'en',
   'xtype' => 'modx-combo-language',
   'namespace' => 'core',
   'area' => 'language',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['date_timezone']= $xpdo->newObject(modSystemSetting::class);
-$settings['date_timezone']->fromArray(array (
+$settings['date_timezone']->fromArray([
   'key' => 'date_timezone',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['debug']= $xpdo->newObject(modSystemSetting::class);
-$settings['debug']->fromArray(array (
+$settings['debug']->fromArray([
   'key' => 'debug',
   'value' => '',
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_duplicate_publish_option']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_duplicate_publish_option']->fromArray(array (
+$settings['default_duplicate_publish_option']->fromArray([
   'key' => 'default_duplicate_publish_option',
   'value' => 'preserve',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_media_source']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_media_source']->fromArray(array (
+$settings['default_media_source']->fromArray([
   'key' => 'default_media_source',
   'value' => 1,
   'xtype' => 'modx-combo-source',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_media_source_type']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_media_source_type']->fromArray(array (
+$settings['default_media_source_type']->fromArray([
     'key' => 'default_media_source_type',
     'value' => MODX\Revolution\Sources\modFileMediaSource::class,
     'xtype' => 'modx-combo-source-type',
     'namespace' => 'core',
     'area' => 'manager',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_per_page']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_per_page']->fromArray(array (
+$settings['default_per_page']->fromArray([
   'key' => 'default_per_page',
   'value' => '20',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_context']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_context']->fromArray(array (
+$settings['default_context']->fromArray([
   'key' => 'default_context',
   'value' => 'web',
   'xtype' => 'modx-combo-context',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_template']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_template']->fromArray(array (
+$settings['default_template']->fromArray([
   'key' => 'default_template',
   'value' => 1,
   'xtype' => 'modx-combo-template',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_content_type']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_content_type']->fromArray(array (
+$settings['default_content_type']->fromArray([
   'key' => 'default_content_type',
   'value' => 1,
   'xtype' => 'modx-combo-content-type',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['emailsender']= $xpdo->newObject(modSystemSetting::class);
-$settings['emailsender']->fromArray(array (
+$settings['emailsender']->fromArray([
   'key' => 'emailsender',
   'value' => 'email@example.com',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['enable_dragdrop']= $xpdo->newObject(modSystemSetting::class);
-$settings['enable_dragdrop']->fromArray(array (
+$settings['enable_dragdrop']->fromArray([
   'key' => 'enable_dragdrop',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['error_page']= $xpdo->newObject(modSystemSetting::class);
-$settings['error_page']->fromArray(array (
+$settings['error_page']->fromArray([
   'key' => 'error_page',
   'value' => 1,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['failed_login_attempts']= $xpdo->newObject(modSystemSetting::class);
-$settings['failed_login_attempts']->fromArray(array (
+$settings['failed_login_attempts']->fromArray([
   'key' => 'failed_login_attempts',
   'value' => 5,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['feed_modx_news']= $xpdo->newObject(modSystemSetting::class);
-$settings['feed_modx_news']->fromArray(array (
+$settings['feed_modx_news']->fromArray([
   'key' => 'feed_modx_news',
   'value' => 'https://feeds.feedburner.com/modx-announce',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['feed_modx_news_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['feed_modx_news_enabled']->fromArray(array (
+$settings['feed_modx_news_enabled']->fromArray([
   'key' => 'feed_modx_news_enabled',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['feed_modx_security']= $xpdo->newObject(modSystemSetting::class);
-$settings['feed_modx_security']->fromArray(array (
+$settings['feed_modx_security']->fromArray([
   'key' => 'feed_modx_security',
   'value' => 'https://forums.modx.com/board.xml?board=294',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['feed_modx_security_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['feed_modx_security_enabled']->fromArray(array (
+$settings['feed_modx_security_enabled']->fromArray([
   'key' => 'feed_modx_security_enabled',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['filemanager_path']= $xpdo->newObject(modSystemSetting::class);
-$settings['filemanager_path']->fromArray(array (
+$settings['filemanager_path']->fromArray([
   'key' => 'filemanager_path',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['filemanager_path_relative']= $xpdo->newObject(modSystemSetting::class);
-$settings['filemanager_path_relative']->fromArray(array (
+$settings['filemanager_path_relative']->fromArray([
   'key' => 'filemanager_path_relative',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['filemanager_url']= $xpdo->newObject(modSystemSetting::class);
-$settings['filemanager_url']->fromArray(array (
+$settings['filemanager_url']->fromArray([
   'key' => 'filemanager_url',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['filemanager_url_relative']= $xpdo->newObject(modSystemSetting::class);
-$settings['filemanager_url_relative']->fromArray(array (
+$settings['filemanager_url_relative']->fromArray([
   'key' => 'filemanager_url_relative',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['form_customization_use_all_groups']= $xpdo->newObject(modSystemSetting::class);
-$settings['form_customization_use_all_groups']->fromArray(array (
+$settings['form_customization_use_all_groups']->fromArray([
   'key' => 'form_customization_use_all_groups',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['forward_merge_excludes']= $xpdo->newObject(modSystemSetting::class);
-$settings['forward_merge_excludes']->fromArray(array (
+$settings['forward_merge_excludes']->fromArray([
   'key' => 'forward_merge_excludes',
   'value' => 'type,published,class_key',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_lowercase_only']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_lowercase_only']->fromArray(array (
+$settings['friendly_alias_lowercase_only']->fromArray([
   'key' => 'friendly_alias_lowercase_only',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_max_length']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_max_length']->fromArray(array (
+$settings['friendly_alias_max_length']->fromArray([
   'key' => 'friendly_alias_max_length',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_realtime']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_realtime']->fromArray(array (
+$settings['friendly_alias_realtime']->fromArray([
   'key' => 'friendly_alias_realtime',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_restrict_chars']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_restrict_chars']->fromArray(array (
+$settings['friendly_alias_restrict_chars']->fromArray([
   'key' => 'friendly_alias_restrict_chars',
   'value' => 'pattern',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_restrict_chars_pattern']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_restrict_chars_pattern']->fromArray(array (
+$settings['friendly_alias_restrict_chars_pattern']->fromArray([
   'key' => 'friendly_alias_restrict_chars_pattern',
   'value' => '/[\0\x0B\t\n\r\f\a&=+%#<>"~:`@\?\[\]\{\}\|\^\'\\\\]/',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_strip_element_tags']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_strip_element_tags']->fromArray(array (
+$settings['friendly_alias_strip_element_tags']->fromArray([
   'key' => 'friendly_alias_strip_element_tags',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_translit']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_translit']->fromArray(array (
+$settings['friendly_alias_translit']->fromArray([
   'key' => 'friendly_alias_translit',
   'value' => 'none',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_translit_class']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_translit_class']->fromArray(array (
+$settings['friendly_alias_translit_class']->fromArray([
   'key' => 'friendly_alias_translit_class',
   'value' => 'translit.modTransliterate',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_translit_class_path']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_translit_class_path']->fromArray(array (
+$settings['friendly_alias_translit_class_path']->fromArray([
   'key' => 'friendly_alias_translit_class_path',
   'value' => '{core_path}components/',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_trim_chars']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_trim_chars']->fromArray(array (
+$settings['friendly_alias_trim_chars']->fromArray([
   'key' => 'friendly_alias_trim_chars',
   'value' => '/.-_',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_word_delimiter']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_word_delimiter']->fromArray(array (
+$settings['friendly_alias_word_delimiter']->fromArray([
   'key' => 'friendly_alias_word_delimiter',
   'value' => '-',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_alias_word_delimiters']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_alias_word_delimiters']->fromArray(array (
+$settings['friendly_alias_word_delimiters']->fromArray([
   'key' => 'friendly_alias_word_delimiters',
   'value' => '-_',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_urls']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_urls']->fromArray(array (
+$settings['friendly_urls']->fromArray([
   'key' => 'friendly_urls',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['friendly_urls_strict']= $xpdo->newObject(modSystemSetting::class);
-$settings['friendly_urls_strict']->fromArray(array (
+$settings['friendly_urls_strict']->fromArray([
   'key' => 'friendly_urls_strict',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['use_frozen_parent_uris']= $xpdo->newObject(modSystemSetting::class);
-$settings['use_frozen_parent_uris']->fromArray(array (
+$settings['use_frozen_parent_uris']->fromArray([
   'key' => 'use_frozen_parent_uris',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['global_duplicate_uri_check']= $xpdo->newObject(modSystemSetting::class);
-$settings['global_duplicate_uri_check']->fromArray(array (
+$settings['global_duplicate_uri_check']->fromArray([
   'key' => 'global_duplicate_uri_check',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['hidemenu_default']= $xpdo->newObject(modSystemSetting::class);
-$settings['hidemenu_default']->fromArray(array (
+$settings['hidemenu_default']->fromArray([
   'key' => 'hidemenu_default',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['inline_help']= $xpdo->newObject(modSystemSetting::class);
-$settings['inline_help']->fromArray(array (
+$settings['inline_help']->fromArray([
   'key' => 'inline_help',
   'value' => 1,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['locale']= $xpdo->newObject(modSystemSetting::class);
-$settings['locale']->fromArray(array (
+$settings['locale']->fromArray([
   'key' => 'locale',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'language',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['log_level']= $xpdo->newObject(modSystemSetting::class);
-$settings['log_level']->fromArray(array (
+$settings['log_level']->fromArray([
   'key' => 'log_level',
   'value' => 1,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['log_target']= $xpdo->newObject(modSystemSetting::class);
-$settings['log_target']->fromArray(array (
+$settings['log_target']->fromArray([
   'key' => 'log_target',
   'value' => 'FILE',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['log_deprecated']= $xpdo->newObject(modSystemSetting::class);
-$settings['log_deprecated']->fromArray(array (
+$settings['log_deprecated']->fromArray([
   'key' => 'log_deprecated',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['link_tag_scheme']= $xpdo->newObject(modSystemSetting::class);
-$settings['link_tag_scheme']->fromArray(array (
+$settings['link_tag_scheme']->fromArray([
   'key' => 'link_tag_scheme',
   'value' => -1,
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['lock_ttl']= $xpdo->newObject(modSystemSetting::class);
-$settings['lock_ttl']->fromArray(array (
+$settings['lock_ttl']->fromArray([
   'key' => 'lock_ttl',
   'value' => 360,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_charset']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_charset']->fromArray(array (
+$settings['mail_charset']->fromArray([
   'key' => 'mail_charset',
   'value' => 'UTF-8',
   'xtype' => 'modx-combo-charset',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_encoding']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_encoding']->fromArray(array (
+$settings['mail_encoding']->fromArray([
   'key' => 'mail_encoding',
   'value' => '8bit',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_use_smtp']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_use_smtp']->fromArray(array (
+$settings['mail_use_smtp']->fromArray([
   'key' => 'mail_use_smtp',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_auth']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_auth']->fromArray(array (
+$settings['mail_smtp_auth']->fromArray([
   'key' => 'mail_smtp_auth',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_helo']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_helo']->fromArray(array (
+$settings['mail_smtp_helo']->fromArray([
   'key' => 'mail_smtp_helo',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_hosts']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_hosts']->fromArray(array (
+$settings['mail_smtp_hosts']->fromArray([
   'key' => 'mail_smtp_hosts',
   'value' => 'localhost',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_keepalive']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_keepalive']->fromArray(array (
+$settings['mail_smtp_keepalive']->fromArray([
   'key' => 'mail_smtp_keepalive',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_pass']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_pass']->fromArray(array (
+$settings['mail_smtp_pass']->fromArray([
   'key' => 'mail_smtp_pass',
   'value' => '',
   'xtype' => 'text-password',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_port']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_port']->fromArray(array (
+$settings['mail_smtp_port']->fromArray([
   'key' => 'mail_smtp_port',
   'value' => 587,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_prefix']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_prefix']->fromArray(array (
+$settings['mail_smtp_prefix']->fromArray([
   'key' => 'mail_smtp_prefix',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_single_to']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_single_to']->fromArray(array (
+$settings['mail_smtp_single_to']->fromArray([
   'key' => 'mail_smtp_single_to',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_timeout']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_timeout']->fromArray(array (
+$settings['mail_smtp_timeout']->fromArray([
   'key' => 'mail_smtp_timeout',
   'value' => 10,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mail_smtp_user']= $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_user']->fromArray(array (
+$settings['mail_smtp_user']->fromArray([
   'key' => 'mail_smtp_user',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'mail',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_date_format']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_date_format']->fromArray(array (
+$settings['manager_date_format']->fromArray([
   'key' => 'manager_date_format',
   'value' => 'Y-m-d',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_favicon_url']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_favicon_url']->fromArray(array (
+$settings['manager_favicon_url']->fromArray([
   'key' => 'manager_favicon_url',
   'value' => 'favicon.ico',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_time_format']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_time_format']->fromArray(array (
+$settings['manager_time_format']->fromArray([
   'key' => 'manager_time_format',
   'value' => 'H:i',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_direction']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_direction']->fromArray(array (
+$settings['manager_direction']->fromArray([
   'key' => 'manager_direction',
   'value' => 'ltr',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'language',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_login_url_alternate']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_login_url_alternate']->fromArray(array (
+$settings['manager_login_url_alternate']->fromArray([
   'key' => 'manager_login_url_alternate',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_tooltip_enable']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_tooltip_enable']->fromArray(array (
+$settings['manager_tooltip_enable']->fromArray([
   'namespace' => 'core',
   'key' => 'manager_tooltip_enable',
   'value' => true,
   'xtype' => 'combo-boolean',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_tooltip_delay']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_tooltip_delay']->fromArray(array (
+$settings['manager_tooltip_delay']->fromArray([
   'key' => 'manager_tooltip_delay',
   'value' => 2300,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['login_background_image']= $xpdo->newObject(modSystemSetting::class);
-$settings['login_background_image']->fromArray(array (
+$settings['login_background_image']->fromArray([
   'key' => 'login_background_image',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['login_logo']= $xpdo->newObject(modSystemSetting::class);
-$settings['login_logo']->fromArray(array (
+$settings['login_logo']->fromArray([
   'key' => 'login_logo',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['login_help_button']= $xpdo->newObject(modSystemSetting::class);
-$settings['login_help_button']->fromArray(array (
+$settings['login_help_button']->fromArray([
   'key' => 'login_help_button',
   'value' => '',
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_theme']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_theme']->fromArray(array (
+$settings['manager_theme']->fromArray([
   'key' => 'manager_theme',
   'value' => 'default',
   'xtype' => 'modx-combo-manager-theme',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_logo']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_logo']->fromArray(array (
+$settings['manager_logo']->fromArray([
     'key' => 'manager_logo',
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'manager',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_week_start']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_week_start']->fromArray(array (
+$settings['manager_week_start']->fromArray([
   'key' => 'manager_week_start',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['modx_browser_tree_hide_files']= $xpdo->newObject(modSystemSetting::class);
-$settings['modx_browser_tree_hide_files']->fromArray(array (
+$settings['modx_browser_tree_hide_files']->fromArray([
   'key' => 'modx_browser_tree_hide_files',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['modx_browser_tree_hide_tooltips']= $xpdo->newObject(modSystemSetting::class);
-$settings['modx_browser_tree_hide_tooltips']->fromArray(array (
+$settings['modx_browser_tree_hide_tooltips']->fromArray([
   'key' => 'modx_browser_tree_hide_tooltips',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['modx_browser_default_sort']= $xpdo->newObject(modSystemSetting::class);
-$settings['modx_browser_default_sort']->fromArray(array (
+$settings['modx_browser_default_sort']->fromArray([
   'key' => 'modx_browser_default_sort',
   'value' => 'name',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['modx_browser_default_viewmode']= $xpdo->newObject(modSystemSetting::class);
-$settings['modx_browser_default_viewmode']->fromArray(array (
+$settings['modx_browser_default_viewmode']->fromArray([
   'key' => 'modx_browser_default_viewmode',
   'value' => 'grid',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['modx_charset']= $xpdo->newObject(modSystemSetting::class);
-$settings['modx_charset']->fromArray(array (
+$settings['modx_charset']->fromArray([
   'key' => 'modx_charset',
   'value' => 'UTF-8',
   'xtype' => 'modx-combo-charset',
   'namespace' => 'core',
   'area' => 'language',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['principal_targets']= $xpdo->newObject(modSystemSetting::class);
-$settings['principal_targets']->fromArray(array (
+$settings['principal_targets']->fromArray([
   'key' => 'principal_targets',
   'value' => 'modAccessContext,modAccessResourceGroup,modAccessCategory,sources.modAccessMediaSource,modAccessNamespace',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['proxy_auth_type']= $xpdo->newObject(modSystemSetting::class);
-$settings['proxy_auth_type']->fromArray(array (
+$settings['proxy_auth_type']->fromArray([
   'key' => 'proxy_auth_type',
   'value' => 'BASIC',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'proxy',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['proxy_host']= $xpdo->newObject(modSystemSetting::class);
-$settings['proxy_host']->fromArray(array (
+$settings['proxy_host']->fromArray([
   'key' => 'proxy_host',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'proxy',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['proxy_password']= $xpdo->newObject(modSystemSetting::class);
-$settings['proxy_password']->fromArray(array (
+$settings['proxy_password']->fromArray([
   'key' => 'proxy_password',
   'value' => '',
   'xtype' => 'text-password',
   'namespace' => 'core',
   'area' => 'proxy',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['proxy_port']= $xpdo->newObject(modSystemSetting::class);
-$settings['proxy_port']->fromArray(array (
+$settings['proxy_port']->fromArray([
   'key' => 'proxy_port',
   'value' => '',
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'proxy',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['proxy_username']= $xpdo->newObject(modSystemSetting::class);
-$settings['proxy_username']->fromArray(array (
+$settings['proxy_username']->fromArray([
   'key' => 'proxy_username',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'proxy',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['password_generated_length']= $xpdo->newObject(modSystemSetting::class);
-$settings['password_generated_length']->fromArray(array (
+$settings['password_generated_length']->fromArray([
   'key' => 'password_generated_length',
   'value' => 10,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['password_min_length']= $xpdo->newObject(modSystemSetting::class);
-$settings['password_min_length']->fromArray(array (
+$settings['password_min_length']->fromArray([
   'key' => 'password_min_length',
   'value' => 8,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'authentication',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 
 $settings['phpthumb_allow_src_above_docroot']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_allow_src_above_docroot']->fromArray(array (
+$settings['phpthumb_allow_src_above_docroot']->fromArray([
   'key' => 'phpthumb_allow_src_above_docroot',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_cache_maxage']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_cache_maxage']->fromArray(array (
+$settings['phpthumb_cache_maxage']->fromArray([
   'key' => 'phpthumb_cache_maxage',
   'value' => 30, // 30 days
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_cache_maxsize']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_cache_maxsize']->fromArray(array (
+$settings['phpthumb_cache_maxsize']->fromArray([
   'key' => 'phpthumb_cache_maxsize',
   'value' => 100, // 100MB
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_cache_maxfiles']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_cache_maxfiles']->fromArray(array (
+$settings['phpthumb_cache_maxfiles']->fromArray([
   'key' => 'phpthumb_cache_maxfiles',
   'value' => 10000, // 10k files
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_cache_source_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_cache_source_enabled']->fromArray(array (
+$settings['phpthumb_cache_source_enabled']->fromArray([
   'key' => 'phpthumb_cache_source_enabled',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_document_root']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_document_root']->fromArray(array (
+$settings['phpthumb_document_root']->fromArray([
   'key' => 'phpthumb_document_root',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_error_bgcolor']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_error_bgcolor']->fromArray(array (
+$settings['phpthumb_error_bgcolor']->fromArray([
   'key' => 'phpthumb_error_bgcolor',
   'value' => 'CCCCFF',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_error_textcolor']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_error_textcolor']->fromArray(array (
+$settings['phpthumb_error_textcolor']->fromArray([
   'key' => 'phpthumb_error_textcolor',
   'value' => 'FF0000',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_error_fontsize']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_error_fontsize']->fromArray(array (
+$settings['phpthumb_error_fontsize']->fromArray([
   'key' => 'phpthumb_error_fontsize',
   'value' => 1,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_far']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_far']->fromArray(array (
+$settings['phpthumb_far']->fromArray([
   'key' => 'phpthumb_far',
   'value' => 'C',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_imagemagick_path']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_imagemagick_path']->fromArray(array (
+$settings['phpthumb_imagemagick_path']->fromArray([
   'key' => 'phpthumb_imagemagick_path',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nohotlink_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nohotlink_enabled']->fromArray(array (
+$settings['phpthumb_nohotlink_enabled']->fromArray([
   'key' => 'phpthumb_nohotlink_enabled',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nohotlink_erase_image']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nohotlink_erase_image']->fromArray(array (
+$settings['phpthumb_nohotlink_erase_image']->fromArray([
   'key' => 'phpthumb_nohotlink_erase_image',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nohotlink_valid_domains']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nohotlink_valid_domains']->fromArray(array (
+$settings['phpthumb_nohotlink_valid_domains']->fromArray([
   'key' => 'phpthumb_nohotlink_valid_domains',
   'value' => '{http_host}',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nohotlink_text_message']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nohotlink_text_message']->fromArray(array (
+$settings['phpthumb_nohotlink_text_message']->fromArray([
   'key' => 'phpthumb_nohotlink_text_message',
   'value' => 'Off-server thumbnailing is not allowed',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nooffsitelink_enabled']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nooffsitelink_enabled']->fromArray(array (
+$settings['phpthumb_nooffsitelink_enabled']->fromArray([
   'key' => 'phpthumb_nooffsitelink_enabled',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nooffsitelink_erase_image']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nooffsitelink_erase_image']->fromArray(array (
+$settings['phpthumb_nooffsitelink_erase_image']->fromArray([
   'key' => 'phpthumb_nooffsitelink_erase_image',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nooffsitelink_require_refer']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nooffsitelink_require_refer']->fromArray(array (
+$settings['phpthumb_nooffsitelink_require_refer']->fromArray([
   'key' => 'phpthumb_nooffsitelink_require_refer',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nooffsitelink_text_message']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nooffsitelink_text_message']->fromArray(array (
+$settings['phpthumb_nooffsitelink_text_message']->fromArray([
   'key' => 'phpthumb_nooffsitelink_text_message',
   'value' => 'Off-server linking is not allowed',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nooffsitelink_valid_domains']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nooffsitelink_valid_domains']->fromArray(array (
+$settings['phpthumb_nooffsitelink_valid_domains']->fromArray([
   'key' => 'phpthumb_nooffsitelink_valid_domains',
   'value' => '{http_host}',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_nooffsitelink_watermark_src']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_nooffsitelink_watermark_src']->fromArray(array (
+$settings['phpthumb_nooffsitelink_watermark_src']->fromArray([
   'key' => 'phpthumb_nooffsitelink_watermark_src',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['phpthumb_zoomcrop']= $xpdo->newObject(modSystemSetting::class);
-$settings['phpthumb_zoomcrop']->fromArray(array (
+$settings['phpthumb_zoomcrop']->fromArray([
   'key' => 'phpthumb_zoomcrop',
   'value' => '0',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'phpthumb',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 
 $settings['publish_default']= $xpdo->newObject(modSystemSetting::class);
-$settings['publish_default']->fromArray(array (
+$settings['publish_default']->fromArray([
   'key' => 'publish_default',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['rb_base_dir']= $xpdo->newObject(modSystemSetting::class);
-$settings['rb_base_dir']->fromArray(array (
+$settings['rb_base_dir']->fromArray([
   'key' => 'rb_base_dir',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['rb_base_url']= $xpdo->newObject(modSystemSetting::class);
-$settings['rb_base_url']->fromArray(array (
+$settings['rb_base_url']->fromArray([
   'key' => 'rb_base_url',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['request_controller']= $xpdo->newObject(modSystemSetting::class);
-$settings['request_controller']->fromArray(array (
+$settings['request_controller']->fromArray([
   'key' => 'request_controller',
   'value' => 'index.php',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'gateway',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['request_method_strict']= $xpdo->newObject(modSystemSetting::class);
-$settings['request_method_strict']->fromArray(array (
+$settings['request_method_strict']->fromArray([
   'key' => 'request_method_strict',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'gateway',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['request_param_alias']= $xpdo->newObject(modSystemSetting::class);
-$settings['request_param_alias']->fromArray(array (
+$settings['request_param_alias']->fromArray([
   'key' => 'request_param_alias',
   'value' => 'q',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'gateway',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['request_param_id']= $xpdo->newObject(modSystemSetting::class);
-$settings['request_param_id']->fromArray(array (
+$settings['request_param_id']->fromArray([
   'key' => 'request_param_id',
   'value' => 'id',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'gateway',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['resource_tree_node_name']= $xpdo->newObject(modSystemSetting::class);
-$settings['resource_tree_node_name']->fromArray(array (
+$settings['resource_tree_node_name']->fromArray([
   'key' => 'resource_tree_node_name',
   'value' => 'pagetitle',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['resource_tree_node_name_fallback']= $xpdo->newObject(modSystemSetting::class);
-$settings['resource_tree_node_name_fallback']->fromArray(array (
+$settings['resource_tree_node_name_fallback']->fromArray([
   'key' => 'resource_tree_node_name_fallback',
   'value' => 'alias',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['resource_tree_node_tooltip']= $xpdo->newObject(modSystemSetting::class);
-$settings['resource_tree_node_tooltip']->fromArray(array (
+$settings['resource_tree_node_tooltip']->fromArray([
   'key' => 'resource_tree_node_tooltip',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['richtext_default']= $xpdo->newObject(modSystemSetting::class);
-$settings['richtext_default']->fromArray(array (
+$settings['richtext_default']->fromArray([
   'key' => 'richtext_default',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['search_default']= $xpdo->newObject(modSystemSetting::class);
-$settings['search_default']->fromArray(array (
+$settings['search_default']->fromArray([
   'key' => 'search_default',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['server_offset_time']= $xpdo->newObject(modSystemSetting::class);
-$settings['server_offset_time']->fromArray(array (
+$settings['server_offset_time']->fromArray([
   'key' => 'server_offset_time',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_cookie_domain']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_cookie_domain']->fromArray(array (
+$settings['session_cookie_domain']->fromArray([
   'key' => 'session_cookie_domain',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['default_username']= $xpdo->newObject(modSystemSetting::class);
-$settings['default_username']->fromArray(array (
+$settings['default_username']->fromArray([
   'key' => 'default_username',
   'value' => '(anonymous)',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['anonymous_sessions']= $xpdo->newObject(modSystemSetting::class);
-$settings['anonymous_sessions']->fromArray(array (
+$settings['anonymous_sessions']->fromArray([
   'key' => 'anonymous_sessions',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_cookie_lifetime']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_cookie_lifetime']->fromArray(array (
+$settings['session_cookie_lifetime']->fromArray([
   'key' => 'session_cookie_lifetime',
   'value' => 604800,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_cookie_path']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_cookie_path']->fromArray(array (
+$settings['session_cookie_path']->fromArray([
   'key' => 'session_cookie_path',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_cookie_secure']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_cookie_secure']->fromArray(array (
+$settings['session_cookie_secure']->fromArray([
   'key' => 'session_cookie_secure',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_cookie_httponly']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_cookie_httponly']->fromArray(array (
+$settings['session_cookie_httponly']->fromArray([
   'key' => 'session_cookie_httponly',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_gc_maxlifetime']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_gc_maxlifetime']->fromArray(array (
+$settings['session_gc_maxlifetime']->fromArray([
   'key' => 'session_gc_maxlifetime',
   'value' => '604800',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_handler_class']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_handler_class']->fromArray(array (
+$settings['session_handler_class']->fromArray([
   'key' => 'session_handler_class',
   'value' => modSessionHandler::class,
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['session_name']= $xpdo->newObject(modSystemSetting::class);
-$settings['session_name']->fromArray(array (
+$settings['session_name']->fromArray([
   'key' => 'session_name',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'session',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['set_header']= $xpdo->newObject(modSystemSetting::class);
-$settings['set_header']->fromArray(array (
+$settings['set_header']->fromArray([
   'key' => 'set_header',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'system',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['send_poweredby_header']= $xpdo->newObject(modSystemSetting::class);
-$settings['send_poweredby_header']->fromArray(array (
+$settings['send_poweredby_header']->fromArray([
     'key' => 'send_poweredby_header',
     'value' => false,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'system',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['show_tv_categories_header']= $xpdo->newObject(modSystemSetting::class);
-$settings['show_tv_categories_header']->fromArray(array (
+$settings['show_tv_categories_header']->fromArray([
   'key' => 'show_tv_categories_header',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['site_name']= $xpdo->newObject(modSystemSetting::class);
-$settings['site_name']->fromArray(array (
+$settings['site_name']->fromArray([
   'key' => 'site_name',
   'value' => 'MODX Revolution',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['site_start']= $xpdo->newObject(modSystemSetting::class);
-$settings['site_start']->fromArray(array (
+$settings['site_start']->fromArray([
   'key' => 'site_start',
   'value' => 1,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['site_status']= $xpdo->newObject(modSystemSetting::class);
-$settings['site_status']->fromArray(array (
+$settings['site_status']->fromArray([
   'key' => 'site_status',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['site_unavailable_message']= $xpdo->newObject(modSystemSetting::class);
-$settings['site_unavailable_message']->fromArray(array (
+$settings['site_unavailable_message']->fromArray([
   'key' => 'site_unavailable_message',
   'value' => 'The site is currently unavailable',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['site_unavailable_page']= $xpdo->newObject(modSystemSetting::class);
-$settings['site_unavailable_page']->fromArray(array (
+$settings['site_unavailable_page']->fromArray([
   'key' => 'site_unavailable_page',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_automate_templates']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_automate_templates']->fromArray(array (
+$settings['static_elements_automate_templates']->fromArray([
   'key' => 'static_elements_automate_templates',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_automate_tvs']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_automate_tvs']->fromArray(array (
+$settings['static_elements_automate_tvs']->fromArray([
   'key' => 'static_elements_automate_tvs',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_automate_chunks']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_automate_chunks']->fromArray(array (
+$settings['static_elements_automate_chunks']->fromArray([
   'key' => 'static_elements_automate_chunks',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_automate_snippets']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_automate_snippets']->fromArray(array (
+$settings['static_elements_automate_snippets']->fromArray([
   'key' => 'static_elements_automate_snippets',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_automate_plugins']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_automate_plugins']->fromArray(array (
+$settings['static_elements_automate_plugins']->fromArray([
   'key' => 'static_elements_automate_plugins',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_default_mediasource']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_default_mediasource']->fromArray(array (
+$settings['static_elements_default_mediasource']->fromArray([
   'key' => 'static_elements_default_mediasource',
   'value' => 0,
   'xtype' => 'modx-combo-source',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_default_category']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_default_category']->fromArray(array (
+$settings['static_elements_default_category']->fromArray([
   'key' => 'static_elements_default_category',
   'value' => 0,
   'xtype' => 'modx-combo-category',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['static_elements_basepath']= $xpdo->newObject(modSystemSetting::class);
-$settings['static_elements_basepath']->fromArray(array (
+$settings['static_elements_basepath']->fromArray([
   'key' => 'static_elements_basepath',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'static_elements',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['strip_image_paths']= $xpdo->newObject(modSystemSetting::class);
-$settings['strip_image_paths']->fromArray(array (
+$settings['strip_image_paths']->fromArray([
   'key' => 'strip_image_paths',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['symlink_merge_fields']= $xpdo->newObject(modSystemSetting::class);
-$settings['symlink_merge_fields']->fromArray(array (
+$settings['symlink_merge_fields']->fromArray([
   'key' => 'symlink_merge_fields',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['syncsite_default']= $xpdo->newObject(modSystemSetting::class);
-$settings['syncsite_default']->fromArray(array (
+$settings['syncsite_default']->fromArray([
     'key' => 'syncsite_default',
     'value' => true,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'caching',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['topmenu_show_descriptions']= $xpdo->newObject(modSystemSetting::class);
-$settings['topmenu_show_descriptions']->fromArray(array (
+$settings['topmenu_show_descriptions']->fromArray([
   'key' => 'topmenu_show_descriptions',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['tree_default_sort']= $xpdo->newObject(modSystemSetting::class);
-$settings['tree_default_sort']->fromArray(array (
+$settings['tree_default_sort']->fromArray([
   'key' => 'tree_default_sort',
   'value' => 'menuindex',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['tree_root_id']= $xpdo->newObject(modSystemSetting::class);
-$settings['tree_root_id']->fromArray(array (
+$settings['tree_root_id']->fromArray([
   'key' => 'tree_root_id',
   'value' => 0,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['tvs_below_content']= $xpdo->newObject(modSystemSetting::class);
-$settings['tvs_below_content']->fromArray(array (
+$settings['tvs_below_content']->fromArray([
   'key' => 'tvs_below_content',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['unauthorized_page']= $xpdo->newObject(modSystemSetting::class);
-$settings['unauthorized_page']->fromArray(array (
+$settings['unauthorized_page']->fromArray([
   'key' => 'unauthorized_page',
   'value' => 1,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['upload_files']= $xpdo->newObject(modSystemSetting::class);
-$settings['upload_files']->fromArray(array (
+$settings['upload_files']->fromArray([
   'key' => 'upload_files',
   'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot,scss,less,css.map,webp',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['upload_images']= $xpdo->newObject(modSystemSetting::class);
-$settings['upload_images']->fromArray(array (
+$settings['upload_images']->fromArray([
   'key' => 'upload_images',
   'value' => 'jpg,jpeg,png,gif,psd,ico,bmp,tiff,svg,svgz,webp',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['upload_maxsize']= $xpdo->newObject(modSystemSetting::class);
-$settings['upload_maxsize']->fromArray(array (
+$settings['upload_maxsize']->fromArray([
   'key' => 'upload_maxsize',
   'value' => 1048576,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['upload_media']= $xpdo->newObject(modSystemSetting::class);
-$settings['upload_media']->fromArray(array (
+$settings['upload_media']->fromArray([
   'key' => 'upload_media',
   'value' => 'mp3,wav,au,wmv,avi,mpg,mpeg',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['use_alias_path']= $xpdo->newObject(modSystemSetting::class);
-$settings['use_alias_path']->fromArray(array (
+$settings['use_alias_path']->fromArray([
   'key' => 'use_alias_path',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['use_browser']= $xpdo->newObject(modSystemSetting::class);
-$settings['use_browser']->fromArray(array (
+$settings['use_browser']->fromArray([
   'key' => 'use_browser',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'file',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['use_editor']= $xpdo->newObject(modSystemSetting::class);
-$settings['use_editor']->fromArray(array (
+$settings['use_editor']->fromArray([
   'key' => 'use_editor',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'editor',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['use_multibyte']= $xpdo->newObject(modSystemSetting::class);
-$settings['use_multibyte']->fromArray(array (
+$settings['use_multibyte']->fromArray([
   'key' => 'use_multibyte',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'language',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['use_weblink_target']= $xpdo->newObject(modSystemSetting::class);
-$settings['use_weblink_target']->fromArray(array (
+$settings['use_weblink_target']->fromArray([
   'key' => 'use_weblink_target',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['welcome_screen']= $xpdo->newObject(modSystemSetting::class);
-$settings['welcome_screen']->fromArray(array (
+$settings['welcome_screen']->fromArray([
   'key' => 'welcome_screen',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['welcome_screen_url']= $xpdo->newObject(modSystemSetting::class);
-$settings['welcome_screen_url']->fromArray(array (
+$settings['welcome_screen_url']->fromArray([
   'key' => 'welcome_screen_url',
   'value' => '//misc.modx.com/revolution/welcome.27.html ',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['welcome_action']= $xpdo->newObject(modSystemSetting::class);
-$settings['welcome_action']->fromArray(array (
+$settings['welcome_action']->fromArray([
   'key' => 'welcome_action',
   'value' => 'welcome',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['welcome_namespace']= $xpdo->newObject(modSystemSetting::class);
-$settings['welcome_namespace']->fromArray(array (
+$settings['welcome_namespace']->fromArray([
   'key' => 'welcome_namespace',
   'value' => 'core',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['which_editor']= $xpdo->newObject(modSystemSetting::class);
-$settings['which_editor']->fromArray(array (
+$settings['which_editor']->fromArray([
   'key' => 'which_editor',
   'value' => '',
   'xtype' => 'modx-combo-rte',
   'namespace' => 'core',
   'area' => 'editor',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['which_element_editor']= $xpdo->newObject(modSystemSetting::class);
-$settings['which_element_editor']->fromArray(array (
+$settings['which_element_editor']->fromArray([
   'key' => 'which_element_editor',
   'value' => '',
   'xtype' => 'modx-combo-rte',
   'namespace' => 'core',
   'area' => 'editor',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['xhtml_urls']= $xpdo->newObject(modSystemSetting::class);
-$settings['xhtml_urls']->fromArray(array (
+$settings['xhtml_urls']->fromArray([
   'key' => 'xhtml_urls',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['enable_gravatar']= $xpdo->newObject(modSystemSetting::class);
-$settings['enable_gravatar']->fromArray(array (
+$settings['enable_gravatar']->fromArray([
   'key' => 'enable_gravatar',
   'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mgr_tree_icon_context']= $xpdo->newObject(modSystemSetting::class);
-$settings['mgr_tree_icon_context']->fromArray(array (
+$settings['mgr_tree_icon_context']->fromArray([
   'key' => 'mgr_tree_icon_context',
   'value' => 'tree-context',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['mgr_source_icon']= $xpdo->newObject(modSystemSetting::class);
-$settings['mgr_source_icon']->fromArray(array (
+$settings['mgr_source_icon']->fromArray([
   'key' => 'mgr_source_icon',
   'value' => 'icon-folder-open-o',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['main_nav_parent']= $xpdo->newObject(modSystemSetting::class);
-$settings['main_nav_parent']->fromArray(array (
+$settings['main_nav_parent']->fromArray([
   'key' => 'main_nav_parent',
   'value' => 'topnav',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['user_nav_parent']= $xpdo->newObject(modSystemSetting::class);
-$settings['user_nav_parent']->fromArray(array (
+$settings['user_nav_parent']->fromArray([
   'key' => 'user_nav_parent',
   'value' => 'usernav',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['auto_isfolder']= $xpdo->newObject(modSystemSetting::class);
-$settings['auto_isfolder']->fromArray(array (
+$settings['auto_isfolder']->fromArray([
     'key' => 'auto_isfolder',
     'value' => true,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'site',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['manager_use_fullname']= $xpdo->newObject(modSystemSetting::class);
-$settings['manager_use_fullname']->fromArray(array (
+$settings['manager_use_fullname']->fromArray([
     'key' => 'manager_use_fullname',
     'value' => false,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'manager',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['parser_recurse_uncacheable']= $xpdo->newObject(modSystemSetting::class);
-$settings['parser_recurse_uncacheable']->fromArray(array (
+$settings['parser_recurse_uncacheable']->fromArray([
     'key' => 'parser_recurse_uncacheable',
     'value' => true,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'system',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['preserve_menuindex']= $xpdo->newObject(modSystemSetting::class);
-$settings['preserve_menuindex']->fromArray(array (
+$settings['preserve_menuindex']->fromArray([
     'key' => 'preserve_menuindex',
     'value' => false,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'manager',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['log_snippet_not_found']= $xpdo->newObject(modSystemSetting::class);
-$settings['log_snippet_not_found']->fromArray(array (
+$settings['log_snippet_not_found']->fromArray([
     'key' => 'log_snippet_not_found',
     'value' => true,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'site',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['error_log_filename']= $xpdo->newObject(modSystemSetting::class);
-$settings['error_log_filename']->fromArray(array (
+$settings['error_log_filename']->fromArray([
     'key' => 'error_log_filename',
     'value' => 'error.log',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'system',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['error_log_filepath']= $xpdo->newObject(modSystemSetting::class);
-$settings['error_log_filepath']->fromArray(array (
+$settings['error_log_filepath']->fromArray([
     'key' => 'error_log_filepath',
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'system',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['passwordless_activated']= $xpdo->newObject(modSystemSetting::class);
-$settings['passwordless_activated']->fromArray(array (
+$settings['passwordless_activated']->fromArray([
     'key' => 'passwordless_activated',
     'value' => true,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'authentication',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['passwordless_expiration']= $xpdo->newObject(modSystemSetting::class);
-$settings['passwordless_expiration']->fromArray(array (
+$settings['passwordless_expiration']->fromArray([
     'key' => 'passwordless_expiration',
     'value' => '3600',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'authentication',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['passwordless_activated']= $xpdo->newObject(modSystemSetting::class);
-$settings['passwordless_activated']->fromArray(array (
+$settings['passwordless_activated']->fromArray([
     'key' => 'passwordless_activated',
     'value' => false,
     'xtype' => 'combo-boolean',
     'namespace' => 'core',
     'area' => 'authentication',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['passwordless_expiration']= $xpdo->newObject(modSystemSetting::class);
-$settings['passwordless_expiration']->fromArray(array (
+$settings['passwordless_expiration']->fromArray([
     'key' => 'passwordless_expiration',
     'value' => '3600',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'authentication',
     'editedon' => null,
-), '', true, true);
+], '', true, true);
 
 return $settings;

--- a/_build/data/transport.core.usergrouproles.php
+++ b/_build/data/transport.core.usergrouproles.php
@@ -2,16 +2,16 @@
 use MODX\Revolution\modUserGroupRole;
 
 $collection['1']= $xpdo->newObject(modUserGroupRole::class);
-$collection['1']->fromArray(array (
+$collection['1']->fromArray([
   'id' => 1,
   'name' => 'Member',
   'description' => 'NULL',
   'authority' => 9999,
-), '', true, true);
+], '', true, true);
 $collection['2']= $xpdo->newObject(modUserGroupRole::class);
-$collection['2']->fromArray(array (
+$collection['2']->fromArray([
   'id' => 2,
   'name' => 'Super User',
   'description' => 'NULL',
   'authority' => 0,
-), '', true, true);
+], '', true, true);

--- a/_build/data/transport.core.usergroups.php
+++ b/_build/data/transport.core.usergroups.php
@@ -1,8 +1,8 @@
 <?php
 use MODX\Revolution\modUserGroup;
 $collection['1']= $xpdo->newObject(modUserGroup::class);
-$collection['1']->fromArray(array (
+$collection['1']->fromArray([
   'id' => 1,
   'name' => 'Administrator',
   'parent' => 0,
-), '', true, true);
+], '', true, true);

--- a/_build/resolvers/resolve.actionfields.php
+++ b/_build/resolvers/resolve.actionfields.php
@@ -30,14 +30,14 @@ foreach ($xml->action as $action) {
     foreach ($action->tab as $tab) {
         $tabName = (string)$tab['name'];
         if ($tabName != 'modx-resource-content') {
-            $tabObj = $modx->getObject(modActionField::class,array(
+            $tabObj = $modx->getObject(modActionField::class, [
                 'action' => (string)$action['controller'],
                 'name' => $tabName,
                 'type' => 'tab',
-            ));
+            ]);
             if (!$tabObj) {
                 $tabObj = $modx->newObject(modActionField::class);
-                $tabObj->fromArray(array(
+                $tabObj->fromArray([
                     'action' => (string)$action['controller'],
                     'name' => $tabName,
                     'type' => 'tab',
@@ -45,21 +45,21 @@ foreach ($xml->action as $action) {
                     'form' => (string)$action['form'],
                     'other' => !empty($tab['other']) ? (string)$tab['other'] : '',
                     'rank' => $tabIdx,
-                ));
+                ]);
                 $success = $tabObj->save();
             }
         }
 
         $fieldIdx = 0;
         foreach ($tab->field as $field) {
-            $fieldObj = $modx->getObject(modActionField::class,array(
+            $fieldObj = $modx->getObject(modActionField::class, [
                 'action' => (string)$action['controller'],
                 'name' => (string)$field['name'],
                 'type' => 'field',
-            ));
+            ]);
             if (!$fieldObj) {
                 $fieldObj = $modx->newObject(modActionField::class);
-                $fieldObj->fromArray(array(
+                $fieldObj->fromArray([
                     'action' => (string)$action['controller'],
                     'name' => (string)$field['name'],
                     'type' => 'field',
@@ -67,7 +67,7 @@ foreach ($xml->action as $action) {
                     'form' => (string)$action['form'],
                     'other' => !empty($tab['other']) ? (string)$tab['other'] : '',
                     'rank' => $fieldIdx,
-                ));
+                ]);
                 $success = $fieldObj->save();
             }
             $fieldIdx++;

--- a/_build/resolvers/resolve.policies.php
+++ b/_build/resolvers/resolve.policies.php
@@ -12,7 +12,7 @@ use xPDO\xPDO;
 $success= false;
 
 /* map of Policy -> Template */
-$map = array(
+$map = [
     'Resource' => 'ResourceTemplate',
     'Administrator' => 'AdministratorTemplate',
     'Content Editor' => 'AdministratorTemplate',
@@ -24,12 +24,12 @@ $map = array(
     'Media Source Admin' => 'MediaSourceTemplate',
     'Media Source User' => 'MediaSourceTemplate',
     'Hidden Namespace' => 'NamespaceTemplate',
-);
+];
 
 $policies = $transport->xpdo->getCollection(modAccessPolicy::class);
 foreach ($policies as $policy) {
     if (isset($map[$policy->get('name')])) {
-        $template = $transport->xpdo->getObject(modAccessPolicyTemplate::class,array('name' => $map[$policy->get('name')]));
+        $template = $transport->xpdo->getObject(modAccessPolicyTemplate::class, ['name' => $map[$policy->get('name')]]);
         if ($template) {
             $policy->set('template',$template->get('id'));
             $success = $policy->save();

--- a/_build/resolvers/resolve.policytemplates.php
+++ b/_build/resolvers/resolve.policytemplates.php
@@ -14,7 +14,7 @@ use xPDO\xPDO;
 $success= false;
 
 /* map of Template -> TemplateGroup */
-$map = array(
+$map = [
     'ResourceTemplate' => 'Resource',
     'AdministratorTemplate' => 'Admin',
     'ObjectTemplate' => 'Object',
@@ -22,12 +22,13 @@ $map = array(
     'ElementTemplate' => 'Element',
     'MediaSourceTemplate' => 'MediaSource',
     'NamespaceTemplate' => 'Namespace',
-);
+];
 
 $templates = $transport->xpdo->getCollection(modAccessPolicyTemplate::class);
 foreach ($templates as $template) {
     if (isset($map[$template->get('name')])) {
-        $templateGroup = $transport->xpdo->getObject(modAccessPolicyTemplateGroup::class,array('name' => $map[$template->get('name')]));
+        $templateGroup = $transport->xpdo->getObject(modAccessPolicyTemplateGroup::class,
+            ['name' => $map[$template->get('name')]]);
         if ($templateGroup) {
             $template->set('template_group',$templateGroup->get('id'));
             $success = $template->save();

--- a/_build/test/MODxControllerTestCase.php
+++ b/_build/test/MODxControllerTestCase.php
@@ -38,9 +38,9 @@ abstract class MODxControllerTestCase extends MODxTestCase {
 
         /* load smarty template engine */
         $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
-        $this->modx->getService('smarty', modSmarty::class, '', array(
+        $this->modx->getService('smarty', modSmarty::class, '', [
             'template_dir' => $templatePath,
-        ));
+        ]);
         $this->modx->smarty->setCachePath('mgr/smarty/default/');
         $this->modx->smarty->assign('_config',$this->modx->config);
         $this->modx->smarty->assignByRef('modx',$this->modx);
@@ -49,12 +49,12 @@ abstract class MODxControllerTestCase extends MODxTestCase {
         $className = $this->controllerName;
 
         if (!empty($className)) {
-            $this->controller = new $className($this->modx,array(
+            $this->controller = new $className($this->modx, [
                 'namespace' => 'core',
                 'namespace_name' => 'core',
                 'namespace_path' => MODX_MANAGER_PATH,
                 'controller' => $this->controllerPath,
-            ));
+            ]);
             $this->controller->setProperties($_REQUEST);
         }
     }

--- a/_build/test/MODxTestCase.php
+++ b/_build/test/MODxTestCase.php
@@ -72,6 +72,6 @@ abstract class MODxTestCase extends TestCase {
     public function getResults(&$result) {
         $response = ltrim(rtrim($result->response,')'),'(');
         $response = json_decode($response, true);
-        return !empty($response['results']) ? $response['results'] : array();
+        return !empty($response['results']) ? $response['results'] : [];
     }
 }

--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -26,9 +26,9 @@ use xPDO\xPDOException;
  */
 class MODxTestHarness {
     /** @var array $fixtures */
-    protected static $fixtures = array();
+    protected static $fixtures = [];
     /** @var array $properties */
-    protected static $properties = array();
+    protected static $properties = [];
     /** @var boolean $debug */
     protected static $debug = false;
 
@@ -45,11 +45,11 @@ class MODxTestHarness {
      * @return object|null An instance of the specified fixture class or null on failure.
      * @throws xPDOException
      */
-    public static function &getFixture($class, $name, $new = false, array $options = array()) {
+    public static function &getFixture($class, $name, $new = false, array $options = []) {
         if (!$new && array_key_exists($name, self::$fixtures) && self::$fixtures[$name] instanceof $class) {
             $fixture =& self::$fixtures[$name];
         } else {
-            $properties = array();
+            $properties = [];
             include_once dirname(dirname(__DIR__)) . '/core/model/modx/modx.class.php';
             include dirname(__FILE__) . '/properties.inc.php';
             self::$properties = $properties;

--- a/_build/test/Tests/Cases/Modx/ReplaceReservedTest.php
+++ b/_build/test/Tests/Cases/Modx/ReplaceReservedTest.php
@@ -41,29 +41,29 @@ class ReplaceReservedTest extends TestCase
         );
 
         $this->assertEquals(
-            array($replacing => $replacing),
-            modX::replaceReserved(array(
+            [$replacing => $replacing],
+            modX::replaceReserved([
                 $source => $source
-            ))
+            ])
         );
 
         $this->assertEquals(
-            array(
-                $replacing => array(
+            [
+                $replacing => [
                     $replacing => $replacing
-                )
-            ),
-            modX::replaceReserved(array(
-                $source => array(
+                ]
+            ],
+            modX::replaceReserved([
+                $source => [
                     $source => $source
-                )
-            ))
+                ]
+            ])
         );
     }
 
     public function testChangingProperty()
     {
-        $property = array('[' => '', ']' => '&#93;');
+        $property = ['[' => '', ']' => '&#93;'];
 
         $this->assertEquals(
             'clear string',
@@ -79,27 +79,27 @@ class ReplaceReservedTest extends TestCase
         );
 
         $this->assertEquals(
-            array($replacing => $replacing),
+            [$replacing => $replacing],
             modX::replaceReserved(
-                array(
+                [
                     $source => $source
-                ),
+                ],
                 $property
             )
         );
 
         $this->assertEquals(
-            array(
-                $replacing => array(
+            [
+                $replacing => [
                     $replacing => $replacing
-                )
-            ),
+                ]
+            ],
             modX::replaceReserved(
-                array(
-                    $source => array(
+                [
+                    $source => [
                         $source => $source
-                    )
-                ),
+                    ]
+                ],
                 $property
             )
         );

--- a/_build/test/Tests/Cases/Request/MakeUrlTest.php
+++ b/_build/test/Tests/Cases/Request/MakeUrlTest.php
@@ -29,7 +29,7 @@ class MakeUrlTest extends MODxTestCase {
 
         /** @var modResource $resource */
         $resource = $this->modx->newObject(modResource::class);
-        $resource->fromArray(array(
+        $resource->fromArray([
             'id' => 12345,
             'pagetitle' => 'Unit Test Resource',
             'type' => 'document',
@@ -51,11 +51,11 @@ class MakeUrlTest extends MODxTestCase {
             'class_key' => modDocument::class,
             'context_key' => 'web',
             'content_type' => 1,
-        ),'',true,true);
+        ],'',true,true);
         $resource->save();
 
         $resource = $this->modx->newObject(modResource::class);
-        $resource->fromArray(array(
+        $resource->fromArray([
             'id' => 12346,
             'parent' => 12345,
             'pagetitle' => 'Unit Test Child Resource',
@@ -77,7 +77,7 @@ class MakeUrlTest extends MODxTestCase {
             'class_key' => modDocument::class,
             'context_key' => 'web',
             'content_type' => 1,
-        ),'',true,true);
+        ],'',true,true);
         $resource->save();
 
         $this->modx->setOption('friendly_urls', true);
@@ -90,9 +90,9 @@ class MakeUrlTest extends MODxTestCase {
     public function tearDown() {
         parent::tearDown();
         /** @var modResource $resource */
-        $resource = $this->modx->getObject(modResource::class,array('pagetitle' => 'Unit Test Resource'));
+        $resource = $this->modx->getObject(modResource::class, ['pagetitle' => 'Unit Test Resource']);
         if ($resource) $resource->remove();
-        $resource = $this->modx->getObject(modResource::class,array('pagetitle' => 'Unit Test Child Resource'));
+        $resource = $this->modx->getObject(modResource::class, ['pagetitle' => 'Unit Test Child Resource']);
         if ($resource) $resource->remove();
     }
 
@@ -111,12 +111,12 @@ class MakeUrlTest extends MODxTestCase {
      * @return array
      */
     public function providerSingleParameter() {
-        return array(
+        return [
             // Dummy data to pass on first makeUrl
-            array(12345, ''),
-            array(12345, 'unit-test/'),
-            array(12346, 'unit-test/child.html'),
-        );
+            [12345, ''],
+            [12345, 'unit-test/'],
+            [12346, 'unit-test/child.html'],
+        ];
     }
 
     /**
@@ -137,12 +137,12 @@ class MakeUrlTest extends MODxTestCase {
      * @return array
      */
     public function providerArguments() {
-        return array(
-            array(12345,array(),'unit-test/'),
-            array(12345,array('one' => 1),'unit-test/?one=1'),
-            array(12345,array('one' => 1,'two' => 2),'unit-test/?one=1&two=2'),
-            array(12345,array('one' => 1,'two' => 2),'unit-test/?one=1&amp;two=2',true),
-        );
+        return [
+            [12345, [],'unit-test/'],
+            [12345, ['one' => 1],'unit-test/?one=1'],
+            [12345, ['one' => 1,'two' => 2],'unit-test/?one=1&two=2'],
+            [12345, ['one' => 1,'two' => 2],'unit-test/?one=1&amp;two=2',true],
+        ];
     }
 
     /**
@@ -161,12 +161,12 @@ class MakeUrlTest extends MODxTestCase {
      * @return array
      */
     public function providerScheme() {
-        return array(
-            array(12345,'','unit-test/'),
-            array(12345,'abs','/unit-test/'),
-            array(12345,'full','http://unit.modx.com/unit-test/'),
-            array(12345,'http','http://unit.modx.com/unit-test/'),
-            array(12345,'https','https://unit.modx.com/unit-test/'),
-        );
+        return [
+            [12345,'','unit-test/'],
+            [12345,'abs','/unit-test/'],
+            [12345,'full','http://unit.modx.com/unit-test/'],
+            [12345,'http','http://unit.modx.com/unit-test/'],
+            [12345,'https','https://unit.modx.com/unit-test/'],
+        ];
     }
 }

--- a/_build/test/Tests/Controllers/DeprecatedControllerTest.php
+++ b/_build/test/Tests/Controllers/DeprecatedControllerTest.php
@@ -20,9 +20,9 @@ class DeprecatedControllerTest extends MODxTestCase {
 
         /* load smarty template engine */
         $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
-        $this->modx->getService('smarty', modSmarty::class, '', array(
+        $this->modx->getService('smarty', modSmarty::class, '', [
             'template_dir' => $templatePath,
-        ));
+        ]);
         $this->modx->smarty->setCachePath('mgr/smarty/default/');
         $this->modx->smarty->assign('_config',$this->modx->config);
         $this->modx->smarty->assignByRef('modx',$this->modx);

--- a/_build/test/Tests/Controllers/WelcomeControllerTest.php
+++ b/_build/test/Tests/Controllers/WelcomeControllerTest.php
@@ -38,15 +38,15 @@ class WelcomeControllerTest extends MODxControllerTestCase {
 
         /** @var modDashboard $dashboard */
         $this->controller->dashboard = $this->modx->newObject(modDashboard::class);
-        $this->controller->dashboard->fromArray(array(
+        $this->controller->dashboard->fromArray([
             'id' => 10000,
             'name' => 'Unit Test Dashboard',
-        ),'',true,true);
+        ],'',true,true);
         $this->controller->dashboard->save();
 
         /** @var modDashboardWidget $dashboardWidget */
         $dashboardWidget = $this->modx->newObject(modDashboardWidget::class);
-        $dashboardWidget->fromArray(array(
+        $dashboardWidget->fromArray([
             'id' => 10000,
             'name' => 'Unit Test Dashboard Widget',
             'type' => 'html',
@@ -54,46 +54,46 @@ class WelcomeControllerTest extends MODxControllerTestCase {
             'namespace' => 'core',
             'lexicon' => 'core:dashboards',
             'size' => 'half',
-        ),'',true,true);
+        ],'',true,true);
         $dashboardWidget->save();
 
         /** @var modDashboardWidgetPlacement $dashboardWidgetPlacement */
         $dashboardWidgetPlacement = $this->modx->newObject(modDashboardWidgetPlacement::class);
-        $dashboardWidgetPlacement->fromArray(array(
+        $dashboardWidgetPlacement->fromArray([
             'dashboard' => $this->controller->dashboard->get('id'),
             'widget' => $dashboardWidget->get('id'),
             'rank' => 0,
-        ),'',true,true);
+        ],'',true,true);
         $dashboardWidgetPlacement->save();
 
         /** @var modUserGroup $userGroup */
         $userGroup = $this->modx->newObject(modUserGroup::class);
-        $userGroup->fromArray(array(
+        $userGroup->fromArray([
             'id' => 10000,
             'name' => 'Unit Test User Group 1',
             'parent' => 0,
             'rank' => 0,
             'dashboard' => 10000,
-        ),'',true,true);
+        ],'',true,true);
         $userGroup->save();
 
     }
 
     public function tearDown() {
         parent::tearDown();
-        $userGroups = $this->modx->getCollection(modUserGroup::class, array('name:LIKE' => '%Unit Test%'));
+        $userGroups = $this->modx->getCollection(modUserGroup::class, ['name:LIKE' => '%Unit Test%']);
         /** @var modUserGroup $userGroup */
         foreach ($userGroups as $userGroup) {
             $userGroup->remove();
         }
 
-        $dashboards = $this->modx->getCollection(modDashboard::class, array('name:LIKE' => '%Unit Test%'));
+        $dashboards = $this->modx->getCollection(modDashboard::class, ['name:LIKE' => '%Unit Test%']);
         /** @var modDashboard $dashboard */
         foreach ($dashboards as $dashboard) {
             $dashboard->remove();
         }
 
-        $widgets = $this->modx->getCollection(modDashboardWidget::class, array('name:LIKE' => '%Unit Test%'));
+        $widgets = $this->modx->getCollection(modDashboardWidget::class, ['name:LIKE' => '%Unit Test%']);
         /** @var modDashboardWidget $widget */
         foreach ($widgets as $widget) {
             $widget->remove();
@@ -115,11 +115,11 @@ class WelcomeControllerTest extends MODxControllerTestCase {
      * @return array
      */
     public function providerGetDashboard() {
-        return array(
-            array(0), /* default dashboard */
-            array(10000),/* custom unit test dashboard */
-            array(99999),/* invalid primary group, should fallback to default dashboard */
-        );
+        return [
+            [0], /* default dashboard */
+            [10000],/* custom unit test dashboard */
+            [99999],/* invalid primary group, should fallback to default dashboard */
+        ];
     }
 
     /**
@@ -146,10 +146,10 @@ class WelcomeControllerTest extends MODxControllerTestCase {
      * @return array
      */
     public function providerWelcomeScreen() {
-        return array(
-            array(false),
-            array(true),
-        );
+        return [
+            [false],
+            [true],
+        ];
     }
 
     /**

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -52,13 +52,13 @@ class modDashboardTest extends MODxTestCase {
      */
     public function testRender() {
         /** @var modManagerController $controller Fake running the welcome controller */
-        $controller = new \WelcomeManagerController($this->modx,array(
+        $controller = new \WelcomeManagerController($this->modx, [
             'namespace' => 'core',
             'namespace_name' => 'core',
             'namespace_path' => MODX_MANAGER_PATH,
             'lang_topics' => 'dashboards',
             'controller' => 'system/dashboards',
-        ));
+        ]);
         /** @var modDashboard $dashboard */
         $dashboard = modDashboard::getDefaultDashboard($this->modx);
         $output = $dashboard->render($controller);

--- a/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
@@ -42,7 +42,7 @@ class modDashboardWidgetTest extends MODxTestCase {
         require_once MODX_MANAGER_PATH.'controllers/default/welcome.class.php';
 
         $this->widget = $this->modx->newObject(modDashboardWidget::class);
-        $this->widget->fromArray(array(
+        $this->widget->fromArray([
             'name' => 'w_recentlyeditedresources',
             'description' => 'w_recentlyeditedresources_desc',
             'type' => 'file',
@@ -50,7 +50,7 @@ class modDashboardWidgetTest extends MODxTestCase {
             'content' => '[[++manager_path]]controllers/default/dashboard/widget.grid-rer.php',
             'namespace' => 'core',
             'lexicon' => 'core:dashboards',
-        ));
+        ]);
     }
 
     /**
@@ -58,13 +58,13 @@ class modDashboardWidgetTest extends MODxTestCase {
      */
     public function testGetContent() {
         /** @var modManagerController $controller Fake running the welcome controller */
-        $controller = new \WelcomeManagerController($this->modx,array(
+        $controller = new \WelcomeManagerController($this->modx, [
             'namespace' => 'core',
             'namespace_name' => 'core',
             'namespace_path' => MODX_MANAGER_PATH,
             'lang_topics' => 'dashboards',
             'controller' => 'system/dashboards',
-        ));
+        ]);
         /** @var modDashboard $dashboard */
         $output = $this->widget->getContent($controller);
         $this->assertNotEmpty($output);

--- a/_build/test/Tests/Model/Element/modChunkTest.php
+++ b/_build/test/Tests/Model/Element/modChunkTest.php
@@ -33,15 +33,15 @@ class modChunkTest extends MODxTestCase {
     public function setUp() {
         parent::setUp();
         $this->chunk = $this->modx->newObject(modChunk::class);
-        $this->chunk->fromArray(array(
+        $this->chunk->fromArray([
             'id' => 12345,
             'name' => 'Unit Test Chunk',
             'description' => 'A chunk for unit testing.',
             'snippet' => '<p>Hello, [[+name]]!</p>',
             'category' => 0,
             'locked' => 0,
-        ),'',true,true);
-        $this->chunk->setProperties(array('name' => 'John'));
+        ],'',true,true);
+        $this->chunk->setProperties(['name' => 'John']);
         $this->chunk->setCacheable(false);
     }
     public function tearDown() {
@@ -69,9 +69,9 @@ class modChunkTest extends MODxTestCase {
      * @return array
      */
     public function providerSetContent() {
-        return array(
-            array('Test content.'),
-        );
+        return [
+            ['Test content.'],
+        ];
     }
 
     /**
@@ -80,7 +80,7 @@ class modChunkTest extends MODxTestCase {
      * @param null|string $content
      * @dataProvider providerProcess
      */
-    public function testProcess($expected,array $properties = array(),$content = null) {
+    public function testProcess($expected,array $properties = [],$content = null) {
         $result = $this->chunk->process($properties,$content);
         $this->assertEquals($expected,$result);
     }
@@ -88,11 +88,11 @@ class modChunkTest extends MODxTestCase {
      * @return array
      */
     public function providerProcess() {
-        return array(
-            array('<p>Hello, John!</p>'),
-            array('<p>Hello, Mark!</p>',array('name' => 'Mark')),
-            array('<p>Having fun.</p>',array(),'<p>Having fun.</p>'),
-            array('<p>Test 1</p>',array('number' => 1),'<p>Test [[+number]]</p>'),
-        );
+        return [
+            ['<p>Hello, John!</p>'],
+            ['<p>Hello, Mark!</p>', ['name' => 'Mark']],
+            ['<p>Having fun.</p>', [],'<p>Having fun.</p>'],
+            ['<p>Test 1</p>', ['number' => 1],'<p>Test [[+number]]</p>'],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Element/modElementTest.php
+++ b/_build/test/Tests/Model/Element/modElementTest.php
@@ -43,48 +43,48 @@ class modElementTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Expected properties were not found.");
     }
     public function providerGetProperties() {
-        return array(
-            array(
+        return [
+            [
                 'element1',
                 '',
                 null,
-                array()
-            ),
-            array(
+                []
+            ],
+            [
                 'element2',
                 'food=beer&bard=muse',
                 null,
-                array(
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                )
-            ),
-            array(
+                ]
+            ],
+            [
                 'element3',
-                array(
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                ),
+                ],
                 null,
-                array(
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                )
-            ),
-            array(
+                ]
+            ],
+            [
                 'element4',
-                array(
+                [
                     'food' => 'beer',
-                ),
-                array(
+                ],
+                [
                     'bard' => 'muse'
-                ),
-                array(
+                ],
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 
     /**
@@ -99,55 +99,55 @@ class modElementTest extends MODxTestCase {
         $element = $this->modx->newObject(modElement::class);
         $element->set('name', $name);
         $element->process($properties, $content);
-        $result = array(
+        $result = [
             $element->_content,
             $element->_properties,
             $element->_result,
             $element->_processed,
             $element->get('name'),
             $element->_tag,
-        );
+        ];
         $this->assertEquals($expected, $result, "Did not get expected results");
     }
     public function providerProcess() {
-        return array(
-            array(
+        return [
+            [
                 'element1',
                 '[[element1]]',
-                array(
+                [
                     'property1' => 'value1',
                     'property2' => 'value2',
-                ),
+                ],
                 "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                array(
+                [
                     "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                    array(
+                    [
                         'property1' => 'value1',
                         'property2' => 'value2',
-                    ),
+                    ],
                     true,
                     false,
                     'element1',
                     '[[element1?property1=`value1`&property2=`value2`]]'
-                )
-            ),
-            array(
+                ]
+            ],
+            [
                 'element2',
                 '[[element2? &property1=`value1` &property2=`value2`]]',
                 '&property1=`value1` &property2=`value2`',
                 "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                array(
+                [
                     "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                    array(
+                    [
                         'property1' => 'value1',
                         'property2' => 'value2',
-                    ),
+                    ],
                     true,
                     false,
                     'element2',
                     '[[element2?property1=`value1`&property2=`value2`]]'
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Element/modPluginTest.php
+++ b/_build/test/Tests/Model/Element/modPluginTest.php
@@ -33,7 +33,7 @@ class modPluginTest extends MODxTestCase {
     public function setUp() {
         parent::setUp();
         $this->plugin = $this->modx->newObject(modPlugin::class);
-        $this->plugin->fromArray(array(
+        $this->plugin->fromArray([
             'id' => 12345,
             'name' => 'Unit Test Plugin',
             'description' => 'A plugin for unit testing.',
@@ -41,8 +41,8 @@ class modPluginTest extends MODxTestCase {
             'category' => 0,
             'locked' => false,
             'disabled' => false,
-        ),'',true,true);
-        $this->plugin->setProperties(array('name' => 'John'));
+        ],'',true,true);
+        $this->plugin->setProperties(['name' => 'John']);
         $this->plugin->setCacheable(false);
     }
     public function tearDown() {
@@ -70,9 +70,9 @@ class modPluginTest extends MODxTestCase {
      * @return array
      */
     public function providerSetContent() {
-        return array(
-            array('return "Goodbye.";'),
-        );
+        return [
+            ['return "Goodbye.";'],
+        ];
     }
 
 }

--- a/_build/test/Tests/Model/Element/modSnippetTest.php
+++ b/_build/test/Tests/Model/Element/modSnippetTest.php
@@ -34,14 +34,14 @@ class modSnippetTest extends MODxTestCase {
     public function setUp() {
         parent::setUp();
         $this->snippet = $this->modx->newObject(modSnippet::class);
-        $this->snippet->fromArray(array(
+        $this->snippet->fromArray([
             'name' => 'Unit Test Snippet',
             'description' => 'A snippet for unit testing.',
             'snippet' => str_replace('<?php','',file_get_contents(MODX_BASE_PATH.'_build/test/data/snippets/modSnippetTest/modSnippetTest.snippet.php')),
             'category' => 0,
             'locked' => false,
-        ),'',true,true);
-        $this->snippet->setProperties(array('name' => 'John'));
+        ],'',true,true);
+        $this->snippet->setProperties(['name' => 'John']);
         $this->snippet->setCacheable(false);
         $this->snippet->save();
         $this->modx->event= new modSystemEvent();
@@ -72,9 +72,9 @@ class modSnippetTest extends MODxTestCase {
      * @return array
      */
     public function providerSetContent() {
-        return array(
-            array('return "Goodbye.";'),
-        );
+        return [
+            ['return "Goodbye.";'],
+        ];
     }
 
 
@@ -92,9 +92,9 @@ class modSnippetTest extends MODxTestCase {
      * @return array
      */
     public function providerProcess() {
-        return array(
-            array('Hello, John'),
-            array('Hello, Mark',array('name' => 'Mark')),
-        );
+        return [
+            ['Hello, John'],
+            ['Hello, Mark', ['name' => 'Mark']],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Element/modTagTest.php
+++ b/_build/test/Tests/Model/Element/modTagTest.php
@@ -47,48 +47,48 @@ class modTagTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Expected properties were not found.");
     }
     public function providerGetProperties() {
-        return array(
-            array(
+        return [
+            [
                 'element1',
                 '',
                 null,
-                array()
-            ),
-            array(
+                []
+            ],
+            [
                 'element2',
                 'food=beer&bard=muse',
                 null,
-                array(
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                )
-            ),
-            array(
+                ]
+            ],
+            [
                 'element3',
-                array(
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                ),
+                ],
                 null,
-                array(
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                )
-            ),
-            array(
+                ]
+            ],
+            [
                 'element4',
-                array(
+                [
                     'food' => 'beer',
-                ),
-                array(
+                ],
+                [
                     'bard' => 'muse'
-                ),
-                array(
+                ],
+                [
                     'food' => 'beer',
                     'bard' => 'muse'
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 
     /**
@@ -103,55 +103,55 @@ class modTagTest extends MODxTestCase {
         $element = new modTagElement($this->modx);
         $element->set('name', $name);
         $element->process($properties, $content);
-        $result = array(
+        $result = [
             $element->_content,
             $element->_properties,
             $element->_result,
             $element->_processed,
             $element->get('name'),
             $element->_tag,
-        );
+        ];
         $this->assertEquals($expected, $result, "Did not get expected results");
     }
     public function providerProcess() {
-        return array(
-            array(
+        return [
+            [
                 'element1',
                 '[[element1]]',
-                array(
+                [
                     'property1' => 'value1',
                     'property2' => 'value2',
-                ),
+                ],
                 "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                array(
+                [
                     "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                    array(
+                    [
                         'property1' => 'value1',
                         'property2' => 'value2',
-                    ),
+                    ],
                     true,
                     false,
                     'element1',
                     '[[element1?property1=`value1`&property2=`value2`]]'
-                )
-            ),
-            array(
+                ]
+            ],
+            [
                 'element2',
                 '[[element2? &property1=`value1` &property2=`value2`]]',
                 '&property1=`value1` &property2=`value2`',
                 "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                array(
+                [
                     "<p>This is some sample content with some tags: [[+notAPlaceholder]] [[!+notAnotherPlaceholder]]</p>",
-                    array(
+                    [
                         'property1' => 'value1',
                         'property2' => 'value2',
-                    ),
+                    ],
                     true,
                     false,
                     'element2',
                     '[[element2?property1=`value1`&property2=`value2`]]'
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Element/modTemplateTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateTest.php
@@ -32,15 +32,15 @@ class modTemplateTest extends MODxTestCase {
     public function setUp() {
         parent::setUp();
         $this->template = $this->modx->newObject(modTemplate::class);
-        $this->template->fromArray(array(
+        $this->template->fromArray([
             'id' => 12345,
             'templatename' => 'Unit Test Template',
             'description' => 'A template for unit testing.',
             'content' => '<p>Hello, [[+name]]!</p>',
             'category' => 0,
             'locked' => 0,
-        ),'',true,true);
-        $this->template->setProperties(array('name' => 'John'));
+        ],'',true,true);
+        $this->template->setProperties(['name' => 'John']);
         $this->template->setCacheable(false);
     }
     public function tearDown() {
@@ -68,9 +68,9 @@ class modTemplateTest extends MODxTestCase {
      * @return array
      */
     public function providerSetContent() {
-        return array(
-            array('Test content.'),
-        );
+        return [
+            ['Test content.'],
+        ];
     }
 
     /**
@@ -79,7 +79,7 @@ class modTemplateTest extends MODxTestCase {
      * @param null|string $content
      * @dataProvider providerProcess
      */
-    public function testProcess($expected,array $properties = array(),$content = null) {
+    public function testProcess($expected,array $properties = [],$content = null) {
         $result = $this->template->process($properties,$content);
         $this->assertEquals($expected,$result);
     }
@@ -87,11 +87,11 @@ class modTemplateTest extends MODxTestCase {
      * @return array
      */
     public function providerProcess() {
-        return array(
-            array('<p>Hello, John!</p>'),
-            array('<p>Hello, Mark!</p>',array('name' => 'Mark')),
-            array('<p>Having fun.</p>',array(),'<p>Having fun.</p>'),
-            array('<p>Test 1</p>',array('number' => 1),'<p>Test [[+number]]</p>'),
-        );
+        return [
+            ['<p>Hello, John!</p>'],
+            ['<p>Hello, Mark!</p>', ['name' => 'Mark']],
+            ['<p>Having fun.</p>', [],'<p>Having fun.</p>'],
+            ['<p>Test 1</p>', ['number' => 1],'<p>Test [[+number]]</p>'],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Element/modTemplateVarTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateVarTest.php
@@ -32,7 +32,7 @@ class modTemplateVarTest extends MODxTestCase {
     public function setUp() {
         parent::setUp();
         $this->tv = $this->modx->newObject(modTemplateVar::class);
-        $this->tv->fromArray(array(
+        $this->tv->fromArray([
             'id' => 12345,
             'name' => 'Unit Test Template Var',
             'caption' => 'UTTV',
@@ -40,8 +40,8 @@ class modTemplateVarTest extends MODxTestCase {
             'default_text' => '<p>Hello, [[+name]]!</p>',
             'category' => 0,
             'locked' => 0,
-        ),'',true,true);
-        $this->tv->setProperties(array('name' => 'John'));
+        ],'',true,true);
+        $this->tv->setProperties(['name' => 'John']);
         $this->tv->setCacheable(false);
     }
     public function tearDown() {
@@ -69,9 +69,9 @@ class modTemplateVarTest extends MODxTestCase {
      * @return array
      */
     public function providerSetContent() {
-        return array(
-            array('Test content.'),
-        );
+        return [
+            ['Test content.'],
+        ];
     }
 
     /**
@@ -80,7 +80,7 @@ class modTemplateVarTest extends MODxTestCase {
      * @param null|string $content
      * @dataProvider providerProcess
      */
-    public function testProcess($expected,array $properties = array(),$content = null) {
+    public function testProcess($expected,array $properties = [],$content = null) {
         $result = $this->tv->process($properties,$content);
         $this->assertEquals($expected,$result);
     }
@@ -88,11 +88,11 @@ class modTemplateVarTest extends MODxTestCase {
      * @return array
      */
     public function providerProcess() {
-        return array(
-            array('<p>Hello, John!</p>'),
-            array('<p>Hello, Mark!</p>',array('name' => 'Mark')),
+        return [
+            ['<p>Hello, John!</p>'],
+            ['<p>Hello, Mark!</p>', ['name' => 'Mark']],
             //array('<p>Having fun.</p>',array(),'<p>Having fun.</p>'),
             //array('<p>Test 1</p>',array('number' => 1),'<p>Test [[+number]]</p>'),
-        );
+        ];
     }
 }

--- a/_build/test/Tests/Model/Error/modErrorTest.php
+++ b/_build/test/Tests/Model/Error/modErrorTest.php
@@ -53,10 +53,10 @@ class modErrorTest extends MODxTestCase {
         $this->assertTrue($this->error->errors[0] == $errorMsg,'modError.addError failed to insert the correct error.');
     }
     public function providerTestAddError() {
-        return array(
-            array('A test error'),
-            array(''), /* should this work? does now... */
-        );
+        return [
+            ['A test error'],
+            [''], /* should this work? does now... */
+        ];
     }
 
     /**
@@ -72,11 +72,11 @@ class modErrorTest extends MODxTestCase {
         $this->assertEquals($message,$this->error->errors[0]['msg'],'modError.addField failed to insert the correct error message.');
     }
     public function providerTestAddField() {
-        return array(
-            array('name','Please enter a valid name.'),
-            array('score',0),
-            array('empty',''),
-        );
+        return [
+            ['name','Please enter a valid name.'],
+            ['score',0],
+            ['empty',''],
+        ];
     }
 
     /**
@@ -121,12 +121,12 @@ class modErrorTest extends MODxTestCase {
         $this->assertEquals($shouldPass,$passed);
     }
     public function providerTestIsFieldError() {
-        return array(
-            array(array('id' => 'name','msg' => 'Please enter a name.'),true),
-            array(array('id' => 'fake'),false),
-            array(array('msg' => 'A bad error'),false),
-            array('An invalid error',false),
-        );
+        return [
+            [['id' => 'name','msg' => 'Please enter a name.'],true],
+            [['id' => 'fake'],false],
+            [['msg' => 'A bad error'],false],
+            ['An invalid error',false],
+        ];
     }
 
     /**
@@ -140,12 +140,12 @@ class modErrorTest extends MODxTestCase {
         $this->assertEquals($shouldPass,$passed);
     }
     public function providerTestIsNotFieldError() {
-        return array(
-            array('A standard error',true),
-            array(array('id' => 'fake'),true),
-            array(array('msg' => 'A bad error'),true),
-            array(array('id' => 'name','msg' => 'Please enter a name.'),false),
-        );
+        return [
+            ['A standard error',true],
+            [['id' => 'fake'],true],
+            [['msg' => 'A bad error'],true],
+            [['id' => 'name','msg' => 'Please enter a name.'],false],
+        ];
     }
 
     /**
@@ -195,16 +195,16 @@ class modErrorTest extends MODxTestCase {
      * @dataProvider providerTestSuccess
      */
     public function testSuccess($message,$id) {
-        $response = $this->error->success($message,array('id' => $id));
+        $response = $this->error->success($message, ['id' => $id]);
 
         $this->assertTrue($response['success']);
         $this->assertEquals($message,$response['message']);
         $this->assertEquals($id,$response['object']['id']);
     }
     public function providerTestSuccess() {
-        return array(
-            array('A win occurred!',456),
-        );
+        return [
+            ['A win occurred!',456],
+        ];
     }
 
     /**
@@ -214,7 +214,7 @@ class modErrorTest extends MODxTestCase {
     public function testFailure() {
         $generalErrorMessage = 'Please check the values in your form.';
         $this->error->addField('name','Name is required.');
-        $response = $this->error->failure($generalErrorMessage,array('id' => 123));
+        $response = $this->error->failure($generalErrorMessage, ['id' => 123]);
 
         $this->assertFalse($response['success']);
         $this->assertEquals($generalErrorMessage,$response['message']);

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -54,11 +54,11 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerCat() {
-        return array(
-            array('','',''),
-            array('This dog',' went home','This dog went home'),
-            array('','hello?','hello?'),
-        );
+        return [
+            ['','',''],
+            ['This dog',' went home','This dog went home'],
+            ['','hello?','hello?'],
+        ];
     }
 
     /**
@@ -78,12 +78,12 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerUppercase() {
-        return array(
-            array('',''),
-            array('ALREADY THERE','ALREADY THERE'),
-            array('booyah','BOOYAH'),
-            array('i\'m not yelling','I\'M NOT YELLING'),
-        );
+        return [
+            ['',''],
+            ['ALREADY THERE','ALREADY THERE'],
+            ['booyah','BOOYAH'],
+            ['i\'m not yelling','I\'M NOT YELLING'],
+        ];
     }
 
     /**
@@ -103,12 +103,12 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerLowercase() {
-        return array(
-            array('',''),
-            array('BOOYAH','booyah'),
-            array('BoOyAh','booyah'),
-            array('THiS CaT WENt To THe  cITy','this cat went to the  city'),
-        );
+        return [
+            ['',''],
+            ['BOOYAH','booyah'],
+            ['BoOyAh','booyah'],
+            ['THiS CaT WENt To THe  cITy','this cat went to the  city'],
+        ];
     }
 
     /**
@@ -128,12 +128,12 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerUCWords() {
-        return array(
-            array('',''),
-            array('test','Test'),
-            array('A big fat elephant','A Big Fat Elephant'),
-            array('Have you read a Dr. Seuss Book?','Have You Read A Dr. Seuss Book?'),
-        );
+        return [
+            ['',''],
+            ['test','Test'],
+            ['A big fat elephant','A Big Fat Elephant'],
+            ['Have you read a Dr. Seuss Book?','Have You Read A Dr. Seuss Book?'],
+        ];
     }
 
     /**
@@ -153,12 +153,12 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerUCFirst() {
-        return array(
-            array('',''),
-            array('test','Test'),
-            array('green eggers and hammond','Green eggers and hammond'),
-            array('bocce ball, anyone?','Bocce ball, anyone?'),
-        );
+        return [
+            ['',''],
+            ['test','Test'],
+            ['green eggers and hammond','Green eggers and hammond'],
+            ['bocce ball, anyone?','Bocce ball, anyone?'],
+        ];
     }
 
     /**
@@ -179,10 +179,10 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerStripString() {
-        return array(
-            array('','',''),
-            array('Don\'t even think about it','Don\'t even ','think about it'),
-        );
+        return [
+            ['','',''],
+            ['Don\'t even think about it','Don\'t even ','think about it'],
+        ];
     }
 
     /**
@@ -203,11 +203,11 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerReplace() {
-        return array(
-            array('','',''),
-            array('Strip it all out','it all==none','Strip none out'),
-            array('foobar','foo==bar','barbar'),
-        );
+        return [
+            ['','',''],
+            ['Strip it all out','it all==none','Strip none out'],
+            ['foobar','foo==bar','barbar'],
+        ];
     }
 
     /**
@@ -227,12 +227,12 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerStripTags() {
-        return array(
-            array('Hi!<br />','Hi!'),
-            array('<strong>Boo!</strong> No.','Boo! No.'),
-            array('Dogs are cool <p>Cats are weird','Dogs are cool Cats are weird'),
-            array('',''),
-        );
+        return [
+            ['Hi!<br />','Hi!'],
+            ['<strong>Boo!</strong> No.','Boo! No.'],
+            ['Dogs are cool <p>Cats are weird','Dogs are cool Cats are weird'],
+            ['',''],
+        ];
     }
 
     /**
@@ -252,11 +252,11 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerStrLen() {
-        return array(
-            array('abcdefghijklmnopqrstuvwxyz',26),
-            array('',0),
-            array('a big dog',9),
-        );
+        return [
+            ['abcdefghijklmnopqrstuvwxyz',26],
+            ['',0],
+            ['a big dog',9],
+        ];
     }
 
     /**
@@ -276,11 +276,11 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerEsrever() {
-        return array(
-            array('a brown fox','xof nworb a'),
-            array('level','level'),
-            array('somemeninterpretninememos','somemeninterpretninememos'),
-        );
+        return [
+            ['a brown fox','xof nworb a'],
+            ['level','level'],
+            ['somemeninterpretninememos','somemeninterpretninememos'],
+        ];
     }
 
     /**
@@ -301,13 +301,17 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerLimit() {
-        return array(
-            array('Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
-            ,10,'Lurem ipso'),
-            array('Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
-            ,1000000,'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'),
-            array('','',''),
-        );
+        return [
+            [
+                'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
+            ,10,'Lurem ipso'
+            ],
+            [
+                'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
+            ,1000000,'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
+            ],
+            ['','',''],
+        ];
     }
 
     /**
@@ -328,13 +332,17 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerEllipsis() {
-        return array(
-            array('Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
-            ,10,'Lurem ipsoom&#8230;'),
-            array('Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
-            ,1000000,'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'),
-            array('','',''),
-        );
+        return [
+            [
+                'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
+            ,10,'Lurem ipsoom&#8230;'
+            ],
+            [
+                'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
+            ,1000000,'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
+            ],
+            ['','',''],
+        ];
     }
 
     /**
@@ -354,12 +362,14 @@ class modOutputFilterTest extends MODxTestCase {
      * @return array
      */
     public function providerNL2BR() {
-        return array(
-            array('A test paragraph
+        return [
+            [
+                'A test paragraph
 goes here','A test paragraph<br />
-goes here'),
-            array('',''),
-        );
+goes here'
+            ],
+            ['',''],
+        ];
     }
 
     /**
@@ -380,12 +390,12 @@ goes here'),
      * @return array
      */
     public function providerAdd() {
-        return array(
-            array('',0,0),
-            array('123',1,124),
-            array(-1,1,0),
-            array(5,-1,4),
-        );
+        return [
+            ['',0,0],
+            ['123',1,124],
+            [-1,1,0],
+            [5,-1,4],
+        ];
     }
 
     /**
@@ -406,13 +416,13 @@ goes here'),
      * @return array
      */
     public function providerSubtract() {
-        return array(
-            array('',0,0),
-            array('123',1,122),
-            array(-1,1,-2),
-            array(1,1,0),
-            array(5,-1,6),
-        );
+        return [
+            ['',0,0],
+            ['123',1,122],
+            [-1,1,-2],
+            [1,1,0],
+            [5,-1,6],
+        ];
     }
 
     /**
@@ -433,12 +443,12 @@ goes here'),
      * @return array
      */
     public function providerMultiply() {
-        return array(
-            array('',0,0),
-            array(1,5,5),
-            array(4,7,28),
-            array('100',2,200),
-        );
+        return [
+            ['',0,0],
+            [1,5,5],
+            [4,7,28],
+            ['100',2,200],
+        ];
     }
 
     /**
@@ -459,11 +469,11 @@ goes here'),
      * @return array
      */
     public function providerDivide() {
-        return array(
-            array(1,0,.5),
-            array(0,0,0),
-            array(10,5,2),
-        );
+        return [
+            [1,0,.5],
+            [0,0,0],
+            [10,5,2],
+        ];
     }
 
     /**
@@ -484,13 +494,13 @@ goes here'),
      * @return array
      */
     public function providerModulus() {
-        return array(
-            array(4,2,0),
-            array(9,3,0),
-            array(0,0,0),
-            array(4,3,1),
-            array(10,4,2),
-        );
+        return [
+            [4,2,0],
+            [9,3,0],
+            [0,0,0],
+            [4,3,1],
+            [10,4,2],
+        ];
     }
 
     /**
@@ -511,10 +521,10 @@ goes here'),
      * @return array
      */
     public function providerDefault() {
-        return array(
-            array('','foo','foo'),
-            array('z','a','z'),
-        );
+        return [
+            ['','foo','foo'],
+            ['z','a','z'],
+        ];
     }
 
     /**
@@ -535,11 +545,11 @@ goes here'),
      * @return array
      */
     public function providerNotEmpty() {
-        return array(
-            array('','foo',''),
-            array('z','a','a'),
-            array('name','John','John'),
-        );
+        return [
+            ['','foo',''],
+            ['z','a','a'],
+            ['name','John','John'],
+        ];
     }
 
     /**
@@ -558,10 +568,10 @@ goes here'),
      * @return array
      */
     public function providerStrToTime() {
-        return array(
-            array('2011-05-01 10:23:11'),
-            array(''),
-        );
+        return [
+            ['2011-05-01 10:23:11'],
+            [''],
+        ];
     }
 
     /**
@@ -580,10 +590,10 @@ goes here'),
      * @return array
      */
     public function providerMD5() {
-        return array(
-            array('coolio'),
-            array(''),
-        );
+        return [
+            ['coolio'],
+            [''],
+        ];
     }
 
     /**
@@ -603,10 +613,10 @@ goes here'),
      * @return array
      */
     public function providerCData() {
-        return array(
-            array('code here','<![CDATA[code here]]>'),
-            array('','<![CDATA[]]>'),
-        );
+        return [
+            ['code here','<![CDATA[code here]]>'],
+            ['','<![CDATA[]]>'],
+        ];
     }
 
     /**
@@ -626,10 +636,10 @@ goes here'),
      * @return array
      */
     public function providerUrlEncode() {
-        return array(
-            array('test','test'),
-            array('test with space','test+with+space'),
-        );
+        return [
+            ['test','test'],
+            ['test with space','test+with+space'],
+        ];
     }
 
     /**
@@ -649,10 +659,10 @@ goes here'),
      * @return array
      */
     public function providerUrlDecode() {
-        return array(
-            array('test','test'),
-            array('test+with+space','test with space'),
-        );
+        return [
+            ['test','test'],
+            ['test+with+space','test with space'],
+        ];
     }
 
     /**
@@ -676,10 +686,10 @@ goes here'),
      * @return array
      */
     public function providerCssToHead() {
-        return array(
-            array('assets/css/style.css',true),
-            array('<link rel="stylesheet" href="assets/css/style.css" type="text/css" />',false),
-        );
+        return [
+            ['assets/css/style.css',true],
+            ['<link rel="stylesheet" href="assets/css/style.css" type="text/css" />',false],
+        ];
     }
 
     /**
@@ -699,9 +709,9 @@ goes here'),
      * @return array
      */
     public function providerHtmlToHead() {
-        return array(
-            array('<style>'),
-        );
+        return [
+            ['<style>'],
+        ];
     }
 
     /**
@@ -721,9 +731,9 @@ goes here'),
      * @return array
      */
     public function providerHtmlToBottom() {
-        return array(
-            array('<footer>'),
-        );
+        return [
+            ['<footer>'],
+        ];
     }
 
     /**
@@ -748,11 +758,11 @@ goes here'),
      * @return array
      */
     public function providerJsToBottom() {
-        return array(
-            array('assets/js/script.js',true,false),
-            array('<script type="text/javascript" src="assets/js/script2.js"></script>',false,false),
-            array('assets/js/script3.js',false,true),
-        );
+        return [
+            ['assets/js/script.js',true,false],
+            ['<script type="text/javascript" src="assets/js/script2.js"></script>',false,false],
+            ['assets/js/script3.js',false,true],
+        ];
     }
 
     /**
@@ -777,11 +787,11 @@ goes here'),
      * @return array
      */
     public function providerJsToHead() {
-        return array(
-            array('assets/js/hscript.js',true,false),
-            array('<script type="text/javascript" src="assets/js/hscript2.js"></script>',false,false),
-            array('assets/js/hscript3.js',false,true),
-        );
+        return [
+            ['assets/js/hscript.js',true,false],
+            ['<script type="text/javascript" src="assets/js/hscript2.js"></script>',false,false],
+            ['assets/js/hscript3.js',false,true],
+        ];
     }
 
     /**
@@ -804,15 +814,15 @@ goes here'),
      */
     public function providerDirname()
     {
-        return array(
-            array('/icon.ico', '/'),
-            array('/assets/images/logo.jpg', '/assets/images'),
-            array('./assets/files/doc.pdf', './assets/files'),
+        return [
+            ['/icon.ico', '/'],
+            ['/assets/images/logo.jpg', '/assets/images'],
+            ['./assets/files/doc.pdf', './assets/files'],
             // last three tests for pathinfo() function documentation notes
-            array('/test/test.inc.php', '/test'),
-            array('/test/test', '/test'),
-            array('/test/.test', '/test'),
-        );
+            ['/test/test.inc.php', '/test'],
+            ['/test/test', '/test'],
+            ['/test/.test', '/test'],
+        ];
     }
 
     /**
@@ -836,15 +846,15 @@ goes here'),
      */
     public function providerBasename()
     {
-        return array(
-            array('/icon.ico', 'icon.ico'),
-            array('/assets/images/logo.jpg', 'logo.jpg'),
-            array('./assets/files/doc.pdf', 'doc.pdf'),
+        return [
+            ['/icon.ico', 'icon.ico'],
+            ['/assets/images/logo.jpg', 'logo.jpg'],
+            ['./assets/files/doc.pdf', 'doc.pdf'],
             // last three tests for pathinfo() function documentation notes
-            array('/test/test.inc.php', 'test.inc.php'),
-            array('/test/test', 'test'),
-            array('/test/.test', '.test'),
-        );
+            ['/test/test.inc.php', 'test.inc.php'],
+            ['/test/test', 'test'],
+            ['/test/.test', '.test'],
+        ];
     }
 
     /**
@@ -867,15 +877,15 @@ goes here'),
      */
     public function providerFilename()
     {
-        return array(
-            array('/icon.ico', 'icon'),
-            array('/assets/images/logo.jpg', 'logo'),
-            array('./assets/files/doc.pdf', 'doc'),
+        return [
+            ['/icon.ico', 'icon'],
+            ['/assets/images/logo.jpg', 'logo'],
+            ['./assets/files/doc.pdf', 'doc'],
             // last three tests for pathinfo() function documentation notes
-            array('/test/test.inc.php', 'test.inc'),
-            array('/test/test', 'test'),
-            array('/test/.test', ''),
-        );
+            ['/test/test.inc.php', 'test.inc'],
+            ['/test/test', 'test'],
+            ['/test/.test', ''],
+        ];
     }
 
     /**
@@ -898,15 +908,15 @@ goes here'),
      */
     public function providerExtension()
     {
-        return array(
-            array('/icon.ico', 'ico'),
-            array('/assets/images/logo.jpg', 'jpg'),
-            array('./assets/files/doc.pdf', 'pdf'),
+        return [
+            ['/icon.ico', 'ico'],
+            ['/assets/images/logo.jpg', 'jpg'],
+            ['./assets/files/doc.pdf', 'pdf'],
             // last three tests for pathinfo() function documentation notes
-            array('/test/test.inc.php', 'php'),
-            array('/test/test', ''),
-            array('/test/.test', 'test'),
-        );
+            ['/test/test.inc.php', 'php'],
+            ['/test/test', ''],
+            ['/test/.test', 'test'],
+        ];
     }
 
     /**
@@ -929,9 +939,9 @@ goes here'),
      * @return array
      */
     public function providerToPlaceholder() {
-        return array(
-            array('myPlaceholder','Test'),
-            array('emptyPlaceholder',''),
-        );
+        return [
+            ['myPlaceholder','Test'],
+            ['emptyPlaceholder',''],
+        ];
     }
 }

--- a/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
+++ b/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
@@ -40,7 +40,7 @@ class modActionDomTest extends MODxTestCase {
     public function testApply($expected,$ruleType,$name,$value,$container) {
         /** @var modActionDom $rule */
         $rule = $this->modx->newObject(modActionDom::class);
-        $rule->fromArray(array(
+        $rule->fromArray([
             'set' => 0,
             'action' => 1,
             'xtype' => '',
@@ -51,7 +51,7 @@ class modActionDomTest extends MODxTestCase {
             'container' => $container,
             'for_parent' => 0,
             'rank' => 0,
-        ));
+        ]);
         $content = $rule->apply(1);
         $this->assertEquals($expected,$content);
     }
@@ -59,25 +59,37 @@ class modActionDomTest extends MODxTestCase {
      * @return array
      */
     public function providerApply() {
-        return array(
-            array('MODx.hideField("modx-panel-resource",["description"]);',
-                'fieldVisible','description',0,'modx-panel-resource'),
+        return [
+            [
+                'MODx.hideField("modx-panel-resource",["description"]);',
+                'fieldVisible','description',0,'modx-panel-resource'
+            ],
 
-            array('MODx.renameLabel("modx-panel-resource",["published"],["Active"]);',
-                'fieldTitle','published','Active','modx-panel-resource'),
+            [
+                'MODx.renameLabel("modx-panel-resource",["published"],["Active"]);',
+                'fieldTitle','published','Active','modx-panel-resource'
+            ],
 
-            array('MODx.renameTab("modx-resource-settings","Other Settings");',
-                'tabTitle','modx-resource-settings','Other Settings','modx-resource-tabs'),
+            [
+                'MODx.renameTab("modx-resource-settings","Other Settings");',
+                'tabTitle','modx-resource-settings','Other Settings','modx-resource-tabs'
+            ],
 
-            array('MODx.hideRegion("modx-resource-tabs","modx-resource-settings");',
-                'tabVisible','modx-resource-settings',0,'modx-resource-tabs'),
+            [
+                'MODx.hideRegion("modx-resource-tabs","modx-resource-settings");',
+                'tabVisible','modx-resource-settings',0,'modx-resource-tabs'
+            ],
 
-            array('MODx.addTab("modx-resource-tabs",{title:"Other Tab",id:"tab-other"});',
-                'tabNew','tab-other','Other Tab','modx-resource-tabs'),
+            [
+                'MODx.addTab("modx-resource-tabs",{title:"Other Tab",id:"tab-other"});',
+                'tabNew','tab-other','Other Tab','modx-resource-tabs'
+            ],
 
-            array('MODx.moveTV(["tv15"],"modx-resource-settings");',
-                'tvMove','tv15','modx-resource-settings','modx-panel-resource'),
-        );
+            [
+                'MODx.moveTV(["tv15"],"modx-resource-settings");',
+                'tvMove','tv15','modx-resource-settings','modx-panel-resource'
+            ],
+        ];
     }
 
 }

--- a/_build/test/Tests/Model/Hashing/modHashingTest.php
+++ b/_build/test/Tests/Model/Hashing/modHashingTest.php
@@ -43,17 +43,17 @@ class modHashingTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Did not get the expected option value.");
     }
     public function providerGetOption() {
-        return array(
-            array('option1', array(), array(), array('hashing_option1' => 'modx'), 'modx'),
-            array('option2', array(), array('option2' => 'hashing'), array(), 'hashing'),
-            array('option3', array('option3' => 'local'), array(), array(), 'local'),
-            array('option4', array('option4' => 'local'), array('option4' => 'hashing'), array('hashing_option4' => 'modx'), 'local'),
-            array('option5', array('option99' => 'local'), array('option5' => 'hashing'), array('hashing_option5' => 'modx'), 'hashing'),
-            array('option6', null, null, array('hashing_option6' => 'modx'), 'modx'),
-            array('option7', array(), null, array('hashing_option7' => 'modx'), 'modx'),
-            array('option8', null, null, array(), null),
-            array('option8', array(), null, array(), null),
-            array('option8', null, array(), array(), null),
-        );
+        return [
+            ['option1', [], [], ['hashing_option1' => 'modx'], 'modx'],
+            ['option2', [], ['option2' => 'hashing'], [], 'hashing'],
+            ['option3', ['option3' => 'local'], [], [], 'local'],
+            ['option4', ['option4' => 'local'], ['option4' => 'hashing'], ['hashing_option4' => 'modx'], 'local'],
+            ['option5', ['option99' => 'local'], ['option5' => 'hashing'], ['hashing_option5' => 'modx'], 'hashing'],
+            ['option6', null, null, ['hashing_option6' => 'modx'], 'modx'],
+            ['option7', [], null, ['hashing_option7' => 'modx'], 'modx'],
+            ['option8', null, null, [], null],
+            ['option8', [], null, [], null],
+            ['option8', null, [], [], null],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Hashing/modMD5HashTest.php
+++ b/_build/test/Tests/Model/Hashing/modMD5HashTest.php
@@ -42,11 +42,11 @@ class modMD5HashTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Expected hash value not generated.");
     }
     public function providerHash() {
-        return array(
-            array('password', array(), md5('password')),
-            array('password', null, md5('password')),
-            array('what do you think of this?', array(), md5('what do you think of this?')),
-            array('what do you think of this?', null, md5('what do you think of this?')),
-        );
+        return [
+            ['password', [], md5('password')],
+            ['password', null, md5('password')],
+            ['what do you think of this?', [], md5('what do you think of this?')],
+            ['what do you think of this?', null, md5('what do you think of this?')],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Hashing/modNativeHashTest.php
+++ b/_build/test/Tests/Model/Hashing/modNativeHashTest.php
@@ -47,11 +47,11 @@ class modNativeHashTest extends MODxTestCase {
     }
 
     public function providerHash() {
-        return array(
-            array('password123'),
-            array('123456'),
-            array('what do you think of this?'),
-            array('letmein'),
-        );
+        return [
+            ['password123'],
+            ['123456'],
+            ['what do you think of this?'],
+            ['letmein'],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Hashing/modPBKDF2HashTest.php
+++ b/_build/test/Tests/Model/Hashing/modPBKDF2HashTest.php
@@ -42,11 +42,11 @@ class modPBKDF2HashTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Expected hash value not generated.");
     }
     public function providerHash() {
-        return array(
-            array('password', array('salt' => '123'), 'VCIGwMm0t9bKMa8xeOKMG6BZ0wNadGAikev95fnnkkQ='),
-            array('password', array('salt' => 'abc'), 'e/+7RSuHvTHideDuZkpvFXtq65+oHM9xONAsEVJaV6s='),
-            array('what do you think of this?', array('salt' => 'abc123'), 'Pgf+nVGBXjkX6kqWsSYvyn8kWsf0jeArBJW8V50wUoE='),
-            array('what do you think of this?', array('salt' => '123abc'), 'zh7hBkVxmK9JZ8RKqRJCrLr9wkRn48O+g0igHi+H2WY='),
-        );
+        return [
+            ['password', ['salt' => '123'], 'VCIGwMm0t9bKMa8xeOKMG6BZ0wNadGAikev95fnnkkQ='],
+            ['password', ['salt' => 'abc'], 'e/+7RSuHvTHideDuZkpvFXtq65+oHM9xONAsEVJaV6s='],
+            ['what do you think of this?', ['salt' => 'abc123'], 'Pgf+nVGBXjkX6kqWsSYvyn8kWsf0jeArBJW8V50wUoE='],
+            ['what do you think of this?', ['salt' => '123abc'], 'zh7hBkVxmK9JZ8RKqRJCrLr9wkRn48O+g0igHi+H2WY='],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Lexicon/modLexiconTest.php
+++ b/_build/test/Tests/Model/Lexicon/modLexiconTest.php
@@ -56,9 +56,9 @@ class modLexiconTest extends MODxTestCase {
         require_once dirname(dirname(dirname(dirname(dirname(__DIR__))))) . '/core/lexicon/en/about.inc.php';
         /** @var array $_lang */
         $total = count($_lang);
-        return array(
-            array('about', $total),
-        );
+        return [
+            ['about', $total],
+        ];
     }
 
     /**
@@ -81,13 +81,13 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerLoad() {
-        return array(
-            array('user'),
-            array('context'),
-            array('core:element'),
-            array('en:core:action'),
-            array('fr:core:action'),
-        );
+        return [
+            ['user'],
+            ['context'],
+            ['core:element'],
+            ['en:core:action'],
+            ['fr:core:action'],
+        ];
     }
 
     /**
@@ -116,14 +116,14 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerGetCacheKey() {
-        return array(
-            array('lexicon/en/core/user','core','user','en'),
-            array('lexicon/en/core/about','core','about','en'),
-            array('lexicon/fr/core/user','core','user','fr'),
-            array('lexicon/fr/core/about','core','about','fr'),
-            array('lexicon/en/formit/default','formit','default','en'),
-            array('lexicon/de/formit/default','formit','default','de'),
-        );
+        return [
+            ['lexicon/en/core/user','core','user','en'],
+            ['lexicon/en/core/about','core','about','en'],
+            ['lexicon/fr/core/user','core','user','fr'],
+            ['lexicon/fr/core/about','core','about','fr'],
+            ['lexicon/en/formit/default','formit','default','en'],
+            ['lexicon/de/formit/default','formit','default','de'],
+        ];
     }
 
     /**
@@ -140,11 +140,11 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerGetFileTopic() {
-        return array(
-            array('en','core','default'),
-            array('fr','core','default'),
-            array('en','core','action'),
-        );
+        return [
+            ['en','core','default'],
+            ['fr','core','default'],
+            ['en','core','action'],
+        ];
     }
 
     /**
@@ -161,9 +161,9 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerGetNamespacePath() {
-        return array(
-            array('core',''),
-        );
+        return [
+            ['core',''],
+        ];
     }
 
     /**
@@ -180,11 +180,11 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerGetTopicList() {
-        return array(
-            array('en','core'),
-            array('fr','core'),
-            array('de','core'),
-        );
+        return [
+            ['en','core'],
+            ['fr','core'],
+            ['de','core'],
+        ];
     }
 
     /**
@@ -200,9 +200,9 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerGetLanguageList() {
-        return array(
-            array('core'),
-        );
+        return [
+            ['core'],
+        ];
     }
 
     /**
@@ -222,13 +222,13 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerProcess() {
-        return array(
-            array('chunk','chunk',array(),'Chunk'),
-            array('chunk','chunks',array(),'Chunks'),
-            array('chunk','chunk_err_nfs',array('id' => 1),'Chunk not found with id: 1'),
-            array('chunk','chunk_err_nfs',array('id' => 123),'Chunk not found with id: 123'),
-            array('chunk','chunk_err_nfs',array('id' => 'potatoes'),'Chunk not found with id: potatoes'),
-        );
+        return [
+            ['chunk','chunk', [],'Chunk'],
+            ['chunk','chunks', [],'Chunks'],
+            ['chunk','chunk_err_nfs', ['id' => 1],'Chunk not found with id: 1'],
+            ['chunk','chunk_err_nfs', ['id' => 123],'Chunk not found with id: 123'],
+            ['chunk','chunk_err_nfs', ['id' => 'potatoes'],'Chunk not found with id: potatoes'],
+        ];
     }
 
     /**
@@ -247,12 +247,12 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerExists() {
-        return array(
-            array('chunk','chunk_err_nf',true),
-            array('chunk','chunks',true),
-            array('chunk','potatoes',false),
-            array('respect','for_programmers',false),
-        );
+        return [
+            ['chunk','chunk_err_nf',true],
+            ['chunk','chunks',true],
+            ['chunk','potatoes',false],
+            ['respect','for_programmers',false],
+        ];
     }
 
     /**
@@ -274,11 +274,11 @@ class modLexiconTest extends MODxTestCase {
      * @return array
      */
     public function providerFetch() {
-        return array(
-            array('about','help_about'),
-            array('chunk','chunks'),
-            array('element','tv_elements','tv_'),
-            array('element','elements','tv_',true),
-        );
+        return [
+            ['about','help_about'],
+            ['chunk','chunks'],
+            ['element','tv_elements','tv_'],
+            ['element','elements','tv_',true],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Mail/modMailTest.php
+++ b/_build/test/Tests/Model/Mail/modMailTest.php
@@ -33,7 +33,7 @@ class modMailTest extends MODxTestCase {
 
     public function setUp() {
         parent::setUp();
-        $this->mail = $this->getMockForAbstractClass(modMail::class, array(&$this->modx));
+        $this->mail = $this->getMockForAbstractClass(modMail::class, [&$this->modx]);
         $this->mail->expects($this->any())
                    ->method('_getMailer')
                    ->will($this->returnValue(true));
@@ -52,10 +52,10 @@ class modMailTest extends MODxTestCase {
      * @return array
      */
     public function providerSet() {
-        return array(
-            array('mail_use_smtp',true),
-            array('mail_use_smtp',false),
-        );
+        return [
+            ['mail_use_smtp',true],
+            ['mail_use_smtp',false],
+        ];
     }
 
     /**
@@ -73,10 +73,10 @@ class modMailTest extends MODxTestCase {
      * @return array
      */
     public function providerGet() {
-        return array(
-            array('mail_use_smtp',true),
-            array('mail_use_smtp',false),
-        );
+        return [
+            ['mail_use_smtp',true],
+            ['mail_use_smtp',false],
+        ];
     }
 
     /**
@@ -102,10 +102,10 @@ class modMailTest extends MODxTestCase {
      * @return array
      */
     public function providerAttach() {
-        return array(
-            array('test/file.txt'),
-            array(array('tmp_name' => 'test/file.txt','error' => 0,'name' => 'file.txt')),
-        );
+        return [
+            ['test/file.txt'],
+            [['tmp_name' => 'test/file.txt','error' => 0,'name' => 'file.txt']],
+        ];
     }
 
     /**
@@ -131,9 +131,9 @@ class modMailTest extends MODxTestCase {
      * @return array
      */
     public function providerHeader() {
-        return array(
-            array('Content-type:text/html','Content-type','text/html'),
-        );
+        return [
+            ['Content-type:text/html','Content-type','text/html'],
+        ];
     }
 
 }

--- a/_build/test/Tests/Model/Registry/modFileRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modFileRegisterTest.php
@@ -31,7 +31,7 @@ class modFileRegisterTest extends MODxTestCase {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');
-        $modx->registry->addRegister('register', 'registry.modFileRegister', array('directory' => 'register'));
+        $modx->registry->addRegister('register', 'registry.modFileRegister', ['directory' => 'register']);
     }
 
     public static function tearDownAfterClass() {
@@ -60,13 +60,13 @@ class modFileRegisterTest extends MODxTestCase {
         $this->assertTrue(in_array($topic, $this->modx->registry->register->subscriptions), "Could not subscribe to register topic {$topic}");
     }
     public function providerSubscribe() {
-        return array(
-            array('/food'),
-            array('/food/'),
-            array('/beer/'),
-            array('/beer'),
-            array('/food/beer/'),
-        );
+        return [
+            ['/food'],
+            ['/food/'],
+            ['/beer/'],
+            ['/beer'],
+            ['/food/beer/'],
+        ];
     }
 
     /**
@@ -81,12 +81,12 @@ class modFileRegisterTest extends MODxTestCase {
         $this->assertEquals($expected, $this->modx->registry->register->getCurrentTopic(), "Could not set current topic.");
     }
     public function providerSetCurrentTopic() {
-        return array(
-            array('/', ''),
-            array('/food/', 'food'),
-            array('/beer/', '/beer'),
-            array('/food/beer/', '/food/beer/'),
-        );
+        return [
+            ['/', ''],
+            ['/food/', 'food'],
+            ['/beer/', '/beer'],
+            ['/food/beer/', '/food/beer/'],
+        ];
     }
 
     /**
@@ -105,32 +105,32 @@ class modFileRegisterTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Could not send msg(s) to the topic.");
     }
     public function providerSend() {
-        return array(
-            array(
+        return [
+            [
                 true,
                 '/topic1/',
                 '1',
-                array()
-            ),
-            array(
+                []
+            ],
+            [
                 true,
                 '/topic2/',
-                array('1', '2', '3'),
-                array()
-            ),
-            array(
+                ['1', '2', '3'],
+                []
+            ],
+            [
                 true,
                 '/topic3/',
-                array('a' => '1', 'b' => '2', 'c' => '3'),
-                array()
-            ),
-            array(
+                ['a' => '1', 'b' => '2', 'c' => '3'],
+                []
+            ],
+            [
                 true,
                 '/topic4/',
-                array('a' => 1, 'b' => 2.0, 'c' => 3.25, 'd' => 4.1390, 'e' => 5),
-                array()
-            ),
-        );
+                ['a' => 1, 'b' => 2.0, 'c' => 3.25, 'd' => 4.1390, 'e' => 5],
+                []
+            ],
+        ];
     }
 
     /**
@@ -149,66 +149,66 @@ class modFileRegisterTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Could not read msg(s) from topic.");
     }
     public function providerRead() {
-        return array(
-            array(
-                array('1'),
+        return [
+            [
+                ['1'],
                 '/topic1/',
-                array(
+                [
                     'poll_limit' => 1,
-                )
-            ),
-            array(
-                array('1', '2', '3'),
+                ]
+            ],
+            [
+                ['1', '2', '3'],
                 '/topic2/',
-                array(
+                [
                     'poll_limit' => 1,
-                )
-            ),
-            array(
-                array('1', '2', '3'),
+                ]
+            ],
+            [
+                ['1', '2', '3'],
                 '/topic3/',
-                array(
+                [
                     'poll_limit' => 1,
                     'remove_read' => false,
-                )
-            ),
-            array(
-                array('1'),
+                ]
+            ],
+            [
+                ['1'],
                 '/topic3/a',
-                array(
+                [
                     'poll_limit' => 1,
-                )
-            ),
-            array(
-                array('2'),
+                ]
+            ],
+            [
+                ['2'],
                 '/topic3/b',
-                array(
+                [
                     'poll_limit' => 1,
-                )
-            ),
-            array(
-                array('3'),
+                ]
+            ],
+            [
+                ['3'],
                 '/topic3/c',
-                array(
+                [
                     'poll_limit' => 1,
-                )
-            ),
-            array(
-                array('a' => 1, 'b' => 2.0, 'c' => 3.25, 'd' => 4.1390, 'e' => 5),
+                ]
+            ],
+            [
+                ['a' => 1, 'b' => 2.0, 'c' => 3.25, 'd' => 4.1390, 'e' => 5],
                 '/topic4/',
-                array(
+                [
                     'poll_limit' => 1,
                     'remove_read' => false,
                     'include_keys' => true
-                )
-            ),
-            array(
-                array(1, 2.0, 3.25, 4.1390, 5),
+                ]
+            ],
+            [
+                [1, 2.0, 3.25, 4.1390, 5],
                 '/topic4/',
-                array(
+                [
                     'poll_limit' => 1,
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Registry/modMemoryRegister.php
+++ b/_build/test/Tests/Model/Registry/modMemoryRegister.php
@@ -11,7 +11,7 @@ class modMemoryRegister extends modRegister {
      * @param array $options An array of general or protocol specific options.
      * @return mixed The resulting message from the register.
      */
-    public function read(array $options = array()) {
+    public function read(array $options = []) {
         // TODO: Implement read() method.
         return null;
     }
@@ -28,7 +28,7 @@ class modMemoryRegister extends modRegister {
      * specific message properties.
      * @return boolean Indicates if the message was recorded.
      */
-    public function send($topic, $message, array $options = array()) {
+    public function send($topic, $message, array $options = []) {
         // TODO: Implement send() method.
         return true;
     }
@@ -40,7 +40,7 @@ class modMemoryRegister extends modRegister {
      * connection to the register.
      * @return boolean Indicates if the connection was successful.
      */
-    public function connect(array $attributes = array()) {
+    public function connect(array $attributes = []) {
         return true;
     }
 

--- a/_build/test/Tests/Model/Registry/modRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modRegisterTest.php
@@ -31,7 +31,7 @@ class modRegisterTest extends MODxTestCase {
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');
         $modx->loadClass('registry.modRegister', '', false, true);
-        $modx->registry->addRegister('register', modMemoryRegister::class, array('directory' => 'register'));
+        $modx->registry->addRegister('register', modMemoryRegister::class, ['directory' => 'register']);
     }
 
     public static function tearDownAfterClass() {
@@ -60,13 +60,13 @@ class modRegisterTest extends MODxTestCase {
         $this->assertTrue(in_array($topic, $this->modx->registry->register->subscriptions), "Could not subscribe to register topic {$topic}");
     }
     public function providerSubscribe() {
-        return array(
-            array('/food'),
-            array('/food/'),
-            array('/beer/'),
-            array('/beer'),
-            array('/food/beer/'),
-        );
+        return [
+            ['/food'],
+            ['/food/'],
+            ['/beer/'],
+            ['/beer'],
+            ['/food/beer/'],
+        ];
     }
 
     /**
@@ -81,11 +81,11 @@ class modRegisterTest extends MODxTestCase {
         $this->assertEquals($expected, $this->modx->registry->register->getCurrentTopic(), "Could not set current topic.");
     }
     public function providerSetCurrentTopic() {
-        return array(
-            array('/', ''),
-            array('/food/', 'food'),
-            array('/beer/', '/beer'),
-            array('/food/beer/', '/food/beer/'),
-        );
+        return [
+            ['/', ''],
+            ['/food/', 'food'],
+            ['/beer/', '/beer'],
+            ['/food/beer/', '/food/beer/'],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Registry/modRegistryTest.php
+++ b/_build/test/Tests/Model/Registry/modRegistryTest.php
@@ -57,14 +57,14 @@ class modRegistryTest extends MODxTestCase {
         }
     }
     public function providerGetRegister() {
-        return array(
-            array(true, 'testFileRegister', modFileRegister::class, array('directory' => 'testFileRegister')),
-            array(true, 'testFileRegister2', modFileRegister::class, array('directory' => 'testFileRegister2')),
-            array(true, 'testDbRegister', modDbRegister::class, array('directory' => 'testDbRegister')),
-            array(true, 'testDbRegister2', modDbRegister::class, array('directory' => 'testDbRegister2')),
-            array(false, 'testDbRegister3', '\MODX\Revolution\Registry\modDbRegister3', array('directory' => 'testDbRegister3')),
-            array(false, 'modx', modFileRegister::class, array('directory' => 'modx')),
-        );
+        return [
+            [true, 'testFileRegister', modFileRegister::class, ['directory' => 'testFileRegister']],
+            [true, 'testFileRegister2', modFileRegister::class, ['directory' => 'testFileRegister2']],
+            [true, 'testDbRegister', modDbRegister::class, ['directory' => 'testDbRegister']],
+            [true, 'testDbRegister2', modDbRegister::class, ['directory' => 'testDbRegister2']],
+            [false, 'testDbRegister3', '\MODX\Revolution\Registry\modDbRegister3', ['directory' => 'testDbRegister3']],
+            [false, 'modx', modFileRegister::class, ['directory' => 'modx']],
+        ];
     }
 
     /**
@@ -89,14 +89,14 @@ class modRegistryTest extends MODxTestCase {
         }
     }
     public function providerAddRegister() {
-        return array(
-            array(true, 'testFileRegister', modFileRegister::class, array('directory' => 'testFileRegister')),
-            array(true, 'testFileRegister2', modFileRegister::class, array('directory' => 'testFileRegister2')),
-            array(true, 'testDbRegister', modDbRegister::class, array('directory' => 'testDbRegister')),
-            array(true, 'testDbRegister2', modDbRegister::class, array('directory' => 'testDbRegister2')),
-            array(false, 'testDbRegister3', '\MODX\Revolution\Registry\modDbRegister3', array('directory' => 'testDbRegister3')),
-            array(false, 'modx', modFileRegister::class, array('directory' => 'modx')),
-        );
+        return [
+            [true, 'testFileRegister', modFileRegister::class, ['directory' => 'testFileRegister']],
+            [true, 'testFileRegister2', modFileRegister::class, ['directory' => 'testFileRegister2']],
+            [true, 'testDbRegister', modDbRegister::class, ['directory' => 'testDbRegister']],
+            [true, 'testDbRegister2', modDbRegister::class, ['directory' => 'testDbRegister2']],
+            [false, 'testDbRegister3', '\MODX\Revolution\Registry\modDbRegister3', ['directory' => 'testDbRegister3']],
+            [false, 'modx', modFileRegister::class, ['directory' => 'modx']],
+        ];
     }
 
     /**
@@ -110,14 +110,14 @@ class modRegistryTest extends MODxTestCase {
         $this->assertNotInstanceOf(modRegister::class, $this->modx->registry->$name, "Could not remove register with key {$name}");
     }
     public function providerRemoveRegister() {
-        return array(
-            array('testFileRegister'),
-            array('testFileRegister2'),
-            array('testDbRegister'),
-            array('testDbRegister2'),
-            array('testDbRegister3'),
-            array('modx'),
-        );
+        return [
+            ['testFileRegister'],
+            ['testFileRegister2'],
+            ['testDbRegister'],
+            ['testDbRegister2'],
+            ['testDbRegister3'],
+            ['modx'],
+        ];
     }
 
     public function testSetLogging() {

--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -41,13 +41,13 @@ class modRequestTest extends MODxTestCase {
 
         /** @var modAction $action */
         $action = $this->modx->newObject(modAction::class);
-        $action->fromArray(array(
+        $action->fromArray([
             'namespace' => 'unit-test',
             'parent' => 0,
             'controller' => 'index',
             'haslayout' => 1,
             'lang_topics' => '',
-        ));
+        ]);
         $action->save();
 
 
@@ -65,12 +65,12 @@ class modRequestTest extends MODxTestCase {
         parent::tearDown();
 
         /** @var modNamespace $namespace */
-        $namespace = $this->modx->getObject(modNamespace::class,array('name' => 'unit-test'));
+        $namespace = $this->modx->getObject(modNamespace::class, ['name' => 'unit-test']);
         if ($namespace) { $namespace->remove(); }
 
-        $actions = $this->modx->getCollection(modAction::class,array(
+        $actions = $this->modx->getCollection(modAction::class, [
             'namespace' => 'unit-test',
-        ));
+        ]);
         /** @var modAction $action */
         foreach ($actions as $action) {
             $action->remove();
@@ -116,13 +116,13 @@ class modRequestTest extends MODxTestCase {
      * @return array
      */
     public function providerGetResourceMethod() {
-        return array(
-            array('id','id',123),
-            array('id','idx',123,null,'idx'),
-            array('alias','p',2112,'p'),
-            array('alias','q','test.html'),
-            array('alias','page','test.html','page'),
-        );
+        return [
+            ['id','id',123],
+            ['id','idx',123,null,'idx'],
+            ['alias','p',2112,'p'],
+            ['alias','q','test.html'],
+            ['alias','page','test.html','page'],
+        ];
     }
 
     /**
@@ -150,16 +150,16 @@ class modRequestTest extends MODxTestCase {
      * @return array
      */
     public function providerGetResourceIdentifier() {
-        return array(
-            array('test.html','q','test.html','alias'),
-            array('test.html','qz','test.html','alias','qz'),
-            array('','no','test.html','alias'),
-            array(123,'id',123,'id'),
-            array(123,'idx',123,'id',null,'idx'),
-            array('1',null,null,''),
-            array('1','qq','test.html',''),
-            array('1','idx',123,''),
-        );
+        return [
+            ['test.html','q','test.html','alias'],
+            ['test.html','qz','test.html','alias','qz'],
+            ['','no','test.html','alias'],
+            [123,'id',123,'id'],
+            [123,'idx',123,'id',null,'idx'],
+            ['1',null,null,''],
+            ['1','qq','test.html',''],
+            ['1','idx',123,''],
+        ];
     }
 
     /**
@@ -175,7 +175,7 @@ class modRequestTest extends MODxTestCase {
      * @return void
      */
     public function testRetrieveRequest() {
-        if (empty($_SESSION)) $_SESSION = array();
+        if (empty($_SESSION)) $_SESSION = [];
         $_SESSION['modx.request.unit-test'] = $_REQUEST;
         $request = $this->request->retrieveRequest('unit-test');
         $this->assertNotEmpty($request,'modRequest.retrieveRequest did not correctly retrieve the REQUEST data.');
@@ -189,7 +189,7 @@ class modRequestTest extends MODxTestCase {
      * @depends testRetrieveRequest
      */
     public function testPreserveRequest() {
-        if (empty($_SESSION)) $_SESSION = array();
+        if (empty($_SESSION)) $_SESSION = [];
         $this->request->preserveRequest('unit-test');
         $request = $this->request->retrieveRequest('unit-test');
         $this->assertNotEmpty($request,'modRequest.preserveRequest did not correctly preserve the REQUEST data.');
@@ -207,7 +207,7 @@ class modRequestTest extends MODxTestCase {
 //        $this->assertTrue(count($actions) == $total,'The getAllActionIDs method did not get all of the Actions that exist.');
 
         $actions = $this->request->getAllActionIDs('unit-test');
-        $total = $this->modx->getCount(modAction::class,array('namespace' => 'unit-test'));
+        $total = $this->modx->getCount(modAction::class, ['namespace' => 'unit-test']);
         $this->assertTrue(count($actions) == $total,'The getAllActionIDs method did not filter down by namespace when grabbing actions.');
     }
 
@@ -217,17 +217,17 @@ class modRequestTest extends MODxTestCase {
     public function testGetParameters() {
         $parameters = $this->request->getParameters();
         $this->assertEquals(2,$parameters['testGet']);
-        $parameters = $this->request->getParameters(array(),'POST');
+        $parameters = $this->request->getParameters([],'POST');
         $this->assertEquals(1,$parameters['testPost']);
-        $parameters = $this->request->getParameters(array(),'COOKIE');
+        $parameters = $this->request->getParameters([],'COOKIE');
         $this->assertEquals(3,$parameters['testCookie']);
-        $parameters = $this->request->getParameters(array(),'REQUEST');
+        $parameters = $this->request->getParameters([],'REQUEST');
         $this->assertEquals(4,$parameters['testRequest']);
 
-        $parameters = $this->request->getParameters(array('testRequest'),'REQUEST');
+        $parameters = $this->request->getParameters(['testRequest'],'REQUEST');
         $this->assertEquals(4,$parameters['testRequest']);
 
-        $parameters = $this->request->getParameters(array('testShouldNotExist'),'REQUEST');
+        $parameters = $this->request->getParameters(['testShouldNotExist'],'REQUEST');
         $this->assertEmpty($parameters);
     }
 
@@ -250,19 +250,19 @@ class modRequestTest extends MODxTestCase {
      * @return array
      */
     public function providerGetClientIp() {
-        return array(
-            array('123.45.67.100','REMOTE_ADDR'),
-            array('123.45.67.100','HTTP_X_FORWARDED_FOR'),
-            array('123.45.67.100','HTTP_X_FORWARDED'),
-            array('123.45.67.100','HTTP_X_CLUSTER_CLIENT_IP'),
-            array('123.45.67.100','HTTP_X_COMING_FROM'),
-            array('123.45.67.100','HTTP_FORWARDED_FOR'),
-            array('123.45.67.100','HTTP_FORWARDED'),
-            array('123.45.67.100','HTTP_COMING_FROM'),
-            array('123.45.67.100','HTTP_CLIENT_IP'),
-            array('123.45.67.100','HTTP_FROM'),
-            array('123.45.67.100','HTTP_VIA'),
-        );
+        return [
+            ['123.45.67.100','REMOTE_ADDR'],
+            ['123.45.67.100','HTTP_X_FORWARDED_FOR'],
+            ['123.45.67.100','HTTP_X_FORWARDED'],
+            ['123.45.67.100','HTTP_X_CLUSTER_CLIENT_IP'],
+            ['123.45.67.100','HTTP_X_COMING_FROM'],
+            ['123.45.67.100','HTTP_FORWARDED_FOR'],
+            ['123.45.67.100','HTTP_FORWARDED'],
+            ['123.45.67.100','HTTP_COMING_FROM'],
+            ['123.45.67.100','HTTP_CLIENT_IP'],
+            ['123.45.67.100','HTTP_FROM'],
+            ['123.45.67.100','HTTP_VIA'],
+        ];
     }
 
     /**
@@ -286,12 +286,12 @@ class modRequestTest extends MODxTestCase {
      * @return array
      */
     public function providerCleanResourceIdentifier() {
-        return array(
-            array('test.html','alias',true),
-            array('the-cake-is-a-lie.png','alias',true),
-            array('fail.html','id',false),
-            array('','id'),
-        );
+        return [
+            ['test.html','alias',true],
+            ['the-cake-is-a-lie.png','alias',true],
+            ['fail.html','id',false],
+            ['','id'],
+        ];
     }
 
     /**
@@ -315,15 +315,17 @@ class modRequestTest extends MODxTestCase {
      * @return array
      */
     public function providerSanitizeRequest() {
-        return array(
-            array('A test string','A test string'),
-            array('MODX [[fakeSnippet]] Tags','MODX  Tags'),
-            array("MODX [[\$chunk? &property=`test`\n &across=`lines
+        return [
+            ['A test string','A test string'],
+            ['MODX [[fakeSnippet]] Tags','MODX  Tags'],
+            [
+                "MODX [[\$chunk? &property=`test`\n &across=`lines
 
-` &test=1]] Tags",'MODX  Tags'),
-            array('Javascript! <script>alert(\'test\');</script> Yay.','Javascript!  Yay.'),
-            array("Javascript line break! <script>alert('test');\n</script>Yay.","Javascript line break! Yay."),
-            array('Testing entities &#123;kthx','Testing entities kthx'),
-        );
+` &test=1]] Tags",'MODX  Tags'
+            ],
+            ['Javascript! <script>alert(\'test\');</script> Yay.','Javascript!  Yay.'],
+            ["Javascript line break! <script>alert('test');\n</script>Yay.","Javascript line break! Yay."],
+            ['Testing entities &#123;kthx','Testing entities kthx'],
+        ];
     }
 }

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -31,7 +31,7 @@ class modUserTest extends MODxTestCase {
     public function setUp() {
         parent::setUp();
         $this->user = $this->modx->newObject(modUser::class);
-        $this->user->fromArray(array(
+        $this->user->fromArray([
             'id' => 123456,
             'username' => 'unit-test-user',
             'password' => md5('boogles'),
@@ -39,11 +39,11 @@ class modUserTest extends MODxTestCase {
             'class_key' => 'modUser',
             'active' => true,
             'remote_key' => '',
-            'remote_data' => array(),
+            'remote_data' => [],
             'hash_class' => 'hashing.modMD5',
             'salt' => '',
             'primary_group' => 1,
-        ),'',true,true);
+        ],'',true,true);
     }
 
     /**
@@ -63,10 +63,10 @@ class modUserTest extends MODxTestCase {
      * @return array
      */
     public function providerSet() {
-        return array(
-            array('password','boogie',md5('boogie')),
-            array('cachepwd','boogie',md5('boogie')),
-        );
+        return [
+            ['password','boogie',md5('boogie')],
+            ['cachepwd','boogie',md5('boogie')],
+        ];
     }
 
     /**
@@ -84,7 +84,7 @@ class modUserTest extends MODxTestCase {
      * @param array $options
      * @dataProvider providerGeneratePassword
      */
-    public function testGeneratePassword($length,array $options = array()) {
+    public function testGeneratePassword($length,array $options = []) {
         $password = $this->user->generatePassword($length,$options);
         $this->assertNotEmpty($password);
         $this->assertEquals($length,strlen($password));
@@ -93,10 +93,10 @@ class modUserTest extends MODxTestCase {
      * @return array
      */
     public function providerGeneratePassword() {
-        return array(
-            array(10),
-            array(8),
-        );
+        return [
+            [10],
+            [8],
+        ];
     }
 
     public function testGeneratePasswordWithPasswordLengthOption()

--- a/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
@@ -34,12 +34,12 @@ class modFileMediaSourceTest extends MODxTestCase {
         parent::setUp();
 
         $this->source = $this->modx->newObject(modFileMediaSource::class);
-        $this->source->fromArray(array(
+        $this->source->fromArray([
             'name' => 'UnitTestFileSource',
             'description' => '',
             'class_key' => modFileMediaSource::class,
-            'properties' => array(),
-        ),'',true);
+            'properties' => [],
+        ],'',true);
     }
     public function tearDown() {
         parent::tearDown();

--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -33,12 +33,12 @@ class modMediaSourceTest extends MODxTestCase {
         parent::setUp();
 
         $this->source = $this->modx->newObject(modMediaSource::class);
-        $this->source->fromArray(array(
+        $this->source->fromArray([
             'name' => 'UnitTestSource',
             'description' => '',
             'class_key' => modFileMediaSource::class,
-            'properties' => array(),
-        ),'',true);
+            'properties' => [],
+        ],'',true);
     }
     public function tearDown() {
         parent::tearDown();

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -25,11 +25,11 @@ use MODX\Revolution\MODxTestHarness;
  * @group modParser
  */
 class modParserTest extends MODxTestCase {
-    public static $scope = array();
+    public static $scope = [];
 
     public static function setUpBeforeClass() {
         $modx = MODxTestHarness::getFixture(modX::class, 'modx', true);
-        $placeholders = array('tag' => 'Tag', 'tag1' => 'Tag1', 'tag2' => 'Tag2');
+        $placeholders = ['tag' => 'Tag', 'tag1' => 'Tag1', 'tag2' => 'Tag2'];
         self::$scope = $modx->toPlaceholders($placeholders, '', '.', true);
     }
 
@@ -53,7 +53,7 @@ class modParserTest extends MODxTestCase {
      * @param $expected
      */
     public function testCollectElementTags($input, $prefix, $suffix, $expectedMatches, $expectedCount) {
-        $matches = array();
+        $matches = [];
         $tagCount = $this->modx->parser->collectElementTags($input, $matches, $prefix, $suffix);
         $this->assertEquals($expectedMatches, $matches, "Did not collect expected tags.");
         $this->assertEquals($expectedCount, $tagCount, "Did not collect expected number of tags.");
@@ -62,29 +62,35 @@ class modParserTest extends MODxTestCase {
      * dataProvider for testCollectElementTags
      */
     public function providerCollectElementTags() {
-        return array(
-            array("", '[[', ']]', array(), 0),
-            array("[[tag]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
-            array("<title>[[*pagetitle]] - [[++site_name]]</title><body>[something]</body>", '[[', ']]', array(array("[[*pagetitle]]", "*pagetitle"), array("[[++site_name]]", "++site_name")), 2),
-            array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', array(array("[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", "[[*field:is=`0`:then=`Tag`:else=`Tag`]]")), 1),
-            array("[[!+fi.successMessage:empty=`
+        return [
+            ["", '[[', ']]', [], 0],
+            ["[[tag]]", '[[', ']]', [["[[tag]]", "tag"]], 1],
+            ["<title>[[*pagetitle]] - [[++site_name]]</title><body>[something]</body>", '[[', ']]', [["[[*pagetitle]]", "*pagetitle"], ["[[++site_name]]", "++site_name"]], 2],
+            ["[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", '[[', ']]', [["[[[[*field:is=`0`:then=`Tag`:else=`Tag`]]]]", "[[*field:is=`0`:then=`Tag`:else=`Tag`]]"]], 1],
+            [
+                "[[!+fi.successMessage:empty=`
     test[]
 	[[~[[*id]]]]
-`]]", '[[', ']]', array(array("[[!+fi.successMessage:empty=`
+`]]", '[[', ']]', [
+                [
+                    "[[!+fi.successMessage:empty=`
     test[]
 	[[~[[*id]]]]
 `]]", "!+fi.successMessage:empty=`
     test[]
 	[[~[[*id]]]]
-`")), 1),
-            array("items[[[tag]]]", '[[', ']]', array(array("[[tag]]", "tag")), 1),
-            array("[[tag]][[tag2]]", '[[', ']]', array(array("[[tag]]", "tag"), array("[[tag2]]", "tag2")), 2),
-            array("[[tag[[tag2]]]]", '[[', ']]', array(array("[[tag[[tag2]]]]", "tag[[tag2]]")), 1),
-            array("[[tag[[tag2[[tag3]]]]]]", '[[', ']]', array(array("[[tag[[tag2[[tag3]]]]]]", "tag[[tag2[[tag3]]]]")), 1),
-            array("[[tag\n?food=`beer`\n[[tag2]]]]", '[[', ']]', array(array("[[tag\n?food=`beer`\n[[tag2]]]]", "tag\n?food=`beer`\n[[tag2]]")), 1),
-            array("\n[[ tag? &food=`beer` [[tag2]][[tag3]]]]", '[[', ']]', array(array("[[ tag? &food=`beer` [[tag2]][[tag3]]]]", " tag? &food=`beer` [[tag2]][[tag3]]")), 1),
+`"
+                ]
+            ], 1
+            ],
+            ["items[[[tag]]]", '[[', ']]', [["[[tag]]", "tag"]], 1],
+            ["[[tag]][[tag2]]", '[[', ']]', [["[[tag]]", "tag"], ["[[tag2]]", "tag2"]], 2],
+            ["[[tag[[tag2]]]]", '[[', ']]', [["[[tag[[tag2]]]]", "tag[[tag2]]"]], 1],
+            ["[[tag[[tag2[[tag3]]]]]]", '[[', ']]', [["[[tag[[tag2[[tag3]]]]]]", "tag[[tag2[[tag3]]]]"]], 1],
+            ["[[tag\n?food=`beer`\n[[tag2]]]]", '[[', ']]', [["[[tag\n?food=`beer`\n[[tag2]]]]", "tag\n?food=`beer`\n[[tag2]]"]], 1],
+            ["\n[[ tag? &food=`beer` [[tag2]][[tag3]]]]", '[[', ']]', [["[[ tag? &food=`beer` [[tag2]][[tag3]]]]", " tag? &food=`beer` [[tag2]][[tag3]]"]], 1],
             /*array("\n[[ tag? <![CDATA[Some CDATA content]]> &food=`beer` [[tag2]][[tag3]]]]", '[[', ']]', array(array("[[ tag? <![CDATA[Some CDATA content]]> &food=`beer` [[tag2]][[tag3]]]]", " tag? <![CDATA[Some CDATA content]]> &food=`beer` [[tag2]][[tag3]]")), 1),*/
-        );
+        ];
     }
 
     /**
@@ -106,226 +112,226 @@ class modParserTest extends MODxTestCase {
             $params['tokens'],
             $params['depth']
         );
-        $actual = array(
+        $actual = [
             'processed' => $processed,
             'content' => $content
-        );
+        ];
         $this->assertEquals($expected, $actual, "Did not get expected results from tag parsing.");
     }
     /**
      * dataProvider for testProcessElementTags.
      */
     public function providerProcessElementTags() {
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     'processed' => 0,
                     'content' => ""
-                ),
+                ],
                 "",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => false,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 0,
                     'content' => "[[!doNotCacheMe]]"
-                ),
+                ],
                 "[[!doNotCacheMe]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => false,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 0,
                     'content' => "[[!doNotCacheMe? &but=`[[youCanCacheMe]]`]]"
-                ),
+                ],
                 "[[!doNotCacheMe? &but=`[[youCanCacheMe]]`]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => false,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 0,
                     'content' => "[[!doNotCacheMe]]"
-                ),
+                ],
                 "[[!doNotCacheMe]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => true,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 1,
                     'content' => ""
-                ),
+                ],
                 "[[!doNotCacheMe]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => true,
                     'removeUnprocessed' => true,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 0,
                     'content' => "[[!doNotCacheMe? &but=`[[youCanCacheMe]]`]]"
-                ),
+                ],
                 "[[!doNotCacheMe? &but=`[[youCanCacheMe]]`]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => false,
                     'removeUnprocessed' => true,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 1,
                     'content' => ""
-                ),
+                ],
                 "[[!doNotCacheMe? &but=`[[youCanCacheMe]]`]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => true,
                     'removeUnprocessed' => true,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 1,
                     'content' => "[[!doNotCacheMe? &but=`Tag`]]"
-                ),
+                ],
                 "[[!doNotCacheMe? &but=`[[+tag]]`]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => false,
                     'removeUnprocessed' => true,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 2,
                     'content' => "[[!doNotCacheMe? &but=`Tag`]]Tag2"
-                ),
+                ],
                 "[[!doNotCacheMe? &but=`[[+tag]]`]][[+tag2]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => false,
                     'removeUnprocessed' => true,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 2,
                     'content' => "[[!+tag1? &but=`Tag`]]Tag2[[!+tag1]]"
-                ),
+                ],
                 "[[!+tag1? &but=`[[+tag]]`]][[+tag2]][[!+tag1]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => false,
                     'removeUnprocessed' => true,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 3,
                     'content' => "Tag1Tag2Tag1"
-                ),
+                ],
                 "[[!+tag1? &but=`[[+tag]]`]][[+tag2]][[!+tag1]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => true,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 3,
                     'content' => "[[+notATag? &but=`Tag`]]Tag2Tag1"
-                ),
+                ],
                 "[[+notATag? &but=`[[+tag]]`]][[+tag2]][[!+tag1]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => true,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-            array(
-                array(
+                ]
+            ],
+            [
+                [
                     'processed' => 3,
                     'content' => "[[+notATag? &but=`Tag2`]]Tag2Tag1"
-                ),
+                ],
                 "[[+notATag? &but=`[[+tag2]]`]][[+tag2]][[!+tag1]]",
-                array(
+                [
                     'parentTag' => '',
                     'processUncacheable' => true,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',
-                    'tokens' => array(),
+                    'tokens' => [],
                     'depth' => 0
-                )
-            ),
-        );
+                ]
+            ],
+        ];
     }
 
     /**
@@ -342,103 +348,103 @@ class modParserTest extends MODxTestCase {
         $this->assertEquals($expected, $actual, "Property string not parsed properly");
     }
     public function providerParsePropertyString() {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 "",
                 false
-            ),
-            array(
-                array(
-                    'property' => array(
+            ],
+            [
+                [
+                    'property' => [
                         'name' => 'property',
                         'desc' => '',
                         'type' => 'textfield',
-                        'options' => array(),
+                        'options' => [],
                         'value' => 'value'
-                    )
-                ),
+                    ]
+                ],
                 "&property=value",
                 false
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value'
-                ),
+                ],
                 "&property=value",
                 true
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value'
-                ),
+                ],
                 " &property=value ",
                 true
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value',
                     'property2' => 'value2',
-                ),
+                ],
                 " &property=value &property2=value2 ",
                 true
-            ),
-            array(
-                array(
-                    'property' => array(
+            ],
+            [
+                [
+                    'property' => [
                         'name' => 'property',
                         'desc' => '',
                         'type' => 'textfield',
-                        'options' => array(),
+                        'options' => [],
                         'value' => 'value'
-                    ),
-                    'property2' => array(
+                    ],
+                    'property2' => [
                         'name' => 'property2',
                         'desc' => '',
                         'type' => 'textfield',
-                        'options' => array(),
+                        'options' => [],
                         'value' => 'value2'
-                    ),
-                ),
+                    ],
+                ],
                 " &property=value &property2=value2 ",
                 false
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value&value=value',
-                ),
+                ],
                 "property=`value&value=value`",
                 true
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value? &value=`value` ',
-                ),
+                ],
                 "property=`value? &value=`value` `",
                 true
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value? &value=`value`',
-                ),
+                ],
                 "property=`value? &value=``value```",
                 true
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value with ` nested backticks',
-                ),
+                ],
                 " &property=`value with `` nested backticks`",
                 true
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'property' => 'value with nested backticks`',
-                ),
+                ],
                 " &property=`value with nested backticks```",
                 true
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -456,19 +462,19 @@ class modParserTest extends MODxTestCase {
      * dataProvider for testRealname.
      */
     public function providerTestRealname() {
-        return array(
-            array("", ""),
-            array("name", "name"),
-            array("name", "name:"),
-            array("name", "name:filter"),
-            array("name", "name@propset:filter"),
-            array("name", "name@propset:filter=`name@propset:filter`"),
-        );
+        return [
+            ["", ""],
+            ["name", "name"],
+            ["name", "name:"],
+            ["name", "name:filter"],
+            ["name", "name@propset:filter"],
+            ["name", "name@propset:filter=`name@propset:filter`"],
+        ];
     }
 
     public function testDefaultNonExistingTvValue() {
         $output = "[[*foo:default=`bar`]]";
-        $this->modx->parser->processElementTags('', $output, true, false, '[[', ']]', array(), 10);
+        $this->modx->parser->processElementTags('', $output, true, false, '[[', ']]', [], 10);
         $this->assertEquals($output, "bar", "Did not parse non-existing TV with default modifier correctly");
 
     }

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -53,33 +53,33 @@ class modXTest extends MODxTestCase
          *                                   └──18 SubCategory
          *                                      └──19 SubCategory
          */
-        $this->modx->resourceMap = array(
-            0 => array(1, 2, 6),
-            2 => array(3),
-            3 => array(4),
-            4 => array(5),
-            6 => array(7),
-            7 => array(8),
-            8 => array(9),
-            9 => array(10),
-            10 => array(11),
-            11 => array(12),
-            12 => array(13),
-            13 => array(14),
-            14 => array(15),
-            15 => array(16),
-            16 => array(17),
-            17 => array(18),
-            18 => array(19)
-        );
+        $this->modx->resourceMap = [
+            0 => [1, 2, 6],
+            2 => [3],
+            3 => [4],
+            4 => [5],
+            6 => [7],
+            7 => [8],
+            8 => [9],
+            9 => [10],
+            10 => [11],
+            11 => [12],
+            12 => [13],
+            13 => [14],
+            14 => [15],
+            15 => [16],
+            16 => [17],
+            17 => [18],
+            18 => [19]
+        ];
 
         $ctx = new stdClass();
-        $ctx->resourceMap = array(
-            21 => array(22),
-            22 => array(23),
-            23 => array(24),
-            24 => array(25)
-        );
+        $ctx->resourceMap = [
+            21 => [22],
+            22 => [23],
+            23 => [24],
+            24 => [25]
+        ];
         $this->modx->contexts['custom'] = $ctx;
     }
 
@@ -87,8 +87,8 @@ class modXTest extends MODxTestCase
 
     public function tearDown() {
         parent::tearDown();
-        $this->modx->placeholders = array();
-        $this->modx->resourceMap = array(array(1));
+        $this->modx->placeholders = [];
+        $this->modx->resourceMap = [[1]];
         unset($this->modx->contexts['custom']);
     }
     /**
@@ -106,8 +106,8 @@ class modXTest extends MODxTestCase
      * @param string $allowedTags
      * @dataProvider providerSanitizeString
      */
-    public function testSanitizeString($expected,$string,$chars = array('/',"'",'"','(',')',';','>','<'),$allowedTags = '') {
-        if ($chars == null) $chars = array('/',"'",'"','(',')',';','>','<');
+    public function testSanitizeString($expected,$string,$chars = ['/',"'",'"','(',')',';','>','<'],$allowedTags = '') {
+        if ($chars == null) $chars = ['/',"'",'"','(',')',';','>','<'];
         if ($allowedTags == null) $allowedTags = '';
 
         $result = $this->modx->sanitizeString($string,$chars,$allowedTags);
@@ -117,10 +117,10 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerSanitizeString() {
-        return array(
-            array('test','test'),
-            array('Get this','Get (this)'),
-        );
+        return [
+            ['test','test'],
+            ['Get this','Get (this)'],
+        ];
     }
 
     /**
@@ -136,13 +136,13 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerToQueryString() {
-        return array(
-            array(array('r' => 1),'r=1'),
-            array(array('r' => 1,'s' => 2),'r=1&s=2'),
-            array(array('r' => 1,'s' => 2,'t'),'r=1&s=2&0=t'),
-            array(array('z' => 'Test space'),'z=Test+space'),
-            array(array('a' => 'test/slash'),'a=test%2Fslash'),
-        );
+        return [
+            [['r' => 1],'r=1'],
+            [['r' => 1,'s' => 2],'r=1&s=2'],
+            [['r' => 1,'s' => 2,'t'],'r=1&s=2&0=t'],
+            [['z' => 'Test space'],'z=Test+space'],
+            [['a' => 'test/slash'],'a=test%2Fslash'],
+        ];
     }
 
     /**
@@ -161,10 +161,10 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerSetDebug() {
-        return array(
-            array(true),
-            array(false),
-        );
+        return [
+            [true],
+            [false],
+        ];
     }
 
     /**
@@ -189,10 +189,10 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerSetPlaceholder() {
-        return array(
-            array('name', 'Joe'),
-            array('testArray', array('one' => 1,'two' => 2)),
-        );
+        return [
+            ['name', 'Joe'],
+            ['testArray', ['one' => 1,'two' => 2]],
+        ];
     }
 
     /**
@@ -210,10 +210,10 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerSetPlaceholders() {
-        return array(
-            array(array('one' => 1,'two' => 2),'two',2),
-            array(array('one' => 1,'two' => 2),'test.two',2,'test.'),
-        );
+        return [
+            [['one' => 1,'two' => 2],'two',2],
+            [['one' => 1,'two' => 2],'test.two',2,'test.'],
+        ];
     }
 
     /**
@@ -233,11 +233,11 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerToPlaceholders() {
-        return array(
-            array(array('one' => 1,'two' => 2),'two',2),
-            array(array('one' => 1,'two' => 2),'test.two',2,'test'),
-            array(array('one' => 1,'two' => 2),'test-two',2,'test','-'),
-        );
+        return [
+            [['one' => 1,'two' => 2],'two',2],
+            [['one' => 1,'two' => 2],'test.two',2,'test'],
+            [['one' => 1,'two' => 2],'test-two',2,'test','-'],
+        ];
     }
 
     /**
@@ -257,11 +257,11 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerToPlaceholder() {
-        return array(
-            array('two',2,'two'),
-            array('two',2,'test.two','test'),
-            array('two',2,'test-two','test','-'),
-        );
+        return [
+            ['two',2,'two'],
+            ['two',2,'test.two','test'],
+            ['two',2,'test-two','test','-'],
+        ];
     }
 
     /**
@@ -278,11 +278,11 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerGetPlaceholder() {
-        return array(
-            array('test','one'),
-            array('one',array('two' => 2)),
-            array('123',456),
-        );
+        return [
+            ['test','one'],
+            ['one', ['two' => 2]],
+            ['123',456],
+        ];
     }
 
     /**
@@ -299,11 +299,11 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerUnsetPlaceholder() {
-        return array(
-            array('test','one'),
-            array('one',array('two' => 2)),
-            array(3,534),
-        );
+        return [
+            ['test','one'],
+            ['one', ['two' => 2]],
+            [3,534],
+        ];
     }
 
     /**
@@ -321,10 +321,10 @@ class modXTest extends MODxTestCase
      * @return array
      */
     public function providerUnsetPlaceholders() {
-        return array(
-            array(array('test' => 'testing'),array('test'),'test'),
-            array(array('test' => 'testing','one' => 1),array('one'),'one'),
-        );
+        return [
+            [['test' => 'testing'], ['test'],'test'],
+            [['test' => 'testing','one' => 1], ['one'],'one'],
+        ];
     }
 
     /**
@@ -336,19 +336,19 @@ class modXTest extends MODxTestCase
      */
     public function testGetTree($start, $depth, array $options, array $result)
     {
-        $tree = $this->modx->getTree($start, is_null($depth) ? 10 : $depth, $options ?: array());
+        $tree = $this->modx->getTree($start, is_null($depth) ? 10 : $depth, $options ?: []);
         $this->assertEquals($result, $tree);
     }
 
     public function providerGetTree()
     {
-        return array(
-            array(0, 0, array(), array(1 => 1, 2 => 2, 6 => 6)),
-            array(0, 1, array(), array(1 => 1, 2 => array(3 => 3), 6 => array(7 => 7))),
-            array(7, 5, array(), array(8 => array(9 => array(10 => array(11 => array(12 => array(13 => 13))))))),
-            array(6, null, array(), array(7 => array(8 => array(9 => array(10 => array(11 => array(12 => array(13 => array(14 => array(15 => array(16 => array(17 => 17)))))))))))),
-            array(21, 3, array('context' => 'custom'), array(22 => array(23 => array(24 => array(25 => 25)))))
-        );
+        return [
+            [0, 0, [], [1 => 1, 2 => 2, 6 => 6]],
+            [0, 1, [], [1 => 1, 2 => [3 => 3], 6 => [7 => 7]]],
+            [7, 5, [], [8 => [9 => [10 => [11 => [12 => [13 => 13]]]]]]],
+            [6, null, [], [7 => [8 => [9 => [10 => [11 => [12 => [13 => [14 => [15 => [16 => [17 => 17]]]]]]]]]]]],
+            [21, 3, ['context' => 'custom'], [22 => [23 => [24 => [25 => 25]]]]]
+        ];
     }
 
     /**
@@ -366,12 +366,12 @@ class modXTest extends MODxTestCase
 
     public function providerGetChildIds()
     {
-        return array(
-            array(0, 0, array(), array()),
-            array(0, 1, array(), array(1, 2, 6)),
-            array(6, 5, array(), array(7, 8, 9, 10, 11)),
-            array(6, null, array(), array(7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
-            array(22, 2, array('context' => 'custom'), array(23, 24))
-        );
+        return [
+            [0, 0, [], []],
+            [0, 1, [], [1, 2, 6]],
+            [6, 5, [], [7, 8, 9, 10, 11]],
+            [6, null, [], [7, 8, 9, 10, 11, 12, 13, 14, 15, 16]],
+            [22, 2, ['context' => 'custom'], [23, 24]]
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -58,9 +58,9 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
             return;
         }
 
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'name' => $dir,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '. Create::class .' processor');
         }
@@ -72,10 +72,10 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerCreateDirectory() {
-        return array(
-            array('assets/test2'),
-            array('assets/test3'),
-        );
+        return [
+            ['assets/test2'],
+            ['assets/test3'],
+        ];
     }
 
     /**
@@ -101,10 +101,10 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
             $this->fail('Old directory could not be created for test: '.$adir);
         }
 
-        $result = $this->modx->runProcessor(Update::class,array(
+        $result = $this->modx->runProcessor(Update::class, [
             'dir' => $oldDirectory,
             'name' => $this->modx->getOption('base_path').$newDirectory,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Update::class.' processor');
         }
@@ -116,9 +116,9 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerUpdateDirectory() {
-        return array(
-            array('assets/test3/','assets/test4'),
-        );
+        return [
+            ['assets/test3/','assets/test4'],
+        ];
     }
 
     /**
@@ -141,9 +141,9 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
             $this->fail('Old directory could not be created for test: '.$adir);
         }
 
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'dir' => $dir,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -155,10 +155,10 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerRemoveDirectory() {
-        return array(
-            array('assets/test2'),
-            array('assets/test4'),
-        );
+        return [
+            ['assets/test2'],
+            ['assets/test4'],
+        ];
     }
 
     /**
@@ -170,9 +170,9 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
      */
     public function testGetDirectoryList($dir,$shouldWork = true) {
         /** @var ProcessorResponse $response */
-        $response = $this->modx->runProcessor(GetList::class,array(
+        $response = $this->modx->runProcessor(GetList::class, [
             'id' => $dir,
-        ));
+        ]);
         if (empty($response)) {
             $this->fail('Could not load '.GetList::class.' processor');
         }
@@ -191,10 +191,10 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerGetDirectoryList() {
-        return array(
-            array('manager/',true),
-            array('manager/assets',true),
-            array('fakedirectory/',false),
-        );
+        return [
+            ['manager/',true],
+            ['manager/assets',true],
+            ['fakedirectory/',false],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Browser/FileTest.php
+++ b/_build/test/Tests/Processors/Browser/FileTest.php
@@ -49,8 +49,8 @@ class BrowserFileProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerGet() {
-        return array(
-            array('manager/index.php'),
-        );
+        return [
+            ['manager/index.php'],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Context/ContextSettingTest.php
+++ b/_build/test/Tests/Processors/Context/ContextSettingTest.php
@@ -46,9 +46,9 @@ class ContextSettingProcessorsTest extends MODxTestCase {
         $ctx = $this->modx->getObject(modContext::class,'unittest');
         if ($ctx) $ctx->remove();
 
-        $settings = $this->modx->getCollection(modContextSetting::class,array(
+        $settings = $this->modx->getCollection(modContextSetting::class, [
             'context_key' => 'unittest',
-        ));
+        ]);
         /** @var modContextSetting $setting */
         foreach ($settings as $setting) {
             $setting->remove();
@@ -85,8 +85,8 @@ class ContextSettingProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextSettingCreate() {
-        return array(
-            array('unittest','unittest_setting',''),
-        );
+        return [
+            ['unittest','unittest_setting',''],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Context/ContextTest.php
+++ b/_build/test/Tests/Processors/Context/ContextTest.php
@@ -37,9 +37,9 @@ class ContextProcessorsTest extends MODxTestCase {
         parent::setUp();
         /** @var modContext $ctx */
         $ctx = $this->modx->newObject(modContext::class);
-        $ctx->fromArray(array(
+        $ctx->fromArray([
             'key' => 'unittest',
-        ),'',true,true);
+        ],'',true,true);
         $ctx->save();
 
         $ctx = $this->modx->newObject(modContext::class);
@@ -50,9 +50,9 @@ class ContextProcessorsTest extends MODxTestCase {
 
     public function tearDown() {
         parent::tearDown();
-        $contexts = $this->modx->getCollection(modContext::class,array(
+        $contexts = $this->modx->getCollection(modContext::class, [
             'key:LIKE' => '%unittest%'
-        ));
+        ]);
         /** @var modContext $ctx */
         foreach ($contexts as $ctx) {
             $ctx->remove();
@@ -69,10 +69,10 @@ class ContextProcessorsTest extends MODxTestCase {
     public function testContextCreate($ctx,$description = '') {
         if (empty($ctx)) return;
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'key' => $ctx,
             'description' => $description,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.'processor');
         }
@@ -85,9 +85,9 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextCreate() {
-        return array(
-            array('unittest4','Our unit testing context.'),
-        );
+        return [
+            ['unittest4','Our unit testing context.'],
+        ];
     }
 
     /**
@@ -104,11 +104,11 @@ class ContextProcessorsTest extends MODxTestCase {
         $this->assertTrue(true); return true;
         if (empty($ctx)) return;
 
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'key' => $ctx,
-        ));
+        ]);
         $s = $this->checkForSuccess($result);
-        $ct = !in_array($ctx,array('mgr','web')) ? $this->modx->getCount(modContext::class,$ctx) : 0;
+        $ct = !in_array($ctx, ['mgr','web']) ? $this->modx->getCount(modContext::class,$ctx) : 0;
         $success = $s == false && $ct == 0;
         $this->assertTrue($success,'Was able to create an invalid context: `'.$ctx.'`: '.$result->getMessage());
         return $success;
@@ -118,10 +118,10 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextCreateInvalid() {
-        return array(
-            array('mgr'),
-            array('_12test'),
-        );
+        return [
+            ['mgr'],
+            ['_12test'],
+        ];
     }
 
     /**
@@ -135,12 +135,12 @@ class ContextProcessorsTest extends MODxTestCase {
     public function testContextDuplicate($ctx,$newKey) {
         if (empty($ctx) || empty($newKey)) return false;
 
-        $result = $this->modx->runProcessor(Duplicate::class,array(
+        $result = $this->modx->runProcessor(Duplicate::class, [
             'key' => $ctx,
             'newkey' => $newKey,
-        ));
+        ]);
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getCount(modContext::class,array('key' => $ctx));
+        $ct = $this->modx->getCount(modContext::class, ['key' => $ctx]);
         $success = $s && $ct > 0;
         $this->assertTrue($success,'Could not duplicate context: `'.$ctx.'` to key `'.$newKey.'`: '.$result->getMessage().' : '.implode(',',$result->getFieldErrors()));
         return $success;
@@ -150,9 +150,9 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextDuplicate() {
-        return array(
-            array('unittest','unittestCopy'),
-        );
+        return [
+            ['unittest','unittestCopy'],
+        ];
     }
 
     /**
@@ -168,10 +168,10 @@ class ContextProcessorsTest extends MODxTestCase {
         if (empty($ctx)) return;
 
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Update::class,array(
+        $result = $this->modx->runProcessor(Update::class, [
             'key' => $ctx,
             'description' => $description,
-        ));
+        ]);
         $s = $this->checkForSuccess($result);
         $r = $result->getObject();
         $match = !empty($r) && $r['description'] == 'Changing the description of our test context.';
@@ -183,9 +183,9 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextUpdate() {
-        return array(
-            array('unittest','Changing the description of our test context.'),
-        );
+        return [
+            ['unittest','Changing the description of our test context.'],
+        ];
     }
 
     /**
@@ -201,9 +201,9 @@ class ContextProcessorsTest extends MODxTestCase {
         if (empty($ctx)) return false;
 
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'key' => $ctx,
-        ));
+        ]);
         $s = $this->checkForSuccess($result);
         $r = $result->getObject();
         $match = !empty($r['key']) && $r['key'] == $ctx;
@@ -216,9 +216,9 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextGet() {
-        return array(
-            array('unittest'),
-        );
+        return [
+            ['unittest'],
+        ];
     }
 
 
@@ -234,9 +234,9 @@ class ContextProcessorsTest extends MODxTestCase {
         if (empty($ctx)) return false;
 
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'key' => $ctx,
-        ));
+        ]);
         $s = $this->checkForSuccess($result);
         $r = $result->getObject();
         $match = empty($r);
@@ -249,9 +249,9 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextGetInvalid() {
-        return array(
-            array('unittestdoesntexistatall'),
-        );
+        return [
+            ['unittestdoesntexistatall'],
+        ];
     }
 
     /**
@@ -266,12 +266,12 @@ class ContextProcessorsTest extends MODxTestCase {
      * @dataProvider providerContextGetList
      */
     public function testContextGetList($sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $this->assertTrue(!empty($results),'Could not get list of contexts: '.$result->getMessage());
     }
@@ -280,9 +280,9 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextGetList() {
-        return array(
-            array('key','ASC',5,0),
-        );
+        return [
+            ['key','ASC',5,0],
+        ];
     }
 
     /**
@@ -309,9 +309,9 @@ class ContextProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerContextRemove() {
-        return array(
-            array('unittest'),
-            array('unittestdupe'),
-        );
+        return [
+            ['unittest'],
+            ['unittestdupe'],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -35,11 +35,11 @@ class CategoryProcessorsTest extends MODxTestCase {
         parent::setUp();
         /** @var modCategory $category */
         $category = $this->modx->newObject(modCategory::class);
-        $category->fromArray(array('category' => 'UnitTestCategory'));
+        $category->fromArray(['category' => 'UnitTestCategory']);
         $category->save();
 
         $category = $this->modx->newObject(modCategory::class);
-        $category->fromArray(array('category' => 'UnitTestCategory2'));
+        $category->fromArray(['category' => 'UnitTestCategory2']);
         $category->save();
     }
 
@@ -49,9 +49,9 @@ class CategoryProcessorsTest extends MODxTestCase {
     public function tearDown() {
         parent::tearDown();
         /** @var modCategory $category */
-        $categories = $this->modx->getCollection(modCategory::class,array(
+        $categories = $this->modx->getCollection(modCategory::class, [
             'category:LIKE' => 'UnitTest%',
-        ));
+        ]);
         foreach ($categories as $category) {
             $category->remove();
         }
@@ -67,14 +67,14 @@ class CategoryProcessorsTest extends MODxTestCase {
      */
     public function testCategoryCreate($shouldPass,$categoryPk) {
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'category' => $categoryPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');
         }
         $s = $this->checkForSuccess($result);
-        $newCategory = $this->modx->getObject(modCategory::class,array('category' => $categoryPk));
+        $newCategory = $this->modx->getObject(modCategory::class, ['category' => $categoryPk]);
         $passed = $s && $newCategory;
         if (!$shouldPass) {
             $passed = !$passed;
@@ -86,12 +86,12 @@ class CategoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerCategoryCreate() {
-        return array(
-            array(true,'UnitTestCat'),
-            array(true,'UnitTestCat2'),
-            array(false,'UnitTestCategory'), /* already exists */
-            array(false,''),
-        );
+        return [
+            [true,'UnitTestCat'],
+            [true,'UnitTestCat2'],
+            [false,'UnitTestCategory'], /* already exists */
+            [false,''],
+        ];
     }
 
     /**
@@ -104,16 +104,16 @@ class CategoryProcessorsTest extends MODxTestCase {
      */
     public function testCategoryGet($shouldPass,$categoryPk) {
         /** @var modCategory $category */
-        $category = $this->modx->getObject(modCategory::class,array('category' => $categoryPk));
+        $category = $this->modx->getObject(modCategory::class, ['category' => $categoryPk]);
         if (empty($category) && $shouldPass) {
             $this->fail('No category found "'.$categoryPk.'" as specified in test provider.');
             return false;
         }
 
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'id' => $category ? $category->get('id') : $categoryPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Get::class.' processor');
         }
@@ -128,11 +128,11 @@ class CategoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerCategoryGet() {
-        return array(
-            array(true,'UnitTestCategory'),
-            array(false,234),
-            array(false,''),
-        );
+        return [
+            [true,'UnitTestCategory'],
+            [false,234],
+            [false,''],
+        ];
     }
 
     /**
@@ -147,12 +147,12 @@ class CategoryProcessorsTest extends MODxTestCase {
      */
     public function testCategoryGetList($shouldPass,$sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $passed = !empty($results);
         $passed = $shouldPass ? $passed : !$passed;
@@ -163,13 +163,13 @@ class CategoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerCategoryGetList() {
-        return array(
-            array(true,'category','ASC',5,0),
-            array(true,'id','ASC',5,0),
-            array(true,'category','DESC',null,0),
-            array(false,'category','ASC',5,7),
-            array(false,'name','ASC',5,0), /* use invalid pk field */
-        );
+        return [
+            [true,'category','ASC',5,0],
+            [true,'id','ASC',5,0],
+            [true,'category','DESC',null,0],
+            [false,'category','ASC',5,7],
+            [false,'name','ASC',5,0], /* use invalid pk field */
+        ];
     }
 
     /**
@@ -182,16 +182,16 @@ class CategoryProcessorsTest extends MODxTestCase {
      */
     public function testCategoryRemove($shouldPass,$categoryPk) {
         /** @var modCategory $category */
-        $category = $this->modx->getObject(modCategory::class,array('category' => $categoryPk));
+        $category = $this->modx->getObject(modCategory::class, ['category' => $categoryPk]);
         if (empty($category) && $shouldPass) {
             $this->fail('No category found "'.$categoryPk.'" as specified in test provider.');
             return false;
         }
 
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'id' => $category ? $category->get('id') : $categoryPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -205,10 +205,10 @@ class CategoryProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerCategoryRemove() {
-        return array(
-            array(true,'UnitTestCategory'),
-            array(false,234),
-            array(false,''),
-        );
+        return [
+            [true,'UnitTestCategory'],
+            [false,234],
+            [false,''],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -39,7 +39,7 @@ class ChunkProcessorsTest extends MODxTestCase {
         $this->modx->lexicon->load('chunk');
         /** @var modChunk $chunk */
         $chunk = $this->modx->newObject(modChunk::class);
-        $chunk->fromArray(array('name' => 'UnitTestChunk'));
+        $chunk->fromArray(['name' => 'UnitTestChunk']);
         $chunk->save();
 
         /** @var modCategory $category */
@@ -54,14 +54,14 @@ class ChunkProcessorsTest extends MODxTestCase {
      */
     public function tearDown() {
         parent::tearDown();
-        $chunks = $this->modx->getCollection(modChunk::class,array('name:LIKE' => '%UnitTest%'));
+        $chunks = $this->modx->getCollection(modChunk::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modChunk $chunk */
         foreach ($chunks as $chunk) {
             $chunk->remove();
         }
 
         /** @var modCategory $category */
-        $category = $this->modx->getObject(modCategory::class,array('category' => 'UnitTestChunks'));
+        $category = $this->modx->getObject(modCategory::class, ['category' => 'UnitTestChunks']);
         if ($category) {
             $category->remove();
         }
@@ -76,14 +76,14 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @param array $properties
      * @dataProvider providerChunkCreate
      */
-    public function testChunkCreate($shouldPass,$chunkPk,array $properties = array()) {
+    public function testChunkCreate($shouldPass,$chunkPk,array $properties = []) {
         $properties['name'] = $chunkPk;
         $result = $this->modx->runProcessor(Create::class,$properties);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');
         }
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getCount(modChunk::class,array('name' => $chunkPk));
+        $ct = $this->modx->getCount(modChunk::class, ['name' => $chunkPk]);
         $passed = $s && $ct > 0;
         $passed = $shouldPass ? $passed : !$passed;
         $this->assertTrue($passed,'Could not create Chunk: `'.$chunkPk.'`: '.$result->getMessage());
@@ -93,25 +93,31 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerChunkCreate() {
-        return array(
+        return [
             /* pass: straight up chunk */
-            array(true,'UnitTestChunk2'),
+            [true,'UnitTestChunk2'],
             /* pass: another chunk with valid other fields */
-            array(true,'UnitTestChunk3',array(
+            [
+                true,'UnitTestChunk3',
+                [
                 'description' => '2nd Unit Testing chunk',
                 'snippet' => '<p>Test</p>',
                 'locked' => false,
                 'category' => 1,
-            )),
+                ]
+            ],
             /* fail: invalid category */
-            array(false,'UnitTestChunk3',array(
+            [
+                false,'UnitTestChunk3',
+                [
                 'category' => 123,
-            )),
+                ]
+            ],
             /* fail: already exists */
-            array(false,'UnitTestChunk'),
+            [false,'UnitTestChunk'],
             /* fail: no data */
-            array(false,''),
-        );
+            [false,''],
+        ];
     }
 
 
@@ -126,7 +132,7 @@ class ChunkProcessorsTest extends MODxTestCase {
      */
     public function testChunkDuplicate($shouldPass,$chunkPk,$newName) {
         /** @var modChunk $chunk */
-        $chunk = $this->modx->getObject(modChunk::class,array('name' => $chunkPk));
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => $chunkPk]);
         if (empty($chunk) && $shouldPass) {
             $this->fail('No Chunk found "'.$chunkPk.'" as specified in test provider.');
             return false;
@@ -134,19 +140,19 @@ class ChunkProcessorsTest extends MODxTestCase {
         $this->modx->lexicon->load('default');
 
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Duplicate::class,array(
+        $result = $this->modx->runProcessor(Duplicate::class, [
             'id' => $chunk ? $chunk->get('id') : $chunkPk,
             'name' => $newName,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Duplicate::class.' processor');
         }
         $s = $this->checkForSuccess($result);
         if (empty($newName) && $chunk) {
-            $newName = $this->modx->lexicon('duplicate_of',array('name' => $chunk->get('name')));
+            $newName = $this->modx->lexicon('duplicate_of', ['name' => $chunk->get('name')]);
         }
         /** @var modChunk $ct */
-        $ct = $this->modx->getObject(modChunk::class,array('name' => $newName));
+        $ct = $this->modx->getObject(modChunk::class, ['name' => $newName]);
         $passed = $s && $ct;
         $passed = $shouldPass ? $passed : !$passed;
         if ($ct) { /* remove test data */
@@ -160,12 +166,12 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerChunkDuplicate() {
-        return array(
-            array(true,'UnitTestChunk','UnitTestChunk3'), /* pass: standard name */
-            array(true,'UnitTestChunk',''), /* pass: with blank name */
-            array(false,'',''), /* fail: no data */
-            array(false,'','UnitTestChunk3'), /* fail: blank chunk to duplicate */
-        );
+        return [
+            [true,'UnitTestChunk','UnitTestChunk3'], /* pass: standard name */
+            [true,'UnitTestChunk',''], /* pass: with blank name */
+            [false,'',''], /* fail: no data */
+            [false,'','UnitTestChunk3'], /* fail: blank chunk to duplicate */
+        ];
     }
 
     /**
@@ -178,9 +184,9 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @dataProvider providerChunkUpdate
      * @depends testChunkCreate
      */
-    public function testChunkUpdate($shouldPass,$chunkPk,array $properties = array()) {
+    public function testChunkUpdate($shouldPass,$chunkPk,array $properties = []) {
         /** @var modChunk $chunk */
-        $chunk = $this->modx->getObject(modChunk::class,array('name' => $chunkPk));
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => $chunkPk]);
         if (empty($chunk) && $shouldPass) {
             $this->fail('No Chunk found "'.$chunkPk.'" as specified in test provider.');
             return false;
@@ -207,32 +213,47 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerChunkUpdate() {
-        return array(
+        return [
             /* pass: change the description/locked */
-            array(true,'UnitTestChunk',array(
+            [
+                true,'UnitTestChunk',
+                [
                 'name' => 'UnitTestChunk',
                 'description' => 'Changing the description of our test chunk.',
                 'locked' => false,
-            )),
+                ]
+            ],
             /* pass: change the category */
-            array(true,'UnitTestChunk',array(
+            [
+                true,'UnitTestChunk',
+                [
                 'name' => 'UnitTestChunk',
                 'category' => 1,
-            )),
+                ]
+            ],
             /* fail: change to invalid category */
-            array(false,'UnitTestChunk',array(
+            [
+                false,'UnitTestChunk',
+                [
                 'name' => 'UnitTestChunk',
                 'category' => 9999,
-            )),
+                ]
+            ],
             /* fail: no data */
-            array(false,'',array(
+            [
+                false,'',
+                [
                 'name' => 'UnitTestChunk',
-            )),
+                ]
+            ],
             /* fail: invalid ID */
-            array(false,9999,array(
+            [
+                false,9999,
+                [
                 'name' => 'UnitTestChunk',
-            )),
-        );
+                ]
+            ],
+        ];
     }
 
 
@@ -241,15 +262,15 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @dataProvider providerChunkGet
      */
     public function testChunkGet($shouldPass,$chunkPk) {
-        $chunk = $this->modx->getObject(modChunk::class,array('name' => $chunkPk));
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => $chunkPk]);
         if (empty($chunk) && $shouldPass) {
             $this->fail('No Chunk found "'.$chunkPk.'" as specified in test provider.');
             return false;
         }
 
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'id' => $chunk ? $chunk->get('id') : $chunkPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Get::class.' processor');
         }
@@ -261,11 +282,11 @@ class ChunkProcessorsTest extends MODxTestCase {
      * Data provider for element/chunk/create processor test.
      */
     public function providerChunkGet() {
-        return array(
-            array(true,'UnitTestChunk'), /* pass: get chunk from create test */
-            array(false,9999), /* fail: invalid ID */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestChunk'], /* pass: get chunk from create test */
+            [false,9999], /* fail: invalid ID */
+            [false,''], /* fail: no data */
+        ];
     }
 
     /**
@@ -274,12 +295,12 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @dataProvider providerChunkGetList
      */
     public function testChunkGetList($shouldPass = true,$sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $passed = !empty($results);
         $passed = $shouldPass ? $passed : !$passed;
@@ -290,12 +311,12 @@ class ChunkProcessorsTest extends MODxTestCase {
      * Data provider for element/chunk/getlist processor test.
      */
     public function providerChunkGetList() {
-        return array(
-            array(true,'name','ASC',5,0), /* pass: sort 5 by name asc */
-            array(true,'name','DESC',5,0), /* pass: sort 5 by name desc */
-            array(false,'name','ASC',5,5), /* fail: start beyond what exists */
-            array(false,'badname','ASC',5,5), /* fail: invalid sort column */
-        );
+        return [
+            [true,'name','ASC',5,0], /* pass: sort 5 by name asc */
+            [true,'name','DESC',5,0], /* pass: sort 5 by name desc */
+            [false,'name','ASC',5,5], /* fail: start beyond what exists */
+            [false,'badname','ASC',5,5], /* fail: invalid sort column */
+        ];
     }
 
     /**
@@ -303,15 +324,15 @@ class ChunkProcessorsTest extends MODxTestCase {
      * @dataProvider providerChunkRemove
      */
     public function testChunkRemove($shouldPass,$chunkPk) {
-        $chunk = $this->modx->getObject(modChunk::class,array('name' => $chunkPk));
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => $chunkPk]);
         if (empty($chunk) && $shouldPass) {
             $this->fail('No Chunk found "'.$chunkPk.'" as specified in test provider.');
             return false;
         }
 
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'id' => $chunk ? $chunk->get('id') : $chunkPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -323,10 +344,10 @@ class ChunkProcessorsTest extends MODxTestCase {
      * Data provider for element/chunk/remove processor test.
      */
     public function providerChunkRemove() {
-        return array(
-            array(true,'UnitTestChunk'), /* pass: remove chunk from create test */
-            array(false,9999), /* fail: invalid ID */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestChunk'], /* pass: remove chunk from create test */
+            [false,9999], /* fail: invalid ID */
+            [false,''], /* fail: no data */
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Element/PluginTest.php
+++ b/_build/test/Tests/Processors/Element/PluginTest.php
@@ -35,15 +35,15 @@ class PluginProcessorsTest extends MODxTestCase {
         parent::setUp();
         /** @var modPlugin $plugin */
         $plugin = $this->modx->newObject(modPlugin::class);
-        $plugin->fromArray(array(
+        $plugin->fromArray([
             'name' => 'UnitTestPlugin'
-        ));
+        ]);
         $plugin->save();
     }
 
     public function tearDown() {
         parent::tearDown();
-        $plugins = $this->modx->getCollection(modPlugin::class,array('name:LIKE' => '%UnitTest%'));
+        $plugins = $this->modx->getCollection(modPlugin::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modPlugin $plugin */
         foreach ($plugins as $plugin) {
             $plugin->remove();
@@ -58,14 +58,14 @@ class PluginProcessorsTest extends MODxTestCase {
      * @dataProvider providerPluginCreate
      */
     public function testPluginCreate($shouldPass,$pluginPk) {
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'name' => $pluginPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');
         }
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getCount(modPlugin::class,array('name' => $pluginPk));
+        $ct = $this->modx->getCount(modPlugin::class, ['name' => $pluginPk]);
         $passed = $s && $ct > 0;
         $passed = $shouldPass ? $passed : !$passed;
         $this->assertTrue($passed,'Could not create Plugin: `'.$pluginPk.'`: '.$result->getMessage());
@@ -75,12 +75,12 @@ class PluginProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPluginCreate() {
-        return array(
-            array(true,'UnitTestPlugin2'), /* pass: 1st plugin */
-            array(true,'UnitTestPlugin3'), /* pass: 2nd plugin */
-            array(false,'UnitTestPlugin'), /* fail: already exists */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestPlugin2'], /* pass: 1st plugin */
+            [true,'UnitTestPlugin3'], /* pass: 2nd plugin */
+            [false,'UnitTestPlugin'], /* fail: already exists */
+            [false,''], /* fail: no data */
+        ];
     }
 
 
@@ -92,25 +92,25 @@ class PluginProcessorsTest extends MODxTestCase {
      * @dataProvider providerPluginDuplicate
      */
     public function testPluginDuplicate($shouldPass,$pluginPk,$newName) {
-        $plugin = $this->modx->getObject(modPlugin::class,array('name' => $pluginPk));
+        $plugin = $this->modx->getObject(modPlugin::class, ['name' => $pluginPk]);
         if (empty($plugin) && $shouldPass) {
             $this->fail('No Plugin found "'.$pluginPk.'" as specified in test provider.');
             return;
         }
         $this->modx->lexicon->load('default');
 
-        $result = $this->modx->runProcessor(Duplicate::class,array(
+        $result = $this->modx->runProcessor(Duplicate::class, [
             'id' => $plugin ? $plugin->get('id') : $pluginPk,
             'name' => $newName,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Duplicate::class.' processor');
         }
         $s = $this->checkForSuccess($result);
         if (empty($newName) && $plugin) {
-            $newName = $this->modx->lexicon('duplicate_of',array('name' => $plugin->get('name')));
+            $newName = $this->modx->lexicon('duplicate_of', ['name' => $plugin->get('name')]);
         }
-        $ct = $this->modx->getObject(modPlugin::class,array('name' => $newName));
+        $ct = $this->modx->getObject(modPlugin::class, ['name' => $newName]);
         $passed = $s && $ct;
         $passed = $shouldPass ? $passed : !$passed;
         if ($ct) { /* remove test data */
@@ -123,12 +123,12 @@ class PluginProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPluginDuplicate() {
-        return array(
-            array(true,'UnitTestPlugin','UnitTestPlugin3'), /* pass: standard name */
-            array(true,'UnitTestPlugin',''), /* pass: with blank name */
-            array(false,'',''), /* fail: no data */
-            array(false,'','UnitTestPlugin3'), /* fail: blank plugin to duplicate */
-        );
+        return [
+            [true,'UnitTestPlugin','UnitTestPlugin3'], /* pass: standard name */
+            [true,'UnitTestPlugin',''], /* pass: with blank name */
+            [false,'',''], /* fail: no data */
+            [false,'','UnitTestPlugin3'], /* fail: blank plugin to duplicate */
+        ];
     }
     /**
      * Tests the element/plugin/get processor, which gets a Plugin
@@ -137,15 +137,15 @@ class PluginProcessorsTest extends MODxTestCase {
      * @dataProvider providerPluginGet
      */
     public function testPluginGet($shouldPass,$pluginPk) {
-        $plugin = $this->modx->getObject(modPlugin::class,array('name' => $pluginPk));
+        $plugin = $this->modx->getObject(modPlugin::class, ['name' => $pluginPk]);
         if (empty($plugin) && $shouldPass) {
             $this->fail('No Plugin found "'.$pluginPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'id' => $plugin ? $plugin->get('id') : $pluginPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Get::class.' processor');
         }
@@ -158,11 +158,11 @@ class PluginProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPluginGet() {
-        return array(
-            array(true,'UnitTestPlugin'), /* pass: get first plugin */
-            array(false,234), /* fail: invalid ID */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestPlugin'], /* pass: get first plugin */
+            [false,234], /* fail: invalid ID */
+            [false,''], /* fail: no data */
+        ];
     }
 
     /**
@@ -176,12 +176,12 @@ class PluginProcessorsTest extends MODxTestCase {
      * @dataProvider providerPluginGetList
      */
     public function testPluginGetList($shouldPass = true,$sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $passed = !empty($results);
         $passed = $shouldPass ? $passed : !$passed;
@@ -192,12 +192,12 @@ class PluginProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPluginGetList() {
-        return array(
-            array(true,'name','ASC',5,0), /* pass: get first 5 sorted by name ASC */
-            array(true,'name','DESC',5,0), /* pass: get first 5 sorted by name DESC */
-            array(false,'zzz','ASC',5,0), /* fail: invalid sort column */
-            array(false,'name','ASC',5,5), /* fail: start beyond the total # of plugins */
-        );
+        return [
+            [true,'name','ASC',5,0], /* pass: get first 5 sorted by name ASC */
+            [true,'name','DESC',5,0], /* pass: get first 5 sorted by name DESC */
+            [false,'zzz','ASC',5,0], /* fail: invalid sort column */
+            [false,'name','ASC',5,5], /* fail: start beyond the total # of plugins */
+        ];
     }
 
     /**
@@ -208,15 +208,15 @@ class PluginProcessorsTest extends MODxTestCase {
      * @dataProvider providerPluginRemove
      */
     public function testPluginRemove($shouldPass,$pluginPk) {
-        $plugin = $this->modx->getObject(modPlugin::class,array('name' => $pluginPk));
+        $plugin = $this->modx->getObject(modPlugin::class, ['name' => $pluginPk]);
         if (empty($plugin) && $shouldPass) {
             $this->fail('No Plugin found "'.$pluginPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'id' => $plugin ? $plugin->get('id') : $pluginPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -229,10 +229,10 @@ class PluginProcessorsTest extends MODxTestCase {
      * Data provider for element/plugin/remove processor test.
      */
     public function providerPluginRemove() {
-        return array(
-            array(true,'UnitTestPlugin'), /* pass: remove first plugin */
-            array(false,234), /* fail: invalid ID */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestPlugin'], /* pass: remove first plugin */
+            [false,234], /* fail: invalid ID */
+            [false,''], /* fail: no data */
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Element/PropertySetTest.php
+++ b/_build/test/Tests/Processors/Element/PropertySetTest.php
@@ -36,7 +36,7 @@ class PropertySetProcessorsTest extends MODxTestCase {
         parent::setUp();
         /** @var modPropertySet $propertySet */
         $propertySet = $this->modx->newObject(modPropertySet::class);
-        $propertySet->fromArray(array('name' => 'UnitTestPropertySet'));
+        $propertySet->fromArray(['name' => 'UnitTestPropertySet']);
         $propertySet->save();
     }
 
@@ -45,7 +45,7 @@ class PropertySetProcessorsTest extends MODxTestCase {
      */
     public function tearDown() {
         parent::tearDown();
-        $propertySets = $this->modx->getCollection(modPropertySet::class,array('name:LIKE' => '%UnitTest%'));
+        $propertySets = $this->modx->getCollection(modPropertySet::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modPropertySet $propertySet */
         foreach ($propertySets as $propertySet) {
             $propertySet->remove();
@@ -62,14 +62,14 @@ class PropertySetProcessorsTest extends MODxTestCase {
      */
     public function testPropertySetCreate($shouldPass,$propertySetPk) {
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'name' => $propertySetPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');
         }
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getCount(modPropertySet::class,array('name' => $propertySetPk));
+        $ct = $this->modx->getCount(modPropertySet::class, ['name' => $propertySetPk]);
         $passed = $s && $ct > 0;
         $passed = $shouldPass ? $passed : !$passed;
         $this->assertTrue($passed,'Could not create PropertySet: `'.$propertySetPk.'`: '.$result->getMessage());
@@ -79,12 +79,12 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPropertySetCreate() {
-        return array(
-            array(true,'UnitTestPropertySet2'), /* pass: 1st propertyset */
-            array(true,'UnitTestPropertySet3'), /* pass: 2nd propertyset */
-            array(false,'UnitTestPropertySet'), /* fail: already exists */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestPropertySet2'], /* pass: 1st propertyset */
+            [true,'UnitTestPropertySet3'], /* pass: 2nd propertyset */
+            [false,'UnitTestPropertySet'], /* fail: already exists */
+            [false,''], /* fail: no data */
+        ];
     }
 
 
@@ -102,22 +102,22 @@ class PropertySetProcessorsTest extends MODxTestCase {
 	    );
 	    return;
 
-        $propertySet = $this->modx->getObject(modPropertySet::class,array('name' => $propertySetPk));
+        $propertySet = $this->modx->getObject(modPropertySet::class, ['name' => $propertySetPk]);
         if (empty($propertySet) && $shouldPass) {
             $this->fail('No PropertySet found "'.$propertySetPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Duplicate::class,array(
+        $result = $this->modx->runProcessor(Duplicate::class, [
             'id' => $propertySet ? $propertySet->get('id') : $propertySetPk,
             'new_name' => $newName,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Duplicate::class.' processor');
             return;
         }
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getObject(modPropertySet::class,array('name' => $newName));
+        $ct = $this->modx->getObject(modPropertySet::class, ['name' => $newName]);
         $passed = $s && $ct;
         $passed = $shouldPass ? $passed : !$passed;
         if ($ct) { /* remove test data */
@@ -130,12 +130,12 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPropertySetDuplicate() {
-        return array(
-            array(true,'UnitTestPropertySet','UnitTestPropertySet3'), /* pass: standard name */
-            array(false,'UnitTestPropertySet',''), /* pass: with blank name */
-            array(false,'',''), /* fail: no data */
+        return [
+            [true,'UnitTestPropertySet','UnitTestPropertySet3'], /* pass: standard name */
+            [false,'UnitTestPropertySet',''], /* pass: with blank name */
+            [false,'',''], /* fail: no data */
             //array(false,'','UnitTestPropertySet3'), /* fail: blank propertyset to duplicate */
-        );
+        ];
     }
     /**
      * Tests the element/propertyset/get processor, which gets a PropertySet
@@ -146,15 +146,15 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @dataProvider providerPropertySetGet
      */
     public function testPropertySetGet($shouldPass,$propertySetPk) {
-        $propertyset = $this->modx->getObject(modPropertySet::class,array('name' => $propertySetPk));
+        $propertyset = $this->modx->getObject(modPropertySet::class, ['name' => $propertySetPk]);
         if (empty($propertyset) && $shouldPass) {
             $this->fail('No PropertySet found "'.$propertySetPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'id' => $propertyset ? $propertyset->get('id') : $propertySetPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Get::class.' processor');
         }
@@ -167,11 +167,11 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPropertySetGet() {
-        return array(
-            array(true,'UnitTestPropertySet'), /* pass: get first propertyset */
-            array(false,234), /* fail: invalid ID */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestPropertySet'], /* pass: get first propertyset */
+            [false,234], /* fail: invalid ID */
+            [false,''], /* fail: no data */
+        ];
     }
 
     /**
@@ -186,12 +186,12 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @dataProvider providerPropertySetGetList
      */
     public function testPropertySetGetList($shouldPass = true,$sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $passed = !empty($results);
         $passed = $shouldPass ? $passed : !$passed;
@@ -202,12 +202,12 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPropertySetGetList() {
-        return array(
-            array(true,'name','ASC',5,0), /* pass: get first 5 sorted by name ASC */
-            array(true,'name','DESC',5,0), /* pass: get first 5 sorted by name DESC */
-            array(false,'zzz','ASC',5,0), /* fail: invalid sort column */
-            array(false,'name','ASC',5,5), /* fail: start beyond the total # of propertysets */
-        );
+        return [
+            [true,'name','ASC',5,0], /* pass: get first 5 sorted by name ASC */
+            [true,'name','DESC',5,0], /* pass: get first 5 sorted by name DESC */
+            [false,'zzz','ASC',5,0], /* fail: invalid sort column */
+            [false,'name','ASC',5,5], /* fail: start beyond the total # of propertysets */
+        ];
     }
 
     /**
@@ -218,15 +218,15 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @dataProvider providerPropertySetRemove
      */
     public function testPropertySetRemove($shouldPass,$propertySetPk) {
-        $propertyset = $this->modx->getObject(modPropertySet::class,array('name' => $propertySetPk));
+        $propertyset = $this->modx->getObject(modPropertySet::class, ['name' => $propertySetPk]);
         if (empty($propertyset) && $shouldPass) {
             $this->fail('No PropertySet found "'.$propertySetPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'id' => $propertyset ? $propertyset->get('id') : $propertySetPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -239,10 +239,10 @@ class PropertySetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerPropertySetRemove() {
-        return array(
-            array(true,'UnitTestPropertySet'), /* pass: remove first propertyset */
-            array(false,234), /* fail: invalid ID */
-            array(false,''), /* fail: no data */
-        );
+        return [
+            [true,'UnitTestPropertySet'], /* pass: remove first propertyset */
+            [false,234], /* fail: invalid ID */
+            [false,''], /* fail: no data */
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Element/SnippetTest.php
+++ b/_build/test/Tests/Processors/Element/SnippetTest.php
@@ -34,7 +34,7 @@ class SnippetProcessorsTest extends MODxTestCase {
         parent::setUp();
         /** @var modSnippet $snippet */
         $snippet = $this->modx->newObject(modSnippet::class);
-        $snippet->fromArray(array('name' => 'UnitTestSnippet'));
+        $snippet->fromArray(['name' => 'UnitTestSnippet']);
         $snippet->save();
     }
 
@@ -42,7 +42,7 @@ class SnippetProcessorsTest extends MODxTestCase {
      * Cleanup data after this test.
      */
     public function tearDown() {
-        $snippets = $this->modx->getCollection(modSnippet::class,array('name:LIKE' => '%UnitTest%'));
+        $snippets = $this->modx->getCollection(modSnippet::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modSnippet $snippet */
         foreach ($snippets as $snippet) {
             $snippet->remove();
@@ -59,14 +59,14 @@ class SnippetProcessorsTest extends MODxTestCase {
      */
     public function testSnippetCreate($shouldPass,$snippetPk) {
         if (empty($snippetPk)) return;
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'name' => $snippetPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');
         }
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getCount(modSnippet::class,array('name' => $snippetPk));
+        $ct = $this->modx->getCount(modSnippet::class, ['name' => $snippetPk]);
         $passed = $s && $ct > 0;
         $passed = $shouldPass ? $passed : !$passed;
         $this->assertTrue($passed,'Could not create Snippet: `'.$snippetPk.'`: '.$result->getMessage());
@@ -76,11 +76,11 @@ class SnippetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerSnippetCreate() {
-        return array(
-            array(true,'UnitTestSnippet2'),
-            array(true,'UnitTestSnippet3'),
-            array(false,'UnitTestSnippet'),
-        );
+        return [
+            [true,'UnitTestSnippet2'],
+            [true,'UnitTestSnippet3'],
+            [false,'UnitTestSnippet'],
+        ];
     }
 
     /**
@@ -92,15 +92,15 @@ class SnippetProcessorsTest extends MODxTestCase {
     public function testSnippetGet($shouldPass,$snippetPk) {
         if (empty($snippetPk)) return;
 
-        $snippet = $this->modx->getObject(modSnippet::class,array('name' => $snippetPk));
+        $snippet = $this->modx->getObject(modSnippet::class, ['name' => $snippetPk]);
         if (empty($snippet) && $shouldPass) {
             $this->fail('No Snippet found "'.$snippetPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'id' => $snippet ? $snippet->get('id') : $snippetPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Get::class.' processor');
         }
@@ -113,10 +113,10 @@ class SnippetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerSnippetGet() {
-        return array(
-            array(true,'UnitTestSnippet'),
-            array(false,234),
-        );
+        return [
+            [true,'UnitTestSnippet'],
+            [false,234],
+        ];
     }
 
     /**
@@ -129,12 +129,12 @@ class SnippetProcessorsTest extends MODxTestCase {
      * @dataProvider providerSnippetGetList
      */
     public function testSnippetGetList($sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $this->assertTrue(!empty($results),'Could not get list of Snippets: '.$result->getMessage());
     }
@@ -143,9 +143,9 @@ class SnippetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerSnippetGetList() {
-        return array(
-            array('name','ASC',5,0),
-        );
+        return [
+            ['name','ASC',5,0],
+        ];
     }
 
     /**
@@ -158,15 +158,15 @@ class SnippetProcessorsTest extends MODxTestCase {
     public function testSnippetRemove($shouldPass,$snippetPk) {
         if (empty($snippetPk)) return;
 
-        $snippet = $this->modx->getObject(modSnippet::class,array('name' => $snippetPk));
+        $snippet = $this->modx->getObject(modSnippet::class, ['name' => $snippetPk]);
         if (empty($snippet) && $shouldPass) {
             $this->fail('No Snippet found "'.$snippetPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'id' => $snippet ? $snippet->get('id') : $snippetPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -179,9 +179,9 @@ class SnippetProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerSnippetRemove() {
-        return array(
-            array(true,'UnitTestSnippet'),
-            array(false,234),
-        );
+        return [
+            [true,'UnitTestSnippet'],
+            [false,234],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Element/TemplateTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateTest.php
@@ -36,7 +36,7 @@ class TemplateProcessorsTest extends MODxTestCase {
         $this->modx->error->reset();
         /** @var modTemplate $template */
         $template = $this->modx->newObject(modTemplate::class);
-        $template->fromArray(array('templatename' => 'UnitTestTemplate'));
+        $template->fromArray(['templatename' => 'UnitTestTemplate']);
         $template->save();
 
     }
@@ -46,7 +46,7 @@ class TemplateProcessorsTest extends MODxTestCase {
      */
     public function tearDown() {
         parent::tearDown();
-        $templates = $this->modx->getCollection(modTemplate::class,array('templatename:LIKE' => '%UnitTest%'));
+        $templates = $this->modx->getCollection(modTemplate::class, ['templatename:LIKE' => '%UnitTest%']);
         /** @var modTemplate $template */
         foreach ($templates as $template) {
             $template->remove();
@@ -63,14 +63,14 @@ class TemplateProcessorsTest extends MODxTestCase {
      */
     public function testTemplateCreate($shouldPass,$templatePk) {
         if (empty($templatePk)) return;
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'templatename' => $templatePk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');
         }
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getCount(modTemplate::class,array('templatename' => $templatePk));
+        $ct = $this->modx->getCount(modTemplate::class, ['templatename' => $templatePk]);
         $passed = $s && $ct > 0;
         $passed = $shouldPass ? $passed : !$passed;
         $this->assertTrue($passed,'Could not create Template: `'.$templatePk.'`: '.$result->getMessage());
@@ -80,11 +80,11 @@ class TemplateProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTemplateCreate() {
-        return array(
-            array(true,'UnitTestTemplate2'),
-            array(true,'UnitTestTemplate3'),
-            array(false,'UnitTestTemplate'),
-        );
+        return [
+            [true,'UnitTestTemplate2'],
+            [true,'UnitTestTemplate3'],
+            [false,'UnitTestTemplate'],
+        ];
     }
 
     /**
@@ -96,15 +96,15 @@ class TemplateProcessorsTest extends MODxTestCase {
     public function testTemplateGet($shouldPass,$templatePk) {
         if (empty($templatePk)) return;
 
-        $template = $this->modx->getObject(modTemplate::class,array('templatename' => $templatePk));
+        $template = $this->modx->getObject(modTemplate::class, ['templatename' => $templatePk]);
         if (empty($template) && $shouldPass) {
             $this->fail('No Template found "'.$templatePk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'id' => $template ? $template->get('id') : $templatePk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Get::class.' processor');
         }
@@ -117,10 +117,10 @@ class TemplateProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTemplateGet() {
-        return array(
-            array(true,'UnitTestTemplate'),
-            array(false,234),
-        );
+        return [
+            [true,'UnitTestTemplate'],
+            [false,234],
+        ];
     }
 
     /**
@@ -133,12 +133,12 @@ class TemplateProcessorsTest extends MODxTestCase {
      * @dataProvider providerTemplateGetList
      */
     public function testTemplateGetList($sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $this->assertTrue(!empty($results),'Could not get list of Templates: '.$result->getMessage());
     }
@@ -147,9 +147,9 @@ class TemplateProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTemplateGetList() {
-        return array(
-            array('templatename','ASC',5,0),
-        );
+        return [
+            ['templatename','ASC',5,0],
+        ];
     }
 
     /**
@@ -163,15 +163,15 @@ class TemplateProcessorsTest extends MODxTestCase {
         if (empty($templatePk)) return;
 
         /** @var modTemplate $template */
-        $template = $this->modx->getObject(modTemplate::class,array('templatename' => $templatePk));
+        $template = $this->modx->getObject(modTemplate::class, ['templatename' => $templatePk]);
         if (empty($template) && $shouldPass) {
             $this->fail('No Template found "'.$templatePk.'" as specified in test provider.');
             return;
         }
         /** @var ProcessorResponse $result */
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'id' => $template ? $template->get('id') : $templatePk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -184,9 +184,9 @@ class TemplateProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTemplateRemove() {
-        return array(
-            array(true,'UnitTestTemplate'),
-            array(false,234),
-        );
+        return [
+            [true,'UnitTestTemplate'],
+            [false,234],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Element/TemplateVarTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateVarTest.php
@@ -34,7 +34,7 @@ class TemplateVarProcessorsTest extends MODxTestCase {
         parent::setUp();
         /** @var modTemplateVar $tv */
         $tv = $this->modx->newObject(modTemplateVar::class);
-        $tv->fromArray(array('name' => 'UnitTestTv'));
+        $tv->fromArray(['name' => 'UnitTestTv']);
         $tv->save();
     }
 
@@ -42,7 +42,7 @@ class TemplateVarProcessorsTest extends MODxTestCase {
      * Cleanup data after this test.
      */
     public function tearDown() {
-        $tvs = $this->modx->getCollection(modTemplateVar::class,array('name:LIKE' => '%UnitTest%'));
+        $tvs = $this->modx->getCollection(modTemplateVar::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modTemplateVar $tv */
         foreach ($tvs as $tv) {
             $tv->remove();
@@ -59,14 +59,14 @@ class TemplateVarProcessorsTest extends MODxTestCase {
      */
     public function testTvCreate($shouldPass,$tvPk) {
         if (empty($tvPk)) return;
-        $result = $this->modx->runProcessor(Create::class,array(
+        $result = $this->modx->runProcessor(Create::class, [
             'name' => $tvPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Create::class.' processor');
         }
         $s = $this->checkForSuccess($result);
-        $ct = $this->modx->getCount(modTemplateVar::class,array('name' => $tvPk));
+        $ct = $this->modx->getCount(modTemplateVar::class, ['name' => $tvPk]);
         $passed = $s && $ct > 0;
         $passed = $shouldPass ? $passed : !$passed;
         $this->assertTrue($passed,'Could not create Tv: `'.$tvPk.'`: '.$result->getMessage());
@@ -77,11 +77,11 @@ class TemplateVarProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTvCreate() {
-        return array(
-            array(true,'UnitTestTv2'),
-            array(true,'UnitTestTv3'),
-            array(false,'UnitTestTv'),
-        );
+        return [
+            [true,'UnitTestTv2'],
+            [true,'UnitTestTv3'],
+            [false,'UnitTestTv'],
+        ];
     }
 
     /**
@@ -94,15 +94,15 @@ class TemplateVarProcessorsTest extends MODxTestCase {
     public function testTvGet($shouldPass,$tvPk) {
         if (empty($tvPk)) return;
 
-        $tv = $this->modx->getObject(modTemplateVar::class,array('name' => $tvPk));
+        $tv = $this->modx->getObject(modTemplateVar::class, ['name' => $tvPk]);
         if (empty($tv) && $shouldPass) {
             $this->fail('No Tv found "'.$tvPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Get::class,array(
+        $result = $this->modx->runProcessor(Get::class, [
             'id' => $tv ? $tv->get('id') : $tvPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Get::class.' processor');
         }
@@ -115,10 +115,10 @@ class TemplateVarProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTvGet() {
-        return array(
-            array(true,'UnitTestTv'),
-            array(false,234),
-        );
+        return [
+            [true,'UnitTestTv'],
+            [false,234],
+        ];
     }
 
     /**
@@ -131,12 +131,12 @@ class TemplateVarProcessorsTest extends MODxTestCase {
      * @dataProvider providerTvGetList
      */
     public function testTvGetList($sort = 'key',$dir = 'ASC',$limit = 10,$start = 0) {
-        $result = $this->modx->runProcessor(GetList::class,array(
+        $result = $this->modx->runProcessor(GetList::class, [
             'sort' => $sort,
             'dir' => $dir,
             'limit' => $limit,
             'start' => $start,
-        ));
+        ]);
         $results = $this->getResults($result);
         $this->assertTrue(!empty($results),'Could not get list of TVs: '.$result->getMessage());
     }
@@ -145,9 +145,9 @@ class TemplateVarProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTvGetList() {
-        return array(
-            array('name','ASC',5,0),
-        );
+        return [
+            ['name','ASC',5,0],
+        ];
     }
 
     /**
@@ -160,15 +160,15 @@ class TemplateVarProcessorsTest extends MODxTestCase {
     public function testTvRemove($shouldPass,$tvPk) {
         if (empty($tvPk)) return;
 
-        $tv = $this->modx->getObject(modTemplateVar::class,array('name' => $tvPk));
+        $tv = $this->modx->getObject(modTemplateVar::class, ['name' => $tvPk]);
         if (empty($tv) && $shouldPass) {
             $this->fail('No Tv found "'.$tvPk.'" as specified in test provider.');
             return;
         }
 
-        $result = $this->modx->runProcessor(Remove::class,array(
+        $result = $this->modx->runProcessor(Remove::class, [
             'id' => $tv ? $tv->get('id') : $tvPk,
-        ));
+        ]);
         if (empty($result)) {
             $this->fail('Could not load '.Remove::class.' processor');
         }
@@ -181,9 +181,9 @@ class TemplateVarProcessorsTest extends MODxTestCase {
      * @return array
      */
     public function providerTvRemove() {
-        return array(
-            array(true,'UnitTestTv'),
-            array(false,234),
-        );
+        return [
+            [true,'UnitTestTv'],
+            [false,234],
+        ];
     }
 }

--- a/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
+++ b/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
@@ -31,11 +31,11 @@ use MODX\Revolution\Processors\Resource\Create;
 class ResourceCreateProcessorTest extends MODxTestCase {
     public function setUp() {
         parent::setUp();
-        $this->modx->eventMap = array();
+        $this->modx->eventMap = [];
         if ($this->modx instanceof modX) {
-            $resources = $this->modx->getCollection(modResource::class,array(
+            $resources = $this->modx->getCollection(modResource::class, [
                 'pagetitle:LIKE' => '%Unit Test Resource%'
-            ));
+            ]);
             /** @var modResource $resource */
             foreach ($resources as $resource) {
                 $resource->remove();
@@ -49,9 +49,9 @@ class ResourceCreateProcessorTest extends MODxTestCase {
     public function tearDown() {
         parent::tearDown();
         if ($this->modx instanceof modX) {
-            $resources = $this->modx->getCollection(modResource::class,array(
+            $resources = $this->modx->getCollection(modResource::class, [
                 'pagetitle:LIKE' => '%Unit Test Resource%'
-            ));
+            ]);
             /** @var modResource $resource */
             foreach ($resources as $resource) {
                 $resource->remove();
@@ -69,7 +69,8 @@ class ResourceCreateProcessorTest extends MODxTestCase {
      * @param array $settings
      * @dataProvider providerCreate
      */
-    public function testCreate($shouldPass = true,$pageTitle = '',array $fields = array(),array $expectedFieldsToCheck = array(),array $settings = array()) {
+    public function testCreate($shouldPass = true,$pageTitle = '',array $fields = [],array $expectedFieldsToCheck = [],array $settings = []
+    ) {
         if (empty($pageTitle)) {
             $this->fail('No pagetitle specified in test condition!');
             return;
@@ -90,7 +91,7 @@ class ResourceCreateProcessorTest extends MODxTestCase {
         if ($shouldPass) {
             if ($s) {
                 /** @var modResource $resource */
-                $resource = $this->modx->getObject(modResource::class,array('pagetitle' => $pageTitle));
+                $resource = $this->modx->getObject(modResource::class, ['pagetitle' => $pageTitle]);
                 $this->assertNotEmpty($resource,'Resource not found, although processor returned true: `'.$pageTitle.'`: '.$result->getMessage());
                 if ($resource) {
                     foreach ($expectedFieldsToCheck as $k => $v) {
@@ -109,108 +110,108 @@ class ResourceCreateProcessorTest extends MODxTestCase {
      * @return array
      */
     public function providerCreate() {
-        return array(
-            array( /* test basic resource creation */
+        return [
+            [ /* test basic resource creation */
                 true,
                 'Unit Test Resource 1',
-                array(
+                [
                     'alias' => 'unit-test-1',
                     'template' => 0,
                     'published' => true,
-                ),
-                array(
+                ],
+                [
                     'alias' => 'unit-test-1',
                     'published' => true,
                     'template' => 0,
-                )
-            ),
-            array( /* test resource creation with parent */
+                ]
+            ],
+            [ /* test resource creation with parent */
                 true,
                 'Unit Test Resource 2',
-                array(
+                [
                     'parent' => 1,
-                ),
-                array(
+                ],
+                [
                     'parent' => 1,
-                )
-            ),
-            array( /* test resource creation with parent as context */
+                ]
+            ],
+            [ /* test resource creation with parent as context */
                 true,
                 'Unit Test Resource 3',
-                array(
+                [
                     'parent' => 'web',
-                ),
-                array(
+                ],
+                [
                     'parent' => 0,
-                )
-            ),
-            array( /* test resource creation with invalid parent */
+                ]
+            ],
+            [ /* test resource creation with invalid parent */
                 false,
                 'Unit Test Resource 4',
-                array(
+                [
                     'parent' => 999999999,
-                ),
-            ),
-            array( /* test resource creation with invalid context_key */
+                ],
+            ],
+            [ /* test resource creation with invalid context_key */
                 false,
                 'Unit Test Resource 5',
-                array(
+                [
                     'context_key' => 'never-would-exist-ever-you-hear-me',
-                ),
-            ),
-            array( /* test resource creation with a template */
+                ],
+            ],
+            [ /* test resource creation with a template */
                 true,
                 'Unit Test Resource 6',
-                array(
+                [
                     'template' => 1,
-                ),
-                array(
+                ],
+                [
                     'template' => 1,
-                )
-            ),
-            array( /* test resource creation with no template passed, but using a default_template System Setting */
+                ]
+            ],
+            [ /* test resource creation with no template passed, but using a default_template System Setting */
                 true,
                 'Unit Test Resource 7',
-                array(
-                ),
-                array(
+                [
+                ],
+                [
                     'template' => 10,
-                ),
-                array(
+                ],
+                [
                     'default_template' => 10,
-                ),
-            ),
-            array( /* test resource creation with pagetitle with whitespace at end, should trim it */
+                ],
+            ],
+            [ /* test resource creation with pagetitle with whitespace at end, should trim it */
                 true,
                 'Unit Test Resource 8  ',
-                array(
-                ),
-                array(
+                [
+                ],
+                [
                     'pagetitle' => 'Unit Test Resource 8',
-                ),
-            ),
-            array( /* test resource creation with manual menuindex */
+                ],
+            ],
+            [ /* test resource creation with manual menuindex */
                 true,
                 'Unit Test Resource 9',
-                array(
+                [
                     'menuindex' => 100,
-                ),
-                array(
+                ],
+                [
                     'menuindex' => 100,
-                ),
-            ),
-            array( /* test resource creation with auto_menuindex off and no menuindex passed */
+                ],
+            ],
+            [ /* test resource creation with auto_menuindex off and no menuindex passed */
                 true,
                 'Unit Test Resource 10',
-                array(
-                ),
-                array(
+                [
+                ],
+                [
                     'menuindex' => 0,
-                ),
-                array(
+                ],
+                [
                     'auto_menuindex' => false,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 }

--- a/_build/test/data/processors/demo.processor.php
+++ b/_build/test/data/processors/demo.processor.php
@@ -9,8 +9,8 @@
  */
 
 if (!empty($scriptProperties['fail'])) {
-    return $modx->error->failure('A failure message.',array('bad' => true));
+    return $modx->error->failure('A failure message.', ['bad' => true]);
 }
 
-return $modx->error->success('Success!',array('id' => 123));
- 
+return $modx->error->success('Success!', ['id' => 123]);
+

--- a/_build/test/properties.sample.inc.php
+++ b/_build/test/properties.sample.inc.php
@@ -29,12 +29,12 @@ $properties['mysql_string_dsn_nodb']= 'mysql:host=localhost;charset=utf8';
 $properties['mysql_string_dsn_error']= 'mysql:host= nonesuchhost;dbname=nonesuchdb';
 $properties['mysql_string_username']= '';
 $properties['mysql_string_password']= '';
-$properties['mysql_array_options']= array(
+$properties['mysql_array_options']= [
     xPDO::OPT_HYDRATE_FIELDS => true,
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
-);
-$properties['mysql_array_driverOptions']= array();
+];
+$properties['mysql_array_driverOptions']= [];
 
 /* sqlsrv */
 $properties['sqlsrv_string_dsn_test']= 'sqlsrv:server=(local);database=revo_test';
@@ -42,22 +42,22 @@ $properties['sqlsrv_string_dsn_nodb']= 'sqlsrv:server=(local)';
 $properties['sqlsrv_string_dsn_error']= 'sqlsrv:server=xyz;123';
 $properties['sqlsrv_string_username']= '';
 $properties['sqlsrv_string_password']= '';
-$properties['sqlsrv_array_options']= array(
+$properties['sqlsrv_array_options']= [
     xPDO::OPT_HYDRATE_FIELDS => true,
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
-);
-$properties['sqlsrv_array_driverOptions']= array(/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/);
+];
+$properties['sqlsrv_array_driverOptions']= [/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/];
 
 /* PHPUnit test config */
 $properties['xpdo_driver']= 'mysql';
-$properties['logTarget']= array(
+$properties['logTarget']= [
     'target' => 'file',
-    'options' => array(
+    'options' => [
         'filename' => "unit_test_{$properties['runtime']}.log",
         'filepath' => dirname(__FILE__) . '/'
-    )
-);
+    ]
+];
 $properties['logLevel']= xPDO::LOG_LEVEL_INFO;
 $properties['context'] = 'web';
 $properties['debug'] = false;

--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -75,7 +75,7 @@ if (!defined('MODX_BUILD_DIR'))
     define('MODX_BUILD_DIR', MODX_BASE_PATH . '_build/');
 
 /* get properties */
-$properties = array();
+$properties = [];
 $f = dirname(__FILE__) . '/build.properties.php';
 $included = false;
 if (file_exists($f)) {
@@ -88,13 +88,13 @@ unset($f, $included);
 
 /* instantiate xpdo instance */
 $xpdo = new xPDO(XPDO_DSN, XPDO_DB_USER, XPDO_DB_PASS,
-    array (
+    [
         xPDO::OPT_TABLE_PREFIX => XPDO_TABLE_PREFIX,
         xPDO::OPT_CACHE_PATH => MODX_CORE_PATH . 'cache/',
-    ),
-    array (
+    ],
+    [
         PDO::ATTR_ERRMODE => PDO::ERRMODE_WARNING,
-    )
+    ]
 );
 $cacheManager= $xpdo->getCacheManager();
 $xpdo->setLogLevel(xPDO::LOG_LEVEL_INFO);
@@ -109,11 +109,11 @@ if (file_exists($packageDirectory . 'core.transport.zip')) {
     @unlink($packageDirectory . 'core.transport.zip');
 }
 if (file_exists($packageDirectory . 'core') && is_dir($packageDirectory . 'core')) {
-    $cacheManager->deleteTree($packageDirectory . 'core',array(
+    $cacheManager->deleteTree($packageDirectory . 'core', [
         'deleteTop' => true,
         'skipDirs' => false,
-        'extensions' => array(),
-    ));
+        'extensions' => [],
+    ]);
 }
 if (!file_exists($packageDirectory . 'core') && !file_exists($packageDirectory . 'core.transport.zip')) {
     $xpdo->log(xPDO::LOG_LEVEL_INFO,'Removed pre-existing core/ and core.transport.zip.'); flush();
@@ -132,26 +132,26 @@ $namespace = $xpdo->newObject(modNamespace::class);
 $namespace->set('name','core');
 $namespace->set('path','{core_path}');
 $namespace->set('assets_path','{assets_path}');
-$package->put($namespace,array(
+$package->put($namespace, [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => true,
-));
+]);
 unset($namespace);
 $xpdo->log(xPDO::LOG_LEVEL_INFO,'Core Namespace packaged.'); flush();
 
 /* modWorkspace */
-$collection = array ();
+$collection = [];
 $collection['1'] = $xpdo->newObject(modWorkspace::class);
-$collection['1']->fromArray(array (
+$collection['1']->fromArray([
     'id' => 1,
     'name' => 'Default MODX workspace',
     'path' => '{core_path}',
     'active' => 1,
-), '', true, true);
-$attributes = array (
+], '', true, true);
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
-);
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -160,20 +160,20 @@ unset ($collection, $c, $attributes);
 $xpdo->log(xPDO::LOG_LEVEL_INFO,'Default workspace packaged.'); flush();
 
 /* modx.com extras provisioner */
-$collection = array ();
+$collection = [];
 $collection['1'] = $xpdo->newObject(modTransportProvider::class);
-$collection['1']->fromArray(array (
+$collection['1']->fromArray([
     'id' => 1,
     'name' => 'modx.com',
     'description' => 'The official MODX transport provider for 3rd party components.',
     'service_url' => 'https://rest.modx.com/extras/',
     'created' => strftime('%Y-%m-%d %H:%M:%S'),
-), '', true, true);
-$attributes = array (
+], '', true, true);
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => false,
     xPDOTransport::UPDATE_OBJECT => true,
-    xPDOTransport::UNIQUE_KEY => array ('name'),
-);
+    xPDOTransport::UNIQUE_KEY => ['name'],
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -184,19 +184,19 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged modx.com transport provider.'); flush(
 /* modMenu */
 $collection = include MODX_BUILD_DIR . 'data/transport.core.menus.php';
 if (!empty($collection)) {
-    $attributes = array (
+    $attributes = [
         xPDOTransport::PRESERVE_KEYS => true,
         xPDOTransport::UPDATE_OBJECT => true,
         xPDOTransport::UNIQUE_KEY => 'text',
         xPDOTransport::RELATED_OBJECTS => true,
-        xPDOTransport::RELATED_OBJECT_ATTRIBUTES => array(
-            'Children' => array(
+        xPDOTransport::RELATED_OBJECT_ATTRIBUTES => [
+            'Children' => [
                 xPDOTransport::PRESERVE_KEYS => true,
                 xPDOTransport::UPDATE_OBJECT => true,
                 xPDOTransport::UNIQUE_KEY => 'text',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
     foreach ($collection as $c) {
         $package->put($c, $attributes);
     }
@@ -208,13 +208,13 @@ if (!empty($collection)) {
 }
 
 /* modContentTypes */
-$collection = array ();
+$collection = [];
 include MODX_BUILD_DIR . 'data/transport.core.content_types.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => false,
     xPDOTransport::UPDATE_OBJECT => false,
     xPDOTransport::UNIQUE_KEY => 'mime_type',
-);
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -225,10 +225,10 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged all default modContentTypes.'); flush(
 /* modEvent collection */
 $events = include MODX_BUILD_DIR . 'data/transport.core.events.php';
 if (is_array($events) && !empty($events)) {
-    $attributes = array (
+    $attributes = [
         xPDOTransport::PRESERVE_KEYS => true,
         xPDOTransport::UPDATE_OBJECT => true,
-    );
+    ];
     foreach ($events as $evt) {
         $package->put($evt, $attributes);
     }
@@ -241,10 +241,10 @@ unset ($events, $evt, $attributes);
 /* modSystemSetting collection */
 $settings = include MODX_BUILD_DIR . 'data/transport.core.system_settings.php';
 if (!is_array($settings) || empty($settings)) { $xpdo->log(xPDO::LOG_LEVEL_FATAL,'Could not package in settings!'); flush(); }
-$attributes= array (
+$attributes= [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
-);
+];
 foreach ($settings as $setting) {
     $package->put($setting, $attributes);
 }
@@ -253,13 +253,13 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($settings).' default system
 unset ($settings, $setting, $attributes);
 
 /* modContextSetting collection */
-$collection = array ();
+$collection = [];
 include MODX_BUILD_DIR . 'data/transport.core.context_settings.php';
-$attributes= array(
+$attributes= [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
-    xPDOTransport::UNIQUE_KEY => array('context_key', 'key')
-);
+    xPDOTransport::UNIQUE_KEY => ['context_key', 'key']
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -268,12 +268,12 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default cont
 unset ($collection, $c, $attributes);
 
 /* modUserGroup */
-$collection = array ();
+$collection = [];
 include MODX_BUILD_DIR . 'data/transport.core.usergroups.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
-);
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -282,13 +282,13 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default user
 unset ($collection, $c, $attributes);
 
 /* modDashboard */
-$collection = array ();
+$collection = [];
 include MODX_BUILD_DIR . 'data/transport.core.dashboards.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => true,
-    xPDOTransport::UNIQUE_KEY => array ('id'),
-);
+    xPDOTransport::UNIQUE_KEY => ['id'],
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -297,13 +297,13 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default dash
 unset ($collection, $c, $attributes);
 
 /* modMediaSource */
-$collection = array ();
+$collection = [];
 include MODX_BUILD_DIR . 'data/transport.core.media_sources.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
-    xPDOTransport::UNIQUE_KEY => array ('id'),
-);
+    xPDOTransport::UNIQUE_KEY => ['id'],
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -314,20 +314,20 @@ unset ($collection, $c, $attributes);
 /* modDashboardWidget */
 $widgets = include MODX_BUILD_DIR . 'data/transport.core.dashboard_widgets.php';
 if (is_array($widgets)) {
-    $attributes = array (
+    $attributes = [
         xPDOTransport::PRESERVE_KEYS => false,
         xPDOTransport::UPDATE_OBJECT => false,
-        xPDOTransport::UNIQUE_KEY => array ('name'),
-    );
+        xPDOTransport::UNIQUE_KEY => ['name'],
+    ];
     $ct = count($widgets);
     $idx = 0;
     foreach ($widgets as $widget) {
         $idx++;
         if ($idx == $ct) {
-            $attributes['resolve'][] = array (
+            $attributes['resolve'][] = [
                 'type' => 'php',
                 'source' => MODX_BUILD_DIR . 'resolvers/resolve.dashboardwidgets.php',
-            );
+            ];
         }
         $package->put($widget, $attributes);
     }
@@ -338,12 +338,12 @@ if (is_array($widgets)) {
 unset ($widgets,$widget,$attributes,$ct,$idx);
 
 /* modUserGroupRole */
-$collection = array ();
+$collection = [];
 include MODX_BUILD_DIR . 'data/transport.core.usergrouproles.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
-);
+];
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
@@ -353,11 +353,11 @@ unset ($collection, $c, $attributes);
 
 /* modAccessPolicyTemplateGroups */
 $templateGroups = include MODX_BUILD_DIR . 'data/transport.core.accesspolicytemplategroups.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => false,
-    xPDOTransport::UNIQUE_KEY => array('name'),
+    xPDOTransport::UNIQUE_KEY => ['name'],
     xPDOTransport::UPDATE_OBJECT => true,
-);
+];
 if (is_array($templateGroups)) {
     foreach ($templateGroups as $templateGroup) {
         $package->put($templateGroup, $attributes);
@@ -371,29 +371,29 @@ unset ($templateGroups, $templateGroup, $attributes);
 
 /* modAccessPolicyTemplate */
 $templates = include MODX_BUILD_DIR . 'data/transport.core.accesspolicytemplates.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => false,
-    xPDOTransport::UNIQUE_KEY => array('name'),
+    xPDOTransport::UNIQUE_KEY => ['name'],
     xPDOTransport::UPDATE_OBJECT => true,
     xPDOTransport::RELATED_OBJECTS => true,
-    xPDOTransport::RELATED_OBJECT_ATTRIBUTES => array (
-        'Permissions' => array (
+    xPDOTransport::RELATED_OBJECT_ATTRIBUTES => [
+        'Permissions' => [
             xPDOTransport::PRESERVE_KEYS => false,
             xPDOTransport::UPDATE_OBJECT => true,
-            xPDOTransport::UNIQUE_KEY => array ('template','name'),
-        ),
-    )
-);
+            xPDOTransport::UNIQUE_KEY => ['template','name'],
+        ],
+    ]
+];
 if (is_array($templates)) {
     $ct = count($templates);
     $idx = 0;
     foreach ($templates as $template) {
         $idx++;
         if ($idx == $ct) {
-            $attributes['resolve'][] = array (
+            $attributes['resolve'][] = [
                 'type' => 'php',
                 'source' => MODX_BUILD_DIR . 'resolvers/resolve.policytemplates.php',
-            );
+            ];
         }
         $package->put($template, $attributes);
     }
@@ -405,21 +405,21 @@ unset ($templates,$template,$idx,$ct,$attributes);
 
 /* modAccessPolicy */
 $policies = include MODX_BUILD_DIR . 'data/transport.core.accesspolicies.php';
-$attributes = array (
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => false,
-    xPDOTransport::UNIQUE_KEY => array('name'),
+    xPDOTransport::UNIQUE_KEY => ['name'],
     xPDOTransport::UPDATE_OBJECT => true,
-);
+];
 if (is_array($policies)) {
     $ct = count($policies);
     $idx = 0;
     foreach ($policies as $policy) {
         $idx++;
         if ($idx == $ct) {
-            $attributes['resolve'][] = array (
+            $attributes['resolve'][] = [
                 'type' => 'php',
                 'source' => MODX_BUILD_DIR . 'resolvers/resolve.policies.php',
-            );
+            ];
         }
         $package->put($policy, $attributes);
     }
@@ -433,30 +433,30 @@ unset ($policies,$policy,$idx,$ct,$attributes);
 
 /* modContext = web */
 $c = $xpdo->newObject(modContext::class);
-$c->fromArray(array (
+$c->fromArray([
     'key' => 'web',
     'name' => 'Website',
     'description' => 'The default front-end context for your web site.',
-), '', true, true);
-$attributes = array (
+], '', true, true);
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'file',
     'source' => MODX_BASE_PATH . 'index.php',
     'target' => "return MODX_BASE_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'file',
     'source' => MODX_BASE_PATH . 'ht.access',
     'target' => "return MODX_BASE_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'php',
     'source' => MODX_BUILD_DIR . 'resolvers/resolve.core.php',
     'target' => "return MODX_BASE_PATH . 'config.core.php';",
-);
+];
 $package->put($c, $attributes);
 unset ($c, $attributes);
 
@@ -464,83 +464,83 @@ $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in web context.'); flush();
 
 /* modContext = mgr */
 $c = $xpdo->newObject(modContext::class);
-$c->fromArray(array (
+$c->fromArray([
     'key' => 'mgr',
     'name' => 'Manager',
     'description' => 'The default manager or administration context for content management activity.',
-), '', true, true);
-$attributes = array (
+], '', true, true);
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'file',
     'source' => MODX_BASE_PATH . 'manager/assets',
     'target' => "return MODX_MANAGER_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'file',
     'source' => MODX_BASE_PATH . 'manager/controllers',
     'target' => "return MODX_MANAGER_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'file',
     'source' => MODX_BASE_PATH . 'manager/templates',
     'target' => "return MODX_MANAGER_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'file',
     'source' => MODX_BASE_PATH . 'manager/ht.access',
     'target' => "return MODX_MANAGER_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'file',
     'source' => MODX_BASE_PATH . 'manager/index.php',
     'target' => "return MODX_MANAGER_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'php',
     'source' => MODX_BUILD_DIR . 'resolvers/resolve.core.php',
     'target' => "return MODX_MANAGER_PATH . 'config.core.php';",
-);
+];
 $package->put($c, $attributes);
 unset ($c, $attributes);
 
 $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in mgr context.'); flush();
 
 /* connector file transport */
-$attributes = array (
+$attributes = [
     'vehicle_class' => xPDOFileVehicle::class,
-);
-$files[] = array (
+];
+$files[] = [
     'source' => MODX_BASE_PATH . 'connectors/system',
     'target' => "return MODX_CONNECTORS_PATH;",
-);
-$files[] = array (
+];
+$files[] = [
     'source' => MODX_BASE_PATH . 'connectors/lang.js.php',
     'target' => "return MODX_CONNECTORS_PATH;",
-);
-$files[] = array (
+];
+$files[] = [
     'source' => MODX_BASE_PATH . 'connectors/modx.config.js.php',
     'target' => "return MODX_CONNECTORS_PATH;",
-);
+];
 foreach ($files as $fileset) {
     $package->put($fileset, $attributes);
 }
 unset ($files, $fileset);
-$fileset = array (
+$fileset = [
     'source' => MODX_BASE_PATH . 'connectors/index.php',
     'target' => "return MODX_CONNECTORS_PATH;",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'php',
     'source' => MODX_BUILD_DIR . 'resolvers/resolve.core.php',
     'target' => "return MODX_CONNECTORS_PATH . 'config.core.php';",
-);
-$attributes['resolve'][] = array (
+];
+$attributes['resolve'][] = [
     'type' => 'php',
     'source' => MODX_BUILD_DIR . 'resolvers/resolve.actionfields.php',
-);
+];
 $package->put($fileset, $attributes);
 unset ($fileset, $attributes);
 

--- a/_build/transport.data.php
+++ b/_build/transport.data.php
@@ -30,7 +30,7 @@ $modx->setLogTarget('ECHO');
 // Get all Actions
 $content= "<?php\n";
 $query= $modx->newQuery(\MODX\Revolution\modAction::class);
-$query->where(array('namespace' => 'core'));
+$query->where(['namespace' => 'core']);
 $query->sortby('id');
 
 $collection= $modx->getCollection(\MODX\Revolution\modAction::class, $query);
@@ -79,8 +79,8 @@ unset($content, $collection, $key, $c);
 // Get all System Settings
 $content= "<?php\n";
 $query= $modx->newQuery(\MODX\Revolution\modSystemSetting::class);
-$query->select($modx->getSelectColumns(\MODX\Revolution\modSystemSetting::class, '', '', array('editedon'), true));
-$query->where(array('namespace' => 'core'));
+$query->select($modx->getSelectColumns(\MODX\Revolution\modSystemSetting::class, '', '', ['editedon'], true));
+$query->where(['namespace' => 'core']);
 $query->sortby($modx->escape('key'));
 $collection= $modx->getCollection(\MODX\Revolution\modSystemSetting::class, $query);
 foreach ($collection as $key => $c) {
@@ -93,8 +93,8 @@ unset($content, $collection, $key, $c);
 // Get all Context Settings
 $content= "<?php\n";
 $query= $modx->newQuery(\MODX\Revolution\modContextSetting::class);
-$query->select($modx->getSelectColumns(\MODX\Revolution\modContextSetting::class, '', '', array('editedon'), true));
-$query->where(array('namespace' => 'core'));
+$query->select($modx->getSelectColumns(\MODX\Revolution\modContextSetting::class, '', '', ['editedon'], true));
+$query->where(['namespace' => 'core']);
 $query->sortby($modx->escape('context_key'));
 $query->sortby($modx->escape('key'));
 $collection= $modx->getCollection(\MODX\Revolution\modContextSetting::class, $query);
@@ -107,7 +107,7 @@ unset($content, $collection, $key, $c);
 
 // Get the Admin Group
 $content= "<?php\n";
-$collection= $modx->getCollection(\MODX\Revolution\modUserGroup::class, array('id' => 1));
+$collection= $modx->getCollection(\MODX\Revolution\modUserGroup::class, ['id' => 1]);
 foreach ($collection as $key => $c) {
     $content.= $cacheManager->generateObject($c, "collection['{$key}']", false, false, 'xpdo');
 }

--- a/connectors/index.php
+++ b/connectors/index.php
@@ -33,15 +33,15 @@ if (!defined('MODX_CORE_PATH')) {
 if (!require_once(MODX_CORE_PATH . 'vendor/autoload.php')) {
     header("Content-Type: application/json; charset=UTF-8");
     header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
-    echo json_encode(array(
+    echo json_encode([
         'success' => false,
         'code' => 404,
-    ));
+    ]);
     die();
 }
 
 /* load modX instance */
-$modx = new \MODX\Revolution\modX('', array(\xPDO\xPDO::OPT_CONN_INIT => array(\xPDO\xPDO::OPT_CONN_MUTABLE => true)));
+$modx = new \MODX\Revolution\modX('', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 
 /* initialize the proper context */
 $ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) && is_string($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';
@@ -52,10 +52,10 @@ if (defined('MODX_REQP') && MODX_REQP === false) {
 } else if (!is_object($modx->context) || !$modx->context->checkPolicy('load')) {
     header("Content-Type: application/json; charset=UTF-8");
     header($_SERVER['SERVER_PROTOCOL'] . ' 401 Not Authorized');
-    echo json_encode(array(
+    echo json_encode([
         'success' => false,
         'code' => 401,
-    ));
+    ]);
     @session_write_close();
     die();
 }

--- a/connectors/lang.js.php
+++ b/connectors/lang.js.php
@@ -47,7 +47,7 @@ var _ = function(s,v) {
 }';
 
 function esc($s) {
-    return strtr($s,array('\\'=>'\\\\',"'"=>"\\'",'"'=>'\\"',"\r"=>'\\r',"\n"=>'\\n','</'=>'<\/'));
+    return strtr($s, ['\\'=>'\\\\',"'"=>"\\'",'"'=>'\\"',"\r"=>'\\r',"\n"=>'\\n','</'=>'<\/']);
 }
 
 /* gather output from buffer */

--- a/connectors/modx.config.js.php
+++ b/connectors/modx.config.js.php
@@ -16,4 +16,4 @@ define('MODX_CONNECTOR_INCLUDED', 1);
 define('MODX_REQP',false);
 require_once dirname(__FILE__).'/index.php';
 $_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));
-$modx->request->handleRequest(array('location' => 'system','action' => 'System\ConfigJs'));
+$modx->request->handleRequest(['location' => 'system','action' => 'System\ConfigJs']);

--- a/connectors/system/phpthumb.php
+++ b/connectors/system/phpthumb.php
@@ -16,4 +16,4 @@ session_cache_limiter('public');
 define('MODX_CONNECTOR_INCLUDED', 1);
 require_once dirname(__DIR__).'/index.php';
 $_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));
-$modx->request->handleRequest(array('location' => 'system','action' => 'System\PhpThumb'));
+$modx->request->handleRequest(['location' => 'system','action' => 'System\PhpThumb']);

--- a/core/docs/version.inc.php
+++ b/core/docs/version.inc.php
@@ -1,5 +1,5 @@
 <?php
-$v= array ();
+$v= [];
 $v['version']= '3'; // Current version.
 $v['major_version']= '0'; // Current major version.
 $v['minor_version']= '0'; // Current minor version.

--- a/core/model/schema/config.php
+++ b/core/model/schema/config.php
@@ -20,18 +20,18 @@ return [
         \xPDO\xPDO::OPT_HYDRATE_FIELDS => true,
         \xPDO\xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
         \xPDO\xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
-        \xPDO\xPDO::OPT_CONN_INIT => array(\xPDO\xPDO::OPT_CONN_MUTABLE => true),
-        \xPDO\xPDO::OPT_CONNECTIONS => array(
-            array(
+        \xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true],
+        \xPDO\xPDO::OPT_CONNECTIONS => [
+            [
                 'dsn' => $properties['mysql_string_dsn_test'],
                 'username' => $properties['mysql_string_username'],
                 'password' => $properties['mysql_string_password'],
-                'options' => array(
+                'options' => [
                     \xPDO\xPDO::OPT_CONN_MUTABLE => true,
-                ),
+                ],
                 'driverOptions' => [],
-            ),
-        ),
+            ],
+        ],
         'log_target' => 'ECHO',
         'log_level' => \xPDO\xPDO::LOG_LEVEL_WARN,
     ],
@@ -40,18 +40,18 @@ return [
         \xPDO\xPDO::OPT_HYDRATE_FIELDS => true,
         \xPDO\xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
         \xPDO\xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
-        \xPDO\xPDO::OPT_CONN_INIT => array(\xPDO\xPDO::OPT_CONN_MUTABLE => true),
-        \xPDO\xPDO::OPT_CONNECTIONS => array(
-            array(
+        \xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true],
+        \xPDO\xPDO::OPT_CONNECTIONS => [
+            [
                 'dsn' => $properties['sqlsrv_string_dsn_test'],
                 'username' => $properties['sqlsrv_string_username'],
                 'password' => $properties['sqlsrv_string_password'],
-                'options' => array(
+                'options' => [
                     \xPDO\xPDO::OPT_CONN_MUTABLE => true,
-                ),
+                ],
                 'driverOptions' => [],
-            ),
-        ),
+            ],
+        ],
         'log_target' => 'ECHO',
         'log_level' => \xPDO\xPDO::LOG_LEVEL_WARN,
     ]

--- a/core/src/Revolution/Error/modError.php
+++ b/core/src/Revolution/Error/modError.php
@@ -45,7 +45,7 @@ class modError
     /**
      * @var array An array of objects to validate against
      */
-    protected $_objects = array();
+    protected $_objects = [];
 
     /**
      * @param modX $modx A reference to the modX instance
@@ -60,7 +60,7 @@ class modError
         } else {
             $this->message = '';
         }
-        $this->errors = array ();
+        $this->errors = [];
     }
 
     /**
@@ -84,7 +84,7 @@ class modError
      * add to the validation queue.
      * @return string The validation message returned.
      */
-    public function checkValidation($objs= array()) {
+    public function checkValidation($objs= []) {
         if (is_object($objs)) {
             $this->addObjectToValidate($objs);
         }
@@ -110,10 +110,10 @@ class modError
             if ($validator= $obj->getValidator()) {
                 $messages= $validator->getMessages();
                 if (!empty($messages)) {
-                    $fields = array();
+                    $fields = [];
                     foreach ($messages as $message) {
                         $s .= $message['message'].'<br />'."\n";
-                        if (!isset($fields[$message['field']])) $fields[$message['field']] = array();
+                        if (!isset($fields[$message['field']])) $fields[$message['field']] = [];
                         $fields[$message['field']][$message['name']] = $message['message'];
                     }
                     foreach ($fields as $fieldKey => $field) {
@@ -151,7 +151,7 @@ class modError
         if ($message != '') {
             $this->message = $message;
         }
-        $objarray = array ();
+        $objarray = [];
         if (is_array($object)) {
             $obj = reset($object);
             if (is_object($obj) && $obj instanceof xPDOObject) {
@@ -160,13 +160,13 @@ class modError
             unset ($obj);
         }
         $objarray = $this->toArray($object);
-        return array (
+        return [
             'success' => $status,
             'message' => $this->message,
             'total' => isset ($this->total) && $this->total != 0 ? $this->total : count($this->errors),
             'errors' => $this->errors,
             'object' => $objarray,
-        );
+        ];
     }
 
     /**
@@ -176,10 +176,10 @@ class modError
      * @param string $error The error message.
      */
     public function addField($name, $error) {
-        $this->errors[] = array (
+        $this->errors[] = [
             'id' => $name,
             'msg' => $error
-        );
+        ];
     }
 
     /**
@@ -188,8 +188,8 @@ class modError
      * @return array An array of errors for specific fields.
      */
     public function getFields() {
-        $f = array ();
-        $errors = array_values(array_filter($this->errors, array($this, 'isFieldError')));
+        $f = [];
+        $errors = array_values(array_filter($this->errors, [$this, 'isFieldError']));
         foreach ($errors as $fi) {
             $f[] = $fi['msg'];
         }
@@ -214,7 +214,7 @@ class modError
     public function getErrors($includeFields = false) {
         $errors = $this->errors;
         if (!$includeFields) {
-            $errors = array_values(array_filter($this->errors, array($this, 'isNotFieldError')));
+            $errors = array_values(array_filter($this->errors, [$this, 'isNotFieldError']));
         }
         return $errors;
     }
@@ -280,7 +280,7 @@ class modError
      * @return array Returns an array representation of the object(s).
      */
     public function toArray($object) {
-        $array = array ();
+        $array = [];
         if (is_array($object)) {
             foreach ($object as $key => $value) {
                 if (!is_resource($value)) {
@@ -308,7 +308,7 @@ class modError
      * Resets the error messages.
      */
     public function reset() {
-        $this->errors = array();
+        $this->errors = [];
         $this->message = '';
         $this->total = 0;
         $this->status = true;

--- a/core/src/Revolution/File/modFileHandler.php
+++ b/core/src/Revolution/File/modFileHandler.php
@@ -24,7 +24,7 @@ class modFileHandler {
      * An array of configuration properties for the class
      * @var array $config
      */
-    public $config = array();
+    public $config = [];
     /**
      * The current context in which this File Manager instance should operate
      * @var modContext|null $context
@@ -37,7 +37,7 @@ class modFileHandler {
      * @param modX &$modx A reference to the modX object.
      * @param array $config An array of options.
      */
-    function __construct(modX &$modx, array $config = array()) {
+    function __construct(modX &$modx, array $config = []) {
         $this->modx =& $modx;
         $this->config = array_merge($this->config, $this->modx->_userConfig, $config);
         if (!isset($this->config['context'])) {
@@ -57,7 +57,7 @@ class modFileHandler {
      * of the object as the specified class.
      * @return mixed The appropriate modFile/modDirectory object
      */
-    public function make($path, array $options = array(), $overrideClass = '') {
+    public function make($path, array $options = [], $overrideClass = '') {
         $path = $this->sanitizePath($path);
 
         if (!empty($overrideClass)) {
@@ -82,15 +82,15 @@ class modFileHandler {
     public function getBasePath() {
         $basePath = $this->context->getOption('filemanager_path', '', $this->config);
         /* expand placeholders */
-        $basePath = str_replace(array(
+        $basePath = str_replace([
             '{base_path}',
             '{core_path}',
             '{assets_path}',
-        ), array(
+        ], [
             $this->context->getOption('base_path', MODX_BASE_PATH, $this->config),
             $this->context->getOption('core_path', MODX_CORE_PATH, $this->config),
             $this->context->getOption('assets_path', MODX_ASSETS_PATH, $this->config),
-        ), $basePath);
+        ], $basePath);
         return !empty($basePath) ? $this->postfixSlash($basePath) : $basePath;
     }
 
@@ -103,15 +103,15 @@ class modFileHandler {
         $baseUrl = $this->context->getOption('filemanager_url', $this->context->getOption('rb_base_url', MODX_BASE_URL, $this->config), $this->config);
 
         /* expand placeholders */
-        $baseUrl = str_replace(array(
+        $baseUrl = str_replace([
             '{base_url}',
             '{core_url}',
             '{assets_url}',
-        ), array(
+        ], [
             $this->context->getOption('base_url', MODX_BASE_PATH, $this->config),
             $this->context->getOption('core_url', MODX_CORE_PATH, $this->config),
             $this->context->getOption('assets_url', MODX_ASSETS_PATH, $this->config),
-        ), $baseUrl);
+        ], $baseUrl);
         return !empty($baseUrl) ? $this->postfixSlash($baseUrl) : $baseUrl;
     }
 
@@ -122,7 +122,7 @@ class modFileHandler {
      * @return string The sanitized path
      */
     public function sanitizePath($path) {
-        return preg_replace(array("/\.*[\/|\\\]/i", "/[\/|\\\]+/i"), array('/', '/'), $path);
+        return preg_replace(["/\.*[\/|\\\]/i", "/[\/|\\\]+/i"], ['/', '/'], $path);
     }
 
     /**

--- a/core/src/Revolution/Import/modImport.php
+++ b/core/src/Revolution/Import/modImport.php
@@ -27,11 +27,11 @@ class modImport {
     /**
      * @var array A collection of results in an array
      */
-    public $results = array();
+    public $results = [];
     /**
      * @var array A collection of properties that are being used in this import
      */
-    public $properties = array ();
+    public $properties = [];
 
     /**
      * @param modX $modx A reference to the modX instance
@@ -47,7 +47,7 @@ class modImport {
      * @param int $count The current count iteration
      * @return array
      */
-    public function getFiles(& $filesfound, $directory, $listing= array (), $count= 0) {
+    public function getFiles(& $filesfound, $directory, $listing= [], $count= 0) {
         if ($directory[-1] !== '/') {
             $directory.= '/';
         }
@@ -60,7 +60,7 @@ class modImport {
                     if ($h= @ opendir($directory . $file . '/')) {
                         @ closedir($h);
                         $count= -1;
-                        $listing["$file"]= $this->getFiles($filesfound, $directory . $file, array (), $count +1);
+                        $listing["$file"]= $this->getFiles($filesfound, $directory . $file, [], $count +1);
                     } else {
                         $listing[$dummy]= $file;
                         $dummy= $dummy +1;
@@ -99,9 +99,9 @@ class modImport {
      * @return string The content-type of the file
      */
     public function getFileContentType($extension) {
-        if (!$contentType= $this->modx->getObject(modContentType::class, array('file_extensions:LIKE' => '%'.$extension.'%'))) {
+        if (!$contentType= $this->modx->getObject(modContentType::class, ['file_extensions:LIKE' => '%'.$extension.'%'])) {
             $this->log("Could not find content type for extension '$extension'; using <samp>text/plain</samp>.");
-            $contentType= $this->modx->getObject(modContentType::class, array('mime_type' => 'text/plain'));
+            $contentType= $this->modx->getObject(modContentType::class, ['mime_type' => 'text/plain']);
         }
         return $contentType;
     }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/Controllers/TvInputManagerController.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/Controllers/TvInputManagerController.php
@@ -25,10 +25,10 @@ class TvInputManagerController extends modManagerController {
         return $this->modx->hasPermission('view_tv');
     }
     public function loadCustomCssJs() {}
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
     public function getPageTitle() {return '';}
     public function getTemplateFile() {
         return 'empty.tpl';
     }
-    public function getLanguageTopics() {return array();}
+    public function getLanguageTopics() {return [];}
 }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/Controllers/TvInputPropertiesManagerController.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/Controllers/TvInputPropertiesManagerController.php
@@ -25,10 +25,10 @@ class TvInputPropertiesManagerController extends modManagerController {
         return $this->modx->hasPermission('view_tv');
     }
     public function loadCustomCssJs() {}
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
     public function getPageTitle() {return '';}
     public function getTemplateFile() {
         return 'empty.tpl';
     }
-    public function getLanguageTopics() {return array();}
+    public function getLanguageTopics() {return [];}
 }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
@@ -37,7 +37,7 @@ class GetInputProperties extends Processor {
         return $this->modx->hasPermission('view_tv');
     }
     public function getLanguageTopics() {
-        return array('tv_widget','tv_input_types');
+        return ['tv_widget','tv_input_types'];
     }
 
     public function initialize() {
@@ -48,9 +48,9 @@ class GetInputProperties extends Processor {
         if (empty($context)) {
             $this->setProperty('context',$this->modx->context->get('key'));
         }
-        $this->setDefaultProperties(array(
+        $this->setDefaultProperties([
             'type' => 'default',
-        ));
+        ]);
         return true;
     }
 
@@ -90,7 +90,8 @@ class GetInputProperties extends Processor {
      */
     public function renderController() {
         $c = new TvInputPropertiesManagerController($this->modx);
-        $this->modx->controller = call_user_func_array(array($c,'getInstance'),array(&$this->modx,TvInputPropertiesManagerController::class));
+        $this->modx->controller = call_user_func_array([$c,'getInstance'],
+            [&$this->modx,TvInputPropertiesManagerController::class]);
         return $this->modx->controller->render();
     }
 
@@ -99,7 +100,7 @@ class GetInputProperties extends Processor {
      * @return array
      */
     public function getInputProperties() {
-        $settings = array();
+        $settings = [];
         $tvId = $this->getProperty('tv');
         if (!empty($tvId)) {
             /** @var modTemplateVar $tv */
@@ -120,12 +121,12 @@ class GetInputProperties extends Processor {
      * @return array
      */
     public function fireOnTVPropertiesListEvent() {
-        $pluginResult = $this->modx->invokeEvent($this->onPropertiesListEvent, array(
+        $pluginResult = $this->modx->invokeEvent($this->onPropertiesListEvent, [
             'context' => $this->getProperty('context'),
-        ));
-        if (!is_array($pluginResult) && !empty($pluginResult)) { $pluginResult = array($pluginResult); }
+        ]);
+        if (!is_array($pluginResult) && !empty($pluginResult)) { $pluginResult = [$pluginResult]; }
 
-        return !empty($pluginResult) ? $pluginResult : array();
+        return !empty($pluginResult) ? $pluginResult : [];
     }
 
     /**
@@ -133,8 +134,8 @@ class GetInputProperties extends Processor {
      * @return array
      */
     public function loadNamespaceCache() {
-        $cache = $this->modx->call(modNamespace::class, 'loadCache', array(&$this->modx));
-        $cachedDirs = array();
+        $cache = $this->modx->call(modNamespace::class, 'loadCache', [&$this->modx]);
+        $cachedDirs = [];
         if (!empty($cache) && is_array($cache)) {
             foreach ($cache as $namespace) {
                 $inputDir = rtrim($namespace['path'],'/').'/tv/'.$this->renderDirectory.'/';
@@ -151,9 +152,9 @@ class GetInputProperties extends Processor {
      */
     public function getRenderDirectories() {
         /* handle dynamic paths */
-        $renderDirectories = array(
+        $renderDirectories = [
             dirname(__FILE__).'/'.$this->getProperty('context').'/'.$this->renderDirectory.'/',
-        );
+        ];
 
         $pluginResult = $this->fireOnTVPropertiesListEvent();
         $cached = $this->loadNamespaceCache();

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
@@ -30,7 +30,7 @@ class GetInputs extends Processor {
         return $this->modx->hasPermission('view_tv');
     }
     public function getLanguageTopics() {
-        return array('tv_widget','tv_input_types');
+        return ['tv_widget','tv_input_types'];
     }
 
     public function initialize() {
@@ -50,16 +50,16 @@ class GetInputs extends Processor {
         $renderDirectories = [__DIR__ . '/' . $context . '/input/'];
 
         /* allow for custom directories */
-        $pluginResult = $this->modx->invokeEvent('OnTVInputRenderList',array(
+        $pluginResult = $this->modx->invokeEvent('OnTVInputRenderList', [
             'context' => $context,
-        ));
-        if (!is_array($pluginResult) && !empty($pluginResult)) { $pluginResult = array($pluginResult); }
+        ]);
+        if (!is_array($pluginResult) && !empty($pluginResult)) { $pluginResult = [$pluginResult]; }
         if (!empty($pluginResult)) {
             $renderDirectories = array_merge($renderDirectories,$pluginResult);
         }
 
         /* load namespace caches */
-        $cache = $this->modx->call(modNamespace::class,'loadCache',array(&$this->modx));
+        $cache = $this->modx->call(modNamespace::class,'loadCache', [&$this->modx]);
         if (!empty($cache) && is_array($cache)) {
             foreach ($cache as $namespace) {
                 $inputDir = rtrim($namespace['path'],'/').'/tv/input/';
@@ -70,25 +70,25 @@ class GetInputs extends Processor {
         }
 
         /* search directories */
-        $types = array();
+        $types = [];
         foreach ($renderDirectories as $renderDirectory) {
             if (empty($renderDirectory) || !is_dir($renderDirectory)) continue;
             try {
                 $dirIterator = new DirectoryIterator($renderDirectory);
                 foreach ($dirIterator as $file) {
                     if (!$file->isReadable() || !$file->isFile()) continue;
-                    $type = str_replace(array('.php','.class','.class.php'),'',$file->getFilename());
-                    $types[$type] = array(
+                    $type = str_replace(['.php','.class','.class.php'],'',$file->getFilename());
+                    $types[$type] = [
                         'name' => $this->modx->lexicon($type),
                         'value' => $type,
-                    );
+                    ];
                 }
             } catch (UnexpectedValueException $e) {}
         }
 
         /* sort types */
         asort($types);
-        $otypes = array();
+        $otypes = [];
         foreach ($types as $type) {
             $otypes[] = $type;
         }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetOutputs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetOutputs.php
@@ -38,7 +38,7 @@ class GetOutputs extends Processor {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('tv_widget');
+        return ['tv_widget'];
     }
 
     /**
@@ -47,12 +47,12 @@ class GetOutputs extends Processor {
      * @return array
      */
     public function fireOnTVOutputRenderListEvent($context) {
-        $pluginResult = $this->modx->invokeEvent('OnTVOutputRenderList',array(
+        $pluginResult = $this->modx->invokeEvent('OnTVOutputRenderList', [
             'context' => $context,
-        ));
-        if (!is_array($pluginResult) && !empty($pluginResult)) { $pluginResult = array($pluginResult); }
+        ]);
+        if (!is_array($pluginResult) && !empty($pluginResult)) { $pluginResult = [$pluginResult]; }
 
-        return !empty($pluginResult) ? $pluginResult : array();
+        return !empty($pluginResult) ? $pluginResult : [];
     }
 
     /**
@@ -60,8 +60,8 @@ class GetOutputs extends Processor {
      * @return array
      */
     public function loadNamespaceCache() {
-        $cache = $this->modx->call(modNamespace::class, 'loadCache', array(&$this->modx));
-        $cachedDirs = array();
+        $cache = $this->modx->call(modNamespace::class, 'loadCache', [&$this->modx]);
+        $cachedDirs = [];
         if (!empty($cache) && is_array($cache)) {
             foreach ($cache as $namespace) {
                 $inputDir = rtrim($namespace['path'],'/').'/tv/output/';
@@ -80,9 +80,9 @@ class GetOutputs extends Processor {
     public function getRenderDirectories() {
         $context = $this->getProperty('context', 'web');
 
-        $renderDirectories = array(
+        $renderDirectories = [
             dirname(__FILE__).'/'.$context.'/output/',
-        );
+        ];
 
         $pluginResult = $this->fireOnTVOutputRenderListEvent($context);
         $cached = $this->loadNamespaceCache();
@@ -97,18 +97,18 @@ class GetOutputs extends Processor {
      * @return array
      */
     public function iterate(array $data) {
-        $types = array();
+        $types = [];
         foreach ($data as $renderDirectory) {
             if (empty($renderDirectory) || !is_dir($renderDirectory)) continue;
             try {
                 $dirIterator = new DirectoryIterator($renderDirectory);
                 foreach ($dirIterator as $file) {
                     if (!$file->isReadable() || !$file->isFile()) continue;
-                    $type = str_replace(array('.php', '.class', '.class.php'), '', $file->getFilename());
-                    $types[$type] = array(
+                    $type = str_replace(['.php', '.class', '.class.php'], '', $file->getFilename());
+                    $types[$type] = [
                         'name' => $this->modx->lexicon($type),
                         'value' => $type,
-                    );
+                    ];
                 }
             } catch (UnexpectedValueException $e) {}
         }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/autotag.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/autotag.class.php
@@ -22,7 +22,7 @@ class modTemplateVarInputRenderAutoTag extends modTemplateVarInputRender {
     public function getTemplate() {
         return 'element/tv/renders/input/autotag.tpl';
     }
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         if (empty($params['parent_resources'])) $params['parent_resources'] = '';
         $value = explode(",",$value);
 
@@ -34,11 +34,11 @@ class modTemplateVarInputRenderAutoTag extends modTemplateVarInputRender {
         $c = $this->modx->newQuery(modTemplateVarResource::class);
         $c->innerJoin(modTemplateVar::class,'TemplateVar');
         $c->innerJoin(modResource::class,'Resource');
-        $c->where(array(
+        $c->where([
             'tmplvarid' => $this->tv->get('id'),
-        ));
+        ]);
         if (!empty($params['parent_resources'])) {
-            $ids = array();
+            $ids = [];
             $parents = explode(',',$params['parent_resources']);
 
             $currCtx = 'web';
@@ -51,19 +51,19 @@ class modTemplateVarInputRenderAutoTag extends modTemplateVarInputRender {
                     $currCtx = $r->get('context_key');
                 }
                 if ($r) {
-                    $pids = $this->modx->getChildIds($id,10,array('context' => $r->get('context_key')));
+                    $pids = $this->modx->getChildIds($id,10, ['context' => $r->get('context_key')]);
                     $ids = array_merge($ids,$pids);
                 }
                 $ids[] = $id;
             }
             $this->modx->switchContext('mgr');
             $ids = array_unique($ids);
-            $c->where(array(
+            $c->where([
                 'Resource.id:IN' => $ids,
-            ));
+            ]);
         }
         $tags = $this->modx->getCollection(modTemplateVarResource::class,$c);
-        $options = array();
+        $options = [];
         /** @var modTemplateVarResource $tag */
         foreach ($tags as $tag) {
             $vs = explode(',',$tag->get('value'));
@@ -71,8 +71,8 @@ class modTemplateVarInputRenderAutoTag extends modTemplateVarInputRender {
         }
         $options = array_unique($options);
         sort($options);
-        $opts = array();
-        $defaults = array();
+        $opts = [];
+        $defaults = [];
         $i = 0;
         foreach ($options as $tag) {
             $checked = false;
@@ -82,10 +82,10 @@ class modTemplateVarInputRenderAutoTag extends modTemplateVarInputRender {
                 $defaults[] = 'tv'.$this->tv->get('id').'-'.$i;
             }
 
-            $opts[] = array(
+            $opts[] = [
                 'value' => htmlspecialchars($tag,ENT_COMPAT,'UTF-8'),
                 'checked' => $checked,
-            );
+            ];
             $i++;
         }
 

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/checkbox.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/checkbox.class.php
@@ -18,15 +18,15 @@ class modTemplateVarInputRenderCheckbox extends modTemplateVarInputRender {
     public function getTemplate() {
         return 'element/tv/renders/input/checkbox.tpl';
     }
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $value = explode("||",$value);
 
         $default = explode("||",$this->tv->get('default_text'));
 
         $options = $this->getInputOptions();
 
-        $items = array();
-        $defaults = array();
+        $items = [];
+        $defaults = [];
         $i = 0;
         foreach ($options as $option) {
             $opt = explode("==",$option);
@@ -48,11 +48,11 @@ class modTemplateVarInputRenderCheckbox extends modTemplateVarInputRender {
                 $opt[1] = '"'.str_replace('"','\"',$opt[1]).'"';
             }
 
-            $items[] = array(
+            $items[] = [
                 'text' => htmlspecialchars($opt[0],ENT_COMPAT,'UTF-8'),
                 'value' => $opt[1],
                 'checked' => $checked,
-            );
+            ];
             $i++;
         }
         $this->setPlaceholder('cbdefaults',implode(',',$defaults));

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarInputRender;
  * @subpackage processors.element.tv.renders.mgr.input
  */
 class modTemplateVarInputRenderDate extends modTemplateVarInputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $v = $value;
         if ($v != '' && $v != '0' && $v != '0000-00-00 00:00:00') {
             $v = strftime('%Y-%m-%d %H:%M:%S',strtotime($v));

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/file.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/file.class.php
@@ -22,8 +22,8 @@ use MODX\Revolution\Sources\modMediaSource;
  * @subpackage processors.element.tv.renders.mgr.input
  */
 class modTemplateVarInputRenderFile extends modTemplateVarInputRender {
-    public function process($value,array $params = array()) {
-        $this->modx->getService('fileHandler', modFileHandler::class, '', array('context' => $this->modx->context->get('key')));
+    public function process($value,array $params = []) {
+        $this->modx->getService('fileHandler', modFileHandler::class, '', ['context' => $this->modx->context->get('key')]);
 
         /** @var modMediaSource $source */
         $source = $this->tv->getSource($this->modx->resource->get('context_key'));

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/image.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/image.class.php
@@ -22,8 +22,8 @@ use MODX\Revolution\Sources\modMediaSource;
  * @subpackage processors.element.tv.renders.mgr.input
  */
 class modTemplateVarInputRenderImage extends modTemplateVarInputRender {
-    public function process($value,array $params = array()) {
-        $this->modx->getService('fileHandler', modFileHandler::class, '', array('context' => $this->modx->context->get('key')));
+    public function process($value,array $params = []) {
+        $this->modx->getService('fileHandler', modFileHandler::class, '', ['context' => $this->modx->context->get('key')]);
 
         /** @var modMediaSource $source */
         $source = $this->tv->getSource($this->modx->resource->get('context_key'));

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/list-multiple-legacy.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/list-multiple-legacy.class.php
@@ -18,19 +18,19 @@ class modTemplateVarInputRenderListboxMultipleNoJs extends modTemplateVarInputRe
     public function getTemplate() {
         return 'element/tv/renders/input/list-multiple-legacy.tpl';
     }
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $options = $this->getInputOptions();
-        $items = array();
+        $items = [];
 
         $values = @explode('||', $value);
         foreach ($options as $option) {
             $opt = explode("==",$option);
             if (!isset($opt[1])) $opt[1] = $opt[0];
-            $items[] = array(
+            $items[] = [
                 'text' => htmlspecialchars($opt[0],ENT_COMPAT,'UTF-8'),
                 'value' => htmlspecialchars($opt[1],ENT_COMPAT,'UTF-8'),
                 'selected' => in_array($opt[1], $values),
-            );
+            ];
         }
         $this->setPlaceholder('opts',$items);
     }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/listbox-multiple.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/listbox-multiple.class.php
@@ -18,23 +18,23 @@ class modTemplateVarInputRenderListboxMultiple extends modTemplateVarInputRender
     public function getTemplate() {
         return 'element/tv/renders/input/listbox-multiple.tpl';
     }
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $value = explode("||",$value);
 
         $options = $this->getInputOptions();
-        $items = array();
+        $items = [];
         foreach ($options as $option) {
             $opt = explode("==",$option);
             if (!isset($opt[1])) $opt[1] = $opt[0];
-            $items[] = array(
+            $items[] = [
                 'text' => htmlspecialchars($opt[0],ENT_COMPAT,'UTF-8'),
                 'value' => htmlspecialchars($opt[1],ENT_COMPAT,'UTF-8'),
                 'selected' => in_array($opt[1],$value),
-            );
+            ];
         }
 
         // preserve the order of selected values
-        $orderedItems = array();
+        $orderedItems = [];
         // loop trough the selected values
         foreach ($value as $val) {
             // find the corresponding option in the items array

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/listbox.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/listbox.class.php
@@ -18,9 +18,9 @@ class modTemplateVarInputRenderListbox extends modTemplateVarInputRender {
     public function getTemplate() {
         return 'element/tv/renders/input/listbox-single.tpl';
     }
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $options = $this->getInputOptions();
-        $items = array();
+        $items = [];
 
         $found = false;
         foreach ($options as $option) {
@@ -32,19 +32,19 @@ class modTemplateVarInputRenderListbox extends modTemplateVarInputRender {
                 $found = true;
             }
 
-            $items[] = array(
+            $items[] = [
                 'text' => htmlspecialchars($opt[0],ENT_COMPAT,'UTF-8'),
                 'value' => htmlspecialchars($opt[1],ENT_COMPAT,'UTF-8'),
                 'selected' => $selected,
-            );
+            ];
         }
 
         if (!empty($value) && $found === false) {
-            $items[] = array(
+            $items[] = [
                 'text' => htmlspecialchars($value,ENT_COMPAT,'UTF-8'),
                 'value' => htmlspecialchars($value,ENT_COMPAT,'UTF-8'),
                 'selected' => 1,
-            );
+            ];
         }
 
         $this->setPlaceholder('opts',$items);

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/option.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/option.class.php
@@ -15,12 +15,12 @@ use MODX\Revolution\modTemplateVarInputRender;
  * @subpackage processors.element.tv.renders.mgr.input
  */
 class modTemplateVarInputRenderOption extends modTemplateVarInputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $default = $this->tv->get('default_text');
 
         // handles radio buttons
         $options = $this->getInputOptions();
-        $items = array();
+        $items = [];
         $defaultIndex = '';
         $i = 0;
         foreach ($options as $option) {
@@ -44,11 +44,11 @@ class modTemplateVarInputRenderOption extends modTemplateVarInputRender {
                 $opt[1] = '"'.str_replace('"','\"',$opt[1]).'"';
             }
 
-            $items[] = array(
+            $items[] = [
                 'text' => htmlspecialchars($opt[0],ENT_COMPAT,'UTF-8'),
                 'value' => $opt[1],
                 'checked' => $checked,
-            );
+            ];
 
             $i++;
         }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/resourcelist.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/resourcelist.class.php
@@ -20,15 +20,15 @@ use MODX\Revolution\modTemplateVarInputRender;
  * @subpackage processors.element.tv.renders.mgr.input
  */
 class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $parents = $this->getInputOptions();
         $params['parents'] = isset($params['parents']) ? $params['parents'] : '';
         $parents = !empty($params['parents']) || $params['parents'] === '0' ? explode(',',$params['parents']) : $parents;
         $params['depth'] = !empty($params['depth']) ? $params['depth'] : 10;
         if (empty($parents) || (empty($parents[0]) && $parents[0] !== '0')) {
-            $parents = array();
+            $parents = [];
         }
-        $parentList = array();
+        $parentList = [];
         foreach ($parents as $parent) {
             /** @var modResource $parent */
             $parent = $this->modx->getObject(modResource::class,$parent);
@@ -36,13 +36,13 @@ class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
         }
 
         /* get all children */
-        $ids = array();
+        $ids = [];
         if (!empty($parentList)) {
             foreach ($parentList as $parent) {
                 if (!empty($params['includeParent'])) $ids[] = $parent->get('id');
-                $children = $this->modx->getChildIds($parent->get('id'),$params['depth'],array(
+                $children = $this->modx->getChildIds($parent->get('id'),$params['depth'], [
                     'context' => $parent->get('context_key'),
-                ));
+                ]);
                 $ids = array_merge($ids,$children);
             }
             $ids = array_unique($ids);
@@ -51,9 +51,9 @@ class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
         $c = $this->modx->newQuery(modResource::class);
         $c->leftJoin(modResource::class,'Parent');
         if (!empty($ids)) {
-            $c->where(array('modResource.id:IN' => $ids));
+            $c->where(['modResource.id:IN' => $ids]);
         } else if (!empty($parents) && $parents[0] == 0) {
-            $c->where(array('modResource.parent' => 0));
+            $c->where(['modResource.parent' => 0]);
         }
         if (!empty($params['where'])) {
             $params['where'] = $this->modx->fromJSON($params['where']);
@@ -61,7 +61,7 @@ class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
         }
         if (!empty($params['limitRelatedContext']) && ($params['limitRelatedContext'] == 1 || $params['limitRelatedContext'] == 'true')) {
             $context_key = $this->modx->resource->get('context_key');
-            $c->where(array('modResource.context_key' => $context_key));
+            $c->where(['modResource.context_key' => $context_key]);
         }
         $c->sortby('Parent.menuindex,modResource.menuindex','ASC');
         if (!empty($params['limit'])) {
@@ -70,18 +70,18 @@ class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
         $resources = $this->modx->getCollection(modResource::class, $c);
 
         /* iterate */
-        $opts = array();
+        $opts = [];
         if (!empty($params['showNone'])) {
-            $opts[] = array('value' => '','text' => '-','selected' => $this->tv->get('value') == '');
+            $opts[] = ['value' => '','text' => '-','selected' => $this->tv->get('value') == ''];
         }
         /** @var modResource $resource */
         foreach ($resources as $resource) {
             $selected = $resource->get('id') == $this->tv->get('value');
-            $opts[] = array(
+            $opts[] = [
                 'value' => $resource->get('id'),
                 'text' => $resource->get('pagetitle').' ('.$resource->get('id').')',
                 'selected' => $selected,
-            );
+            ];
         }
         $this->setPlaceholder('opts',$opts);
     }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/richtext.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/richtext.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarInputRender;
  * @subpackage processors.element.tv.renders.mgr.input
  */
 class modTemplateVarInputRenderRichText extends modTemplateVarInputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $which_editor = $this->modx->getOption('which_editor',null,'');
         $this->setPlaceholder('which_editor',$which_editor);
     }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/tag.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/tag.class.php
@@ -22,11 +22,11 @@ class modTemplateVarInputRenderTag extends modTemplateVarInputRender
      * @param array $params
      * @return mixed|void
      */
-    public function process($value, array $params = array())
+    public function process($value, array $params = [])
     {
         $value = is_array($value) ? $value : explode(',', $value);
 
-        $options = array();
+        $options = [];
 
         foreach ($this->getInputOptions() as $option) {
             if (!$option) { continue; }
@@ -35,11 +35,11 @@ class modTemplateVarInputRenderTag extends modTemplateVarInputRender
                 $option[] = $option[0];
             }
             list($inputOptionText, $inputOptionValue) = $option;
-            $options[] = array(
+            $options[] = [
                 'value' => htmlspecialchars($inputOptionValue, ENT_COMPAT, 'UTF-8'),
                 'text' => htmlspecialchars($inputOptionText,ENT_COMPAT,'UTF-8'),
                 'checked' => in_array($inputOptionValue, $value, false),
-            );
+            ];
         }
 
         $this->setPlaceholder('options', $options);

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/url.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/url.class.php
@@ -18,8 +18,8 @@ class modTemplateVarInputRenderUrl extends modTemplateVarInputRender {
     public function getTemplate() {
         return 'element/tv/renders/input/url.tpl';
     }
-    public function process($value,array $params = array()) {
-        $urls= array(''=>'--', 'http://'=>'http://', 'https://'=>'https://', 'ftp://'=>'ftp://', 'mailto:'=>'mailto:');
+    public function process($value,array $params = []) {
+        $urls= [''=>'--', 'http://'=>'http://', 'https://'=>'https://', 'ftp://'=>'ftp://', 'mailto:'=>'mailto:'];
         $this->setPlaceholder('urls',$urls);
         foreach ($urls as $k => $v) {
             $test = $this->modx->getOption('use_multibyte',null,false) ? mb_strpos($value,$v,null,$this->modx->getOption('modx_charset',null,'UTF-8')) : strpos($value,$v);

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/date.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/date.class.php
@@ -19,11 +19,11 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderDate extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         /* default properties */
         $params['format'] = !empty($params['format']) ? $params['format'] : "%A %d, %B %Y";
         /* fix for 2.0.0-pl bug where 1=yes and 0=no */
-        $params['default'] = !empty($params['default']) && in_array($params['default'],array('yes',1,'1')) ? 1 : 0;
+        $params['default'] = !empty($params['default']) && in_array($params['default'], ['yes',1,'1']) ? 1 : 0;
 
         $value= $this->tv->parseInput($value);
 

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/default.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/default.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderDefault extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $value= $this->tv->parseInput($value);
         if ($this->tv->get('type') == 'checkbox' || $this->tv->get('type') == 'listbox-multiple') {
             // remove delimiter from checkbox and listbox-multiple TVs

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/delim.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/delim.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderDelim extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $value= $this->tv->parseInput($value, "||");
         $p= isset($params['delimiter']) ? $params['delimiter'] : ',';
 

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/htmltag.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/htmltag.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderHtmlTag extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $value= $this->tv->parseInput($value, "||", "array");
         $tagid = !empty($params['tagid']) ? $params['tagid'] : '';
         $tagname = !empty($params['tagname']) ? $params['tagname'] : 'div';
@@ -31,11 +31,11 @@ class modTemplateVarOutputRenderHtmlTag extends modTemplateVarOutputRender {
             $domId .= count($value) > 1 ? $i : '';
 
             $attributes = '';
-            $attr = array(
+            $attr = [
                 'id' => $domId, /* 'tv' already added to id */
                 'class' => !empty($params['class']) ? $params['class'] : null,
                 'style' => !empty($params['style']) ? $params['style'] : null,
-            );
+            ];
             foreach ($attr as $k => $v) $attributes.= ($v ? ' '.$k.'="'.$v.'"' : '');
             if (!empty($params['attrib'])) {
                 $attributes .= ' '.$params['attrib'];
@@ -46,10 +46,10 @@ class modTemplateVarOutputRenderHtmlTag extends modTemplateVarOutputRender {
         }
         if (empty($o)) {
             $attributes = '';
-            $attr = array(
+            $attr = [
                 'class' => !empty($params['class']) ? $params['class'] : null,
                 'style' => !empty($params['style']) ? $params['style'] : null,
-            );
+            ];
             foreach ($attr as $k => $v) $attributes.= ($v ? ' '.$k.'="'.$v.'"' : '');
             if (!empty($params['attrib'])) {
                 $attributes .= ' '.$params['attrib']; /* add extra */

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/image.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/image.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderImage extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $images= $this->tv->parseInput($value, '||', 'array');
         $o= '';
         foreach ($images as $image) {
@@ -24,14 +24,14 @@ class modTemplateVarOutputRenderImage extends modTemplateVarOutputRender {
             }
             $src= $image[0];
             if ($src) {
-                $attributes = array();
-                $attr = array(
+                $attributes = [];
+                $attr = [
                     'class' => $params['class'],
                     'src' => $src,
                     'id' => ($params['id'] ? $params['id'] : ''),
                     'alt' => htmlspecialchars($params['alttext']),
                     'style' => $params['style']
-                );
+                ];
                 foreach ($attr as $k => $v) {
                     if (!empty($v)) {
                         $attributes[] = $k.'="'.$v.'"';

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/richtext.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/richtext.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderRichText extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $id = 'tv'.$this->tv->get('name');
         $value= $this->tv->parseInput($value);
         $w= !empty($params['w']) ? $params['w'] : '100%';
@@ -24,19 +24,19 @@ class modTemplateVarOutputRenderRichText extends modTemplateVarOutputRender {
         $o= '<div class="MODX_RichTextWidget"><textarea id="' . $id . '" name="' . $id . '" style="width:' . $w . '; height:' . $h . ';">';
         $o .= htmlspecialchars($value);
         $o .= '</textarea></div>';
-        $replace_richtext= array (
+        $replace_richtext= [
             $id
-        );
+        ];
         // setup editors
         if (!empty ($replace_richtext) && !empty ($richtexteditor)) {
             // invoke OnRichTextEditorInit event
-            $evtOut= $this->modx->invokeEvent('OnRichTextEditorInit', array (
+            $evtOut= $this->modx->invokeEvent('OnRichTextEditorInit', [
                 'editor' => $richtexteditor,
                 'elements' => $replace_richtext,
                 'forfrontend' => 1,
                 'width' => $w,
                 'height' => $h
-            ));
+            ]);
             if (is_array($evtOut))
                 $o .= implode('', $evtOut);
         }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/string.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/string.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderString extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $value= $this->tv->parseInput($value);
         $format= !empty($params['format']) ? strtolower($params['format']) : '';
         switch ($format) {

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/text.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/text.class.php
@@ -15,7 +15,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderText extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         $value= $this->tv->parseInput($value);
         if ($this->tv->get('type') == 'checkbox' || $this->tv->get('type') == 'listbox-multiple') {
             // remove delimiter from checkbox and listbox-multiple TVs

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/url.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/url.class.php
@@ -20,7 +20,7 @@ use MODX\Revolution\modTemplateVarOutputRender;
  * @subpackage processors.element.tv.renders.mgr.output
  */
 class modTemplateVarOutputRenderUrl extends modTemplateVarOutputRender {
-    public function process($value,array $params = array()) {
+    public function process($value,array $params = []) {
         if (empty($value)) return $value;
 
         $value= $this->tv->parseInput($value, "||", "array");
@@ -50,13 +50,13 @@ class modTemplateVarOutputRenderUrl extends modTemplateVarOutputRender {
                 if($o) $o.='<br />';
                 $attributes = '';
                 /* setup the link attributes */
-                $attr = array(
+                $attr = [
                     'href' => $url,
                     'title' => !empty($params['title']) ? htmlspecialchars($params['title']) : $name,
                     'class' => !empty($params['class']) ? $params['class'] : null,
                     'style' => !empty($params['style']) ? $params['style'] : null,
                     'target' => !empty($params['target']) ? $params['target'] : null,
-                );
+                ];
                 foreach ($attr as $k => $v) $attributes .= ($v ? ' '.$k.'="'.$v.'"' : '');
                 if (!empty($params['attrib'])) {
                     $attributes .= ' '.$params['attrib']; /* add extra */

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -32,7 +32,7 @@ abstract class Processor {
      * The array of properties being passed to this processor
      * @var array $properties
      */
-    public $properties = array();
+    public $properties = [];
 
     /**
      * Creates a modProcessor object.
@@ -40,7 +40,7 @@ abstract class Processor {
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
      */
-    public function __construct(modX $modx,array $properties = array()) {
+    public function __construct(modX $modx,array $properties = []) {
         $this->modx =& $modx;
         $this->setProperties($properties);
     }
@@ -94,7 +94,7 @@ abstract class Processor {
      * @return array
      */
     public function getLanguageTopics() {
-        return array();
+        return [];
     }
 
     /**
@@ -145,7 +145,7 @@ abstract class Processor {
      * @param array $properties An array of properties being run with the processor
      * @return Processor The class specified by $className
      */
-    public static function getInstance(modX $modx,$className,$properties = array()) {
+    public static function getInstance(modX $modx,$className,$properties = []) {
         /** @var Processor $processor */
         $processor = new $className($modx,$properties);
         return $processor;
@@ -235,7 +235,7 @@ abstract class Processor {
      * @param array $properties
      * @return array The newly merged properties array
      */
-    public function setDefaultProperties(array $properties = array()) {
+    public function setDefaultProperties(array $properties = []) {
         $this->properties = array_merge($properties,$this->properties);
         return $this->properties;
     }
@@ -253,14 +253,16 @@ abstract class Processor {
      */
     public function outputArray(array $array,$count = false) {
         if ($count === false) { $count = count($array); }
-        $output = json_encode(array(
+        $output = json_encode(
+            [
             'success' => true,
             'total' => $count,
             'results' => $array
-        ));
+            ]
+        );
         if ($output === false) {
             $this->modx->log(modX::LOG_LEVEL_ERROR, 'Processor failed creating output array due to JSON error '.json_last_error());
-            return json_encode(array('success' => false));
+            return json_encode(['success' => false]);
         }
         return $output;
     }
@@ -277,7 +279,7 @@ abstract class Processor {
      */
     public function toJSON($data) {
         if (is_array($data)) {
-            array_walk_recursive($data, array(&$this, '_encodeLiterals'));
+            array_walk_recursive($data, [&$this, '_encodeLiterals']);
         }
         return $this->_decodeLiterals($this->modx->toJSON($data));
     }

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -198,12 +198,12 @@ class Search extends Processor
         $collection = $this->modx->getIterator(modUser::class, $c);
 
         foreach ($collection as $record) {
-            $this->results[] = array(
+            $this->results[] = [
                 'name' => $record->get('username'),
                 'description' => $record->get('fullname') .' / '. $record->get('email'),
                 '_action' => 'security/user/update&id=' . $record->get('internalKey'),
                 'type' => static::TYPE_USER . 's',
-            );
+            ];
         }
     }
 }

--- a/core/src/Revolution/Processors/Security/Access/GetNodes.php
+++ b/core/src/Revolution/Processors/Security/Access/GetNodes.php
@@ -58,7 +58,7 @@ class GetNodes extends ModelProcessor
                 'leaf' => 0,
                 'type' => 'modAccessContext',
             ];
-            $da[] = array(
+            $da[] = [
                 'text' => $this->modx->lexicon('resource_groups'),
                 'id' => 'n_modResourceGroup_0',
                 'cls' => 'icon-resourcegroup folder',
@@ -66,7 +66,7 @@ class GetNodes extends ModelProcessor
                 'target_cls' => modResourceGroup::class,
                 'leaf' => 0,
                 'type' => 'modAccessResourceGroup',
-            );
+            ];
         } else {
             $targets = $this->modx->getCollection($targetClass);
             /** @var modAccess $target */

--- a/core/src/Revolution/Processors/Security/Profile/Update.php
+++ b/core/src/Revolution/Processors/Security/Profile/Update.php
@@ -81,9 +81,9 @@ class Update extends Processor
 
             $this->modx->logManagerAction('change_profile_password', modUser::class, $this->modx->user->get('id'));
 
-            return $this->success($this->modx->lexicon('user_password_changed', array(
+            return $this->success($this->modx->lexicon('user_password_changed', [
                 'password' => $this->getProperty('password_new')
-            )));
+            ]));
         }
 
         return $this->success($this->modx->lexicon('success'), $this->profile->toArray());

--- a/core/src/Revolution/Processors/Security/User/Create.php
+++ b/core/src/Revolution/Processors/Security/User/Create.php
@@ -31,7 +31,7 @@ use MODX\Revolution\Smarty\modSmarty;
  */
 class Create extends CreateProcessor {
     public $classKey = modUser::class;
-    public $languageTopics = array('user', 'login');
+    public $languageTopics = ['user', 'login'];
     public $permission = 'new_user';
     public $objectType = 'user';
     public $beforeSaveEvent = 'OnBeforeUserFormSave';
@@ -54,11 +54,11 @@ class Create extends CreateProcessor {
      * @param array $properties
      * @return Processor
      */
-    public static function getInstance(modX &$modx,$className,$properties = array()) {
+    public static function getInstance(modX &$modx,$className,$properties = []) {
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : modUser::class;
         $object = $modx->newObject($classKey);
 
-        if (!in_array($classKey,array(modUser::class,''))) {
+        if (!in_array($classKey, [modUser::class,''])) {
             $className = $classKey.'CreateProcessor';
             if (!class_exists($className)) {
                 $className = static::class;
@@ -70,11 +70,13 @@ class Create extends CreateProcessor {
     }
 
     public function initialize() {
-        $this->setDefaultProperties(array(
+        $this->setDefaultProperties(
+            [
             'class_key' => $this->classKey,
             'blocked' => false,
             'active' => false,
-        ));
+            ]
+        );
         $this->classKey = $this->getProperty('class_key', modUser::class);
         $this->setProperty('blocked',$this->getProperty('blocked') ? true : false);
         return parent::initialize();
@@ -106,12 +108,12 @@ class Create extends CreateProcessor {
      */
     public function setUserGroups()
     {
-        $memberships = array();
+        $memberships = [];
         $groups = $this->getProperty('groups', null);
         if ($groups !== null) {
             $primaryGroupId = 0;
             $groups = is_array($groups) ? $groups : json_decode($groups, true);
-            $groupsAdded = array();
+            $groupsAdded = [];
             $idx = 0;
             foreach ($groups as $group) {
                 if (in_array($group['usergroup'], $groupsAdded)) {
@@ -120,23 +122,26 @@ class Create extends CreateProcessor {
 
                 /** @var modUserGroupMember $membership */
                 $membership = $this->modx->newObject(modUserGroupMember::class);
-                $membership->fromArray(array(
+                $membership->fromArray(
+                    [
                     'user_group' => $group['usergroup'],
                     'role' => $group['role'],
                     'member' => $this->object->get('id'),
                     'rank' => isset($group['rank']) ? $group['rank'] : $idx
-                ));
+                    ]
+                );
                 if (empty($group['rank'])) {
                     $primaryGroupId = $group['usergroup'];
                 }
 
                 $usergroup = $this->modx->getObject(modUserGroup::class, $group['usergroup']);
                 /* invoke OnUserBeforeAddToGroup event */
-                $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', array(
+                $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', [
                     'user' => &$this->object,
                     'usergroup' => &$usergroup,
                     'membership' => &$membership,
-                ));
+                ]
+                );
                 $canSave = $this->processEventResponse($OnUserBeforeAddToGroup);
                 if (!empty($canSave)) {
                     $this->object->save();
@@ -151,11 +156,12 @@ class Create extends CreateProcessor {
                 }
 
                 /* invoke OnUserAddToGroup event */
-                $this->modx->invokeEvent('OnUserAddToGroup', array(
+                $this->modx->invokeEvent('OnUserAddToGroup', [
                     'user' => &$this->object,
                     'usergroup' => &$usergroup,
                     'membership' => &$membership,
-                ));
+                ]
+                );
 
                 $groupsAdded[] = $group['usergroup'];
                 $idx++;

--- a/core/src/Revolution/Processors/Security/User/Update.php
+++ b/core/src/Revolution/Processors/Security/User/Update.php
@@ -30,7 +30,7 @@ use MODX\Revolution\modX;
  */
 class Update extends UpdateProcessor {
     public $classKey = modUser::class;
-    public $languageTopics = array('user');
+    public $languageTopics = ['user'];
     public $permission = 'save_user';
     public $objectType = 'user';
     public $beforeSaveEvent = 'OnBeforeUserFormSave';
@@ -60,11 +60,11 @@ class Update extends UpdateProcessor {
      * @param array $properties
      * @return Processor
      */
-    public static function getInstance(modX &$modx,$className,$properties = array()) {
+    public static function getInstance(modX &$modx,$className,$properties = []) {
         $classKey = !empty($properties['class_key']) ? $properties['class_key'] : modUser::class;
         $object = $modx->newObject($classKey);
 
-        if (!in_array($classKey,array('modUser',''))) {
+        if (!in_array($classKey, ['modUser',''])) {
             $className = $classKey.'UpdateProcessor';
             if (!class_exists($className)) {
                 $className = static::class;
@@ -80,9 +80,11 @@ class Update extends UpdateProcessor {
      * @return boolean|string
      */
     public function initialize() {
-        $this->setDefaultProperties(array(
+        $this->setDefaultProperties(
+            [
             'class_key' => $this->classKey,
-        ));
+            ]
+        );
         return parent::initialize();
     }
 
@@ -130,11 +132,13 @@ class Update extends UpdateProcessor {
         $this->newActiveStatus = $this->object->get('active');
         if ($this->activeStatusChanged) {
             $event = $this->newActiveStatus == true ? 'OnBeforeUserActivate' : 'OnBeforeUserDeactivate';
-            $OnBeforeUserActivate = $this->modx->invokeEvent($event,array(
+            $OnBeforeUserActivate = $this->modx->invokeEvent($event,
+                                                             [
                 'id' => $this->object->get('id'),
                 'user' => &$this->object,
                 'mode' => modSystemEvent::MODE_UPD,
-            ));
+                                                             ]
+            );
             $canChange = $this->processEventResponse($OnBeforeUserActivate);
             if (!empty($canChange)) {
                 return $canChange;
@@ -177,14 +181,14 @@ class Update extends UpdateProcessor {
      * @return modUserGroupMember[] new added member groups
      */
     public function setUserGroups() {
-        $memberships = array();
+        $memberships = [];
         $groups = $this->getProperty('groups', null);
         if ($groups !== null) {
             $groups = is_array($groups) ? $groups : json_decode($groups, true);
             $primaryGroupId = $this->object->get('primary_group');
 
-            $currentGroups = array();
-            $currentGroupIds = array();
+            $currentGroups = [];
+            $currentGroupIds = [];
             foreach ($groups as $group) {
                 $currentGroups[$group['usergroup']] = $group;
                 $currentGroupIds[] = $group['usergroup'];
@@ -194,7 +198,7 @@ class Update extends UpdateProcessor {
                 $primaryGroupId = 0;
             }
 
-            $remainingGroupIds = array();
+            $remainingGroupIds = [];
             /** @var modUserGroupMember[] $existingMemberships */
             $existingMemberships = $this->object->getMany('UserGroupMembers');
             foreach ($existingMemberships as $existingMembership) {
@@ -202,16 +206,18 @@ class Update extends UpdateProcessor {
                     $existingMembership->remove();
                 } else {
                     $existingGroup = $currentGroups[$existingMembership->get('user_group')];
-                    $existingMembership->fromArray(array(
+                    $existingMembership->fromArray(
+                        [
                         'role' => $existingGroup['role'],
                         'rank' => isset($existingGroup['rank']) ? $existingGroup['rank'] : 0
-                    ));
+                        ]
+                    );
                     $remainingGroupIds[] = $existingMembership->get('user_group');
                 }
             }
 
             $newGroupIds = array_diff($currentGroupIds, $remainingGroupIds);
-            $newGroups = array();
+            $newGroups = [];
             foreach ($groups as $group) {
                 if (in_array($group['usergroup'], $newGroupIds)) {
                     $newGroups[] = $group;
@@ -225,23 +231,26 @@ class Update extends UpdateProcessor {
             foreach ($newGroups as $newGroup) {
                 /** @var modUserGroupMember $membership */
                 $membership = $this->modx->newObject(modUserGroupMember::class);
-                $membership->fromArray(array(
+                $membership->fromArray(
+                    [
                     'user_group' => $newGroup['usergroup'],
                     'role' => $newGroup['role'],
                     'member' => $this->object->get('id'),
                     'rank' => isset($newGroup['rank']) ? $newGroup['rank'] : $idx
-                ));
+                    ]
+                );
                 if (empty($newGroup['rank'])) {
                     $primaryGroupId = $newGroup['usergroup'];
                 }
 
                 $usergroup = $this->modx->getObject(modUserGroup::class, $newGroup['usergroup']);
                 /* invoke OnUserBeforeAddToGroup event */
-                $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', array(
+                $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', [
                     'user' => &$this->object,
                     'usergroup' => &$usergroup,
                     'membership' => &$membership,
-                ));
+                ]
+                );
                 $canSave = $this->processEventResponse($OnUserBeforeAddToGroup);
                 if (!empty($canSave)) {
                     return $this->failure($canSave);
@@ -254,11 +263,12 @@ class Update extends UpdateProcessor {
                 }
 
                 /* invoke OnUserAddToGroup event */
-                $this->modx->invokeEvent('OnUserAddToGroup', array(
+                $this->modx->invokeEvent('OnUserAddToGroup', [
                     'user' => &$this->object,
                     'usergroup' => &$usergroup,
                     'membership' => &$membership,
-                ));
+                ]
+                );
 
                 $idx++;
             }
@@ -286,11 +296,13 @@ class Update extends UpdateProcessor {
      */
     public function fireAfterActiveStatusChange() {
         $event = $this->newActiveStatus == true ? 'OnUserActivate' : 'OnUserDeactivate';
-        $this->modx->invokeEvent($event,array(
+        $this->modx->invokeEvent($event,
+                                 [
             'id' => $this->object->get('id'),
             'user' => &$this->object,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+                                 ]
+        );
     }
 
     /**
@@ -300,9 +312,11 @@ class Update extends UpdateProcessor {
     public function cleanup() {
         $passwordNotifyMethod = $this->getProperty('passwordnotifymethod');
         if (!empty($passwordNotifyMethod) && !empty($this->newPassword) && $passwordNotifyMethod  == 's') {
-            return $this->success($this->modx->lexicon('user_updated_password_message',array(
+            return $this->success($this->modx->lexicon('user_updated_password_message',
+                                                       [
                 'password' => $this->newPassword,
-            )),$this->object);
+                                                       ]
+            ), $this->object);
         } else {
             return $this->success('',$this->object);
         }

--- a/core/src/Revolution/Processors/Security/User/Validation.php
+++ b/core/src/Revolution/Processors/Security/User/Validation.php
@@ -65,10 +65,12 @@ class Validation {
     }
 
     public function alreadyExists($name) {
-        return $this->modx->getCount(modUser::class,array(
+        return $this->modx->getCount(modUser::class,
+                                     [
                 'username' => $name,
                 'id:!=' => $this->user->get('id'),
-            )) > 0;
+                                     ]
+            ) > 0;
     }
 
     public function checkPassword() {
@@ -112,7 +114,7 @@ class Validation {
 
         if (!$this->modx->getOption('allow_multiple_emails',null,true)) {
             /** @var modUserProfile $emailExists */
-            $emailExists = $this->modx->getObject(modUserProfile::class,array('email' => $email));
+            $emailExists = $this->modx->getObject(modUserProfile::class, ['email' => $email]);
             if ($emailExists) {
                 if ($emailExists->get('internalKey') != $this->processor->getProperty('id')) {
                     $this->processor->addFieldError('email',$this->modx->lexicon('user_err_already_exists_email'));

--- a/core/src/Revolution/Processors/Workspace/Theme/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Theme/GetList.php
@@ -27,12 +27,12 @@ class GetList extends ModelProcessor
     public function process()
     {
         $themePath = $this->modx->config['manager_path'] . 'templates/';
-        $themes = array();
+        $themes = [];
 
         $dir = new DirectoryIterator($themePath);
         foreach ($dir as $fileInfo) {
             if ($fileInfo->isDir() && !$fileInfo->isDot()) {
-                $themes[] = array('theme' => $fileInfo->getFilename());
+                $themes[] = ['theme' => $fileInfo->getFilename()];
             }
         }
 

--- a/core/src/Revolution/Rest/modRestClient.php
+++ b/core/src/Revolution/Rest/modRestClient.php
@@ -60,7 +60,7 @@ class modRestClient {
      * @var array $config The configuration array.
      * @access public
      */
-    public $config = array();
+    public $config = [];
     /**
      * @var modRestClient $conn The client connection instance to use.
      * @access public
@@ -90,14 +90,14 @@ class modRestClient {
      * @param modX &$modx A reference to the modX instance.
      * @param array $config An array of configuration options.
      */
-    function __construct(modX &$modx,array $config = array()) {
+    function __construct(modX &$modx,array $config = []) {
         $this->modx =& $modx;
-        $this->config = array_merge(array(
+        $this->config = array_merge([
             modRestClient::OPT_PORT => 80,
             modRestClient::OPT_TIMEOUT => 30,
             modRestClient::OPT_PATH => '/',
             modRestClient::OPT_USERAGENT => "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0)"
-        ),$config);
+        ],$config);
         $this->modx->deprecated('2.3.0', 'Use the modRest classes instead.');
     }
 
@@ -134,7 +134,7 @@ class modRestClient {
      * @param array $options An array of options to pass to the request.
      * @return modRestResponse The response object.
      */
-    public function request($host,$path,$method = 'GET',array $params = array(),array $options = array()) {
+    public function request($host,$path,$method = 'GET',array $params = [],array $options = []) {
         if (!is_object($this->conn)) {
             $loaded = $this->getConnection();
             if (!$loaded) return false;
@@ -171,9 +171,9 @@ class modRestClient {
         foreach ($children as $elementName => $node)
         {
             $nextIdx = count($arr);
-            $arr[$nextIdx] = array();
+            $arr[$nextIdx] = [];
             $arr[$nextIdx]['name'] = strtolower((string)$elementName);
-            $arr[$nextIdx]['attributes'] = array();
+            $arr[$nextIdx]['attributes'] = [];
             $attributes = $node->attributes();
             foreach ($attributes as $attributeName => $attributeValue) {
                 $attribName = strtolower(trim((string)$attributeName));
@@ -185,7 +185,7 @@ class modRestClient {
             if (strlen($text) > 0) {
                 $arr[$nextIdx]['text'] = $text;
             }
-            $arr[$nextIdx]['children'] = array();
+            $arr[$nextIdx]['children'] = [];
             $this->xml2array($node, $arr[$nextIdx]['children']);
         }
         return true;

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1175,7 +1175,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      *
      * @return string
      */
-    public function getOpenTo($value,array $parameters = array()) {
+    public function getOpenTo($value,array $parameters = []) {
         $dirname = dirname($value);
         return $dirname == '.' ? '' : $dirname . '/';
     }

--- a/core/src/Revolution/modDashboardSnippetWidget.php
+++ b/core/src/Revolution/modDashboardSnippetWidget.php
@@ -21,14 +21,18 @@ class modDashboardSnippetWidget extends modDashboardWidgetInterface
     public function render()
     {
         /** @var modSnippet $snippet */
-        $snippet = $this->modx->getObject(modSnippet::class,array(
+        $snippet = $this->modx->getObject(modSnippet::class,
+                                          [
             'name' => $this->widget->get('content'),
-        ));
+                                          ]
+        );
         if ($snippet) {
             $snippet->setCacheable(false);
-            $content = $snippet->process(array(
+            $content = $snippet->process(
+                [
                 'controller' => $this->controller,
-            ));
+                ]
+            );
         } else {
             $content = '';
         }

--- a/core/src/Revolution/modDashboardWidgetInterface.php
+++ b/core/src/Revolution/modDashboardWidgetInterface.php
@@ -119,7 +119,7 @@ abstract class modDashboardWidgetInterface
      * @param array $placeholders
      * @return string
      */
-    public function getFileChunk($tpl,array $placeholders = array()) {
+    public function getFileChunk($tpl,array $placeholders = []) {
         $output = '';
         $file = $tpl;
         if (!file_exists($file)) {

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -179,7 +179,7 @@ class modParser
      * returned by prior passes, 0 by default.
      * @return int The number of processed tags
      */
-    public function processElementTags($parentTag, & $content, $processUncacheable= false, $removeUnprocessed= false, $prefix= "[[", $suffix= "]]", $tokens= array (), $depth= 0) {
+    public function processElementTags($parentTag, & $content, $processUncacheable= false, $removeUnprocessed= false, $prefix= "[[", $suffix= "]]", $tokens= [], $depth= 0) {
         if ($processUncacheable) {
             $this->_startedProcessingUncacheable = true;
         }
@@ -191,14 +191,14 @@ class modParser
         $this->_removingUnprocessed = (boolean) $removeUnprocessed;
         $depth = $depth > 0 ? $depth - 1 : 0;
         $processed= 0;
-        $tags= array ();
+        $tags= [];
         /* invoke OnParseDocument event */
         $this->modx->documentOutput = $content;
-        $this->modx->invokeEvent('OnParseDocument', array('content' => &$content));
+        $this->modx->invokeEvent('OnParseDocument', ['content' => &$content]);
         $content = $this->modx->documentOutput;
         unset($this->modx->documentOutput);
         if ($collected= $this->collectElementTags($content, $tags, $prefix, $suffix, $tokens)) {
-            $tagMap= array ();
+            $tagMap= [];
             foreach ($tags as $tag) {
                 $token= substr($tag[1], 0, 1);
                 if (!$processUncacheable && $token === '!') {
@@ -260,7 +260,7 @@ class modParser
      * the property string or array definition.
      */
     public function parseProperties($propSource) {
-        $properties= array ();
+        $properties= [];
         if (!empty ($propSource)) {
             if (is_string($propSource)) {
                 $properties = $this->parsePropertyString($propSource, true);
@@ -286,7 +286,7 @@ class modParser
      * @return array The processed properties in array format
      */
     public function parsePropertyString($string, $valuesOnly = false) {
-        $properties = array();
+        $properties = [];
         $tagProps= xPDO :: escSplit("&", $string);
         foreach ($tagProps as $prop) {
             $property= xPDO :: escSplit('=', $prop);
@@ -298,7 +298,7 @@ class modParser
                 $propValue= $property[1];
                 $propType= 'textfield';
                 $propDesc= '';
-                $propOptions= array();
+                $propOptions= [];
                 $pvTmp= xPDO :: escSplit(';', $propValue);
                 if ($pvTmp && isset ($pvTmp[1])) {
                     $propDesc= $pvTmp[0];
@@ -307,7 +307,7 @@ class modParser
                             $propType = modParser::_XType($pvTmp[1]);
                             $options = explode(',', $pvTmp[2]);
                             if ($options) {
-                                foreach ($options as $option) $propOptions[] = array('name' => ucfirst($option), 'value' => $option);
+                                foreach ($options as $option) $propOptions[] = ['name' => ucfirst($option), 'value' => $option];
                             }
                         }
                         $propValue = $pvTmp[3];
@@ -328,13 +328,13 @@ class modParser
                 if ($valuesOnly) {
                     $properties[$propName]= $propValue;
                 } else {
-                    $properties[$propName]= array(
+                    $properties[$propName]= [
                         'name' => $propName,
                         'desc' => $propDesc,
                         'type' => $propType,
                         'options' => $propOptions,
                         'value' => $propValue
-                    );
+                    ];
                 }
             }
         }
@@ -366,7 +366,8 @@ class modParser
             case 'list':
                 break;
             default:
-                if (!in_array($xtype, array('checkbox', 'combo', 'datefield', 'numberfield', 'radio', 'textarea', 'textfield', 'timefield'))) {
+                if (!in_array($xtype, ['checkbox', 'combo', 'datefield', 'numberfield', 'radio', 'textarea', 'textfield', 'timefield']
+                )) {
                     $xtype = 'textfield';
                 }
                 break;
@@ -550,24 +551,25 @@ class modParser
             }
         } else {
             /** @var modElement $element */
-            $element = $this->modx->getObjectGraph($class,array('Source' => array()),array('name' => $realname), true);
+            $element = $this->modx->getObjectGraph($class, ['Source' => []], ['name' => $realname], true);
             if ($element && array_key_exists($class, $this->modx->sourceCache)) {
-                $this->modx->sourceCache[$class][$realname] = array(
+                $this->modx->sourceCache[$class][$realname] = [
                     'fields' => $element->toArray(),
                     'policies' => $element->getPolicies(),
-                    'source' => $element->Source ? $element->Source->toArray() : array(),
-                );
+                    'source' => $element->Source ? $element->Source->toArray() : [],
+                ];
             }
             elseif(!$element) {
-                $evtOutput = $this->modx->invokeEvent('OnElementNotFound', array('class' => $class, 'name' => $realname));
+                $evtOutput = $this->modx->invokeEvent('OnElementNotFound', ['class' => $class, 'name' => $realname]);
                 $element = false;
                 if ($evtOutput != false) {
                     foreach ((array) $evtOutput as $elm) {
                         if (!empty($elm) && is_string($elm)) {
-                            $element = $this->modx->newObject($class, array(
+                            $element = $this->modx->newObject($class, [
                                 'name' => $realname,
                                 'snippet' => $elm
-                            ));
+                            ]
+                            );
                         }
                         elseif ($elm instanceof modElement ) {
                             $element = $elm;

--- a/core/src/Revolution/modTemplateVarInputRender.php
+++ b/core/src/Revolution/modTemplateVarInputRender.php
@@ -17,7 +17,7 @@ namespace MODX\Revolution;
  * @package MODX\Revolution
  */
 abstract class modTemplateVarInputRender extends modTemplateVarRender {
-    public function render($value,array $params = array()) {
+    public function render($value,array $params = []) {
         $this->setPlaceholder('tv',$this->tv);
         $this->setPlaceholder('id',$this->tv->get('id'));
         $this->setPlaceholder('ctx',isset($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'web');

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -1022,13 +1022,13 @@ class modUser extends modPrincipal
         /** @var modMediaSource $source */
         $source = modMediaSource::getDefaultSource($this->xpdo, $this->xpdo->getOption('photo_profile_source'));
 
-        $thumb_param = array(
+        $thumb_param = [
             "zc" => 1,
             "h" => $height,
             "w" => $width,
             "src" => $this->Profile->photo,
             "source" => $source->id
-        );
+        ];
 
         return $this->xpdo->getOption('connectors_url', null, MODX_CONNECTORS_URL)
             . "system/phpthumb.php?" . http_build_query($thumb_param);

--- a/core/src/Revolution/modUserGroupSetting.php
+++ b/core/src/Revolution/modUserGroupSetting.php
@@ -30,7 +30,7 @@ class modUserGroupSetting extends xPDOObject
      * @param array $options An array of options for the update
      * @return bool
      */
-    public function updateTranslation($key,$value = '',array $options = array()) {
+    public function updateTranslation($key,$value = '',array $options = []) {
         if (!is_array($options) || empty($options)) return false;
 
         $options['namespace'] = $this->xpdo->getOption('namespace',$options,'core');
@@ -40,12 +40,13 @@ class modUserGroupSetting extends xPDOObject
 
         $entries = $this->xpdo->lexicon->getFileTopic($options['cultureKey'],$options['namespace'],$options['topic']);
         /** @var modLexiconEntry $entry */
-        $entry = $this->xpdo->getObject(modLexiconEntry::class, array(
+        $entry = $this->xpdo->getObject(modLexiconEntry::class, [
             'name' => $key,
             'namespace' => $options['namespace'],
             'language' => $options['cultureKey'],
             'topic' => $options['topic'],
-        ));
+        ]
+        );
         if ((!empty($entries[$key]) && $entries[$key] == $value) || strcmp($key,$value) == 0 || empty($value)) {
             if ($entry) {
                 $saved = $entry->remove();

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -72,7 +72,7 @@ class modX extends xPDO {
     /**
      * @var array An array of secondary contexts loaded on demand.
      */
-    public $contexts= array();
+    public $contexts= [];
     /**
      * @var modRequest|modConnectorRequest|modManagerRequest Represents a web request and provides helper methods for
      * dealing with request parameters and other attributes of a request.
@@ -117,12 +117,12 @@ class modX extends xPDO {
     /**
      * @var array A map of already processed Elements.
      */
-    public $elementCache= array ();
+    public $elementCache= [];
     /**
      * @var array An array of key=> value pairs that can be used by any Resource
      * or Element.
      */
-    public $placeholders= array ();
+    public $placeholders= [];
     /**
      * @var modResource An instance of the current modResource controlling the
      * request.
@@ -179,16 +179,16 @@ class modX extends xPDO {
      * @var array An array of javascript content to be inserted into the HEAD
      * of an HTML resource.
      */
-    public $sjscripts= array ();
+    public $sjscripts= [];
     /**
      * @var array An array of javascript content to be inserted into the BODY
      * of an HTML resource.
      */
-    public $jscripts= array ();
+    public $jscripts= [];
     /**
      * @var array An array of already loaded javascript/css code
      */
-    public $loadedjscripts= array ();
+    public $loadedjscripts= [];
     /**
      * @var string Stores the virtual path for a request to MODX if the
      * friendly_alias_paths option is enabled.
@@ -225,16 +225,16 @@ class modX extends xPDO {
     /**
      * @var array $processors An array of loaded processors and their class name
      */
-    public $processors = array();
+    public $processors = [];
     /**
      * @var array An array of regex patterns regulary cleansed from content.
      */
-    public $sanitizePatterns = array(
+    public $sanitizePatterns = [
         'scripts'       => '@<script[^>]*?>.*?</script>@si',
         'entities'      => '@&#(\d+);@',
         'tags1'          => '@\[\[(.*?)\]\]@si',
         'tags2'          => '@(\[\[|\]\])@si',
-    );
+    ];
     /**
      * @var integer An integer representing the session state of modX.
      */
@@ -246,11 +246,11 @@ class modX extends xPDO {
     /**
      * @var array A config array that stores the system-wide settings.
      */
-    public $_systemConfig= array();
+    public $_systemConfig= [];
     /**
      * @var array A config array that stores the user settings.
      */
-    public $_userConfig= array();
+    public $_userConfig= [];
     /**
      * @var int The current log sequence
      */
@@ -259,15 +259,15 @@ class modX extends xPDO {
     /**
      * @var array An array of plugins that have been cached for execution
      */
-    public $pluginCache= array();
+    public $pluginCache= [];
     /**
      * @var array The element source cache used for caching and preparing Element data
      */
-    public $sourceCache= array(
-        modChunk::class => array()
-        ,modSnippet::class => array()
-        ,modTemplateVar::class => array(),
-    );
+    public $sourceCache= [
+        modChunk::class => []
+        ,modSnippet::class => []
+        ,modTemplateVar::class => [],
+    ];
     /** @var modCacheManager $cacheManager */
     public $cacheManager;
 
@@ -302,7 +302,7 @@ class modX extends xPDO {
                 unset ($GLOBALS[$key]);
             }
         }
-        $targets= array ('PHP_SELF', 'HTTP_USER_AGENT', 'HTTP_REFERER', 'QUERY_STRING');
+        $targets= ['PHP_SELF', 'HTTP_USER_AGENT', 'HTTP_REFERER', 'QUERY_STRING'];
         foreach ($targets as $target) {
             $_SERVER[$target] = isset ($_SERVER[$target]) ? htmlspecialchars($_SERVER[$target], ENT_QUOTES) : null;
         }
@@ -320,7 +320,7 @@ class modX extends xPDO {
      * @param integer $nesting The maximum nesting level in which to dive
      * @return array The sanitized array.
      */
-    public static function sanitize(array &$target, array $patterns= array(), $depth= 99, $nesting= 10) {
+    public static function sanitize(array &$target, array $patterns= [], $depth= 99, $nesting= 10) {
         foreach ($target as $key => &$value) {
             if (is_array($value) && $depth > 0) {
                 modX :: sanitize($value, $patterns, $depth-1);
@@ -362,10 +362,10 @@ class modX extends xPDO {
      * @param array $replaceable
      * @return array|string The sanitized data
      */
-    public static function replaceReserved($data, array $replaceable = array ('[' => '&#91;', ']' => '&#93;', '`' => '&#96;'))
+    public static function replaceReserved($data, array $replaceable = ['[' => '&#91;', ']' => '&#93;', '`' => '&#96;'])
     {
         if (\is_array($data)) {
-            $result = array();
+            $result = [];
             foreach ($data as $key => &$value) {
                 $key = self::replaceReserved($key, $replaceable);
                 $result[$key] = self::replaceReserved($value, $replaceable);
@@ -387,7 +387,7 @@ class modX extends xPDO {
      * @param string $allowedTags A list of tags to allow.
      * @return string The sanitized string.
      */
-    public function sanitizeString($str,$chars = array('/',"'",'"','(',')',';','>','<'),$allowedTags = '') {
+    public function sanitizeString($str,$chars = ['/',"'",'"','(',')',';','>','<'],$allowedTags = '') {
         $str = str_replace($chars,'',strip_tags($str,$allowedTags));
         return preg_replace("/[^A-Za-z0-9_\-\.\/\\p{L}[\p{L} _.-]/u",'',$str);
     }
@@ -402,7 +402,7 @@ class modX extends xPDO {
      * @param string $argSeparator The string used to separate arguments in the resulting query string.
      * @return string A valid query string representing the parameters.
      */
-    public static function toQueryString(array $parameters = array(), $numPrefix = '', $argSeparator = '&') {
+    public static function toQueryString(array $parameters = [], $numPrefix = '', $argSeparator = '&') {
         return http_build_query($parameters, $numPrefix, $argSeparator);
     }
 
@@ -467,9 +467,9 @@ class modX extends xPDO {
             $this->addPackage('MODX\Revolution\Sources', MODX_CORE_PATH . 'src/', null, 'MODX\\');
             $this->addPackage('MODX\Revolution\Transport', MODX_CORE_PATH . 'src/', null, 'MODX\\');
         } catch (xPDOException $xe) {
-            $this->sendError('unavailable', array('error_message' => $xe->getMessage()));
+            $this->sendError('unavailable', ['error_message' => $xe->getMessage()]);
         } catch (Exception $e) {
-            $this->sendError('unavailable', array('error_message' => $e->getMessage()));
+            $this->sendError('unavailable', ['error_message' => $e->getMessage()]);
         }
     }
 
@@ -483,8 +483,8 @@ class modX extends xPDO {
      * @return Container A DI container containing the config data ready for use by the modX::__construct() method.
      * @throws xPDOException
      */
-    protected function loadConfig($configPath = '', $data = array(), $driverOptions = null) {
-        if (!is_array($data)) $data = array();
+    protected function loadConfig($configPath = '', $data = [], $driverOptions = null) {
+        if (!is_array($data)) $data = [];
         modX :: protect();
         if (!defined('MODX_CONFIG_KEY')) {
             define('MODX_CONFIG_KEY', 'config');
@@ -496,10 +496,10 @@ class modX extends xPDO {
         if (file_exists($configPath . MODX_CONFIG_KEY . '.inc.php') && include ($configPath . MODX_CONFIG_KEY . '.inc.php')) {
             $cachePath= MODX_CORE_PATH . 'cache/';
             if (MODX_CONFIG_KEY !== 'config') $cachePath .= MODX_CONFIG_KEY . '/';
-            if (!is_array($config_options)) $config_options = array();
-            if (!is_array($driver_options)) $driver_options = array();
+            if (!is_array($config_options)) $config_options = [];
+            if (!is_array($driver_options)) $driver_options = [];
             $data = array_merge(
-                array (
+                [
                     xPDO::OPT_CACHE_KEY => 'default',
                     xPDO::OPT_CACHE_HANDLER => xPDOFileCache::class,
                     xPDO::OPT_CACHE_PATH => $cachePath,
@@ -512,21 +512,21 @@ class modX extends xPDO {
                     'cache_system_settings' => true,
                     'cache_system_settings_key' => 'system_settings',
                     'load_deprecated_global_class_aliases' => true,
-                ),
+                ],
                 $config_options,
                 $data
             );
-            $primaryConnection = array(
+            $primaryConnection = [
                 'dsn' => $database_dsn,
                 'username' => $database_user,
                 'password' => $database_password,
-                'options' => array(
+                'options' => [
                     xPDO::OPT_CONN_MUTABLE => isset($data[xPDO::OPT_CONN_MUTABLE]) ? (boolean) $data[xPDO::OPT_CONN_MUTABLE] : true,
-                ),
+                ],
                 'driverOptions' => $driver_options,
-            );
+            ];
             if (!array_key_exists(xPDO::OPT_CONNECTIONS, $data) || !is_array($data[xPDO::OPT_CONNECTIONS])) {
-                $data[xPDO::OPT_CONNECTIONS] = array();
+                $data[xPDO::OPT_CONNECTIONS] = [];
             }
             array_unshift($data[xPDO::OPT_CONNECTIONS], $primaryConnection);
             if (!empty($site_id)) $this->site_id = $site_id;
@@ -576,10 +576,10 @@ class modX extends xPDO {
 
             $this->invokeEvent(
                 'OnMODXInit',
-                array(
+                [
                      'contextKey' => $contextKey,
                      'options' => $options,
-                )
+                ]
             );
 
             if (is_array ($this->config)) {
@@ -611,7 +611,7 @@ class modX extends xPDO {
      * extension packages which will be merged with those specified via config.
      */
     protected function _loadExtensionPackages($options = null) {
-        $cache = $this->call(modExtensionPackage::class,'loadCache',array(&$this));
+        $cache = $this->call(modExtensionPackage::class, 'loadCache', [&$this]);
         if (!empty($cache)) {
             foreach ($cache as $package) {
                 $package['table_prefix'] = isset($package['table_prefix']) ? $package['table_prefix'] : null;
@@ -634,7 +634,7 @@ class modX extends xPDO {
     protected function _loadExtensionPackagesDeprecated($options = null) {
         $extPackages = $this->getOption('extension_packages');
         $extPackages = $this->fromJSON($extPackages);
-        if (!is_array($extPackages)) $extPackages = array();
+        if (!is_array($extPackages)) $extPackages = [];
         if (is_array($options) && array_key_exists('extension_packages', $options)) {
             $optPackages = $this->fromJSON($options['extension_packages']);
             if (is_array($optPackages)) {
@@ -649,17 +649,19 @@ class modX extends xPDO {
                 foreach ($extPackage as $packageName => $package) {
                     if (!empty($package) && !empty($package['path'])) {
                         $package['tablePrefix'] = isset($package['tablePrefix']) ? $package['tablePrefix'] : null;
-                        $package['path'] = str_replace(array(
+                        $package['path'] = str_replace(
+                            [
                             '[[++core_path]]',
                             '[[++base_path]]',
                             '[[++assets_path]]',
                             '[[++manager_path]]',
-                        ),array(
+                            ],
+                            [
                             $this->config['core_path'],
                             $this->config['base_path'],
                             $this->config['assets_path'],
                             $this->config['manager_path'],
-                        ),$package['path']);
+                            ], $package['path']);
                         $this->addPackage($packageName,$package['path'],$package['tablePrefix']);
                         if (!empty($package['serviceName']) && !empty($package['serviceClass'])) {
                             $packagePath = str_replace('//','/',$package['path'].$packageName.'/');
@@ -717,7 +719,8 @@ class modX extends xPDO {
      * @param array $options An array of options to send to the cache manager instance
      * @return modCacheManager A modCacheManager instance registered for this modX instance.
      */
-    public function getCacheManager($class= 'xPDO\\Cache\\xPDOCacheManager', $options = array('path' => XPDO_CORE_PATH, 'ignorePkg' => true)) {
+    public function getCacheManager($class= 'xPDO\\Cache\\xPDOCacheManager', $options = ['path' => XPDO_CORE_PATH, 'ignorePkg' => true]
+    ) {
         if ($this->cacheManager === null) {
             $className = $this->getOption('modCacheManager.class', null, modCacheManager::class);
             if ($this->cacheManager = new $className($this)) {
@@ -756,9 +759,9 @@ class modX extends xPDO {
      * @param array $options An array of filtering options, such as 'context' to specify the context to grab from
      * @return array An array of all the parent resource ids for the specified resource.
      */
-    public function getParentIds($id= null, $height= 10,array $options = array()) {
+    public function getParentIds($id= null, $height= 10,array $options = []) {
         $parentId= 0;
-        $parents= array ();
+        $parents= [];
         if ($id && $height > 0) {
 
             $context = '';
@@ -791,8 +794,8 @@ class modX extends xPDO {
      * @param array $options An array of filtering options, such as 'context' to specify the context to grab from
      * @return array An array of all the child resource ids for the specified resource.
      */
-    public function getChildIds($id= null, $depth= 10,array $options = array()) {
-        $children= array ();
+    public function getChildIds($id= null, $depth= 10,array $options = []) {
+        $children= [];
         if ($id !== null && intval($depth) >= 1) {
             $id= is_int($id) ? $id : intval($id);
 
@@ -826,8 +829,8 @@ class modX extends xPDO {
      * @param array $options An array of filtering options, such as 'context' to specify the context to grab from
      * @return array An array containing the tree structure.
      */
-    public function getTree($id= null, $depth= 10, array $options = array()) {
-        $tree= array ();
+    public function getTree($id= null, $depth= 10, array $options = []) {
+        $tree= [];
         if (!empty($options['context'])) {
             $this->getContext($options['context']);
         }
@@ -896,8 +899,8 @@ class modX extends xPDO {
      * is true, 'restore' containing an array of placeholder values that were overwritten by the method.
      */
     public function toPlaceholders($subject, $prefix= '', $separator= '.', $restore= false) {
-        $keys = array();
-        $restored = array();
+        $keys = [];
+        $restored = [];
         if (is_object($subject)) {
             if ($subject instanceof xPDOObject) {
                 $subject= $subject->toArray();
@@ -916,7 +919,7 @@ class modX extends xPDO {
                 }
             }
         }
-        $return = array('keys' => $keys);
+        $return = ['keys' => $keys];
         if ($restore === true) $return['restore'] = $restored;
         return $return;
     }
@@ -936,8 +939,8 @@ class modX extends xPDO {
      * is true, 'restore' containing an array of placeholder values that were overwritten by the method.
      */
     public function toPlaceholder($key, $value, $prefix= '', $separator= '.', $restore= false) {
-        $return = array('keys' => array());
-        if ($restore === true) $return['restore'] = array();
+        $return = ['keys' => []];
+        if ($restore === true) $return['restore'] = [];
         if (!empty($prefix) && !empty($separator)) {
             $prefix .= $separator;
         }
@@ -1028,7 +1031,7 @@ class modX extends xPDO {
      * @param array $options An array of options for generating the Resource URL.
      * @return string The URL for the resource.
      */
-    public function makeUrl($id, $context= '', $args= '', $scheme= -1, array $options= array()) {
+    public function makeUrl($id, $context= '', $args= '', $scheme= -1, array $options= []) {
         $url= '';
         if ($validid = intval($id)) {
             $id = $validid;
@@ -1070,8 +1073,8 @@ class modX extends xPDO {
      *
      * @return string|null A valid path segment string or null if an error occurs.
      */
-    public function filterPathSegment($string, array $options = array()) {
-        return $this->call(modResource::class, 'filterPathSegment', array(&$this, $string, $options));
+    public function filterPathSegment($string, array $options = []) {
+        return $this->call(modResource::class, 'filterPathSegment', [&$this, $string, $options]);
     }
 
     public function findResource($uri, $context = '') {
@@ -1090,8 +1093,9 @@ class modX extends xPDO {
                 }
             }
             if (!$resourceId && !$useAliasMap) {
-                $query = $this->newQuery(modResource::class, array('context_key' => $context, 'uri' => $uri, 'deleted' => false));
-                $query->select($this->getSelectColumns(modResource::class, '', '', array('id')));
+                $query = $this->newQuery(modResource::class, ['context_key' => $context, 'uri' => $uri, 'deleted' => false]
+                );
+                $query->select($this->getSelectColumns(modResource::class, '', '', ['id']));
                 $stmt = $query->prepare();
                 if ($stmt) {
                     $value = $this->getValue($stmt);
@@ -1110,7 +1114,7 @@ class modX extends xPDO {
      * @param string $type The type of error to present.
      * @param array $options An array of options to provide for the error file.
      */
-    public function sendError($type = '', $options = array()) {
+    public function sendError($type = '', $options = []) {
         if (!is_string($type) || empty($type)) $type = $this->getOption('error_type', $options, 'unavailable');
         while (ob_get_level() && @ob_end_clean()) {}
         if (!XPDO_CLI_MODE) {
@@ -1154,7 +1158,7 @@ class modX extends xPDO {
             $this->log(modX::LOG_LEVEL_FATAL, "Could not load response class.");
         }
         if (!is_array($options)) {
-            $options = array('count_attempts' => (boolean) $options);
+            $options = ['count_attempts' => (boolean) $options];
         }
         if ($type) {
             $this->deprecated('2.0.5', 'Use type in options array instead.', 'sendRedirect method parameter $type');
@@ -1182,25 +1186,25 @@ class modX extends xPDO {
         }
         $idInt = intval($id);
         if (is_string($options) && !empty($options)) {
-            $options = array('response_code' => $options);
+            $options = ['response_code' => $options];
         } elseif (!is_array($options)) {
-            $options = array();
+            $options = [];
         }
-        $this->elementCache = array();
+        $this->elementCache = [];
         if ($idInt > 0) {
             $merge = array_key_exists('merge', $options) && !empty($options['merge']);
-            $currentResource = array();
+            $currentResource = [];
             if ($merge) {
                 $excludes = array_merge(
                     explode(',', $this->getOption('forward_merge_excludes', $options, 'type,published,class_key')),
-                    array(
+                    [
                         'content'
                         ,'pub_date'
                         ,'unpub_date'
                         ,'richtext'
                         ,'_content'
                         ,'_processed',
-                    )
+                    ]
                 );
                 if (!empty($this->resource->_fields)) {
                     foreach ($this->resource->_fields as $fkey => $fval) {
@@ -1214,11 +1218,11 @@ class modX extends xPDO {
                     }
                 }
             }
-            $this->resource= $this->request->getResource('id', $idInt, array('forward' => true));
+            $this->resource= $this->request->getResource('id', $idInt, ['forward' => true]);
             if ($this->resource) {
                 if ($merge && !empty($currentResource)) {
                     $this->resource->_fields = array_merge($this->resource->_fields, $currentResource);
-                    $this->elementCache = array();
+                    $this->elementCache = [];
                     unset($currentResource);
                 }
                 $this->resourceIdentifier= $this->resource->get('id');
@@ -1232,12 +1236,12 @@ class modX extends xPDO {
                 $this->sendErrorPage();
             }
             $options= array_merge(
-                array(
+                [
                     'error_type' => '404'
                     ,'error_header' => $this->getOption('error_page_header', $options,$_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found')
                     ,'error_pagetitle' => $this->getOption('error_page_pagetitle', $options,'Error 404: Page not found')
                     ,'error_message' => $this->getOption('error_page_message', $options,'<h1>Page not found</h1><p>The page you requested was not found.</p>'),
-                ),
+                ],
                 $options
             );
         }
@@ -1253,15 +1257,15 @@ class modX extends xPDO {
      * page.
      */
     public function sendErrorPage($options = null) {
-        if (!is_array($options)) $options = array();
+        if (!is_array($options)) $options = [];
         $options= array_merge(
-            array(
+            [
                 'response_code' => $this->getOption('error_page_header', $options, $_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found')
                 ,'error_type' => '404'
                 ,'error_header' => $this->getOption('error_page_header', $options, $_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found')
                 ,'error_pagetitle' => $this->getOption('error_page_pagetitle', $options, 'Error 404: Page not found')
                 ,'error_message' => $this->getOption('error_page_message', $options, '<h1>Page not found</h1><p>The page you requested was not found.</p>'),
-            ),
+            ],
             $options
         );
         $this->invokeEvent('OnPageNotFound', $options);
@@ -1277,15 +1281,15 @@ class modX extends xPDO {
      * event and unauthorized page.
      */
     public function sendUnauthorizedPage($options = null) {
-        if (!is_array($options)) $options = array();
+        if (!is_array($options)) $options = [];
         $options= array_merge(
-            array(
+            [
                 'response_code' => $this->getOption('unauthorized_page_header' ,$options ,$_SERVER['SERVER_PROTOCOL'] . ' 401 Unauthorized')
                 ,'error_type' => '401'
                 ,'error_header' => $this->getOption('unauthorized_page_header', $options,$_SERVER['SERVER_PROTOCOL'] . ' 401 Unauthorized')
                 ,'error_pagetitle' => $this->getOption('unauthorized_page_pagetitle',$options, 'Error 401: Unauthorized')
                 ,'error_message' => $this->getOption('unauthorized_page_message', $options,'<h1>Unauthorized</h1><p>You are not authorized to view the requested content.</p>'),
-            ),
+            ],
             $options
         );
         $this->invokeEvent('OnPageUnauthorized', $options);
@@ -1317,11 +1321,11 @@ class modX extends xPDO {
                 if (!$forceLoadSettings && isset ($_SESSION["modx.{$contextKey}.user.config"])) {
                     $this->_userConfig= $_SESSION["modx.{$contextKey}.user.config"];
                 } else {
-                    $this->_userConfig= array();
+                    $this->_userConfig= [];
                     $settings= $this->user->getSettings();
                     if (is_array($settings) && !empty ($settings)) {
                         foreach ($settings as $k => $v) {
-                            $matches= array();
+                            $matches= [];
                             if (preg_match_all('~\{(.*?)\}~', $v, $matches, PREG_SET_ORDER)) {
                                 foreach ($matches as $match) {
                                     if (isset($this->_userConfig["{$match[1]}"])) {
@@ -1345,13 +1349,14 @@ class modX extends xPDO {
             }
         } else {
             $this->user = $this->newObject(modUser::class);
-            $this->user->fromArray(array(
+            $this->user->fromArray(
+                [
                 'id' => 0,
                 'username' => $this->getOption('default_username','','(anonymous)',true),
-            ), '', true);
+                ], '', true);
         }
         ksort($this->config);
-        $this->toPlaceholders($this->user->get(array('id','username')),'modx.user');
+        $this->toPlaceholders($this->user->get(['id','username']), 'modx.user');
         return $this->user;
     }
 
@@ -1652,7 +1657,7 @@ class modX extends xPDO {
      * @param array $params Optional params provided to the elements registered with an event.
      * @return bool|array
      */
-    public function invokeEvent($eventName, array $params= array ()) {
+    public function invokeEvent($eventName, array $params= []) {
         if (!$eventName)
             return false;
         if ($this->eventMap === null && $this->context instanceof modContext)
@@ -1661,7 +1666,7 @@ class modX extends xPDO {
             //$this->log(modX::LOG_LEVEL_DEBUG,'System event '.$eventName.' was executed but does not exist.');
             return false;
         }
-        $results= array ();
+        $results= [];
         if (count($this->eventMap[$eventName])) {
             $this->event= new modSystemEvent();
             foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
@@ -1682,7 +1687,7 @@ class modX extends xPDO {
                         $plugin= null;
                     }
                 } else {
-                    $plugin= $this->getObject(modPlugin::class, array ('id' => intval($pluginId), 'disabled' => '0'), true);
+                    $plugin= $this->getObject(modPlugin::class, ['id' => intval($pluginId), 'disabled' => '0'], true);
                 }
                 if ($plugin && !$plugin->get('disabled')) {
                     $this->event->plugin =& $plugin;
@@ -1721,7 +1726,7 @@ class modX extends xPDO {
      *
      * @return ProcessorResponse|mixed The result of the processor. Typically a ProcessorResponse object, but may be different for specific processors.
      */
-    public function runProcessor($action = '', $scriptProperties = array(), $options = array()) {
+    public function runProcessor($action = '', $scriptProperties = [], $options = []) {
         $result = null;
 
         // Make sure the required services are loaded before initialising a processor
@@ -1785,7 +1790,7 @@ class modX extends xPDO {
                 $section = explode('/', $action);
                 $pieces = [];
                 foreach ($section as $k) {
-                    $pieces[] = ucfirst(str_replace(array('.', '_', '-'), '', $k));
+                    $pieces[] = ucfirst(str_replace(['.', '_', '-'], '', $k));
                 }
                 // This is an older construct, introduced in MODX 2.2. It's better to be explicit and return the name of your class in the processor
                 $className = 'mod' . implode('', $pieces) . 'Processor';
@@ -1898,7 +1903,7 @@ class modX extends xPDO {
      * snippet.
      * @return string The processed output of the snippet.
      */
-    public function runSnippet($snippetName, array $params= array ()) {
+    public function runSnippet($snippetName, array $params= []) {
         $output= '';
         if ($this->getParser()) {
             $snippet= $this->parser->getElement(modSnippet::class, $snippetName);
@@ -1918,7 +1923,7 @@ class modX extends xPDO {
      * the Chunk with, treated as placeholders within the scope of the Element.
      * @return string The processed output of the Chunk.
      */
-    public function getChunk($chunkName, array $properties= array ()) {
+    public function getChunk($chunkName, array $properties= []) {
         $output= '';
         if ($this->getParser()) {
             $chunk= $this->parser->getElement(modChunk::class, $chunkName);
@@ -1961,7 +1966,7 @@ class modX extends xPDO {
      * @param int $depth The depth in which the parser will strip given the patterns specified
      * @return boolean True if anything was stripped
      */
-    public function stripTags($html, $allowed= '', $patterns= array(), $depth= 10) {
+    public function stripTags($html, $allowed= '', $patterns= [], $depth= 10) {
         $stripped= strip_tags($html, $allowed);
         if (is_array($patterns)) {
             if (empty($patterns)) {
@@ -2047,7 +2052,7 @@ class modX extends xPDO {
      */
     public function removeAllEventListener() {
         unset ($this->eventMap);
-        $this->eventMap= array ();
+        $this->eventMap= [];
     }
 
     /**
@@ -2063,7 +2068,7 @@ class modX extends xPDO {
         $pluginId = intval($pluginId);
         if ($event && $pluginId) {
             if (!isset($this->eventMap[$event]) || empty ($this->eventMap[$event])) {
-                $this->eventMap[$event]= array();
+                $this->eventMap[$event]= [];
             }
             $this->eventMap[$event][$pluginId]= $pluginId . (!empty($propertySetName) ? ':' . $propertySetName : '');
             $added = true;
@@ -2112,7 +2117,7 @@ class modX extends xPDO {
      */
     public function getContext($contextKey) {
         if (!isset($this->contexts[$contextKey])) {
-            $this->contexts[$contextKey]= $this->getObject(modContext::class, array('key' => $contextKey));
+            $this->contexts[$contextKey]= $this->getObject(modContext::class, ['key' => $contextKey]);
             if ($this->contexts[$contextKey]) {
                 $this->contexts[$contextKey]->prepare();
             }
@@ -2135,7 +2140,7 @@ class modX extends xPDO {
      * @return array A map of events and registered plugins for each.
      */
     public function getEventMap($contextKey) {
-        $eventElementMap= array ();
+        $eventElementMap= [];
         if ($contextKey) {
             switch ($contextKey) {
                 case 'mgr':
@@ -2183,11 +2188,13 @@ class modX extends xPDO {
         $msg= false;
         $id= intval($id);
         if (!$id) $id= $this->getLoginUserID();
-        if ($au = $this->getObject(modActiveUser::class,array('action' => $action, 'internalKey:!=' => $id))) {
-            $msg = $this->lexicon('lock_msg',array(
+        if ($au = $this->getObject(modActiveUser::class, ['action' => $action, 'internalKey:!=' => $id])) {
+            $msg = $this->lexicon('lock_msg',
+                                  [
                 'name' => $au->get('username'),
                 'object' => $type,
-            ));
+                                  ]
+            );
         }
         return $msg;
     }
@@ -2201,7 +2208,7 @@ class modX extends xPDO {
      * @param string $language
      * @return null|string The translated string, or null if none is set
      */
-    public function lexicon($key,$params = array(),$language = '') {
+    public function lexicon($key,$params = [],$language = '') {
         $language = !empty($language) ? $language : $this->getOption('cultureKey',null,'en');
         if ($this->lexicon) {
             return $this->lexicon->process($key,$params,$language);
@@ -2274,17 +2281,19 @@ class modX extends xPDO {
      * @param array $options
      * @return boolean
      */
-    public function addExtensionPackage($name,$path,array $options = array()) {
+    public function addExtensionPackage($name,$path,array $options = []) {
         $extPackages = $this->getOption('extension_packages');
-        $extPackages = !empty($extPackages) ? $extPackages : array();
+        $extPackages = !empty($extPackages) ? $extPackages : [];
         $extPackages = is_array($extPackages) ? $extPackages : $this->fromJSON($extPackages);
         $extPackages[$name] = $options;
         $extPackages['path'] = $path;
 
         /** @var modSystemSetting $setting */
-        $setting = $this->getObject(modSystemSetting::class,array(
+        $setting = $this->getObject(modSystemSetting::class,
+                                    [
             'key' => 'extension_packages',
-        ));
+                                    ]
+        );
         if (empty($setting)) {
             $setting = $this->newObject(modSystemSetting::class);
             $setting->set('key','extension_packages');
@@ -2295,7 +2304,7 @@ class modX extends xPDO {
         $value = $setting->get('value');
         $value = is_array($value) ? $value : $this->fromJSON($value);
         if (empty($value)) {
-            $value = array();
+            $value = [];
             $value[$name] = $options;
             $value[$name]['path'] = $path;
             $value = '['.$this->toJSON($value).']';
@@ -2328,9 +2337,11 @@ class modX extends xPDO {
      */
     public function removeExtensionPackage($name) {
         /** @var modSystemSetting $setting */
-        $setting = $this->getObject(modSystemSetting::class,array(
+        $setting = $this->getObject(modSystemSetting::class,
+                                    [
             'key' => 'extension_packages',
-        ));
+                                    ]
+        );
         if (!$setting) {
             return false;
         }
@@ -2426,8 +2437,8 @@ class modX extends xPDO {
 
         // We use the trace to identify both the method that is deprecated, and the caller
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-        $deprecatedMethod = isset($trace[1]) ? $trace[1] : array();
-        $caller = isset($trace[2]) ? $trace[2] : array();
+        $deprecatedMethod = isset($trace[1]) ? $trace[1] : [];
+        $caller = isset($trace[2]) ? $trace[2] : [];
 
         // Format the deprecated function definition with the class, if it has one
         if ($deprecatedDef === '') {
@@ -2525,7 +2536,7 @@ class modX extends xPDO {
             }
         }
         if ($this->context) {
-            if (!$this->context->prepare((boolean) $regenerate, is_array($options) ? $options : array())) {
+            if (!$this->context->prepare((boolean) $regenerate, is_array($options) ? $options : [])) {
                 $this->context= null;
                 $this->log(modX::LOG_LEVEL_ERROR, 'Could not prepare context: ' . $contextKey);
             } else {
@@ -2564,15 +2575,17 @@ class modX extends xPDO {
 
             $logTarget = $this->getOption('log_target', $options, 'FILE', true);
             if ($logTarget === 'FILE') {
-                $options = array();
+                $options = [];
                 $filename = $this->getOption('error_log_filename', $options, '');
                 if (!empty($filename)) $options['filename'] = $filename;
                 $filepath = $this->getOption('error_log_filepath', $options, '');
                 if (!empty($filepath)) $options['filepath'] = rtrim($filepath, '/') . '/';
-                $this->setLogTarget(array(
+                $this->setLogTarget(
+                    [
                     'target' => 'FILE',
                     'options' => $options,
-                ));
+                    ]
+                );
             } else {
                 $this->setLogTarget($logTarget);
             }
@@ -2622,7 +2635,7 @@ class modX extends xPDO {
                 $ehPath = $this->getOption('error_handler_path', $options, '', true);
                 if ($ehClass = $this->loadClass($ehClass, $ehPath, false, true)) {
                     if ($this->errorHandler = new $ehClass($this)) {
-                        $result = set_error_handler(array ($this->errorHandler, 'handleError'), $this->getOption('error_handler_types', $options, error_reporting(), true));
+                        $result = set_error_handler([$this->errorHandler, 'handleError'], $this->getOption('error_handler_types', $options, error_reporting(), true));
                         if ($result === false) {
                             $this->log(modX::LOG_LEVEL_ERROR, 'Could not set error handler.  Make sure your class has a function called handleError(). Result: ' . print_r($result, true));
                         }
@@ -2651,18 +2664,18 @@ class modX extends xPDO {
     protected function _initSession($options = null) {
         $contextKey= $this->context instanceof modContext ? $this->context->get('key') : null;
         if ($this->getOption('session_enabled', $options, true) || isset($_GET['preview'])) {
-            if (!in_array($this->getSessionState(), array(modX::SESSION_STATE_INITIALIZED, modX::SESSION_STATE_EXTERNAL, modX::SESSION_STATE_UNAVAILABLE), true)) {
+            if (!in_array($this->getSessionState(), [modX::SESSION_STATE_INITIALIZED, modX::SESSION_STATE_EXTERNAL, modX::SESSION_STATE_UNAVAILABLE], true)) {
                 $sh = false;
                 if ($sessionHandlerClass = $this->getOption('session_handler_class', $options)) {
                     if ($shClass = $this->loadClass($sessionHandlerClass, '', false, true)) {
                         if ($sh = new $shClass($this)) {
                             session_set_save_handler(
-                                array (& $sh, 'open'),
-                                array (& $sh, 'close'),
-                                array (& $sh, 'read'),
-                                array (& $sh, 'write'),
-                                array (& $sh, 'destroy'),
-                                array (& $sh, 'gc')
+                                [& $sh, 'open'],
+                                [& $sh, 'close'],
+                                [& $sh, 'read'],
+                                [& $sh, 'write'],
+                                [& $sh, 'destroy'],
+                                [& $sh, 'gc']
                             );
                         }
                     }
@@ -2728,16 +2741,17 @@ class modX extends xPDO {
         $this->config = $this->_config;
 
         $this->getCacheManager();
-        $config = $this->cacheManager->get('config', array(
+        $config = $this->cacheManager->get('config', [
             xPDO::OPT_CACHE_KEY => $this->getOption('cache_system_settings_key', null, 'system_settings'),
             xPDO::OPT_CACHE_HANDLER => $this->getOption('cache_system_settings_handler', null, $this->getOption(xPDO::OPT_CACHE_HANDLER)),
             xPDO::OPT_CACHE_FORMAT => (integer) $this->getOption('cache_system_settings_format', null, $this->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
-        ));
+        ]
+        );
         if (empty($config)) {
             $config = $this->cacheManager->generateConfig();
         }
         if (empty($config)) {
-            $config = array();
+            $config = [];
             if (!$settings = $this->getCollection(modSystemSetting::class)) {
                 return false;
             }
@@ -2760,7 +2774,7 @@ class modX extends xPDO {
         if (empty($target)) {
             $target = $this->logTarget;
         }
-        $targetOptions = array();
+        $targetOptions = [];
         $targetObj = $target;
         if (is_array($target)) {
             if (isset($target['options'])) $targetOptions = $target['options'];
@@ -2805,19 +2819,19 @@ class modX extends xPDO {
         $timestamp = strftime('%Y-%m-%d %H:%M:%S');
         $messageKey = (string) time();
         $messageKey .= '-' . sprintf("%06d", $this->_logSequence);
-        $message = array(
+        $message = [
             'timestamp' => $timestamp,
             'level' => $this->_getLogLevel($level),
             'msg' => $msg,
             'def' => $def,
             'file' => $file,
             'line' => $line,
-        );
-        $options = array();
+        ];
+        $options = [];
         if ($level === xPDO::LOG_LEVEL_FATAL) {
             $options['kill'] = true;
         }
-        $register->send('', array($messageKey => $message), $options);
+        $register->send('', [$messageKey => $message], $options);
         $this->_logSequence++;
     }
 

--- a/manager/controllers/default/browser/index.class.php
+++ b/manager/controllers/default/browser/index.class.php
@@ -47,8 +47,8 @@ MODx.ctx = "'.$this->ctx.'";
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         $scriptProperties['ctx'] = !empty($scriptProperties['ctx']) ? $scriptProperties['ctx'] : 'web';
 
@@ -89,6 +89,6 @@ MODx.ctx = "'.$this->ctx.'";
      * @return array
      */
     public function getLanguageTopics() {
-        return array('file');
+        return ['file'];
     }
 }

--- a/manager/controllers/default/context/index.class.php
+++ b/manager/controllers/default/context/index.class.php
@@ -44,7 +44,7 @@ class ContextManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -68,7 +68,7 @@ class ContextManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('context');
+        return ['context'];
     }
 
     /**

--- a/manager/controllers/default/context/update.class.php
+++ b/manager/controllers/default/context/update.class.php
@@ -48,7 +48,7 @@ class ContextUpdateManagerController extends modManagerController {
      * @return void
      */
     public function initialize() {
-        $this->context= $this->modx->getObjectGraph(modContext::class, '{"ContextSettings":{}}', array('key' => $this->scriptProperties['key']));
+        $this->context= $this->modx->getObjectGraph(modContext::class, '{"ContextSettings":{}}', ['key' => $this->scriptProperties['key']]);
         if ($this->context) {
             $this->contextKey = $this->context->get('key');
         }
@@ -81,11 +81,11 @@ class ContextUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         if (empty($this->context)) {
             return $this->failure(sprintf($this->modx->lexicon('context_with_key_not_found'), $this->scriptProperties['key']));
         }
-        if (!$this->context->checkPolicy(array('view' => true, 'save' => true))) {
+        if (!$this->context->checkPolicy(['view' => true, 'save' => true])) {
             return $this->failure($this->modx->lexicon('permission_denied'));
         }
         /* prepare context data for display */
@@ -110,11 +110,11 @@ class ContextUpdateManagerController extends modManagerController {
      * @return mixed
      */
     public function onPreRender() {
-        $onContextFormPrerender = $this->modx->invokeEvent('OnContextFormPrerender',array(
+        $onContextFormPrerender = $this->modx->invokeEvent('OnContextFormPrerender', [
             'key' => $this->context->get('key'),
             'context' => &$this->context,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($onContextFormPrerender)) $onContextFormPrerender = implode('',$onContextFormPrerender);
         return $onContextFormPrerender;
     }
@@ -123,13 +123,13 @@ class ContextUpdateManagerController extends modManagerController {
      * @return mixed
      */
     public function onRender() {
-        $this->onContextFormRender = $this->modx->invokeEvent('OnContextFormRender',array(
+        $this->onContextFormRender = $this->modx->invokeEvent('OnContextFormRender', [
             'key' => $this->context->get('key'),
             'context' => &$this->context,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onContextFormRender)) $this->onContextFormRender = implode('',$this->onContextFormRender);
-        $this->onContextFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onContextFormRender);
+        $this->onContextFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onContextFormRender);
         return $this->onContextFormRender;
     }
 
@@ -155,7 +155,7 @@ class ContextUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('context','setting','access','policy','user');
+        return ['context','setting','access','policy','user'];
     }
 
     /**

--- a/manager/controllers/default/context/view.class.php
+++ b/manager/controllers/default/context/view.class.php
@@ -47,11 +47,12 @@ class ContextViewManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         /* get context by key */
         $context= $this->modx->getObjectGraph(modContext::class, '{"ContextSettings":{}}', $scriptProperties['key']);
         if ($context == null) {
-            return $this->failure($this->modx->lexicon('context_with_key_not_found',array('key' =>  $scriptProperties['key'])));
+            return $this->failure($this->modx->lexicon('context_with_key_not_found',
+                ['key' =>  $scriptProperties['key']]));
         }
         if (!$context->checkPolicy('view')) return $this->failure($this->modx->lexicon('permission_denied'));
 
@@ -61,7 +62,7 @@ class ContextViewManagerController extends modManagerController {
         }
 
         /* assign context and display */
-        $placeholders = array();
+        $placeholders = [];
         $placeholders['context'] = $context;
         $placeholders['_ctx'] = $context->get('key');
         $this->contextKey = $context->get('key');
@@ -90,7 +91,7 @@ class ContextViewManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('context');
+        return ['context'];
     }
 
     /**

--- a/manager/controllers/default/element/chunk/create.class.php
+++ b/manager/controllers/default/element/chunk/create.class.php
@@ -61,8 +61,8 @@ class ElementChunkCreateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         $placeholders['category'] = $this->getCategory($scriptProperties);
 
@@ -114,13 +114,13 @@ class ElementChunkCreateManagerController extends modManagerController {
      * @return mixed
      */
     public function fireRenderEvent() {
-        $this->onChunkFormRender = $this->modx->invokeEvent('OnChunkFormRender',array(
+        $this->onChunkFormRender = $this->modx->invokeEvent('OnChunkFormRender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
             'chunk' => null,
-        ));
+        ]);
         if (is_array($this->onChunkFormRender)) $this->onChunkFormRender = implode('', $this->onChunkFormRender);
-        $this->onChunkFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onChunkFormRender);
+        $this->onChunkFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onChunkFormRender);
         return $this->onChunkFormRender;
     }
 
@@ -131,11 +131,11 @@ class ElementChunkCreateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onChunkFormPrerender = $this->modx->invokeEvent('OnChunkFormPrerender',array(
+        $this->onChunkFormPrerender = $this->modx->invokeEvent('OnChunkFormPrerender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
             'chunk' => null,
-        ));
+        ]);
         if (is_array($this->onChunkFormPrerender)) { $this->onChunkFormPrerender = implode('',$this->onChunkFormPrerender); }
         $this->setPlaceholder('onChunkFormPrerender', $this->onChunkFormPrerender);
     }
@@ -162,7 +162,7 @@ class ElementChunkCreateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('chunk','category','propertyset','element');
+        return ['chunk','category','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -26,7 +26,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
     /** @var modChunk $chunk */
     public $chunk;
     /** @var array $chunkArray */
-    public $chunkArray = array();
+    public $chunkArray = [];
 
     /**
      * Check for any permissions or requirements to load page
@@ -66,15 +66,16 @@ class ElementChunkUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* grab chunk */
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('chunk_err_ns'));
         }
-        $this->chunk = $this->modx->getObject(modChunk::class, array('id' => $scriptProperties['id']));
-        if (empty($this->chunk)) return $this->failure($this->modx->lexicon('chunk_err_nfs',array('id' => $scriptProperties['id'])));
+        $this->chunk = $this->modx->getObject(modChunk::class, ['id' => $scriptProperties['id']]);
+        if (empty($this->chunk)) return $this->failure($this->modx->lexicon('chunk_err_nfs',
+            ['id' => $scriptProperties['id']]));
         if (!$this->chunk->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
         /* grab category for chunk, assign to parser */
@@ -85,22 +86,22 @@ class ElementChunkUpdateManagerController extends modManagerController {
 
         /* get properties */
         $properties = $this->chunk->get('properties');
-        if (!is_array($properties)) $properties = array();
+        if (!is_array($properties)) $properties = [];
 
-        $data = array();
+        $data = [];
         foreach ($properties as $property) {
-            $data[] = array(
+            $data[] = [
                 $property['name'],
                 $property['desc'],
                 !empty($property['type']) ? $property['type'] : 'textfield',
-                !empty($property['options']) ? $property['options'] : array(),
+                !empty($property['options']) ? $property['options'] : [],
                 $property['value'],
                 !empty($property['lexicon']) ? $property['lexicon'] : '',
                 false, /* overridden set to false */
                 $property['desc_trans'],
                 !empty($property['area']) ? $property['area'] : '',
                 !empty($property['area_trans']) ? $property['area_trans'] : '',
-            );
+            ];
         }
         $this->chunkArray = $this->chunk->toArray();
         $this->chunkArray['properties'] = $data;
@@ -138,11 +139,11 @@ class ElementChunkUpdateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onChunkFormPrerender = $this->modx->invokeEvent('OnChunkFormPrerender',array(
+        $this->onChunkFormPrerender = $this->modx->invokeEvent('OnChunkFormPrerender', [
             'id' => $this->chunkArray['id'],
             'mode' => modSystemEvent::MODE_UPD,
             'chunk' => $this->chunk,
-        ));
+        ]);
         if (is_array($this->onChunkFormPrerender)) { $this->onChunkFormPrerender = implode('',$this->onChunkFormPrerender); }
         $this->setPlaceholder('onChunkFormPrerender', $this->onChunkFormPrerender);
     }
@@ -154,11 +155,11 @@ class ElementChunkUpdateManagerController extends modManagerController {
     public function loadRte() {
         $o = '';
         if ($this->modx->getOption('use_editor') === 1) {
-            $onRTEInit = $this->modx->invokeEvent('OnRichTextEditorInit',array(
-                'elements' => array('post'),
+            $onRTEInit = $this->modx->invokeEvent('OnRichTextEditorInit', [
+                'elements' => ['post'],
                 'chunk' => &$this->chunk,
                 'mode' => modSystemEvent::MODE_UPD,
-            ));
+            ]);
             if (is_array($onRTEInit)) {
                 $onRTEInit = implode('', $onRTEInit);
             }
@@ -172,13 +173,13 @@ class ElementChunkUpdateManagerController extends modManagerController {
      * @return mixed
      */
     public function fireRenderEvent() {
-        $this->onChunkFormRender = $this->modx->invokeEvent('OnChunkFormRender',array(
+        $this->onChunkFormRender = $this->modx->invokeEvent('OnChunkFormRender', [
             'id' => $this->chunk->get('id'),
             'mode' => modSystemEvent::MODE_UPD,
             'chunk' => $this->chunk,
-        ));
+        ]);
         if (is_array($this->onChunkFormRender)) $this->onChunkFormRender = implode('', $this->onChunkFormRender);
-        $this->onChunkFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onChunkFormRender);
+        $this->onChunkFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onChunkFormRender);
         return $this->onChunkFormRender;
     }
 
@@ -205,7 +206,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('chunk','category','propertyset','element');
+        return ['chunk','category','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/element/plugin/create.class.php
+++ b/manager/controllers/default/element/plugin/create.class.php
@@ -87,10 +87,10 @@ class ElementPluginCreateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onPluginFormPrerender = $this->modx->invokeEvent('OnPluginFormPrerender',array(
+        $this->onPluginFormPrerender = $this->modx->invokeEvent('OnPluginFormPrerender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onPluginFormPrerender)) $this->onPluginFormPrerender = implode('',$this->onPluginFormPrerender);
         $this->setPlaceholder('onPluginFormPrerender', $this->onPluginFormPrerender);
     }
@@ -100,12 +100,12 @@ class ElementPluginCreateManagerController extends modManagerController {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onPluginFormRender = $this->modx->invokeEvent('OnPluginFormRender',array(
+        $this->onPluginFormRender = $this->modx->invokeEvent('OnPluginFormRender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onPluginFormRender)) $this->onPluginFormRender = implode('',$this->onPluginFormRender);
-        $this->onPluginFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onPluginFormRender);
+        $this->onPluginFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onPluginFormRender);
         return $this->onPluginFormRender;
     }
 
@@ -131,7 +131,7 @@ class ElementPluginCreateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('plugin','category','system_events','propertyset','element');
+        return ['plugin','category','system_events','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -68,35 +68,35 @@ class ElementPluginUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* load plugin */
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('plugin_err_ns'));
         }
-        $this->plugin = $this->modx->getObject(modPlugin::class, array('id' => $scriptProperties['id']));
+        $this->plugin = $this->modx->getObject(modPlugin::class, ['id' => $scriptProperties['id']]);
         if ($this->plugin == null) return $this->failure($this->modx->lexicon('plugin_err_nf'));
         if (!$this->plugin->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
         /* get properties */
         $properties = $this->plugin->get('properties');
-        if (!is_array($properties)) $properties = array();
+        if (!is_array($properties)) $properties = [];
 
-        $data = array();
+        $data = [];
         foreach ($properties as $property) {
-            $data[] = array(
+            $data[] = [
                 $property['name'],
                 $property['desc'],
                 !empty($property['type']) ? $property['type'] : 'textfield',
-                !empty($property['options']) ? $property['options'] : array(),
+                !empty($property['options']) ? $property['options'] : [],
                 $property['value'],
                 !empty($property['lexicon']) ? $property['lexicon'] : '',
                 false, /* overridden set to false */
                 $property['desc_trans'],
                 !empty($property['area']) ? $property['area'] : '',
                 !empty($property['area_trans']) ? $property['area_trans'] : '',
-            );
+            ];
         }
         $this->pluginArray = $this->plugin->toArray();
         $this->pluginArray['properties'] = $data;
@@ -137,11 +137,11 @@ class ElementPluginUpdateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onPluginFormPrerender = $this->modx->invokeEvent('OnPluginFormPrerender',array(
+        $this->onPluginFormPrerender = $this->modx->invokeEvent('OnPluginFormPrerender', [
             'id' => $this->pluginArray['id'],
             'plugin' => &$this->plugin,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onPluginFormPrerender)) $this->onPluginFormPrerender = implode('',$this->onPluginFormPrerender);
         $this->setPlaceholder('onPluginFormPrerender', $this->onPluginFormPrerender);
     }
@@ -151,13 +151,13 @@ class ElementPluginUpdateManagerController extends modManagerController {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onPluginFormRender = $this->modx->invokeEvent('OnPluginFormRender',array(
+        $this->onPluginFormRender = $this->modx->invokeEvent('OnPluginFormRender', [
             'id' => $this->pluginArray['id'],
             'plugin' => &$this->plugin,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onPluginFormRender)) $this->onPluginFormRender = implode('',$this->onPluginFormRender);
-        $this->onPluginFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onPluginFormRender);
+        $this->onPluginFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onPluginFormRender);
         return $this->onPluginFormRender;
     }
 
@@ -183,7 +183,7 @@ class ElementPluginUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('plugin','category','system_events','propertyset','element');
+        return ['plugin','category','system_events','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/element/propertyset/index.class.php
+++ b/manager/controllers/default/element/propertyset/index.class.php
@@ -46,7 +46,7 @@ class ElementPropertySetManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -70,7 +70,7 @@ class ElementPropertySetManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('element','category','propertyset');
+        return ['element','category','propertyset'];
     }
 
     /**

--- a/manager/controllers/default/element/snippet/create.class.php
+++ b/manager/controllers/default/element/snippet/create.class.php
@@ -86,10 +86,10 @@ class ElementSnippetCreateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onSnipFormPrerender = $this->modx->invokeEvent('OnSnipFormPrerender',array(
+        $this->onSnipFormPrerender = $this->modx->invokeEvent('OnSnipFormPrerender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onSnipFormPrerender)) $this->onSnipFormPrerender = implode('',$this->onSnipFormPrerender);
         $this->setPlaceholder('onSnipFormPrerender', $this->onSnipFormPrerender);
     }
@@ -99,12 +99,12 @@ class ElementSnippetCreateManagerController extends modManagerController {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onSnipFormRender = $this->modx->invokeEvent('OnSnipFormRender',array(
+        $this->onSnipFormRender = $this->modx->invokeEvent('OnSnipFormRender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onSnipFormRender)) $this->onSnipFormRender = implode('',$this->onSnipFormRender);
-        $this->onSnipFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onSnipFormRender);
+        $this->onSnipFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onSnipFormRender);
         return $this->onSnipFormRender;
     }
 
@@ -130,7 +130,7 @@ class ElementSnippetCreateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('snippet','category','system_events','propertyset','element');
+        return ['snippet','category','system_events','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -67,35 +67,35 @@ class ElementSnippetUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* load snippet */
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('snippet_err_ns'));
         }
-        $this->snippet = $this->modx->getObject(modSnippet::class, array('id' => $scriptProperties['id']));
+        $this->snippet = $this->modx->getObject(modSnippet::class, ['id' => $scriptProperties['id']]);
         if ($this->snippet == null) return $this->failure($this->modx->lexicon('snippet_err_nf'));
         if (!$this->snippet->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
         /* get properties */
         $properties = $this->snippet->get('properties');
-        if (!is_array($properties)) $properties = array();
+        if (!is_array($properties)) $properties = [];
 
-        $data = array();
+        $data = [];
         foreach ($properties as $property) {
-            $data[] = array(
+            $data[] = [
                 $property['name'],
                 $property['desc'],
                 !empty($property['type']) ? $property['type'] : 'textfield',
-                !empty($property['options']) ? $property['options'] : array(),
+                !empty($property['options']) ? $property['options'] : [],
                 $property['value'],
                 !empty($property['lexicon']) ? $property['lexicon'] : '',
                 false, /* overridden set to false */
                 $property['desc_trans'],
                 !empty($property['area']) ? $property['area'] : '',
                 !empty($property['area_trans']) ? $property['area_trans'] : '',
-            );
+            ];
         }
         $this->snippetArray = $this->snippet->toArray();
         $this->snippetArray['properties'] = $data;
@@ -136,11 +136,11 @@ class ElementSnippetUpdateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onSnipFormPrerender = $this->modx->invokeEvent('OnSnipFormPrerender',array(
+        $this->onSnipFormPrerender = $this->modx->invokeEvent('OnSnipFormPrerender', [
             'id' => $this->snippetArray['id'],
             'snippet' => &$this->snippet,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onSnipFormPrerender)) $this->onSnipFormPrerender = implode('',$this->onSnipFormPrerender);
         $this->setPlaceholder('onSnipFormPrerender', $this->onSnipFormPrerender);
     }
@@ -150,13 +150,13 @@ class ElementSnippetUpdateManagerController extends modManagerController {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onSnipFormRender = $this->modx->invokeEvent('OnSnipFormRender',array(
+        $this->onSnipFormRender = $this->modx->invokeEvent('OnSnipFormRender', [
             'id' => $this->snippetArray['id'],
             'snippet' => &$this->snippet,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onSnipFormRender)) $this->onSnipFormRender = implode('',$this->onSnipFormRender);
-        $this->onSnipFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onSnipFormRender);
+        $this->onSnipFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onSnipFormRender);
         return $this->onSnipFormRender;
     }
 
@@ -182,7 +182,7 @@ class ElementSnippetUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('snippet','category','system_events','propertyset','element');
+        return ['snippet','category','system_events','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/element/template/create.class.php
+++ b/manager/controllers/default/element/template/create.class.php
@@ -62,8 +62,8 @@ class ElementTemplateCreateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* grab category if preset */
         if (isset($scriptProperties['category'])) {
@@ -86,10 +86,10 @@ class ElementTemplateCreateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onTempFormPrerender = $this->modx->invokeEvent('OnTempFormPrerender',array(
+        $this->onTempFormPrerender = $this->modx->invokeEvent('OnTempFormPrerender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onTempFormPrerender)) $this->onTempFormPrerender = implode('',$this->onTempFormPrerender);
         $this->setPlaceholder('onTempFormPrerender', $this->onTempFormPrerender);
     }
@@ -99,12 +99,12 @@ class ElementTemplateCreateManagerController extends modManagerController {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onTempFormRender = $this->modx->invokeEvent('OnTempFormRender',array(
+        $this->onTempFormRender = $this->modx->invokeEvent('OnTempFormRender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onTempFormRender)) $this->onTempFormRender = implode('',$this->onTempFormRender);
-        $this->onTempFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onTempFormRender);
+        $this->onTempFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onTempFormRender);
         return $this->onTempFormRender;
     }
 
@@ -130,7 +130,7 @@ class ElementTemplateCreateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('template','category','propertyset','element','tv');
+        return ['template','category','propertyset','element','tv'];
     }
 
     /**

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -68,35 +68,35 @@ class ElementTemplateUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* load template */
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('template_err_ns'));
         }
-        $this->template = $this->modx->getObject(modTemplate::class, array('id' => $scriptProperties['id']));
+        $this->template = $this->modx->getObject(modTemplate::class, ['id' => $scriptProperties['id']]);
         if ($this->template == null) return $this->failure($this->modx->lexicon('template_err_nf'));
         if (!$this->template->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
         /* get properties */
         $properties = $this->template->get('properties');
-        if (!is_array($properties)) $properties = array();
+        if (!is_array($properties)) $properties = [];
 
-        $data = array();
+        $data = [];
         foreach ($properties as $property) {
-            $data[] = array(
+            $data[] = [
                 $property['name'],
                 $property['desc'],
                 !empty($property['type']) ? $property['type'] : 'textfield',
-                !empty($property['options']) ? $property['options'] : array(),
+                !empty($property['options']) ? $property['options'] : [],
                 $property['value'],
                 !empty($property['lexicon']) ? $property['lexicon'] : '',
                 false, /* overridden set to false */
                 $property['desc_trans'],
                 !empty($property['area']) ? $property['area'] : '',
                 !empty($property['area_trans']) ? $property['area_trans'] : '',
-            );
+            ];
         }
         $this->templateArray = $this->template->toArray();
         $this->templateArray['properties'] = $data;
@@ -134,11 +134,11 @@ class ElementTemplateUpdateManagerController extends modManagerController {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onTempFormPrerender = $this->modx->invokeEvent('OnTempFormPrerender',array(
+        $this->onTempFormPrerender = $this->modx->invokeEvent('OnTempFormPrerender', [
             'id' => $this->templateArray['id'],
             'template' => &$this->template,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onTempFormPrerender)) $this->onTempFormPrerender = implode('',$this->onTempFormPrerender);
         $this->setPlaceholder('onTempFormPrerender', $this->onTempFormPrerender);
     }
@@ -148,13 +148,13 @@ class ElementTemplateUpdateManagerController extends modManagerController {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onTempFormRender = $this->modx->invokeEvent('OnTempFormRender',array(
+        $this->onTempFormRender = $this->modx->invokeEvent('OnTempFormRender', [
             'id' => $this->templateArray['id'],
             'template' => &$this->template,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onTempFormRender)) $this->onTempFormRender = implode('',$this->onTempFormRender);
-        $this->onTempFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onTempFormRender);
+        $this->onTempFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onTempFormRender);
         return $this->onTempFormRender;
     }
 
@@ -180,7 +180,7 @@ class ElementTemplateUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('template','category','system_events','propertyset','element','tv');
+        return ['template','category','system_events','propertyset','element','tv'];
     }
 
     /**

--- a/manager/controllers/default/element/tv/create.class.php
+++ b/manager/controllers/default/element/tv/create.class.php
@@ -66,8 +66,8 @@ Ext.onReady(function() {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* grab category if preset */
         if (isset($scriptProperties['category'])) {
@@ -85,23 +85,23 @@ Ext.onReady(function() {
 
     public function getElementSources() {
         $c = $this->modx->newQuery(modContext::class);
-        $c->where(array(
+        $c->where([
             'key:!=' => 'mgr',
-        ));
+        ]);
         $c->sortby($this->modx->escape('rank'));
         $c->sortby($this->modx->escape('key'),'DESC');
         $contexts = $this->modx->getCollection(modContext::class, $c);
-        $list = array();
+        $list = [];
         $this->modx->loadClass('sources.modMediaSource');
         /** @var $source modMediaSource */
         $source = modMediaSource::getDefaultSource($this->modx);
         /** @var modContext $context */
         foreach ($contexts as $context) {
-            $list[] = array(
+            $list[] = [
                 $context->get('key'),
                 $source->get('id'),
                 $source->get('name'),
-            );
+            ];
         }
         return $list;
     }
@@ -113,10 +113,10 @@ Ext.onReady(function() {
     public function firePreRenderEvents() {
         /* PreRender events inject directly into the HTML, as opposed to the JS-based Render event which injects HTML
         into the panel */
-        $this->onTVFormPrerender = $this->modx->invokeEvent('OnTVFormPrerender',array(
+        $this->onTVFormPrerender = $this->modx->invokeEvent('OnTVFormPrerender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onTVFormPrerender)) $this->onTVFormPrerender = implode('',$this->onTVFormPrerender);
         $this->setPlaceholder('onTVFormPrerender', $this->onTVFormPrerender);
     }
@@ -126,12 +126,12 @@ Ext.onReady(function() {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onTVFormRender = $this->modx->invokeEvent('OnTVFormRender',array(
+        $this->onTVFormRender = $this->modx->invokeEvent('OnTVFormRender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onTVFormRender)) $this->onTVFormRender = implode('',$this->onTVFormRender);
-        $this->onTVFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onTVFormRender);
+        $this->onTVFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onTVFormRender);
         return $this->onTVFormRender;
     }
 
@@ -157,7 +157,7 @@ Ext.onReady(function() {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('tv','category','tv_widget','propertyset','element');
+        return ['tv','category','tv_widget','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -25,7 +25,7 @@ class ElementTVUpdateManagerController extends modManagerController {
     /** @var modTemplateVar $tv */
     public $tv;
     /** @var array $tvArray */
-    public $tvArray = array();
+    public $tvArray = [];
     /** @var string $onTVFormRender */
     public $onTVFormRender = '';
     /** @var string $onTVFormPrerender */
@@ -71,35 +71,35 @@ class ElementTVUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* load tv */
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('tv_err_ns'));
         }
-        $this->tv = $this->modx->getObject(modTemplateVar::class, array('id' => $scriptProperties['id']));
+        $this->tv = $this->modx->getObject(modTemplateVar::class, ['id' => $scriptProperties['id']]);
         if ($this->tv == null) return $this->failure($this->modx->lexicon('tv_err_nf'));
         if (!$this->tv->checkPolicy('view')) return $this->failure($this->modx->lexicon('access_denied'));
 
         /* get properties */
         $properties = $this->tv->get('properties');
-        if (!is_array($properties)) $properties = array();
+        if (!is_array($properties)) $properties = [];
 
-        $data = array();
+        $data = [];
         foreach ($properties as $property) {
-            $data[] = array(
+            $data[] = [
                 $property['name'],
                 $property['desc'],
                 !empty($property['type']) ? $property['type'] : 'textfield',
-                !empty($property['options']) ? $property['options'] : array(),
+                !empty($property['options']) ? $property['options'] : [],
                 $property['value'],
                 !empty($property['lexicon']) ? $property['lexicon'] : '',
                 false, /* overridden set to false */
                 $property['desc_trans'],
                 !empty($property['area']) ? $property['area'] : '',
                 !empty($property['area_trans']) ? $property['area_trans'] : '',
-            );
+            ];
         }
         $this->tvArray = $this->tv->toArray();
         $this->tvArray['properties'] = $data;
@@ -185,13 +185,13 @@ class ElementTVUpdateManagerController extends modManagerController {
      * @return string
      */
     public function fireRenderEvent() {
-        $this->onTVFormRender = $this->modx->invokeEvent('OnTVFormRender',array(
+        $this->onTVFormRender = $this->modx->invokeEvent('OnTVFormRender', [
             'id' => $this->tvArray['id'],
             'tv' => &$this->tv,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($this->onTVFormRender)) $this->onTVFormRender = implode('',$this->onTVFormRender);
-        $this->onTVFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onTVFormRender);
+        $this->onTVFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onTVFormRender);
         return $this->onTVFormRender;
     }
 
@@ -217,7 +217,7 @@ class ElementTVUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('tv','category','tv_widget','propertyset','element');
+        return ['tv','category','tv_widget','propertyset','element'];
     }
 
     /**

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -112,10 +112,10 @@ class TopMenu
         if (empty($username)) {
             $username = $this->modx->getLoginUserName();
         }
-        $placeholders = array(
+        $placeholders = [
             'username' => $username,
             'userImage' => $this->getUserImage(),
-        );
+        ];
 
         $this->controller->setPlaceholders($placeholders);
     }
@@ -230,7 +230,7 @@ class TopMenu
     {
         $key = $this->getCacheKey($name);
 
-        $menus = $this->modx->cacheManager->get($key, array(
+        $menus = $this->modx->cacheManager->get($key, [
             xPDO::OPT_CACHE_KEY => $this->modx->getOption('cache_menu_key', null, 'menu'),
             xPDO::OPT_CACHE_HANDLER => $this->modx->getOption(
                 'cache_menu_handler',
@@ -242,7 +242,7 @@ class TopMenu
                 null,
                 $this->modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)
             ),
-        ));
+        ]);
 
         if ($menus == null || !is_array($menus)) {
             /** @var modMenu $menu */
@@ -293,7 +293,7 @@ class TopMenu
         if (empty($perms)) {
             return true;
         }
-        $permissions = array();
+        $permissions = [];
         $exploded = explode(',', $perms);
         foreach ($exploded as $permission) {
             $permissions[trim($permission)] = true;
@@ -310,7 +310,7 @@ class TopMenu
      *
      * @return void
      */
-    public function processSubMenus(&$output, array $menus = array())
+    public function processSubMenus(&$output, array $menus = [])
     {
         foreach ($menus as $menu) {
             if (!$this->hasPermission($menu['permissions'])) {

--- a/manager/controllers/default/help.class.php
+++ b/manager/controllers/default/help.class.php
@@ -47,6 +47,6 @@ class HelpManagerController extends modParsedManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('about');
+        return ['about'];
     }
 }

--- a/manager/controllers/default/language.class.php
+++ b/manager/controllers/default/language.class.php
@@ -14,7 +14,7 @@ class LanguageManagerController extends modParsedManagerController
         return $this->modx->hasPermission('language');
     }
 
-    public function process(array $scriptProperties = array())
+    public function process(array $scriptProperties = [])
     {
         $targetLanguage = $this->modx->getOption('switch', $scriptProperties, 'en');
 

--- a/manager/controllers/default/media/browser.class.php
+++ b/manager/controllers/default/media/browser.class.php
@@ -47,9 +47,9 @@ HTML
     /**
      * @inherit
      */
-    public function process(array $scriptProperties = array())
+    public function process(array $scriptProperties = [])
     {
-        return array();
+        return [];
     }
 
     /**
@@ -73,6 +73,6 @@ HTML
      */
     public function getLanguageTopics()
     {
-        return array('file');
+        return ['file'];
     }
 }

--- a/manager/controllers/default/resource/trash.class.php
+++ b/manager/controllers/default/resource/trash.class.php
@@ -51,7 +51,7 @@ class ResourceTrashManagerController extends modManagerController
      */
     public function getLanguageTopics()
     {
-        return array('trash', 'namespace');
+        return ['trash', 'namespace'];
     }
 
     /**
@@ -59,7 +59,7 @@ class ResourceTrashManagerController extends modManagerController
      * @param array $scriptProperties A array of REQUEST parameters.
      * @return mixed Either an error or output string, or an array of placeholders to set.
      */
-    public function process(array $scriptProperties = array())
+    public function process(array $scriptProperties = [])
     {
         return null;
     }

--- a/manager/controllers/default/search.class.php
+++ b/manager/controllers/default/search.class.php
@@ -50,7 +50,7 @@ class SearchManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         if (!empty($this->scriptProperties['q'])) {
             $this->searchQuery = str_replace("'","\'",urldecode($this->scriptProperties['q']));
         }
@@ -78,6 +78,6 @@ class SearchManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('resource');
+        return ['resource'];
     }
 }

--- a/manager/controllers/default/security/access/policy/template/update.class.php
+++ b/manager/controllers/default/security/access/policy/template/update.class.php
@@ -20,7 +20,7 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
     /** @var modAccessPolicyTemplate $template */
     public $template;
     /** @var array $templateArray */
-    public $templateArray = array();
+    public $templateArray = [];
 
     /**
      * Check for any permissions or requirements to load page
@@ -36,7 +36,7 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
      */
     public function initialize() {
         if (!empty($this->scriptProperties['id']) && strlen($this->scriptProperties['id']) === strlen((integer)$this->scriptProperties['id'])) {
-            $this->template = $this->modx->getObject(modAccessPolicyTemplate::class, array('id' => $this->scriptProperties['id']));
+            $this->template = $this->modx->getObject(modAccessPolicyTemplate::class, ['id' => $this->scriptProperties['id']]);
         }
     }
 
@@ -67,10 +67,10 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         if (empty($this->template)) return $this->failure($this->modx->lexicon('policy_template_err_nf'));
 
-        $placeholders = array();
+        $placeholders = [];
 
         /* get permissions */
         $this->templateArray = $this->template->toArray();
@@ -88,12 +88,12 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
                 }
                 $desc = $this->modx->lexicon($desc);
             }
-            $this->templateArray['permissions'][] = array(
+            $this->templateArray['permissions'][] = [
                 $permission->get('name'),
                 $permission->get('description'),
                 $desc,
                 $permission->get('value'),
-            );
+            ];
         }
 
         $placeholders['template'] = $this->templateArray;
@@ -123,7 +123,7 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access','policy','context');
+        return ['user','access','policy','context'];
     }
 
     /**

--- a/manager/controllers/default/security/access/policy/update.class.php
+++ b/manager/controllers/default/security/access/policy/update.class.php
@@ -17,7 +17,7 @@ use MODX\Revolution\modManagerController;
  * @subpackage manager.controllers
  */
 class SecurityAccessPolicyUpdateManagerController extends modManagerController {
-    public $policyArray = array();
+    public $policyArray = [];
 
     /**
      * Check for any permissions or requirements to load page
@@ -54,18 +54,18 @@ class SecurityAccessPolicyUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('access_policy_err_ns'));
         }
-        $policy = $this->modx->getObject(modAccessPolicy::class, array('id' => $scriptProperties['id']));
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['id' => $scriptProperties['id']]);
         if (empty($policy)) return $this->failure($this->modx->lexicon('access_policy_err_nf'));
         $placeholders['policy'] = $policy;
 
         /* setup policy array */
-        $this->policyArray = $policy->get(array(
+        $this->policyArray = $policy->get([
             'id',
             'name',
             'description',
@@ -73,7 +73,7 @@ class SecurityAccessPolicyUpdateManagerController extends modManagerController {
             'class',
             'template',
             'parent',
-        ));
+        ]);
         $this->policyArray['permissions'] = $policy->getPermissions();
         $placeholders['policy'] = $this->policyArray;
 
@@ -102,7 +102,7 @@ class SecurityAccessPolicyUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access','policy','context');
+        return ['user','access','policy','context'];
     }
 
     /**

--- a/manager/controllers/default/security/forms/index.class.php
+++ b/manager/controllers/default/security/forms/index.class.php
@@ -44,7 +44,7 @@ class SecurityFormsManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -68,7 +68,7 @@ class SecurityFormsManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access','policy','formcustomization');
+        return ['user','access','policy','formcustomization'];
     }
 
     /**

--- a/manager/controllers/default/security/forms/profile/update.class.php
+++ b/manager/controllers/default/security/forms/profile/update.class.php
@@ -20,7 +20,7 @@ use MODX\Revolution\modUserGroup;
  * @subpackage manager.controllers
  */
 class SecurityFormsProfileUpdateManagerController extends modManagerController {
-    public $profileArray = array();
+    public $profileArray = [];
 
     /**
      * Check for any permissions or requirements to load page
@@ -58,31 +58,32 @@ class SecurityFormsProfileUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('profile_err_ns'));
         }
-        $profile = $this->modx->getObject(modFormCustomizationProfile::class, array('id' => $scriptProperties['id']));
-        if (empty($profile)) return $this->failure($this->modx->lexicon('profile_err_nfs',array('id' => $scriptProperties['id'])));
+        $profile = $this->modx->getObject(modFormCustomizationProfile::class, ['id' => $scriptProperties['id']]);
+        if (empty($profile)) return $this->failure($this->modx->lexicon('profile_err_nfs',
+            ['id' => $scriptProperties['id']]));
 
         $this->profileArray = $profile->toArray();
 
         $c = $this->modx->newQuery(modUserGroup::class);
         $c->innerJoin(modFormCustomizationProfileUserGroup::class,'FormCustomizationProfiles');
-        $c->where(array(
+        $c->where([
             'FormCustomizationProfiles.profile' => $profile->get('id'),
-        ));
+        ]);
         $c->sortby('name','ASC');
         $usergroups = $this->modx->getCollection(modUserGroup::class, $c);
 
-        $this->profileArray['usergroups'] = array();
+        $this->profileArray['usergroups'] = [];
         foreach ($usergroups as $usergroup) {
-            $this->profileArray['usergroups'][] = array(
+            $this->profileArray['usergroups'][] = [
                 $usergroup->get('id'),
                 $usergroup->get('name'),
-            );
+            ];
         }
 
         $placeholders['profile'] = $this->profileArray;
@@ -112,7 +113,7 @@ class SecurityFormsProfileUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access','policy','formcustomization');
+        return ['user','access','policy','formcustomization'];
     }
 
     /**

--- a/manager/controllers/default/security/forms/set/update.class.php
+++ b/manager/controllers/default/security/forms/set/update.class.php
@@ -19,7 +19,7 @@ use MODX\Revolution\modTemplate;
  * @subpackage manager.controllers
  */
 class SecurityFormsSetUpdateManagerController extends modManagerController {
-    public $setArray = array();
+    public $setArray = [];
     /**
      * Check for any permissions or requirements to load page
      * @return bool
@@ -55,32 +55,32 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* get profile */
         if (empty($scriptProperties['id'])) return $this->failure($this->modx->lexicon('set_err_ns'));
         $c = $this->modx->newQuery(modFormCustomizationSet::class);
         $c->leftJoin(modTemplate::class,'Template');
         $c->select($this->modx->getSelectColumns(modFormCustomizationSet::class,'modFormCustomizationSet'));
-        $c->select(array(
+        $c->select([
             'Template.templatename',
-        ));
-        $c->where(array(
+        ]);
+        $c->where([
             'id' => $scriptProperties['id'],
-        ));
+        ]);
         /** @var modFormCustomizationSet $set */
         $set = $this->modx->getObject(modFormCustomizationSet::class, $c);
-        if (empty($set)) return $this->failure($this->modx->lexicon('set_err_nfs',array('id' => $scriptProperties['id'])));
+        if (empty($set)) return $this->failure($this->modx->lexicon('set_err_nfs', ['id' => $scriptProperties['id']]));
 
         $this->setArray = $set->toArray();
         $setData = $set->getData();
 
         /* format fields */
-        $this->setArray['fields'] = array();
+        $this->setArray['fields'] = [];
         if (!empty($setData['fields'])) {
             foreach ($setData['fields'] as $field) {
-                $this->setArray['fields'][] = array(
+                $this->setArray['fields'][] = [
                     $field['id'],
                     $field['action'],
                     $field['name'],
@@ -91,15 +91,15 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
                     (boolean)$field['visible'],
                     $field['label'],
                     $field['default_value'],
-                );
+                ];
             }
         }
 
         /* format tabs */
-        $this->setArray['tabs'] = array();
+        $this->setArray['tabs'] = [];
         if (!empty($setData['tabs'])) {
             foreach ($setData['tabs'] as $tab) {
-                $this->setArray['tabs'][] = array(
+                $this->setArray['tabs'][] = [
                     (int)$tab['id'],
                     $tab['action'],
                     $tab['name'],
@@ -110,15 +110,15 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
                     $tab['label'],
                     $tab['type'],
                     'core',
-                );
+                ];
             }
         }
 
         /* format tvs */
-        $this->setArray['tvs'] = array();
+        $this->setArray['tvs'] = [];
         if (!empty($setData['tvs'])) {
             foreach ($setData['tvs'] as $tv) {
-                $this->setArray['tvs'][] = array(
+                $this->setArray['tvs'][] = [
                     (int)$tv['id'],
                     $tv['name'],
                     $tv['tab'],
@@ -128,7 +128,7 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
                     $tv['default_value'],
                     !empty($tv['category_name']) ? $tv['category_name'] : $this->modx->lexicon('none'),
                     htmlspecialchars($tv['default_text'],null,$this->modx->getOption('modx_charset',null,'UTF-8')),
-                );
+                ];
             }
         }
 
@@ -161,7 +161,7 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access','policy','formcustomization');
+        return ['user','access','policy','formcustomization'];
     }
 
     /**

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -51,7 +51,7 @@ class SecurityLoginManagerController extends modManagerController
      * @param array $scriptProperties
      * @return void
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         $this->handleForgotLoginHash();
         $this->handleMagicLoginLink();
         $this->preserveReturnUrl();
@@ -125,7 +125,7 @@ class SecurityLoginManagerController extends modManagerController
 
         $this->setPlaceholder('show_help', (int)$this->modx->getOption('login_help_button'));
         $lifetime = $this->modx->getOption('session_cookie_lifetime', null, 0);
-        $this->setPlaceholder('rememberme', $output = $this->modx->lexicon('login_remember', array('lifetime' => $this->getLifetimeString($lifetime))));
+        $this->setPlaceholder('rememberme', $output = $this->modx->lexicon('login_remember', ['lifetime' => $this->getLifetimeString($lifetime)]));
 
 
         $this->checkForActiveInstallation();
@@ -160,7 +160,7 @@ class SecurityLoginManagerController extends modManagerController
         if ($minutes) $diff = $diff % 60;
 
         $diff = intval($diff);
-        $agoTS = array(
+        $agoTS = [
             'years' => $years,
             'months' => $months,
             'weeks' => $weeks,
@@ -168,29 +168,31 @@ class SecurityLoginManagerController extends modManagerController
             'hours' => $hours,
             'minutes' => $minutes,
             'seconds' => $diff,
-        );
+        ];
 
-        $ago = array();
+        $ago = [];
         if (!empty($agoTS['years'])) {
-            $ago[] = $this->modx->lexicon(($agoTS['years'] > 1 ? 'ago_years' : 'ago_year'),array('time' => $agoTS['years']));
+            $ago[] = $this->modx->lexicon(($agoTS['years'] > 1 ? 'ago_years' : 'ago_year'), ['time' => $agoTS['years']]);
         }
         if (!empty($agoTS['months'])) {
-            $ago[] = $this->modx->lexicon(($agoTS['months'] > 1 ? 'ago_months' : 'ago_month'),array('time' => $agoTS['months']));
+            $ago[] = $this->modx->lexicon(($agoTS['months'] > 1 ? 'ago_months' : 'ago_month'),
+                ['time' => $agoTS['months']]);
         }
         if (!empty($agoTS['weeks']) && empty($agoTS['years'])) {
-            $ago[] = $this->modx->lexicon(($agoTS['weeks'] > 1 ? 'ago_weeks' : 'ago_week'),array('time' => $agoTS['weeks']));
+            $ago[] = $this->modx->lexicon(($agoTS['weeks'] > 1 ? 'ago_weeks' : 'ago_week'), ['time' => $agoTS['weeks']]);
         }
         if (!empty($agoTS['days']) && empty($agoTS['months']) && empty($agoTS['years'])) {
-            $ago[] = $this->modx->lexicon(($agoTS['days'] > 1 ? 'ago_days' : 'ago_day'),array('time' => $agoTS['days']));
+            $ago[] = $this->modx->lexicon(($agoTS['days'] > 1 ? 'ago_days' : 'ago_day'), ['time' => $agoTS['days']]);
         }
         if (!empty($agoTS['hours']) && empty($agoTS['weeks']) && empty($agoTS['months']) && empty($agoTS['years'])) {
-            $ago[] = $this->modx->lexicon(($agoTS['hours'] > 1 ? 'ago_hours' : 'ago_hour'),array('time' => $agoTS['hours']));
+            $ago[] = $this->modx->lexicon(($agoTS['hours'] > 1 ? 'ago_hours' : 'ago_hour'), ['time' => $agoTS['hours']]);
         }
         if (!empty($agoTS['minutes']) && empty($agoTS['days']) && empty($agoTS['weeks']) && empty($agoTS['months']) && empty($agoTS['years'])) {
-            $ago[] = $this->modx->lexicon($agoTS['minutes'] == 1 ? 'ago_minute' : 'ago_minutes' ,array('time' => $agoTS['minutes']));
+            $ago[] = $this->modx->lexicon($agoTS['minutes'] == 1 ? 'ago_minute' : 'ago_minutes' ,
+                ['time' => $agoTS['minutes']]);
         }
         if (empty($ago)) { /* handle <1 min */
-            $ago[] = $this->modx->lexicon('ago_seconds',array('time' => !empty($agoTS['seconds']) ? $agoTS['seconds'] : 0));
+            $ago[] = $this->modx->lexicon('ago_seconds', ['time' => !empty($agoTS['seconds']) ? $agoTS['seconds'] : 0]);
         }
         $output = implode(', ',$ago);
         return $output;
@@ -348,7 +350,7 @@ class SecurityLoginManagerController extends modManagerController
      */
     public function preserveReturnUrl() {
         if (!empty($_SERVER['REQUEST_URI'])) {
-            $chars = array("'",'"','(',')',';','>','<','!');
+            $chars = ["'",'"','(',')',';','>','<','!'];
             $returnUrl = str_replace($chars,'',$_SERVER['REQUEST_URI']);
             $this->setPlaceholder('returnUrl',$returnUrl);
         }
@@ -376,12 +378,12 @@ class SecurityLoginManagerController extends modManagerController
      * @return void
      */
     public function handlePost() {
-        $san = array("'",'"','(',')',';','>','<','../');
+        $san = ["'",'"','(',')',';','>','<','../'];
         foreach ($this->scriptProperties as $k => $v) {
-            if (!in_array($k,array('returnUrl'))) {
+            if (!in_array($k, ['returnUrl'])) {
                 $this->scriptProperties[$k] = str_replace($san,'',$v);
             } else {
-                $chars = array("'",'"','(',')',';','>','<','!','../');
+                $chars = ["'",'"','(',')',';','>','<','!','../'];
                 $this->scriptProperties[$k] = str_replace($chars,'',$v);
             }
         }
@@ -592,17 +594,17 @@ class SecurityLoginManagerController extends modManagerController
             if (!$sent) {
                 $this->setPlaceholder('error_message', $this->modx->lexicon('login_magiclink_error_msg'));
             } else {
-                $this->setPlaceholder('success_message', $this->modx->lexicon('login_magiclink_default_msg', array(
+                $this->setPlaceholder('success_message', $this->modx->lexicon('login_magiclink_default_msg', [
                     'email' => $this->scriptProperties['passwordless_login_email']
-                )));
+                ]));
             }
         } else {
             // this logline can be used to feed fail2ban to blog continuing failures from an IP
             $this->modx->log(modX::LOG_LEVEL_WARN, "Magic login link failure. User with email '" .
                 $this->scriptProperties['passwordless_login_email'] . "' does not exist. IP: ".$_SERVER["REMOTE_ADDR"]);
-            $this->setPlaceholder('success_message', $this->modx->lexicon('login_magiclink_default_msg', array(
+            $this->setPlaceholder('success_message', $this->modx->lexicon('login_magiclink_default_msg', [
                 'email' => $this->scriptProperties['passwordless_login_email'],
-            )));
+            ]));
         }
     }
 
@@ -629,6 +631,6 @@ class SecurityLoginManagerController extends modManagerController
      * @return array
      */
     public function getLanguageTopics() {
-        return array('login');
+        return ['login'];
     }
 }

--- a/manager/controllers/default/security/logout.class.php
+++ b/manager/controllers/default/security/logout.class.php
@@ -30,7 +30,7 @@ class SecurityLogoutManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         $this->modx->runProcessor('security/logout');
         $url = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->modx->sendRedirect($url);
@@ -58,6 +58,6 @@ class SecurityLogoutManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('access','user');
+        return ['access','user'];
     }
 }

--- a/manager/controllers/default/security/message.class.php
+++ b/manager/controllers/default/security/message.class.php
@@ -46,7 +46,7 @@ class SecurityMessageManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -70,6 +70,6 @@ class SecurityMessageManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','messages');
+        return ['user','messages'];
     }
 }

--- a/manager/controllers/default/security/permission.class.php
+++ b/manager/controllers/default/security/permission.class.php
@@ -50,7 +50,7 @@ class SecurityPermissionManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -74,7 +74,7 @@ class SecurityPermissionManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access','policy','context');
+        return ['user','access','policy','context'];
     }
 
     /**

--- a/manager/controllers/default/security/profile.class.php
+++ b/manager/controllers/default/security/profile.class.php
@@ -51,7 +51,7 @@ class SecurityProfileManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -79,6 +79,6 @@ class SecurityProfileManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('access','user');
+        return ['access','user'];
     }
 }

--- a/manager/controllers/default/security/resourcegroup/index.class.php
+++ b/manager/controllers/default/security/resourcegroup/index.class.php
@@ -22,7 +22,7 @@ class SecurityResourceGroupManagerController extends modManagerController {
      * @return bool
      */
     public function checkPermissions() {
-        return $this->modx->hasPermission(array('resourcegroup_resource_list' => true,'resourcegroup_resource_edit' => true));
+        return $this->modx->hasPermission(['resourcegroup_resource_list' => true,'resourcegroup_resource_edit' => true]);
     }
 
     /**
@@ -46,7 +46,7 @@ class SecurityResourceGroupManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -70,7 +70,7 @@ class SecurityResourceGroupManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access');
+        return ['user','access'];
     }
 
     /**

--- a/manager/controllers/default/security/user/create.class.php
+++ b/manager/controllers/default/security/user/create.class.php
@@ -56,24 +56,24 @@ class SecurityUserCreateManagerController extends modManagerController
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* invoke OnUserFormPrerender event */
-        $onUserFormPrerender = $this->modx->invokeEvent('OnUserFormPrerender', array(
+        $onUserFormPrerender = $this->modx->invokeEvent('OnUserFormPrerender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($onUserFormPrerender)) $onUserFormPrerender = implode('',$onUserFormPrerender);
         $placeholders['OnUserFormPrerender'] = $onUserFormPrerender;
 
         /* invoke OnUserFormRender event */
-        $this->onUserFormRender = $this->modx->invokeEvent('OnUserFormRender', array(
+        $this->onUserFormRender = $this->modx->invokeEvent('OnUserFormRender', [
             'id' => 0,
             'mode' => modSystemEvent::MODE_NEW,
-        ));
+        ]);
         if (is_array($this->onUserFormRender)) $this->onUserFormRender = implode('',$this->onUserFormRender);
-        $this->onUserFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$this->onUserFormRender);
+        $this->onUserFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$this->onUserFormRender);
 
         $placeholders['OnUserFormRender'] = $this->onUserFormRender;
 
@@ -102,7 +102,7 @@ class SecurityUserCreateManagerController extends modManagerController
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','setting','access');
+        return ['user','setting','access'];
     }
 
     /**

--- a/manager/controllers/default/security/user/index.class.php
+++ b/manager/controllers/default/security/user/index.class.php
@@ -44,7 +44,7 @@ class SecurityUserManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -68,7 +68,7 @@ class SecurityUserManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user');
+        return ['user'];
     }
 
     /**

--- a/manager/controllers/default/security/user/update.class.php
+++ b/manager/controllers/default/security/user/update.class.php
@@ -22,9 +22,9 @@ class SecurityUserUpdateManagerController extends modManagerController {
     /** @var string $onUserFormRender */
     public $onUserFormRender = '';
     /** @var array $extendedFields */
-    public $extendedFields = array();
+    public $extendedFields = [];
     /** @var array $remoteFields */
-    public $remoteFields = array();
+    public $remoteFields = [];
     /** @var modUser $user */
     public $user;
 
@@ -75,18 +75,18 @@ Ext.onReady(function() {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
 
         /* get user */
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('user_err_ns'));
         }
-        $this->user = $this->modx->getObject(modUser::class, array('id' => $scriptProperties['id']));
+        $this->user = $this->modx->getObject(modUser::class, ['id' => $scriptProperties['id']]);
         if ($this->user == null) return $this->failure($this->modx->lexicon('user_err_nf'));
 
         /* process remote data, if existent */
-        $this->remoteFields = array();
+        $this->remoteFields = [];
         $remoteData = $this->user->get('remote_data');
         if (!empty($remoteData)) {
             $this->remoteFields = $this->_parseCustomData($remoteData);
@@ -95,7 +95,7 @@ Ext.onReady(function() {
         /* parse extended data, if existent */
         $this->user->getOne('Profile');
         if ($this->user->Profile) {
-            $this->extendedFields = array();
+            $this->extendedFields = [];
             $extendedData = $this->user->Profile->get('extended');
             if (!empty($extendedData)) {
                 $this->extendedFields = $this->_parseCustomData($extendedData);
@@ -103,38 +103,38 @@ Ext.onReady(function() {
         }
 
         /* invoke OnUserFormPrerender event */
-        $onUserFormPrerender = $this->modx->invokeEvent('OnUserFormPrerender', array(
+        $onUserFormPrerender = $this->modx->invokeEvent('OnUserFormPrerender', [
             'id' => $this->user->get('id'),
             'user' => &$this->user,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($onUserFormPrerender)) {
             $onUserFormPrerender = implode('',$onUserFormPrerender);
         }
         $placeholders['OnUserFormPrerender'] = $onUserFormPrerender;
 
         /* invoke OnUserFormRender event */
-        $onUserFormRender = $this->modx->invokeEvent('OnUserFormRender', array(
+        $onUserFormRender = $this->modx->invokeEvent('OnUserFormRender', [
             'id' => $this->user->get('id'),
             'user' => &$this->user,
             'mode' => modSystemEvent::MODE_UPD,
-        ));
+        ]);
         if (is_array($onUserFormRender)) $onUserFormRender = implode('',$onUserFormRender);
-        $this->onUserFormRender = str_replace(array('"',"\n","\r"),array('\"','',''),$onUserFormRender);
+        $this->onUserFormRender = str_replace(['"',"\n","\r"], ['\"','',''],$onUserFormRender);
         $placeholders['OnUserFormRender'] = $this->onUserFormRender;
 
         return $placeholders;
     }
 
-    private function _parseCustomData(array $remoteData = array(),$path = '') {
+    private function _parseCustomData(array $remoteData = [],$path = '') {
         $usemb = function_exists('mb_strlen') && (boolean)$this->modx->getOption('use_multibyte',null,false);
         $encoding = $this->modx->getOption('modx_charset',null,'UTF-8');
-        $fields = array();
+        $fields = [];
         foreach ($remoteData as $key => $value) {
-            $field = array(
+            $field = [
                 'name' => $key,
                 'id' => (!empty($path) ? $path.'.' : '').$key,
-            );
+            ];
             if (is_array($value)) {
                 $field['iconCls'] = 'icon-folder';
                 $field['text'] = htmlentities($key,ENT_QUOTES,$encoding);
@@ -186,7 +186,7 @@ Ext.onReady(function() {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','setting','access');
+        return ['user','setting','access'];
     }
 
     /**

--- a/manager/controllers/default/security/usergroup/update.class.php
+++ b/manager/controllers/default/security/usergroup/update.class.php
@@ -58,14 +58,14 @@ class SecurityUserGroupUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
         if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
             $this->userGroup = $this->modx->newObject(modUserGroup::class);
             $this->userGroup->set('id',0);
             $this->userGroup->set('name',$this->modx->lexicon('anonymous'));
         } else {
-            $this->userGroup = $this->modx->getObject(modUserGroup::class, array('id' => $scriptProperties['id']));
+            $this->userGroup = $this->modx->getObject(modUserGroup::class, ['id' => $scriptProperties['id']]);
             if (empty($this->userGroup)) {
                 $this->failure($this->modx->lexicon('usergroup_err_nf'));
             }
@@ -96,7 +96,7 @@ class SecurityUserGroupUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('user','access','policy','context','setting');
+        return ['user','access','policy','context','setting'];
     }
 
     /**

--- a/manager/controllers/default/source/index.class.php
+++ b/manager/controllers/default/source/index.class.php
@@ -41,7 +41,7 @@ class SourceManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -65,7 +65,7 @@ class SourceManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('source','namespace');
+        return ['source','namespace'];
     }
 
     /**

--- a/manager/controllers/default/source/update.class.php
+++ b/manager/controllers/default/source/update.class.php
@@ -25,9 +25,9 @@ class SourceUpdateManagerController extends modManagerController {
     /** @var modMediaSource $source */
     public $source;
     /** @var array $sourceArray An array of fields for the source */
-    public $sourceArray = array();
+    public $sourceArray = [];
     /** @var array $sourceDefaultProperties The default properties on the source */
-    public $sourceDefaultProperties = array();
+    public $sourceDefaultProperties = [];
     /**
      * Check for any permissions or requirements to load page
      * @return bool
@@ -59,11 +59,11 @@ class SourceUpdateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         if (empty($this->scriptProperties['id']) || strlen($this->scriptProperties['id']) !== strlen((integer)$this->scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('source_err_ns'));
         }
-        $this->source = $this->modx->getObject('sources.modMediaSource', array('id' => $this->scriptProperties['id']));
+        $this->source = $this->modx->getObject('sources.modMediaSource', ['id' => $this->scriptProperties['id']]);
         if (empty($this->source)) return $this->failure($this->modx->lexicon('source_err_nf'));
 
         $this->sourceArray = $this->source->toArray();
@@ -72,24 +72,24 @@ class SourceUpdateManagerController extends modManagerController {
 
         $this->getDefaultProperties();
 
-        return array();
+        return [];
     }
 
     public function getProperties() {
         $properties = $this->source->getProperties();
-        $data = array();
+        $data = [];
         foreach ($properties as $property) {
-            $data[] = array(
+            $data[] = [
                 $property['name'],
                 !empty($property['desc']) ? $property['desc'] : '',
                 !empty($property['type']) ? $property['type'] : 'textfield',
-                !empty($property['options']) ? $property['options'] : array(),
+                !empty($property['options']) ? $property['options'] : [],
                 $property['value'],
                 !empty($property['lexicon']) ? $property['lexicon'] : '',
                 !empty($property['overridden']) ? $property['overridden'] : 0,
                 !empty($property['desc_trans']) ? $property['desc_trans'] : '',
                 !empty($property['name_trans']) ? $property['name_trans'] : '',
-            );
+            ];
         }
         $this->sourceArray['properties'] = $data;
     }
@@ -97,19 +97,19 @@ class SourceUpdateManagerController extends modManagerController {
     public function getDefaultProperties() {
         $default = $this->source->getDefaultProperties();
         $default = $this->source->prepareProperties($default);
-        $data = array();
+        $data = [];
         foreach ($default as $property) {
-            $data[] = array(
+            $data[] = [
                 $property['name'],
                 !empty($property['desc']) ? $property['desc'] : '',
                 !empty($property['type']) ? $property['type'] : 'textfield',
-                !empty($property['options']) ? $property['options'] : array(),
+                !empty($property['options']) ? $property['options'] : [],
                 $property['value'],
                 !empty($property['lexicon']) ? $property['lexicon'] : '',
                 0,
                 !empty($property['desc_trans']) ? $property['desc_trans'] : '',
                 !empty($property['name_trans']) ? $property['name_trans'] : '',
-            );
+            ];
         }
         $this->sourceDefaultProperties = $data;
         return $data;
@@ -121,21 +121,21 @@ class SourceUpdateManagerController extends modManagerController {
         $c->innerJoin(modAccessPolicy::class, 'Policy');
         $c->innerJoin(modUserGroup::class, 'Principal');
         $c->innerJoin(modUserGroupRole::class, 'MinimumRole');
-        $c->where(array(
+        $c->where([
             'target' => $this->source->get('id'),
-        ));
+        ]);
         $c->select($this->modx->getSelectColumns(modAccessMediaSource::class, 'modAccessMediaSource'));
-        $c->select(array(
+        $c->select([
             'target_name' => 'Target.name',
             'principal_name' => 'Principal.name',
             'policy_name' => 'Policy.name',
             'authority_name' => 'MinimumRole.name',
-        ));
+        ]);
         $acls = $this->modx->getCollection(modAccessMediaSource::class,$c);
-        $access = array();
+        $access = [];
         /** @var modAccessMediaSource $acl */
         foreach ($acls as $acl) {
-            $access[] = array(
+            $access[] = [
                 $acl->get('id'),
                 $acl->get('target'),
                 $acl->get('target_name'),
@@ -147,7 +147,7 @@ class SourceUpdateManagerController extends modManagerController {
                 $acl->get('policy'),
                 $acl->get('policy_name'),
                 $acl->get('context_key'),
-            );
+            ];
         }
 
         $this->sourceArray['access'] = $this->modx->toJSON($access);
@@ -175,7 +175,7 @@ class SourceUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('source','namespace','propertyset');
+        return ['source','namespace','propertyset'];
     }
 
     /**

--- a/manager/controllers/default/system/action.class.php
+++ b/manager/controllers/default/system/action.class.php
@@ -45,7 +45,7 @@ class SystemActionManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -69,7 +69,7 @@ class SystemActionManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('topmenu','menu','namespace');
+        return ['topmenu','menu','namespace'];
     }
 
     public function getHelpUrl() {

--- a/manager/controllers/default/system/contenttype.class.php
+++ b/manager/controllers/default/system/contenttype.class.php
@@ -37,7 +37,7 @@ class SystemContentTypeManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -61,7 +61,7 @@ class SystemContentTypeManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('content_type');
+        return ['content_type'];
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/create.class.php
+++ b/manager/controllers/default/system/dashboards/create.class.php
@@ -32,8 +32,8 @@ class SystemDashboardsCreateManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return array
      */
-    public function process(array $scriptProperties = array()) {
-        return array();
+    public function process(array $scriptProperties = []) {
+        return [];
 
     }
 
@@ -71,7 +71,7 @@ class SystemDashboardsCreateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('dashboards','user');
+        return ['dashboards','user'];
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/index.class.php
+++ b/manager/controllers/default/system/dashboards/index.class.php
@@ -31,8 +31,8 @@ class SystemDashboardsManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return array
      */
-    public function process(array $scriptProperties = array()) {
-        $placeholders = array();
+    public function process(array $scriptProperties = []) {
+        $placeholders = [];
         return $placeholders;
 
     }
@@ -74,7 +74,7 @@ class SystemDashboardsManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('dashboards');
+        return ['dashboards'];
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/update.class.php
+++ b/manager/controllers/default/system/dashboards/update.class.php
@@ -40,12 +40,12 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
      *
      * @return array
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         if (empty($this->scriptProperties['id']) || strlen($this->scriptProperties['id']) !== strlen((integer)$this->scriptProperties['id'])) {
             $this->failure($this->modx->lexicon('dashboard_err_ns'));
             return [];
         }
-        $this->dashboard = $this->modx->getObject(modDashboard::class, array('id' => $this->scriptProperties['id']));
+        $this->dashboard = $this->modx->getObject(modDashboard::class, ['id' => $this->scriptProperties['id']]);
         if (empty($this->dashboard)) {
             $this->failure($this->modx->lexicon('dashboard_err_nf'));
             return [];
@@ -64,13 +64,13 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
      */
     public function getWidgets() {
         $c = $this->modx->newQuery(modDashboardWidgetPlacement::class);
-        $c->where(array(
+        $c->where([
             'dashboard' => $this->dashboard->get('id'),
             'user' => 0,
-        ));
+        ]);
         $c->sortby('modDashboardWidgetPlacement.rank','ASC');
         $placements = $this->modx->getCollection(modDashboardWidgetPlacement::class, $c);
-        $list = array();
+        $list = [];
         /** @var modDashboardWidgetPlacement $placement */
         foreach ($placements as $placement) {
             $placement->getOne('Widget');
@@ -83,7 +83,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
                 $this->modx->lexicon->load($placement->Widget->get('lexicon'));
             }
             $widgetArray = $placement->Widget->toArray();
-            $list[] = array(
+            $list[] = [
                 $placement->get('dashboard'),
                 $placement->get('widget'),
                 $placement->get('rank'),
@@ -91,7 +91,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
                 $widgetArray['name_trans'],
                 $widgetArray['description'],
                 $widgetArray['description_trans'],
-            );
+            ];
         }
         return $list;
     }
@@ -153,7 +153,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('dashboards','user');
+        return ['dashboards','user'];
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/widget/create.class.php
+++ b/manager/controllers/default/system/dashboards/widget/create.class.php
@@ -18,7 +18,7 @@ use MODX\Revolution\modManagerController;
  */
 class SystemDashboardsWidgetCreateManagerController extends modManagerController {
     /** @var array $widgetArray */
-    public $widgetArray = array();
+    public $widgetArray = [];
 
     /**
      * Check for any permissions or requirements to load page
@@ -34,8 +34,8 @@ class SystemDashboardsWidgetCreateManagerController extends modManagerController
      * @param array $scriptProperties
      * @return array
      */
-    public function process(array $scriptProperties = array()) {
-        return array();
+    public function process(array $scriptProperties = []) {
+        return [];
     }
 
     /**
@@ -74,7 +74,7 @@ class SystemDashboardsWidgetCreateManagerController extends modManagerController
      * @return array
      */
     public function getLanguageTopics() {
-        return array('dashboards','user');
+        return ['dashboards','user'];
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/widget/update.class.php
+++ b/manager/controllers/default/system/dashboards/widget/update.class.php
@@ -25,7 +25,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
     /** @var modDashboardWidget $widget */
     public $widget;
     /** @var array $widgetArray */
-    public $widgetArray = array();
+    public $widgetArray = [];
 
     /**
      * Check for any permissions or requirements to load page
@@ -41,7 +41,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
      */
     public function initialize() {
         if (!empty($this->scriptProperties['id']) && strlen($this->scriptProperties['id']) === strlen((integer)$this->scriptProperties['id'])) {
-            $this->widget = $this->modx->getObject(modDashboardWidget::class, array('id' => $this->scriptProperties['id']));
+            $this->widget = $this->modx->getObject(modDashboardWidget::class, ['id' => $this->scriptProperties['id']]);
         }
     }
 
@@ -51,7 +51,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
      * @param array $scriptProperties
      * @return array
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         if (empty($this->widget)) {
             return $this->failure($this->modx->lexicon('widget_err_nf'));
         }
@@ -70,27 +70,27 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
      * @return array
      */
     public function getDashboards($user = 0) {
-        $list = array();
+        $list = [];
         $c = $this->modx->newQuery(modDashboardWidgetPlacement::class);
         $c->innerJoin(modDashboard::class, 'Dashboard');
-        $c->where(array(
+        $c->where([
             'widget' => $this->widget->get('id'),
             'user' => $user,
-        ));
+        ]);
         $c->sortby('Dashboard.name','ASC');
         $c->select($this->modx->getSelectColumns(modDashboardWidgetPlacement::class, 'modDashboardWidgetPlacement'));
-        $c->select(array(
+        $c->select([
             'Dashboard.name',
             'Dashboard.description',
-        ));
+        ]);
         $placements = $this->widget->getMany('Placements',$c);
         /** @var modDashboardWidgetPlacement $placement */
         foreach ($placements as $placement) {
-            $list[] = array(
+            $list[] = [
                 $placement->get('dashboard'),
                 $placement->get('name'),
                 $placement->get('description'),
-            );
+            ];
         }
         return $list;
     }
@@ -136,7 +136,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
      * @return array
      */
     public function getLanguageTopics() {
-        $topics = array('dashboards','user');
+        $topics = ['dashboards','user'];
         if ($this->widget) {
             $lexicon = $this->widget->get('lexicon');
             if (!empty($lexicon) && $lexicon != 'core:dashboards') {

--- a/manager/controllers/default/system/event.class.php
+++ b/manager/controllers/default/system/event.class.php
@@ -11,7 +11,7 @@
 use MODX\Revolution\modManagerController;
 
 class SystemEventManagerController extends modManagerController {
-    public $logArray = array();
+    public $logArray = [];
 
     /**
      * Check for any permissions or requirements to load page
@@ -45,10 +45,10 @@ class SystemEventManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         $logTarget = $this->modx->getLogTarget();
         if (!is_array($logTarget)) {
-            $logTarget = array('options' => array());
+            $logTarget = ['options' => []];
         }
         $filename = $this->modx->getOption('filename', $logTarget['options'], 'error.log', true);
         $filepath = $this->modx->getOption('filepath', $logTarget['options'], $this->modx->getCachePath() . xPDOCacheManager::LOG_DIR, true);
@@ -88,6 +88,6 @@ class SystemEventManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('system_events');
+        return ['system_events'];
     }
 }

--- a/manager/controllers/default/system/import/html.class.php
+++ b/manager/controllers/default/system/import/html.class.php
@@ -45,7 +45,7 @@ class SystemImportHtmlManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -69,6 +69,6 @@ class SystemImportHtmlManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('import');
+        return ['import'];
     }
 }

--- a/manager/controllers/default/system/import/index.class.php
+++ b/manager/controllers/default/system/import/index.class.php
@@ -45,7 +45,7 @@ class SystemImportManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -69,6 +69,6 @@ class SystemImportManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('import');
+        return ['import'];
     }
 }

--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -32,27 +32,27 @@ class SystemInfoManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return array
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         $pi = $this->getPhpInfo(INFO_GENERAL);
         $m = $this->parsePHPModules();
         $dbtype_mysql = $this->modx->config['dbtype'] == 'mysql';
         $dbtype_sqlsrv = $this->modx->config['dbtype'] == 'sqlsrv';
-        if ($dbtype_mysql && !empty($m['mysql'])) $pi = array_merge($pi,array('mysql' => $m['mysql']));
-        if ($dbtype_mysql && !empty($m['mysqlnd'])) $pi = array_merge($pi,array('pdo' => $m['mysqlnd']));
-        if ($dbtype_sqlsrv && !empty($m['sqlsrv'])) $pi = array_merge($pi,array('sqlsrv' => $m['sqlsrv']));
-        if (!empty($m['PDO'])) $pi = array_merge($pi,array('pdo' => $m['PDO']));
-        if ($dbtype_mysql && !empty($m['pdo_mysql'])) $pi = array_merge($pi,array('pdo_mysql' => $m['pdo_mysql']));
-        if ($dbtype_sqlsrv && !empty($m['pdo_sqlsrv'])) $pi = array_merge($pi,array('pdo_sqlsrv' => $m['pdo_sqlsrv']));
-        if (!empty($m['zip'])) $pi = array_merge($pi,array('zip' => $m['zip']));
+        if ($dbtype_mysql && !empty($m['mysql'])) $pi = array_merge($pi, ['mysql' => $m['mysql']]);
+        if ($dbtype_mysql && !empty($m['mysqlnd'])) $pi = array_merge($pi, ['pdo' => $m['mysqlnd']]);
+        if ($dbtype_sqlsrv && !empty($m['sqlsrv'])) $pi = array_merge($pi, ['sqlsrv' => $m['sqlsrv']]);
+        if (!empty($m['PDO'])) $pi = array_merge($pi, ['pdo' => $m['PDO']]);
+        if ($dbtype_mysql && !empty($m['pdo_mysql'])) $pi = array_merge($pi, ['pdo_mysql' => $m['pdo_mysql']]);
+        if ($dbtype_sqlsrv && !empty($m['pdo_sqlsrv'])) $pi = array_merge($pi, ['pdo_sqlsrv' => $m['pdo_sqlsrv']]);
+        if (!empty($m['zip'])) $pi = array_merge($pi, ['zip' => $m['zip']]);
         $this->version = [
             'smarty'=> $this->modx->smarty->_version,
             'PHPMailer'=> PHPMailer\PHPMailer\PHPMailer::VERSION
         ];
 
         $this->pi = array_merge($pi,$this->getPhpInfo(INFO_CONFIGURATION));
-        return array(
+        return [
             'pi' => $this->pi,
-        );
+        ];
 
     }
 
@@ -97,7 +97,7 @@ class SystemInfoManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('system_info');
+        return ['system_info'];
     }
 
     public function getPhpInfo($type = -1) {
@@ -105,26 +105,30 @@ class SystemInfoManagerController extends modManagerController {
          phpinfo($type);
 
          $pi = preg_replace(
-         array('#^.*<body>(.*)</body>.*$#ms', '#<h2>PHP License</h2>.*$#ms',
+         [
+             '#^.*<body>(.*)</body>.*$#ms', '#<h2>PHP License</h2>.*$#ms',
          '#<h1>Configuration</h1>#',  "#\r?\n#", "#</(h1|h2|h3|tr)>#", '# +<#',
          "#[ \t]+#", '#&nbsp;#', '#  +#', '# class=".*?"#', '%&#039;%',
           '#<tr>(?:.*?)" src="(?:.*?)=(.*?)" alt="PHP Logo" /></a>'
           .'<h1>PHP Version (.*?)</h1>(?:\n+?)</td></tr>#',
           '#<h1><a href="(?:.*?)\?=(.*?)">PHP Credits</a></h1>#',
           '#<tr>(?:.*?)" src="(?:.*?)=(.*?)"(?:.*?)Zend Engine (.*?),(?:.*?)</tr>#',
-          "# +#", '#<tr>#', '#</tr>#'),
-         array('$1', '', '', '', '</$1>' . "\n", '<', ' ', ' ', ' ', '', ' ',
+          "# +#", '#<tr>#', '#</tr>#'
+         ],
+         [
+             '$1', '', '', '', '</$1>' . "\n", '<', ' ', ' ', ' ', '', ' ',
           '<h2>PHP Configuration</h2>'."\n".'<tr><td>PHP Version</td><td>$2</td></tr>'.
           "\n".'<tr><td>PHP Egg</td><td>$1</td></tr>',
           '<tr><td>PHP Credits Egg</td><td>$1</td></tr>',
           '<tr><td>Zend Engine</td><td>$2</td></tr>' . "\n" .
-          '<tr><td>Zend Egg</td><td>$1</td></tr>', ' ', '%S%', '%E%'),
+          '<tr><td>Zend Egg</td><td>$1</td></tr>', ' ', '%S%', '%E%'
+         ],
          ob_get_clean());
 
          $sections = explode('<h2>', strip_tags($pi, '<h2><th><td>'));
          unset($sections[0]);
 
-         $pi = array();
+         $pi = [];
          foreach($sections as $section){
            $n = substr($section, 0, strpos($section, '</h2>'));
            preg_match_all(
@@ -146,7 +150,7 @@ class SystemInfoManagerController extends modManagerController {
         $s = preg_replace('/<th[^>]*>([^<]+)<\/th>/',"<info>\\1</info>",$s);
         $s = preg_replace('/<td[^>]*>([^<]+)<\/td>/',"<info>\\1</info>",$s);
         $vTmp = preg_split('/(<h2>[^<]+<\/h2>)/',$s,-1,PREG_SPLIT_DELIM_CAPTURE);
-        $vModules = array();
+        $vModules = [];
         for ($i=1;$i<count($vTmp);$i++) {
             if (preg_match('/<h2>([^<]+)<\/h2>/',$vTmp[$i],$vMat)) {
                 $vName = trim($vMat[1]);
@@ -156,7 +160,7 @@ class SystemInfoManagerController extends modManagerController {
                     $vPat3 = "/$vPat\s*$vPat\s*$vPat/";
                     $vPat2 = "/$vPat\s*$vPat/";
                     if (preg_match($vPat3,$vOne,$vMat)) { // 3cols
-                        $vModules[$vName][trim($vMat[1])] = array(trim($vMat[2]),trim($vMat[3]));
+                        $vModules[$vName][trim($vMat[1])] = [trim($vMat[2]),trim($vMat[3])];
                     } elseif (preg_match($vPat2,$vOne,$vMat)) { // 2cols
                         $vModules[$vName][trim($vMat[1])] = trim($vMat[2]);
                     }

--- a/manager/controllers/default/system/logs/index.class.php
+++ b/manager/controllers/default/system/logs/index.class.php
@@ -43,7 +43,7 @@ class SystemLogsManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -67,6 +67,6 @@ class SystemLogsManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('manager_log');
+        return ['manager_log'];
     }
 }

--- a/manager/controllers/default/system/refresh_site.php
+++ b/manager/controllers/default/system/refresh_site.php
@@ -19,16 +19,16 @@ if (!$modx->hasPermission('empty_cache')) return $modx->error->failure($modx->le
 /* invoke OnBeforeCacheUpdate event */
 $modx->invokeEvent('OnBeforeCacheUpdate');
 
-$results= array();
-$modx->cacheManager->refresh(array(), $results);
+$results= [];
+$modx->cacheManager->refresh([], $results);
 
 /* invoke OnSiteRefresh event */
 $modx->invokeEvent('OnSiteRefresh');
 
 $num_rows_pub = isset($results['publishing']['published']) ? $results['publishing']['published'] : 0;
 $num_rows_unpub = isset($results['publishing']['unpublished']) ? $results['publishing']['unpublished'] : 0;
-$modx->smarty->assign('published',$modx->lexicon('refresh_published',array('num' => $num_rows_pub)));
-$modx->smarty->assign('unpublished',$modx->lexicon('refresh_unpublished',array('num' => $num_rows_unpub)));
+$modx->smarty->assign('published',$modx->lexicon('refresh_published', ['num' => $num_rows_pub]));
+$modx->smarty->assign('unpublished',$modx->lexicon('refresh_unpublished', ['num' => $num_rows_unpub]));
 
 $modx->smarty->assign('results', $results);
 

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -50,7 +50,7 @@ class SystemSettingsManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         $onSiteSettingsRender = $this->modx->invokeEvent('OnSiteSettingsRender');
         if (is_array($onSiteSettingsRender)) {
             $this->onSiteSettingsRender = implode("\"\n+ \"",$onSiteSettingsRender);
@@ -79,7 +79,7 @@ class SystemSettingsManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('setting','events');
+        return ['setting','events'];
     }
 
     /**

--- a/manager/controllers/default/workspaces/index.class.php
+++ b/manager/controllers/default/workspaces/index.class.php
@@ -18,7 +18,7 @@ use MODX\Revolution\Transport\modTransportProvider;
  * @subpackage manager.controllers
  */
 class WorkspacesManagerController extends modManagerController {
-    public $errors = array();
+    public $errors = [];
     /**
      * The template file for this controller
      * @var string $templateFile
@@ -78,14 +78,14 @@ class WorkspacesManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {
+    public function process(array $scriptProperties = []) {
         /* ensure directories for Package Management are created */
         /** @var modCacheManager $cacheManager */
         $cacheManager = $this->modx->getCacheManager();
-        $directoryOptions = array(
+        $directoryOptions = [
             'new_folder_permissions' => $this->modx->getOption('new_folder_permissions',null,0775),
-        );
-        $errors = array();
+        ];
+        $errors = [];
 
         /* create assets/ */
         $assetsPath = $this->modx->getOption('assets_path',null,MODX_ASSETS_PATH);
@@ -93,7 +93,7 @@ class WorkspacesManagerController extends modManagerController {
             $cacheManager->writeTree($assetsPath,$directoryOptions);
         }
         if (!is_dir($assetsPath) || !is_writable($assetsPath)) {
-            $errors[] = $this->modx->lexicon('dir_err_assets',array('path' => $assetsPath));
+            $errors[] = $this->modx->lexicon('dir_err_assets', ['path' => $assetsPath]);
         }
         unset($assetsPath);
 
@@ -103,7 +103,7 @@ class WorkspacesManagerController extends modManagerController {
             $cacheManager->writeTree($assetsCompPath,$directoryOptions);
         }
         if (!is_dir($assetsCompPath) || !is_writable($assetsCompPath)) {
-            $errors[] = $this->modx->lexicon('dir_err_assets_comp',array('path' => $assetsCompPath));
+            $errors[] = $this->modx->lexicon('dir_err_assets_comp', ['path' => $assetsCompPath]);
         }
         unset($assetsCompPath);
 
@@ -113,7 +113,7 @@ class WorkspacesManagerController extends modManagerController {
             $cacheManager->writeTree($coreCompPath,$directoryOptions);
         }
         if (!is_dir($coreCompPath) || !is_writable($coreCompPath)) {
-            $errors[] = $this->modx->lexicon('dir_err_core_comp',array('path' => $coreCompPath));
+            $errors[] = $this->modx->lexicon('dir_err_core_comp', ['path' => $coreCompPath]);
         }
 
         if (!function_exists('curl_init') || !in_array('curl',get_loaded_extensions())) {
@@ -139,14 +139,14 @@ class WorkspacesManagerController extends modManagerController {
         $default = $this->modx->getOption('default_provider');
         $c = $this->modx->newQuery(modTransportProvider::class);
         if ($default) {
-            $c->where(array(
+            $c->where([
                 'id' => $default,
-            ));
+            ]);
         } else {
-            $c->where(array(
+            $c->where([
                 'name:=' => 'modxcms.com',
                 'OR:name:=' => 'modx.com',
-            ));
+            ]);
         }
         /** @var modTransportProvider $provider */
         $provider = $this->modx->getObject(modTransportProvider::class, $c);
@@ -181,7 +181,7 @@ class WorkspacesManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('workspace','namespace');
+        return ['workspace','namespace'];
     }
 
     /**

--- a/manager/controllers/default/workspaces/lexicon.class.php
+++ b/manager/controllers/default/workspaces/lexicon.class.php
@@ -47,7 +47,7 @@ class WorkspacesLexiconManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -71,7 +71,7 @@ class WorkspacesLexiconManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('package_builder','lexicon','namespace');
+        return ['package_builder','lexicon','namespace'];
     }
 
     /**

--- a/manager/controllers/default/workspaces/namespace.class.php
+++ b/manager/controllers/default/workspaces/namespace.class.php
@@ -44,7 +44,7 @@ class WorkspacesNamespaceManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -68,7 +68,7 @@ class WorkspacesNamespaceManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('workspace','namespace');
+        return ['workspace','namespace'];
     }
 
     /**

--- a/manager/controllers/default/workspaces/package/view.class.php
+++ b/manager/controllers/default/workspaces/package/view.class.php
@@ -47,7 +47,7 @@ class WorkspacesPackageViewManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = array()) {}
+    public function process(array $scriptProperties = []) {}
 
     /**
      * Return the pagetitle
@@ -71,7 +71,7 @@ class WorkspacesPackageViewManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return array('workspace','namespace');
+        return ['workspace','namespace'];
     }
 
     /**

--- a/manager/index.php
+++ b/manager/index.php
@@ -42,7 +42,7 @@ if (!(require_once MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* @var \MODX\Revolution\modX $modx create the modX object */
-$modx= new \MODX\Revolution\modX('', array(\xPDO\xPDO::OPT_CONN_INIT => array(\xPDO\xPDO::OPT_CONN_MUTABLE => true)));
+$modx= new \MODX\Revolution\modX('', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     $errorMessage = '<a href="../setup/">MODX not installed. Install now?</a>';
     include MODX_CORE_PATH . 'error/unavailable.include.php';

--- a/setup/controllers/contexts.php
+++ b/setup/controllers/contexts.php
@@ -32,7 +32,7 @@ if (!empty($_POST['proceed'])) {
     $_POST['context_connectors_url'] = !empty($_POST['context_connectors_url']) ? rtrim($_POST['context_connectors_url'],'/').'/' : $webUrl . 'connectors/';
     $install->settings->store($_POST);
 
-    $settings = array();
+    $settings = [];
     $settings['core_path'] = MODX_CORE_PATH;
     $settings['web_path_auto'] = isset ($_POST['context_web_path_toggle']) && $_POST['context_web_path_toggle'] ? 1 : 0;
     $settings['web_path'] = isset($_POST['context_web_path']) ? rtrim($_POST['context_web_path'],'/').'/' : MODX_INSTALL_PATH;

--- a/setup/controllers/database.php
+++ b/setup/controllers/database.php
@@ -28,7 +28,7 @@ if (!empty($_POST['proceed'])) {
     $install->settings->store($_POST);
     $mode = $install->settings->get('installmode');
 
-    $errors = array();
+    $errors = [];
 
     $install->getConnection();
 
@@ -64,7 +64,7 @@ if (!empty($_POST['proceed'])) {
         } else {
             $minlength = 8;
             if (strlen($_POST['cmspassword']) < $minlength) {
-                $errors['cmspassword'] = $install->lexicon('password_err_short', array('length' => $minlength));
+                $errors['cmspassword'] = $install->lexicon('password_err_short', ['length' => $minlength]);
             }
 
             $found = false;
@@ -98,7 +98,7 @@ if (!empty($_POST['proceed'])) {
         switch (MODX_SETUP_KEY) {
             case '@traditional@':
                 $webUrl= substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], 'setup/'));
-                $settings = array();
+                $settings = [];
 
                 if ($mode == modInstall::MODE_NEW) {
                     $settings['core_path'] = MODX_CORE_PATH;

--- a/setup/controllers/options.php
+++ b/setup/controllers/options.php
@@ -45,7 +45,7 @@ if (!empty($_POST['proceed'])) {
     $install->settings->store($settings);
 
     $installmode = $install->settings->get('installmode');
-    if (in_array($installmode,array(modInstall::MODE_UPGRADE_REVO_ADVANCED,modInstall::MODE_NEW))) {
+    if (in_array($installmode, [modInstall::MODE_UPGRADE_REVO_ADVANCED,modInstall::MODE_NEW])) {
         $this->proceed('database');
     } else {
         $this->proceed('summary');

--- a/setup/controllers/welcome.php
+++ b/setup/controllers/welcome.php
@@ -24,7 +24,7 @@ $proceed = false;
 $writable = is_writable(MODX_SETUP_PATH . 'includes/config.core.php');
 $writableError = false;
 $config_key = isset($_POST['config_key']) && !empty($_POST['config_key'])
-    ? str_replace(array('{','}',"'",'"','\$'), '', $_POST['config_key'])
+    ? str_replace(['{','}',"'",'"','\$'], '', $_POST['config_key'])
     : MODX_CONFIG_KEY;
 if (!empty($_POST['proceed'])) {
     if ($config_key !== MODX_CONFIG_KEY) {

--- a/setup/includes/config/modconfigreader.class.php
+++ b/setup/includes/config/modconfigreader.class.php
@@ -21,14 +21,14 @@ abstract class modConfigReader {
     /** @var xPDO $xpdo */
     public $xpdo;
     /** @var array $config */
-    public $config = array();
+    public $config = [];
 
-    function __construct(modInstall $install,array $config = array()) {
+    function __construct(modInstall $install,array $config = []) {
         $this->install =& $install;
         $this->xpdo =& $install->xpdo;
-        $this->config = array_merge(array(
+        $this->config = array_merge([
 
-        ),$config);
+        ],$config);
     }
 
     /**
@@ -36,17 +36,17 @@ abstract class modConfigReader {
      * @abstract
      * @param array $config
      */
-    abstract public function read(array $config = array());
+    abstract public function read(array $config = []);
 
     /**
      * Load defaults for a configuration file if one does not exist; used in new installations
      * @param array $config
      * @return array
      */
-    public function loadDefaults(array $config = array()) {
+    public function loadDefaults(array $config = []) {
         $this->getHttpHost();
 
-        $this->config = array_merge($this->config,array(
+        $this->config = array_merge($this->config, [
             'database_type' => isset ($_POST['databasetype']) ? $_POST['databasetype'] : 'mysql',
             'database_server' => isset ($_POST['databasehost']) ? $_POST['databasehost'] : 'localhost',
             'database_connection_charset' => 'utf8',
@@ -58,9 +58,9 @@ abstract class modConfigReader {
             'site_sessionname' => 'SN' . uniqid(''),
             'inplace' => isset ($_POST['inplace']) ? 1 : 0,
             'unpacked' => isset ($_POST['unpacked']) ? 1 : 0,
-            'config_options' => array(),
-            'driver_options' => array(),
-        ),$config);
+            'config_options' => [],
+            'driver_options' => [],
+        ],$config);
         return $this->config;
     }
 

--- a/setup/includes/config/modevolutionconfigreader.class.php
+++ b/setup/includes/config/modevolutionconfigreader.class.php
@@ -15,7 +15,7 @@ require_once strtr(realpath(MODX_SETUP_PATH.'includes/config/modconfigreader.cla
  * @subpackage setup
  */
 class modEvolutionConfigReader extends modConfigReader {
-    public function read(array $config = array()) {
+    public function read(array $config = []) {
         global $database_dsn, $database_type, $database_server, $dbase, $database_user, $database_password,
                $database_connection_charset, $table_prefix, $config_options, $driver_options;
         $database_connection_charset = 'utf8';
@@ -27,10 +27,10 @@ class modEvolutionConfigReader extends modConfigReader {
         $included = @ include MODX_INSTALL_PATH . 'manager/includes/config.inc.php';
         @ob_end_clean();
         if ($included && isset ($dbase)) {
-            $config_options = is_array($config_options) ? $config_options : array();
-            $driver_options = is_array($driver_options) ? $driver_options : array();
+            $config_options = is_array($config_options) ? $config_options : [];
+            $driver_options = is_array($driver_options) ? $driver_options : [];
 
-            $this->config = array_merge(array(
+            $this->config = array_merge([
                 'database_type' => !empty($database_type) ? $database_type : 'mysql',
                 'database_server' => !empty($database_server) ? $database_server : 'localhost',
                 'dbase' => trim($dbase, '`[]'),
@@ -46,7 +46,7 @@ class modEvolutionConfigReader extends modConfigReader {
                 'unpacked' => isset ($_POST['unpacked']) ? 1 : 0,
                 'config_options' => $config_options,
                 'driver_options' => $driver_options,
-            ),$this->config,$config);
+            ],$this->config,$config);
         }
         return $this->config;
     }

--- a/setup/includes/config/modrevolutionconfigreader.class.php
+++ b/setup/includes/config/modrevolutionconfigreader.class.php
@@ -15,7 +15,7 @@ require_once strtr(realpath(MODX_SETUP_PATH.'includes/config/modconfigreader.cla
  * @subpackage setup
  */
 class modRevolutionConfigReader extends modConfigReader {
-    public function read(array $config = array()) {
+    public function read(array $config = []) {
         global $database_dsn, $database_type, $database_server, $dbase, $database_user, $database_password,
                $database_connection_charset, $table_prefix, $config_options, $driver_options;
         $database_connection_charset = 'utf8';
@@ -46,10 +46,10 @@ class modRevolutionConfigReader extends modConfigReader {
             $this->config['assets_path'] = MODX_ASSETS_PATH;
             $this->config['assets_url'] = MODX_ASSETS_URL;
 
-            $config_options = is_array($config_options) ? $config_options : array();
-            $driver_options = is_array($driver_options) ? $driver_options : array();
+            $config_options = is_array($config_options) ? $config_options : [];
+            $driver_options = is_array($driver_options) ? $driver_options : [];
 
-            $this->config = array_merge(array(
+            $this->config = array_merge([
                 'database_type' => $database_type,
                 'database_server' => $database_server,
                 'dbase' => trim($dbase, '`[]'),
@@ -65,7 +65,7 @@ class modRevolutionConfigReader extends modConfigReader {
                 'unpacked' => isset ($_POST['unpacked']) ? 1 : 0,
                 'config_options' => $config_options,
                 'driver_options' => $driver_options,
-            ),$this->config,$config);
+            ],$this->config,$config);
         }
         return $this->config;
     }

--- a/setup/includes/drivers/modinstalldriver_mysql.class.php
+++ b/setup/includes/drivers/modinstalldriver_mysql.class.php
@@ -57,10 +57,10 @@ class modInstallDriver_mysql extends modInstallDriver {
         $collations = null;
         $stmt = $this->xpdo->query("SHOW COLLATION");
         if ($stmt && $stmt instanceof PDOStatement) {
-            $collations = array();
+            $collations = [];
             if (empty($collation)) $collation = $this->getCollation();
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                $col = array();
+                $col = [];
                 $col['selected'] = ($row['Collation']==$collation ? ' selected="selected"' : '');
                 $col['value'] = $row['Collation'];
                 $col['name'] = $row['Collation'];
@@ -95,10 +95,10 @@ class modInstallDriver_mysql extends modInstallDriver {
         $charsets = null;
         $stmt = $this->xpdo->query('SHOW CHARSET');
         if ($stmt && $stmt instanceof PDOStatement) {
-            $charsets = array();
+            $charsets = [];
             if (empty($charset)) $charset = $this->getCharset();
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                $col = array();
+                $col = [];
                 $col['selected'] = $row['Charset']==$charset ? ' selected="selected"' : '';
                 $col['value'] = $row['Charset'];
                 $col['name'] = $row['Charset'];
@@ -140,7 +140,7 @@ class modInstallDriver_mysql extends modInstallDriver {
             $this->install->settings->set('config_options', $config_options);
             $this->install->settings->store();
 
-            return array('result' => 'warning', 'message' => $this->install->lexicon('mysql_version_server_nf'),'version' => $mysqlVersion);
+            return ['result' => 'warning', 'message' => $this->install->lexicon('mysql_version_server_nf'),'version' => $mysqlVersion];
         }
 
         $mysql_ver_comp = version_compare($mysqlVersion,'4.1.20','>=');
@@ -161,11 +161,20 @@ class modInstallDriver_mysql extends modInstallDriver {
         }
 
         if (!$mysql_ver_comp) { /* ancient driver warning */
-            return array('result' => 'failure','message' => $this->install->lexicon('mysql_version_fail',array('version' => $mysqlVersion)),'version' => $mysqlVersion);
+            return [
+                'result' => 'failure','message' => $this->install->lexicon('mysql_version_fail',
+                    ['version' => $mysqlVersion]),'version' => $mysqlVersion
+            ];
         } else if ($mysql_ver_comp_5051 || $mysql_ver_comp_5051a) { /* 5.0.51a. bad. berry bad. */
-            return array('result' => 'failure','message' => $this->install->lexicon('mysql_version_5051',array('version' => $mysqlVersion)),'version' => $mysqlVersion);
+            return [
+                'result' => 'failure','message' => $this->install->lexicon('mysql_version_5051',
+                    ['version' => $mysqlVersion]),'version' => $mysqlVersion
+            ];
         } else {
-            return array('result' => 'success','message' => $this->install->lexicon('mysql_version_success',array('version' => $mysqlVersion)),'version' => $mysqlVersion);
+            return [
+                'result' => 'success','message' => $this->install->lexicon('mysql_version_success',
+                    ['version' => $mysqlVersion]),'version' => $mysqlVersion
+            ];
         }
     }
 
@@ -177,14 +186,20 @@ class modInstallDriver_mysql extends modInstallDriver {
         $mysqlVersion = $this->xpdo->getAttribute(PDO::ATTR_CLIENT_VERSION);
         $mysqlVersion = $this->_sanitizeVersion($mysqlVersion);
         if (empty($mysqlVersion)) {
-            return array('result' => 'warning','message' => $this->install->lexicon('mysql_version_client_nf'),'version' => $mysqlVersion);
+            return ['result' => 'warning','message' => $this->install->lexicon('mysql_version_client_nf'),'version' => $mysqlVersion];
         }
 
         $mysql_ver_comp = version_compare($mysqlVersion,'4.1.20','>=');
         if (!$mysql_ver_comp) {
-            return array('result' => 'warning','message' => $this->install->lexicon('mysql_version_client_old',array('version' => $mysqlVersion)),'version' => $mysqlVersion);
+            return [
+                'result' => 'warning','message' => $this->install->lexicon('mysql_version_client_old',
+                    ['version' => $mysqlVersion]),'version' => $mysqlVersion
+            ];
         } else {
-            return array('result' => 'success','message' => $this->install->lexicon('mysql_version_success',array('version' => $mysqlVersion)),'version' => $mysqlVersion);
+            return [
+                'result' => 'success','message' => $this->install->lexicon('mysql_version_success',
+                    ['version' => $mysqlVersion]),'version' => $mysqlVersion
+            ];
         }
     }
 
@@ -222,11 +237,11 @@ class modInstallDriver_mysql extends modInstallDriver {
      * @return string The sanitized version
      */
     protected function _sanitizeVersion($mysqlVersion) {
-        $mysqlVersion = str_replace(array(
+        $mysqlVersion = str_replace([
             'mysqlnd ',
             '-dev',
             ' ',
-        ),'',$mysqlVersion);
+        ],'',$mysqlVersion);
         return $mysqlVersion;
     }
 }

--- a/setup/includes/drivers/modinstalldriver_sqlsrv.class.php
+++ b/setup/includes/drivers/modinstalldriver_sqlsrv.class.php
@@ -54,10 +54,10 @@ class modInstallDriver_sqlsrv extends modInstallDriver {
         $collations = null;
         $stmt = $this->xpdo->query("SELECT * FROM sys.fn_helpcollations()");
         if ($stmt && $stmt instanceof PDOStatement) {
-            $collations = array();
+            $collations = [];
             if (empty($collation)) $collation = $this->getCollation();
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                $col = array();
+                $col = [];
                 $col['selected'] = ($row['name']==$collation ? ' selected="selected"' : '');
                 $col['value'] = $row['name'];
                 $col['name'] = $row['name'];
@@ -88,11 +88,13 @@ class modInstallDriver_sqlsrv extends modInstallDriver {
         if (empty($charset)) {
             $charset = $this->getCharset();
         }
-        return array($charset => array(
+        return [
+            $charset => [
             'selected' => ' selected="selected"',
             'value' => $charset,
             'name' => $charset
-        ));
+            ]
+        ];
     }
 
     /**
@@ -119,22 +121,30 @@ class modInstallDriver_sqlsrv extends modInstallDriver {
      * {@inheritDoc}
      */
     public function verifyServerVersion() {
-        return array('result' => 'success','message' => $this->install->lexicon('sqlsrv_version_success',array('version' => '')));
+        return [
+            'result' => 'success','message' => $this->install->lexicon('sqlsrv_version_success', ['version' => ''])
+        ];
 
         $handler = @sqlsrv_connect($this->install->settings->get('database_server'),$this->install->settings->get('database_user'),$this->install->settings->get('database_password'));
         $serverInfo = @sqlsrv_server_info($handler);
         $sqlsrvVersion = $serverInfo['SQLServerVersion'];
         $sqlsrvVersion = $this->_sanitizeVersion($sqlsrvVersion);
         if (empty($sqlsrvVersion)) {
-            return array('result' => 'warning', 'message' => $this->install->lexicon('sqlsrv_version_server_nf'),'version' => $sqlsrvVersion);
+            return ['result' => 'warning', 'message' => $this->install->lexicon('sqlsrv_version_server_nf'),'version' => $sqlsrvVersion];
         }
 
         $sqlsrv_ver_comp = version_compare($sqlsrvVersion,'10.50.0','>=');
 
         if (!$sqlsrv_ver_comp) { /* ancient driver warning */
-            return array('result' => 'failure','message' => $this->install->lexicon('sqlsrv_version_fail',array('version' => $sqlsrvVersion)),'version' => $sqlsrvVersion);
+            return [
+                'result' => 'failure','message' => $this->install->lexicon('sqlsrv_version_fail',
+                    ['version' => $sqlsrvVersion]),'version' => $sqlsrvVersion
+            ];
         } else {
-            return array('result' => 'success','message' => $this->install->lexicon('sqlsrv_version_success',array('version' => $sqlsrvVersion)),'version' => $sqlsrvVersion);
+            return [
+                'result' => 'success','message' => $this->install->lexicon('sqlsrv_version_success',
+                    ['version' => $sqlsrvVersion]),'version' => $sqlsrvVersion
+            ];
         }
     }
 
@@ -146,20 +156,29 @@ class modInstallDriver_sqlsrv extends modInstallDriver {
      * {@inheritDoc}
      */
     public function verifyClientVersion() {
-        return array('result' => 'success', 'message' => $this->install->lexicon('sqlsrv_version_client_success',array('version' => '')));
+        return [
+            'result' => 'success', 'message' => $this->install->lexicon('sqlsrv_version_client_success',
+                ['version' => ''])
+        ];
 
         $clientInfo = @sqlsrv_client_info();
         $sqlsrvVersion = $clientInfo['DriverVer'];
         $sqlsrvVersion = $this->_sanitizeVersion($sqlsrvVersion);
         if (empty($sqlsrvVersion)) {
-            return array('result' => 'warning','message' => $this->install->lexicon('sqlsrv_version_client_nf'),'version' => $sqlsrvVersion);
+            return ['result' => 'warning','message' => $this->install->lexicon('sqlsrv_version_client_nf'),'version' => $sqlsrvVersion];
         }
 
         $sqlsrv_ver_comp = version_compare($sqlsrvVersion,'10.50.0','>=');
         if (!$sqlsrv_ver_comp) {
-            return array('result' => 'warning','message' => $this->install->lexicon('sqlsrv_version_client_old',array('version' => $sqlsrvVersion)),'version' => $sqlsrvVersion);
+            return [
+                'result' => 'warning','message' => $this->install->lexicon('sqlsrv_version_client_old',
+                    ['version' => $sqlsrvVersion]),'version' => $sqlsrvVersion
+            ];
         } else {
-            return array('result' => 'success','message' => $this->install->lexicon('sqlsrv_version_success',array('version' => $sqlsrvVersion)),'version' => $sqlsrvVersion);
+            return [
+                'result' => 'success','message' => $this->install->lexicon('sqlsrv_version_success',
+                    ['version' => $sqlsrvVersion]),'version' => $sqlsrvVersion
+            ];
         }
     }
 

--- a/setup/includes/error/modinstallerror.class.php
+++ b/setup/includes/error/modinstallerror.class.php
@@ -46,12 +46,12 @@ abstract class modInstallError {
      * @var boolean Indicates failure or success.
      */
     public $status = false;
-    protected $_objects = array();
+    protected $_objects = [];
 
     function __construct(&$modx, $message = '') {
         $this->modx =& $modx;
         $this->message = $message;
-        $this->errors = array ();
+        $this->errors = [];
     }
 
     /**
@@ -74,7 +74,7 @@ abstract class modInstallError {
      * add to the validation queue.
      * @return string The validation message returned.
      */
-    public function checkValidation($objs= array()) {
+    public function checkValidation($objs= []) {
         if (is_object($objs)) {
             $this->addObjectToValidate($objs);
         }
@@ -128,7 +128,7 @@ abstract class modInstallError {
         if ($message != '') {
             $this->message = $message;
         }
-        $objarray = array ();
+        $objarray = [];
         if (is_array($object)) {
             $obj = reset($object);
             if (is_object($obj) && $obj instanceof xPDOObject) {
@@ -147,10 +147,10 @@ abstract class modInstallError {
      * @param string $error The error message.
      */
     public function addField($name, $error) {
-        $this->errors[] = array (
+        $this->errors[] = [
             'id' => $name,
             'msg' => $error
-        );
+        ];
     }
 
     /**
@@ -159,7 +159,7 @@ abstract class modInstallError {
      * @return array An array of errors for specific fields.
      */
     public function getFields() {
-        $f = array ();
+        $f = [];
         foreach ($this->errors as $fi)
             $f[] = $fi['msg'];
 
@@ -204,7 +204,7 @@ abstract class modInstallError {
      * @return array Returns an array representation of the object(s).
      */
     public function toArray($object) {
-        $array = array ();
+        $array = [];
         if (is_array($object)) {
             foreach ($object as $key => $value) {
                 if (!is_resource($value)) {

--- a/setup/includes/error/modinstalljsonerror.class.php
+++ b/setup/includes/error/modinstalljsonerror.class.php
@@ -22,7 +22,7 @@ class modInstallJSONError extends modInstallError {
 
     function __construct(&$modx, $message= '', $type= 'error') {
         $this->message= $message;
-        $this->fields= array ();
+        $this->fields= [];
         $this->type= $type;
         parent :: __construct($modx, $message);
     }
@@ -32,24 +32,24 @@ class modInstallJSONError extends modInstallError {
         @header("Content-Type: text/json; charset=UTF-8");
         if ($message != '') $this->message= $message;
 
-        return json_encode(array (
+        return json_encode([
             'message' => $this->message,
             'fields' => $this->fields,
             'type' => $this->type,
             'object' => $objarray,
             'success' => $status,
-        ));
+        ]);
     }
 
     public function addField($name, $error) {
-        $this->fields[]= array (
+        $this->fields[]= [
             'name' => $name,
             'error' => $error
-        );
+        ];
     }
 
     public function getFields() {
-        $f= array ();
+        $f= [];
         foreach ($this->fields as $fi) $f[]= $fi['name'];
         return $f;
     }

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -33,7 +33,7 @@ class modInstall {
 
     /** @var xPDO $xpdo */
     public $xpdo = null;
-    public $options = array ();
+    public $options = [];
     /** @var modInstallRequest $request */
     public $request = null;
     /** @var modInstallSettings $settings */
@@ -47,7 +47,7 @@ class modInstall {
     /** @var modInstallRunner $runner */
     public $runner;
     /** @var array $config */
-    public $config = array ();
+    public $config = [];
     public $action = '';
     public $finished = false;
 
@@ -57,7 +57,7 @@ class modInstall {
      * @constructor
      * @param array $options An array of configuration options.
      */
-    function __construct(array $options = array()) {
+    function __construct(array $options = []) {
         if (isset ($_REQUEST['action'])) {
             $this->action = preg_replace('/[\.]{2,}/', '', htmlspecialchars($_REQUEST['action']));
         }
@@ -102,17 +102,19 @@ class modInstall {
      * @param array $config
      * @return Object|null
      */
-    public function getService($name,$class,$path = '',array $config = array()) {
+    public function getService($name,$class,$path = '',array $config = []) {
         if (empty($this->$name)) {
             $className = $this->loadClass($class,$path);
             if (!empty($className)) {
                 $this->$name = new $className($this,$config);
             } else {
-                $this->_fatalError($this->lexicon('service_err_nf',array(
+                $this->_fatalError($this->lexicon('service_err_nf',
+                                                  [
                     'name' => $name,
                     'class' => $class,
                     'path' => $path,
-                )));
+                                                  ]
+                ));
             }
         }
         return $this->$name;
@@ -132,7 +134,7 @@ class modInstall {
             if (!empty($className)) {
                 $this->settings = new $className($this);
             } else {
-                $this->_fatalError($this->lexicon('settings_handler_err_nf',array('path' => $className)));
+                $this->_fatalError($this->lexicon('settings_handler_err_nf', ['path' => $className]));
             }
         }
         return $this->settings;
@@ -145,7 +147,7 @@ class modInstall {
      * @param array $placeholders
      * @return string
      */
-    public function lexicon($key,array $placeholders = array()) {
+    public function lexicon($key,array $placeholders = []) {
         return $this->lexicon->get($key,$placeholders);
     }
 
@@ -161,10 +163,10 @@ class modInstall {
         if ($this->settings && empty($mode)) $mode = (int)$this->settings->get('installmode');
         if (empty($mode)) $mode = modInstall::MODE_NEW;
         if ($mode === modInstall::MODE_UPGRADE_REVO) {
-            $errors = array ();
+            $errors = [];
             $this->xpdo = $this->_modx($errors);
         } else if (!is_object($this->xpdo)) {
-            $options = array();
+            $options = [];
             if ($this->settings->get('new_folder_permissions')) $options['new_folder_permissions'] = $this->settings->get('new_folder_permissions');
             if ($this->settings->get('new_file_permissions')) $options['new_file_permissions'] = $this->settings->get('new_file_permissions');
             $this->xpdo = $this->_connect(
@@ -186,7 +188,7 @@ class modInstall {
 
             if ($mode === modInstall::MODE_UPGRADE_REVO_ADVANCED) {
                 if ($this->xpdo->connect()) {
-                    $errors = array ();
+                    $errors = [];
                     $this->xpdo = $this->_modx($errors);
                 } else {
                     return $this->lexicon('db_err_connect_upgrade');
@@ -194,12 +196,14 @@ class modInstall {
             }
         }
         if (is_object($this->xpdo) && $this->xpdo instanceof xPDO) {
-            $this->xpdo->setLogTarget(array(
+            $this->xpdo->setLogTarget(
+                [
                 'target' => 'FILE',
-                'options' => array(
+                'options' => [
                     'filename' => 'install.' . MODX_CONFIG_KEY . '.' . strftime('%Y-%m-%dT%H.%M.%S').'.log'
-                )
-            ));
+                ]
+                ]
+            );
             $this->xpdo->setLogLevel(xPDO::LOG_LEVEL_ERROR);
             $this->xpdo->setPackage('Revolution', MODX_CORE_PATH . 'src/', $this->settings->get('table_prefix'));
             $this->xpdo->addPackage('Revolution\Registry\Db', MODX_CORE_PATH . 'src/', $this->settings->get('table_prefix'));
@@ -217,7 +221,7 @@ class modInstall {
      * @param array $config
      * @return modInstallTest|void
      */
-    public function loadTestHandler($class = 'test.modInstallTest',$path = '',array $config = array()) {
+    public function loadTestHandler($class = 'test.modInstallTest',$path = '',array $config = []) {
         $className = $this->loadClass($class,$path);
         if (!empty($className)) {
             $this->lexicon->load('test');
@@ -225,11 +229,11 @@ class modInstall {
             $distributionClass = 'test.'.$className.ucfirst(trim(MODX_SETUP_KEY, '@'));
             $distributionClassName = $this->loadClass($distributionClass,$path);
             if (empty($distributionClassName)) {
-                $this->_fatalError($this->lexicon('test_version_class_nf',array('path' => $distributionClass)));
+                $this->_fatalError($this->lexicon('test_version_class_nf', ['path' => $distributionClass]));
             }
             $this->test = new $distributionClassName($this);
         } else {
-            $this->_fatalError($this->lexicon('test_class_nf',array('path' => $path)));
+            $this->_fatalError($this->lexicon('test_class_nf', ['path' => $path]));
         }
         return $this->test;
     }
@@ -253,7 +257,7 @@ class modInstall {
      * @return array An array of error messages collected during the process.
      */
     public function verify() {
-        $errors = array ();
+        $errors = [];
         $modx = $this->_modx($errors);
         if (is_object($modx) && $modx instanceof modX) {
             if ($modx->getCacheManager()) {
@@ -270,8 +274,8 @@ class modInstall {
      * @param array $options
      * @return array
      */
-    public function cleanup(array $options = array ()) {
-        $errors = array();
+    public function cleanup(array $options = []) {
+        $errors = [];
         $modx = $this->_modx($errors);
         if (empty($modx) || !($modx instanceof modX)) {
             $errors['modx_class'] = $this->lexicon('modx_err_instantiate');
@@ -281,9 +285,9 @@ class modInstall {
         /* create the directories for Package Management */
         /** @var modCacheManager $cacheManager */
         $cacheManager = $modx->getCacheManager();
-        $directoryOptions = array(
+        $directoryOptions = [
             'new_folder_permissions' => $modx->getOption('new_folder_permissions',null,0775),
-        );
+        ];
 
         /* create assets/ */
         $assetsPath = $this->settings->get('assets_path',$this->settings->get('web_path',$modx->getOption('base_path')).'assets/');
@@ -325,8 +329,8 @@ class modInstall {
      * @param array $options
      * @return array
      */
-    public function removeSetupDirectory(array $options = array()) {
-        $errors = array();
+    public function removeSetupDirectory(array $options = []) {
+        $errors = [];
 
         $modx = $this->_modx($errors);
         if ($modx) {
@@ -366,8 +370,8 @@ class modInstall {
      * @param array $attributes An array of installation attributes.
      * @return array An array of error messages collected during the process.
      */
-    public function installPackage($pkg, array $attributes = array ()) {
-        $errors = array ();
+    public function installPackage($pkg, array $attributes = []) {
+        $errors = [];
 
         /* instantiate the modX class */
         if (class_exists('MODX\Revolution\modX')) {
@@ -385,12 +389,12 @@ class modInstall {
                     $package = xPDOTransport :: retrieve($modx, $packageDirectory . $pkg . '.transport.zip', $packageDirectory, $packageState);
                     if ($package) {
                         if (!$package->install($attributes)) {
-                            $errors[] = '<p>'.$this->lexicon('package_err_install',array('package' => $pkg)).'</p>';
+                            $errors[] = '<p>'.$this->lexicon('package_err_install', ['package' => $pkg]).'</p>';
                         } else {
-                            $modx->log(xPDO::LOG_LEVEL_INFO,$this->lexicon('package_installed',array('package' => $pkg)));
+                            $modx->log(xPDO::LOG_LEVEL_INFO,$this->lexicon('package_installed', ['package' => $pkg]));
                         }
                     } else {
-                        $errors[] = '<p>'.$this->lexicon('package_err_nf',array('package' => $pkg)).'</p>';
+                        $errors[] = '<p>'.$this->lexicon('package_err_nf', ['package' => $pkg]).'</p>';
                     }
                 }
             }
@@ -457,26 +461,29 @@ class modInstall {
      * @return xPDO|string The xPDO instance to be used by the installation.
      * @throws xPDOException
      */
-    public function _connect($dsn, $user = '', $password = '', $prefix = '', array $options = array()) {
+    public function _connect($dsn, $user = '', $password = '', $prefix = '', array $options = []) {
         require_once MODX_CORE_PATH . 'vendor/autoload.php';
         if (class_exists('\xPDO\xPDO')) {
-            $this->xpdo = new xPDO($dsn, $user, $password, array_merge(array(
+            $this->xpdo = new xPDO($dsn, $user, $password, array_merge(
+                [
                     xPDO::OPT_CACHE_PATH => MODX_CORE_PATH . 'cache/',
                     xPDO::OPT_TABLE_PREFIX => $prefix,
                     xPDO::OPT_SETUP => true,
-                ), $options),
-                array(PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT)
+                ], $options),
+                                   [PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT]
             );
-            $this->xpdo->setLogTarget(array(
+            $this->xpdo->setLogTarget(
+                [
                 'target' => 'FILE',
-                'options' => array(
+                'options' => [
                     'filename' => 'install.' . MODX_CONFIG_KEY . '.' . strftime('%Y%m%dT%H%M%S') . '.log'
-                )
-            ));
+                ]
+                ]
+            );
             $this->xpdo->setLogLevel(xPDO::LOG_LEVEL_ERROR);
             return $this->xpdo;
         } else {
-            return $this->lexicon('xpdo_err_nf', array('path' => MODX_CORE_PATH.'vendor/xpdo/xpdo/src/xPDO/xPDO.php'));
+            return $this->lexicon('xpdo_err_nf', ['path' => MODX_CORE_PATH.'vendor/xpdo/xpdo/src/xPDO/xPDO.php']);
         }
     }
 
@@ -491,18 +498,21 @@ class modInstall {
 
         /* to validate installation, instantiate the modX class and run a few tests */
         if (class_exists(modX::class)) {
-            $modx = new modX(MODX_CORE_PATH . 'config/', array(
+            $modx = new modX(MODX_CORE_PATH . 'config/', [
                 xPDO::OPT_SETUP => true,
-            ));
+            ]
+            );
             if (!is_object($modx) || !($modx instanceof modX)) {
                 $errors[] = '<p>'.$this->lexicon('modx_err_instantiate').'</p>';
             } else {
-                $modx->setLogTarget(array(
+                $modx->setLogTarget(
+                    [
                     'target' => 'FILE',
-                    'options' => array(
+                    'options' => [
                         'filename' => 'install.' . MODX_CONFIG_KEY . '.' . strftime('%Y%m%dT%H%M%S') . '.log'
-                    )
-                ));
+                    ]
+                    ]
+                );
 
                 /* try to initialize the mgr context */
                 $modx->initialize('mgr');
@@ -544,7 +554,7 @@ class modInstall {
      */
     public function doPreloadChecks() {
         $this->lexicon->load('preload');
-        $errors= array();
+        $errors= [];
 
         if (!extension_loaded('pdo')) {
             $errors[] = $this->lexicon('preload_err_pdo');
@@ -553,7 +563,7 @@ class modInstall {
             $errors[] = $this->lexicon('preload_err_core_path');
         }
         if (!file_exists(MODX_CORE_PATH . 'cache/') || !is_dir(MODX_CORE_PATH . 'cache/') || !$this->is_writable2(MODX_CORE_PATH . 'cache/')) {
-            $errors[] = $this->lexicon('preload_err_cache',array('path' => MODX_CORE_PATH));
+            $errors[] = $this->lexicon('preload_err_cache', ['path' => MODX_CORE_PATH]);
         }
 
         if (!empty($errors)) {
@@ -634,7 +644,7 @@ class modInstall {
         if (!empty($className)) {
             $this->driver = new $className($this);
         } else {
-            $this->_fatalError($this->lexicon('driver_class_err_nf',array('path' => $class)));
+            $this->_fatalError($this->lexicon('driver_class_err_nf', ['path' => $class]));
         }
         return !empty($className);
     }

--- a/setup/includes/modinstalllexicon.class.php
+++ b/setup/includes/modinstalllexicon.class.php
@@ -66,7 +66,7 @@ class modInstallLexicon
      * @param array $placeholders An array of placeholders
      * @return string
      */
-    public function parse($str = '',array $placeholders = array()) {
+    public function parse($str = '',array $placeholders = []) {
         if (empty($str)) return '';
         if (empty($placeholders) || !is_array($placeholders)) return $str;
 
@@ -96,7 +96,7 @@ class modInstallLexicon
      */
     public function fetch($prefix = '',$removePrefix = false) {
         if (!empty($prefix)) {
-            $lex = array();
+            $lex = [];
             $lang = $this->lexicon;
             foreach ($lang as $k => $v) {
                 if (strpos($k,$prefix) !== false) {

--- a/setup/includes/modinstallsettings.class.php
+++ b/setup/includes/modinstallsettings.class.php
@@ -13,13 +13,13 @@
  */
 class modInstallSettings {
     public $install = null;
-    public $config = array();
+    public $config = [];
     public $fileName = '';
-    public $settings = array();
+    public $settings = [];
 
-    function __construct(modInstall &$install,array $config = array()) {
+    function __construct(modInstall &$install,array $config = []) {
         $this->install =& $install;
-        $this->config = array_merge(array(),$config);
+        $this->config = array_merge([],$config);
 
         $this->fileName = $this->getCachePath().'settings.cache.php';
         $this->load();
@@ -63,7 +63,7 @@ class modInstallSettings {
      */
     public function set($k,$v) {
         $this->settings[$k] = $v;
-        if (in_array($k, array('database_type', 'database_server', 'dbase', 'database_connection_charset'))) {
+        if (in_array($k, ['database_type', 'database_server', 'dbase', 'database_connection_charset'])) {
             $this->rebuildDSN();
         }
     }
@@ -74,7 +74,7 @@ class modInstallSettings {
      * @return mixed
      */
     public function get($k,$default = null) {
-        if (in_array($k, array('database_dsn', 'server_dsn'))) {
+        if (in_array($k, ['database_dsn', 'server_dsn'])) {
             $this->rebuildDSN();
         }
         return isset($this->settings[$k]) ? $this->settings[$k] : $default;
@@ -136,7 +136,7 @@ class modInstallSettings {
      * @param int $expire
      * @return bool|int
      */
-    public function store(array $settings = array(),$expire = 900) {
+    public function store(array $settings = [],$expire = 900) {
         $this->settings = array_merge($this->settings,$settings);
         $this->rebuildDSN();
         $written = false;

--- a/setup/includes/modinstallversion.class.php
+++ b/setup/includes/modinstallversion.class.php
@@ -20,7 +20,7 @@
  * @package setup
  */
 class modInstallVersion {
-    public $results = array();
+    public $results = [];
     public $version = '';
 
     function __construct(modInstallRunner &$runner) {
@@ -45,10 +45,12 @@ class modInstallVersion {
             return $dbcreated;
         } else {
             if (!$dbcreated = $this->install->xpdo->manager->createObjectContainer($class)) {
-                $this->runner->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">' . $this->install->lexicon('table_err_create',array('class' => $class)) . '</p>');
+                $this->runner->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">' . $this->install->lexicon('table_err_create',
+                        ['class' => $class]) . '</p>');
                 return false;
             } else {
-                $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">' . $this->install->lexicon('table_created',array('class' => $class)) . '</p>');
+                $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">' . $this->install->lexicon('table_created',
+                        ['class' => $class]) . '</p>');
                 return true;
             }
         }
@@ -61,7 +63,7 @@ class modInstallVersion {
      * @return array An array of results
      */
     public function install() {
-        $this->results = array();
+        $this->results = [];
 
         $connected = $this->install->xpdo->connect();
         if ($connected) {
@@ -92,7 +94,7 @@ class modInstallVersion {
      * @param array $params Optional parameters to be passed to a callable function.
      * @return boolean True if successful
      */
-    public function processResults($class,$description,$callable,array $params=array()) {
+    public function processResults($class,$description,$callable,array $params= []) {
         $result = false;
         if (is_callable($callable)) {
             $result = call_user_func_array($callable, $params);
@@ -100,10 +102,12 @@ class modInstallVersion {
             $result = $this->install->xpdo->exec($callable);
         }
         if ($result === false) {
-            $this->runner->addResult(modInstallRunner::RESULT_WARNING,'<p class="notok">'.$this->install->lexicon('err_update_table',array('class' => $class)).'<br /><small>' . nl2br(print_r($this->install->xpdo->errorInfo(), true)) . '</small></p>');
+            $this->runner->addResult(modInstallRunner::RESULT_WARNING,'<p class="notok">'.$this->install->lexicon('err_update_table',
+                    ['class' => $class]).'<br /><small>' . nl2br(print_r($this->install->xpdo->errorInfo(), true)) . '</small></p>');
             return false;
         } else {
-            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">'.$this->install->lexicon('table_updated',array('class' => $class)).'<br /><small>' . $description . '</small></p>');
+            $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,'<p class="ok">'.$this->install->lexicon('table_updated',
+                    ['class' => $class]).'<br /><small>' . $description . '</small></p>');
             return true;
         }
     }
@@ -116,7 +120,7 @@ class modInstallVersion {
      * @return array An array of script filenames to load
      */
     private function _getUpgradeScripts() {
-        $scripts = array();
+        $scripts = [];
         $path = dirname(__FILE__).'/upgrades/'.$this->install->settings->get('database_type','mysql').'/';
         $sc = '';
         if (is_dir($path)) {
@@ -141,9 +145,9 @@ class modInstallVersion {
      */
     private function _getVersion() {
         $installVersion = '2.0.0-alpha-1';
-        if ($settings_version = $this->install->xpdo->getObject(modSystemSetting::class, array(
+        if ($settings_version = $this->install->xpdo->getObject(modSystemSetting::class, [
                 'key' => 'settings_version'
-            ))) {
+        ])) {
             $installVersion = $settings_version->get('value');
         }
         $this->version = $installVersion;

--- a/setup/includes/new.install.php
+++ b/setup/includes/new.install.php
@@ -70,7 +70,7 @@ if ($saved) {
     }
     if ($saved) {
         /** @var modSystemSetting $emailSender */
-        $emailSender = $modx->getObject(modSystemSetting::class, array('key' => 'emailsender'));
+        $emailSender = $modx->getObject(modSystemSetting::class, ['key' => 'emailsender']);
         if ($emailSender) {
             $emailSender->set('value', $settings->get('cmsadminemail'));
             $saved = $emailSender->save();
@@ -102,19 +102,19 @@ if ($install->settings->get('new_file_permissions')) {
 /* setup load only anonymous ACL*/
 
 /** @var modAccessPolicy $loadOnly */
-$loadOnly = $modx->getObject(modAccessPolicy::class,array(
+$loadOnly = $modx->getObject(modAccessPolicy::class, [
     'name' => 'Load Only',
-));
+]);
 if ($loadOnly) {
     /** @var modAccessContext $access */
     $access= $modx->newObject(modAccessContext::class);
-    $access->fromArray(array(
+    $access->fromArray([
       'target' => 'web',
       'principal_class' => modUserGroup::class,
       'principal' => 0,
       'authority' => 9999,
       'policy' => $loadOnly->get('id'),
-    ));
+    ]);
     $access->save();
     unset($access);
 }
@@ -124,34 +124,34 @@ unset($loadOnly);
 /* setup default admin ACLs*/
 
 /** @var modAccessPolicy $adminPolicy */
-$adminPolicy = $modx->getObject(modAccessPolicy::class,array(
+$adminPolicy = $modx->getObject(modAccessPolicy::class, [
     'name' => 'Administrator',
-));
+]);
 /** @var modUserGroup $adminGroup */
-$adminGroup = $modx->getObject(modUserGroup::class,array(
+$adminGroup = $modx->getObject(modUserGroup::class, [
     'name' => 'Administrator',
-));
+]);
 if ($adminPolicy && $adminGroup) {
     /** @var modAccessContext $access */
     $access= $modx->newObject(modAccessContext::class);
-    $access->fromArray(array(
+    $access->fromArray([
       'target' => 'mgr',
       'principal_class' => modUserGroup::class,
       'principal' => $adminGroup->get('id'),
       'authority' => 0,
       'policy' => $adminPolicy->get('id'),
-    ));
+    ]);
     $access->save();
     unset($access);
 
     $access= $modx->newObject(modAccessContext::class);
-    $access->fromArray(array(
+    $access->fromArray([
       'target' => 'web',
       'principal_class' => modUserGroup::class,
       'principal' => $adminGroup->get('id'),
       'authority' => 0,
       'policy' => $adminPolicy->get('id'),
-    ));
+    ]);
     $access->save();
     unset($access);
 }
@@ -161,24 +161,24 @@ unset($adminPolicy,$adminGroup);
 $templateContent = file_get_contents(dirname(__DIR__) . '/templates/base_template.tpl');
 /** @var modTemplate $template */
 $template = $modx->newObject(modTemplate::class);
-$template->fromArray(array(
+$template->fromArray([
     'templatename' => $install->lexicon('base_template'),
     'content' => $templateContent,
-));
+]);
 if ($template->save()) {
 
     /** @var modSystemSetting $setting */
-    $setting = $modx->getObject(modSystemSetting::class,array(
+    $setting = $modx->getObject(modSystemSetting::class, [
         'key' => 'default_template',
-    ));
+    ]);
     if (!$setting) {
         $setting = $modx->newObject(modSystemSetting::class);
-        $setting->fromArray(array(
+        $setting->fromArray([
             'key' => 'default_template',
             'namespace' => 'core',
             'xtype' => 'modx-combo-template',
             'area' => 'site',
-        ));
+        ]);
     }
     $setting->set('value', $template->get('id'));
     $setting->save();
@@ -186,7 +186,7 @@ if ($template->save()) {
     $resourceContent = file_get_contents(dirname(__DIR__) . '/templates/base_resource.tpl');
     /** @var modResource $resource */
     $resource = $modx->newObject(modResource::class);
-    $resource->fromArray(array(
+    $resource->fromArray([
         'pagetitle' => $install->lexicon('home'),
         'longtitle' => $install->lexicon('congratulations'),
         'alias' => 'index',
@@ -202,22 +202,22 @@ if ($template->save()) {
         'class_key' => modDocument::class,
         'context_key' => 'web',
         'content_type' => 1,
-    ));
+    ]);
 
     if ($resource->save()) {
 
          /* site_start */
-        $setting = $modx->getObject(modSystemSetting::class,array(
+        $setting = $modx->getObject(modSystemSetting::class, [
             'key' => 'site_start',
-        ));
+        ]);
         if (!$setting) {
             $setting = $modx->newObject(modSystemSetting::class);
-            $setting->fromArray(array(
+            $setting->fromArray([
                 'key' => 'site_start',
                 'namespace' => 'core',
                 'xtype' => 'textfield',
                 'area' => 'site',
-            ));
+            ]);
         }
         $setting->set('value', $resource->get('id'));
         $setting->save();
@@ -230,17 +230,17 @@ if ($template->save()) {
 $usemb = function_exists('mb_strlen');
 if ($usemb) {
     /** @var modSystemSetting $setting */
-    $setting = $modx->getObject(modSystemSetting::class,array(
+    $setting = $modx->getObject(modSystemSetting::class, [
         'key' => 'use_multibyte',
-    ));
+    ]);
     if (!$setting) {
         $setting = $modx->newObject(modSystemSetting::class);
-        $setting->fromArray(array(
+        $setting->fromArray([
             'key' => 'use_multibyte',
             'namespace' => 'core',
             'xtype' => 'combo-boolean',
             'area' => 'language',
-        ));
+        ]);
     }
     $setting->set('value',1);
     $setting->save();
@@ -250,17 +250,17 @@ if ($usemb) {
 $language = $settings->get('language','en');
 if ($language != 'en') {
     // cultureKey
-    $setting = $modx->getObject(modSystemSetting::class,array(
+    $setting = $modx->getObject(modSystemSetting::class, [
         'key' => 'cultureKey',
-    ));
+    ]);
     if (!$setting) {
         $setting = $modx->newObject(modSystemSetting::class);
-        $setting->fromArray(array(
+        $setting->fromArray([
             'key' => 'cultureKey',
             'namespace' => 'core',
             'xtype' => 'textfield',
             'area' => 'language',
-        ));
+        ]);
     }
     $setting->set('value',$language);
     $setting->save();
@@ -270,13 +270,13 @@ if ($language != 'en') {
 if ('sdk' === trim($currentVersion['distro'], '@')) {
     $setting = $modx->newObject(modSystemSetting::class);
     $setting->fromArray(
-        array(
+        [
             'key' => 'ext_debug',
             'namespace' => 'core',
             'xtype' => 'combo-boolean',
             'area' => 'system',
             'value' => false
-        ),
+        ],
         '',
         true
     );
@@ -296,16 +296,16 @@ switch ($last) {
         $maxFileSize *= 1024;
 }
 
-$settings_maxFileSize = $modx->getObject(modSystemSetting::class, array('key' => 'upload_maxsize'));
+$settings_maxFileSize = $modx->getObject(modSystemSetting::class, ['key' => 'upload_maxsize']);
 if (!$settings_maxFileSize) {
     $settings_maxFileSize = $modx->newObject(modSystemSetting::class);
     $settings_maxFileSize->fromArray(
-        array(
+        [
             'key' => 'upload_maxsize',
             'namespace' => 'core',
             'area' => 'system',
             'xtype' => 'textfield'
-        ),
+        ],
         '',
         true
     );

--- a/setup/includes/parser/modinstallsmarty.class.php
+++ b/setup/includes/parser/modinstallsmarty.class.php
@@ -24,16 +24,16 @@ class modInstallSmarty extends Smarty implements modInstallParser {
     public $_blocks;
     public $_derived;
 
-    function __construct(array $params= array ()) {
+    function __construct(array $params= []) {
         parent :: __construct();
 
         /* Set up configuration variables for Smarty. */
         $this->template_dir = MODX_SETUP_PATH . 'templates/';
         $this->compile_dir  = MODX_CORE_PATH . 'cache/' . (MODX_CONFIG_KEY == 'config' ? '' : MODX_CONFIG_KEY . '/') . 'setup/smarty/';
         $this->config_dir   = MODX_CORE_PATH . 'model/smarty/configs';
-        $this->plugins_dir  = array(
+        $this->plugins_dir  = [
             MODX_CORE_PATH . 'vendor/smarty/smarty/libs/plugins'
-        );
+        ];
         $this->caching = false;
 
         foreach ($params as $paramKey => $paramValue) {
@@ -44,7 +44,7 @@ class modInstallSmarty extends Smarty implements modInstallParser {
 
         $this->set('app_name','MODX');
 
-        $this->_blocks = array();
+        $this->_blocks = [];
         $this->_derived = null;
     }
 

--- a/setup/includes/request/modinstallclirequest.class.php
+++ b/setup/includes/request/modinstallclirequest.class.php
@@ -101,9 +101,9 @@ class modInstallCLIRequest extends modInstallRequest {
             foreach ($results['fail'] as $field => $result) {
                 $msg .= $field.': '.$result['title'].' - '.$result['message'];
             }
-            $msg = $this->install->lexicon('cli_tests_failed',array(
+            $msg = $this->install->lexicon('cli_tests_failed', [
                 'errors' => $msg,
-            ));
+            ]);
             $this->end($msg);
         }
 
@@ -113,7 +113,7 @@ class modInstallCLIRequest extends modInstallRequest {
         /* Run installer */
         $this->install->getService('runner','runner.modInstallRunnerWeb');
         $failed = true;
-        $errors = array();
+        $errors = [];
         if ($this->install->runner) {
             $success = $this->install->runner->run($mode);
             $results = $this->install->runner->getResults();
@@ -134,9 +134,9 @@ class modInstallCLIRequest extends modInstallRequest {
             foreach ($errors as $field => $result) {
                 $msg .= $result['msg'];
             }
-            $msg = $this->install->lexicon('cli_install_failed',array(
+            $msg = $this->install->lexicon('cli_install_failed', [
                 'errors' => $msg,
-            ));
+            ]);
             $this->end($msg);
         }
 
@@ -154,9 +154,9 @@ class modInstallCLIRequest extends modInstallRequest {
             $this->install->removeSetupDirectory();
         }
         $this->endTimer();
-        $this->end(''.$this->install->lexicon('installation_finished',array(
+        $this->end(''.$this->install->lexicon('installation_finished', [
             'time' => $this->timeTotal,
-        )));
+            ]));
     }
 
     /**
@@ -165,7 +165,7 @@ class modInstallCLIRequest extends modInstallRequest {
      * @param array $config
      * @return array
      */
-    public function getConfig($mode = 0, array $config = array()) {
+    public function getConfig($mode = 0, array $config = []) {
         /* load the config file */
         $config = array_merge($this->loadConfigFile(), $config);
         $config = parent::getConfig($mode, $config);
@@ -180,7 +180,7 @@ class modInstallCLIRequest extends modInstallRequest {
      * @return array
      */
     public function loadConfigFile() {
-        $settings = array();
+        $settings = [];
         $configFile = $this->install->settings->get('config');
         if (empty($configFile)) $configFile = MODX_INSTALL_PATH.'setup/config.xml';
         if (!empty($configFile)) {
@@ -207,7 +207,7 @@ class modInstallCLIRequest extends modInstallRequest {
             $settings['site_sessionname'] = 'SN' . uniqid('');
         }
         if (empty($settings['config_options'])) {
-            $settings['config_options'] = array();
+            $settings['config_options'] = [];
         }
         if (empty($settings['database']) && !empty($settings['dbase'])) {
             $settings['database'] = $settings['dbase'];
@@ -252,7 +252,7 @@ class modInstallCLIRequest extends modInstallRequest {
         $contents = file_get_contents($file);
         $xml = new SimpleXMLElement($contents);
 
-        $settings = array();
+        $settings = [];
         foreach ($xml as $k => $v) {
             $settings[(string)$k] = (string)$v;
         }
@@ -287,16 +287,16 @@ class modInstallCLIRequest extends modInstallRequest {
             if ($mode == modInstall::MODE_NEW && $xpdo->getManager()) {
                 /* otherwise try to create the database */
                 $dbExists = $xpdo->manager->createSourceContainer(
-                    array(
+                    [
                         'dbname' => $this->install->settings->get('dbase')
                         ,'host' => $this->install->settings->get('database_server')
-                    )
+                    ]
                     ,$this->install->settings->get('database_user')
                     ,$this->install->settings->get('database_password')
-                    ,array(
+                    , [
                         'charset' => $this->install->settings->get('database_connection_charset')
                         ,'collation' => $this->install->settings->get('database_collation')
-                    )
+                    ]
                 );
                 if (!$dbExists) {
                     $this->end($this->install->lexicon('db_err_create_database'));

--- a/setup/includes/request/modinstallconnectorrequest.class.php
+++ b/setup/includes/request/modinstallconnectorrequest.class.php
@@ -45,7 +45,7 @@ class modInstallConnectorRequest extends modInstallRequest {
      * @param array $config
      * @return modInstallError
      */
-    public function loadError($class = 'error.modInstallJSONError',$path = '',array $config = array()) {
+    public function loadError($class = 'error.modInstallJSONError',$path = '',array $config = []) {
         $className = $this->install->loadClass($class,$path);
         if (!empty($className)) {
             $this->error = new $className($this->install,$config);

--- a/setup/includes/request/modinstallrequest.class.php
+++ b/setup/includes/request/modinstallrequest.class.php
@@ -94,7 +94,7 @@ class modInstallRequest {
      * @param array $config An array of config attributes.
      * @return array A copy of the config attributes array.
      */
-    public function getConfig($mode = 0, array $config = array ()) {
+    public function getConfig($mode = 0, array $config = []) {
         switch ($mode) {
             case modInstall::MODE_UPGRADE_EVO :
                 $this->loadConfigReader('config.modEvolutionConfigReader');
@@ -123,10 +123,10 @@ class modInstallRequest {
      * @param array $config
      * @return array
      */
-    public function setDefaultPaths(array $config = array()) {
+    public function setDefaultPaths(array $config = []) {
         $webUrl= substr($_SERVER['SCRIPT_NAME'], 0, strpos($_SERVER['SCRIPT_NAME'], 'setup/'));
         $webUrl= rtrim($webUrl,'/').'/';
-        $defaults = array();
+        $defaults = [];
         $defaults['context_web_path'] = rtrim(MODX_INSTALL_PATH,'/').'/';
         $defaults['context_web_url'] = $webUrl;
         $defaults['context_mgr_path'] = rtrim(MODX_INSTALL_PATH,'/') . '/manager/';

--- a/setup/includes/runner/modinstallrunner.class.php
+++ b/setup/includes/runner/modinstallrunner.class.php
@@ -27,21 +27,21 @@ abstract class modInstallRunner {
     /** @var xPDO $xpdo */
     public $xpdo;
     /** @var array $config */
-    public $config = array();
+    public $config = [];
 
     public $success = false;
 
     /** @var modInstallVersion $versioner */
     public $versioner;
     /** @var array $results */
-    public $results = array();
+    public $results = [];
 
-    function __construct(modInstall $install,array $config = array()) {
+    function __construct(modInstall $install,array $config = []) {
         $this->install =& $install;
         $this->xpdo =& $install->xpdo;
-        $this->config = array_merge(array(
+        $this->config = array_merge([
 
-        ),$config);
+        ],$config);
     }
 
     public function run($mode) {
@@ -54,10 +54,10 @@ abstract class modInstallRunner {
     }
 
     public function addResult($type,$message) {
-        $this->results[] = array(
+        $this->results[] = [
             'class' => $type,
             'msg' => $message,
-        );
+        ];
     }
 
     public function getResults() {
@@ -78,7 +78,7 @@ abstract class modInstallRunner {
             $this->versioner = new $className($this);
             return $this->versioner;
         } else {
-            $this->install->_fatalError($this->install->lexicon('versioner_err_nf',array('path' => $path)));
+            $this->install->_fatalError($this->install->lexicon('versioner_err_nf', ['path' => $path]));
         }
         return $this->versioner;
     }
@@ -90,9 +90,9 @@ abstract class modInstallRunner {
     public function updateWorkspace() {
         $updated = false;
         /* @var modWorkspace $workspace set default workspace path */
-        $workspace = $this->install->xpdo->getObject(modWorkspace::class, array (
+        $workspace = $this->install->xpdo->getObject(modWorkspace::class, [
             'active' => 1
-        ));
+        ]);
         if ($workspace) {
             $path = $workspace->get('path');
             if (!empty($path)) {
@@ -122,7 +122,8 @@ abstract class modInstallRunner {
         $packageState = $this->install->settings->get('unpacked') == 1 ? xPDOTransport::STATE_UNPACKED : xPDOTransport::STATE_PACKED;
         $package = xPDOTransport :: retrieve($this->install->xpdo, $packageDirectory . 'core.transport.zip', $packageDirectory, $packageState);
         if (!is_object($package) || !($package instanceof xPDOTransport)) {
-            $this->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">'.$this->install->lexicon('package_execute_err_retrieve',array('path' => $this->install->settings->get('core_path'))).'</p>');
+            $this->addResult(modInstallRunner::RESULT_FAILURE,'<p class="notok">'.$this->install->lexicon('package_execute_err_retrieve',
+                    ['path' => $this->install->settings->get('core_path')]).'</p>');
             return false;
         }
 
@@ -148,11 +149,11 @@ abstract class modInstallRunner {
         if (!defined('MODX_CONNECTORS_URL'))
             define('MODX_CONNECTORS_URL', $this->install->settings->get('context_connectors_url'));
 
-        return $package->install(array (
+        return $package->install([
             xPDOTransport::RESOLVE_FILES => ($this->install->settings->get('inplace') == 0 ? 1 : 0)
             ,xPDOTransport::INSTALL_FILES => ($this->install->settings->get('inplace') == 0 ? 1 : 0)
             , xPDOTransport::PREEXISTING_MODE => xPDOTransport::REMOVE_PREEXISTING
-        ));
+        ]);
     }
 
 
@@ -189,7 +190,7 @@ abstract class modInstallRunner {
                 $content = @ fread($tplHandle, filesize($configTpl));
                 @ fclose($tplHandle);
                 if ($content) {
-                    $replace = array ();
+                    $replace = [];
                     foreach ($settings as $key => $value) {
                         if (is_scalar($value)) {
                             $replace['{' . $key . '}'] = "{$value}";

--- a/setup/includes/runner/modinstallrunnerweb.class.php
+++ b/setup/includes/runner/modinstallrunnerweb.class.php
@@ -96,36 +96,36 @@ class modInstallRunnerWeb extends modInstallRunner {
         $this->install->xpdo->exec($this->install->driver->truncate($tableName));
 
         /* clear cache */
-        $this->install->xpdo->cacheManager->deleteTree(MODX_CORE_PATH.'cache/',array(
+        $this->install->xpdo->cacheManager->deleteTree(MODX_CORE_PATH.'cache/', [
             'skipDirs' => false,
-            'extensions' => array(
+            'extensions' => [
                 '.cache.php',
                 '.tpl.php',
-            ),
-        ));
+            ],
+        ]);
 
         $this->install->lock();
 
-        $this->install->settings->store(array(
+        $this->install->settings->store([
             'finished' => true,
-        ));
+        ]);
     }
 
     public function postRun() {
         $compressJs = $this->install->settings->get('compress_js');
         if ($compressJs === 0) {
             /** @var modSystemSetting $setting */
-            $setting = $this->install->xpdo->getObject(modSystemSetting::class,array(
+            $setting = $this->install->xpdo->getObject(modSystemSetting::class, [
                 'key' => 'compress_js',
-            ));
+            ]);
             if (empty($setting)) {
                 $setting = $this->install->xpdo->newObject(modSystemSetting::class);
-                $setting->fromArray(array(
+                $setting->fromArray([
                     'key' => 'compress_js',
                     'xtype' => 'combo-boolean',
                     'namespace' => 'core',
                     'area' => 'manager',
-                ),'',true);
+                ],'',true);
             }
             $setting->set('value',0);
             $setting->save();
@@ -133,17 +133,17 @@ class modInstallRunnerWeb extends modInstallRunner {
         $compressCss = $this->install->settings->get('compress_css');
         if ($compressCss === 0) {
             /** @var modSystemSetting $setting */
-            $setting = $this->install->xpdo->getObject(modSystemSetting::class,array(
+            $setting = $this->install->xpdo->getObject(modSystemSetting::class, [
                 'key' => 'compress_css',
-            ));
+            ]);
             if (empty($setting)) {
                 $setting = $this->install->xpdo->newObject(modSystemSetting::class);
-                $setting->fromArray(array(
+                $setting->fromArray([
                     'key' => 'compress_css',
                     'xtype' => 'combo-boolean',
                     'namespace' => 'core',
                     'area' => 'manager',
-                ),'',true);
+                ],'',true);
             }
             $setting->set('value',0);
             $setting->save();
@@ -153,9 +153,9 @@ class modInstallRunnerWeb extends modInstallRunner {
         // The setting is installed disabled by default, so we don't have to force it off if unchecked
         $sendPoweredByHeader = $this->install->settings->get('send_poweredby_header');
         if (!empty($sendPoweredByHeader)) {
-            $setting = $this->install->xpdo->getObject(modSystemSetting::class,array(
+            $setting = $this->install->xpdo->getObject(modSystemSetting::class, [
                 'key' => 'send_poweredby_header',
-            ));
+            ]);
             if ($setting instanceof modSystemSetting) {
                 $setting->set('value', 1);
                 $setting->save();

--- a/setup/includes/tables_create.php
+++ b/setup/includes/tables_create.php
@@ -18,8 +18,8 @@
  * @package setup
  */
 
-$results= array ();
-$classes= array (
+$results= [];
+$classes= [
     \MODX\Revolution\modAccessAction::class,
     \MODX\Revolution\modAccessActionDom::class,
     \MODX\Revolution\modAccessCategory::class,
@@ -91,7 +91,7 @@ $classes= array (
     \MODX\Revolution\Sources\modMediaSource::class,
     \MODX\Revolution\Sources\modMediaSourceElement::class,
     \MODX\Revolution\Sources\modMediaSourceContext::class,
-);
+];
 
 $modx->getManager();
 $connected= $modx->connect();
@@ -108,22 +108,28 @@ if (!$connected) {
     $containerOptions['collation']= $install->settings->get('database_collation', 'utf8_general_ci');
     $created = $modx->manager->createSourceContainer($dsnArray, $modx->config['username'], $modx->config['password'], $containerOptions);
     if (!$created) {
-        $results[]= array ('class' => 'failed', 'msg' => '<p class="notok">'.$install->lexicon('db_err_create').'</p>');
+        $results[]= ['class' => 'failed', 'msg' => '<p class="notok">'.$install->lexicon('db_err_create').'</p>'];
     }
     else {
         $connected= $modx->connect();
     }
     if ($connected) {
-        $results[]= array ('class' => 'success', 'msg' => '<p class="ok">'.$install->lexicon('db_created').'</p>');
+        $results[]= ['class' => 'success', 'msg' => '<p class="ok">'.$install->lexicon('db_created').'</p>'];
     }
 }
 if ($connected) {
     ob_start();
     foreach ($classes as $class) {
         if (!$dbcreated= $modx->manager->createObjectContainer($class)) {
-            $results[]= array ('class' => 'failed', 'msg' => '<p class="notok">' . $install->lexicon('table_err_create',array('class' => $class)) . '</p>');
+            $results[]= [
+                'class' => 'failed', 'msg' => '<p class="notok">' . $install->lexicon('table_err_create',
+                        ['class' => $class]) . '</p>'
+            ];
         } else {
-            $results[]= array ('class' => 'success', 'msg' => '<p class="ok">' . $install->lexicon('table_created',array('class' => $class)) . '</p>');
+            $results[]= [
+                'class' => 'success', 'msg' => '<p class="ok">' . $install->lexicon('table_created',
+                        ['class' => $class]) . '</p>'
+            ];
         }
     }
     ob_end_clean();

--- a/setup/includes/test/modinstalltest.class.php
+++ b/setup/includes/test/modinstalltest.class.php
@@ -15,11 +15,11 @@
  * @subpackage tests
  */
 abstract class modInstallTest {
-    public $results = array(
-        'pass' => array(),
-        'fail' => array(),
-        'warn' => array(),
-    );
+    public $results = [
+        'pass' => [],
+        'fail' => [],
+        'warn' => [],
+    ];
     /** @var modInstall $install */
     public $install;
     public $mode;
@@ -36,7 +36,7 @@ abstract class modInstallTest {
      * @return array An array of result messages collected during the process.
      */
     public function run($mode = modInstall::MODE_NEW) {
-        $this->results = array();
+        $this->results = [];
         $this->mode = $mode;
 
         $this->_checkPHPVersion();
@@ -85,14 +85,14 @@ abstract class modInstallTest {
 
         /* -1 if left is less, 0 if equal, +1 if left is higher */
         if (!$php_ver_comp) {
-            $this->fail('php_version','',$this->install->lexicon('test_php_version_fail',array(
+            $this->fail('php_version','',$this->install->lexicon('test_php_version_fail', [
                  'version' => $phpVersion
                 ,'required' => $required_version
                 ,'recommended' => $recommended_version
-            )));
+            ]));
 
         } else {
-            $this->pass('php_version',$this->install->lexicon('test_php_version_success',array('version' => $phpVersion)));
+            $this->pass('php_version',$this->install->lexicon('test_php_version_success', ['version' => $phpVersion]));
         }
     }
 
@@ -113,9 +113,9 @@ abstract class modInstallTest {
 
         $this->title('memory_limit',$this->install->lexicon('test_memory_limit').' ');
         if ($success) {
-            $this->pass('memory_limit',$this->install->lexicon('test_memory_limit_success',array('memory' => $ml)));
+            $this->pass('memory_limit',$this->install->lexicon('test_memory_limit_success', ['memory' => $ml]));
         } else {
-            $this->fail('memory_limit','',$this->install->lexicon('test_memory_limit_fail',array('memory' => $ml)));
+            $this->fail('memory_limit','',$this->install->lexicon('test_memory_limit_fail', ['memory' => $ml]));
         }
     }
 
@@ -188,7 +188,8 @@ abstract class modInstallTest {
      */
     protected function _checkCache() {
         /* cache exists? */
-        $this->title('cache_exists',$this->install->lexicon('test_directory_exists',array('dir' => MODX_CORE_PATH . 'cache')));
+        $this->title('cache_exists',$this->install->lexicon('test_directory_exists',
+            ['dir' => MODX_CORE_PATH . 'cache']));
         if (!file_exists(MODX_CORE_PATH . 'cache')) {
             $this->fail('cache_exists');
         } else {
@@ -196,7 +197,8 @@ abstract class modInstallTest {
         }
 
         /* cache writable? */
-        $this->title('cache_writable',$this->install->lexicon('test_directory_writable',array('dir' => MODX_CORE_PATH . 'cache')));
+        $this->title('cache_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => MODX_CORE_PATH . 'cache']));
         if (!$this->is_writable2(MODX_CORE_PATH . 'cache')) {
             $this->fail('cache_writable');
         } else {
@@ -209,7 +211,8 @@ abstract class modInstallTest {
      */
     protected function _checkExport() {
         /* export exists? */
-        $this->title('assets_export_exists',$this->install->lexicon('test_directory_exists',array('dir' => MODX_CORE_PATH . 'export')));
+        $this->title('assets_export_exists',$this->install->lexicon('test_directory_exists',
+            ['dir' => MODX_CORE_PATH . 'export']));
         if (!file_exists(MODX_CORE_PATH . 'export')) {
             $this->fail('assets_export_exists');
         } else {
@@ -217,7 +220,8 @@ abstract class modInstallTest {
         }
 
         /* export writable? */
-        $this->title('assets_export_writable',$this->install->lexicon('test_directory_writable',array('dir' => MODX_CORE_PATH . 'export')));
+        $this->title('assets_export_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => MODX_CORE_PATH . 'export']));
         if (!$this->is_writable2(MODX_CORE_PATH . 'export')) {
             $this->fail('assets_export_writable');
         } else {
@@ -230,7 +234,8 @@ abstract class modInstallTest {
      */
     protected function _checkPackages() {
         /* core/packages exists? */
-        $this->title('core_packages_exists',$this->install->lexicon('test_directory_exists',array('dir' => MODX_CORE_PATH . 'packages')));
+        $this->title('core_packages_exists',$this->install->lexicon('test_directory_exists',
+            ['dir' => MODX_CORE_PATH . 'packages']));
         if (!file_exists(MODX_CORE_PATH . 'packages')) {
             $this->fail('core_packages_exists');
         } else {
@@ -238,7 +243,8 @@ abstract class modInstallTest {
         }
 
         /* packages writable? */
-        $this->title('core_packages_writable',$this->install->lexicon('test_directory_writable',array('dir' => MODX_CORE_PATH . 'packages')));
+        $this->title('core_packages_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => MODX_CORE_PATH . 'packages']));
         if (!$this->is_writable2(MODX_CORE_PATH . 'packages')) {
             $this->fail('core_packages_writable');
         } else {
@@ -253,7 +259,8 @@ abstract class modInstallTest {
         $coreConfigsExist = false;
         if ($this->install->settings->get('inplace')) {
             /* web_path */
-            $this->title('context_web_exists',$this->install->lexicon('test_directory_exists',array('dir' => $this->install->settings->get('context_web_path'))));
+            $this->title('context_web_exists',$this->install->lexicon('test_directory_exists',
+                ['dir' => $this->install->settings->get('context_web_path')]));
             if (!file_exists($this->install->settings->get('context_web_path'))) {
                 $this->fail('context_web_exists');
             } else {
@@ -261,7 +268,8 @@ abstract class modInstallTest {
             }
 
             /* mgr_path */
-            $this->title('context_mgr_exists',$this->install->lexicon('test_directory_exists',array('dir' => $this->install->settings->get('context_mgr_path'))));
+            $this->title('context_mgr_exists',$this->install->lexicon('test_directory_exists',
+                ['dir' => $this->install->settings->get('context_mgr_path')]));
             if (!file_exists($this->install->settings->get('context_mgr_path'))) {
                 $this->fail('context_mgr_exists');
             } else {
@@ -269,7 +277,8 @@ abstract class modInstallTest {
             }
 
             /* connectors_path */
-            $this->title('context_connectors_exists',$this->install->lexicon('test_directory_exists',array('dir' => $this->install->settings->get('context_connectors_path'))));
+            $this->title('context_connectors_exists',$this->install->lexicon('test_directory_exists',
+                ['dir' => $this->install->settings->get('context_connectors_path')]));
             if (!file_exists($this->install->settings->get('context_connectors_path'))) {
                 $this->fail('context_connectors_exists');
             } else {
@@ -289,7 +298,7 @@ abstract class modInstallTest {
     protected function _checkConfig() {
         $configFileDisplay= 'config/' . MODX_CONFIG_KEY . '.inc.php';
         $configFilePath= MODX_CORE_PATH . $configFileDisplay;
-        $this->title('config_writable',$this->install->lexicon('test_config_file',array('file' => $configFilePath)));
+        $this->title('config_writable',$this->install->lexicon('test_config_file', ['file' => $configFilePath]));
         if (!file_exists($configFilePath)) {
             /* make an attempt to create the file */
             @ $hnd = fopen($configFilePath, 'w');
@@ -298,7 +307,8 @@ abstract class modInstallTest {
         }
         $isWriteable = @is_writable($configFilePath);
         if (!$isWriteable) {
-            $this->fail('config_writable',$this->install->lexicon('failed'),$this->install->lexicon('test_config_file_nw',array('key' => MODX_CONFIG_KEY)));
+            $this->fail('config_writable',$this->install->lexicon('failed'),$this->install->lexicon('test_config_file_nw',
+                ['key' => MODX_CONFIG_KEY]));
         } else {
             $this->pass('config_writable');
         }
@@ -389,7 +399,7 @@ abstract class modInstallTest {
      * @param string $title The title of the check
      */
     protected function title($key,$title) {
-        if (!isset($this->results[$key])) $this->results[$key] = array();
+        if (!isset($this->results[$key])) $this->results[$key] = [];
         $this->results[$key]['msg'] = '<p>'.$title;
     }
 
@@ -402,12 +412,12 @@ abstract class modInstallTest {
     protected function pass($key,$message = '') {
         if (empty($message)) $message = $this->install->lexicon('ok');
 
-        if (!isset($this->results[$key])) $this->results[$key] = array();
+        if (!isset($this->results[$key])) $this->results[$key] = [];
         if (!isset($this->results[$key]['msg'])) $this->results[$key]['msg'] = '';
         $this->results[$key]['msg'] .= '<span class="ok">'.$message.'</span></p>';
         $this->results[$key]['class'] = 'testPassed';
 
-        if (!isset($this->results['pass'][$key])) $this->results['pass'][$key] = array();
+        if (!isset($this->results['pass'][$key])) $this->results['pass'][$key] = [];
         if (!isset($this->results['pass'][$key]['msg'])) $this->results['pass'][$key]['msg'] = '';
         $this->results['pass'][$key]['msg'] .= '<span class="ok">'.$message.'</span></p>';
         $this->results['pass'][$key]['class'] = 'testPassed';
@@ -431,13 +441,13 @@ abstract class modInstallTest {
             if (!empty($messageTitle)) $msg .= '<h3>'.$messageTitle.'</h3>';
             $msg .= '<p>'.$message.'</p></div>';
         }
-        if (!isset($this->results[$key])) $this->results[$key] = array();
+        if (!isset($this->results[$key])) $this->results[$key] = [];
         if (!isset($this->results[$key]['msg'])) $this->results[$key]['msg'] = '';
 
         $this->results[$key]['msg'] .= $msg;
         $this->results[$key]['class'] = 'testWarn';
 
-        if (!isset($this->results['warn'][$key])) $this->results['warn'][$key] = array();
+        if (!isset($this->results['warn'][$key])) $this->results['warn'][$key] = [];
         if (!isset($this->results['warn'][$key]['msg'])) $this->results['warn'][$key]['msg'] = '';
         $this->results['warn'][$key]['msg'] .= $msg;
         $this->results['warn'][$key]['class'] = 'testPassed';
@@ -461,13 +471,13 @@ abstract class modInstallTest {
         if (!empty($message)) {
             $msg .= '<p><strong>'.$message.'</strong></p>';
         }
-        if (!isset($this->results[$key])) $this->results[$key] = array();
+        if (!isset($this->results[$key])) $this->results[$key] = [];
         if (!isset($this->results[$key]['msg'])) $this->results[$key]['msg'] = '';
         $this->results[$key]['msg'] .= $msg;
         $this->results[$key]['class'] = 'testFailed';
 
 
-        if (!isset($this->results['fail'][$key])) $this->results['fail'][$key] = array();
+        if (!isset($this->results['fail'][$key])) $this->results['fail'][$key] = [];
         if (!isset($this->results['fail'][$key]['msg'])) $this->results['fail'][$key]['msg'] = '';
         $this->results['fail'][$key]['msg'] .= $msg;
         $this->results['fail'][$key]['class'] = 'testFailed';

--- a/setup/includes/test/modinstalltestadvanced.class.php
+++ b/setup/includes/test/modinstalltestadvanced.class.php
@@ -42,9 +42,9 @@ class modInstallTestAdvanced extends modInstallTest {
 
         $this->title('zip_memory_limit',$this->install->lexicon('test_zip_memory_limit').' ');
         if ($success) {
-            $this->pass('zip_memory_limit',$this->install->lexicon('test_memory_limit_success',array('memory' => $ml)));
+            $this->pass('zip_memory_limit',$this->install->lexicon('test_memory_limit_success', ['memory' => $ml]));
         } else {
-            $this->fail('zip_memory_limit','',$this->install->lexicon('test_zip_memory_limit_fail',array('memory' => $ml)));
+            $this->fail('zip_memory_limit','',$this->install->lexicon('test_zip_memory_limit_fail', ['memory' => $ml]));
         }
     }
 
@@ -53,7 +53,8 @@ class modInstallTestAdvanced extends modInstallTest {
      */
     protected function _checkAdvPaths() {
         /* web_path */
-        $this->title('context_web_writable',$this->install->lexicon('test_directory_writable',array('dir' => $this->install->settings->get('context_web_path'))));
+        $this->title('context_web_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => $this->install->settings->get('context_web_path')]));
         $webDir = $this->install->settings->get('context_web_path');
         if (!$this->is_writable2($webDir)) {
             $this->fail('context_web_writable');
@@ -62,7 +63,8 @@ class modInstallTestAdvanced extends modInstallTest {
         }
 
         /* mgr_path */
-        $this->title('context_mgr_writable',$this->install->lexicon('test_directory_writable',array('dir' => $this->install->settings->get('context_mgr_path'))));
+        $this->title('context_mgr_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => $this->install->settings->get('context_mgr_path')]));
         $mgrDir = dirname($this->install->settings->get('context_mgr_path'));
         if (!$this->is_writable2($mgrDir)) {
             $this->fail('context_mgr_writable');
@@ -71,7 +73,8 @@ class modInstallTestAdvanced extends modInstallTest {
         }
 
         /* connectors_path */
-        $this->title('context_connectors_writable',$this->install->lexicon('test_directory_writable',array('dir' => $this->install->settings->get('context_connectors_path'))));
+        $this->title('context_connectors_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => $this->install->settings->get('context_connectors_path')]));
         $conDir = dirname($this->install->settings->get('context_connectors_path'));
         if (!$this->is_writable2($conDir)) {
             $this->fail('context_connectors_writable');

--- a/setup/includes/test/modinstalltestgit.class.php
+++ b/setup/includes/test/modinstalltestgit.class.php
@@ -41,9 +41,9 @@ class modInstallTestGit extends modInstallTest {
 
         $this->title('zip_memory_limit',$this->install->lexicon('test_zip_memory_limit').' ');
         if ($success) {
-            $this->pass('zip_memory_limit',$this->install->lexicon('test_memory_limit_success',array('memory' => $ml)));
+            $this->pass('zip_memory_limit',$this->install->lexicon('test_memory_limit_success', ['memory' => $ml]));
         } else {
-            $this->fail('zip_memory_limit','',$this->install->lexicon('test_zip_memory_limit_fail',array('memory' => $ml)));
+            $this->fail('zip_memory_limit','',$this->install->lexicon('test_zip_memory_limit_fail', ['memory' => $ml]));
         }
     }
 
@@ -52,7 +52,8 @@ class modInstallTestGit extends modInstallTest {
      */
     protected function _checkAdvPaths() {
         /* web_path */
-        $this->title('context_web_writable',$this->install->lexicon('test_directory_writable',array('dir' => $this->install->settings->get('context_web_path'))));
+        $this->title('context_web_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => $this->install->settings->get('context_web_path')]));
         $webDir = $this->install->settings->get('context_web_path');
         if (!$this->is_writable2($webDir)) {
             $this->fail('context_web_writable');
@@ -61,7 +62,8 @@ class modInstallTestGit extends modInstallTest {
         }
 
         /* mgr_path */
-        $this->title('context_mgr_writable',$this->install->lexicon('test_directory_writable',array('dir' => $this->install->settings->get('context_mgr_path'))));
+        $this->title('context_mgr_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => $this->install->settings->get('context_mgr_path')]));
         $mgrDir = $this->install->settings->get('context_mgr_path');
         if (!$this->is_writable2($mgrDir)) {
             $this->fail('context_mgr_writable');
@@ -70,7 +72,8 @@ class modInstallTestGit extends modInstallTest {
         }
 
         /* connectors_path */
-        $this->title('context_connectors_writable',$this->install->lexicon('test_directory_writable',array('dir' => $this->install->settings->get('context_connectors_path'))));
+        $this->title('context_connectors_writable',$this->install->lexicon('test_directory_writable',
+            ['dir' => $this->install->settings->get('context_connectors_path')]));
         $conDir = $this->install->settings->get('context_connectors_path');
         if (!$this->is_writable2($conDir)) {
             $this->fail('context_connectors_writable');

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -41,10 +41,10 @@ use MODX\Revolution\Transport\modTransportProvider;
 use xPDO\xPDO;
 
 if ($settings->get('installmode') == modInstall::MODE_UPGRADE_EVO) {
-    $managerTheme = $modx->getObject(modSystemSetting::class, array(
+    $managerTheme = $modx->getObject(modSystemSetting::class, [
         'key' => 'manager_theme',
         'value:!=' => 'default'
-    ));
+    ]);
     if ($managerTheme) {
         $managerTheme->set('value', 'default');
         $managerTheme->save();
@@ -53,9 +53,9 @@ if ($settings->get('installmode') == modInstall::MODE_UPGRADE_EVO) {
 }
 
 /* handle change of default language to proper IANA code based on initial language selection in setup */
-$managerLanguage = $modx->getObject(modSystemSetting::class, array(
+$managerLanguage = $modx->getObject(modSystemSetting::class, [
     'key' => 'manager_language',
-));
+]);
 if ($managerLanguage) {
     $managerLanguage->remove();
 }
@@ -65,9 +65,9 @@ unset($managerLanguage);
 $currentVersion = include MODX_CORE_PATH . 'docs/version.inc.php';
 
 /* update settings_version */
-$settings_version = $modx->getObject(modSystemSetting::class, array(
+$settings_version = $modx->getObject(modSystemSetting::class, [
     'key' => 'settings_version',
-));
+]);
 if ($settings_version == null) {
     $settings_version = $modx->newObject(modSystemSetting::class);
     $settings_version->set('key','settings_version');
@@ -79,9 +79,9 @@ $settings_version->set('value', $currentVersion['full_version']);
 $settings_version->save();
 
 /* update settings_distro */
-$settings_distro = $modx->getObject(modSystemSetting::class, array(
+$settings_distro = $modx->getObject(modSystemSetting::class, [
     'key' => 'settings_distro',
-));
+]);
 if ($settings_distro == null) {
     $settings_distro = $modx->newObject(modSystemSetting::class);
     $settings_distro->set('key','settings_distro');
@@ -95,7 +95,7 @@ $settings_distro->save();
 /* make sure admin user (1) has proper group and role */
 $adminUser = $modx->getObject(modUser::class, 1);
 if ($adminUser) {
-    $userGroupMembership = $modx->getObject(modUserGroupMember::class, array('user_group' => true, 'member' => true));
+    $userGroupMembership = $modx->getObject(modUserGroupMember::class, ['user_group' => true, 'member' => true]);
     if (!$userGroupMembership) {
         $userGroupMembership = $modx->newObject(modUserGroupMember::class);
         $userGroupMembership->set('user_group', 1);
@@ -109,49 +109,49 @@ if ($adminUser) {
 }
 
 /* setup default admin ACLs */
-$adminPolicy = $modx->getObject(modAccessPolicy::class,array(
+$adminPolicy = $modx->getObject(modAccessPolicy::class, [
     'name' => 'Administrator',
-));
-$adminGroup = $modx->getObject(modUserGroup::class,array(
+]);
+$adminGroup = $modx->getObject(modUserGroup::class, [
     'name' => 'Administrator',
-));
+]);
 if ($adminPolicy && $adminGroup) {
-    $access= $modx->getObject(modAccessContext::class,array(
+    $access= $modx->getObject(modAccessContext::class, [
         'target' => 'mgr',
         'principal_class' => modUserGroup::class,
         'principal' => $adminGroup->get('id'),
         'authority' => 0,
         'policy' => $adminPolicy->get('id'),
-    ));
+    ]);
     if (!$access) {
         $access = $modx->newObject(modAccessContext::class);
-        $access->fromArray(array(
+        $access->fromArray([
           'target' => 'mgr',
           'principal_class' => modUserGroup::class,
           'principal' => $adminGroup->get('id'),
           'authority' => 0,
           'policy' => $adminPolicy->get('id'),
-        ));
+        ]);
         $access->save();
     }
     unset($access);
 
-    $access = $modx->getObject(modAccessContext::class,array(
+    $access = $modx->getObject(modAccessContext::class, [
       'target' => 'web',
       'principal_class' => modUserGroup::class,
       'principal' => $adminGroup->get('id'),
       'authority' => 0,
       'policy' => $adminPolicy->get('id'),
-    ));
+    ]);
     if (!$access) {
         $access= $modx->newObject(modAccessContext::class);
-        $access->fromArray(array(
+        $access->fromArray([
           'target' => 'web',
           'principal_class' => modUserGroup::class,
           'principal' => $adminGroup->get('id'),
           'authority' => 0,
           'policy' => $adminPolicy->get('id'),
-        ));
+        ]);
         $access->save();
     }
     unset($access);
@@ -161,10 +161,10 @@ unset($adminPolicy,$adminGroup);
 /* Access Policy changes (have to happen post package install) */
 
 /* setup a setting to run this only once */
-$setting = $modx->getObject(modSystemSetting::class,array(
+$setting = $modx->getObject(modSystemSetting::class, [
     'key' => 'access_policies_version',
     'value' => '1.0',
-));
+]);
 if (!$setting) {
     /* truncate permissions in modAccessPermission and migrate to modAccessPolicyTemplate objects from modAccessPolicy.data
      * first get the standard policies, and then array_diff with Admin policy and unknown policies
@@ -173,11 +173,11 @@ if (!$setting) {
      * based on the Policy's name (first look for an existing one).
      */
     /* get admin policy and list of standard policies */
-    $standards = array('Administrator','Resource','Load Only','Load, List and View','Object','Element');
-    $adminPolicy = $modx->getObject(modAccessPolicy::class, array('name' => 'Administrator'));
-    $adminPolicyData = $adminPolicy ? $adminPolicy->get('data') : array();
+    $standards = ['Administrator','Resource','Load Only','Load, List and View','Object','Element'];
+    $adminPolicy = $modx->getObject(modAccessPolicy::class, ['name' => 'Administrator']);
+    $adminPolicyData = $adminPolicy ? $adminPolicy->get('data') : [];
 
-    $adminPolicyTpl = $modx->getObject(modAccessPolicyTemplate::class, array('name' => 'AdministratorTemplate'));
+    $adminPolicyTpl = $modx->getObject(modAccessPolicyTemplate::class, ['name' => 'AdministratorTemplate']);
     if (!$adminPolicyTpl) {
         $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find Administrator Access Policy Template');
     }
@@ -197,7 +197,7 @@ if (!$setting) {
             $id = $adminPolicyTpl ? $adminPolicyTpl->get('id') : 3; /* default to object */
             switch ($policy->get('name')) {
                 case 'Resource':
-                    $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, array('name' => 'ResourceTemplate'));
+                    $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, ['name' => 'ResourceTemplate']);
                     if ($policyTpl) {
                         $id = $policyTpl->get('id');
                     } else {
@@ -205,7 +205,7 @@ if (!$setting) {
                     }
                     break;
                 case 'Element':
-                    $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, array('name' => 'ElementTemplate'));
+                    $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, ['name' => 'ElementTemplate']);
                     if ($policyTpl) {
                         $id = $policyTpl->get('id');
                     } else {
@@ -215,7 +215,7 @@ if (!$setting) {
                 case 'Object':
                 case 'Load, List and View':
                 case 'Load Only':
-                    $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, array('name' => 'ObjectTemplate'));
+                    $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, ['name' => 'ObjectTemplate']);
                     if ($policyTpl) {
                         $id = $policyTpl->get('id');
                     } else {
@@ -229,10 +229,10 @@ if (!$setting) {
             $modx->log(xPDO::LOG_LEVEL_DEBUG,'Setting template to '.$id.' for standard '.$policy->get('name'));
 
             /* prevent duplicate standard policies */
-            $policyExists = $modx->getObject(modAccessPolicy::class, array(
+            $policyExists = $modx->getObject(modAccessPolicy::class, [
                 'template' => $id,
                 'name' => $policy->get('name'),
-            ));
+            ]);
             if ($policyExists) {
                 $policy->remove();
             } else {
@@ -245,9 +245,9 @@ if (!$setting) {
             $modx->log(xPDO::LOG_LEVEL_DEBUG,'Found non-standard policy: '.$policy->get('name'));
             /* non-standard policies */
             if (!$policyTpl = $policy->getOne('Template')) {
-                $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, array(
+                $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, [
                     'name' => $policy->get('name'),
-                ));
+                ]);
             }
             if (!$policyTpl) {
                 /* array_diff data with standard admin policy */
@@ -265,11 +265,11 @@ if (!$setting) {
                 /* otherwise create a custom policy tpl */
                 } else {
                     $policyTpl = $modx->newObject(modAccessPolicyTemplate::class);
-                    $policyTpl->fromArray(array(
+                    $policyTpl->fromArray([
                         'name' => $policy->get('name').'Template',
                         'template_group' => $adminPolicyTplGroup,
                         'description' => $policy->get('description'),
-                    ));
+                    ]);
                     $lexicon = $policy->get('lexicon');
                     if (!empty($lexicon)) {
                         $modx->log(xPDO::LOG_LEVEL_DEBUG,'Setting lexicon to '.$lexicon.' for policy '.$policy->get('name'));
@@ -280,17 +280,17 @@ if (!$setting) {
                     $policy->set('template',$policyTpl->get('id'));
                     $policy->save();
 
-                    $permissions = $modx->getCollection(modAccessPermission::class, array(
+                    $permissions = $modx->getCollection(modAccessPermission::class, [
                         'policy' => $policy->get('id'),
-                    ));
+                    ]);
                     // add permissions to tpl
                     foreach ($permissions as $permission) {
                         // prevent duplicate permissions
                         /** @var modAccessPermission $permission */
-                        $permExists = $modx->getObject(modAccessPermission::class, array(
+                        $permExists = $modx->getObject(modAccessPermission::class, [
                             'name' => $permission->get('name'),
                             'template' => $policyTpl->get('id'),
-                        ));
+                        ]);
                         if ($permExists) {
                             $permission->remove();
                         } else {
@@ -305,7 +305,7 @@ if (!$setting) {
     }
     unset($policy,$permission,$permissions,$policies,$policy,$policyTpl,$adminPolicy,$adminPolicyData,$adminPolicyTpl,$adminPolicyTplGroup,$data);
     /* now remove all 0 template permissions */
-    $permissions =$modx->getCollection(modAccessPermission::class, array('template' => 0));
+    $permissions =$modx->getCollection(modAccessPermission::class, ['template' => 0]);
     foreach ($permissions as $permission) { $permission->remove(); }
     unset($permissions,$permission);
 
@@ -335,14 +335,14 @@ if (empty($ct) || $modx->getOption('fc_upgrade_100',null,false)) {
     $c = $modx->newQuery(modActionDom::class);
     $c->innerJoin(modAction::class,'Action');
     $c->leftJoin(modAccessActionDom::class,'Access','Access.target = modActionDom.id');
-    $c->where(array(
+    $c->where([
         'modActionDom.active' => true,
-    ));
-    $c->select(array(
+    ]);
+    $c->select([
         $modx->getSelectColumns(modActionDom::class, 'modActionDom'),
-        $modx->getSelectColumns(modAction::class, 'Action', '', array('controller')),
-        $modx->getSelectColumns(modAccessActionDom::class, 'Access', '', array('principal')),
-    ));
+        $modx->getSelectColumns(modAction::class, 'Action', '', ['controller']),
+        $modx->getSelectColumns(modAccessActionDom::class, 'Access', '', ['principal']),
+    ]);
     $c->sortby('Access.principal','ASC');
     $c->sortby('modActionDom.action','ASC');
     $c->sortby('modActionDom.constraint_field','ASC');
@@ -483,16 +483,16 @@ if (empty($ct) || $modx->getOption('fc_upgrade_100',null,false)) {
     }
 
     /* remove all inactive rules */
-    $rules = $modx->getCollection(modActionDom::class,array('active' => false));
+    $rules = $modx->getCollection(modActionDom::class, ['active' => false]);
     foreach ($rules as $rule) { $rule->remove(); }
 
     /* remove all non-resource rules */
     $c = $modx->newQuery(modActionDom::class);
     $c->innerJoin(modAction::class, 'Action');
-    $c->where(array(
+    $c->where([
         'Action.controller:!=' => 'resource/create',
         'AND:Action.controller:!=' => 'resource/update',
-    ));
+    ]);
     $invalidRules = $modx->getCollection(modActionDom::class,$c);
     foreach ($invalidRules as $invalidRule) {
         /** @var modActionDom $invalidRule */
@@ -501,19 +501,19 @@ if (empty($ct) || $modx->getOption('fc_upgrade_100',null,false)) {
 }
 
 /* remove modxcms.com provider if it occurs */
-$provider = $modx->getObject(modTransportProvider::class, array(
+$provider = $modx->getObject(modTransportProvider::class, [
     'service_url' => 'http://rest.modxcms.com/extras/',
-));
-$newProvider = $modx->getObject(modTransportProvider::class, array(
+]);
+$newProvider = $modx->getObject(modTransportProvider::class, [
     'service_url' => 'https://rest.modx.com/extras/',
-));
+]);
 if ($provider && $newProvider && $provider->get('id') != $newProvider->get('id')) {
     /* if 2 providers found, remove old one */
     if ($provider->remove()) {
         /* and then migrate old packages to new provider */
-        $packages = $modx->getCollection(modTransportPackage::class, array(
+        $packages = $modx->getCollection(modTransportPackage::class, [
             'provider' => $provider->get('id'),
-        ));
+        ]);
         foreach ($packages as $package) {
             /** @var modTransportPackage $package */
             $package->set('provider',$newProvider->get('id'));
@@ -526,7 +526,7 @@ if ($provider && $newProvider && $provider->get('id') != $newProvider->get('id')
 }
 
 /* Set session_gc_maxlifetime equal to session_cookie_lifetime or session.gc_maxlifetime if empty */
-$setting = $modx->getObject(modSystemSetting::class, array('key' => 'session_gc_maxlifetime'));
+$setting = $modx->getObject(modSystemSetting::class, ['key' => 'session_gc_maxlifetime']);
 if ($setting && $setting->get('value') == '') {
     $session_gc_maxlifetime = (integer) $modx->getOption('session_cookie_lifetime', null, @ini_get('session.gc_maxlifetime'));
     if ($session_gc_maxlifetime < 1) {
@@ -538,22 +538,22 @@ if ($setting && $setting->get('value') == '') {
 unset($setting);
 
 /* add ext_debug setting for sdk distro and turn it off if it exists outside sdk */
-$setting = $modx->getObject(modSystemSetting::class, array('key' => 'ext_debug'));
+$setting = $modx->getObject(modSystemSetting::class, ['key' => 'ext_debug']);
 if (!$setting && ('sdk' === trim($currentVersion['distro'], '@') || 'git' === trim($currentVersion['distro'], '@'))) {
     $setting = $modx->newObject(modSystemSetting::class);
     $setting->fromArray(
-        array(
+        [
             'key' => 'ext_debug',
             'namespace' => 'core',
             'xtype' => 'combo-boolean',
             'area' => 'system',
             'value' => false
-        ),
+        ],
         '',
         true
     );
     $setting->save();
-} elseif ($setting &&  !in_array(trim($currentVersion['distro'], '@'), array('sdk', 'git'))) {
+} elseif ($setting &&  !in_array(trim($currentVersion['distro'], '@'), ['sdk', 'git'])) {
     $setting->set('value', false);
     $setting->save();
 }

--- a/setup/includes/upgrades/common/2.7-alias-visible.php
+++ b/setup/includes/upgrades/common/2.7-alias-visible.php
@@ -13,5 +13,5 @@ use MODX\Revolution\modResource;
 $class = modResource::class;
 $table = $modx->getTableName($class);
 
-$description = $this->install->lexicon('add_column',array('column' => 'alias_visible','table' => $table));
-$this->processResults($class, $description, array($modx->manager, 'addField'), array($class, 'alias_visible'));
+$description = $this->install->lexicon('add_column', ['column' => 'alias_visible','table' => $table]);
+$this->processResults($class, $description, [$modx->manager, 'addField'], [$class, 'alias_visible']);

--- a/setup/includes/upgrades/common/2.7-browser-tree-hide-files.php
+++ b/setup/includes/upgrades/common/2.7-browser-tree-hide-files.php
@@ -8,7 +8,7 @@
 
 use MODX\Revolution\modSystemSetting;
 
-$object = $modx->getObject(modSystemSetting::class, array('key' => 'modx_browser_tree_hide_files', 'value:!=' => '1'), false);
+$object = $modx->getObject(modSystemSetting::class, ['key' => 'modx_browser_tree_hide_files', 'value:!=' => '1'], false);
 if ($object) {
     $object->set('value', true);
     $object->save();

--- a/setup/includes/upgrades/common/2.7-description-text.php
+++ b/setup/includes/upgrades/common/2.7-description-text.php
@@ -13,5 +13,5 @@ use MODX\Revolution\modResource;
 $class = modResource::class;
 $table = $modx->getTableName($class);
 
-$description = $this->install->lexicon('alter_column',array('column' => 'description','table' => $table));
-$this->processResults($class, $description, array($modx->manager, 'alterField'), array($class, 'description'));
+$description = $this->install->lexicon('alter_column', ['column' => 'description','table' => $table]);
+$this->processResults($class, $description, [$modx->manager, 'alterField'], [$class, 'description']);

--- a/setup/includes/upgrades/common/2.7-native-password-hash.php
+++ b/setup/includes/upgrades/common/2.7-native-password-hash.php
@@ -12,13 +12,13 @@ $class = modUser::class;
 $table = $modx->getTableName($class);
 
 /* modify modUser.password field */
-$password = $this->install->lexicon('alter_column',array('column' => 'password','table' => $table));
-$this->processResults($class, $password, array($modx->manager, 'alterField'), array($class, 'password'));
+$password = $this->install->lexicon('alter_column', ['column' => 'password','table' => $table]);
+$this->processResults($class, $password, [$modx->manager, 'alterField'], [$class, 'password']);
 
 /* modify modUser.cachepwd field */
-$cachepwd = $this->install->lexicon('alter_column',array('column' => 'cachepwd','table' => $table));
-$this->processResults($class, $cachepwd, array($modx->manager, 'alterField'), array($class, 'cachepwd'));
+$cachepwd = $this->install->lexicon('alter_column', ['column' => 'cachepwd','table' => $table]);
+$this->processResults($class, $cachepwd, [$modx->manager, 'alterField'], [$class, 'cachepwd']);
 
 /* modify modUser.hash_class field */
-$hash_class = $this->install->lexicon('alter_column',array('column' => 'hash_class','table' => $table));
-$this->processResults($class, $hash_class, array($modx->manager, 'alterField'), array($class, 'hash_class'));
+$hash_class = $this->install->lexicon('alter_column', ['column' => 'hash_class','table' => $table]);
+$this->processResults($class, $hash_class, [$modx->manager, 'alterField'], [$class, 'hash_class']);

--- a/setup/includes/upgrades/common/2.7-remove-cache-disabled.php
+++ b/setup/includes/upgrades/common/2.7-remove-cache-disabled.php
@@ -8,4 +8,4 @@
 
 use MODX\Revolution\modSystemSetting;
 
-$modx->removeObject(modSystemSetting::class, array('key' => 'cache_disabled'));
+$modx->removeObject(modSystemSetting::class, ['key' => 'cache_disabled']);

--- a/setup/includes/upgrades/common/2.7.1-cleanup-script.php
+++ b/setup/includes/upgrades/common/2.7.1-cleanup-script.php
@@ -6,25 +6,25 @@
  *
  * @package setup
  */
-$paths = array(
+$paths = [
     'assets' => $modx->getOption('assets_path', null, MODX_ASSETS_PATH),
     'base' => $modx->getOption('base_path', null, MODX_BASE_PATH),
     'connectors' => $modx->getOption('connectors_path', null, MODX_CONNECTORS_PATH),
     'core' => $modx->getOption('core_path', null, MODX_CORE_PATH),
     'manager' => $modx->getOption('manager_path', null, MODX_MANAGER_PATH),
     'processors' => $modx->getOption('processors_path', null, MODX_PROCESSORS_PATH),
-);
+];
 
-$cleanup = array(
-    'assets' => array(),
-    'base' => array(),
-    'connectors' => array(),
-    'core' => array(),
-    'manager' => array(),
-    'processors' => array(
+$cleanup = [
+    'assets' => [],
+    'base' => [],
+    'connectors' => [],
+    'core' => [],
+    'manager' => [],
+    'processors' => [
         'system/config.js.php',
-    ),
-);
+    ],
+];
 
 $removedFiles = 0;
 $removedDirs = 0;
@@ -32,7 +32,7 @@ $removedDirs = 0;
 if (!function_exists('recursiveRemoveDir')) {
     function recursiveRemoveDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             (is_dir("$dir/$file")) ? recursiveRemoveDir("$dir/$file") : unlink("$dir/$file");
         }
@@ -62,5 +62,5 @@ foreach ($cleanup as $folder => $files) {
 $this->runner->addResult(
     modInstallRunner::RESULT_SUCCESS,
     '<p class="ok">'.$this->install->lexicon('legacy_cleanup_complete').
-    '<br /><small>'.$this->install->lexicon('legacy_cleanup_count', array('files' => $removedFiles, 'folders' => $removedDirs)).'</small></p>'
+    '<br /><small>'.$this->install->lexicon('legacy_cleanup_count', ['files' => $removedFiles, 'folders' => $removedDirs]).'</small></p>'
 );

--- a/setup/includes/upgrades/common/2.7.2-feed-modx-https.php
+++ b/setup/includes/upgrades/common/2.7.2-feed-modx-https.php
@@ -6,20 +6,20 @@
 use MODX\Revolution\modSystemSetting;
 
 /** @var modSystemSetting $feed_modx_security */
-$feed_modx_security = $modx->getObject(modSystemSetting::class, array(
+$feed_modx_security = $modx->getObject(modSystemSetting::class, [
     'key' => 'feed_modx_security',
     'value' => 'http://forums.modx.com/board.xml?board=294',
-));
+]);
 if ($feed_modx_security) {
     $feed_modx_security->set('value', 'https://forums.modx.com/board.xml?board=294');
     $feed_modx_security->save();
 }
 
 /** @var modSystemSetting $feed_modx_news */
-$feed_modx_news = $modx->getObject(modSystemSetting::class, array(
+$feed_modx_news = $modx->getObject(modSystemSetting::class, [
     'key' => 'feed_modx_news',
     'value' => 'http://feeds.feedburner.com/modx-announce',
-));
+]);
 if ($feed_modx_news) {
     $feed_modx_news->set('value', 'https://feeds.feedburner.com/modx-announce');
     $feed_modx_news->save();

--- a/setup/includes/upgrades/common/3.0-cleanup-files.php
+++ b/setup/includes/upgrades/common/3.0-cleanup-files.php
@@ -6,20 +6,20 @@
  *
  * @package setup
  */
-$paths = array(
+$paths = [
     'assets' => $modx->getOption('assets_path', null, MODX_ASSETS_PATH),
     'base' => $modx->getOption('base_path', null, MODX_BASE_PATH),
     'connectors' => $modx->getOption('connectors_path', null, MODX_CONNECTORS_PATH),
     'core' => $modx->getOption('core_path', null, MODX_CORE_PATH),
     'manager' => $modx->getOption('manager_path', null, MODX_MANAGER_PATH),
     'processors' => $modx->getOption('processors_path', null, MODX_PROCESSORS_PATH),
-);
+];
 
-$cleanup = array(
-    'assets' => array(),
-    'base' => array(),
-    'connectors' => array(),
-    'core' => array(
+$cleanup = [
+    'assets' => [],
+    'base' => [],
+    'connectors' => [],
+    'core' => [
         'model/aws/',
         'model/lib/',
         'model/modx/error/',
@@ -133,15 +133,15 @@ $cleanup = array(
         'model/modx/modcontextresource.class.php',
         'model/phpthumb/',
         'model/smarty/',
-    ),
-    'manager' => array(
+    ],
+    'manager' => [
         'min/',
         'assets/modext/widgets/resource/modx.grid.resource.security.js',
         'assets/modext/widgets/security/modx.grid.role.user.js',
         'assets/modext/workspace/lexicon/language.grid.js',
         'assets/modext/workspace/lexicon/lexicon.topic.grid.js',
-    ),
-);
+    ],
+];
 
 $removedFiles = 0;
 $removedDirs = 0;
@@ -149,7 +149,7 @@ $removedDirs = 0;
 if (!function_exists('recursiveRemoveDir')) {
     function recursiveRemoveDir($dir)
     {
-        $files = array_diff(scandir($dir), array('.', '..'));
+        $files = array_diff(scandir($dir), ['.', '..']);
         foreach ($files as $file) {
             (is_dir("$dir/$file")) ? recursiveRemoveDir("$dir/$file") : unlink("$dir/$file");
         }
@@ -179,5 +179,5 @@ foreach ($cleanup as $folder => $files) {
 $this->runner->addResult(
     modInstallRunner::RESULT_SUCCESS,
     '<p class="ok">'.$this->install->lexicon('legacy_cleanup_complete').
-    '<br /><small>'.$this->install->lexicon('legacy_cleanup_count', array('files' => $removedFiles, 'folders' => $removedDirs)).'</small></p>'
+    '<br /><small>'.$this->install->lexicon('legacy_cleanup_count', ['files' => $removedFiles, 'folders' => $removedDirs]).'</small></p>'
 );

--- a/setup/includes/upgrades/common/3.0.0-update-upload_files-upload_images.php
+++ b/setup/includes/upgrades/common/3.0.0-update-upload_files-upload_images.php
@@ -16,7 +16,7 @@ foreach ($keys as $key) {
     $success = false;
 
     /** @var modSystemSetting $setting */
-    $setting = $modx->getObject(modSystemSetting::class, array('key' => $key));
+    $setting = $modx->getObject(modSystemSetting::class, ['key' => $key]);
     if ($setting) {
         $value = $setting->get('value');
         $tmp = explode(',', $value);

--- a/setup/index.php
+++ b/setup/index.php
@@ -33,7 +33,7 @@ if ($isCommandLine) {
         define('MODX_CORE_PATH',$_REQUEST['core_path']);
     }
     if (!empty($_REQUEST['config_key'])) {
-        $_REQUEST['config_key'] = str_replace(array('{','}',"'",'"','\$'), '', $_REQUEST['config_key']);
+        $_REQUEST['config_key'] = str_replace(['{','}',"'",'"','\$'], '', $_REQUEST['config_key']);
         define('MODX_CONFIG_KEY',$_REQUEST['config_key']);
     }
 }

--- a/setup/processors/database/collation.php
+++ b/setup/processors/database/collation.php
@@ -21,8 +21,8 @@ if($mode === modInstall::MODE_UPGRADE_REVO_ADVANCED) {
     $settings = array_merge($settings, $install->request->getConfig($mode));
 }
 
-$data = array();
-$errors = array();
+$data = [];
+$errors = [];
 
 /* get an instance of xPDO using the install settings */
 $xpdo = $install->getConnection($mode);
@@ -31,10 +31,12 @@ if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
     $this->error->failure($install->lexicon('xpdo_err_ins'));
 }
 
-$xpdo->setLogTarget(array(
+$xpdo->setLogTarget(
+    [
     'target' => 'ARRAY'
-    ,'options' => array('var' => & $errors)
-));
+    ,'options' => ['var' => & $errors]
+    ]
+);
 
 /* try to get a connection to the actual database */
 $dbExists = $xpdo->connect();
@@ -44,16 +46,17 @@ if (!$dbExists) {
     } elseif ($xpdo->getManager()) {
         /* otherwise try to create the database */
         $dbExists = $xpdo->manager->createSourceContainer(
-            array(
+            [
                 'dbname' => $install->settings->get('dbase')
                 ,'host' => $install->settings->get('database_server')
-            )
-            ,$install->settings->get('database_user')
-            ,$install->settings->get('database_password')
-            ,array(
+            ]
+            , $install->settings->get('database_user')
+            , $install->settings->get('database_password')
+            ,
+            [
                 'charset' => $install->settings->get('database_connection_charset')
                 ,'collation' => $install->settings->get('database_collation')
-            )
+            ]
         );
         if (!$dbExists) {
             $this->error->failure($install->lexicon('db_err_create_database'), $errors);
@@ -62,10 +65,12 @@ if (!$dbExists) {
             if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
                 $this->error->failure($install->lexicon('xpdo_err_ins'), $errors);
             }
-            $xpdo->setLogTarget(array(
+            $xpdo->setLogTarget(
+                [
                 'target' => 'ARRAY'
-                ,'options' => array('var' => & $errors)
-            ));
+                ,'options' => ['var' => & $errors]
+                ]
+            );
         }
     } else {
         $this->error->failure($install->lexicon('db_err_connect_server'), $errors);

--- a/setup/processors/database/connection.php
+++ b/setup/processors/database/connection.php
@@ -34,7 +34,7 @@ if (!$install->driver->verifyPDOExtension()) {
 /* get an instance of xPDO using the install settings */
 $xpdo = $install->getConnection($mode);
 
-$errors = array();
+$errors = [];
 $dbExists = false;
 if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
     if (is_bool($xpdo)) {
@@ -43,10 +43,12 @@ if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
         $this->error->failure($xpdo);
     }
 }
-$xpdo->setLogTarget(array(
+$xpdo->setLogTarget(
+    [
     'target' => 'ARRAY'
-    ,'options' => array('var' => & $errors)
-));
+    ,'options' => ['var' => & $errors]
+    ]
+);
 
 /* try to get a connection to the actual database */
 $dbExists = $xpdo->connect();
@@ -64,17 +66,19 @@ if (!$dbExists) {
         if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
             $this->error->failure($install->lexicon('xpdo_err_ins'), $errors);
         }
-        $xpdo->setLogTarget(array(
+        $xpdo->setLogTarget(
+            [
             'target' => 'ARRAY'
-            ,'options' => array('var' => & $errors)
-        ));
+            ,'options' => ['var' => & $errors]
+            ]
+        );
         if (!$xpdo->connect()) {
             $this->error->failure($install->lexicon('db_err_connect_server'), $errors);
         }
     }
 }
 
-$data = array();
+$data = [];
 
 /* verify database versions */
 $server = $install->driver->verifyServerVersion();
@@ -114,11 +118,13 @@ if ($dbCharsets === null) {
 }
 $data['charsets'] = array_values($dbCharsets);
 
-$install->settings->store(array(
+$install->settings->store(
+    [
     'database_charset' => $data['charset'],
     'database_connection_charset' => $data['connection_charset'],
     'database_collation' => $data['collation'],
-));
+    ]
+);
 
 /* test table prefix */
 $count = null;

--- a/setup/templates/findcore.php
+++ b/setup/templates/findcore.php
@@ -18,7 +18,7 @@ if ($posted) {
     if (is_writable(MODX_SETUP_PATH . 'includes/config.core.php')) {
         $content = file_get_contents(MODX_SETUP_PATH . 'includes/config.core.php');
         $pattern = "/define\s*\(\s*'MODX_CORE_PATH'\s*,.*\);/";
-        $core_path = str_replace(array('{','}',"'",'"','\$'), '', $core_path);
+        $core_path = str_replace(['{','}',"'",'"','\$'], '', $core_path);
         $replacement = "define ('MODX_CORE_PATH', '{$core_path}');";
         $content = preg_replace($pattern, $replacement, $content);
         file_put_contents(MODX_SETUP_PATH . 'includes/config.core.php', $content);


### PR DESCRIPTION
### What does it do?
Converts traditional array syntax to short array syntax across the codebase (except generated schema files)

### Why is it needed?
Use more modern syntax in the code base and reduce noise in future commits/PR's where the conversion is only done to a certain piece of code and/or files.

### Related issue(s)/PR(s)
None