### PR TITLE
Check if recursiveRemoveDir function exists

### DIFF
--- a/setup/includes/upgrades/common/2.5-cleanup-script.php
+++ b/setup/includes/upgrades/common/2.5-cleanup-script.php
@@ -766,14 +766,16 @@ $cleanup = array(
 $removedFiles = 0;
 $removedDirs = 0;
 
-function recursiveRemoveDir($dir)
-{
-    $files = array_diff(scandir($dir), array('.', '..'));
-    foreach ($files as $file) {
-        (is_dir("$dir/$file")) ? recursiveRemoveDir("$dir/$file") : unlink("$dir/$file");
-    }
+if (!function_exists('recursiveRemoveDir')) {
+    function recursiveRemoveDir($dir)
+    {
+        $files = array_diff(scandir($dir), array('.', '..'));
+        foreach ($files as $file) {
+            (is_dir("$dir/$file")) ? recursiveRemoveDir("$dir/$file") : unlink("$dir/$file");
+        }
 
-    return rmdir($dir);
+        return rmdir($dir);
+    }
 }
 
 // Loop through legacy files/folders to clean up


### PR DESCRIPTION
### What does it do?
Adds a function_exist check to the recursiveRemoveDir on 2.5-cleanup-script.php

### Why is it needed?
A fatal error citing re-declared functions will happen when upgrading from 2.5.x to 2.7.x.

### Related issue(s)/PR(s)
Fixes issue #15052 
