### PR TITLE
Fix trash getlist processor for invalid parents

### DIFF
--- a/core/model/modx/processors/resource/trash/getlist.class.php
+++ b/core/model/modx/processors/resource/trash/getlist.class.php
@@ -108,9 +108,14 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
         $parents = array();
         $parent = $objectArray['parent'];
 
-        while ($parent!=0) {
-            $parents[] = $this->modx->getObject('modResource', $parent);
-            $parent = end($parents)->get('parent');
+        while ($parent != 0) {
+            $parentObj = $this->modx->getObject('modResource', $parent);
+            if ($parentObj) {
+                $parents[] = $parentObj;
+                $parent = end($parents)->get('parent');
+            } else {
+                $parent = 0;
+            }
         }
 
         $parentPath = "";


### PR DESCRIPTION
### What does it do?
Check, if the parent object could be retrieved

### Why is it needed?
Otherwise the processor will exit with a fatal error:
`PHP Fatal error:  Uncaught Error: Call to a member function get()`

### Related issue(s)/PR(s)
None