### PR TITLE
Disable actionsColumn for ACL grids

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.role.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.js
@@ -5,7 +5,7 @@
  * @extends MODx.grid.Grid
  * @constructor
  * @param {Object} config An object of options.
- * @xtype grid-role
+ * @xtype modx-grid-role
  */
 MODx.grid.Role = function(config) {
     config = config || {};
@@ -71,6 +71,7 @@ Ext.extend(MODx.grid.Role,MODx.grid.Grid,{
         }
         return m;
     }
+
     ,createRole: function(btn,e) {
         this.loadWindow(btn,e,{
             xtype: 'modx-window-role-create'
@@ -84,7 +85,12 @@ Ext.extend(MODx.grid.Role,MODx.grid.Grid,{
 });
 Ext.reg('modx-grid-role',MODx.grid.Role);
 
-
+/**
+ * @class MODx.window.CreateRole
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-role-create
+ */
 MODx.window.CreateRole = function(config) {
     config = config || {};
     this.ident = config.ident || 'crole'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.js
@@ -136,6 +136,7 @@ Ext.extend(MODx.panel.AccessPolicy,MODx.FormPanel,{
             this.initialized = true;
         }
     }
+
     ,beforeSubmit: function(o) {
         var g = Ext.getCmp('modx-grid-policy-permissions');
         Ext.apply(o.form.baseParams,{
@@ -149,8 +150,13 @@ Ext.extend(MODx.panel.AccessPolicy,MODx.FormPanel,{
 });
 Ext.reg('modx-panel-access-policy',MODx.panel.AccessPolicy);
 
-
-
+/**
+ * @class MODx.grid.PolicyPermissions
+ * @extends MODx.grid.LocalGrid
+ * @constructor
+ * @param {Object} config An object of options.
+ * @xtype modx-grid-policy-permissions
+ */
 MODx.grid.PolicyPermissions = function(config) {
     config = config || {};
     var ac = new Ext.ux.grid.CheckColumn({
@@ -161,6 +167,7 @@ MODx.grid.PolicyPermissions = function(config) {
     });
     Ext.applyIf(config,{
         id: 'modx-grid-policy-permissions'
+        ,showActionsColumn: false
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'security/access/policy/getAttributes'
@@ -202,7 +209,13 @@ Ext.extend(MODx.grid.PolicyPermissions,MODx.grid.LocalGrid,{
 });
 Ext.reg('modx-grid-policy-permissions',MODx.grid.PolicyPermissions);
 
-
+/**
+ * @class MODx.combo.AccessPolicyTemplate
+ * @extends MODx.combo.ComboBox
+ * @constructor
+ * @param {Object} config An object of options.
+ * @xtype modx-combo-access-policy-template
+ */
 MODx.combo.AccessPolicyTemplate = function(config) {
     config = config || {};
     Ext.applyIf(config,{


### PR DESCRIPTION
### What does it do?
Disable actionsColumn for ACL grids.
Also added comments.

![acl_1](https://user-images.githubusercontent.com/12523676/71478564-ca2d3b00-2809-11ea-892a-26da70018a13.png)

![acl_2](https://user-images.githubusercontent.com/12523676/71478566-cac5d180-2809-11ea-8bae-ab42ec586e34.png)

### Why is it needed?
Clicking the gear icon has no effect.

### Related issue(s)/PR(s)
None