### PR TITLE
Disable actionsColumn for FC grids

### DIFF
--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -231,6 +231,7 @@ MODx.grid.FCSetFields = function(config) {
     });
     Ext.applyIf(config,{
         id: 'modx-grid-fc-set-fields'
+        ,showActionsColumn: false
         ,fields: ['id','action','name','tab','tab_rank','other','rank','visible','label','default_value']
         ,autoHeight: true
         ,grouping: true
@@ -298,6 +299,7 @@ MODx.grid.FCSetTabs = function(config) {
     });
     Ext.applyIf(config,{
         id: 'modx-grid-fc-set-tabs'
+        ,showActionsColumn: false
         ,fields: ['id','action','name','form','other','rank','visible','label','type']
         ,autoHeight: true
         ,plugins: [this.vcb]
@@ -388,6 +390,7 @@ MODx.grid.FCSetTVs = function(config) {
     });
     Ext.applyIf(config,{
         id: 'modx-grid-fc-set-tvs'
+        ,showActionsColumn: false
         ,fields: ['id','name','tab','rank','visible','label','default_value','category','default_text']
         ,autoHeight: true
         ,grouping: true

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -307,7 +307,7 @@ MODx.grid.FCSetTabs = function(config) {
         ,columns: [{
             header: _('tab_id')
             ,dataIndex: 'name'
-            ,width: 200
+            ,width: 100
         },this.vcb,{
             header: _('tab_title')
             ,dataIndex: 'label'


### PR DESCRIPTION
### What does it do?
Disable actionsColumn for FC grids.
![fc_1](https://user-images.githubusercontent.com/12523676/71478077-2cd10780-2807-11ea-8297-a76d5c81d549.png)

![fc_2](https://user-images.githubusercontent.com/12523676/71478078-2cd10780-2807-11ea-807d-8457069dd17d.png)

![fc_3](https://user-images.githubusercontent.com/12523676/71478079-2cd10780-2807-11ea-9829-3978274f1889.png)

Also reduced the width of the ID column on the "Regions" tab (200 wider than necessary).

### Why is it needed?
Clicking the gear icon has no effect.

### Related issue(s)/PR(s)
None