### PR TITLE
Fix duplicating static elements

### DIFF
--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -55,6 +55,7 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             ,type: 'chunk'
             ,name: _('duplicate_of',{name: this.record.name})
             ,source: this.record.source
+            ,openTo: this.record.openTo
             ,static: this.record.static
             ,static_file: this.record.static_file
             ,category: this.record.category

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -60,6 +60,9 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             ,static_file: this.record.static_file
             ,category: this.record.category
         };
+        if (MODx.config["static_elements_automate_" + rec.type + "s"] == 1) {
+            rec.static_file = MODx.getStaticElementsPath(rec.name, rec.category, rec.type + "s");
+        }
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -55,6 +55,7 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             ,type: 'plugin'
             ,name: _('duplicate_of',{name: this.record.name})
             ,source: this.record.source
+            ,openTo: this.record.openTo
             ,static: this.record.static
             ,static_file: this.record.static_file
             ,category: this.record.category

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -60,6 +60,9 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             ,static_file: this.record.static_file
             ,category: this.record.category
         };
+        if (MODx.config["static_elements_automate_" + rec.type + "s"] == 1) {
+            rec.static_file = MODx.getStaticElementsPath(rec.name, rec.category, rec.type + "s");
+        }
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -55,6 +55,7 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             ,type: 'snippet'
             ,name: _('duplicate_of',{name: this.record.name})
             ,source: this.record.source
+            ,openTo: this.record.openTo
             ,static: this.record.static
             ,static_file: this.record.static_file
             ,category: this.record.category

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -60,6 +60,9 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             ,static_file: this.record.static_file
             ,category: this.record.category
         };
+        if (MODx.config["static_elements_automate_" + rec.type + "s"] == 1) {
+            rec.static_file = MODx.getStaticElementsPath(rec.name, rec.category, rec.type + "s");
+        }
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -55,6 +55,7 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             ,type: 'template'
             ,name: _('duplicate_of',{name: this.record.templatename})
             ,source: this.record.source
+            ,openTo: this.record.openTo
             ,static: this.record.static
             ,static_file: this.record.static_file
             ,category: this.record.category

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -60,6 +60,9 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             ,static_file: this.record.static_file
             ,category: this.record.category
         };
+        if (MODx.config["static_elements_automate_" + rec.type + "s"] == 1) {
+            rec.static_file = MODx.getStaticElementsPath(rec.name, rec.category, rec.type + "s");
+        }
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -56,6 +56,7 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             ,name: _('duplicate_of',{name: this.record.name})
             ,caption: _('duplicate_of',{name: this.record.caption})
             ,source: this.record.source
+            ,openTo: this.record.openTo
             ,static: this.record.static
             ,static_file: this.record.static_file
             ,category: this.record.category

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -61,6 +61,9 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             ,static_file: this.record.static_file
             ,category: this.record.category
         };
+        if (MODx.config["static_elements_automate_" + rec.type + "s"] == 1) {
+            rec.static_file = MODx.getStaticElementsPath(rec.name, rec.category, rec.type + "s");
+        }
         var w = MODx.load({
             xtype: 'modx-window-element-duplicate'
             ,record: rec

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -161,11 +161,16 @@ MODx.window.DuplicateElement = function(config) {
 
     if (config.record.static === true) {
         flds.push({
-                xtype: 'textfield'
+                xtype: 'modx-combo-browser'
+                ,browserEl: 'modx-browser'
                 ,fieldLabel: _('static_file')
                 ,name: 'static_file'
+                ,source: config.record.source != null ? config.record.source : MODx.config.default_media_source
+                ,openTo: config.record.openTo || ''
                 ,id: 'modx-'+this.ident+'-static_file'
+                ,triggerClass: 'x-form-code-trigger'
                 ,anchor: '100%'
+                ,maxLength: 255
             }
         );
     }


### PR DESCRIPTION
### What does it do?
- Make it possible to use MODX Media Browser to select a file when duplicating static elements.
- Implement `MODx.getStaticElementsPath` when automatic static elements is enabled 

#### Work in progress
- ~~Add a "duplicate-of" prefix to the "static file" when automatic static elements is *not* enabled~~
- ~~Allow users to select/use an existing file as "static file"~~

### Why is it needed?
To solve issues when duplicating static elements. Currently you have to change the filename manually when duplicating static elements.

### Related issue(s)/PR(s)
Issue #14188
