### PR TITLE
Changed navigation styles in element tree

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -148,23 +148,31 @@
   background: transparent 0 0;
   display: inline-block;
   width: 10px;
-  padding-left: 6px;
-  margin: 0 0 0 -16px;
+  padding-left: 4px;
+  padding-right: 4px;
+  text-align: center;
+  margin: 0;
+}
+
+.x-tree-arrows .x-tree-elbow-plus:before,
+.x-tree-arrows .x-tree-elbow-minus:before,
+.x-tree-arrows .x-tree-elbow-end-plus:before,
+.x-tree-arrows .x-tree-elbow-end-minus:before {
+  @extend %pseudo-font;
+  content: fa-content($fa-var-caret-right);
 }
 
 .x-tree-arrows .x-tree-elbow-minus:before,
 .x-tree-arrows .x-tree-elbow-end-minus:before {
   @extend %pseudo-font;
   content: fa-content($fa-var-caret-down);
-  padding-left: 4px;
-  width: 12px;
 }
 
 /* tree states */
 .x-tree-node-el {
   color: $treeColor;
   font: $treeNodeFont;
-  padding-left: 6px;
+  padding: 0 0 0 8px;
 
   &.is_folder {
     background: $treeFolderBg;
@@ -292,7 +300,7 @@
     top: 0;
     right: 6px;
     bottom: 0;
-    line-height: 30px;
+    line-height: 34px;
     opacity: 0;
     transition: opacity .4s ease-in;
 
@@ -818,34 +826,6 @@
 
 .x-tree-root-node {
   margin: 0;
-}
-
-.x-tree-arrows .x-tree-elbow-plus,
-.x-tree-arrows .x-tree-elbow-minus,
-.x-tree-arrows .x-tree-elbow-end-plus,
-.x-tree-arrows .x-tree-elbow-end-minus {
-  background: none;
-}
-
-.x-tree-arrows .x-tree-elbow-plus:before,
-.x-tree-arrows .x-tree-elbow-minus:before,
-.x-tree-arrows .x-tree-elbow-end-plus:before,
-.x-tree-arrows .x-tree-elbow-end-minus:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-caret-right);
-  background: transparent 0 0;
-  display: inline-block;
-  width: 10px;
-  padding-left: 6px;
-  margin: 0;
-}
-
-.x-tree-arrows .x-tree-elbow-minus:before,
-.x-tree-arrows .x-tree-elbow-end-minus:before {
-  @extend %pseudo-font;
-  content: fa-content($fa-var-caret-down);
-  padding-left: 4px;
-  width: 12px;
 }
 
 .x-tree-node {


### PR DESCRIPTION
### What does it do?
Changed the navigation styles in the element tree: buttons and selected item and simplified styles.

**Buttons:**
Before (ovals / not centered in height):
![tree_1_before](https://user-images.githubusercontent.com/12523676/73613139-096e5900-460c-11ea-9423-e906ddc43509.png)

After:
![tree_1_after](https://user-images.githubusercontent.com/12523676/73613138-096e5900-460c-11ea-8097-4846dbb15e62.png)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14686 (6)