### PR TITLE
Collapse/expand all child nodes in elements tree

### DIFF
--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -563,6 +563,28 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             });
         }
 
+        if (n.hasChildNodes()) {
+            m.push('-');
+
+            if (n.isExpanded()) {
+                m.push({
+                    text: _('collapse_all')
+                    ,handler: function() {
+                        n.collapseChildNodes();
+                    }
+                });
+            }
+
+            m.push({
+                text: _('expand_all')
+                ,handler: function() {
+                    if (n.isExpandable()) {
+                        n.expand(true);
+                    }
+                }
+            });
+        }
+
         return m;
     }
 

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -563,26 +563,30 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
             });
         }
 
-        if (n.hasChildNodes()) {
-            m.push('-');
+        if (n.isLoaded()) {
+            var childNodes = n.childNodes;
 
-            if (n.isExpanded()) {
+            if (childNodes.some(function(child) { return !child.leaf; })) { // If any childNode has own children
+                m.push('-');
+    
+                if (n.isExpanded() && childNodes.some(function(child) { return child.isExpanded(); })) { // If any childNode is expanded
+                    m.push({
+                        text: _('collapse_all')
+                        ,handler: function() {
+                            n.collapseChildNodes();
+                        }
+                    });
+                }
+    
                 m.push({
-                    text: _('collapse_all')
+                    text: _('expand_all')
                     ,handler: function() {
-                        n.collapseChildNodes();
+                        if (n.isExpandable()) {
+                            n.expand(true);
+                        }
                     }
                 });
             }
-
-            m.push({
-                text: _('expand_all')
-                ,handler: function() {
-                    if (n.isExpandable()) {
-                        n.expand(true);
-                    }
-                }
-            });
         }
 
         return m;


### PR DESCRIPTION
### What does it do?
Added 2 menu items in root menu of elements tree for collapse/expand all child nodes

### Related issue(s)/PR(s)
Partially closes #14829 
