### PR TITLE
Update phpThumb 1.7.15-202004301145

### DIFF
--- a/core/model/phpthumb/phpthumb.bmp.php
+++ b/core/model/phpthumb/phpthumb.bmp.php
@@ -391,7 +391,7 @@ class phpthumb_bmp {
 						case 1:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col = $col) {
-									$paletteindexbyte = ord($BMPpixelData{$pixeldataoffset++});
+									$paletteindexbyte = ord($BMPpixelData[$pixeldataoffset++]);
 									for ($i = 7; $i >= 0; $i--) {
 										$paletteindex = ($paletteindexbyte & (0x01 << $i)) >> $i;
 										$thisfile_bmp['data'][$row][$col] = $thisfile_bmp['palette'][$paletteindex];
@@ -408,7 +408,7 @@ class phpthumb_bmp {
 						case 4:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col = $col) {
-									$paletteindexbyte = ord($BMPpixelData{$pixeldataoffset++});
+									$paletteindexbyte = ord($BMPpixelData[$pixeldataoffset++]);
 									for ($i = 1; $i >= 0; $i--) {
 										$paletteindex = ($paletteindexbyte & (0x0F << (4 * $i))) >> (4 * $i);
 										$thisfile_bmp['data'][$row][$col] = $thisfile_bmp['palette'][$paletteindex];
@@ -425,7 +425,7 @@ class phpthumb_bmp {
 						case 8:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col++) {
-									$paletteindex = ord($BMPpixelData{$pixeldataoffset++});
+									$paletteindex = ord($BMPpixelData[$pixeldataoffset++]);
 									$thisfile_bmp['data'][$row][$col] = $thisfile_bmp['palette'][$paletteindex];
 								}
 								while (($pixeldataoffset % 4) != 0) {
@@ -438,7 +438,7 @@ class phpthumb_bmp {
 						case 24:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col++) {
-									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData{$pixeldataoffset+2}) << 16) | (ord($BMPpixelData{$pixeldataoffset+1}) << 8) | ord($BMPpixelData{$pixeldataoffset});
+									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData[$pixeldataoffset+2]) << 16) | (ord($BMPpixelData[$pixeldataoffset+1]) << 8) | ord($BMPpixelData[$pixeldataoffset]);
 									$pixeldataoffset += 3;
 								}
 								while (($pixeldataoffset % 4) != 0) {
@@ -451,7 +451,7 @@ class phpthumb_bmp {
 						case 32:
 							for ($row = ($thisfile_bmp_header_raw['height'] - 1); $row >= 0; $row--) {
 								for ($col = 0; $col < $thisfile_bmp_header_raw['width']; $col++) {
-									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData{$pixeldataoffset+3}) << 24) | (ord($BMPpixelData{$pixeldataoffset+2}) << 16) | (ord($BMPpixelData{$pixeldataoffset+1}) << 8) | ord($BMPpixelData{$pixeldataoffset});
+									$thisfile_bmp['data'][$row][$col] = (ord($BMPpixelData[$pixeldataoffset+3]) << 24) | (ord($BMPpixelData[$pixeldataoffset+2]) << 16) | (ord($BMPpixelData[$pixeldataoffset+1]) << 8) | ord($BMPpixelData[$pixeldataoffset]);
 									$pixeldataoffset += 4;
 								}
 								while (($pixeldataoffset % 4) != 0) {
@@ -814,7 +814,7 @@ class phpthumb_bmp {
 		$byteword = strrev($byteword);
 		$bytewordlen = strlen($byteword);
 		for ($i = 0; $i < $bytewordlen; $i++) {
-			$intvalue += ord($byteword{$i}) * pow(256, $bytewordlen - 1 - $i);
+			$intvalue += ord($byteword[$i]) * pow(256, $bytewordlen - 1 - $i);
 		}
 		return $intvalue;
 	}
@@ -827,7 +827,7 @@ class phpthumb_bmp {
 		$binvalue = '';
 		$bytewordlen = strlen($byteword);
 		for ($i = 0; $i < $bytewordlen; $i++) {
-			$binvalue .= str_pad(decbin(ord($byteword{$i})), 8, '0', STR_PAD_LEFT);
+			$binvalue .= str_pad(decbin(ord($byteword[$i])), 8, '0', STR_PAD_LEFT);
 		}
 		return $binvalue;
 	}
@@ -840,7 +840,7 @@ class phpthumb_bmp {
 	public function Bin2Dec($binstring, $signed=false) {
 		$signmult = 1;
 		if ($signed) {
-			if ($binstring{0} == '1') {
+			if ($binstring[0] == '1') {
 				$signmult = -1;
 			}
 			$binstring = substr($binstring, 1);

--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -9,12 +9,16 @@
 //                                                         ///
 //////////////////////////////////////////////////////////////
 
-ob_start();
-if (!include_once __DIR__ .'/phpthumb.functions.php' ) {
-	ob_end_flush();
-	die('failed to include_once("'. __DIR__ .'/phpthumb.functions.php")');
+if (!class_exists('phpthumb_functions'))
+{
+	ob_start();
+	if(!include_once __DIR__ . '/phpthumb.functions.php')
+	{
+		ob_end_flush();
+		die('failed to include_once("' . __DIR__ . '/phpthumb.functions.php")');
+	}
+	ob_end_clean();
 }
-ob_end_clean();
 
 class phpthumb {
 
@@ -208,14 +212,14 @@ class phpthumb {
 	public $tempFilesToDelete = array();
 	public $cache_filename    = null;
 
-    public $AlphaCapableFormats = array( 'png', 'ico', 'gif', 'webp');
+	public $AlphaCapableFormats = array( 'png', 'ico', 'gif', 'webp');
 	public $is_alpha = false;
 
 	public $iswindows        = null;
 	public $issafemode       = null;
 	public $php_memory_limit = null;
 
-	public $phpthumb_version = '1.7.15-201902101903';
+	public $phpthumb_version = '1.7.15-202004301145';
 
 	//////////////////////////////////////////////////////////////////////
 
@@ -604,7 +608,7 @@ class phpthumb {
 		// render thumbnail to this file only, do not cache, do not output to browser
 		//$renderfilename = $this->ResolveFilenameToAbsolute(dirname($filename)).DIRECTORY_SEPARATOR.basename($filename);
 		$renderfilename = $filename;
-		if (($filename{0} != '/') && ($filename{0} != '\\') && ($filename{1} != ':')) {
+		if (($filename[0] != '/') && ($filename[0] != '\\') && ($filename[1] != ':')) {
 			$renderfilename = $this->ResolveFilenameToAbsolute($renderfilename);
 		}
 		if (!@is_writable(dirname($renderfilename))) {
@@ -979,6 +983,10 @@ class phpthumb {
 				$this->thumbnailFormat         = 'gif';
 				$AvailableImageOutputFormats[] = 'gif';
 			}
+			if ($imagetypes & IMG_WEBP) {
+				$this->thumbnailFormat         = 'webp';
+				$AvailableImageOutputFormats[] = 'webp';
+			}
 			if ($imagetypes & IMG_PNG) {
 				$this->thumbnailFormat         = 'png';
 				$AvailableImageOutputFormats[] = 'png';
@@ -986,10 +994,6 @@ class phpthumb {
 			if ($imagetypes & IMG_JPG) {
 				$this->thumbnailFormat         = 'jpeg';
 				$AvailableImageOutputFormats[] = 'jpeg';
-			}
-			if ($imagetypes & IMG_WEBP) {
-				$this->thumbnailFormat         = 'webp';
-				$AvailableImageOutputFormats[] = 'webp';
 			}
 		} else {
 			$this->DebugMessage('imagetypes() does not exist - GD support might not be enabled?',  __FILE__, __LINE__);
@@ -1286,7 +1290,7 @@ class phpthumb {
 			return false;
 		}
 
-		if (preg_match('#^[a-z0-9]+\:/{1,2}#i', $filename)) {
+		if (preg_match('#^[a-z0-9]+\\:/{1,2}#i', $filename)) {
 			// eg: http://host/path/file.jpg (HTTP URL)
 			// eg: ftp://host/path/file.jpg  (FTP URL)
 			// eg: data1:/path/file.jpg      (Netware path)
@@ -1294,7 +1298,7 @@ class phpthumb {
 			//$AbsoluteFilename = $filename;
 			return $filename;
 
-		} elseif ($this->iswindows && isset($filename{1}) && ($filename{1} == ':')) {
+		} elseif ($this->iswindows && isset($filename[1]) && ($filename[1] == ':')) {
 
 			// absolute pathname (Windows)
 			$AbsoluteFilename = $filename;
@@ -1304,14 +1308,14 @@ class phpthumb {
 			// absolute pathname (Windows)
 			$AbsoluteFilename = $filename;
 
-		} elseif ($filename{0} == '/') {
+		} elseif ($filename[0] == '/') {
 
 			if (@is_readable($filename) && !@is_readable($this->config_document_root.$filename)) {
 
 				// absolute filename (*nix)
 				$AbsoluteFilename = $filename;
 
-			} elseif (isset($filename{1}) && ($filename{1} == '~')) {
+			} elseif (isset($filename[1]) && ($filename[1] == '~')) {
 
 				// /~user/path
 				if ($ApacheLookupURIarray = phpthumb_functions::ApacheLookupURIarray($filename)) {
@@ -1471,7 +1475,7 @@ class phpthumb {
 				$which_convert = $this->ImageMagickWhichConvert();
 				$IMversion     = $this->ImageMagickVersion();
 
-				if ($which_convert && ($which_convert{0} == '/') && $this->file_exists_ignoreopenbasedir($which_convert)) {
+				if ($which_convert && ($which_convert[0] == '/') && $this->file_exists_ignoreopenbasedir($which_convert)) {
 
 					// `which convert` *should* return the path if "convert" exist, or nothing if it doesn't
 					// other things *may* get returned, like "sh: convert: not found" or "no convert in /usr/local/bin /usr/sbin /usr/bin /usr/ccs/bin"
@@ -1731,7 +1735,7 @@ class phpthumb {
 					// for vector source formats only (WMF, PDF, etc)
 					if (is_array($getimagesize) && isset($getimagesize[2]) && ($getimagesize[2] == IMAGETYPE_PNG)) {
 						// explicitly exclude PNG from "-flatten" to make sure transparency is preserved
-						// https://github.com/JamesHeinrich/phpThumb/issues/65#issuecomment-256454015
+						// https://github.com/JamesHeinrich/phpThumb/issues/65
 					} else {
 						$commandline .= ' -flatten';
 						$commandline .= ' -density '.phpthumb_functions::escapeshellarg_replacement($this->dpi);
@@ -1747,7 +1751,7 @@ class phpthumb {
 					if (!preg_match('#('.implode('|', $this->AlphaCapableFormats).')#i', $outputFormat)) {
 						// not a transparency-capable format
 						$commandline .= ' -background '.phpthumb_functions::escapeshellarg_replacement('#'.($this->bg ? $this->bg : 'FFFFFF'));
-                        if (!stristr($commandline, ' -flatten')) {
+						if (!stristr($commandline, ' -flatten')) {
 							$commandline .= ' -flatten';
 						}
 					} else {
@@ -1874,7 +1878,11 @@ if (false) {
 
 								$commandline .= ' -'.$IMresizeParameter.' '.phpthumb_functions::escapeshellarg_replacement(phpthumb_functions::nonempty_min($this->w, $getimagesize[0]).'x'.phpthumb_functions::nonempty_min($this->h, $getimagesize[1]));
 								$commandline .= ' -gravity center';
-								$commandline .= ' -background '.phpthumb_functions::escapeshellarg_replacement('#'.$this->bg);
+								if ($this->bg) {
+									$commandline .= ' -background ' . phpthumb_functions::escapeshellarg_replacement('#' . $this->bg);
+								} else {
+									$commandline .= ' -background none';
+								}
 								$commandline .= ' -extent '.phpthumb_functions::escapeshellarg_replacement($this->w.'x'.$this->h);
 
 							} else {
@@ -2608,8 +2616,9 @@ if (false) {
 		}
 		switch ($this->thumbnailFormat) {
 			case 'png':
+			case 'webp':
 			case 'ico':
-				// image has alpha transparency, but output as PNG or ICO which can handle it
+				// image has alpha transparency, but output as PNG, WEBP or ICO which can handle it
 				$this->DebugMessage('skipping AlphaChannelFlatten() because ($this->thumbnailFormat == "'.$this->thumbnailFormat.'")', __FILE__, __LINE__);
 				return false;
 				break;

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -219,7 +219,7 @@ class phpthumb_functions {
 		$len = strlen($string);
 		$output = '';
 		for ($i = 0; $i < $len; $i++) {
-			$output .= ' 0x'.str_pad(dechex(ord($string{$i})), 2, '0', STR_PAD_LEFT);
+			$output .= ' 0x'.str_pad(dechex(ord($string[$i])), 2, '0', STR_PAD_LEFT);
 		}
 		return $output;
 	}
@@ -725,7 +725,7 @@ class phpthumb_functions {
 		}
 
 		$cleaned_url  = $parsed_url['scheme'].'://';
-		$cleaned_url .= ($parsed_url['username'] ? $parsed_url['username'].($parsed_url['password'] ? ':'.$parsed_url['password'] : '').'@' : '');
+		$cleaned_url .= ($parsed_url['user'] ? $parsed_url['user'].($parsed_url['pass'] ? ':'.$parsed_url['pass'] : '').'@' : '');
 		$cleaned_url .= $parsed_url['host'];
 		$cleaned_url .= (($parsed_url['port'] && ($parsed_url['port'] != self::URLschemeDefaultPort($parsed_url['scheme']))) ? ':'.$parsed_url['port'] : '');
 		$cleaned_url .= '/'.implode('/', $CleanPathElements);
@@ -1019,7 +1019,7 @@ if (!function_exists('preg_quote')) {
 		if (empty($preg_quote_array)) {
 			$escapeables = '.\\+*?[^]$(){}=!<>|:';
 			for ($i = 0, $iMax = strlen($escapeables); $i < $iMax; $i++) {
-				$strtr_preg_quote[$escapeables{$i}] = $delimiter.$escapeables{$i};
+				$strtr_preg_quote[$escapeables[$i]] = $delimiter.$escapeables[$i];
 			}
 		}
 		return strtr($string, $strtr_preg_quote);

--- a/core/model/phpthumb/phpthumb.gif.php
+++ b/core/model/phpthumb/phpthumb.gif.php
@@ -213,7 +213,7 @@ class CGIFLZW
 	public function LZWCommand(&$data, $bInit)
 	{
 		if ($bInit) {
-			$this->SetCodeSize = ord($data{0});
+			$this->SetCodeSize = ord($data[0]);
 			$data = substr($data, 1);
 
 			$this->CodeSize    = $this->SetCodeSize + 1;
@@ -347,12 +347,12 @@ class CGIFLZW
 			$this->Buf[0] = $this->Buf[$this->LastByte - 2];
 			$this->Buf[1] = $this->Buf[$this->LastByte - 1];
 
-			$Count = ord($data{0});
+			$Count = ord($data[0]);
 			$data  = substr($data, 1);
 
 			if ($Count) {
 				for ($i = 0; $i < $Count; $i++) {
-					$this->Buf[2 + $i] = ord($data{$i});
+					$this->Buf[2 + $i] = ord($data[$i]);
 				}
 				$data = substr($data, $Count);
 			} else {
@@ -403,7 +403,7 @@ class CGIFCOLORTABLE
 				return false;
 			}
 
-			$this->m_arColors[] = (ord($rgb{2}) << 16) + (ord($rgb{1}) << 8) + ord($rgb{0});
+			$this->m_arColors[] = (ord($rgb[2]) << 16) + (ord($rgb[1]) << 8) + ord($rgb[0]);
 			$this->m_nColors++;
 		}
 
@@ -592,7 +592,7 @@ class CGIFIMAGEHEADER
 			return false;
 		}
 
-		$b = ord($lpData{8});
+		$b = ord($lpData[8]);
 		$this->m_bLocalClr  = ($b & 0x80) ? true : false;
 		$this->m_bInterlace = ($b & 0x40) ? true : false;
 		$this->m_bSorted    = ($b & 0x20) ? true : false;
@@ -654,7 +654,7 @@ class CGIFIMAGE
 		$datLen = 0;
 
 		while (true) {
-			$b = ord($data{0});
+			$b = ord($data[0]);
 			$data = substr($data, 1);
 			$datLen++;
 
@@ -700,22 +700,22 @@ class CGIFIMAGE
 	{
 		$extLen = 0;
 
-		$b = ord($data{0});
+		$b = ord($data[0]);
 		$data = substr($data, 1);
 		$extLen++;
 
 		switch($b) {
 		case 0xF9: // Graphic Control
-			$b = ord($data{1});
+			$b = ord($data[1]);
 			$this->m_disp   = ($b & 0x1C) >> 2;
 			$this->m_bUser  = ($b & 0x02) ? true : false;
 			$this->m_bTrans = ($b & 0x01) ? true : false;
 			$this->m_nDelay = $this->w2i(substr($data, 2, 2));
-			$this->m_nTrans = ord($data{4});
+			$this->m_nTrans = ord($data[4]);
 			break;
 
 		case 0xFE: // Comment
-			$this->m_lpComm = substr($data, 1, ord($data{0}));
+			$this->m_lpComm = substr($data, 1, ord($data[0]));
 			break;
 
 		case 0x01: // Plain text
@@ -726,13 +726,13 @@ class CGIFIMAGE
 		}
 
 		// SKIP DEFAULT AS DEFS MAY CHANGE
-		$b = ord($data{0});
+		$b = ord($data[0]);
 		$data = substr($data, 1);
 		$extLen++;
 		while ($b > 0) {
 			$data = substr($data, $b);
 			$extLen += $b;
-			$b    = ord($data{0});
+			$b    = ord($data[0]);
 			$data = substr($data, 1);
 			$extLen++;
 		}
@@ -907,7 +907,7 @@ class CGIF
 					($x <  ($this->m_img->m_gih->m_nLeft + $this->m_img->m_gih->m_nWidth)) &&
 					($y <  ($this->m_img->m_gih->m_nTop  + $this->m_img->m_gih->m_nHeight))) {
 					// PART OF IMAGE
-					if (@$this->m_img->m_bTrans && (ord($data{$nPxl}) == $this->m_img->m_nTrans)) {
+					if (@$this->m_img->m_bTrans && (ord($data[$nPxl]) == $this->m_img->m_nTrans)) {
 						// TRANSPARENT -> BACKGROUND
 						if ($bgColor == -1) {
 							$bmp .= chr($this->m_gfh->m_nBgColor);
@@ -915,7 +915,7 @@ class CGIF
 							$bmp .= chr($bgColor);
 						}
 					} else {
-						$bmp .= $data{$nPxl};
+						$bmp .= $data[$nPxl];
 					}
 				} else {
 					// BACKGROUND
@@ -1007,7 +1007,7 @@ class CGIF
 					($x <  ($this->m_img->m_gih->m_nLeft + $this->m_img->m_gih->m_nWidth)) &&
 					($y <  ($this->m_img->m_gih->m_nTop  + $this->m_img->m_gih->m_nHeight))) {
 					// PART OF IMAGE
-					$bmp .= $data{$nPxl};
+					$bmp .= $data[$nPxl];
 				} else {
 					// BACKGROUND
 					if ($bgColor == -1) {
@@ -1112,10 +1112,10 @@ class CGIF
 					($x <  ($this->m_img->m_gih->m_nLeft + $this->m_img->m_gih->m_nWidth)) &&
 					($y <  ($this->m_img->m_gih->m_nTop  + $this->m_img->m_gih->m_nHeight))) {
 					// PART OF IMAGE
-					if (@$this->m_img->m_bTrans && (ord($data{$nPxl}) == $this->m_img->m_nTrans)) {
+					if (@$this->m_img->m_bTrans && (ord($data[$nPxl]) == $this->m_img->m_nTrans)) {
 						imagesetpixel($PlottingIMG, $x, $this->m_gfh->m_nHeight - $y - 1, $ThisImageColor[$this->m_gfh->m_nBgColor]);
 					} else {
-						imagesetpixel($PlottingIMG, $x, $this->m_gfh->m_nHeight - $y - 1, $ThisImageColor[ord($data{$nPxl})]);
+						imagesetpixel($PlottingIMG, $x, $this->m_gfh->m_nHeight - $y - 1, $ThisImageColor[ord($data[$nPxl])]);
 					}
 				} else {
 					// BACKGROUND


### PR DESCRIPTION
### What does it do?
v1.7.15-202004301145
  ¤ PHP 7.4 curly brace substring compatibility
  ¤ add basic support for WebP
  * [bugfix: G18] fopen() fails when using remote images from SSL
  * [bugfix: G65] ImageMagick -flatten vs PNG transparency
  * [bugfix: G75] improved InitializeTempDirSetting
  * [bugfix: G76] fix memory limit detection
  * [bugfix: G78] AllowOutputEnlargement and Zoom-Crop
  * [bugfix: G90] missing $PHPTHUMB_CONFIG
  * [bugfix: G91] missing config_ prefix in allow_local_http_src
  * [bugfix: G93] ImageMagick unsharp amount/threshold
  * [bugfix: G94] cannot declare class phpthumb_functions
  * [bugfix: G96] language level migration fixes
  * [bugfix: G108] add 'line-height' for text in image
  * [bugfix: G113] fix PNGs losing transparency
  * [bugfix: G123] improved default thumbnail filename
  * [bugfix: G126] overlay on transparent image
  * [bugfix: G133] fix 'wmi' and 'wmt' filters
  * [bugfix: G134] fix fsockopen http status text
  * [bugfix: G140] parse_url return user/pass
  * [bugfix: G142] allow transparent background when using 'far'
  * [bugfix: G144] fix class_exists
  * [bugfix: G149] magic quotes deprecated in PHP 7.4.2
  * bugfix: ImageMagick v7+ parameter order (in, op, out)

### Related issue(s)/PR(s)
NA
