### PR TITLE
Created dedicated method to get a resource preview URL

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -456,35 +456,33 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      * @return string
      */
     public function getPreviewUrl() {
-        $url = '';
-        if (!$this->get('deleted')) {
-            $this->xpdo->setOption('cache_alias_map', false);
-            $sessionEnabled = '';
-            /** @var modContextSetting|null $ctxSetting */
-            $ctxSetting = $this->xpdo->getObject(
-                'modContextSetting',
-                array(
-                    'context_key' => $this->get('context_key'),
-                    'key' => 'session_enabled'
-                )
-            );
+        if ($this->get('deleted')) {
+            return '';
+        }
+        $this->xpdo->setOption('cache_alias_map', false);
+        $sessionEnabled = '';
+        /** @var modContextSetting|null $ctxSetting */
+        $ctxSetting = $this->xpdo->getObject(
+            'modContextSetting',
+            array(
+                'context_key' => $this->get('context_key'),
+                'key' => 'session_enabled'
+            )
+        );
 
-            if ($ctxSetting) {
-                $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
-            }
-
-            $url = $this->xpdo->makeUrl(
-                $this->get('id'),
-                $this->get('context_key'),
-                $sessionEnabled,
-                'full',
-                array(
-                    'xhtml_urls' => false
-                )
-            );
+        if ($ctxSetting && $ctxSetting->get('value') == 0) {
+            $sessionEnabled = array('preview' => 'true');
         }
 
-        return $url;
+        return $this->xpdo->makeUrl(
+            $this->get('id'),
+            $this->get('context_key'),
+            $sessionEnabled,
+            'full',
+            array(
+                'xhtml_urls' => false
+            )
+        );
     }
 
     /**

--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -451,6 +451,43 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     }
 
     /**
+     * Compute the "preview URL" for the resource
+     *
+     * @return string
+     */
+    public function getPreviewUrl() {
+        $url = '';
+        if (!$this->get('deleted')) {
+            $this->xpdo->setOption('cache_alias_map', false);
+            $sessionEnabled = '';
+            /** @var modContextSetting|null $ctxSetting */
+            $ctxSetting = $this->xpdo->getObject(
+                'modContextSetting',
+                array(
+                    'context_key' => $this->get('context_key'),
+                    'key' => 'session_enabled'
+                )
+            );
+
+            if ($ctxSetting) {
+                $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
+            }
+
+            $url = $this->xpdo->makeUrl(
+                $this->get('id'),
+                $this->get('context_key'),
+                $sessionEnabled,
+                'full',
+                array(
+                    'xhtml_urls' => false
+                )
+            );
+        }
+
+        return $url;
+    }
+
+    /**
      * Prepare the resource for output.
      */
     public function prepare()

--- a/core/model/modx/processors/resource/getnodes.class.php
+++ b/core/model/modx/processors/resource/getnodes.class.php
@@ -480,12 +480,6 @@ class modResourceGetNodesProcessor extends modProcessor {
         // Add the ID to the item text if the user has the permission
         $idNote = $this->modx->hasPermission('tree_show_resource_ids') ? ' <span dir="ltr">('.$resource->id.')</span>' : '';
 
-        // Used in the preview_url, if sessions are disabled on the resource context we add an extra url param
-        $sessionEnabled = '';
-        if ($ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $resource->get('context_key'), 'key' => 'session_enabled'))) {
-            $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
-        }
-
         $text = $resource->get($nodeField);
         if (empty($text)) {
             $text = $resource->get($nodeFieldFallback);
@@ -506,7 +500,7 @@ class modResourceGetNodesProcessor extends modProcessor {
             'hasChildren' => $hasChildren,
             'hide_children_in_tree' => $resource->hide_children_in_tree,
             'qtip' => $qtip,
-            'preview_url' => (!$resource->get('deleted')) ? $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'), $sessionEnabled, 'full', array('xhtml_urls' => false)) : '',
+            'preview_url' => $resource->getPreviewUrl(),
             'page' => empty($noHref) ? '?a='.(!empty($this->permissions['edit_document']) ? 'resource/update' : 'resource/data').'&id='.$resource->id : '',
             'allowDrop' => true,
         );

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -153,7 +153,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         }
         $this->checkDeletedStatus();
 
-        // If we are changing an existing modResource that is not already a symlink/weblink, it does not make 
+        // If we are changing an existing modResource that is not already a symlink/weblink, it does not make
         // much sense to run this check, as it would attempt to validate the existing content of the content field
         if ($properties['class_key'] === 'modSymLink' && $this->object->get('class_key') === 'modSymLink') {
             $this->checkSymLinkTarget();
@@ -808,10 +808,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         $returnArray['class_key'] = $this->object->get('class_key');
         $this->workingContext->prepare(false);
         $this->modx->reloadContext($this->workingContext->key);
-        $returnArray['preview_url'] = '';
-        if (!$this->object->get('deleted')) {
-            $returnArray['preview_url'] = $this->modx->makeUrl($this->object->get('id'), $this->object->get('context_key'), '', 'full');
-        }
+        $returnArray['preview_url'] = $this->object->getPreviewUrl();
 
         return $this->success('',$returnArray);
     }

--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -107,7 +107,7 @@ class ResourceDataManagerController extends ResourceManagerController {
      * @return string
      */
     public function getPreviewUrl() {
-        $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'),$this->resource->get('context_key'));
+        $this->previewUrl = $this->resource->getPreviewUrl();
         return $this->previewUrl;
     }
 

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -180,17 +180,8 @@ class ResourceUpdateManagerController extends ResourceManagerController {
      * @return string
      */
     public function getPreviewUrl() {
-        if (!$this->resource->get('deleted')) {
-            $this->modx->setOption('cache_alias_map', false);
-            $sessionEnabled = '';
-            $ctxSetting = $this->modx->getObject('modContextSetting', array('context_key' => $this->resource->get('context_key'), 'key' => 'session_enabled'));
+        $this->previewUrl = $this->resource->getPreviewUrl();
 
-            if ($ctxSetting) {
-                $sessionEnabled = $ctxSetting->get('value') == 0 ? array('preview' => 'true') : '';
-            }
-
-            $this->previewUrl = $this->modx->makeUrl($this->resource->get('id'), $this->resource->get('context_key'), $sessionEnabled, 'full', array('xhtml_urls' => false));
-        }
         return $this->previewUrl;
     }
 


### PR DESCRIPTION
### What does it do?
Extracted the "resource preview URL" computation into a dedicated method inside modResource class

### Why is it needed?
Previously we were having duplicate & inconsistent code to generate those preview URLs

### Related issue(s)/PR(s)
None found
