### PR TITLE
Added allowBlank for TV with RichText type

### DIFF
--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/inputproperties/richtext.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/inputproperties/richtext.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+/**
+ * @package modx
+ * @subpackage processors.element.tv.renders.mgr.inputproperties
+ */
+
+return $modx->controller->fetchTemplate('element/tv/renders/inputproperties/richtext.tpl');

--- a/manager/templates/default/element/tv/renders/input/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/input/richtext.tpl
@@ -1,10 +1,25 @@
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" class="modx-richtext" {literal}onchange="MODx.fireResourceFormChange();"{/literal}>{$tv->get('value')|escape}</textarea>
 
 <script type="text/javascript">
+// <![CDATA[
 {literal}
 Ext.onReady(function() {
+    var fld = MODx.load({
     {/literal}
-    MODx.makeDroppable(Ext.get('tv{$tv->id}'));
+        xtype: 'textarea'
+        ,applyTo: 'tv{$tv->id}'
+        ,value: '{$tv->get('value')|escape:'javascript'}'
+        ,height: 140
+        ,width: '99%'
+        ,enableKeyEvents: true
+        ,msgTarget: 'under'
+        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
     {literal}
-});{/literal}
+        ,listeners: { 'keydown': { fn:MODx.fireResourceFormChange, scope:this}}
+    });
+    MODx.makeDroppable(fld);
+    Ext.getCmp('modx-panel-resource').getForm().add(fld);
+});
+{/literal}
+// ]]>
 </script>

--- a/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
@@ -1,0 +1,45 @@
+<div id="tv-input-properties-form{$tv|default}"></div>
+{literal}
+
+<script type="text/javascript">
+// <![CDATA[
+var params = {
+{/literal}{foreach from=$params key=k item=v name='p'}
+ '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}{literal}
+};
+var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
+MODx.load({
+    xtype: 'panel'
+    ,layout: 'form'
+    ,autoHeight: true
+    ,cls: 'form-with-labels'
+    ,labelAlign: 'top'
+    ,border: false
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,anchor: '100%'
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
+    ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
+});
+// ]]>
+</script>
+{/literal}


### PR DESCRIPTION
### What does it do?
Added allowBlank for TV with RichText type

![richtext-req](https://user-images.githubusercontent.com/12523676/81093480-de491d80-8f0a-11ea-8ccd-709fd5305dd2.png)

### Why is it needed?
For some reason, allowBlank is not for all TVs, which is strange

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/6521 - RichText
https://github.com/modxcms/revolution/pull/15073
