### PR TITLE
Add transliteration of files when uploading to a media source

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -812,6 +812,34 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
     }
 
     /**
+     * Translitiration filenames
+     * @param string $fileName
+     * @return string
+     */
+    public function translitFileName ($fileName)
+    {
+        $charList = array(
+            "А"=>"a","Б"=>"b","В"=>"v","Г"=>"g",
+            "Д"=>"d","Е"=>"e","Ё"=>"e","Ж"=>"j","З"=>"z","И"=>"i",
+            "Й"=>"y","К"=>"k","Л"=>"l","М"=>"m","Н"=>"n",
+            "О"=>"o","П"=>"p","Р"=>"r","С"=>"s","Т"=>"t",
+            "У"=>"u","Ф"=>"f","Х"=>"h","Ц"=>"ts","Ч"=>"ch",
+            "Ш"=>"sh","Щ"=>"sch","Ъ"=>"","Ы"=>"yi","Ь"=>"",
+            "Э"=>"e","Ю"=>"yu","Я"=>"ya","а"=>"a","б"=>"b",
+            "в"=>"v","г"=>"g","д"=>"d","е"=>"e","ё"=>"e","ж"=>"j",
+            "з"=>"z","и"=>"i","й"=>"y","к"=>"k","л"=>"l",
+            "м"=>"m","н"=>"n","о"=>"o","п"=>"p","р"=>"r",
+            "с"=>"s","т"=>"t","у"=>"u","ф"=>"f","х"=>"h",
+            "ц"=>"ts","ч"=>"ch","ш"=>"sh","щ"=>"sch","ъ"=>"y",
+            "ы"=>"yi","ь"=>"","э"=>"e","ю"=>"yu","я"=>"ya",
+            " -"=> "", ","=> "", " "=> "-", "/"=> "_",
+            "-"=> ""
+        );
+
+        return strtr($fileName,$charList);
+    }
+
+    /**
      * Upload files to a specific folder on the file system
      *
      * @param string $container
@@ -847,6 +875,10 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
         /* loop through each file and upload */
         foreach ($objects as $file) {
+            if (!preg_match('/^[A-z]+$/i',$file['name'])){
+                $file['name'] = $this->translitFileName($file['name']);
+            }
+
             /* invoke event */
             $this->xpdo->invokeEvent('OnFileManagerBeforeUpload', array(
                 'files' => &$objects,


### PR DESCRIPTION
Add translit for filenames

### What does it do?
Translates the file name into transliteration of Latin characters when they are found in the file name.

### Why is it needed?
English-speaking MODX users do not even know how many problems a file can give on server, for example, with a russian name.

### Related issue(s)/PR(s)
Related issue #15007
