### PR TITLE
Corrected width for allowBlank in TV form

### DIFF
--- a/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
@@ -23,7 +23,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{

--- a/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
@@ -23,7 +23,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{

--- a/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
@@ -29,7 +29,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{


### PR DESCRIPTION
### What does it do?
Corrected width for allowBlank in TV form with the type:
- Autotag
- Tag
- Textarea

For the rest of the TV, allowBlank is already fixed in PRs.

**Before:**
![blank-before](https://user-images.githubusercontent.com/12523676/81081043-198f2080-8efa-11ea-9c4f-feec87ba54d2.png)

**After:**
![blank-after](https://user-images.githubusercontent.com/12523676/81081039-18f68a00-8efa-11ea-99d1-fa99bcbe90e5.png)

### Why is it needed?
Improves UI / UX

### Related PR(s)
https://github.com/modxcms/revolution/pull/15065
https://github.com/modxcms/revolution/pull/15064
https://github.com/modxcms/revolution/pull/15063
https://github.com/modxcms/revolution/pull/15045
https://github.com/modxcms/revolution/pull/15044
https://github.com/modxcms/revolution/pull/15043
https://github.com/modxcms/revolution/pull/15042
https://github.com/modxcms/revolution/pull/15009