### PR TITLE
Fix drag and drop not working by removing the reference to MODx.action

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -388,7 +388,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             ui.addClass('haschildren');
             ui.removeClass('icon-resource');
         }
-        if((MODx.request.a == MODx.action['Resource/Update'])){
+        if((MODx.request.a === 'Resource/Update')){
             if(dropNode.attributes.pk == MODx.request.id) {
                 var parentFieldCmb = Ext.getCmp('modx-resource-parent');
                 var parentFieldHidden = Ext.getCmp('modx-resource-parent-hidden');
@@ -755,7 +755,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             url: this.config.url
             ,params: {
                 target: dropEvent.target.attributes.id
-                ,activeTarget: MODx.request.a == MODx.action['Resource/Update'] ? MODx.request.id : ''
+                ,activeTarget: MODx.request.a === 'Resource/Update' ? MODx.request.id : ''
                 ,source: dropEvent.source.dragData.node.attributes.id
                 ,point: dropEvent.point
                 ,data: encodeURIComponent(encNodes)

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -322,7 +322,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             ui.addClass('haschildren');
             ui.removeClass('icon-resource');
         }
-        if((MODx.request.a == MODx.action['Resource/Update']) && dropNode.attributes.pk == MODx.request.id){
+        if((MODx.request.a === 'Resource/Update') && dropNode.attributes.pk == MODx.request.id){
             var parentFieldCmb = Ext.getCmp('modx-resource-parent');
             var parentFieldHidden = Ext.getCmp('modx-resource-parent-hidden');
             if(parentFieldCmb && parentFieldHidden){


### PR DESCRIPTION
### What does it do?
Remove reference to MODx.action in ExtJS components

### Why is it needed?
To fix drag and drop of resources

### Related issue(s)/PR(s)
Fixes issue #14987 thanks to @Mark-H 