### PR TITLE
JSON grid xtype

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -235,6 +235,7 @@ $_lang['installed'] = 'Installed';
 $_lang['integer'] = 'Integer';
 $_lang['introtext'] = 'Introtext';
 $_lang['invalid_data'] = 'Invalid data';
+$_lang['json_grid'] = 'JSON Grid';
 $_lang['key'] = 'Key';
 $_lang['keyword'] = 'Keyword';
 $_lang['keywords'] = 'Keywords';

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -1152,3 +1152,188 @@ Ext.ns('Ext.ux.grid');Ext.ux.grid.CheckColumn=function(a){Ext.apply(this,a);if(!
         }}};Ext.preg('checkcolumn',Ext.ux.grid.CheckColumn);Ext.grid.CheckColumn=Ext.ux.grid.CheckColumn;
 
 Ext.grid.PropertyColumnModel=function(a,b){var g=Ext.grid,f=Ext.form;this.grid=a;g.PropertyColumnModel.superclass.constructor.call(this,[{header:this.nameText,width:50,sortable:true,dataIndex:'name',id:'name',menuDisabled:true},{header:this.valueText,width:50,resizable:false,dataIndex:'value',id:'value',menuDisabled:true}]);this.store=b;var c=new f.Field({autoCreate:{tag:'select',children:[{tag:'option',value:'true',html:'true'},{tag:'option',value:'false',html:'false'}]},getValue:function(){return this.el.dom.value=='true'}});this.editors={'date':new g.GridEditor(new f.DateField({selectOnFocus:true})),'string':new g.GridEditor(new f.TextField({selectOnFocus:true})),'number':new g.GridEditor(new f.NumberField({selectOnFocus:true,style:'text-align:left;'})),'boolean':new g.GridEditor(c)};this.renderCellDelegate=this.renderCell.createDelegate(this);this.renderPropDelegate=this.renderProp.createDelegate(this)};Ext.extend(Ext.grid.PropertyColumnModel,Ext.grid.ColumnModel,{nameText:'Name',valueText:'Value',dateFormat:'m/j/Y',renderDate:function(a){return a.dateFormat(this.dateFormat)},renderBool:function(a){return a?'true':'false'},isCellEditable:function(a,b){return a==1},getRenderer:function(a){return a==1?this.renderCellDelegate:this.renderPropDelegate},renderProp:function(v){return this.getPropertyName(v)},renderCell:function(a){var b=a;if(Ext.isDate(a)){b=this.renderDate(a)}else if(typeof a=='boolean'){b=this.renderBool(a)}return Ext.util.Format.htmlEncode(b)},getPropertyName:function(a){var b=this.grid.propertyNames;return b&&b[a]?b[a]:a},getCellEditor:function(a,b){var p=this.store.getProperty(b),n=p.data.name,val=p.data.value;if(this.grid.customEditors[n]){return this.grid.customEditors[n]}if(Ext.isDate(val)){return this.editors.date}else if(typeof val=='number'){return this.editors.number}else if(typeof val=='boolean'){return this.editors['boolean']}else{return this.editors.string}},destroy:function(){Ext.grid.PropertyColumnModel.superclass.destroy.call(this);for(var a in this.editors){Ext.destroy(a)}}});
+/**
+ * MODx JSON Grid
+ */
+MODx.grid.JsonGrid = function (config) {
+    config = config || {};
+    this.ident = config.ident || 'jsongrid-mecitem' + Ext.id();
+    this.buttonColumnTpl = new Ext.XTemplate('<tpl for=".">'
+        + '<tpl if="action_buttons !== null">'
+        + '<ul class="action-buttons">'
+        + '<tpl for="action_buttons">'
+        + '<li><i class="icon {className} icon-{icon}" title="{text}"></i></li>'
+        + '</tpl>'
+        + '</ul>'
+        + '</tpl>'
+        + '</tpl>', {
+        compiled: true
+    });
+    this.hiddenField = new Ext.form.TextArea({
+        name: config.hiddenName || config.name,
+        hidden: true
+    });
+    this.fieldConfig = config.fieldConfig || [{name: 'key'}, {name: 'value'}];
+    this.fieldColumns = [];
+    this.fieldNames = [];
+    Ext.each(this.fieldConfig, function (el) {
+        this.fieldNames.push(el.name);
+        this.fieldColumns.push({
+            header: el.header || _(el.name),
+            dataIndex: el.name,
+            editable: true, editor: {
+                xtype: el.xtype || 'textfield',
+                allowBlank: el.allowBlank || true,
+                listeners: {
+                    change: {
+                        fn: this.saveValue,
+                        scope: this
+                    }
+                }
+            },
+            width: el.width || 100
+        });
+    }, this);
+    this.fieldColumns.push({
+        renderer: {
+            fn: this.buttonColumnRenderer,
+            scope: this
+        },
+        width: 30,
+        align: 'right'
+    });
+    Ext.applyIf(config, {
+        id: this.ident + '-json-grid',
+        fields: this.fieldNames,
+        autoHeight: true,
+        store: new Ext.data.JsonStore({
+            fields: this.fieldNames,
+            data: Ext.util.JSON.decode(config.value)
+        }),
+        enableDragDrop: true,
+        ddGroup: this.ident + '-json-grid-dd',
+        labelStyle: 'position: absolute',
+        columns: this.fieldColumns,
+        tbar: ['->', {
+            text: '<i class="icon icon-plus"></i> ' + _('add'),
+            cls: 'primary-button',
+            handler: this.addElement,
+            scope: this
+        }],
+        listeners: {
+            render: {
+                fn: this.renderListener,
+                scope: this
+            }
+        }
+    });
+    MODx.grid.JsonGrid.superclass.constructor.call(this, config)
+};
+Ext.extend(MODx.grid.JsonGrid, MODx.grid.LocalGrid, {
+    getMenu: function () {
+        var m = [];
+        m.push({
+            text: _('remove'),
+            handler: this.removeElement
+        });
+        return m;
+    },
+    addElement: function () {
+        var ds = this.getStore();
+        var row = {};
+        Ext.each(this.fieldNames, function (fieldname) {
+            row[fieldname] = '';
+        });
+        this.getStore().insert(0, new ds.recordType(row));
+        this.getView().refresh();
+        this.getSelectionModel().selectRow(0);
+    },
+    removeElement: function () {
+        Ext.Msg.confirm(_('remove') || '', _('confirm_remove') || '', function (e) {
+            if (e === 'yes') {
+                var ds = this.getStore();
+                var rows = this.getSelectionModel().getSelections();
+                if (!rows.length) {
+                    return false;
+                }
+                for (var i = 0; i < rows.length; i++) {
+                    var id = rows[i].id;
+                    var index = ds.findBy(function (record, id) {
+                        if (record.id === id) {
+                            return true;
+                        }
+                    });
+                    ds.removeAt(index);
+                }
+                this.getView().refresh();
+                this.saveValue();
+            }
+        }, this);
+    },
+    renderListener: function (grid) {
+        new Ext.dd.DropTarget(grid.container, {
+            copy: false,
+            ddGroup: this.ident + '-json-grid-dd',
+            notifyDrop: function (dd, e, data) {
+                var ds = grid.store;
+                var sm = grid.getSelectionModel();
+                var rows = sm.getSelections();
+
+                var dragData = dd.getDragData(e);
+                if (dragData) {
+                    var cindex = dragData.rowIndex;
+                    if (typeof (cindex) !== "undefined") {
+                        for (var i = 0; i < rows.length; i++) {
+                            ds.remove(ds.getById(rows[i].id));
+                        }
+                        ds.insert(cindex, data.selections);
+                        sm.clearSelections();
+                    }
+                }
+                grid.getView().refresh();
+                grid.saveValue();
+            }
+        });
+        this.add(this.hiddenField);
+        this.saveValue();
+    },
+    buttonColumnRenderer: function () {
+        var values = {
+            action_buttons: [{
+                className: 'remove',
+                icon: 'trash-o',
+                text: _('remove')
+            }]
+        };
+        return this.buttonColumnTpl.apply(values);
+    },
+    onClick: function (e) {
+        var t = e.getTarget();
+        var elm = t.className.split(' ')[0];
+        if (elm === 'icon') {
+            var act = t.className.split(' ')[1];
+            var record = this.getSelectionModel().getSelected();
+            this.menu.record = record.data;
+            switch (act) {
+                case 'remove':
+                    this.removeElement(record, e);
+                    break;
+                default:
+                    break;
+            }
+        }
+    },
+    saveValue: function () {
+        var value = [];
+        Ext.each(this.getStore().getRange(), function (record) {
+            var row = {};
+            Ext.each(this.fieldNames, function (fieldname) {
+                row[fieldname] = record.data[fieldname];
+            });
+            value.push(row);
+        }, this);
+        this.hiddenField.setValue(Ext.util.JSON.encode(value));
+    }
+});
+Ext.reg('grid-json', MODx.grid.JsonGrid);
+Ext.reg('modx-grid-json', MODx.grid.JsonGrid);

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -1154,6 +1154,22 @@ Ext.ns('Ext.ux.grid');Ext.ux.grid.CheckColumn=function(a){Ext.apply(this,a);if(!
 Ext.grid.PropertyColumnModel=function(a,b){var g=Ext.grid,f=Ext.form;this.grid=a;g.PropertyColumnModel.superclass.constructor.call(this,[{header:this.nameText,width:50,sortable:true,dataIndex:'name',id:'name',menuDisabled:true},{header:this.valueText,width:50,resizable:false,dataIndex:'value',id:'value',menuDisabled:true}]);this.store=b;var c=new f.Field({autoCreate:{tag:'select',children:[{tag:'option',value:'true',html:'true'},{tag:'option',value:'false',html:'false'}]},getValue:function(){return this.el.dom.value=='true'}});this.editors={'date':new g.GridEditor(new f.DateField({selectOnFocus:true})),'string':new g.GridEditor(new f.TextField({selectOnFocus:true})),'number':new g.GridEditor(new f.NumberField({selectOnFocus:true,style:'text-align:left;'})),'boolean':new g.GridEditor(c)};this.renderCellDelegate=this.renderCell.createDelegate(this);this.renderPropDelegate=this.renderProp.createDelegate(this)};Ext.extend(Ext.grid.PropertyColumnModel,Ext.grid.ColumnModel,{nameText:'Name',valueText:'Value',dateFormat:'m/j/Y',renderDate:function(a){return a.dateFormat(this.dateFormat)},renderBool:function(a){return a?'true':'false'},isCellEditable:function(a,b){return a==1},getRenderer:function(a){return a==1?this.renderCellDelegate:this.renderPropDelegate},renderProp:function(v){return this.getPropertyName(v)},renderCell:function(a){var b=a;if(Ext.isDate(a)){b=this.renderDate(a)}else if(typeof a=='boolean'){b=this.renderBool(a)}return Ext.util.Format.htmlEncode(b)},getPropertyName:function(a){var b=this.grid.propertyNames;return b&&b[a]?b[a]:a},getCellEditor:function(a,b){var p=this.store.getProperty(b),n=p.data.name,val=p.data.value;if(this.grid.customEditors[n]){return this.grid.customEditors[n]}if(Ext.isDate(val)){return this.editors.date}else if(typeof val=='number'){return this.editors.number}else if(typeof val=='boolean'){return this.editors['boolean']}else{return this.editors.string}},destroy:function(){Ext.grid.PropertyColumnModel.superclass.destroy.call(this);for(var a in this.editors){Ext.destroy(a)}}});
 /**
  * MODx JSON Grid
+ * Local grid with inline editing, it converts the grid value from/to JSON and submits the JSON in a hidden field.
+ * The grid could be sorted by drag & drop, new values could be added with a button and each row could be deleted.
+ *
+ * It could be configured with the fieldConfig property, containing an array of field configs:
+ *
+ * fieldConfig: [{
+ *    name: 'whatever', // required
+ *    width: 100, // defaults to 100
+ *    xtype: 'textfield', // defaults to textfield
+ *    allowBlank: true, // defaults to true
+ *    header: _('whatever') // defaults to the lexicon entry of name value of the current field config
+ * }];
+ *
+ * If there is no fieldConfig property set, the following default fieldConfig is used:
+ *
+ * [{name: 'key'}, {name: 'value'}]
  */
 MODx.grid.JsonGrid = function (config) {
     config = config || {};
@@ -1162,7 +1178,7 @@ MODx.grid.JsonGrid = function (config) {
         + '<tpl if="action_buttons !== null">'
         + '<ul class="action-buttons">'
         + '<tpl for="action_buttons">'
-        + '<li><i class="icon {className} icon-{icon}" title="{text}"></i></li>'
+        + '<li><i class="icon {className:htmlEncode} icon-{icon:htmlEncode}" title="{text:htmlEncode}"></i></li>'
         + '</tpl>'
         + '</ul>'
         + '</tpl>'
@@ -1181,7 +1197,8 @@ MODx.grid.JsonGrid = function (config) {
         this.fieldColumns.push({
             header: el.header || _(el.name),
             dataIndex: el.name,
-            editable: true, editor: {
+            editable: true,
+            editor: {
                 xtype: el.xtype || 'textfield',
                 allowBlank: el.allowBlank || true,
                 listeners: {

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -508,6 +508,7 @@ MODx.combo.xType = function(config) {
                 ,[_('source'),'modx-combo-source']
                 ,[_('source_type'),'modx-combo-source-type']
                 ,[_('setting_manager_theme'),'modx-combo-manager-theme']
+                ,[_('json_grid'),'modx-grid-json']
             ]
         })
         ,displayField: 'd'


### PR DESCRIPTION
### What does it do?
Add a JSON grid xtype

### Why is it needed?
Use a simple grid editor for JSON values in i.e. the system settings.

It could be configured a bit with the fieldConfig property, containing an array of field configs 

```
fieldConfig: [{
    name: 'whatever', // required, name 'id' is reserved and can't be used
    width: 100, // defaults to 100
    xtype: 'textfield', // defaults to textfield
    allowBlank: true, // defaults to true
    header: _('whatever') // defaults to the name value of the current field config
}];
```

If there is no fieldConfig property set, the following default fieldConfig is used:
```
[{name: 'key'}, {name: 'value'}]
```

### Related issue(s)/PR(s)
#12293
