### PR TITLE
Removed unnecessary fully qualified class names

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -37,7 +37,7 @@ use xPDO\xPDO;
  * @property array $properties
  * @property boolean $is_stream
  *
- * @property \MODX\Revolution\Sources\modMediaSourceElement $SourceElement
+ * @property modMediaSourceElement $SourceElement
  *
  * @package MODX\Revolution\Sources
  */
@@ -387,7 +387,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                         'sid' => $this->get('id'),
                         'text' => $file_name,
                         'cls' => implode(' ', $cls),
-                        'iconCls' => 'icon ' . ($visibility == \League\Flysystem\AdapterInterface::VISIBILITY_PRIVATE
+                        'iconCls' => 'icon ' . ($visibility == AdapterInterface::VISIBILITY_PRIVATE
                                 ? 'icon-eye-slash' : 'icon-folder'),
                         'type' => 'dir',
                         'leaf' => false,
@@ -544,7 +544,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         try {
             /** @var File $file */
             $file = $this->filesystem->get($path);
-        } catch (\League\Flysystem\FileNotFoundException $e) {
+        } catch (FileNotFoundException $e) {
             $this->addError('path', $this->xpdo->lexicon('file_err_nf'));
 
             return [];

--- a/core/src/Revolution/modActionDom.php
+++ b/core/src/Revolution/modActionDom.php
@@ -19,7 +19,7 @@ namespace MODX\Revolution;
  *
  * @package MODX\Revolution
  */
-class modActionDom extends \MODX\Revolution\modAccessibleSimpleObject
+class modActionDom extends modAccessibleSimpleObject
 {
     /**
      * Apply the rule to the current page.

--- a/setup/includes/request/modinstallclirequest.class.php
+++ b/setup/includes/request/modinstallclirequest.class.php
@@ -277,7 +277,7 @@ class modInstallCLIRequest extends modInstallRequest {
 
         /* get an instance of xPDO using the install settings */
         $xpdo = $this->install->getConnection($mode);
-        if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
+        if (!is_object($xpdo) || !($xpdo instanceof xPDO)) {
             $this->end($this->install->lexicon('xpdo_err_ins'));
         }
 
@@ -302,7 +302,7 @@ class modInstallCLIRequest extends modInstallRequest {
                     $this->end($this->install->lexicon('db_err_create_database'));
                 } else {
                     $xpdo = $this->install->getConnection($mode);
-                    if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
+                    if (!is_object($xpdo) || !($xpdo instanceof xPDO)) {
                         $this->end($this->install->lexicon('xpdo_err_ins'));
                     }
                 }


### PR DESCRIPTION
### What does it do?
Removes unnecessary fully qualified class names, which can be shortened without adding the use statement.

### Why is it needed?
Cleaner code base.

### Related issue(s)/PR(s)
None