### PR TITLE
Corrected TV form with the Email type

### DIFF
--- a/manager/templates/default/element/tv/renders/inputproperties/email.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/email.tpl
@@ -29,7 +29,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
@@ -38,33 +38,38 @@ MODx.load({
         ,html: _('required_desc')
         ,cls: 'desc-under'
     },{
-        xtype: 'textfield'
-        ,fieldLabel: _('max_length')
-        ,description: MODx.expandHelp ? '' : _('max_length_desc')
-        ,name: 'inopt_maxLength'
-        ,id: 'inopt_maxLength{/literal}{$tv|default}{literal}'
-        ,value: params['maxLength'] || ''
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_maxLength{/literal}{$tv|default}{literal}'
-        ,html: _('max_length_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('min_length')
-        ,description: MODx.expandHelp ? '' : _('min_length_desc')
-        ,name: 'inopt_minLength'
-        ,id: 'inopt_minLength{/literal}{$tv|default}{literal}'
-        ,value: params['minLength'] || ''
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_minLength{/literal}{$tv|default}{literal}'
-        ,html: _('min_length_desc')
-        ,cls: 'desc-under'
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('min_length')
+                ,name: 'inopt_minLength'
+                ,id: 'inopt_minLength{/literal}{$tv|default}{literal}'
+                ,value: params['minLength'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('max_length')
+                ,name: 'inopt_maxLength'
+                ,id: 'inopt_maxLength{/literal}{$tv|default}{literal}'
+                ,value: params['maxLength'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            }]
+        }]
     }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });


### PR DESCRIPTION
### What does it do?
Corrected the TV form with the Email type:
- Changed the order
- Related items grouped

Later I will correct for TV with other types.

**Before:**
![tv-email-1](https://user-images.githubusercontent.com/12523676/80284290-543cd000-8726-11ea-80b2-5d53d9900d6d.png)

**After:**
![tv-email-2](https://user-images.githubusercontent.com/12523676/80284291-54d56680-8726-11ea-8ee2-2164d93d1e76.png)

### Why is it needed?
Improves UI / UX

### Related PR(s)
https://github.com/modxcms/revolution/pull/15063
https://github.com/modxcms/revolution/pull/15045
https://github.com/modxcms/revolution/pull/15044
https://github.com/modxcms/revolution/pull/15043
https://github.com/modxcms/revolution/pull/15042
https://github.com/modxcms/revolution/pull/15009