### PR TITLE
Fix add script tag to meet W3C requirements

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1542,7 +1542,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1565,7 +1565,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
         }
     }
 


### PR DESCRIPTION
W3C validator output warning "The type attribute is unnecessary for JavaScript resources."

### What does it do?
Default code generates script tag with type attribute that is unnecessary. For example <script type="text/javascript" src="{src}"></script>
This pull request fix this by delete type attribute for script tag

### Why is it needed?
W3C HTML Validator doesn't throw warning. SEO page params grows
