### PR TITLE
Fix setting is_folder after appending resource to another resource

### DIFF
--- a/core/src/Revolution/Processors/Resource/Sort.php
+++ b/core/src/Revolution/Processors/Resource/Sort.php
@@ -171,7 +171,7 @@ class Sort extends Processor
         $oldParent = $this->modx->getObject(modResource::class, $nodeObject->parent);
 
         /** @var modResource $newParent */
-        $newParent = $this->modx->getObject(modResource::class, $node->parent);
+        $newParent = $this->modx->getObject(modResource::class, $this->target->id);
 
         if (empty($oldParent) && empty($newParent)) return;
         if ($oldParent->id == $newParent->id) return;


### PR DESCRIPTION
### What does it do?
Fix the logical mistake in fixParents method of resource sorting processor. $node variable still have unsaved object and $newParent get old parent.

### Why is it needed?
After moving the resource, his new parent is_folder field don't set to true

### Related issue(s)/PR(s)
Closes #14747 
