### PR TITLE
Fix contexts.tpl

### DIFF
--- a/setup/templates/contexts.tpl
+++ b/setup/templates/contexts.tpl
@@ -21,10 +21,10 @@ Ext.onReady(function() {literal}{{/literal}
         <label for="context_web_path">{$_lang.context_web_path}:</label>
     </div>
     <div class="col-2">
-        <input type="text" id="context_web_path" name="context_web_path" value="{$context_web_path}" />
+        <input type="text" id="context_web_path" name="context_web_path" value="{$context_web_path}" onchange="document.getElementById('context_web_path_toggle').checked = true;" />
     </div>
     <div class="col-3">
-        <input type="checkbox" id="context_web_path_toggle" name="context_web_path_toggle" value="1" {$context_web_path_checked|default} />
+        <input type="checkbox" id="context_web_path_toggle" name="context_web_path_toggle" value="1" {$context_web_path_checked|default} onclick="if (!this.checked) document.getElementById('context_web_path_toggle').value = '{$context_web_path}';" />
         <label for="context_web_path_toggle"></label>
     </div>
 </div>
@@ -33,10 +33,10 @@ Ext.onReady(function() {literal}{{/literal}
         <label for="context_web_url">{$_lang.context_web_url}:</label>
     </div>
     <div class="col-2">
-        <input type="text" id="context_web_url" name="context_web_url" value="{$context_web_url}" />
+        <input type="text" id="context_web_url" name="context_web_url" value="{$context_web_url}" onchange="document.getElementById('context_web_url_toggle').checked = true;" />
     </div>
     <div class="col-3">
-        <input type="checkbox" id="context_web_url_toggle" name="context_web_url_toggle" value="1" {$context_web_url_checked|default} onclick="if (!this.checked) Ext.get('context_web_url').set({literal}{{/literal} value: '{$context_web_url}' {literal}}{/literal});" />
+        <input type="checkbox" id="context_web_url_toggle" name="context_web_url_toggle" value="1" {$context_web_url_checked|default} onclick="if (!this.checked) document.getElementById('context_web_url_toggle').value = '{$context_web_url}';" />
         <label for="context_web_url_toggle"></label>
     </div>
 </div>
@@ -50,10 +50,10 @@ Ext.onReady(function() {literal}{{/literal}
         <label for="context_connectors_path">{$_lang.context_connector_path}:</label>
     </div>
     <div class="col-2">
-        <input type="text" id="context_connectors_path" name="context_connectors_path" value="{$context_connectors_path}" onchange="$('context_connectors_path_toggle').checked=true;" />
+        <input type="text" id="context_connectors_path" name="context_connectors_path" value="{$context_connectors_path}" onchange="document.getElementById('context_connectors_path_toggle').checked = true;" />
     </div>
     <div class="col-3">
-        <input type="checkbox" id="context_connectors_path_toggle" name="context_connectors_path_toggle" value="1" {$context_connectors_path_checked|default} onclick="if (!this.checked) $('context_connectors_path').value = '{$context_connectors_path}';" />
+        <input type="checkbox" id="context_connectors_path_toggle" name="context_connectors_path_toggle" value="1" {$context_connectors_path_checked|default} onclick="if (!this.checked) document.getElementById('context_connectors_path_toggle').value = '{$context_connectors_path}';" />
         <label for="context_connectors_path_toggle"></label>
     </div>
 </div>
@@ -63,10 +63,10 @@ Ext.onReady(function() {literal}{{/literal}
         <label for="context_connectors_url">{$_lang.context_connector_url}:</label>
     </div>
     <div class="col-2">
-        <input type="text" id="context_connectors_url" name="context_connectors_url" value="{$context_connectors_url}" onchange="$('context_connectors_url_toggle').checked=true;" />
+        <input type="text" id="context_connectors_url" name="context_connectors_url" value="{$context_connectors_url}" onchange="document.getElementById('context_connectors_url_toggle').checked = true;" />
     </div>
     <div class="col-3">
-        <input type="checkbox" id="context_connectors_url_toggle" name="context_connectors_url_toggle" value="1" {$context_connectors_url_checked|default} onclick="if (!this.checked) $('context_connectors_url').value = '{$context_connectors_url}';" />
+        <input type="checkbox" id="context_connectors_url_toggle" name="context_connectors_url_toggle" value="1" {$context_connectors_url_checked|default} onclick="if (!this.checked) document.getElementById('context_connectors_url_toggle').value = '{$context_connectors_url}';" />
         <label for="context_connectors_url_toggle"></label>
     </div>
 </div>
@@ -81,10 +81,10 @@ Ext.onReady(function() {literal}{{/literal}
         <label for="context_mgr_path">{$_lang.context_manager_path}:</label>
     </div>
     <div class="col-2">
-        <input type="text" id="context_mgr_path" name="context_mgr_path" value="{$context_mgr_path}" onchange="$('context_mgr_path_toggle').checked=true;" />
+        <input type="text" id="context_mgr_path" name="context_mgr_path" value="{$context_mgr_path}" onchange="document.getElementById('context_mgr_path_toggle').checked = true;" />
     </div>
     <div class="col-3">
-        <input type="checkbox" id="context_mgr_path_toggle" name="context_mgr_path_toggle" value="1" {$context_mgr_path_checked|default} onclick="if (!this.checked) $('context_mgr_path').value = '{$context_mgr_path}';" />
+        <input type="checkbox" id="context_mgr_path_toggle" name="context_mgr_path_toggle" value="1" {$context_mgr_path_checked|default} onclick="if (!this.checked) document.getElementById('context_mgr_path_toggle').value = '{$context_mgr_path}';" />
         <label for="context_mgr_path_toggle"></label>
     </div>
 </div>
@@ -94,10 +94,10 @@ Ext.onReady(function() {literal}{{/literal}
         <label for="context_mgr_url">{$_lang.context_manager_url}:</label>
     </div>
     <div class="col-2">
-        <input type="text" id="context_mgr_url" name="context_mgr_url" value="{$context_mgr_url}" onchange="$('context_mgr_url_toggle').checked=true;" />
+        <input type="text" id="context_mgr_url" name="context_mgr_url" value="{$context_mgr_url}" onchange="document.getElementById('context_mgr_url_toggle').checked = true;" />
     </div>
     <div class="col-3">
-        <input type="checkbox" id="context_mgr_url_toggle" name="context_mgr_url_toggle" value="1" {$context_mgr_url_checked|default} onclick="if (!this.checked) $('context_mgr_url').value = '{$context_mgr_url}';" />
+        <input type="checkbox" id="context_mgr_url_toggle" name="context_mgr_url_toggle" value="1" {$context_mgr_url_checked|default} onclick="if (!this.checked) document.getElementById('context_mgr_url_toggle').value = '{$context_mgr_url}';" />
         <label for="context_mgr_url_toggle"></label>
     </div>
 </div>


### PR DESCRIPTION
### What does it do?
- Change $() calls to plain javascript
- Change Ext.get() calls to plain javascript

### Why is it needed?
We don't have jQuery installed and ExtJS is overkill for this.
