### PR TITLE
Apply `MODx.util.safeHtml` to make the feed dashboards a bit safer

### DIFF
--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -51,17 +51,17 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel,{
                     success: {
                         fn: function(response) {
                             if (response.success) {
-                                container.update(response.object.html);
+                                container.update(MODx.util.safeHtml(response.object.html, '<h1><h2><h3><h4><span><div><ul><li><p><ol><dl><dd><dt><img><a><br><i><em><b><strong>'));
                             }
                             else if (response.message.length > 0) {
-                                container.update('<p class="error">' + response.message + '</p>');
+                                container.update('<p class="error">' + MODx.util.safeHtml(response.message) + '</p>');
                             }
                         }, scope: this
                     }
                     ,failure: {
                         fn: function(response) {
                             var message = response.message.length > 0 ? response.message : _('error_loading_feed');
-                            container.update('<p class="error">' + message + '</p>');
+                            container.update('<p class="error">' + MODx.util.safeHtml(message) + '</p>');
                         }, scope: this
                     }
                 }


### PR DESCRIPTION
### What does it do?
When loading the RSS feeds in the welcome dashboard apply `MODx.util.safeHtml` to the feed results only allowing the following tags:
`<h1><h2><h3><h4><span><div><ul><li><p><ol><dl><dd><dt><img><a><br><i><em><b><strong>`

### Why is it needed?
To make the feeds a bit safer to use.

### Related issue(s)/PR(s)
#14390