### PR TITLE
Solve a few PHP 7.4 deprecation warnings 

### DIFF
--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -702,7 +702,7 @@ class modTransportPackage extends xPDOObject
     protected function _bytes($value)
     {
         $value = trim($value);
-        $modifier = strtolower($value{strlen($value) - 1});
+        $modifier = strtolower($value[strlen($value) - 1]);
         switch ($modifier) {
             case 'g':
                 $value *= 1024;

--- a/core/src/Revolution/modPhpThumb.php
+++ b/core/src/Revolution/modPhpThumb.php
@@ -356,7 +356,7 @@ class modPhpThumb extends phpthumb
             //$AbsoluteFilename = $filename;
             return $filename;
 
-        } elseif ($this->iswindows && isset($filename{1}) && ($filename{1} == ':')) {
+        } elseif ($this->iswindows && isset($filename[1]) && ($filename[1] == ':')) {
 
             // absolute pathname (Windows)
             $AbsoluteFilename = $filename;
@@ -366,14 +366,14 @@ class modPhpThumb extends phpthumb
             // absolute pathname (Windows)
             $AbsoluteFilename = $filename;
 
-        } elseif ($filename{0} == '/') {
+        } elseif ($filename[0] == '/') {
 
             if (@is_readable($filename) && !@is_readable($this->config_document_root . $filename)) {
 
                 // absolute filename (*nix)
                 $AbsoluteFilename = $filename;
 
-            } elseif (isset($filename{1}) && ($filename{1} == '~')) {
+            } elseif (isset($filename[1]) && ($filename[1] == '~')) {
 
                 // /~user/path
                 if ($ApacheLookupURIarray = phpthumb_functions::ApacheLookupURIarray($filename)) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -698,7 +698,7 @@ class modX extends xPDO {
                 parent :: setDebug(false);
             }
             else {
-                $debug = (is_int($debug) ? $debug : defined($debug) ? intval(constant($debug)) : 0);
+                $debug = (is_int($debug) ? $debug : (defined($debug) ? intval(constant($debug)) : 0));
                 if ($debug) {
                     error_reporting($debug);
                     parent :: setLogLevel(xPDO::LOG_LEVEL_INFO);

--- a/setup/includes/parser/modinstallsmarty.class.php
+++ b/setup/includes/parser/modinstallsmarty.class.php
@@ -70,7 +70,7 @@ class modInstallSmarty extends Smarty implements modInstallParser {
         $written= false;
         if (!empty ($dirname)) {
             $dirname= strtr(trim($dirname), '\\', '/');
-            if ($dirname{strlen($dirname) - 1} == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
+            if ($dirname[strlen($dirname) - 1] == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
             if (is_dir($dirname) || (is_writable(dirname($dirname)) && mkdir($dirname))) {
                 $written= true;
             } elseif (!$this->writeTree(dirname($dirname))) {


### PR DESCRIPTION
### What does it do?
- Migrate deprecated curly brace array access syntax to bracket syntax
- Add parentheses to unparenthesized nested ternary

### Why is it needed?
It solves a few deprecation warnings when running MODX 3 using PHP 7.4 or newer.

### Related issue(s)/PR(s)
Related issue: #15030