### PR TITLE
Corrected TV form with the Number type

### DIFF
--- a/manager/templates/default/element/tv/renders/inputproperties/number.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/number.tpl
@@ -29,7 +29,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
@@ -39,25 +39,11 @@ MODx.load({
         ,cls: 'desc-under'
     },{
         xtype: 'combo-boolean'
-        ,fieldLabel: _('number_allowdecimals')
-        ,name: 'inopt_allowDecimals'
-        ,hiddenName: 'inopt_allowDecimals'
-        ,id: 'inopt_allowDecimals{/literal}{$tv|default}{literal}'
-        ,width: 200
-        ,value: (params['allowDecimals']) ? !(params['allowDecimals'] === 0 || params['allowDecimals'] === 'false') : true
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_allowDecimals{/literal}{$tv|default}{literal}'
-        ,html: _('allowdecimals_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'combo-boolean'
         ,fieldLabel: _('number_allownegative')
         ,name: 'inopt_allowNegative'
         ,hiddenName: 'inopt_allowNegative'
         ,id: 'inopt_allowNegative{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowNegative']) ? !(params['allowNegative'] === 0 || params['allowNegative'] === 'false') : true
         ,listeners: oc
     },{
@@ -66,57 +52,108 @@ MODx.load({
         ,html: _('allownegative_desc')
         ,cls: 'desc-under'
     },{
-        xtype: 'numberfield'
-        ,fieldLabel: _('number_decimalprecision')
-        ,name: 'inopt_decimalPrecision'
-        ,id: 'inopt_decimalPrecision{/literal}{$tv|default}{literal}'
-        ,value: params['decimalPrecision'] || 2
-        ,width: 100
-        ,listeners: oc
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .3
+            ,items: [{
+                xtype: 'combo-boolean'
+                ,fieldLabel: _('number_allowdecimals')
+                ,name: 'inopt_allowDecimals'
+                ,hiddenName: 'inopt_allowDecimals'
+                ,id: 'inopt_allowDecimals{/literal}{$tv|default}{literal}'
+                ,anchor: '100%'
+                ,value: (params['allowDecimals']) ? !(params['allowDecimals'] === 0 || params['allowDecimals'] === 'false') : true
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_allowDecimals{/literal}{$tv|default}{literal}'
+                ,html: _('allowdecimals_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .4
+            ,items: [{
+                xtype: 'numberfield'
+                ,fieldLabel: _('number_decimalprecision')
+                ,name: 'inopt_decimalPrecision'
+                ,id: 'inopt_decimalPrecision{/literal}{$tv|default}{literal}'
+                ,value: params['decimalPrecision'] || 2
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_decimalPrecision{/literal}{$tv|default}{literal}'
+                ,html: _('decimalprecision_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .3
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('number_decimalseparator')
+                ,name: 'inopt_decimalSeparator'
+                ,id: 'inopt_decimalSeparator{/literal}{$tv|default}{literal}'
+                ,value: params['decimalSeparator'] || '.'
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_decimalSeparator{/literal}{$tv|default}{literal}'
+                ,html: _('decimalseparator_desc')
+                ,cls: 'desc-under'
+            }]
+        }]
     },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_decimalPrecision{/literal}{$tv|default}{literal}'
-        ,html: _('decimalprecision_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('number_decimalseparator')
-        ,name: 'inopt_decimalSeparator'
-        ,id: 'inopt_decimalSeparator{/literal}{$tv|default}{literal}'
-        ,value: params['decimalSeparator'] || '.'
-        ,width: 100
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_decimalSeparator{/literal}{$tv|default}{literal}'
-        ,html: _('decimalseparator_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('number_maxvalue')
-        ,name: 'inopt_maxValue'
-        ,id: 'inopt_maxValue{/literal}{$tv|default}{literal}'
-        ,value: params['maxValue'] || ''
-        ,width: 300
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_maxValue{/literal}{$tv|default}{literal}'
-        ,html: _('maxvalue_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('number_minvalue')
-        ,name: 'inopt_minValue'
-        ,id: 'inopt_minValue{/literal}{$tv|default}{literal}'
-        ,value: params['minValue'] || ''
-        ,width: 300
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_minValue{/literal}{$tv|default}{literal}'
-        ,html: _('minvalue_desc')
-        ,cls: 'desc-under'
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('number_minvalue')
+                ,name: 'inopt_minValue'
+                ,id: 'inopt_minValue{/literal}{$tv|default}{literal}'
+                ,value: params['minValue'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_minValue{/literal}{$tv|default}{literal}'
+                ,html: _('minvalue_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('number_maxvalue')
+                ,name: 'inopt_maxValue'
+                ,id: 'inopt_maxValue{/literal}{$tv|default}{literal}'
+                ,value: params['maxValue'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_maxValue{/literal}{$tv|default}{literal}'
+                ,html: _('maxvalue_desc')
+                ,cls: 'desc-under'
+            }]
+        }]
     }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });


### PR DESCRIPTION
### What does it do?
Corrected the TV form with the Number type:
- Changed the order
- Related items grouped

Later I will correct for TV with other types.

**Before:**
![tv-num-1](https://user-images.githubusercontent.com/12523676/78133935-fa4b3200-7427-11ea-9db1-97102ce63765.png)

**After:**
![tv-num-2](https://user-images.githubusercontent.com/12523676/78133946-ff0fe600-7427-11ea-8241-31d94abcc234.png)

### Why is it needed?
Improves UI / UX
It became more beautiful :)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15009