### PR TITLE
Corrected styles for login

### DIFF
--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -193,12 +193,6 @@ label {
   }
 }
 
-label#rememberme-checkbox {
-  display: flex;
-  justify-content: left;
-  align-items: center;
-}
-
 label > input {
   margin-top: 0.25rem;
 }
@@ -258,6 +252,58 @@ label > input {
 #modx-login-username,
 #modx-login-username-reset {
   margin-top: 10px;
+}
+
+#rememberme-checkbox {
+  & input[type="checkbox"] {
+    width: 0;
+    margin: 0;
+    padding: 0;
+    opacity: 0;
+  }
+
+  & label {
+    position: relative;
+    display: inline-block;
+    padding-left: 22px;
+
+    &:before, &:after {
+        position: absolute;
+        content: "";
+        display: inline-block;
+    }
+
+    &:before {
+        width: 18px;
+        height: 18px;
+        background: $lightestGray;
+        border: 1px solid $lightGray;
+        border-radius: $borderRadius;
+        left: -3px;
+    }
+
+    &:after {
+      height: 5px;
+      width: 10px;
+      border-left: 2px solid;
+      border-bottom: 2px solid;
+      transform: rotate(-45deg);
+      left: 1px;
+      top: 5px;
+    }
+  }
+
+  & input[type="checkbox"] + label::after {
+    content: none;
+  }
+
+  & input[type="checkbox"]:checked + label::after {
+    content: "";
+  }
+
+  & input[type="checkbox"]:focus + label::before {
+    border: 1px solid $blue;
+  }
 }
 
 .c-password-label {

--- a/_build/templates/default/sass/login.scss
+++ b/_build/templates/default/sass/login.scss
@@ -152,6 +152,10 @@ a {
   &:hover {
     opacity: .8;
   }
+
+  &:focus {
+    color: $red;
+  }
 }
 
 .lead {
@@ -357,6 +361,18 @@ label > input {
   direction: rtl;
   padding-right: 1.2rem;
   color: $darkestGray;
+
+  &:hover {
+    opacity: .8;
+  }
+
+  &:focus {
+    color: $red;
+  }
+
+  &:focus option {
+    color: $darkestGray;
+  }
 }
 
 .c-languageselect__arrow {
@@ -380,6 +396,10 @@ label > input {
 
   &:hover {
     opacity: .8;
+  }
+
+  &:focus {
+    color: $red;
   }
 
   .c-arrow {

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -95,10 +95,12 @@
                                 <input type="password" id="modx-login-password" name="password" autocomplete="on" required>
                             </label>
 
-                            <label id="rememberme-checkbox">
+                            <div id="rememberme-checkbox">
                                 <input type="checkbox" id="modx-login-rememberme" name="rememberme" autocomplete="on" {if $_post.rememberme|default}checked="checked"{/if} value="1">
-                                {$rememberme}
-                            </label>
+                                <label for="modx-login-rememberme">
+                                    {$rememberme}
+                                </label>
+                            </div>
 
                             {$onManagerLoginFormRender}
 


### PR DESCRIPTION
### What does it do?
Corrected styles for login:
- Added styles for checkbox
- Added styles for :focus on elements
There was a discussion on the forum about what is missing: focus highlighting on elements.
Made it through color.

### How it look like:
![login](https://user-images.githubusercontent.com/12523676/74664877-0486d900-51b8-11ea-985f-700a30c7eda3.gif)

### Why is it needed?
UI / UX improvements

### Related issue(s)/PR(s)
None
