### PR TITLE
Fix package dependency constraints not working

### DIFF
--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -513,7 +513,7 @@ class modTransportPackage extends xPDOObject
                 default:
                     /* get latest installed package version */
                     $latestQuery = $this->xpdo->newQuery(
-                        'modTransportPackage',
+                        modTransportPackage::class,
                         [
                             [
                                 "UCASE({$this->xpdo->escape('package_name')}) LIKE UCASE({$this->xpdo->quote($package)})",
@@ -549,7 +549,7 @@ class modTransportPackage extends xPDOObject
 
             /* get latest installed package version */
             $latestQuery = $this->xpdo->newQuery(
-                'modTransportPackage',
+                modTransportPackage::class,
                 [
                     [
                         "UCASE({$this->xpdo->escape('package_name')}) LIKE UCASE({$this->xpdo->quote($package)})",


### PR DESCRIPTION
### What does it do?
Use the fully qualified classname when checking the latest installed package version for package dependencies

### Why is it needed?
Checking dependency constraints would result in an error because of invalid SQL

### Related issue(s)/PR(s)
-