### PR TITLE
Date TV improvements

### DIFF
--- a/manager/assets/modext/util/datetime.js
+++ b/manager/assets/modext/util/datetime.js
@@ -31,6 +31,11 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      */
     ,hiddenFormat:'Y-m-d H:i:s'
     /**
+     * @cfg {String} hiddenFormat Format of datetime used to store value in hidden field
+     * and submitted to server (defaults to 'Y-m-d H:i:s' that is mysql format)
+     */
+    ,hiddenFormatForTimeHidden:'Y-m-d 00:00:00'
+    /**
      * @cfg {Boolean} otherToNow Set other field to now() if not explicly filled in (defaults to true)
      */
     ,otherToNow:true
@@ -87,6 +92,10 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         // offset time
         if (!this.hasOwnProperty('offset_time') || isNaN(this.offset_time)) {
             this.offset_time = 0;
+        }
+
+        if (this.hideTime) {
+            this.hiddenFormat = this.hiddenFormatForTimeHidden;
         }
 
         // create DateField

--- a/manager/assets/modext/util/datetime.js
+++ b/manager/assets/modext/util/datetime.js
@@ -31,8 +31,8 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      */
     ,hiddenFormat:'Y-m-d H:i:s'
     /**
-     * @cfg {String} hiddenFormat Format of datetime used to store value in hidden field
-     * and submitted to server (defaults to 'Y-m-d H:i:s' that is mysql format)
+     * @cfg {String} hiddenFormatForTimeHidden Format of datetime used to store value in hidden field
+     * and submitted to server when `hideTime` is set to `true` (defaults to 'Y-m-d 00:00:00' that is mysql format)
      */
     ,hiddenFormatForTimeHidden:'Y-m-d 00:00:00'
     /**


### PR DESCRIPTION
### What does it do?
Added an option to set the hidden format for date TV's when the time is hidden

### Why is it needed?
This makes it possible to hide the time option for users and set the saved time to something custom instead of setting the time to the moment it got saved.

### Related issue(s)/PR(s)
Resolves issue #12591