### PR TITLE
Reduce unnecessary and deprecated use of `xPDO::loadClass`

### DIFF
--- a/_build/test/Tests/Model/Lexicon/modLexiconTest.php
+++ b/_build/test/Tests/Model/Lexicon/modLexiconTest.php
@@ -30,7 +30,6 @@ class modLexiconTest extends MODxTestCase {
 
     public function setUp() {
         parent::setUp();
-        $this->modx->loadClass(modLexicon::class,null,true,true);
         $this->lexicon = new modLexicon($this->modx);
     }
 

--- a/_build/test/Tests/Model/Registry/modRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modRegisterTest.php
@@ -30,7 +30,6 @@ class modRegisterTest extends MODxTestCase {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');
-        $modx->loadClass('registry.modRegister', '', false, true);
         $modx->registry->addRegister('register', modMemoryRegister::class, ['directory' => 'register']);
     }
 

--- a/core/src/Revolution/Processors/Browser/Browser.php
+++ b/core/src/Revolution/Processors/Browser/Browser.php
@@ -77,7 +77,6 @@ abstract class Browser extends Processor
     public function getSource()
     {
         $source = $this->getProperty('source', 1);
-        $this->modx->loadClass('sources.modMediaSource');
         $this->source = modMediaSource::getDefaultSource($this->modx, $source);
         if (!$this->source->getWorkingContext()) {
             return $this->modx->lexicon('permission_denied');

--- a/core/src/Revolution/Processors/Source/Type/GetList.php
+++ b/core/src/Revolution/Processors/Source/Type/GetList.php
@@ -43,7 +43,6 @@ class GetList extends Processor
     {
         $this->modx->setPackageMeta('sources', $this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'model/modx/');
 
-        $this->modx->loadClass(modMediaSource::class);
         $descendants = $this->modx->getDescendants(modMediaSource::class);
 
         $list = [];

--- a/core/src/Revolution/Processors/System/PhpThumb.php
+++ b/core/src/Revolution/Processors/System/PhpThumb.php
@@ -97,7 +97,6 @@ class PhpThumb extends Processor
     public function getSource($sourceId)
     {
         /** @var modMediaSource|modFileMediaSource $source */
-        $this->modx->loadClass(modMediaSource::class);
         $this->source = modMediaSource::getDefaultSource($this->modx, $sourceId, false);
         if ($this->source === null) {
             return false;

--- a/core/src/Revolution/Processors/Workspace/Packages/Upload.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Upload.php
@@ -58,7 +58,6 @@ class Upload extends Processor
      */
     public function getSource()
     {
-        $this->modx->loadClass(modMediaSource::class);
         $this->source = modMediaSource::getDefaultSource($this->modx);
         if ($this->source === null || !$this->source->getWorkingContext()) {
             return false;

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -725,7 +725,6 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
                 return false;
             }
-            $this->xpdo->loadClass('sources.modMediaSource');
             /** @var modMediaSource $toSource */
             $toSource = modMediaSource::getDefaultSource($this->xpdo, $to_source);
             if (!$toSource->getWorkingContext()) {

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -542,7 +542,6 @@ class modParser
             if (!empty($this->modx->sourceCache[$class][$realname]['source'])) {
                 if (!empty($this->modx->sourceCache[$class][$realname]['source']['class_key'])) {
                     $sourceClassKey = $this->modx->sourceCache[$class][$realname]['source']['class_key'];
-                    $this->modx->loadClass('sources.modMediaSource');
                     /* @var modMediaSource $source */
                     $source = $this->modx->newObject($sourceClassKey);
                     $source->fromArray($this->modx->sourceCache[$class][$realname]['source'],'',true,true);

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -1018,7 +1018,6 @@ class modUser extends modPrincipal
         if (empty($this->Profile->photo)) {
             return '';
         }
-        $this->xpdo->loadClass('sources.modMediaSource');
         /** @var modMediaSource $source */
         $source = modMediaSource::getDefaultSource($this->xpdo, $this->xpdo->getOption('photo_profile_source'));
 

--- a/manager/controllers/default/element/tv/create.class.php
+++ b/manager/controllers/default/element/tv/create.class.php
@@ -92,7 +92,6 @@ Ext.onReady(function() {
         $c->sortby($this->modx->escape('key'),'DESC');
         $contexts = $this->modx->getCollection(modContext::class, $c);
         $list = [];
-        $this->modx->loadClass('sources.modMediaSource');
         /** @var $source modMediaSource */
         $source = modMediaSource::getDefaultSource($this->modx);
         /** @var modContext $context */

--- a/manager/controllers/default/system/file/create.class.php
+++ b/manager/controllers/default/system/file/create.class.php
@@ -104,7 +104,6 @@ class SystemFileCreateManagerController extends modManagerController
     public function getSource()
     {
         /** @var modMediaSource|modFileMediaSource $source */
-        $this->modx->loadClass(modMediaSource::class);
         $source = $this->modx->getOption('source', $this->scriptProperties, false);
         if (!empty($source)) {
             $source = $this->modx->getObject(modMediaSource::class, $source);

--- a/manager/controllers/default/system/file/edit.class.php
+++ b/manager/controllers/default/system/file/edit.class.php
@@ -121,7 +121,6 @@ class SystemFileEditManagerController extends modManagerController
     public function getSource()
     {
         /** @var modMediaSource|modFileMediaSource $source */
-        $this->modx->loadClass(modMediaSource::class);
         $source = $this->modx->getOption('source', $this->scriptProperties, false);
         if (!empty($source)) {
             $source = $this->modx->getObject(modMediaSource::class, $source);


### PR DESCRIPTION
### What does it do?
Removes calls to `xPDO::loadClass` where we are sure the class in question has already been loaded.

Only calls to `xPDO::loadClass` necessary to support backwards compatibility with older xPDO models are kept. 

### Why is it needed?
As of MODX 3.0, calling `xPDO::loadClass` is no longer necessary and deprecated. Instead of using loadClass, use the PSR-4 class references that are available through the autoloader.

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)
