### PR TITLE
Switched string literals to use single quotes so that it is compatibl…

### DIFF
--- a/core/model/modx/transport/mysql/modtransportpackage.class.php
+++ b/core/model/modx/transport/mysql/modtransportpackage.class.php
@@ -62,7 +62,7 @@ class modTransportPackage_mysql extends modTransportPackage {
         $c->sortby('modTransportPackage.version_major', 'DESC');
         $c->sortby('modTransportPackage.version_minor', 'DESC');
         $c->sortby('modTransportPackage.version_patch', 'DESC');
-        $c->sortby('IF(modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl","z",IF(modTransportPackage.release = "dev","a",modTransportPackage.release))','DESC');
+        $c->sortby('IF(modTransportPackage.release = \'\' OR modTransportPackage.release = \'ga\' OR modTransportPackage.release = \'pl\',\'z\',IF(modTransportPackage.release = \'dev\',\'a\',modTransportPackage.release))','DESC');
         $c->sortby('modTransportPackage.release_index', 'DESC');
         if((int)$limit > 0) {
             $c->limit((int)$limit, (int)$offset);


### PR DESCRIPTION
…e with ANSI_QUOTES sql mode.

### What does it do?
Switched to using single quotes as double quotes are incompatible with ANSI_QUOTES SQL mode. 

### Why is it needed?
With double quotes, the grid to view previous package versions in the package manager can't load any data as the request fails.

### Related issue(s)/PR(s)
See issue: #14991
