### PR TITLE
Add context key to reload URL when switching templates

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -336,7 +336,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     this.warnUnsavedChanges = false;
                     MODx.activePage.submitForm({
                         success: {fn:function(r) {
-                            MODx.loadPage(r.result.object.action, 'id='+r.result.object.id+'&reload='+r.result.object.reload + '&class_key='+ r.result.object.class_key);
+                            MODx.loadPage(r.result.object.action, 'id='+r.result.object.id+'&reload='+r.result.object.reload + '&class_key='+ r.result.object.class_key + '&context_key='+ r.result.object.context_key);
                         },scope:this}
                     },{
                         bypassValidCheck: true


### PR DESCRIPTION
### What does it do?
Adds the context key to the reload url when changing templates of new resources.

### Why is it needed?
When users have, who only have access to a certain context (not web), create a new resource and switch templates they would get a `context_err_nf` error because the manager resource create controller sets the context from the "context_key" script property which wasn't set because it wasn't part of the URL.

### Related issue(s)/PR(s)
Fixes issue #14965

Big thanks to @emiehilbelink-adwise for the real-time steps to reproduce.
