### PR TITLE
Clear phpthumb connector properties

### DIFF
--- a/core/src/Revolution/Processors/System/PhpThumb.php
+++ b/core/src/Revolution/Processors/System/PhpThumb.php
@@ -70,6 +70,8 @@ class PhpThumb extends Processor
             return '';
         }
 
+        $this->unsetProperty('t');
+
         $this->loadPhpThumb();
         /* set source and generate thumbnail */
         $this->phpThumb->set($src);


### PR DESCRIPTION
### What does it do?
Unset the t property used for cachebusting. It should not be sent to modPhpThumb.

### Why is it needed?
Fix logging of not allowed properties in modPhpThumb class.

### Related issue(s)/PR(s)
Fixes #15054 - 3.x version of #15055
