### PR TITLE
Fix deprecated string offset access syntax in modInstallSmarty class

### DIFF
--- a/setup/includes/parser/modinstallsmarty.class.php
+++ b/setup/includes/parser/modinstallsmarty.class.php
@@ -72,7 +72,7 @@ class modInstallSmarty extends Smarty implements modInstallParser {
         $written= false;
         if (!empty ($dirname)) {
             $dirname= strtr(trim($dirname), '\\', '/');
-            if ($dirname{strlen($dirname) - 1} == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
+            if ($dirname[strlen($dirname) - 1] == '/') $dirname = substr($dirname, 0, strlen($dirname) - 1);
             if (is_dir($dirname) || (is_writable(dirname($dirname)) && mkdir($dirname))) {
                 $written= true;
             } elseif (!$this->writeTree(dirname($dirname))) {


### PR DESCRIPTION
### What does it do?
Fixes a deprecated syntax error in setup.

### Why is it needed?
modInstallSmarty was using curly brace syntax to access a string offset and triggering a deprecated error in setup.

### Related issue(s)/PR(s)
N/A