### PR TITLE
Update broken recycle bin getlist

### DIFF
--- a/core/src/Revolution/Processors/Resource/Trash/GetList.php
+++ b/core/src/Revolution/Processors/Resource/Trash/GetList.php
@@ -119,8 +119,13 @@ class GetList extends GetListProcessor
         $parent = $objectArray['parent'];
 
         while ($parent != 0) {
-            $parents[] = $this->modx->getObject(modResource::class, $parent);
-            $parent = end($parents)->get('parent');
+            $o = $this->modx->getObject('modResource', $parent);
+            if($o) {
+                $parents[] = $o;
+            } else {
+                break;
+            }
+            if($parents) $parent = end($parents)->get('parent');
         }
 
         $parentPath = "";

--- a/core/src/Revolution/Processors/Resource/Trash/GetList.php
+++ b/core/src/Revolution/Processors/Resource/Trash/GetList.php
@@ -119,13 +119,14 @@ class GetList extends GetListProcessor
         $parent = $objectArray['parent'];
 
         while ($parent != 0) {
-            $o = $this->modx->getObject('modResource', $parent);
-            if($o) {
-                $parents[] = $o;
-            } else {
+            $parentObject = $this->modx->getObject(modResource::class, $parent);
+            if ($parentObject) {
+                $parents[] = $parentObject;
+                $parent = $parentObject->get('parent');
+            } 
+            else {
                 break;
             }
-            if($parents) $parent = end($parents)->get('parent');
         }
 
         $parentPath = "";


### PR DESCRIPTION
### What does it do?
If a resource has no parent (either by being deleted or hitting an ACL policy - the ) in that the resources parent has been removed but not the main resource, if the main resource is marked as deleted the recycle bin breaks with a 500 error as end() cannot get an object

### Why is it needed?
If a user has access to the recycle bin but not access to all resources (I think) - the recycle bin 500's because we can't always get the parents. This just stops the 500 error

### Related issue(s)/PR(s)
#13491

