### PR TITLE
Clear phpthumb connector properties

### DIFF
--- a/core/model/modx/processors/system/phpthumb.class.php
+++ b/core/model/modx/processors/system/phpthumb.class.php
@@ -54,6 +54,7 @@ class modSystemPhpThumbProcessor extends modProcessor {
         $src = $this->source->prepareSrcForThumb($src);
         if (empty($src)) return '';
 
+        $this->unsetProperty('t');
         $this->loadPhpThumb();
         /* set source and generate thumbnail */
         $this->phpThumb->set($src);


### PR DESCRIPTION
### What does it do?
Unset the t property used for cachebusting. It should not be sent to modPhpThumb.

### Why is it needed?
Fix logging of not allowed properties in modPhpThumb class.

### Related issue(s)/PR(s)
Fixes #15054
