### PR TITLE
Show an error message too, if the core use an old autoloader.

### DIFF
--- a/setup/processors/database/connection.php
+++ b/setup/processors/database/connection.php
@@ -37,7 +37,7 @@ $xpdo = $install->getConnection($mode);
 $errors = [];
 $dbExists = false;
 if (!is_object($xpdo) || !($xpdo instanceof \xPDO\xPDO)) {
-    if (is_bool($xpdo)) {
+    if (is_bool($xpdo) || is_null($xpdo)) {
         $this->error->failure($install->lexicon('xpdo_err_ins'));
     } else {
         $this->error->failure($xpdo);


### PR DESCRIPTION
### What does it do?
Show an error message too, if the core use an old autoloader.

### Why is it needed?
Then $xpdo could be null and a blank error message is shown.

I tried to update an 3.0.0-alpha1 from git without running composer update.

### Related issue(s)/PR(s)
Not as I know.