### PR TITLE
Disable actionsColumn on package version grid

### DIFF
--- a/manager/assets/modext/workspace/package/package.versions.grid.js
+++ b/manager/assets/modext/workspace/package/package.versions.grid.js
@@ -9,26 +9,33 @@ MODx.grid.PackageVersions = function(config) {
         title: _('packages')
         ,id: 'modx-grid-package-versions'
         ,url: MODx.config.connector_url
+        ,showActionsColumn: false
         ,baseParams: {
             action: 'Workspace/Packages/Version/GetList'
             ,signature: config.signature
             ,package_name: MODx.request.package_name
         }
-        ,fields: ['signature','name','version','release','created','updated','installed','state'
-                 ,'workspace','provider','provider_name','disabled','source'
-                 ,'readme','menu']
+        ,fields: ['signature','name','version','release','created','updated','installed','state','workspace','provider','provider_name','disabled','source','readme','menu']
         ,plugins: [this.exp]
         ,pageSize: 20
         ,columns: [this.exp,{
-              header: _('name') ,dataIndex: 'name' }
-           ,{ header: _('version') ,dataIndex: 'version' }
-           ,{ header: _('release') ,dataIndex: 'release' }
-            ,{ header: _('installed') ,dataIndex: 'installed' ,renderer: this._rins }
-            ,{
-                header: _('provider')
-                ,dataIndex: 'provider_name'
-                ,editable: false
-            }]
+            header: _('name')
+            ,dataIndex: 'name'
+        },{
+            header: _('version')
+            ,dataIndex: 'version'
+        },{
+            header: _('release')
+            ,dataIndex: 'release'
+        },{
+            header: _('installed')
+            ,dataIndex: 'installed'
+            ,renderer: this._rins
+        },{
+            header: _('provider')
+            ,dataIndex: 'provider_name'
+            ,editable: false
+        }]
         ,primaryKey: 'signature'
         ,paging: true
         ,autosave: true


### PR DESCRIPTION
### What does it do?
Disable actionsColumn on package version grid.
Also I brought the code to the format, as in other grids files.

### Why is it needed?
Clicking the gear icon has no effect.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14929
