### PR TITLE
Prevent rewrite the .well-known directory used by LetsEncrypt

### DIFF
--- a/ht.access
+++ b/ht.access
@@ -12,6 +12,9 @@ RewriteEngine On
 RewriteBase /
 
 
+# Prevent rewrite the .well-known directory used by LetsEncrypt by rules below of this rule
+RewriteRule "^\.well-known/" - [L]
+
 
 # Prevent dot directories (hidden directories like .git) to be exposed to the public
 # Except for the .well-known directory used by LetsEncrypt a.o


### PR DESCRIPTION
### What does it do?
Prevent rewrite the .well-known directory

### Why is it needed?
The directory is used by LetsEncrypt and should not been rewritten.