### PR TITLE
Fix DSN creation during an update with an existing port

### DIFF
--- a/setup/includes/modinstallsettings.class.php
+++ b/setup/includes/modinstallsettings.class.php
@@ -43,8 +43,10 @@ class modInstallSettings {
                     $server_dsn = "{$this->settings['database_type']}:server={$this->settings['database_server']}";
                     break;
                 case 'mysql':
-                    $database_dsn = "{$this->settings['database_type']}:host={$this->settings['database_server']};dbname={$this->settings['dbase']};charset={$this->settings['database_connection_charset']}";
-                    $server_dsn = "{$this->settings['database_type']}:host={$this->settings['database_server']};charset={$this->settings['database_connection_charset']}";
+                    $server = explode(':', $this->settings['database_server']);
+                    $port = !empty($server[1]) ? "port={$server[1]};" : '';
+                    $database_dsn = "{$this->settings['database_type']}:host={$server[0]};{$port}dbname={$this->settings['dbase']};charset={$this->settings['database_connection_charset']}";
+                    $server_dsn = "{$this->settings['database_type']}:host={$server[0]};{$port}charset={$this->settings['database_connection_charset']}";
                     break;
                 default:
                     $database_dsn = '';


### PR DESCRIPTION
Fixed DSN building in the "rebuildDSN" function when specifying the port in the "database_server" variable for mysql. Example: "127.0.0.1:3310"

### What does it do?
Fix DSN creation during an update, when the database_server setting has a port specified.