### PR TITLE
Improved some styles in the manager panel

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -193,8 +193,8 @@ $tabTextHover: $darkestGray;
 $leftbarTabActiveBg: $mainBg;
 
 /* Windows */
-$winHeaderBg: $white;
-$winHeaderBorderColor: $white;
+$winHeaderBg: $wildSand;
+$winHeaderBorderColor: $wildSand;
 $winBodyBg: $white;
 $winFooterBg: $white;
 $winFooterBorderColor: $white;

--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -215,7 +215,7 @@ $fontMedium: normal 12px $bodyfonts;
 $fontNormal: normal $bodyFontSize $bodyfonts;
 $fontNavbar: normal $bodyFontSize $headfonts;
 $fontH2:     normal 25px $headfonts;
-$fontH3:     bold 15px $headfonts;
+$fontH3:     550 15px $headfonts;
 
 /* Responsive breakpoints */
 $mobile:  (media: "screen and (max-width: 640px)", columns: 4);

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -83,7 +83,6 @@ input::-moz-focus-inner {
 
     .modx-tv-label-title {
       display: inline-block;
-      padding-right: 5px;
     }
 
     .modx-tv-label-description {
@@ -98,7 +97,7 @@ input::-moz-focus-inner {
       height: 16px;
       opacity: 0;
       filter: alpha(opacity=0); /* for IE <= 8 */
-      padding: 17px 8px 0 0;
+      padding: 3px;
       position: relative;
       top: 0;
       right: 0;
@@ -111,11 +110,10 @@ input::-moz-focus-inner {
         box-sizing: border-box;
         color: $coreFieldLabelColor;
         content: fa-content($fa-var-sync);
-        font-size: 16px;
+        font-size: 14px;
         position: relative;
-        bottom: 0;
+        bottom: 3px;
         left: 0;
-        padding-left: 4px;
         text-align: center;
         vertical-align: middle;
         width: 16px;
@@ -263,12 +261,6 @@ input::-moz-focus-inner {
     /* targets .x-form-item */
     padding: 0; /* override the .x-form-label-left rule */
     padding-bottom: 0; /* override extjs default theme styles */
-
-    &:first-of-type {
-      .modx-tv-reset {
-        padding: 2px 8px 0 0;
-      }
-    }
 
     label.x-form-item-label {
       display: inline-block; /* override extjs default theme styles */

--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -105,7 +105,8 @@
 
     &.modx-console,
     &.modx-alert,
-    &.modx-confirm {
+    &.modx-confirm,
+    & .x-window-with-tabs {
       .x-window-body {
         padding-top: 15px;
       }

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -32,7 +32,6 @@
     height: 16px;
     min-width: 100%;
     padding: 0; /* override extjs default theme styles */
-    vertical-align: middle;
 
     .ext-ie8 & {
       padding-top: 0; /* fix IE < 9 (overriding extjs default style) */

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -1609,6 +1609,10 @@ iframe[classname="x-hidden"] {
     position: relative;
   }
 
+  .x-panel-collapsed {
+    min-height: 18px;
+  }
+
   #modx-resource-main-right {
     .modx-resource-panel {
       &:not(:last-child) {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -119,8 +119,13 @@ hr {
   font-weight: bold;
 }
 
+.installed {
+  color: $darkGray;
+}
+
 .not-installed {
-  color: $red;
+  color: $mediumGray;
+  font-style: $hiddenText;
 }
 
 .yellow {
@@ -1849,10 +1854,6 @@ iframe[classname="x-hidden"] {
   margin: 0 0 5px 0;
 }
 
-.x-grid3-cell-inner .x-grid3-col-main .not-installed {
-  color: #999999;
-}
-
 .package-installed {
   color: $darkGray;
   opacity: .5;
@@ -2305,12 +2306,28 @@ iframe[classname="x-hidden"] {
     padding-left: 15px;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
+  h1 {
+    font-size: 1.2em;
+  }
+
+  h2 {
+    font-size: 1.15em;
+  }
+
+  h3 {
+    font-size: 1.1em;
+  }
+
+  h4 {
+    font-size: 1.05em;
+  }
+
   h5 {
-    margin-top: 5px;
+    font-size: 1em;
+  }
+
+  h6 {
+    font-size: .95em;
   }
 }
 


### PR DESCRIPTION
### What does it do?
Improved some styles in the manager panel:

1) **Fixed styles of "set tv to default" link**

![tv_reset_1](https://user-images.githubusercontent.com/12523676/73376380-ca23cd80-42d6-11ea-8c65-ac742357d38b.png)

![tv_reset_2](https://user-images.githubusercontent.com/12523676/73376381-ca23cd80-42d6-11ea-97da-2a6a7e50e6f6.png)

---

2) **Fixed button "vertical-align" styles**

![button_v_1](https://user-images.githubusercontent.com/12523676/73376470-ef184080-42d6-11ea-8064-8ed4966bcc19.png)

![button_v_2](https://user-images.githubusercontent.com/12523676/73376471-ef184080-42d6-11ea-8465-8f396b8b255c.png)

---

3) **Fixed styles for collapsed resource panel**

![panel-collapsed-1](https://user-images.githubusercontent.com/12523676/73376548-0a834b80-42d7-11ea-8b7e-9f37d39446c8.png)

![panel-collapsed-2](https://user-images.githubusercontent.com/12523676/73376549-0b1be200-42d7-11ea-8709-76999f006785.png)

---

4) **Fixed styles for package installer**

![packages_1-1](https://user-images.githubusercontent.com/12523676/73376585-1c64ee80-42d7-11ea-9afe-b35a4b150bad.png)

![packages_1-2](https://user-images.githubusercontent.com/12523676/73376587-1c64ee80-42d7-11ea-807d-16e382b12518.png)

![packages_2](https://user-images.githubusercontent.com/12523676/73376588-1c64ee80-42d7-11ea-8178-44119d02c120.png)

![package-fs-2](https://user-images.githubusercontent.com/12523676/73377209-1d4a5000-42d8-11ea-8be3-ddc99136a3ed.png)

---

5) **Fixed padding in popup window with tabs (and made the window title darker)**

![w-padding-1](https://user-images.githubusercontent.com/12523676/73403291-982b5f00-4308-11ea-8da0-e41444f9c030.png)

![w-padding-2](https://user-images.githubusercontent.com/12523676/73403293-98c3f580-4308-11ea-8df1-b9144bec1ed9.png)


### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14686 (1-5)