### PR TITLE
Corrected TV form with the Text type

### DIFF
--- a/manager/templates/default/element/tv/renders/inputproperties/text.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/text.tpl
@@ -30,7 +30,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
@@ -39,63 +39,87 @@ MODx.load({
         ,html: _('required_desc')
         ,cls: 'desc-under'
     },{
-        xtype: 'numberfield'
-        ,fieldLabel: _('min_length')
-        ,name: 'inopt_minLength'
-        ,id: 'inopt_minLength{/literal}{$tv|default}{literal}'
-        ,value: params['minLength'] || ''
-        ,msgTarget: 'under'
-        ,validator: function (v) {
-            var max = Ext.getCmp('inopt_maxLength{/literal}{$tv|default}{literal}').getValue();
-            if (parseInt(v) > parseInt(max)) {
-                return _('ext_minlenmaxfield');
-            }
-            return true;
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
         }
-        ,width: 200
-        ,listeners: oc
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'numberfield'
+                ,fieldLabel: _('min_length')
+                ,name: 'inopt_minLength'
+                ,id: 'inopt_minLength{/literal}{$tv|default}{literal}'
+                ,value: params['minLength'] || ''
+                ,msgTarget: 'under'
+                ,validator: function (v) {
+                    var max = Ext.getCmp('inopt_maxLength{/literal}{$tv|default}{literal}').getValue();
+                    if (parseInt(v) > parseInt(max)) {
+                        return _('ext_minlenmaxfield');
+                    }
+                    return true;
+                }
+                ,anchor: '100%'
+                ,listeners: oc
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'numberfield'
+                ,fieldLabel: _('max_length')
+                ,name: 'inopt_maxLength'
+                ,id: 'inopt_maxLength{/literal}{$tv|default}{literal}'
+                ,value: params['maxLength'] || ''
+                ,msgTarget: 'under'
+                ,validator: function(v) {
+                    var min = Ext.getCmp('inopt_minLength{/literal}{$tv|default}{literal}').getValue();
+                    if (parseInt(v) < parseInt(min)) {
+                        return _('ext_maxlenminfield');
+                    }
+                    return true;
+                }
+                ,anchor: '100%'
+                ,listeners: oc
+            }]
+        }]
     },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_minLength{/literal}{$tv|default}{literal}'
-        ,html: _('min_length_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'numberfield'
-        ,fieldLabel: _('max_length')
-        ,name: 'inopt_maxLength'
-        ,id: 'inopt_maxLength{/literal}{$tv|default}{literal}'
-        ,value: params['maxLength'] || ''
-        ,msgTarget: 'under'
-        ,validator: function(v) {
-            var min = Ext.getCmp('inopt_minLength{/literal}{$tv|default}{literal}').getValue();
-            if (parseInt(v) < parseInt(min)) {
-                return _('ext_maxlenminfield');
-            }
-            return true;
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
         }
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_maxLength{/literal}{$tv|default}{literal}'
-        ,html: _('max_length_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('regex')
-        ,name: 'inopt_regex'
-        ,id: 'inopt_regex{/literal}{$tv|default}{literal}'
-        ,value: params['regex'] || ''
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('regex_text')
-        ,name: 'inopt_regexText'
-        ,id: 'inopt_regexText{/literal}{$tv|default}{literal}'
-        ,value: params['regexText'] || ''
-        ,width: 200
-        ,listeners: oc
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('regex')
+                ,name: 'inopt_regex'
+                ,id: 'inopt_regex{/literal}{$tv|default}{literal}'
+                ,value: params['regex'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('regex_text')
+                ,name: 'inopt_regexText'
+                ,id: 'inopt_regexText{/literal}{$tv|default}{literal}'
+                ,value: params['regexText'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            }]
+        }]
     }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });


### PR DESCRIPTION
### What does it do?
Corrected the TV form with the Text type:
- Changed the order
- Related items grouped

Later I will correct for TV with other types.

**Before:**
![tv-text-1](https://user-images.githubusercontent.com/12523676/78366886-df182800-75c9-11ea-978c-93169f27475b.png)

**After:**
![tv-text-2](https://user-images.githubusercontent.com/12523676/78366891-e0e1eb80-75c9-11ea-9d29-959d820af9aa.png)

### Why is it needed?
Improves UI / UX

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15044
https://github.com/modxcms/revolution/pull/15043
https://github.com/modxcms/revolution/pull/15042
https://github.com/modxcms/revolution/pull/15009