### PR TITLE
Show "Input Option Values" with labels only on TV where it needed

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -562,9 +562,14 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
     }
 
     ,showInputProperties: function(cb,rc,i) {
+        /**
+         * Hide "Input Option Values" by default
+         */
         var element = Ext.getCmp('modx-tv-elements');
+        var element_label = Ext.select('label[for="' + element.id + '"]');
         if (element) {
-            element.show();
+            element.hide();
+            element_label.hide();
         }
 
         this.markPanelDirty();

--- a/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
@@ -1,14 +1,17 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
@@ -1,14 +1,24 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+// Show "Input Option Values"
+var element = Ext.getCmp('modx-tv-elements');
+var element_label = Ext.select('label[for="' + element.id + '"]');
+if (element) {
+    element.show();
+    element_label.show();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/date.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/date.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/email.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/email.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/file.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/file.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/image.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/image.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
@@ -1,14 +1,24 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+// Show "Input Option Values"
+var element = Ext.getCmp('modx-tv-elements');
+var element_label = Ext.select('label[for="' + element.id + '"]');
+if (element) {
+    element.show();
+    element_label.show();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
@@ -1,14 +1,24 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+// Show "Input Option Values"
+var element = Ext.getCmp('modx-tv-elements');
+var element_label = Ext.select('label[for="' + element.id + '"]');
+if (element) {
+    element.show();
+    element_label.show();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
@@ -1,14 +1,24 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+// Show "Input Option Values"
+var element = Ext.getCmp('modx-tv-elements');
+var element_label = Ext.select('label[for="' + element.id + '"]');
+if (element) {
+    element.show();
+    element_label.show();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/number.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/number.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
@@ -1,14 +1,24 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+// Show "Input Option Values"
+var element = Ext.getCmp('modx-tv-elements');
+var element_label = Ext.select('label[for="' + element.id + '"]');
+if (element) {
+    element.show();
+    element_label.show();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
@@ -1,14 +1,24 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+// Show "Input Option Values"
+var element = Ext.getCmp('modx-tv-elements');
+var element_label = Ext.select('label[for="' + element.id + '"]');
+if (element) {
+    element.show();
+    element_label.show();
+}
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/text.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/text.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|default|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|default|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
@@ -1,19 +1,16 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
-{literal}
 
+{literal}
 <script type="text/javascript">
 // <![CDATA[
 var params = {
-{/literal}{foreach from=$params key=k item=v name='p'}
- '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
-{/foreach}{literal}
+{/literal}
+{foreach from=$params key=k item=v name='p'}
+    '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}
+{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
 
 MODx.load({
     xtype: 'panel'


### PR DESCRIPTION
### What does it do?
In https://github.com/modxcms/revolution/pull/14040, the “Input Option Values” field was hidden on TV forms where they were not needed.

However, https://github.com/modxcms/revolution/pull/14040 has several disadvantages:
1) Some TVs (for example, "Hidden", "RichText") do not have a property rendering template, which is why the "Input Option Values" field is still displayed.
2) TV where the "Input Option Values" field is not needed more than where it is needed.

More competently, in my opinion, hide the "Input Option Values" field by default everywhere, and show only where it is needed ("Radio", "Listbox", etc).

Also, this PR hides the description-label for a hidden "Input Option Values", which has always been shown.

### Why is it needed?
UI/UX improvements

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14424
https://github.com/modxcms/revolution/pull/14040
