### PR TITLE
Also add missing events OnUserBeforeAddToGroup and OnUserAddToGroup for MODX3

### DIFF
--- a/core/src/Revolution/Processors/Security/Group/User/Create.php
+++ b/core/src/Revolution/Processors/Security/Group/User/Create.php
@@ -81,10 +81,29 @@ class Create extends Processor
         $rank = $this->getNewRank();
         $membership->set('rank', $rank);
 
+        /* invoke OnUserBeforeAddToGroup event */
+        $OnUserBeforeAddToGroup = $this->modx->invokeEvent('OnUserBeforeAddToGroup', [
+            'user' => &$this->user,
+            'usergroup' => &$this->userGroup,
+            'membership' => &$membership,
+        ]);
+        $canSave = $this->processEventResponse($OnUserBeforeAddToGroup);
+
+        if (!empty($canSave)) {
+            return $this->failure($canSave);
+        }
+
         /* save membership */
         if ($membership->save() === false) {
             return $this->failure($this->modx->lexicon('user_group_member_err_save'));
         }
+
+        /* invoke OnUserAddToGroup event */
+        $this->modx->invokeEvent('OnUserAddToGroup', [
+            'user' => &$this->user,
+            'usergroup' => &$this->userGroup,
+            'membership' => &$membership,
+        ]);
 
         /* set as primary group if the only group for user */
         if ($rank === 0) {


### PR DESCRIPTION
### What does it do?
Added missing events OnUserBeforeAddToGroup and OnUserAddToGroup to processor

### Why is it needed?
Make the event emit 100% compliant to expected behaviour when a user gets added to a user group.

### Related issue(s)/PR(s)
fix #15020