### PR TITLE
Merge option for setProperties() methods that don't have a merge option

### DIFF
--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -57,11 +57,13 @@ abstract class Processor {
     /**
      * Set the runtime properties for the processor
      * @param array $properties The properties, in array and key-value form, to run on this processor
+     * @param bool $merge Indicates if properties should be merged with existing ones
+     *
      * @return void
      */
-    public function setProperties($properties) {
+    public function setProperties($properties, $merge = true) {
         unset($properties['HTTP_MODAUTH']);
-        $this->properties = array_merge($this->properties,$properties);
+        $this->properties = $merge ? array_merge($this->properties,$properties) : $properties;
     }
 
     /**

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -107,12 +107,13 @@ abstract class modManagerController
      * Sets the properties array for this controller
      *
      * @param array $properties
+     * @param bool $merge Indicates if properties should be merged with existing ones
      *
      * @return void
      */
-    public function setProperties(array $properties)
+    public function setProperties(array $properties, $merge = false)
     {
-        $this->scriptProperties = $properties;
+        $this->scriptProperties = $merge ? array_merge($this->scriptProperties, $properties) : $properties;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Add the `merge` parameter to `setProperties()` methods that don't have a merge option.
The current behavior (merge = true /replace = false) is used as default value.

### Why is it needed?
Improve consistency and make it more clear if calling this function will merge or replace the properties set previously. 

### Related issue(s)/PR(s)
Issue #10337
