### PR TITLE
Temporary solution for long dropdown submenu and on mobile width

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -74,7 +74,8 @@
   #modx-manager-search-icon a,
   #modx-leftbar-trigger a,
   #modx-user-menu a {
-    padding: 12px 0;
+    width: auto;
+    padding: 12px;
   }
 
   #modx-topnav {
@@ -142,9 +143,7 @@
     }
 
     #limenu-user a {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
+      line-height: 0;
     }
   }
 
@@ -215,6 +214,7 @@
     box-sizing: border-box;
     list-style: none;
     position: absolute;
+    left: 0;
     z-index: 10000;
     opacity: 0;
     visibility: hidden;
@@ -310,13 +310,23 @@
     }
 
     &-arrow {
-      right: 100%;
+      right: calc(100% - 80px);
       border: 12px solid transparent;
       border-right-color: $subnavBg;
       content: ' ';
-      position: absolute;
+      position: fixed;
       pointer-events: none;
       margin-top: -6px;
+    }
+
+    &-overlay {
+      position: absolute;
+      left: 80px;
+      width: 100%;
+      height: 100%;
+      overflow-y: auto;
+      z-index: -1;
+      background-color: rgba(0,0,0,.5);
     }
   }
 
@@ -334,14 +344,32 @@
     height: auto !important;
   }
 
+  #modx-headnav,
+  #modx-topnav,
+  #modx-user-menu {
+    >li:not(#modx-home-dashboard) {
+      >a {
+        padding: 12px 0 !important;
+        width: 35px !important;
+        font-size: 0;
+      }
+    }
+  }
+
   #modx-navbar {
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    justify-content: space-between;
 
     #modx-headnav {
-      order: 1;
-      width: 50%;
+      flex-wrap: nowrap;
 
+      >li:not(#modx-home-dashboard) {
+        >a {
+          width: 35px;
+          padding: 12px 0;
+        }
+      }
       a {
         line-height: initial !important;
       }
@@ -352,21 +380,19 @@
     }
 
     #modx-topnav {
-      width: 100%;
-      order: 0;
+      >li {
+        border: none !important;
+      }
     }
 
     #modx-user-menu {
       flex-direction: row-reverse;
       flex-wrap: nowrap;
-      width: 50%;
-      order: 2;
       margin-top: 0;
     }
 
     &>ul {
       display: flex;
-      flex-wrap: wrap;
       align-items: center;
       justify-content: center;
 
@@ -381,7 +407,7 @@
 
     #modx-home-dashboard {
       margin: 0;
-      padding: 5px;
+      padding: 12px 0;
     }
   }
 
@@ -404,7 +430,7 @@
   #modx-footer {
     .modx-subnav {
       min-width: 300px;
-      top: 60px !important;
+      top: 0 !important;
 
       .description {
         display: none;
@@ -441,8 +467,9 @@
       display: none;
     }
 
-    .modx-subnav-wrapper {
-      max-height: 400px;
+    .modx-subnav-overlay {
+      top: 64px;
+      left: 0;
       overflow-y: auto;
     }
   }

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -401,6 +401,9 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                     flip: {
                         enabled: false
                     },
+                    offset: {
+                        offset: window.innerWidth > 640 ? '0,-70' : '',
+                    },
                     applyStyle: {
                         enabled: true,
                         fn: function(data) {
@@ -410,8 +413,8 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                                         ? data.offsets.popper[i] + 'px'
                                         : data.offsets.popper[i];
                                 }
-                                if (data.offsets.arrow.top !== '') {
-                                    data.arrowElement.style.top = data.offsets.arrow.top + 'px';
+                                if (data.offsets.arrow.top !== '' && data.offsets.popper.top !== '') {
+                                    data.arrowElement.style.top = data.offsets.arrow.top + data.offsets.popper.top + 'px';
                                 }
                                 if (data.offsets.arrow.left) {
                                     data.arrowElement.style.left = data.offsets.arrow.left + 'px';
@@ -441,15 +444,18 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
         var submenu = document.getElementById(el.id + '-submenu');
         if (submenu.classList.contains('active')) {
             submenu.classList.remove('active');
+            submenu.parentElement.style.zIndex = -1;
         } else {
             this.hideMenu();
             submenu.classList.add('active');
+            submenu.parentElement.style.zIndex = 200;
         }
     }
     ,hideMenu: function() {
         var submenus = document.getElementsByClassName('modx-subnav');
         for (var i = 0; i < submenus.length; i++) {
             submenus[i].classList.remove('active');
+            submenus[i].parentElement.style.zIndex = -1;
         }
     }
 

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -202,9 +202,9 @@ class TopMenu
             $menuTpl .= '</li>'."\n";
 
             if (!empty($menu['children'])) {
-                $this->submenus .= '<ul id="limenu-'.$menu['id'].'-submenu"class="modx-subnav">';
+                $this->submenus .= '<div class="modx-subnav-overlay"><ul id="limenu-'.$menu['id'].'-submenu" class="modx-subnav">';
                 $this->processSubMenus($this->submenus, $menu['children']);
-                $this->submenus .= '<div class="modx-subnav-arrow"></div></ul>';
+                $this->submenus .= '<div class="modx-subnav-arrow"></div></ul></div>';
             }
 
             /* if has no permissable children, and is not clickable, hide top menu item */

--- a/manager/templates/default/footer.tpl
+++ b/manager/templates/default/footer.tpl
@@ -2,9 +2,11 @@
     <!-- #modx-content-->
     <div id="modx-footer">
         {if $_search}
-            <div class="modx-subnav" id="modx-manager-search-icon-submenu">
-                <div class="modx-subnav-arrow"></div>
-                <div id="modx-manager-search" role="search"></div>
+            <div class="modx-subnav-overlay">
+                <div class="modx-subnav" id="modx-manager-search-icon-submenu">
+                    <div class="modx-subnav-arrow"></div>
+                    <div id="modx-manager-search" role="search"></div>
+                </div>
             </div>
         {/if}
         {eval var=$navb_submenus}


### PR DESCRIPTION
### What does it do?
I added overlay bg block for submenus not for beauty, but in order to solve the problem with overlong dropdown submenu. And fixed it on mobile width. This is a temporary solution because I believe that the whole menu needs to be refactor, but I do not have time. I will refactor later.

![photo_2019-12-23_21-27-57](https://user-images.githubusercontent.com/20814058/71365446-9cf64800-25d1-11ea-8847-27a552818ce6.jpg)


![screencast-www figma com-2019 11 03-02_20_31](https://user-images.githubusercontent.com/20814058/71365763-8e5c6080-25d2-11ea-802d-3087727c6af5.gif)


### Why is it needed?
To make it normal

### Related issue(s)/PR(s)
Closes #11939 and closes #14928