### PR TITLE
Added allowBlank for TV with Image and File type

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -106,13 +106,17 @@ Ext.extend(MODx,Ext.Component,{
                     if (cmp.allowBlank !== false) return;
 
                     var applyTo = cmp.applyTo;
+                    var label = cmp.fieldLabel;
                     if (!applyTo) {
-                        var label = cmp.fieldLabel;
-                        cmp.fieldLabel = markdom+label;
-                    } else if (applyTo && applyTo.match(/^tv[\d]*$/i)) { 
-                        var label = document.getElementById(applyTo+'-caption');
-                        var html = markdom+label.innerHTML;
-                        label.innerHTML = html;
+                        if (label) {
+                            cmp.fieldLabel = markdom + label;
+                        } else if (cmp.caption && document.getElementById(cmp.caption)) {
+                            label = document.getElementById(cmp.caption);
+                            label.innerHTML = markdom + label.innerHTML;
+                        }
+                    } else if (applyTo && applyTo.match(/^tv[\d]*$/i)) {
+                        label = document.getElementById(applyTo+'-caption');
+                        label.innerHTML = markdom+label.innerHTML;
                     }
                 }
             });

--- a/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
@@ -1,6 +1,6 @@
 /**
  * Renders an input for an image TV
- * 
+ *
  * @class MODx.panel.ImageTV
  * @extends MODx.Panel
  * @param {Object} config An object of configuration properties
@@ -23,16 +23,20 @@ MODx.panel.ImageTV = function(config) {
             ,name: 'tv'+config.tv
             ,id: 'tv'+config.tv
             ,value: config.value
+            ,allowBlank: config.allowBlank
         },{
             xtype: 'modx-combo-browser'
             ,browserEl: 'tvbrowser'+config.tv
             ,name: 'tvbrowser'+config.tv
             ,id: 'tvbrowser'+config.tv
+            ,caption: 'tv'+config.tv+'-caption'
             ,triggerClass: 'x-form-image-trigger'
             ,value: config.relativeValue
             // ,hideFiles: true
             ,source: config.source || 1
+            ,allowBlank: config.allowBlank
             ,allowedFileTypes: config.allowedFileTypes || ''
+            ,msgTarget: config.msgTarget
             ,openTo: config.openTo || ''
             ,hideSourceCombo: true
             ,listeners: {
@@ -49,7 +53,7 @@ MODx.panel.ImageTV = function(config) {
                     });
                 },scope:this}
             }
-        }] 
+        }]
     });
     MODx.panel.ImageTV.superclass.constructor.call(this,config);
     this.addEvents({select: true});
@@ -57,6 +61,14 @@ MODx.panel.ImageTV = function(config) {
 Ext.extend(MODx.panel.ImageTV,MODx.Panel);
 Ext.reg('modx-panel-tv-image',MODx.panel.ImageTV);
 
+/**
+ * Renders an input for an file TV
+ *
+ * @class MODx.panel.FileTV
+ * @extends MODx.Panel
+ * @param {Object} config An object of configuration properties
+ * @xtype panel-tv-file
+ */
 MODx.panel.FileTV = function(config) {
     config = config || {};
     config.filemanager_url = MODx.config.filemanager_url;
@@ -74,15 +86,19 @@ MODx.panel.FileTV = function(config) {
             ,name: 'tv'+config.tv
             ,id: 'tv'+config.tv
             ,value: config.value
+            ,allowBlank: config.allowBlank
         },{
             xtype: 'modx-combo-browser'
             ,browserEl: 'tvbrowser'+config.tv
             ,name: 'tvbrowser'+config.tv
             ,id: 'tvbrowser'+config.tv
+            ,caption: 'tv'+config.tv+'-caption'
             ,value: config.relativeValue
             // ,hideFiles: true
             ,source: config.source || 1
+            ,allowBlank: config.allowBlank
             ,allowedFileTypes: config.allowedFileTypes || ''
+            ,msgTarget: config.msgTarget
             ,wctx: config.wctx || 'web'
             ,openTo: config.openTo || ''
             ,hideSourceCombo: true
@@ -100,7 +116,7 @@ MODx.panel.FileTV = function(config) {
                     });
                 },scope:this}
             }
-        }] 
+        }]
     });
     MODx.panel.FileTV.superclass.constructor.call(this,config);
     this.addEvents({select: true});
@@ -110,5 +126,5 @@ Ext.reg('modx-panel-tv-file',MODx.panel.FileTV);
 
 MODx.checkTV = function(id) {
     var cb = Ext.get('tv'+id);
-    Ext.get('tvh'+id).dom.value = cb.dom.checked ? cb.dom.value : '';     
+    Ext.get('tvh'+id).dom.value = cb.dom.checked ? cb.dom.value : '';
 };

--- a/manager/templates/default/element/tv/renders/input/file.tpl
+++ b/manager/templates/default/element/tv/renders/input/file.tpl
@@ -33,15 +33,19 @@ Ext.onReady(function() {
         ,relativeValue: '{$tv->value|escape}'
         ,width: 400
         ,msgTarget: 'under'
-        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         ,source: '{$source}'
-
-        {if $params.allowedFileTypes},allowedFileTypes: '{$params.allowedFileTypes}'{/if}
         ,wctx: '{if $params.wctx|default}{$params.wctx}{else}web{/if}'
+        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
+        {if $params.allowedFileTypes},allowedFileTypes: '{$params.allowedFileTypes}'{/if}
         {if $params.openTo|default},openTo: '{$params.openTo|replace:"'":"\\'"}'{/if}
-
     {literal}
-        ,listeners: { 'select': { fn:MODx.fireResourceFormChange, scope:this}}
+        ,listeners: {'select': {fn:MODx.fireResourceFormChange, scope:this}}
+        ,validate: function () {
+            var value = Ext.getCmp('tv{/literal}{$tv->id}{literal}').value;
+            return !(!this.allowBlank && (value.length < 1));
+        }
+        ,markInvalid : Ext.emptyFn
+        ,clearInvalid : Ext.emptyFn
     });
     MODx.makeDroppable(Ext.get('tvpanel{/literal}{$tv->id}{literal}'),function(v) {
         var cb = Ext.getCmp('tvbrowser{/literal}{$tv->id}{literal}');
@@ -51,6 +55,7 @@ Ext.onReady(function() {
         }
         return '';
     });
+    Ext.getCmp('modx-panel-resource').getForm().add(fld{/literal}{$tv->id}{literal});
 });
 {/literal}
 // ]]>

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -55,6 +55,12 @@
                     }
                 }}
             }
+            ,validate: function () {
+                var value = Ext.getCmp('tv{/literal}{$tv->id}{literal}').value;
+                return !(!this.allowBlank && (value.length < 1));
+            }
+            ,markInvalid : Ext.emptyFn
+            ,clearInvalid : Ext.emptyFn
         });
         MODx.makeDroppable(Ext.get('tv-image-{/literal}{$tv->id}{literal}'),function(v) {
             var cb = Ext.getCmp('tvbrowser{/literal}{$tv->id}{literal}');
@@ -64,6 +70,7 @@
             }
             return '';
         });
+        Ext.getCmp('modx-panel-resource').getForm().add(fld{/literal}{$tv->id}{literal});
     });
     {/literal}
     // ]]>

--- a/manager/templates/default/element/tv/renders/inputproperties/file.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/file.tpl
@@ -22,7 +22,22 @@ MODx.load({
     ,cls: 'form-with-labels'
     ,labelAlign: 'top'
     ,border: false
-    ,items: []
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,anchor: '100%'
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });
 // ]]>

--- a/manager/templates/default/element/tv/renders/inputproperties/image.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/image.tpl
@@ -22,7 +22,22 @@ MODx.load({
     ,cls: 'form-with-labels'
     ,labelAlign: 'top'
     ,border: false
-    ,items: []
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,anchor: '100%'
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });
 // ]]>


### PR DESCRIPTION
### What does it do?

Added allowBlank for TV with Image and File type

![tv-files-req](https://user-images.githubusercontent.com/12523676/82463534-9f4bc800-9ac5-11ea-8ec7-a77c5b87f5ae.gif)

### Why is it needed?
For some reason, allowBlank is not for all TVs, which is strange

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/6521 - Image and File
https://github.com/modxcms/revolution/pull/15074
https://github.com/modxcms/revolution/pull/15073
