### PR TITLE
Changed order of array_merge to have the mediasource value to remain.…

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1302,7 +1302,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             }
             $list[$property['name']] = $value;
         }
-        $list = array_merge($list, $this->properties);
+        $list = array_merge($this->properties, $list);
 
         return $list;
     }


### PR DESCRIPTION
… Fixes #14604

### What does it do?
Reverse the array_merge order in order to maintain the mediasource properties.

### Why is it needed?
It resolves the issue where allowedFileTypes was ignored.

### Related issue(s)/PR(s)
#14604 
