### PR TITLE
Added allowBlank for TV with URL type

### DIFF
--- a/manager/templates/default/element/tv/renders/input/url.tpl
+++ b/manager/templates/default/element/tv/renders/input/url.tpl
@@ -1,37 +1,48 @@
 <select id="tv{$tv->id}_prefix" name="tv{$tv->id}_prefix" onchange="MODx.fireResourceFormChange();">
-{foreach from=$urls item=url}
-	<option value="{$url}" {if $url == $selected|default}selected="selected"{/if}>{$url}</option>
-{/foreach}
+    {foreach from=$urls item=url}
+        <option value="{$url}" {if $url == $selected|default}selected="selected"{/if}>{$url}</option>
+    {/foreach}
 </select>
+
 <input id="tv{$tv->id}" name="tv{$tv->id}"
-	type="text"
-	value="{$tv->get('processedValue')}"
-	onchange="MODx.fireResourceFormChange();"
-	class="textfield x-form-text x-form-field"
-	style="width: 283px;"
+    type="text"
+    value="{$tv->get('processedValue')}"
+    onchange="MODx.fireResourceFormChange();"
+    class="textfield x-form-text x-form-field"
+    style="width: 283px;"
 />
+
 <script type="text/javascript">
 // <![CDATA[
 Ext.onReady(function() {
-	MODx.makeDroppable(Ext.get('tv{$tv->id}'));
-
+    MODx.makeDroppable(Ext.get('tv{$tv->id}'));
     var fld = MODx.load({
         xtype: 'combo'
         ,transform: 'tv{$tv->id}_prefix'
         ,id: 'tv{$tv->id}_prefix'
         ,triggerAction: 'all'
         ,width: 100
-        ,allowBlank: false
         ,maxHeight: 300
         ,typeAhead: false
         ,forceSelection: false
+        ,allowBlank: true
         ,msgTarget: 'under'
         ,listeners: { 'select': { fn:MODx.fireResourceFormChange, scope:this}}
     });
+    fld.wrap.applyStyles({
+        display: "inline-block"
+    });
 
-	fld.wrap.applyStyles({
-		display: "inline-block"
-	});
+    var fld = MODx.load({
+        xtype: 'textfield'
+        ,applyTo: 'tv{$tv->id}'
+        ,enableKeyEvents: true
+        ,msgTarget: 'under'
+        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
+        ,listeners: { 'keydown': { fn:MODx.fireResourceFormChange, scope:this}}
+    });
+    MODx.makeDroppable(fld);
+    Ext.getCmp('modx-panel-resource').getForm().add(fld);
 });
 // ]]>
 </script>

--- a/manager/templates/default/element/tv/renders/inputproperties/url.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/url.tpl
@@ -1,0 +1,39 @@
+<div id="tv-input-properties-form{$tv|default}"></div>
+{literal}
+
+<script type="text/javascript">
+// <![CDATA[
+var params = {
+{/literal}{foreach from=$params key=k item=v name='p'}
+ '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}{literal}
+};
+var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+MODx.load({
+    xtype: 'panel'
+    ,layout: 'form'
+    ,autoHeight: true
+    ,cls: 'form-with-labels'
+    ,labelAlign: 'top'
+    ,border: false
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,anchor: '100%'
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
+    ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
+});
+// ]]>
+</script>
+{/literal}


### PR DESCRIPTION
### What does it do?
Added allowBlank for TV with URL type

![url-req](https://user-images.githubusercontent.com/12523676/81088513-b2766980-8f03-11ea-97a6-2ff761285368.png)

### Why is it needed?
For some reason, allowBlank is not for all TVs, which is strange

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/6521 - URL
