### PR TITLE
Fix loading static element content

### DIFF
--- a/_build/test/Tests/Model/Element/modStaticElementTest.php
+++ b/_build/test/Tests/Model/Element/modStaticElementTest.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+*/
+namespace MODX\Revolution\Tests\Model\Element;
+
+use MODX\Revolution\modSnippet;
+use MODX\Revolution\modX;
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\MODxTestHarness;
+use MODX\Revolution\Sources\modFileMediaSource;
+use MODX\Revolution\Sources\modMediaSource;
+
+/**
+ * Tests related to the modTag class.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group Element
+ * @group modTag
+ */
+class modStaticElementTest extends MODxTestCase {
+    public function setUp()
+    {
+        $this->modx = MODxTestHarness::getFixture(modX::class, 'modx');
+    }
+
+    public function testStaticElement()
+    {
+        $rc = [
+            'recalculate_source_file' => true,
+        ];
+        /** @var modSnippet $el */
+        $el = $this->modx->newObject(modSnippet::class);
+        $el->fromArray([
+            'static' => false,
+            'static_file' => MODX_BASE_PATH.'_build/test/data/snippets/modSnippetTest/modSnippetTest.snippet.php'
+        ]);
+
+        self::assertFalse($el->isStatic());
+        self::assertFalse($el->getSourceFile($rc));
+
+        $el->set('static', true);
+        self::assertTrue($el->isStatic());
+        self::assertEquals(MODX_BASE_PATH . '_build/test/data/snippets/modSnippetTest/modSnippetTest.snippet.php', $el->getSourceFile($rc));
+
+        /** @var modMediaSource $source */
+        $source = $this->modx->newObject(modFileMediaSource::class);
+        $source->setProperties([
+            'basePath' => ['name' => 'basePath', 'value' => '_build/test/data'],
+            'basePathRelative' => ['name' => 'basePathRelative', 'value' => true],
+        ]);
+        $source->save();
+
+        $el->set('source', $source->get('id'));
+        $el->set('static_file', 'snippets/modSnippetTest/modSnippetTest.snippet.php');
+
+        self::assertTrue($el->isStatic());
+        self::assertEquals(MODX_BASE_PATH . '_build/test/data/snippets/modSnippetTest/modSnippetTest.snippet.php', $el->getSourceFile($rc));
+        $source->set('is_stream', false);
+        $source->save();
+
+        $el->setSource($source);
+
+        self::assertTrue($el->isStatic());
+        self::assertEquals('snippets/modSnippetTest/modSnippetTest.snippet.php', $el->getSourceFile($rc));
+        $source->remove();
+    }
+}

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -576,10 +576,10 @@ class modElement extends modAccessibleSimpleObject
         if ($this->get('source') > 0) {
             /** @var modMediaSource $source */
             $source = $this->getSource();
+            $source->initialize();
             if ($source) {
                 // Streaming source? Init and return the full path to be read.
                 if ($source->get('is_stream')) {
-                    $source->initialize();
                     $result = $source->getBasePath() . $filename;
                 }
 


### PR DESCRIPTION
## What does it do? 

The getSourceFile method now returns either a streamable file (abs path), a path within the media source, or false.

The getFileContent method now tries to load a streamable path first, before attempting to fetch through the media source.

### Why is it needed?

Static elements are terribly broken in 3.x. 

### Related issue(s)/PR(s)

..