### PR TITLE
Allow adding new values to Mulit-select listbox TV

### DIFF
--- a/core/lexicon/en/tv_widget.inc.php
+++ b/core/lexicon/en/tv_widget.inc.php
@@ -16,6 +16,7 @@ $_lang['combo_allowaddnewdata'] = 'Allow Add New Items';
 $_lang['combo_allowaddnewdata_desc'] = 'When Yes, allows items to be added that do not already exist in the list. Defaults to No.';
 $_lang['combo_forceselection'] = 'Force Selection to List';
 $_lang['combo_forceselection_desc'] = 'If using Type-Ahead, if this is set to Yes, only allow inputting of items in the list.';
+$_lang['combo_forceselection_multi_desc'] = 'If this is set to Yes, only items already in the list are allowed. If No, new values can be entered a well.';
 $_lang['combo_listempty_text'] = 'Empty List Text';
 $_lang['combo_listempty_text_desc'] = 'If Type-Ahead is on, and the user types a value not in the list, display this text.';
 $_lang['combo_listheight'] = 'List Height';

--- a/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
@@ -44,7 +44,8 @@ Ext.onReady(function() {
         {if $params.listEmptyText|default}
             ,listEmptyText: '{$params.listEmptyText|default}'
         {/if}
-        ,forceSelection: true
+        ,allowAddNewData: {if $params.forceSelection|default && $params.forceSelection|default != 'false'}false{else}true{/if}
+        ,addNewDataOnBlur: true
         ,stackItems: {if $params.stackItems|default && $params.stackItems|default != 'false'}true{else}false{/if}
         ,msgTarget: 'under'
 

--- a/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
@@ -54,7 +54,10 @@ Ext.onReady(function() {
             'select': {fn:MODx.fireResourceFormChange, scope:this}
             ,'beforeadditem': {fn:MODx.fireResourceFormChange, scope:this}
             ,'newitem': {fn:function(bs,v,f) {
-                bs.addNewItem({"id": v,"text": v});
+                var item = {};
+                item[bs.valueField] = v;
+                item[bs.displayField] = v;
+                bs.addNewItem(item);
                 MODx.fireResourceFormChange();
                 return true;
             },scope:this}

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
@@ -89,6 +89,21 @@ MODx.load({
         ,html: _('typeahead_delay_desc')
         ,cls: 'desc-under'
     },{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('combo_forceselection')
+        ,description: MODx.expandHelp ? '' : _('combo_forceselection_desc')
+        ,name: 'inopt_forceSelection'
+        ,hiddenName: 'inopt_forceSelection'
+        ,id: 'inopt_forceSelection{/literal}{$tv|default}{literal}'
+        ,width: 200
+        ,value: (params['forceSelection']) ? !(params['forceSelection'] === 0 || params['forceSelection'] === 'false') : false
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_forceSelection{/literal}{$tv|default}{literal}'
+        ,html: _('combo_forceselection_multi_desc')
+        ,cls: 'desc-under'
+    },{
         xtype: 'textfield'
         ,fieldLabel: _('combo_listempty_text')
         ,description: MODx.expandHelp ? '' : _('combo_listempty_text_desc')


### PR DESCRIPTION
### What does it do?
When using a `Listbox (Single-Select)` type TV one can set the ''Force Selection to List" option effectively allowing the manager to choose from the list OR enter a custom value.
The same option however was not available for `Listbox (Multi-Select)` type TVs, but this PR enables it.

### Why is it needed?
The need to benefit from both the ability to choose a value from a predefined list AND to enter a custom value if needed is not related to the choice if the given input accepts a single value or more as well, so it is not reasonable to allow such option for the Single variant, but not for the Multi.

Since there was a bug that prevented new values to be added to a `Listbox (Multi-Select)` TV, even if the option was enabled, my assumption that it was not allowed in the first place, because it didn't work anyway. 5729093 fixes that, and c3b4f1d adds a very similar TV Input Option as the one already available for `Listbox (Single-Select)`: the ''Force Selection to List".


### Related issue(s)/PR(s)
I've found none.
