### PR TITLE
Prevent rewrite the .well-known directory used by LetsEncrypt

### DIFF
--- a/ht.access
+++ b/ht.access
@@ -19,7 +19,7 @@ RewriteRule "/\.|^\.(?!well-known/)" - [F]
 
 
 # Prevent rewrite the .well-known directory used by LetsEncrypt by rules below of this rule
-RewriteRule "^\.well-known" - [L]
+RewriteRule "^\.well-known/" - [L]
 
 
 # Rewrite www.example.com -> example.com -- used with SEO Strict URLs plugin

--- a/ht.access
+++ b/ht.access
@@ -18,6 +18,10 @@ RewriteBase /
 RewriteRule "/\.|^\.(?!well-known/)" - [F]
 
 
+# Prevent rewrite the .well-known directory used by LetsEncrypt by rules below of this rule
+RewriteRule "^\.well-known" - [L]
+
+
 # Rewrite www.example.com -> example.com -- used with SEO Strict URLs plugin
 #RewriteCond %{HTTP_HOST} .
 #RewriteCond %{HTTP_HOST} ^www.(.*)$ [NC]


### PR DESCRIPTION
### What does it do?
Prevent rewrite the .well-known directory

### Why is it needed?
The directory is used by LetsEncrypt and should not been rewritten.