### PR TITLE
Fix typeAhead parameter check

### DIFF
--- a/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
@@ -34,7 +34,7 @@ Ext.onReady(function() {
         {if $params.title|default},title: '{$params.title|default}'{/if}
         {if $params.listWidth|default},listWidth: {$params.listWidth|default}{/if}
         ,maxHeight: {if $params.maxHeight|default}{$params.maxHeight|default}{else}300{/if}
-        {if $params.typeAhead|default}
+        {if $params.typeAhead == 1 || $params.typeAhead == 'true'}
             ,typeAhead: true
             ,typeAheadDelay: {if $params.typeAheadDelay|default && $params.typeAheadDelay|default != ''}{$params.typeAheadDelay|default}{else}250{/if}
             ,editable: true

--- a/manager/templates/default/element/tv/renders/input/listbox-single.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-single.tpl
@@ -21,7 +21,7 @@ Ext.onReady(function() {
         {if $params.title|default},title: '{$params.title|default}'{/if}
         {if $params.listWidth|default},listWidth: {$params.listWidth|default}{/if}
         ,maxHeight: {if $params.maxHeight|default}{$params.maxHeight|default}{else}300{/if}
-        {if $params.typeAhead|default}
+        {if $params.typeAhead == 1 || $params.typeAhead == 'true'}
             ,typeAhead: true
             ,typeAheadDelay: {if $params.typeAheadDelay|default && $params.typeAheadDelay|default != ''}{$params.typeAheadDelay|default}{else}250{/if}
         {else}

--- a/manager/templates/default/element/tv/renders/input/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/input/resourcelist.tpl
@@ -21,7 +21,7 @@ Ext.onReady(function() {
         {if $params.title|default},title: '{$params.title}'{/if}
         {if $params.listWidth|default},listWidth: {$params.listWidth}{/if}
         ,maxHeight: {if $params.maxHeight|default}{$params.maxHeight}{else}300{/if}
-        {if $params.typeAhead|default}
+        {if $params.typeAhead == 1 || $params.typeAhead == 'true'}
             ,typeAhead: true
             ,typeAheadDelay: {if $params.typeAheadDelay && $params.typeAheadDelay != ''}{$params.typeAheadDelay}{else}250{/if}
         {else}


### PR DESCRIPTION
### What does it do?
Fix the check of the typeAhead parameter

### Why is it needed?
With the current check the else branch is never reached, since the value will contain the string 'true' or 'false', which could not be wrong.

### Related issue(s)/PR(s)
Detected during testing #15044 
