### PR TITLE
Changes isfolder field dynamically on active resource

### DIFF
--- a/core/src/Revolution/Processors/Resource/Sort.php
+++ b/core/src/Revolution/Processors/Resource/Sort.php
@@ -31,6 +31,7 @@ class Sort extends Processor
     public $target;
     public $activeTarget;
     public $menuindex;
+    public $isFolder;
     public $point;
 
     public $autoIsFolder = true;
@@ -62,7 +63,6 @@ class Sort extends Processor
         $this->fireBeforeSort();
 
         $target = $this->getProperty('target', '');
-        $activeTarget = (int) $this->getProperty('activeTarget', '');
         $source = $this->getProperty('source', '');
         $point = $this->getProperty('point', '');
 
@@ -79,6 +79,7 @@ class Sort extends Processor
         }
 
         $this->point = $point;
+        $this->activeTarget = (int) $this->getProperty('activeTarget', '');
         $this->parseNodes($source, $target);
 
         $sorted = $this->sort();
@@ -98,14 +99,14 @@ class Sort extends Processor
             $this->getProperty('source_pk')
         );
 
-        if (!empty($activeTarget)) {
-            $resource = $this->modx->getObject(modResource::class, $activeTarget);
+        if (!empty($this->activeTarget)) {
+            $resource = $this->modx->getObject(modResource::class, $this->activeTarget);
             if ($resource instanceof modResource) {
                 $this->menuindex = $resource->get('menuindex');
             }
         }
 
-        return $this->success('', ['menuindex' => $this->menuindex]);
+        return $this->success('', ['menuindex' => $this->menuindex, 'isfolder' => $this->isFolder]);
     }
 
     protected function getNodesFormatted($currentLevel, $parent = 0)
@@ -181,12 +182,20 @@ class Sort extends Processor
             if ($oldParentChildrenCount <= 0 || $oldParentChildrenCount == null) {
                 $oldParent->set('isfolder', false);
                 $oldParent->save();
+
+                if (!empty($this->activeTarget) && $this->activeTarget == $oldParent->get('id')) {
+                    $this->isFolder = false;
+                }
             }
         }
 
         if (!empty($newParent)) {
             $newParent->set('isfolder', true);
             $newParent->save();
+
+            if (!empty($this->activeTarget) && $this->activeTarget == $newParent->get('id')) {
+                $this->isFolder = true;
+            }
         }
     }
 

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -402,7 +402,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 menuindexField.setValue(o.result.object.menuindex);
             }
             var isfolderFieldCmb = Ext.getCmp('modx-resource-isfolder');
-            if(isfolderFieldCmb && o.result.object.isfolder !== undefined && typeof o.result.object.isfolder === 'boolean'){
+            if(isfolderFieldCmb && typeof o.result.object.isfolder === 'boolean'){
                 isfolderFieldCmb.setValue(o.result.object.isfolder);
             }
         }

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -401,6 +401,10 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             if(menuindexField && o.result.object.menuindex !== undefined){
                 menuindexField.setValue(o.result.object.menuindex);
             }
+            var isfolderFieldCmb = Ext.getCmp('modx-resource-isfolder');
+            if(isfolderFieldCmb && o.result.object.isfolder !== undefined && typeof o.result.object.isfolder === 'boolean'){
+                isfolderFieldCmb.setValue(o.result.object.isfolder);
+            }
         }
     }
 


### PR DESCRIPTION
### What does it do?
Changes isfolder field of editing resource after sort process

### Why is it needed?
If we append a resource to the resource being edited, the value of the isfolder field in the DB will change, but it will remain the same in the form of editing. 

### Attention

This PR needs to be tested after merging next PRs: #15076 and #15077 because they are related, but it doesn't make sense to put them together in one PR. 

### Related issue(s)/PR(s)
#15076 #15077
