### PR TITLE
JSON Grid xtype

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -234,6 +234,7 @@ $_lang['installed'] = 'Installed';
 $_lang['integer'] = 'Integer';
 $_lang['introtext'] = 'Introtext';
 $_lang['invalid_data'] = 'Invalid data';
+$_lang['json_grid'] = 'JSON Grid';
 $_lang['key'] = 'Key';
 $_lang['keyword'] = 'Keyword';
 $_lang['keywords'] = 'Keywords';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -41,6 +41,7 @@ $_lang['setting_err'] = 'Please check your data for the following fields: ';
 $_lang['setting_err_ae'] = 'Setting with that key already exists. Please specify another key name.';
 $_lang['setting_err_nf'] = 'Setting not found.';
 $_lang['setting_err_ns'] = 'Setting not specified';
+$_lang['setting_err_not_editable'] = 'This setting can\'t be edited in the grid. Please use the gear/context menu to edit the value!';
 $_lang['setting_err_remove'] = 'An error occurred while trying to remove the setting.';
 $_lang['setting_err_save'] = 'An error occurred while trying to save the setting.';
 $_lang['setting_err_startint'] = 'Settings may not start with an integer.';

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -1429,3 +1429,189 @@ Ext.preg('checkcolumn', Ext.ux.grid.CheckColumn);
 Ext.grid.CheckColumn = Ext.ux.grid.CheckColumn;
 
 Ext.grid.PropertyColumnModel=function(a,b){var g=Ext.grid,f=Ext.form;this.grid=a;g.PropertyColumnModel.superclass.constructor.call(this,[{header:this.nameText,width:50,sortable:true,dataIndex:'name',id:'name',menuDisabled:true},{header:this.valueText,width:50,resizable:false,dataIndex:'value',id:'value',menuDisabled:true}]);this.store=b;var c=new f.Field({autoCreate:{tag:'select',children:[{tag:'option',value:'true',html:'true'},{tag:'option',value:'false',html:'false'}]},getValue:function(){return this.el.dom.value=='true'}});this.editors={'date':new g.GridEditor(new f.DateField({selectOnFocus:true})),'string':new g.GridEditor(new f.TextField({selectOnFocus:true})),'number':new g.GridEditor(new f.NumberField({selectOnFocus:true,style:'text-align:left;'})),'boolean':new g.GridEditor(c)};this.renderCellDelegate=this.renderCell.createDelegate(this);this.renderPropDelegate=this.renderProp.createDelegate(this)};Ext.extend(Ext.grid.PropertyColumnModel,Ext.grid.ColumnModel,{nameText:'Name',valueText:'Value',dateFormat:'m/j/Y',renderDate:function(a){return a.dateFormat(this.dateFormat)},renderBool:function(a){return a?'true':'false'},isCellEditable:function(a,b){return a==1},getRenderer:function(a){return a==1?this.renderCellDelegate:this.renderPropDelegate},renderProp:function(v){return this.getPropertyName(v)},renderCell:function(a){var b=a;if(Ext.isDate(a)){b=this.renderDate(a)}else if(typeof a=='boolean'){b=this.renderBool(a)}return Ext.util.Format.htmlEncode(b)},getPropertyName:function(a){var b=this.grid.propertyNames;return b&&b[a]?b[a]:a},getCellEditor:function(a,b){var p=this.store.getProperty(b),n=p.data.name,val=p.data.value;if(this.grid.customEditors[n]){return this.grid.customEditors[n]}if(Ext.isDate(val)){return this.editors.date}else if(typeof val=='number'){return this.editors.number}else if(typeof val=='boolean'){return this.editors['boolean']}else{return this.editors.string}},destroy:function(){Ext.grid.PropertyColumnModel.superclass.destroy.call(this);for(var a in this.editors){Ext.destroy(a)}}});
+
+/**
+ * MODx JSON Grid
+ * Local grid with inline editing, it converts the grid value from/to JSON and submits the JSON in a hidden field.
+ * The grid could be sorted by drag & drop, new values could be added with a button and each row could be deleted.
+ *
+ * It could be configured with the fieldConfig property, containing an array of field configs:
+ *
+ * fieldConfig: [{
+ *    name: 'whatever', // required, name 'id' is reserved and can't be used
+ *    width: 100, // defaults to 100
+ *    xtype: 'textfield', // defaults to textfield
+ *    allowBlank: true, // defaults to true
+ *    header: _('whatever') // defaults to the lexicon entry of name value of the current field config
+ * }];
+ *
+ * If there is no fieldConfig property set, the following default fieldConfig is used:
+ *
+ * [{name: 'key'}, {name: 'value'}]
+ */
+MODx.grid.JsonGrid = function (config) {
+    config = config || {};
+    this.ident = config.ident || 'jsongrid-mecitem' + Ext.id();
+    this.hiddenField = new Ext.form.TextArea({
+        name: config.hiddenName || config.name,
+        hidden: true
+    });
+    this.fieldConfig = config.fieldConfig || [{name: 'key'}, {name: 'value'}];
+    this.fieldConfig.push({name: 'id', hidden: true});
+    this.fieldColumns = [];
+    this.fieldNames = [];
+    Ext.each(this.fieldConfig, function (el) {
+        this.fieldNames.push(el.name);
+        this.fieldColumns.push({
+            header: el.header || _(el.name),
+            dataIndex: el.name,
+            editable: true,
+            hidden: el.hidden || false,
+            editor: {
+                xtype: el.xtype || 'textfield',
+                allowBlank: el.allowBlank || true,
+                listeners: {
+                    change: {
+                        fn: this.saveValue,
+                        scope: this
+                    }
+                }
+            },
+            renderer: function(value, metadata) {
+                metadata.css += 'x-editable-column ';
+                return value;
+            },
+            width: el.width || 100
+        });
+    }, this);
+    Ext.applyIf(config, {
+        id: this.ident + '-json-grid',
+        fields: this.fieldNames,
+        autoHeight: true,
+        store: new Ext.data.JsonStore({
+            fields: this.fieldNames,
+            data: this.loadValue(config.value)
+        }),
+        enableDragDrop: true,
+        ddGroup: this.ident + '-json-grid-dd',
+        labelStyle: 'position: absolute',
+        columns: this.fieldColumns,
+        disableContextMenuAction: true,
+        tbar: ['->', {
+            text: '<i class="icon icon-plus"></i> ' + _('add'),
+            cls: 'primary-button',
+            handler: this.addElement,
+            scope: this
+        }],
+        listeners: {
+            render: {
+                fn: this.renderListener,
+                scope: this
+            }
+        }
+    });
+    MODx.grid.JsonGrid.superclass.constructor.call(this, config)
+};
+Ext.extend(MODx.grid.JsonGrid, MODx.grid.LocalGrid, {
+    getMenu: function () {
+        var m = [];
+        m.push({
+            text: _('remove'),
+            handler: this.removeElement
+        });
+        return m;
+    },
+    getActions: function () {
+        return [{
+            action: 'removeElement',
+            icon: 'trash-o',
+            text: _('remove')
+        }]
+    },
+    addElement: function () {
+        var ds = this.getStore();
+        var row = {};
+        Ext.each(this.fieldNames, function (fieldname) {
+            row[fieldname] = '';
+        });
+        row['id'] = this.getStore().getCount();
+        this.getStore().insert(this.getStore().getCount(), new ds.recordType(row));
+        this.getView().refresh();
+        this.getSelectionModel().selectRow(0);
+    },
+    removeElement: function () {
+        Ext.Msg.confirm(_('remove') || '', _('confirm_remove') || '', function (e) {
+            if (e === 'yes') {
+                var ds = this.getStore();
+                var rows = this.getSelectionModel().getSelections();
+                if (!rows.length) {
+                    return false;
+                }
+                for (var i = 0; i < rows.length; i++) {
+                    var id = rows[i].id;
+                    var index = ds.findBy(function (record) {
+                        if (record.id === id) {
+                            return true;
+                        }
+                    });
+                    ds.removeAt(index);
+                }
+                this.getView().refresh();
+                this.saveValue();
+            }
+        }, this);
+    },
+    renderListener: function (grid) {
+        new Ext.dd.DropTarget(grid.container, {
+            copy: false,
+            ddGroup: this.ident + '-json-grid-dd',
+            notifyDrop: function (dd, e, data) {
+                var ds = grid.store;
+                var sm = grid.getSelectionModel();
+                var rows = sm.getSelections();
+
+                var dragData = dd.getDragData(e);
+                if (dragData) {
+                    var cindex = dragData.rowIndex;
+                    if (typeof (cindex) !== "undefined") {
+                        for (var i = 0; i < rows.length; i++) {
+                            ds.remove(ds.getById(rows[i].id));
+                        }
+                        ds.insert(cindex, data.selections);
+                        sm.clearSelections();
+                    }
+                }
+                grid.getView().refresh();
+                grid.saveValue();
+            }
+        });
+        this.add(this.hiddenField);
+        this.saveValue();
+    },
+    loadValue: function (value) {
+        value = Ext.util.JSON.decode(value);
+        if (value && Array.isArray(value)) {
+            Ext.each(value, function (record, idx) {
+                value[idx]['id'] = idx;
+            });
+        } else {
+            value = [];
+        }
+        return value;
+    },
+    saveValue: function () {
+        var value = [];
+        Ext.each(this.getStore().getRange(), function (record) {
+            var row = {};
+            Ext.each(this.fieldNames, function (fieldname) {
+                if (fieldname !== 'id') {
+                    row[fieldname] = record.data[fieldname];
+                }
+            });
+            value.push(row);
+        }, this);
+        this.hiddenField.setValue(Ext.util.JSON.encode(value));
+    }
+});
+Ext.reg('grid-json', MODx.grid.JsonGrid);
+Ext.reg('modx-grid-json', MODx.grid.JsonGrid);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -124,7 +124,21 @@ MODx.grid.SettingsGrid = function(config) {
             ,sortable: true
             ,hidden: true
             ,editable: false
-        }]
+        }],
+        isCellEditable: function(col, row) {
+            var record = config.store.getAt(row);
+            if (record.get('xtype') === 'modx-grid-json' || record.get('xtype') === 'grid-json') {
+                Ext.MessageBox.show({
+                    title: _('info')
+                    ,msg:  _('setting_err_not_editable')
+                    ,buttons: Ext.MessageBox.OK
+                    ,icon: Ext.MessageBox.INFO
+                    ,modal: true
+                });
+                return false;
+            }
+            return Ext.grid.ColumnModel.prototype.isCellEditable.call(this, col, row);
+        }
         /* Editors are pushed here. I think that they should be in general grid
          * definitions (modx.grid.js) and activated via a config property (loadEditor: true) */
         ,getCellEditor: function(colIndex, rowIndex) {
@@ -305,7 +319,9 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         var r = s.getAt(ri).data;
         v = Ext.util.Format.htmlEncode(v);
         var f;
-        if (r.xtype == 'combo-boolean' || r.xtype == 'modx-combo-boolean') {
+        if (r.xtype === 'grid-json' || r.xtype === 'modx-grid-json') {
+            return v;
+        } else if (r.xtype === 'combo-boolean' || r.xtype === 'modx-combo-boolean') {
             f = MODx.grid.Grid.prototype.rendYesNo;
             return this.renderEditableColumn(f)(v,md,rec,ri,ci,s,g);
         } else if (r.xtype === 'datefield') {
@@ -518,6 +534,7 @@ MODx.combo.xType = function(config) {
                 ,[_('source'),'modx-combo-source']
                 ,[_('source_type'),'modx-combo-source-type']
                 ,[_('setting_manager_theme'),'modx-combo-manager-theme']
+                ,[_('json_grid'),'modx-grid-json']
             ]
         })
         ,displayField: 'd'


### PR DESCRIPTION
### What does it do?
Add a JSON grid xtype

### Why is it needed?
Use a simple grid editor for JSON values in i.e. the system settings.

It could be configured a bit with the fieldConfig property, containing an array of field configs 

```
fieldConfig: [{
    name: 'whatever', // required, name 'id' is reserved and can't be used
    width: 100, // defaults to 100
    xtype: 'textfield', // defaults to textfield
    allowBlank: true, // defaults to true
    header: _('whatever') // defaults to the name value of the current field config
}];
```

If there is no fieldConfig property set, the following default fieldConfig is used:
```
[{name: 'key'}, {name: 'value'}]
```

### Related issue(s)/PR(s)
#12293

(Requires rebuild)