### PR TITLE
Added breadcrumbs to FC and ACL sections

### DIFF
--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -15,11 +15,7 @@ MODx.panel.FCProfile = function(config) {
         ,cls: 'container'
         ,class_key: 'MODX\\Revolution\\modFormCustomizationProfile'
         ,bodyStyle: ''
-        ,items: [{
-            html: _('profile_new')
-            ,id: 'modx-fcp-header'
-            ,xtype: 'modx-header'
-        },MODx.getPageStructure([{
+        ,items: [this.getPageHeader(config), MODx.getPageStructure([{
             title: _('profile')
             ,defaults: { border: false ,msgTarget: 'side' }
             ,layout: 'form'
@@ -51,7 +47,7 @@ MODx.panel.FCProfile = function(config) {
                     ,value: config.record.name
                     ,listeners: {
                         'keyup': {scope:this,fn:function(f,e) {
-                            Ext.getCmp('modx-fcp-header').getEl().update(_('profile') + ': ' + Ext.util.Format.htmlEncode(f.getValue()));
+                            Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getValue()));
                         }}
                     }
                 },{
@@ -107,12 +103,11 @@ MODx.panel.FCProfile = function(config) {
 };
 Ext.extend(MODx.panel.FCProfile,MODx.FormPanel,{
     initialized: false
+
     ,setup: function() {
         if (!this.initialized) { this.getForm().setValues(this.config.record); }
         if (!Ext.isEmpty(this.config.record.name)) {
-            Ext.defer(function() {
-                Ext.getCmp('modx-fcp-header').update(_('profile') + ': ' + Ext.util.Format.htmlEncode(this.config.record.name));
-            }, 250, this);
+            Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(this.config.record.name));
         }
         this.fireEvent('ready',this.config.record);
         this.clearDirty();
@@ -120,6 +115,7 @@ Ext.extend(MODx.panel.FCProfile,MODx.FormPanel,{
         MODx.fireEvent('ready');
         return true;
     }
+
     ,beforeSubmit: function(o) {
         Ext.apply(o.form.baseParams,{
             usergroups: Ext.getCmp('modx-grid-fc-profile-usergroups').encode()
@@ -128,9 +124,17 @@ Ext.extend(MODx.panel.FCProfile,MODx.FormPanel,{
             values: this.getForm().getValues()
         });
     }
+
     ,success: function(r) {
         Ext.getCmp('modx-grid-fc-profile-usergroups').getStore().commitChanges();
         this.getForm().setValues(r.result.object);
+    }
+
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-fcp-header', [{
+            text: _('form_customization'),
+            href: MODx.getPage('security/forms')
+        }]);
     }
 });
 Ext.reg('modx-panel-fc-profile',MODx.panel.FCProfile);

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -14,11 +14,7 @@ MODx.panel.FCSet = function(config) {
         ,id: 'modx-panel-fc-set'
         ,class_key: 'MODX\\Revolution\\modFormCustomizationSet'
         ,cls: 'container'
-        ,items: [{
-            html: _('set_edit')
-            ,id: 'modx-fcs-header'
-            ,xtype: 'modx-header'
-        },MODx.getPageStructure([{
+        ,items: [this.getPageHeader(config), MODx.getPageStructure([{
             title: _('set_and_fields')
             ,xtype: 'panel'
             ,border: false
@@ -49,7 +45,7 @@ MODx.panel.FCSet = function(config) {
                     ,value: config.record.action
                     ,listeners: {
                         'select': {scope:this,fn:function(f,e) {
-                            Ext.getCmp('modx-fcs-header').getEl().update(_('set')+': '+f.getRawValue());
+                            Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getRawValue()));
                         }}
                     }
                 },{
@@ -167,9 +163,7 @@ Ext.extend(MODx.panel.FCSet,MODx.FormPanel,{
 
     ,setup: function() {
         if (!this.initialized) {this.getForm().setValues(this.config.record);}
-        if (!Ext.isEmpty(this.config.record.controller)) {
-            Ext.getCmp('modx-fcs-header').update(_('set')+': '+this.config.record.controller);
-        }
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(_('set'));
 
         this.fireEvent('ready',this.config.record);
         this.clearDirty();
@@ -211,6 +205,17 @@ Ext.extend(MODx.panel.FCSet,MODx.FormPanel,{
             },this);
         }
         return false;
+    }
+
+    ,getPageHeader: function(config) {
+        var profile = config.record.profile;
+        return MODx.util.getHeaderBreadCrumbs('modx-fcs-header', [{
+            text: _('form_customization'),
+            href: MODx.getPage('security/forms')
+        },{
+            text: _('profile'),
+            href: MODx.getPage('security/forms/profile/update&id='+profile)
+        }]);
     }
 });
 Ext.reg('modx-panel-fc-set',MODx.panel.FCSet);

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.js
@@ -19,11 +19,7 @@ MODx.panel.AccessPolicy = function(config) {
         ,plugin: ''
         ,bodyStyle: ''
         ,defaults: { collapsible: false ,autoHeight: true }
-        ,items: [{
-            html: _('policy')+(config.record ? ': '+config.record.name : '')
-            ,id: 'modx-policy-header'
-            ,xtype: 'modx-header'
-        },{
+        ,items: [this.getPageHeader(config),{
             xtype: 'modx-tabs'
             ,defaults: {
                 autoHeight: true
@@ -63,8 +59,8 @@ MODx.panel.AccessPolicy = function(config) {
                         ,anchor: '100%'
                         ,listeners: {
                             'keyup': {scope:this,fn:function(f,e) {
-                                    Ext.getCmp('modx-policy-header').getEl().update(_('policy')+': '+f.getValue());
-                                }}
+                                Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getValue()));
+                            }}
                         }
                     },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
@@ -128,6 +124,8 @@ Ext.extend(MODx.panel.AccessPolicy,MODx.FormPanel,{
             var r = this.config.record;
 
             this.getForm().setValues(r);
+            Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(r.name));
+
             var g = Ext.getCmp('modx-grid-policy-permissions');
             if (g) { g.getStore().loadData(r.permissions); }
 
@@ -146,6 +144,13 @@ Ext.extend(MODx.panel.AccessPolicy,MODx.FormPanel,{
 
     ,success: function(o) {
         Ext.getCmp('modx-grid-policy-permissions').getStore().commitChanges();
+    }
+
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-policy-header', [{
+            text: _('user_group_management'),
+            href: MODx.getPage('security/permission')
+        }]);
     }
 });
 Ext.reg('modx-panel-access-policy',MODx.panel.AccessPolicy);

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
@@ -16,21 +16,17 @@ MODx.panel.AccessPolicyTemplate = function(config) {
             ,id: MODx.request.id
         }
         ,id: 'modx-panel-access-policy-template'
-		,cls: 'container form-with-labels'
+        ,cls: 'container form-with-labels'
         ,class_key: 'modAccessPolicyTemplate'
         ,plugin: ''
         ,bodyStyle: ''
         ,defaults: { collapsible: false ,autoHeight: true }
-        ,items: [{
-            html: _('policy_template')+(config.record ? ': '+config.record.name : '')
-            ,id: 'modx-policy-template-header'
-            ,xtype: 'modx-header'
-        },{
+        ,items: [this.getPageHeader(config),{
             xtype: 'modx-tabs'
             ,defaults: {
                 autoHeight: true
                 ,border: true
-				,bodyCssClass: 'tab-panel-wrapper'
+                ,bodyCssClass: 'tab-panel-wrapper'
             }
             ,forceLayout: true
             ,deferredRender: false
@@ -41,58 +37,58 @@ MODx.panel.AccessPolicyTemplate = function(config) {
                     html: '<p>'+_('policy_template.desc')+'</p>'
                     ,xtype: 'modx-description'
                 },{
-					xtype: 'panel'
-					,border: false
-					,cls:'main-wrapper'
-					,layout: 'form'
-					,defaults:{ anchor: '100%' }
-					,labelAlign: 'top'
-					,labelSeparator: ''
-					,items: [{
-						xtype: 'hidden'
-						,name: 'id'
-					},{
-						xtype: 'textfield'
-						,fieldLabel: _('name')
-						,description: MODx.expandHelp ? '' : _('policy_template_desc_name')
-						,name: 'name'
-						,id: 'modx-policy-template-name'
-						,maxLength: 255
-						,enableKeyEvents: true
-						,allowBlank: false
-						,listeners: {
-							'keyup': {scope:this,fn:function(f,e) {
-								Ext.getCmp('modx-policy-template-header').getEl().update(_('policy')+': '+f.getValue());
-							}}
-						}
-					},{
+                    xtype: 'panel'
+                    ,border: false
+                    ,cls:'main-wrapper'
+                    ,layout: 'form'
+                    ,defaults:{ anchor: '100%' }
+                    ,labelAlign: 'top'
+                    ,labelSeparator: ''
+                    ,items: [{
+                        xtype: 'hidden'
+                        ,name: 'id'
+                    },{
+                        xtype: 'textfield'
+                        ,fieldLabel: _('name')
+                        ,description: MODx.expandHelp ? '' : _('policy_template_desc_name')
+                        ,name: 'name'
+                        ,id: 'modx-policy-template-name'
+                        ,maxLength: 255
+                        ,enableKeyEvents: true
+                        ,allowBlank: false
+                        ,listeners: {
+                            'keyup': {scope:this,fn:function(f,e) {
+                                Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getValue()));
+                            }}
+                        }
+                    },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-policy-template-name'
                         ,html: _('policy_template_desc_name')
                         ,cls: 'desc-under'
 
                     },{
-						xtype: 'textarea'
-						,fieldLabel: _('description')
-						,description: MODx.expandHelp ? '' : _('policy_template_desc_description')
-						,name: 'description'
-						,id: 'modx-policy-template-description'
-						,grow: true
-					},{
+                        xtype: 'textarea'
+                        ,fieldLabel: _('description')
+                        ,description: MODx.expandHelp ? '' : _('policy_template_desc_description')
+                        ,name: 'description'
+                        ,id: 'modx-policy-template-description'
+                        ,grow: true
+                    },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-policy-template-description'
                         ,html: _('policy_template_desc_description')
                         ,cls: 'desc-under'
 
                     },{
-						xtype: 'textfield'
-						,fieldLabel: _('lexicon')
-						,description: MODx.expandHelp ? '' : _('policy_template_desc_lexicon')
-						,name: 'lexicon'
-						,id: 'modx-policy-template-lexicon'
-						,allowBlank: true
-						,value: 'permissions'
-					},{
+                        xtype: 'textfield'
+                        ,fieldLabel: _('lexicon')
+                        ,description: MODx.expandHelp ? '' : _('policy_template_desc_lexicon')
+                        ,name: 'lexicon'
+                        ,id: 'modx-policy-template-lexicon'
+                        ,allowBlank: true
+                        ,value: 'permissions'
+                    },{
                         xtype: MODx.expandHelp ? 'label' : 'hidden'
                         ,forId: 'modx-policy-template-lexicon'
                         ,html: _('policy_template_desc_lexicon')
@@ -103,7 +99,7 @@ MODx.panel.AccessPolicyTemplate = function(config) {
                     ,xtype: 'modx-description'
                 },{
                     xtype: 'modx-grid-template-permissions'
-					,cls:'main-wrapper'
+                    ,cls:'main-wrapper'
                     ,policy: MODx.request.id
                     ,autoHeight: true
                     ,preventRender: true
@@ -129,6 +125,7 @@ Ext.extend(MODx.panel.AccessPolicyTemplate,MODx.FormPanel,{
         var r = this.config.record;
 
         this.getForm().setValues(r);
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(r.name));
 
         var g = Ext.getCmp('modx-grid-template-permissions');
         if (g && r.permissions) { g.getStore().loadData(r.permissions); }
@@ -147,11 +144,23 @@ Ext.extend(MODx.panel.AccessPolicyTemplate,MODx.FormPanel,{
     ,success: function(o) {
         Ext.getCmp('modx-grid-template-permissions').getStore().commitChanges();
     }
+
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-policy-template-header', [{
+            text: _('user_group_management'),
+            href: MODx.getPage('security/permission')
+        }]);
+    }
 });
 Ext.reg('modx-panel-access-policy-template',MODx.panel.AccessPolicyTemplate);
 
-
-
+/**
+ * @class MODx.grid.TemplatePermissions
+ * @extends MODx.grid.LocalGrid
+ * @constructor
+ * @param {Object} config An object of options.
+ * @xtype modx-grid-template-permissions
+ */
 MODx.grid.TemplatePermissions = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -232,7 +241,12 @@ Ext.extend(MODx.grid.TemplatePermissions,MODx.grid.LocalGrid,{
 });
 Ext.reg('modx-grid-template-permissions',MODx.grid.TemplatePermissions);
 
-
+/**
+ * @class MODx.window.NewTemplatePermission
+ * @extends MODx.Window
+ * @param {Object} config An object of options.
+ * @xtype modx-window-template-permission-create
+ */
 MODx.window.NewTemplatePermission = function(config) {
     config = config || {};
     this.ident = config.ident || 'polpc'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -14,11 +14,7 @@ MODx.panel.UserGroup = function(config) {
             action: 'Security/Group/Update'
         }
         ,defaults: { collapsible: false ,autoHeight: true }
-        ,items: [{
-            html: _('user_group_new')
-            ,id: 'modx-user-group-header'
-            ,xtype: 'modx-header'
-        },{
+        ,items: [this.getPageHeader(config),{
             xtype: 'modx-tabs'
             ,defaults: {
                 autoHeight: true
@@ -74,7 +70,7 @@ MODx.panel.UserGroup = function(config) {
                                 ,anchor: '100%'
                                 ,listeners: {
                                     'keyup': {scope:this,fn:function(f,e) {
-                                        Ext.getCmp('modx-user-group-header').getEl().update('<h2>'+_('user_group')+': '+Ext.util.Format.htmlEncode(f.getValue())+'</h2>');
+                                        Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getValue()));
                                     }}
                                 }
                             },{
@@ -313,9 +309,7 @@ Ext.extend(MODx.panel.UserGroup,MODx.FormPanel,{
         }
         var r = this.config.record;
         this.getForm().setValues(r);
-        Ext.defer(function() {
-            Ext.get('modx-user-group-header').update('<h2>'+_('user_group')+': '+Ext.util.Format.htmlEncode(r.name)+'</h2>');
-        }, 250, this);
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(r.name));
 
         this.fireEvent('ready',r);
         MODx.fireEvent('ready');
@@ -323,6 +317,12 @@ Ext.extend(MODx.panel.UserGroup,MODx.FormPanel,{
     }
     ,beforeSubmit: function(o) {}
     ,success: function(o) {}
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-user-group-header', [{
+            text: _('user_group_management'),
+            href: MODx.getPage('security/permission')
+        }]);
+    }
 });
 Ext.reg('modx-panel-user-group',MODx.panel.UserGroup);
 

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -13,22 +13,19 @@ MODx.panel.User = function(config) {
         ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,bodyStyle: ''
-        ,items: [
-            MODx.util.getHeaderBreadCrumbs('modx-user-header', [{text: _('users'), href: MODx.getPage('security/user')}]),
-            {
-                xtype: 'modx-tabs'
-                ,id: 'modx-user-tabs'
-                ,deferredRender: false
-                ,defaults: {
-                    autoHeight: true
-                    ,layout: 'form'
-                    ,labelWidth: 150
-                    ,bodyCssClass: 'tab-panel-wrapper'
-                    ,layoutOnTabChange: true
-                }
-                ,items: this.getFields(config)
+        ,items: [this.getPageHeader(config),{
+            xtype: 'modx-tabs'
+            ,id: 'modx-user-tabs'
+            ,deferredRender: false
+            ,defaults: {
+                autoHeight: true
+                ,layout: 'form'
+                ,labelWidth: 150
+                ,bodyCssClass: 'tab-panel-wrapper'
+                ,layoutOnTabChange: true
             }
-        ]
+            ,items: this.getFields(config)
+        }]
         ,useLoadingMask: true
         ,listeners: {
             'setup': {fn:this.setup,scope:this}
@@ -65,13 +62,14 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                         if (s) { s.loadData(d); }
                     }
 
-                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(r.object.username);
+                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(r.object.username));
                     this.fireEvent('ready',r.object);
                     MODx.fireEvent('ready');
                 },scope:this}
             }
         });
     }
+
     ,beforeSubmit: function(o) {
         var d = {};
         var g = Ext.getCmp('modx-grid-user-settings');
@@ -682,6 +680,13 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             html: MODx.onUserFormRender
             ,border: false
         }];
+    }
+
+    ,getPageHeader: function(config) {
+        return MODx.util.getHeaderBreadCrumbs('modx-user-header', [{
+            text: _('users'),
+            href: MODx.getPage('security/user')
+        }]);
     }
 });
 Ext.reg('modx-panel-user',MODx.panel.User);

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -1,3 +1,9 @@
+/**
+ * @class MODx.panel.Source
+ * @extends MODx.FormPanel
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-panel-source
+ */
 MODx.panel.Source = function(config) {
     config = config || {};
     Ext.applyIf(config,{
@@ -7,13 +13,13 @@ MODx.panel.Source = function(config) {
             action: 'Source/Update'
         }
         ,defaults: { collapsible: false ,autoHeight: true }
-		,cls: 'container form-with-labels'
+        ,cls: 'container form-with-labels'
         ,items: [this.getPageHeader(config),{
             xtype: 'modx-tabs'
             ,defaults: {
                 autoHeight: true
                 ,border: true
-				,bodyCssClass: 'tab-panel-wrapper'
+                ,bodyCssClass: 'tab-panel-wrapper'
             }
             ,id: 'modx-source-tabs'
             ,forceLayout: true
@@ -26,26 +32,26 @@ MODx.panel.Source = function(config) {
             }
             ,items: [{
                 title: _('general_information')
-				,defaults: { border: false, msgTarget: 'side' }
+                ,defaults: { border: false, msgTarget: 'side' }
                 ,layout: 'form'
                 ,id: 'modx-dashboard-form'
                 ,labelWidth: 150
                 ,items: [{
-					xtype: 'panel'
-					,border: false
-					,cls: 'main-wrapper'
-					,layout: 'form'
-					,labelAlign: 'top'
-					,items: [{
-					    layout: 'column'
-					    ,border: false
+                    xtype: 'panel'
+                    ,border: false
+                    ,cls: 'main-wrapper'
+                    ,layout: 'form'
+                    ,labelAlign: 'top'
+                    ,items: [{
+                        layout: 'column'
+                        ,border: false
                         ,defaults: {
                             layout: 'form'
                             ,labelAlign: 'top'
                             ,anchor: '100%'
                             ,border: false
                         }
-					    ,items: [{
+                        ,items: [{
                             columnWidth: .65
                             ,cls: 'main-content'
                             ,items: [{
@@ -64,7 +70,7 @@ MODx.panel.Source = function(config) {
                                 ,anchor: '100%'
                                 ,listeners: {
                                     'keyup': {scope:this,fn:function(f,e) {
-                                        Ext.getCmp('modx-source-header').getEl().update(Ext.util.Format.htmlEncode(f.getValue()));
+                                        Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(f.getValue()));
                                     }}
                                 }
                             },{
@@ -103,7 +109,6 @@ MODx.panel.Source = function(config) {
                                 ,html: _('source_type_desc')
                                 ,cls: 'desc-under'
                             }]
-
                         }]
                     }]
                 },{
@@ -150,6 +155,7 @@ MODx.panel.Source = function(config) {
 };
 Ext.extend(MODx.panel.Source,MODx.FormPanel,{
     initialized: false
+
     ,setup: function() {
         if (this.initialized) { return false; }
         if (Ext.isEmpty(this.config.record.id)) {
@@ -157,8 +163,8 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
             return false;
         }
         this.getForm().setValues(this.config.record);
-		/* The component rendering is deferred since we are not using renderTo */
-        Ext.getCmp('modx-source-header').html = this.config.record.name;
+        /* The component rendering is deferred since we are not using renderTo */
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(this.config.record.name));
 
         var g,d;
         if (!Ext.isEmpty(this.config.record.properties)) {
@@ -184,6 +190,7 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
         MODx.fireEvent('ready');
         this.initialized = true;
     }
+
     ,beforeSubmit: function(o) {
         var bp = {};
         var sp = Ext.getCmp('modx-grid-source-properties');
@@ -196,6 +203,7 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
         }
         Ext.apply(o.form.baseParams,bp);
     }
+
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
             MODx.loadPage('Source/Update', 'id='+o.result.object.id);
@@ -216,4 +224,3 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
     }
 });
 Ext.reg('modx-panel-source',MODx.panel.Source);
-

--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -12,7 +12,7 @@ MODx.panel.Context = function(config) {
             action: 'Context/Get'
         }
         ,id: 'modx-panel-context'
-		,cls: 'container'
+        ,cls: 'container'
         ,class_key: 'modContext'
         ,plugin: ''
         ,bodyStyle: ''
@@ -21,55 +21,55 @@ MODx.panel.Context = function(config) {
             ,autoHeight: true
             ,layout: 'form'
             ,defaults: { border: false ,msgTarget: 'side' }
-			,items:[{
-				xtype: 'panel'
-				,border: false
-				,cls:'main-wrapper'
-				,layout: 'form'
-				,items: [{
-					xtype: 'statictextfield'
-					,fieldLabel: _('key')
-					,name: 'key'
-					,width: 300
-					,maxLength: 100
-					,enableKeyEvents: true
-					,allowBlank: true
-					,value: config.context
-					,submitValue: true
-				},{
-					xtype: 'textfield'
-					,fieldLabel: _('name')
-					,name: 'name'
-					,width: 300
-					,maxLength: 255
-				},{
-					xtype: 'textarea'
-					,fieldLabel: _('description')
-					,name: 'description'
-					,width: 300
-					,grow: true
-				},{
-					xtype: 'numberfield'
-					,fieldLabel: _('rank')
-					,name: 'rank'
-					,allowBlank: true
-					,width: 300
-				},{
-					html: MODx.onContextFormRender
-					,border: false
-				}]
-			}]
+            ,items:[{
+                xtype: 'panel'
+                ,border: false
+                ,cls:'main-wrapper'
+                ,layout: 'form'
+                ,items: [{
+                    xtype: 'statictextfield'
+                    ,fieldLabel: _('key')
+                    ,name: 'key'
+                    ,width: 300
+                    ,maxLength: 100
+                    ,enableKeyEvents: true
+                    ,allowBlank: true
+                    ,value: config.context
+                    ,submitValue: true
+                },{
+                    xtype: 'textfield'
+                    ,fieldLabel: _('name')
+                    ,name: 'name'
+                    ,width: 300
+                    ,maxLength: 255
+                },{
+                    xtype: 'textarea'
+                    ,fieldLabel: _('description')
+                    ,name: 'description'
+                    ,width: 300
+                    ,grow: true
+                },{
+                    xtype: 'numberfield'
+                    ,fieldLabel: _('rank')
+                    ,name: 'rank'
+                    ,allowBlank: true
+                    ,width: 300
+                },{
+                    html: MODx.onContextFormRender
+                    ,border: false
+                }]
+            }]
         },{
             title: _('context_settings')
             ,autoHeight: true
-			,layout: 'form'
+            ,layout: 'form'
             ,items: [{
                 html: '<p>'+_('context_settings_desc')+'</p>'
                 ,id: 'modx-context-settings-desc'
                 ,xtype: 'modx-description'
             },{
                 xtype: 'modx-grid-context-settings'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,title: ''
                 ,preventRender: true
                 ,context_key: config.context
@@ -82,7 +82,7 @@ MODx.panel.Context = function(config) {
             ,autoHeight: true
             ,items:[{
                 xtype: 'modx-grid-access-context'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,title: ''
                 ,preventRender: true
                 ,context_key: config.context
@@ -104,6 +104,7 @@ MODx.panel.Context = function(config) {
 };
 Ext.extend(MODx.panel.Context,MODx.FormPanel,{
     initialized: false
+
     ,setup: function() {
         if (this.initialized || (this.config.context === '' || this.config.context === 0)) {
             this.fireEvent('ready');
@@ -116,16 +117,17 @@ Ext.extend(MODx.panel.Context,MODx.FormPanel,{
                 ,key: this.config.context
             }
             ,listeners: {
-            	'success': {fn:function(r) {
+                'success': {fn:function(r) {
                     this.getForm().setValues(r.object);
-                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(r.object.key);
+                    Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(r.object.key));
                     this.fireEvent('ready');
                     MODx.fireEvent('ready');
                     this.initialized = true;
-            	},scope:this}
+                },scope:this}
             }
         });
     }
+
     ,beforeSubmit: function(o) {
         var r = {};
 
@@ -134,6 +136,7 @@ Ext.extend(MODx.panel.Context,MODx.FormPanel,{
 
         Ext.apply(o.form.baseParams,r);
     }
+
     ,success: function(o) {
         var g = Ext.getCmp('modx-grid-context-settings');
         if (g) { g.getStore().commitChanges(); }
@@ -141,6 +144,7 @@ Ext.extend(MODx.panel.Context,MODx.FormPanel,{
         var t = parent.Ext.getCmp('modx-resource-tree');
         if (t) { t.refresh(); }
     }
+
     ,getPageHeader: function(config) {
         return MODx.util.getHeaderBreadCrumbs('modx-context-name', [{
             text: _('contexts'),

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -144,6 +144,7 @@ MODx.panel.Dashboard = function(config) {
 };
 Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
     initialized: false
+
     ,setup: function() {
         if (this.initialized) { return false; }
         if (Ext.isEmpty(this.config.record.id)) {
@@ -151,7 +152,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
             return false;
         }
         this.getForm().setValues(this.config.record);
-        Ext.getCmp('modx-header-breadcrumbs').updateHeader(this.config.record.name);
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(this.config.record.name));
 
         /*
         var d = this.config.record.usergroups;
@@ -170,6 +171,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
         MODx.fireEvent('ready');
         this.initialized = true;
     }
+
     ,beforeSubmit: function(o) {
         var bp = {};
         var wg = Ext.getCmp('modx-grid-dashboard-widget-placements');
@@ -178,6 +180,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
         }
         Ext.apply(o.form.baseParams,bp);
     }
+
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
             MODx.loadPage('system/dashboards/update', 'id='+o.result.object.id);
@@ -188,6 +191,7 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
 
         }
     }
+
     ,getPageHeader: function(config) {
         return MODx.util.getHeaderBreadCrumbs('modx-dashboard-header', [{
             text: _('dashboards'),

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -47,7 +47,7 @@ MODx.panel.DashboardWidget = function(config) {
                         'keyup': {scope:this,fn:function(f,e) {
                             var s = _(f.getValue());
                             if (s == undefined) { s = f.getValue(); }
-                                Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(s));
+                            Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(s));
                         }}
                     }
                 },{
@@ -282,7 +282,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
             return false;
         }
         this.getForm().setValues(this.config.record);
-        Ext.getCmp('modx-header-breadcrumbs').updateHeader(this.config.record.name_trans);
+        Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(this.config.record.name_trans));
 
         var d = this.config.record.dashboards;
         var g = Ext.getCmp('modx-grid-dashboard-widget-dashboards');
@@ -320,6 +320,7 @@ Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
             if (g) { g.getStore().commitChanges(); }
         }
     }
+
     ,getPageHeader: function(config) {
         return MODx.util.getHeaderBreadCrumbs('modx-dashboard-widget-header', [{
             text: _('dashboards'),

--- a/manager/controllers/default/security/forms/set/update.class.php
+++ b/manager/controllers/default/security/forms/set/update.class.php
@@ -145,7 +145,7 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('form_customization');
+        return $this->modx->lexicon('form_customization').': '.$this->modx->lexicon('set');
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Added breadcrumbs to Form Customization section:
- Profile section;
- Set section.

Added breadcrumbs to Access Control Lists section:
- User Group section;
- Access Policy section;
- Policy Template section.

### Why is it needed?
As described in the issue #14769, it seems nice to have breadcrumbs in more places than just in resources. @theboxer in https://github.com/modxcms/revolution/pull/14890 did not add breadcrumbs to all sections, this PR adds missing ones.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/14890
https://github.com/modxcms/revolution/issues/14769