### PR TITLE
Corrected TV form with the ResourceList type

### DIFF
--- a/core/lexicon/en/tv_widget.inc.php
+++ b/core/lexicon/en/tv_widget.inc.php
@@ -113,8 +113,6 @@ $_lang['resourcelist_where'] = 'Where Conditions';
 $_lang['resourcelist_where_desc'] = 'A JSON object of where conditions to filter by in the query that grabs the list of Resources. (Does not support TV searching.)<br/>Examples: [{"template:=":"4"}], [{"pagetitle:!=":"Home"}], [{"parent:IN":[34,56]}]';
 $_lang['richtext'] = 'RichText';
 $_lang['sentence_case'] = 'Sentence Case';
-$_lang['shownone'] = 'Allow Empty Choice';
-$_lang['shownone_desc'] = 'Allow the user to select an empty choice which is a blank value.';
 $_lang['start_day'] = 'Start Day';
 $_lang['start_day_desc'] = 'Day index at which the week should begin, 0-based (defaults to 0, which is Sunday)';
 $_lang['string'] = 'String';

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/resourcelist.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/resourcelist.class.php
@@ -70,10 +70,8 @@ class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
         $resources = $this->modx->getCollection(modResource::class, $c);
 
         /* iterate */
-        $opts = [];
-        if (!empty($params['showNone'])) {
-            $opts[] = ['value' => '','text' => '-','selected' => $this->tv->get('value') == ''];
-        }
+        $opts[] = ['value' => '','text' => '-','selected' => $this->tv->get('value') == ''];
+
         /** @var modResource $resource */
         foreach ($resources as $resource) {
             $selected = $resource->get('id') == $this->tv->get('value');

--- a/manager/templates/default/element/tv/renders/input/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/input/resourcelist.tpl
@@ -1,9 +1,8 @@
 <select id="tv{$tv->id}" name="tv{$tv->id}">
 {foreach from=$opts item=item}
-	<option value="{$item.value}" {if $item.selected} selected="selected"{/if}>{$item.text}</option>
+    <option value="{$item.value}" {if $item.selected}selected="selected"{/if}>{$item.text}</option>
 {/foreach}
 </select>
-
 
 <script type="text/javascript">
 // <![CDATA[
@@ -17,31 +16,22 @@ Ext.onReady(function() {
         ,triggerAction: 'all'
         ,width: 400
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
-
-        {if $params.title|default},title: '{$params.title}'{/if}
-        {if $params.listWidth|default},listWidth: {$params.listWidth}{/if}
-        ,maxHeight: {if $params.maxHeight|default}{$params.maxHeight}{else}300{/if}
-        {if $params.typeAhead|default}
-            ,typeAhead: true
-            ,typeAheadDelay: {if $params.typeAheadDelay && $params.typeAheadDelay != ''}{$params.typeAheadDelay}{else}250{/if}
-        {else}
-            ,editable: false
-            ,typeAhead: false
-        {/if}
-        {if $params.listEmptyText|default}
-            ,listEmptyText: '{$params.listEmptyText}'
-        {/if}
-        ,forceSelection: {if $params.forceSelection|default && $params.forceSelection != 'false'}true{else}false{/if}
+        ,editable: false
+        ,typeAhead: false
+        ,forceSelection: false
         ,msgTarget: 'under'
 
-        {if $params.allowBlank == 1 || $params.allowBlank == 'true'}{else}{literal}
+        {if $params.allowBlank == 1 || $params.allowBlank == 'true'}
+        {else}
+        {literal}
         ,validator: function(v) {
             if (Ext.isEmpty(v) || v == '' || v == '-') {
                 return _('field_required');
             }
             return true;
         }
-        {/literal}{/if}
+        {/literal}
+        {/if}
         {literal}
         ,listeners: { 'select': { fn:MODx.fireResourceFormChange, scope:this}}
     });

--- a/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
@@ -29,7 +29,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
@@ -38,78 +38,116 @@ MODx.load({
         ,html: _('required_desc')
         ,cls: 'desc-under'
     },{
-        xtype: 'combo-boolean'
-        ,fieldLabel: _('shownone')
-        ,description: MODx.expandHelp ? '' : _('shownone_desc')
-        ,name: 'inopt_showNone'
-        ,hiddenName: 'inopt_showNone'
-        ,id: 'inopt_showNone{/literal}{$tv|default}{literal}'
-        ,width: 200
-        ,value: (params['showNone']) ? !(params['showNone'] === 0 || params['showNone'] === 'false') : true
-        ,listeners: oc
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('resourcelist_parents')
+                ,description: MODx.expandHelp ? '' : _('resourcelist_parents_desc')
+                ,name: 'inopt_parents'
+                ,id: 'inopt_parents{/literal}{$tv|default}{literal}'
+                ,value: params['parents'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_parents{/literal}{$tv|default}{literal}'
+                ,html: _('resourcelist_parents_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'combo-boolean'
+                ,fieldLabel: _('resourcelist_includeparent')
+                ,description: MODx.expandHelp ? '' : _('resourcelist_includeparent_desc')
+                ,name: 'inopt_includeParent'
+                ,hiddenName: 'inopt_includeParent'
+                ,id: 'inopt_includeParent{/literal}{$tv|default}{literal}'
+                ,anchor: '100%'
+                ,value: (params['includeParent']) ? !(params['includeParent'] === 0 || params['includeParent'] === 'false') : true
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_includeParent{/literal}{$tv|default}{literal}'
+                ,html: _('resourcelist_includeparent_desc')
+                ,cls: 'desc-under'
+            }]
+        }]
     },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_showNone{/literal}{$tv|default}{literal}'
-        ,html: _('shownone_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('resourcelist_parents')
-        ,description: MODx.expandHelp ? '' : _('resourcelist_parents_desc')
-        ,name: 'inopt_parents'
-        ,id: 'inopt_parents{/literal}{$tv|default}{literal}'
-        ,value: params['parents'] || ''
-        ,anchor: '100%'
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_parents{/literal}{$tv|default}{literal}'
-        ,html: _('resourcelist_parents_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('resourcelist_depth')
-        ,description: MODx.expandHelp ? '' : _('resourcelist_depth_desc')
-        ,name: 'inopt_depth'
-        ,id: 'inopt_depth{/literal}{$tv|default}{literal}'
-        ,value: params['depth'] || 10
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_depth{/literal}{$tv|default}{literal}'
-        ,html: _('resourcelist_depth_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'combo-boolean'
-        ,fieldLabel: _('resourcelist_includeparent')
-        ,description: MODx.expandHelp ? '' : _('resourcelist_includeparent_desc')
-        ,name: 'inopt_includeParent'
-        ,hiddenName: 'inopt_includeParent'
-        ,id: 'inopt_includeParent{/literal}{$tv|default}{literal}'
-        ,width: 200
-        ,value: (params['includeParent']) ? !(params['includeParent'] === 0 || params['includeParent'] === 'false') : true
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_includeParent{/literal}{$tv|default}{literal}'
-        ,html: _('resourcelist_includeparent_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'combo-boolean'
-        ,fieldLabel: _('resourcelist_limitrelatedcontext')
-        ,description: MODx.expandHelp ? '' : _('resourcelist_limitrelatedcontext_desc')
-        ,name: 'inopt_limitRelatedContext'
-        ,hiddenName: 'inopt_limitRelatedContext'
-        ,id: 'inopt_limitRelatedContext{/literal}{$tv|default}{literal}'
-        ,width: 200
-        ,value: (params['limitRelatedContext']) ? !(params['limitRelatedContext'] === 0 || params['limitRelatedContext'] === 'false') : false
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_limitRelatedContext{/literal}{$tv|default}{literal}'
-        ,html: _('resourcelist_limitrelatedcontext_desc')
-        ,cls: 'desc-under'
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .3
+            ,items: [{
+                xtype: 'numberfield'
+                ,fieldLabel: _('resourcelist_limit')
+                ,description: MODx.expandHelp ? '' : _('resourcelist_limit_desc')
+                ,name: 'inopt_limit'
+                ,id: 'inopt_limit{/literal}{$tv|default}{literal}'
+                ,value: params['limit'] || 0
+                ,allowNegative: false
+                ,allowDecimals: false
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_limit{/literal}{$tv|default}{literal}'
+                ,html: _('resourcelist_limit_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .4
+            ,items: [{
+                xtype: 'combo-boolean'
+                ,fieldLabel: _('resourcelist_limitrelatedcontext')
+                ,description: MODx.expandHelp ? '' : _('resourcelist_limitrelatedcontext_desc')
+                ,name: 'inopt_limitRelatedContext'
+                ,hiddenName: 'inopt_limitRelatedContext'
+                ,id: 'inopt_limitRelatedContext{/literal}{$tv|default}{literal}'
+                ,anchor: '100%'
+                ,value: (params['limitRelatedContext']) ? !(params['limitRelatedContext'] === 0 || params['limitRelatedContext'] === 'false') : false
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_limitRelatedContext{/literal}{$tv|default}{literal}'
+                ,html: _('resourcelist_limitrelatedcontext_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .3
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('resourcelist_depth')
+                ,description: MODx.expandHelp ? '' : _('resourcelist_depth_desc')
+                ,name: 'inopt_depth'
+                ,id: 'inopt_depth{/literal}{$tv|default}{literal}'
+                ,value: params['depth'] || 10
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_depth{/literal}{$tv|default}{literal}'
+                ,html: _('resourcelist_depth_desc')
+                ,cls: 'desc-under'
+            }]
+        }]
     },{
         xtype: 'textarea'
         ,fieldLabel: _('resourcelist_where')
@@ -123,22 +161,6 @@ MODx.load({
         xtype: MODx.expandHelp ? 'label' : 'hidden'
         ,forId: 'inopt_where{/literal}{$tv|default}{literal}'
         ,html: _('resourcelist_where_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'numberfield'
-        ,fieldLabel: _('resourcelist_limit')
-        ,description: MODx.expandHelp ? '' : _('resourcelist_limit_desc')
-        ,name: 'inopt_limit'
-        ,id: 'inopt_limit{/literal}{$tv|default}{literal}'
-        ,value: params['limit'] || 0
-        ,allowNegative: false
-        ,allowDecimals: false
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_limit{/literal}{$tv|default}{literal}'
-        ,html: _('resourcelist_limit_desc')
         ,cls: 'desc-under'
     }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'


### PR DESCRIPTION
### What does it do?
Corrected the TV form with the ResourceList type:
- Changed the order
- Related items grouped
- Removed unused params in TV render in resource
- **Added list check via "Allow blank" instead of "Allow empty choice"**

Later I will correct for TV with other types.

**Before:**
![tv-res-1](https://user-images.githubusercontent.com/12523676/78137183-8f045e80-742d-11ea-9c42-e70dbce3fe57.png)

**After:**
![tv-res-2](https://user-images.githubusercontent.com/12523676/78147379-1658ce80-743c-11ea-914a-d51f24e9e391.png)

### Why is it needed?
Improves UI / UX
It became more beautiful :)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15042
https://github.com/modxcms/revolution/pull/15009