### PR TITLE
Make MODX Revolution to work with SQLite3

### DIFF
--- a/_build/build.properties.sample.php
+++ b/_build/build.properties.sample.php
@@ -31,6 +31,21 @@ $properties['sqlsrv_array_options']= array(
 );
 $properties['sqlsrv_array_driverOptions']= array(/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/);
 
+/* sqlite */
+$properties['sqlite_string_dsn_test']= 'sqlite:/core/data/modx.db3';
+$properties['sqlite_string_dsn_nodb']= 'sqlite:/core/data/modx.db3';
+$properties['sqlite_string_dsn_error']= 'sqlite-err:nodb';
+$properties['sqlite_string_username']= '';  /*NEXT DRIVER*/
+$properties['sqlite_string_password']= '';  /*NEXT DRIVER*/
+$properties['sqlite_array_options']= array(
+    xPDO::OPT_CACHE_PATH => $properties['cache_path'],
+    xPDO::OPT_HYDRATE_FIELDS => true,
+    xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
+    xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
+);
+$properties['sqlite_array_driverOptions']= array(/*NEXT DRIVER*/);
+
+
 /* PHPUnit test config */
 $properties['xpdo_driver']= 'mysql';
 $properties['logLevel']= xPDO::LOG_LEVEL_INFO;

--- a/_build/build.sqlite.config.sample.php
+++ b/_build/build.sqlite.config.sample.php
@@ -1,0 +1,11 @@
+<?php
+/* define the MODX path constants necessary for core installation */
+define('MODX_CORE_PATH', dirname(dirname(__FILE__)) . '/core/');
+define('MODX_CONFIG_KEY', 'config');
+
+
+/* define the connection variables */
+define('XPDO_DSN', 'sqlite:/core/data/modx.db3');
+define('XPDO_DB_USER', ''); /*NEXT DRIVER*/
+define('XPDO_DB_PASS', ''); /*NEXT DRIVER*/
+define('XPDO_TABLE_PREFIX', 'modx_');

--- a/core/data/SET_NEW_PASSWD
+++ b/core/data/SET_NEW_PASSWD
@@ -1,0 +1,10 @@
+#////////////////////////////////// 
+#   ADD NEW HTACCESS USER
+#//////////////////////////////////
+
+$ htpasswd -c .htpasswd <user_name>
+
+new password> _____
+repeat new password> ____
+
+Enjoy! 

--- a/core/model/modx/metadata.sqlite.php
+++ b/core/model/modx/metadata.sqlite.php
@@ -1,0 +1,111 @@
+<?php
+
+$xpdo_meta_map = array (
+  'xPDOSimpleObject' => 
+  array (
+    0 => 'modAccess',
+    1 => 'modAccessPolicy',
+    2 => 'modAccessPolicyTemplate',
+    3 => 'modAccessPolicyTemplateGroup',
+    4 => 'modAccessPermission',
+    5 => 'modActionField',
+    6 => 'modClassMap',
+    7 => 'modContentType',
+    8 => 'modDashboard',
+    9 => 'modDashboardWidget',
+    10 => 'modFormCustomizationProfile',
+    11 => 'modFormCustomizationSet',
+    12 => 'modLexiconEntry',
+    13 => 'modManagerLog',
+    14 => 'modExtensionPackage',
+    15 => 'modPrincipal',
+    16 => 'modPropertySet',
+    17 => 'modResourceGroupResource',
+    18 => 'modTemplateVarResource',
+    19 => 'modTemplateVarResourceGroup',
+    20 => 'modUserGroupMember',
+    21 => 'modUserGroupRole',
+    22 => 'modUserMessage',
+    23 => 'modUserProfile',
+    24 => 'modWorkspace',
+  ),
+  'modAccess' => 
+  array (
+    0 => 'modAccessAction',
+    1 => 'modAccessActionDom',
+    2 => 'modAccessCategory',
+    3 => 'modAccessNamespace',
+    4 => 'modAccessContext',
+    5 => 'modAccessElement',
+    6 => 'modAccessMenu',
+    7 => 'modAccessResource',
+    8 => 'modAccessResourceGroup',
+  ),
+  'modAccessElement' => 
+  array (
+    0 => 'modAccessTemplateVar',
+  ),
+  'xPDOObject' => 
+  array (
+    0 => 'modAccessibleObject',
+    1 => 'modActiveUser',
+    2 => 'modCategoryClosure',
+    3 => 'modContextSetting',
+    4 => 'modContextResource',
+    5 => 'modDashboardWidgetPlacement',
+    6 => 'modElementPropertySet',
+    7 => 'modEvent',
+    8 => 'modFormCustomizationProfileUserGroup',
+    9 => 'modPluginEvent',
+    10 => 'modSession',
+    11 => 'modSystemSetting',
+    12 => 'modTemplateVarTemplate',
+    13 => 'modUserGroupSetting',
+    14 => 'modUserSetting',
+  ),
+  'modAccessibleObject' => 
+  array (
+    0 => 'modAccessibleSimpleObject',
+    1 => 'modContext',
+    2 => 'modMenu',
+    3 => 'modNamespace',
+  ),
+  'modAccessibleSimpleObject' => 
+  array (
+    0 => 'modAction',
+    1 => 'modActionDom',
+    2 => 'modCategory',
+    3 => 'modElement',
+    4 => 'modResource',
+    5 => 'modResourceGroup',
+  ),
+  'modElement' => 
+  array (
+    0 => 'modChunk',
+    1 => 'modScript',
+    2 => 'modTemplate',
+    3 => 'modTemplateVar',
+  ),
+  'modResource' => 
+  array (
+    0 => 'modDocument',
+    1 => 'modStaticResource',
+    2 => 'modSymLink',
+    3 => 'modWebLink',
+    4 => 'modXMLRPCResource',
+  ),
+  'modXMLRPCResource' => 
+  array (
+    0 => 'modJSONRPCResource',
+  ),
+  'modScript' => 
+  array (
+    0 => 'modPlugin',
+    1 => 'modSnippet',
+  ),
+  'modPrincipal' => 
+  array (
+    0 => 'modUser',
+    1 => 'modUserGroup',
+  ),
+);

--- a/core/model/modx/processors/system/settings/getareas.class.php
+++ b/core/model/modx/processors/system/settings/getareas.class.php
@@ -1,13 +1,4 @@
 <?php
-/*
- * This file is part of MODX Revolution.
- *
- * Copyright (c) MODX, LLC. All Rights Reserved.
- *
- * For complete copyright and license information, see the COPYRIGHT and LICENSE
- * files found in the top-level directory of this distribution.
- */
-
 /**
  * Get a list of setting areas
  *
@@ -94,7 +85,7 @@ class modSystemSettingsGetAreasProcessor extends modProcessor {
             'COUNT(settingsCount.' . $this->modx->escape('key') . ') AS num_settings'
         ));
         $c->groupby('settingsArea.' . $this->modx->escape('area') . ', settingsArea.' . $this->modx->escape('namespace'));
-        $c->sortby($this->modx->escape('area'),$this->getProperty('dir','ASC'));
+        $c->sortby('settingsArea.' .$this->modx->escape('area'),$this->getProperty('dir','ASC'));
         return $c;
     }
 }

--- a/core/model/modx/processors/workspace/namespace/getlist.class.php
+++ b/core/model/modx/processors/workspace/namespace/getlist.class.php
@@ -1,13 +1,4 @@
 <?php
-/*
- * This file is part of MODX Revolution.
- *
- * Copyright (c) MODX, LLC. All Rights Reserved.
- *
- * For complete copyright and license information, see the COPYRIGHT and LICENSE
- * files found in the top-level directory of this distribution.
- */
-
 /**
  * Gets a list of namespaces
  *
@@ -26,10 +17,6 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
     public $languageTopics = array('namespace','workspace');
     public $permission = 'namespaces';
 
-    /**
-     * {@inheritDoc}
-     * @return boolean
-     */
     public function initialize() {
         $initialized = parent::initialize();
         $this->setDefaultProperties(array(
@@ -38,11 +25,6 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
         return $initialized;
     }
 
-    /**
-     * {@inheritDoc}
-     * @param xPDOQuery $c
-     * @return xPDOQuery
-     */
     public function prepareQueryBeforeCount(xPDOQuery $c) {
         $search = $this->getProperty('search','');
         if (!empty($search)) {
@@ -55,23 +37,8 @@ class modNamespaceGetListProcessor extends modObjectGetListProcessor {
     }
 
     /**
-     * Filter the query by the name property to get the right value in preselectFirstValue of MODx.combo.Namespace
-     * @param xPDOQuery $c
-     * @return xPDOQuery
-     */
-    public function prepareQueryAfterCount(xPDOQuery $c) {
-        $name = $this->getProperty('name','');
-        if (!empty($name)) {
-            $c->where(array(
-                $this->classKey . '.name:IN' => is_string($name) ? explode(',', $name) : $name,
-            ));
-        }
-        return $c;
-    }
-
-    /**
      * Prepare the Namespace for listing
-     *
+     * 
      * @param xPDOObject $object
      * @return array
      */

--- a/core/model/modx/registry/db/metadata.sqlite.php
+++ b/core/model/modx/registry/db/metadata.sqlite.php
@@ -1,0 +1,13 @@
+<?php
+
+$xpdo_meta_map = array (
+  'xPDOSimpleObject' => 
+  array (
+    0 => 'modDbRegisterQueue',
+    1 => 'modDbRegisterTopic',
+  ),
+  'xPDOObject' => 
+  array (
+    0 => 'modDbRegisterMessage',
+  ),
+);

--- a/core/model/modx/registry/db/sqlite/moddbregistermessage.class.php
+++ b/core/model/modx/registry/db/sqlite/moddbregistermessage.class.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package modx
+ * @subpackage registry.db.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moddbregistermessage.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modDbRegisterMessage_sqlite extends modDbRegisterMessage {
+    public static function getValidMessages(modDbRegister &$register, $topic, $topicBase, $topicMsg, $limit, array $options = array()) {
+        $messages = array();
+        $fetchMode = isset($options['fetchMode']) ? $options['fetchMode'] : PDO::FETCH_OBJ;
+        $msgTable = $register->modx->getTableName('registry.db.modDbRegisterMessage');
+        $topicTable = $register->modx->getTableName('registry.db.modDbRegisterTopic');
+        $limitClause = $limit > 0 ? "LIMIT {$limit}" : '';
+        $query = new xPDOCriteria(
+            $register->modx,
+            "SELECT msg.* FROM {$msgTable} msg JOIN {$topicTable} topic ON msg.valid <= :now AND (topic.name = :topic OR (topic.name = :topicbase AND msg.id = :topicmsg)) AND topic.id = msg.topic ORDER BY msg.created ASC {$limitClause}",
+            array(
+                ':now' => strftime('%Y-%m-%d %H:%M:%S'),
+                ':topic' => $topic,
+                ':topicbase' => $topicBase,
+                ':topicmsg' => $topicMsg
+            )
+        );
+        if ($query->stmt && $query->stmt->execute()) {
+            $messages = $query->stmt->fetchAll($fetchMode);
+        }
+        return $messages;
+    }
+}

--- a/core/model/modx/registry/db/sqlite/moddbregistermessage.map.inc.php
+++ b/core/model/modx/registry/db/sqlite/moddbregistermessage.map.inc.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * @package modx
+ * @subpackage registry.db.sqlite
+ */
+$xpdo_meta_map['modDbRegisterMessage']= array (
+  'package' => 'modx.registry.db',
+  'version' => '1.1',
+  'table' => 'register_messages',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'topic' => NULL,
+    'id' => NULL,
+    'created' => NULL,
+    'valid' => NULL,
+    'accessed' => NULL,
+    'accesses' => 0,
+    'expires' => 0,
+    'payload' => NULL,
+    'kill' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'topic' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+    ),
+    'id' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'created' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => false,
+      'index' => 'index',
+    ),
+    'valid' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => false,
+      'index' => 'index',
+    ),
+    'accessed' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'index' => 'index',
+        //'null' => false,
+        //'default' => 0,
+    ),
+    'accesses' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'expires' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'payload' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+    ),
+    'kill' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'id' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'created' => 
+    array (
+      'alias' => 'created',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'created' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'valid' => 
+    array (
+      'alias' => 'valid',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'valid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'accessed' => 
+    array (
+      'alias' => 'accessed',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'accessed' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'accesses' => 
+    array (
+      'alias' => 'accesses',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'accesses' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'expires' => 
+    array (
+      'alias' => 'expires',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'expires' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Topic' => 
+    array (
+      'class' => 'registry.db.modDbRegisterTopic',
+      'local' => 'topic',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/registry/db/sqlite/moddbregisterqueue.class.php
+++ b/core/model/modx/registry/db/sqlite/moddbregisterqueue.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage registry.db.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moddbregisterqueue.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modDbRegisterQueue_sqlite extends modDbRegisterQueue {
+}

--- a/core/model/modx/registry/db/sqlite/moddbregisterqueue.map.inc.php
+++ b/core/model/modx/registry/db/sqlite/moddbregisterqueue.map.inc.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @package modx
+ * @subpackage registry.db.sqlite
+ */
+$xpdo_meta_map['modDbRegisterQueue']= array (
+  'package' => 'modx.registry.db',
+  'version' => '1.1',
+  'table' => 'register_queues',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => NULL,
+    'options' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'unique',
+    ),
+    'options' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Topics' => 
+    array (
+      'class' => 'registry.db.modDbRegisterTopic',
+      'local' => 'id',
+      'foreign' => 'queue',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/registry/db/sqlite/moddbregistertopic.class.php
+++ b/core/model/modx/registry/db/sqlite/moddbregistertopic.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage registry.db.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moddbregistertopic.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modDbRegisterTopic_sqlite extends modDbRegisterTopic {
+}

--- a/core/model/modx/registry/db/sqlite/moddbregistertopic.map.inc.php
+++ b/core/model/modx/registry/db/sqlite/moddbregistertopic.map.inc.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @package modx
+ * @subpackage registry.db.sqlite
+ */
+$xpdo_meta_map['modDbRegisterTopic']= array (
+  'package' => 'modx.registry.db',
+  'version' => '1.1',
+  'table' => 'register_topics',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'queue' => NULL,
+    'name' => NULL,
+    'created' => NULL,
+    'updated' => NULL,
+    'options' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'queue' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'index' => 'fk',
+    ),
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'fk',
+    ),
+    'created' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => false,
+    ),
+    'updated' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'timestamp',
+    ),
+    'options' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'queue' => 
+    array (
+      'alias' => 'queue',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'queue' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Messages' => 
+    array (
+      'class' => 'registry.db.modDbRegisterMessage',
+      'local' => 'id',
+      'foreign' => 'topic',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Queue' => 
+    array (
+      'class' => 'registry.db.modDbRegisterQueue',
+      'local' => 'queue',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/registry/moddbregister.class.php
+++ b/core/model/modx/registry/moddbregister.class.php
@@ -1,26 +1,23 @@
 <?php
-/*
- * This file is part of MODX Revolution.
+/**
+ * This file contains a simple database implementation of modRegister.
  *
- * Copyright (c) MODX, LLC. All Rights Reserved.
- *
- * For complete copyright and license information, see the COPYRIGHT and LICENSE
- * files found in the top-level directory of this distribution.
+ * @package modx
+ * @subpackage registry
  */
-
+/** Make sure the modRegister class is included. */
 require_once dirname(__FILE__) . '/modregister.class.php';
 
 /**
- * A simple, database-based implementation of modRegister.
+ * A simple, file-based implementation of modRegister.
  *
  * This implementation does not address transactional conflicts and should be
  * used in non-critical processes that are easily recoverable.
  *
  * @package modx
- * @subpackage registry.db
+ * @subpackage registry
  */
-class modDbRegister extends modRegister
-{
+class modDbRegister extends modRegister {
     /**
      * The queue object representing this modRegister instance.
      * @access protected
@@ -77,19 +74,9 @@ class modDbRegister extends modRegister
      *
      * {@inheritdoc}
      */
-    public function clear($topic)
-    {
-        $topicObject = $this->modx->getObject('registry.db.modDbRegisterTopic', array(
-            'queue' => $this->_queue->get('id'),
-            'name' => $topic
-        ));
-        if (!$topicObject) {
-            return false;
-        }
-
-        return (bool) $this->modx->removeCollection('registry.db.modDbRegisterMessage', array(
-            'topic' => $topicObject->get('id')
-        ));
+    public function clear($topic) {
+        $result = $this->modx->removeCollection('modDbRegisterMessage', array('topic' => $topic));
+        return (bool)$result;
     }
 
     /**
@@ -189,7 +176,7 @@ class modDbRegister extends modRegister
         if (is_object($obj) && !empty($obj->payload)) {
             $message = eval($obj->payload);
             if ($remove || ($obj->expires > 1 && $obj->expires < time())) {
-                $this->modx->removeObject('registry.db.modDbRegisterMessage', array('topic' => $obj->topic, 'id' => $obj->id));
+                $this->modx->removeObject('modDbRegisterMessage', array('topic' => $obj->topic, 'id' => $obj->id));
             }
             if ($obj->kill) $this->__kill = true;
         }

--- a/core/model/modx/rest/modrestcurlclient.class.php
+++ b/core/model/modx/rest/modrestcurlclient.class.php
@@ -1,13 +1,8 @@
 <?php
-/*
- * This file is part of MODX Revolution.
- *
- * Copyright (c) MODX, LLC. All Rights Reserved.
- *
- * For complete copyright and license information, see the COPYRIGHT and LICENSE
- * files found in the top-level directory of this distribution.
+/**
+ * @package modx
+ * @subpackage rest
  */
-
 require_once dirname(__FILE__) . '/modrestclient.class.php';
 /**
  * Handles REST requests through a cURL-based client
@@ -50,9 +45,13 @@ class modRestCurlClient extends modRestClient {
 
         /* execute request */
         $result = trim(curl_exec($ch));
-
+        
         /* make sure to close connection */
         curl_close($ch);
+
+
+
+
 
         return $result;
     }
@@ -102,12 +101,16 @@ class modRestCurlClient extends modRestClient {
         }
         /* prevent invalid xhtml ampersands in request path and strip unnecessary ampersands from the end of the url */
         $url = rtrim(str_replace('&amp;', '&', $host.$path), '&');
+        $url = str_replace('sqlite', 'mysql', $url); // ALEX
+
+
+
         return curl_setopt($ch, CURLOPT_URL,$url);
     }
 
     /**
      * Set up cURL-specific options
-     *
+     * 
      * @param resource $ch The cURL connection resource
      * @param array $options An array of options
      */
@@ -173,7 +176,7 @@ class modRestCurlClient extends modRestClient {
 
     /**
      * Set up proxy configuration , if specified, to be used with REST request.
-     *
+     * 
      * @param resource $ch The cURL connection resource.
      * @param array $options An array of options
      * @return boolean True if the proxy was setup.
@@ -206,7 +209,7 @@ class modRestCurlClient extends modRestClient {
 if (!class_exists('modRestArrayToXML')) {
 /**
  * Utility class for array-to-XML transformations.
- *
+ * 
  * @package modx
  * @subpackage rest
  */

--- a/core/model/modx/sources/metadata.sqllite.php
+++ b/core/model/modx/sources/metadata.sqllite.php
@@ -1,0 +1,22 @@
+<?php
+
+$xpdo_meta_map = array (
+  'modAccess' => 
+  array (
+    0 => 'modAccessMediaSource',
+  ),
+  'modAccessibleObject' => 
+  array (
+    0 => 'modMediaSource',
+  ),
+  'modMediaSource' => 
+  array (
+    0 => 'modFileMediaSource',
+    1 => 'modS3MediaSource',
+  ),
+  'xPDOObject' => 
+  array (
+    0 => 'modMediaSourceContext',
+    1 => 'modMediaSourceElement',
+  ),
+);

--- a/core/model/modx/sources/sqlite/modaccessmediasource.class.php
+++ b/core/model/modx/sources/sqlite/modaccessmediasource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessmediasource.class.php');
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+class modAccessMediaSource_sqlite extends modAccessMediaSource {
+}

--- a/core/model/modx/sources/sqlite/modaccessmediasource.map.inc.php
+++ b/core/model/modx/sources/sqlite/modaccessmediasource.map.inc.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+$xpdo_meta_map['modAccessMediaSource']= array (
+  'package' => 'modx.sources',
+  'version' => '1.1',
+  'table' => 'access_media_source',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+    'context_key' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'sources.modMediaSource',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sources/sqlite/modfilemediasource.class.php
+++ b/core/model/modx/sources/sqlite/modfilemediasource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modfilemediasource.class.php');
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+class modFileMediaSource_sqlite extends modFileMediaSource {
+}

--- a/core/model/modx/sources/sqlite/modfilemediasource.map.inc.php
+++ b/core/model/modx/sources/sqlite/modfilemediasource.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+$xpdo_meta_map['modFileMediaSource']= array (
+  'package' => 'modx.sources',
+  'version' => '1.1',
+  'extends' => 'modMediaSource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sources/sqlite/modmediasource.class.php
+++ b/core/model/modx/sources/sqlite/modmediasource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modmediasource.class.php');
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+class modMediaSource_sqlite extends modMediaSource {
+}

--- a/core/model/modx/sources/sqlite/modmediasource.map.inc.php
+++ b/core/model/modx/sources/sqlite/modmediasource.map.inc.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+$xpdo_meta_map['modMediaSource']= array (
+  'package' => 'modx.sources',
+  'version' => '1.1',
+  'table' => 'media_sources',
+  'extends' => 'modAccessibleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => NULL,
+    'class_key' => 'sources.modFileMediaSource',
+    'properties' => NULL,
+    'is_stream' => 1,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => true,
+    ),
+    'class_key' => 
+    array (
+      'dbtype' => 'varchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'sources.modFileMediaSource',
+      'index' => 'index',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+    'is_stream' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'class_key' => 
+    array (
+      'alias' => 'class_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'class_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'is_stream' => 
+    array (
+      'alias' => 'is_stream',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'is_stream' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'SourceElement' => 
+    array (
+      'class' => 'sources.modMediaSourceElement',
+      'local' => 'id',
+      'foreign' => 'source',
+      'cardinality' => 'one',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Chunks' => 
+    array (
+      'class' => 'modChunk',
+      'local' => 'id',
+      'foreign' => 'source',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Plugins' => 
+    array (
+      'class' => 'modPlugin',
+      'local' => 'id',
+      'foreign' => 'source',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Snippets' => 
+    array (
+      'class' => 'modSnippet',
+      'local' => 'id',
+      'foreign' => 'source',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Templates' => 
+    array (
+      'class' => 'modTemplate',
+      'local' => 'id',
+      'foreign' => 'source',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'TemplateVars' => 
+    array (
+      'class' => 'modTemplateVar',
+      'local' => 'id',
+      'foreign' => 'source',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sources/sqlite/modmediasourcecontext.class.php
+++ b/core/model/modx/sources/sqlite/modmediasourcecontext.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modmediasourcecontext.class.php');
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+class modMediaSourceContext_sqlite extends modMediaSourceContext {
+}

--- a/core/model/modx/sources/sqlite/modmediasourcecontext.map.inc.php
+++ b/core/model/modx/sources/sqlite/modmediasourcecontext.map.inc.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+$xpdo_meta_map['modMediaSourceContext']= array (
+  'package' => 'modx.sources',
+  'version' => '1.1',
+  'table' => 'media_sources_contexts',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'source' => 0,
+    'context_key' => 'web',
+  ),
+  'fieldMeta' => 
+  array (
+    'source' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'web',
+      'index' => 'pk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'source' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Source' => 
+    array (
+      'class' => 'sources.modMediaSource',
+      'local' => 'source',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sources/sqlite/modmediasourceelement.class.php
+++ b/core/model/modx/sources/sqlite/modmediasourceelement.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modmediasourceelement.class.php');
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+class modMediaSourceElement_sqlite extends modMediaSourceElement {
+}

--- a/core/model/modx/sources/sqlite/modmediasourceelement.map.inc.php
+++ b/core/model/modx/sources/sqlite/modmediasourceelement.map.inc.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+$xpdo_meta_map['modMediaSourceElement']= array (
+  'package' => 'modx.sources',
+  'version' => '1.1',
+  'table' => 'media_sources_tvs',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'source' => 0,
+    'object_class' => 'modTemplateVar',
+    'object' => 0,
+    'context_key' => 'web',
+  ),
+  'fieldMeta' => 
+  array (
+    'source' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'object_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'modTemplateVar',
+      'index' => 'pk',
+    ),
+    'object' =>
+      array (
+          'dbtype' => 'integer',
+          'phptype' => 'integer',
+          'null' => false,
+          'default' => 0,
+          'index' => 'pk',
+      ),
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'web',
+      'index' => 'pk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'source' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'object' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'object_class' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Source' => 
+    array (
+      'class' => 'sources.modMediaSource',
+      'local' => 'source',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Element' => 
+    array (
+      'class' => 'modElement',
+      'local' => 'object',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sources/sqlite/mods3mediasource.class.php
+++ b/core/model/modx/sources/sqlite/mods3mediasource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/mods3mediasource.class.php');
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+class modS3MediaSource_sqlite extends modS3MediaSource {
+}

--- a/core/model/modx/sources/sqlite/mods3mediasource.map.inc.php
+++ b/core/model/modx/sources/sqlite/mods3mediasource.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sources.sqlite
+ */
+$xpdo_meta_map['modS3MediaSource']= array (
+  'package' => 'modx.sources',
+  'version' => '1.1',
+  'extends' => 'modMediaSource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sqlite/modaccess.class.php
+++ b/core/model/modx/sqlite/modaccess.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccess.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccess_sqlite extends modAccess {
+}

--- a/core/model/modx/sqlite/modaccess.map.inc.php
+++ b/core/model/modx/sqlite/modaccess.map.inc.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccess']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'target' => '',
+    'principal_class' => 'modPrincipal',
+    'principal' => 0,
+    'authority' => 9999,
+    'policy' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'target' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+    'principal_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'modPrincipal',
+      'index' => 'index',
+    ),
+    'principal' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'authority' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 9999,
+      'index' => 'index',
+    ),
+    'policy' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'target' => 
+    array (
+      'alias' => 'target',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'target' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'principal_class' => 
+    array (
+      'alias' => 'principal_class',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'principal_class' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'principal' => 
+    array (
+      'alias' => 'principal',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'principal' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'authority' => 
+    array (
+      'alias' => 'authority',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'authority' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'policy' => 
+    array (
+      'alias' => 'policy',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'policy' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Policy' => 
+    array (
+      'class' => 'modAccessPolicy',
+      'local' => 'policy',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Principal' => 
+    array (
+      'class' => 'modPrincipal',
+      'local' => 'principal',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'GroupPrincipal' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'principal',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+      'criteria' => 
+      array (
+        'local' => 
+        array (
+          'principal_class' => 'modUserGroup',
+        ),
+      ),
+    ),
+    'UserPrincipal' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'principal',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+      'criteria' => 
+      array (
+        'local' => 
+        array (
+          'principal_class' => 'modUser',
+        ),
+      ),
+    ),
+    'MinimumRole' => 
+    array (
+      'class' => 'modUserGroupRole',
+      'local' => 'authority',
+      'foreign' => 'authority',
+      'owner' => 'local',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccessaction.class.php
+++ b/core/model/modx/sqlite/modaccessaction.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessaction.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessAction_sqlite extends modAccessAction {
+}

--- a/core/model/modx/sqlite/modaccessaction.map.inc.php
+++ b/core/model/modx/sqlite/modaccessaction.map.inc.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessAction']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_actions',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modAction',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccessactiondom.class.php
+++ b/core/model/modx/sqlite/modaccessactiondom.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessactiondom.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessActionDom_sqlite extends modAccessActionDom {
+}

--- a/core/model/modx/sqlite/modaccessactiondom.map.inc.php
+++ b/core/model/modx/sqlite/modaccessactiondom.map.inc.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessActionDom']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_actiondom',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modActionDom',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesscategory.class.php
+++ b/core/model/modx/sqlite/modaccesscategory.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesscategory.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessCategory_sqlite extends modAccessCategory {
+}

--- a/core/model/modx/sqlite/modaccesscategory.map.inc.php
+++ b/core/model/modx/sqlite/modaccesscategory.map.inc.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessCategory']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_category',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+    'context_key' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modCategory',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesscontext.class.php
+++ b/core/model/modx/sqlite/modaccesscontext.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesscontext.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessContext_sqlite extends modAccessContext {
+}

--- a/core/model/modx/sqlite/modaccesscontext.map.inc.php
+++ b/core/model/modx/sqlite/modaccesscontext.map.inc.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessContext']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_context',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'target',
+      'foreign' => 'key',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesselement.class.php
+++ b/core/model/modx/sqlite/modaccesselement.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesselement.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessElement_sqlite extends modAccessElement {
+}

--- a/core/model/modx/sqlite/modaccesselement.map.inc.php
+++ b/core/model/modx/sqlite/modaccesselement.map.inc.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessElement']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_elements',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+    'context_key' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modElement',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccessibleobject.class.php
+++ b/core/model/modx/sqlite/modaccessibleobject.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessibleobject.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessibleObject_sqlite extends modAccessibleObject {
+}

--- a/core/model/modx/sqlite/modaccessibleobject.map.inc.php
+++ b/core/model/modx/sqlite/modaccessibleobject.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessibleObject']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sqlite/modaccessiblesimpleobject.class.php
+++ b/core/model/modx/sqlite/modaccessiblesimpleobject.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessiblesimpleobject.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessibleSimpleObject_sqlite extends modAccessibleSimpleObject {
+}

--- a/core/model/modx/sqlite/modaccessiblesimpleobject.map.inc.php
+++ b/core/model/modx/sqlite/modaccessiblesimpleobject.map.inc.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessibleSimpleObject']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'modAccessibleObject',
+  'fields' => 
+  array (
+    'id' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'id' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'index' => 'pk',
+      'generated' => 'native',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'id' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccessmenu.class.php
+++ b/core/model/modx/sqlite/modaccessmenu.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessmenu.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessMenu_sqlite extends modAccessMenu {
+}

--- a/core/model/modx/sqlite/modaccessmenu.map.inc.php
+++ b/core/model/modx/sqlite/modaccessmenu.map.inc.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessMenu']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_menus',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modMenu',
+      'local' => 'target',
+      'foreign' => 'text',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccessnamespace.class.php
+++ b/core/model/modx/sqlite/modaccessnamespace.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(__DIR__) . '/modaccessnamespace.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessNamespace_sqlite extends modAccessNamespace {
+}

--- a/core/model/modx/sqlite/modaccessnamespace.map.inc.php
+++ b/core/model/modx/sqlite/modaccessnamespace.map.inc.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package modx
+ * @subpackage mysql
+ */
+$xpdo_meta_map['modAccessNamespace']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_namespace',
+  'extends' => 'modAccess',
+  'fields' =>
+  array (
+    'context_key' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'target',
+      'foreign' => 'name',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesspermission.class.php
+++ b/core/model/modx/sqlite/modaccesspermission.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesspermission.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessPermission_sqlite extends modAccessPermission {
+}

--- a/core/model/modx/sqlite/modaccesspermission.map.inc.php
+++ b/core/model/modx/sqlite/modaccesspermission.map.inc.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessPermission']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_permissions',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'template' => 0,
+    'name' => '',
+    'description' => '',
+    'value' => 1,
+  ),
+  'fieldMeta' => 
+  array (
+    'template' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'template' => 
+    array (
+      'alias' => 'template',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'template' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Template' => 
+    array (
+      'class' => 'modAccessPolicyTemplate',
+      'local' => 'template',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesspolicy.class.php
+++ b/core/model/modx/sqlite/modaccesspolicy.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesspolicy.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessPolicy_sqlite extends modAccessPolicy {
+}

--- a/core/model/modx/sqlite/modaccesspolicy.map.inc.php
+++ b/core/model/modx/sqlite/modaccesspolicy.map.inc.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessPolicy']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_policies',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => NULL,
+    'description' => NULL,
+    'parent' => 0,
+    'template' => 0,
+    'class' => '',
+    'data' => '{}',
+    'lexicon' => 'permissions',
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'parent' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'template' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'data' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'json',
+      'default' => '{}',
+    ),
+    'lexicon' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'permissions',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'parent' => 
+    array (
+      'alias' => 'parent',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'parent' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'class' => 
+    array (
+      'alias' => 'class',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'class' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'template' => 
+    array (
+      'alias' => 'template',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'template' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Children' => 
+    array (
+      'class' => 'modAccessPolicy',
+      'local' => 'id',
+      'foreign' => 'parent',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Parent' => 
+    array (
+      'class' => 'modAccessPolicy',
+      'local' => 'parent',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Template' => 
+    array (
+      'class' => 'modAccessPolicyTemplate',
+      'local' => 'template',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesspolicytemplate.class.php
+++ b/core/model/modx/sqlite/modaccesspolicytemplate.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesspolicytemplate.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessPolicyTemplate_sqlite extends modAccessPolicyTemplate {
+}

--- a/core/model/modx/sqlite/modaccesspolicytemplate.map.inc.php
+++ b/core/model/modx/sqlite/modaccesspolicytemplate.map.inc.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessPolicyTemplate']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_policy_templates',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'template_group' => 0,
+    'name' => '',
+    'description' => NULL,
+    'lexicon' => 'permissions',
+  ),
+  'fieldMeta' => 
+  array (
+    'template_group' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'lexicon' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'permissions',
+    ),
+  ),
+  'composites' => 
+  array (
+    'Permissions' => 
+    array (
+      'class' => 'modAccessPermission',
+      'local' => 'id',
+      'foreign' => 'template',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'Policies' => 
+    array (
+      'class' => 'modAccessPolicy',
+      'local' => 'id',
+      'foreign' => 'template',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'TemplateGroup' => 
+    array (
+      'class' => 'modAccessPolicyTemplateGroup',
+      'local' => 'template_group',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesspolicytemplategroup.class.php
+++ b/core/model/modx/sqlite/modaccesspolicytemplategroup.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesspolicytemplategroup.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessPolicyTemplateGroup_sqlite extends modAccessPolicyTemplateGroup {
+}

--- a/core/model/modx/sqlite/modaccesspolicytemplategroup.map.inc.php
+++ b/core/model/modx/sqlite/modaccesspolicytemplategroup.map.inc.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessPolicyTemplateGroup']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_policy_template_groups',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+  ),
+  'composites' => 
+  array (
+    'Templates' => 
+    array (
+      'class' => 'modAccessPolicyTemplate',
+      'local' => 'id',
+      'foreign' => 'template_group',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccessresource.class.php
+++ b/core/model/modx/sqlite/modaccessresource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessResource_sqlite extends modAccessResource {
+}

--- a/core/model/modx/sqlite/modaccessresource.map.inc.php
+++ b/core/model/modx/sqlite/modaccessresource.map.inc.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_resources',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+    'context_key' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccessresourcegroup.class.php
+++ b/core/model/modx/sqlite/modaccessresourcegroup.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccessresourcegroup.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessResourceGroup_sqlite extends modAccessResourceGroup {
+}

--- a/core/model/modx/sqlite/modaccessresourcegroup.map.inc.php
+++ b/core/model/modx/sqlite/modaccessresourcegroup.map.inc.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessResourceGroup']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_resource_groups',
+  'extends' => 'modAccess',
+  'fields' => 
+  array (
+    'context_key' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'principal_class' =>
+    array (
+      'alias' => 'principal_class',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'principal_class' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'target' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'principal' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'authority' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modResourceGroup',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaccesstemplatevar.class.php
+++ b/core/model/modx/sqlite/modaccesstemplatevar.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaccesstemplatevar.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAccessTemplateVar_sqlite extends modAccessTemplateVar {
+}

--- a/core/model/modx/sqlite/modaccesstemplatevar.map.inc.php
+++ b/core/model/modx/sqlite/modaccesstemplatevar.map.inc.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAccessTemplateVar']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'access_templatevars',
+  'extends' => 'modAccessElement',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+  'aggregates' => 
+  array (
+    'Target' => 
+    array (
+      'class' => 'modTemplateVar',
+      'local' => 'target',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modaction.class.php
+++ b/core/model/modx/sqlite/modaction.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modaction.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modAction_sqlite extends modAction {
+}

--- a/core/model/modx/sqlite/modaction.map.inc.php
+++ b/core/model/modx/sqlite/modaction.map.inc.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modAction']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'actions',
+  'extends' => 'modAccessibleSimpleObject',
+  'fields' => 
+  array (
+    'namespace' => 'core',
+    'controller' => NULL,
+    'haslayout' => 1,
+    'lang_topics' => NULL,
+    'assets' => '',
+    'help_url' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+      'index' => 'index',
+    ),
+    'controller' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'index',
+    ),
+    'haslayout' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 1,
+    ),
+    'lang_topics' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+    ),
+    'assets' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'help_url' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'namespace' => 
+    array (
+      'alias' => 'namespace',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'namespace' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'controller' => 
+    array (
+      'alias' => 'controller',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'controller' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Menus' => 
+    array (
+      'class' => 'modMenu',
+      'local' => 'id',
+      'foreign' => 'action',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'Acls' => 
+    array (
+      'class' => 'modAccessAction',
+      'local' => 'id',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'Fields' => 
+    array (
+      'class' => 'modActionField',
+      'local' => 'id',
+      'foreign' => 'action',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'DOM' => 
+    array (
+      'class' => 'modActionDom',
+      'local' => 'id',
+      'foreign' => 'action',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Namespace' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'namespace',
+      'foreign' => 'name',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modactiondom.class.php
+++ b/core/model/modx/sqlite/modactiondom.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modactiondom.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modActionDom_sqlite extends modActionDom {
+}

--- a/core/model/modx/sqlite/modactiondom.map.inc.php
+++ b/core/model/modx/sqlite/modactiondom.map.inc.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modActionDom']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'actiondom',
+  'extends' => 'modAccessibleSimpleObject',
+  'fields' => 
+  array (
+    'set' => 0,
+    'action' => '',
+    'name' => '',
+    'description' => NULL,
+    'xtype' => '',
+    'container' => '',
+    'rule' => '',
+    'value' => '',
+    'constraint' => '',
+    'constraint_field' => '',
+    'constraint_class' => '',
+    'active' => 1,
+    'for_parent' => 0,
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'set' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'action' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'xtype' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'container' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'rule' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'constraint' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'constraint_field' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'constraint_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'active' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'for_parent' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'set' => 
+    array (
+      'alias' => 'set',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'set' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'action' => 
+    array (
+      'alias' => 'action',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'action' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'active' => 
+    array (
+      'alias' => 'active',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'active' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'for_parent' => 
+    array (
+      'alias' => 'for_parent',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'for_parent' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' => 
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'rank' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Access' => 
+    array (
+      'class' => 'modAccessActionDom',
+      'local' => 'id',
+      'foreign' => 'target',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'FCSet' => 
+    array (
+      'class' => 'modFormCustomizationSet',
+      'local' => 'set',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Action' => 
+    array (
+      'class' => 'modAction',
+      'local' => 'action',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modactionfield.class.php
+++ b/core/model/modx/sqlite/modactionfield.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modactionfield.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modActionField_sqlite extends modActionField {
+}

--- a/core/model/modx/sqlite/modactionfield.map.inc.php
+++ b/core/model/modx/sqlite/modactionfield.map.inc.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modActionField']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'actions_fields',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'action' => '',
+    'name' => '',
+    'type' => 'field',
+    'tab' => '',
+    'form' => '',
+    'other' => '',
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'action' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'type' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'field',
+      'index' => 'index',
+    ),
+    'tab' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'form' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'other' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'action' => 
+    array (
+      'alias' => 'action',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'action' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'type' => 
+    array (
+      'alias' => 'type',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'type' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'tab' => 
+    array (
+      'alias' => 'tab',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'tab' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Action' => 
+    array (
+      'class' => 'modAction',
+      'local' => 'action',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modactiveuser.class.php
+++ b/core/model/modx/sqlite/modactiveuser.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modactiveuser.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modActiveUser_sqlite extends modActiveUser {
+}

--- a/core/model/modx/sqlite/modactiveuser.map.inc.php
+++ b/core/model/modx/sqlite/modactiveuser.map.inc.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modActiveUser']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'active_users',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'internalKey' => 0,
+    'username' => '',
+    'lasthit' => 0,
+    'id' => NULL,
+    'action' => '',
+    'ip' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'internalKey' => 
+    array (
+      'dbtype' => 'integer',
+      'precision' => '9',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'username' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'lasthit' => 
+    array (
+      'dbtype' => 'integer',
+      'precision' => '20',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
+    'id' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => true,
+    ),
+    'action' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'ip' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'internalKey' => 
+    array (
+      'alias' => 'internalKey',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'internalKey' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'User' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'internalKey',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modcategory.class.php
+++ b/core/model/modx/sqlite/modcategory.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modcategory.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modCategory_sqlite extends modCategory {
+}

--- a/core/model/modx/sqlite/modcategory.map.inc.php
+++ b/core/model/modx/sqlite/modcategory.map.inc.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modCategory']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'categories',
+  'extends' => 'modAccessibleSimpleObject',
+  'fields' => 
+  array (
+    'parent' => 0,
+    'category' => '',
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'parent' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'category' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '45',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+      'indexgrp' => 'category',
+    ),
+    'rank' =>
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'parent' => 
+    array (
+      'alias' => 'parent',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'parent' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'category' => 
+    array (
+      'alias' => 'category',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'parent' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'category' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' =>
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'rank' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Children' => 
+    array (
+      'class' => 'modCategory',
+      'local' => 'id',
+      'foreign' => 'parent',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Acls' => 
+    array (
+      'class' => 'modAccessCategory',
+      'local' => 'id',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'Ancestors' => 
+    array (
+      'class' => 'modCategoryClosure',
+      'local' => 'id',
+      'foreign' => 'ancestor',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Descendants' => 
+    array (
+      'class' => 'modCategoryClosure',
+      'local' => 'id',
+      'foreign' => 'descendant',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Parent' => 
+    array (
+      'class' => 'modCategory',
+      'local' => 'parent',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Chunks' => 
+    array (
+      'class' => 'modChunk',
+      'key' => 'id',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Snippets' => 
+    array (
+      'class' => 'modSnippet',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Plugins' => 
+    array (
+      'class' => 'modPlugin',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Templates' => 
+    array (
+      'class' => 'modTemplate',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'TemplateVars' => 
+    array (
+      'class' => 'modTemplateVar',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'PropertySets' => 
+    array (
+      'class' => 'modPropertySet',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'modChunk' => 
+    array (
+      'class' => 'modChunk',
+      'key' => 'id',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'modSnippet' => 
+    array (
+      'class' => 'modSnippet',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'modPlugin' => 
+    array (
+      'class' => 'modPlugin',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'modTemplate' => 
+    array (
+      'class' => 'modTemplate',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'modTemplateVar' => 
+    array (
+      'class' => 'modTemplateVar',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'modPropertySet' => 
+    array (
+      'class' => 'modPropertySet',
+      'local' => 'id',
+      'foreign' => 'category',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'validation' => 
+  array (
+    'rules' => 
+    array (
+      'category' => 
+      array (
+        'preventBlank' => 
+        array (
+          'type' => 'xPDOValidationRule',
+          'rule' => 'xPDOMinLengthValidationRule',
+          'value' => '1',
+          'message' => 'category_err_ns_name',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modcategoryclosure.class.php
+++ b/core/model/modx/sqlite/modcategoryclosure.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modcategoryclosure.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modCategoryClosure_sqlite extends modCategoryClosure {
+}

--- a/core/model/modx/sqlite/modcategoryclosure.map.inc.php
+++ b/core/model/modx/sqlite/modcategoryclosure.map.inc.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modCategoryClosure']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'categories_closure',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'ancestor' => 0,
+    'descendant' => 0,
+    'depth' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'ancestor' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'descendant' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'depth' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'ancestor' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'descendant' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Ancestor' => 
+    array (
+      'class' => 'modCategory',
+      'local' => 'ancestor',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Descendant' => 
+    array (
+      'class' => 'modCategory',
+      'local' => 'descendant',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modchunk.class.php
+++ b/core/model/modx/sqlite/modchunk.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modchunk.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modChunk_sqlite extends modChunk {
+}

--- a/core/model/modx/sqlite/modchunk.map.inc.php
+++ b/core/model/modx/sqlite/modchunk.map.inc.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modChunk']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_htmlsnippets',
+  'extends' => 'modElement',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => 'Chunk',
+    'editor_type' => 0,
+    'category' => 0,
+    'cache_type' => 0,
+    'snippet' => NULL,
+    'locked' => 0,
+    'properties' => NULL,
+    'static' => 0,
+    'static_file' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'Chunk',
+    ),
+    'editor_type' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'category' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'cache_type' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'snippet' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'locked' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+    'static' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'static_file' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'fieldAliases' => 
+  array (
+    'content' => 'snippet',
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'category' => 
+    array (
+      'alias' => 'category',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'category' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'locked' => 
+    array (
+      'alias' => 'locked',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'locked' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'static' => 
+    array (
+      'alias' => 'static',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'static' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'PropertySets' => 
+    array (
+      'class' => 'modElementPropertySet',
+      'local' => 'id',
+      'foreign' => 'element',
+      'owner' => 'local',
+      'cardinality' => 'many',
+      'criteria' => 
+      array (
+        'foreign' => 
+        array (
+          'element_class' => 'modChunk',
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Category' => 
+    array (
+      'class' => 'modCategory',
+      'key' => 'id',
+      'local' => 'category',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+  'validation' => 
+  array (
+    'rules' => 
+    array (
+      'name' => 
+      array (
+        'invalid' => 
+        array (
+          'type' => 'preg_match',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?!\\s)$/',
+          'message' => 'chunk_err_invalid_name',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modclassmap.class.php
+++ b/core/model/modx/sqlite/modclassmap.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modclassmap.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modClassMap_sqlite extends modClassMap {
+}

--- a/core/model/modx/sqlite/modclassmap.map.inc.php
+++ b/core/model/modx/sqlite/modclassmap.map.inc.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modClassMap']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'class_map',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'class' => '',
+    'parent_class' => '',
+    'name_field' => 'name',
+    'path' => '',
+    'lexicon' => 'core:resource',
+  ),
+  'fieldMeta' => 
+  array (
+    'class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '120',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'parent_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '120',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'name_field' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'name',
+      'index' => 'index',
+    ),
+    'path' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '512',
+      'phptype' => 'string',
+      'default' => '',
+    ),
+    'lexicon' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core:resource',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'class' => 
+    array (
+      'alias' => 'class',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'class' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'parent_class' => 
+    array (
+      'alias' => 'parent_class',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'parent_class' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'name_field' => 
+    array (
+      'alias' => 'name_field',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name_field' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modcontenttype.class.php
+++ b/core/model/modx/sqlite/modcontenttype.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modcontenttype.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modContentType_sqlite extends modContentType {
+}

--- a/core/model/modx/sqlite/modcontenttype.map.inc.php
+++ b/core/model/modx/sqlite/modcontenttype.map.inc.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modContentType']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'content_type',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => NULL,
+    'description' => NULL,
+    'mime_type' => NULL,
+    'file_extensions' => NULL,
+    'headers' => NULL,
+    'binary' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '512',
+      'phptype' => 'string',
+      'null' => true,
+    ),
+    'mime_type' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '512',
+      'phptype' => 'string',
+    ),
+    'file_extensions' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '512',
+      'phptype' => 'string',
+    ),
+    'headers' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+    ),
+    'binary' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Resources' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'content_type',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+  'validation' => 
+  array (
+    'rules' => 
+    array (
+      'name' => 
+      array (
+        'name' => 
+        array (
+          'type' => 'xPDOValidationRule',
+          'rule' => 'xPDOMinLengthValidationRule',
+          'value' => '1',
+          'message' => 'content_type_err_ns_name',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modcontext.class.php
+++ b/core/model/modx/sqlite/modcontext.class.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+include_once (strtr(realpath(dirname(__FILE__)), '\\', '/') . '/../modcontext.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modContext_sqlite extends modContext {
+    public static function getResourceCacheMapStmt(&$context) {
+        $stmt = false;
+        if ($context instanceof modContext) {
+            $time=microtime(true);
+            $cache_alias_map = $context->getOption('cache_alias_map');
+            $use_context_resource_table = $context->getOption('use_context_resource_table',null,1);
+
+            $tblResource= $context->xpdo->getTableName('modResource');
+            $tblContextResource= $context->xpdo->getTableName('modContextResource');
+
+            $resourceFields= array('id','parent','uri');
+
+            // we do not need to select uri if cache_alias_map is set to false
+            if ($cache_alias_map == 0) {
+                $resourceFields = array('id','parent');
+            }
+
+            $resourceCols= $context->xpdo->getSelectColumns('modResource', 'r', '', $resourceFields);
+            $contextKey = $context->get('key');
+
+            $bindings = array();
+            $sql  = "SELECT {$resourceCols} FROM {$tblResource} `r` ";
+            if ($use_context_resource_table) {
+                $bindings = array($contextKey, $contextKey);
+                $sql .= "FORCE INDEX (`cache_refresh_idx`) ";
+                $sql .= "LEFT JOIN {$tblContextResource} `cr` ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` ";
+            }
+            $sql .= "WHERE `r`.`deleted` = 0 "; //"AND `r`.`id` != `r`.`parent`";
+            if ($use_context_resource_table) {
+                $sql .= "AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) ";
+                $sql .= "GROUP BY `r`.`parent`, `r`.`menuindex`, `r`.`id`, `r`.`uri` ";
+            } else {
+                $bindings = array($contextKey);
+                $sql .= "   AND `r`.`context_key` = ?";
+            }
+
+            $criteria = new xPDOCriteria($context->xpdo, $sql, $bindings, false);
+            if ($criteria && $criteria->stmt && $criteria->stmt->execute()) {
+                $stmt =& $criteria->stmt;
+            }
+
+            // output warning if query is too slow
+            $time = ((microtime(true)-$time));
+            if ($time >= 1.0 && $use_context_resource_table==1) {
+                $context->xpdo->log(modX::LOG_LEVEL_WARN,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            }
+        }
+        return $stmt;
+    }
+
+    public static function getWebLinkCacheMapStmt(&$context) {
+        $stmt = false;
+        if ($context instanceof modContext) {
+            $time=microtime(true);
+            $use_context_resource_table = $context->getOption('use_context_resource_table',null,1);
+
+            $tblResource = $context->xpdo->getTableName('modResource');
+            $tblContextResource = $context->xpdo->getTableName('modContextResource');
+            $resourceFields= array('id','content');
+
+            $resourceCols= $context->xpdo->getSelectColumns('modResource', 'r', '', $resourceFields);
+            $contextKey = $context->get('key');
+
+            $bindings = array();
+            $sql  = "SELECT {$resourceCols} ";
+            $sql .= "FROM {$tblResource} `r` ";
+            if ($use_context_resource_table) {
+                $bindings = array($contextKey, $contextKey);
+                $sql .= "LEFT JOIN {$tblContextResource} `cr` ";
+                $sql .= "ON `cr`.`context_key` = ? AND `r`.`id` = `cr`.`resource` ";
+            }
+            $sql .= "WHERE `r`.`deleted` = 0 "; //"`r`.`id` != `r`.`parent` ";
+            $sql .= "AND `r`.`class_key` = 'modWebLink' ";
+
+            if ($use_context_resource_table) {
+                $sql .= "AND (`r`.`context_key` = ? OR `cr`.`context_key` IS NOT NULL) ";
+                $sql .= "GROUP BY `r`.`id`";
+            } else {
+                $bindings = array($contextKey);
+                $sql .= "   AND `r`.`context_key` = ?";
+            }
+
+            $criteria = new xPDOCriteria($context->xpdo, $sql, $bindings, false);
+            if ($criteria && $criteria->stmt && $criteria->stmt->execute()) {
+                $stmt =& $criteria->stmt;
+            }
+
+            $time = ((microtime(true)-$time));
+            if ($time >= 1.0 && $use_context_resource_table==1) {
+                $context->xpdo->log(modX::LOG_LEVEL_WARN,"[modContext_mysql] Slow query detected. Consider to set 'use_context_resource_table' to false.");
+            }
+        }
+        return $stmt;
+    }
+}

--- a/core/model/modx/sqlite/modcontext.map.inc.php
+++ b/core/model/modx/sqlite/modcontext.map.inc.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modContext']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'context',
+  'extends' => 'modAccessibleObject',
+  'fields' => 
+  array (
+    'key' => NULL,
+    'name' => NULL,
+    'description' => NULL,
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'name' =>
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '191',
+      'phptype' => 'string',
+      'index' => 'index',
+    ),
+    'description' =>
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '512',
+      'phptype' => 'string',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'precision' => '11',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'name' =>
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'name' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' =>
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'rank' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'ContextResources' => 
+    array (
+      'class' => 'modContextResource',
+      'local' => 'key',
+      'foreign' => 'context_key',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'ContextSettings' => 
+    array (
+      'class' => 'modContextSetting',
+      'local' => 'key',
+      'foreign' => 'context_key',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'SourceElements' =>
+    array (
+      'class' => 'sources.modMediaSourceElement',
+      'local' => 'key',
+      'foreign' => 'context_key',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Acls' =>
+    array (
+      'class' => 'modAccessContext',
+      'local' => 'key',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+  'validation' => 
+  array (
+    'rules' => 
+    array (
+      'key' => 
+      array (
+        'key' => 
+        array (
+          'type' => 'preg_match',
+          'rule' => '/^[a-zA-Z\\x7f-\\xff][a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff]*$/',
+          'message' => 'context_err_ns_key',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modcontextresource.class.php
+++ b/core/model/modx/sqlite/modcontextresource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modcontextresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modContextResource_sqlite extends modContextResource {
+}

--- a/core/model/modx/sqlite/modcontextresource.map.inc.php
+++ b/core/model/modx/sqlite/modcontextresource.map.inc.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modContextResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'context_resource',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'context_key' => NULL,
+    'resource' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'resource' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'index' => 'pk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'resource' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Resource' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'resource',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modcontextsetting.class.php
+++ b/core/model/modx/sqlite/modcontextsetting.class.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+include_once (strtr(realpath(dirname(__FILE__)), '\\', '/') . '/../modcontextsetting.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modContextSetting_sqlite extends modContextSetting {
+    public static function listSettings(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+        /* build query */
+        $c = $xpdo->newQuery('modContextSetting');
+        $c->select(array(
+            $xpdo->getSelectColumns('modContextSetting','modContextSetting'),
+        ));
+        $c->select(array(
+            'Entry.value AS name_trans',
+            'Description.value AS description_trans',
+        ));
+        $c->leftJoin('modLexiconEntry','Entry',"'setting_' + modContextSetting.{$xpdo->escape('key')} = Entry.name");
+        $c->leftJoin('modLexiconEntry','Description',"'setting_' + modContextSetting.{$xpdo->escape('key')} + '_desc' = Description.name");
+        $c->where($criteria);
+        $c->groupby('modContextSetting.' . $xpdo->escape('context_key') . ', modContextSetting.' . $xpdo->escape('key')); // лечение ALEX
+
+        $count = $xpdo->getCount('modContextSetting',$c);
+        $c->sortby($xpdo->getSelectColumns('modContextSetting','modContextSetting','',array('area')),'ASC');
+        foreach($sort as $field=> $dir) {
+            $c->sortby($xpdo->getSelectColumns('modContextSetting','modContextSetting','',array($field)),$dir);
+        }
+        if ((int) $limit > 0) {
+            $c->limit((int) $limit, (int) $offset);
+        }
+        //$c->prepare();
+        return array(
+            'count'=> $count,
+            'collection'=> $xpdo->getCollection('modContextSetting',$c)
+        );
+    }
+}

--- a/core/model/modx/sqlite/modcontextsetting.map.inc.php
+++ b/core/model/modx/sqlite/modcontextsetting.map.inc.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modContextSetting']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'context_setting',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'context_key' => NULL,
+    'key' => NULL,
+    'value' => NULL,
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => '',
+    'editedon' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'xtype' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '75',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'textfield',
+    ),
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '40',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+    ),
+    'area' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'editedon' => 
+    array (
+        'dbtype' => 'bigint',
+        'phptype' => 'timestamp',
+        'null' => false,
+        'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'key' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'key' => 'context_key',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'SystemSetting' => 
+    array (
+      'class' => 'modSystemSetting',
+      'key' => 'key',
+      'local' => 'key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/moddashboard.class.php
+++ b/core/model/modx/sqlite/moddashboard.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moddashboard.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modDashboard_sqlite extends modDashboard {
+}

--- a/core/model/modx/sqlite/moddashboard.map.inc.php
+++ b/core/model/modx/sqlite/moddashboard.map.inc.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modDashboard']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'dashboard',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => NULL,
+    'hide_trees' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'hide_trees' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'hide_trees' => 
+    array (
+      'alias' => 'hide_trees',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'hide_trees' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Placements' => 
+    array (
+      'class' => 'modDashboardWidgetPlacement',
+      'local' => 'id',
+      'foreign' => 'dashboard',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'UserGroups' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'id',
+      'foreign' => 'dashboard',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/moddashboardwidget.class.php
+++ b/core/model/modx/sqlite/moddashboardwidget.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moddashboardwidget.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modDashboardWidget_sqlite extends modDashboardWidget {
+}

--- a/core/model/modx/sqlite/moddashboardwidget.map.inc.php
+++ b/core/model/modx/sqlite/moddashboardwidget.map.inc.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modDashboardWidget']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'dashboard_widget',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => NULL,
+    'type' => NULL,
+    'content' => NULL,
+    'namespace' => '',
+    'lexicon' => 'core:dashboards',
+    'size' => 'half',
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'type' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'index',
+    ),
+    'content' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'lexicon' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core:dashboards',
+      'index' => 'index',
+    ),
+    'size' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'half',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'type' => 
+    array (
+      'alias' => 'type',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'type' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'namespace' => 
+    array (
+      'alias' => 'namespace',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'namespace' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'lexicon' => 
+    array (
+      'alias' => 'lexicon',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'lexicon' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Placements' => 
+    array (
+      'class' => 'modDashboardWidgetPlacement',
+      'local' => 'id',
+      'foreign' => 'widget',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Namespace' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'namespace',
+      'foreign' => 'name',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/moddashboardwidgetplacement.class.php
+++ b/core/model/modx/sqlite/moddashboardwidgetplacement.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moddashboardwidgetplacement.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modDashboardWidgetPlacement_sqlite extends modDashboardWidgetPlacement {
+}

--- a/core/model/modx/sqlite/moddashboardwidgetplacement.map.inc.php
+++ b/core/model/modx/sqlite/moddashboardwidgetplacement.map.inc.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modDashboardWidgetPlacement']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'dashboard_widget_placement',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'dashboard' => 0,
+    'widget' => 0,
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'dashboard' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'widget' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'columns' => 
+      array (
+        'dashboard' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'widget' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' => 
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'rank' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Dashboard' => 
+    array (
+      'class' => 'modDashboard',
+      'local' => 'dashboard',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Widget' => 
+    array (
+      'class' => 'modDashboardWidget',
+      'local' => 'widget',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/moddocument.class.php
+++ b/core/model/modx/sqlite/moddocument.class.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moddocument.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modDocument_sqlite extends modDocument {}

--- a/core/model/modx/sqlite/moddocument.map.inc.php
+++ b/core/model/modx/sqlite/moddocument.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modDocument']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'modResource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sqlite/modelement.class.php
+++ b/core/model/modx/sqlite/modelement.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modelement.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modElement_sqlite extends modElement {
+}

--- a/core/model/modx/sqlite/modelement.map.inc.php
+++ b/core/model/modx/sqlite/modelement.map.inc.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modElement']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_element',
+  'extends' => 'modAccessibleSimpleObject',
+  'fields' => 
+  array (
+    'source' => 0,
+    'property_preprocess' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'source' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'property_preprocess' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'composites' => 
+  array (
+    'Acls' => 
+    array (
+      'class' => 'modAccessElement',
+      'local' => 'id',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'CategoryAcls' => 
+    array (
+      'class' => 'modAccessCategory',
+      'local' => 'category',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'Source' => 
+    array (
+      'class' => 'sources.modMediaSource',
+      'local' => 'source',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modelementpropertyset.class.php
+++ b/core/model/modx/sqlite/modelementpropertyset.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modelementpropertyset.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modElementPropertySet_sqlite extends modElementPropertySet {
+}

--- a/core/model/modx/sqlite/modelementpropertyset.map.inc.php
+++ b/core/model/modx/sqlite/modelementpropertyset.map.inc.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modElementPropertySet']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'element_property_sets',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'element' => 0,
+    'element_class' => '',
+    'property_set' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'element' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'element_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'pk',
+    ),
+    'property_set' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'columns' => 
+      array (
+        'element' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'element_class' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'property_set' => 
+        array (
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Element' => 
+    array (
+      'class' => 'modElement',
+      'local' => 'element',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'PropertySet' => 
+    array (
+      'class' => 'modPropertySet',
+      'local' => 'property_set',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modevent.class.php
+++ b/core/model/modx/sqlite/modevent.class.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modevent.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modEvent_sqlite extends modEvent {
+    public static function listEvents(xPDO &$xpdo, $plugin, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+        $c = $xpdo->newQuery('modEvent');
+        $count = $xpdo->getCount('modEvent',$c);
+        $c->select($xpdo->getSelectColumns('modEvent','modEvent'));
+        $c->select(array(
+            'IFNULL(modPluginEvent.pluginid,0) AS enabled',
+            'modPluginEvent.priority AS priority',
+            'modPluginEvent.propertyset AS propertyset',
+        ));
+
+        $c->leftJoin('modPluginEvent','modPluginEvent','
+            modPluginEvent.event = modEvent.name
+            AND modPluginEvent.pluginid = '.$plugin.'
+        ');
+        $c->where($criteria);
+        foreach($sort as $field=> $dir) {
+            $c->sortby($xpdo->getSelectColumns('modEvent','modEvent','',array($field)),$dir);
+        }
+        if ((int) $limit > 0) {
+            $c->limit((int) $limit, (int) $offset);
+        }
+        //$c->prepare();
+        return array(
+            'count'=> $count,
+            'collection'=> $xpdo->getCollection('modEvent',$c)
+        );
+    }
+}

--- a/core/model/modx/sqlite/modevent.map.inc.php
+++ b/core/model/modx/sqlite/modevent.map.inc.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modEvent']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'system_eventnames',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'name' => NULL,
+    'service' => 0,
+    'groupname' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'service' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '4',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'groupname' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'PluginEvents' => 
+    array (
+      'class' => 'modPluginEvent',
+      'local' => 'name',
+      'foreign' => 'event',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modextensionpackage.class.php
+++ b/core/model/modx/sqlite/modextensionpackage.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modextensionpackage.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modExtensionPackage_sqlite extends modExtensionPackage {
+}

--- a/core/model/modx/sqlite/modextensionpackage.map.inc.php
+++ b/core/model/modx/sqlite/modextensionpackage.map.inc.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modExtensionPackage']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'extension_packages',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'namespace' => 'core',
+    'name' => 'core',
+    'path' => NULL,
+    'table_prefix' => '',
+    'service_class' => '',
+    'service_name' => '',
+    'created_at' => NULL,
+    'updated_at' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '40',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+      'index' => 'index',
+    ),
+    'name' =>
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+      'index' => 'index',
+    ),
+    'path' =>
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'table_prefix' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'service_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'service_name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'created_at' =>
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => true,
+    ),
+    'updated_at' =>
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => true,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'namespace' => 
+    array (
+      'alias' => 'namespace',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'namespace' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'name' =>
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'name' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Namespace' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'namespace',
+      'foreign' => 'name',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modformcustomizationprofile.class.php
+++ b/core/model/modx/sqlite/modformcustomizationprofile.class.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(__DIR__) . '/modformcustomizationprofile.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modFormCustomizationProfile_sqlite extends modFormCustomizationProfile {
+    public static function listProfiles(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+        /* query for profiles */
+        $c = $xpdo->newQuery('modFormCustomizationProfile');
+        $c->select(array(
+            'modFormCustomizationProfile.*',
+        ));
+        $c->select('
+            (SELECT GROUP_CONCAT(UserGroup.name) FROM '.$xpdo->getTableName('modUserGroup').' AS UserGroup
+                INNER JOIN '.$xpdo->getTableName('modFormCustomizationProfileUserGroup').' AS fcpug
+                ON fcpug.usergroup = UserGroup.id
+             WHERE fcpug.profile = modFormCustomizationProfile.id
+            ) AS usergroups
+        ');
+        $c->where($criteria,null,2);// also log issue in remine to look at this usage of where()
+        $count = $xpdo->getCount('modFormCustomizationProfile',$c);
+
+        foreach($sort as $field=> $dir) {
+            $c->sortby($xpdo->getSelectColumns('modFormCustomizationProfile','modFormCustomizationProfile','',array($field)),$dir);
+        }
+        if ((int) $limit > 0) {
+            $c->limit((int) $limit, (int) $offset);
+        }
+        return array(
+            'count'=> $count,
+            'collection'=> $xpdo->getCollection('modFormCustomizationProfile',$c)
+        );
+    }
+}

--- a/core/model/modx/sqlite/modformcustomizationprofile.map.inc.php
+++ b/core/model/modx/sqlite/modformcustomizationprofile.map.inc.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modFormCustomizationProfile']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'fc_profiles',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => '',
+    'active' => 0,
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'active' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' => 
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'rank' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'active' => 
+    array (
+      'alias' => 'active',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'active' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Sets' => 
+    array (
+      'class' => 'modFormCustomizationSet',
+      'local' => 'id',
+      'foreign' => 'profile',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'UserGroups' => 
+    array (
+      'class' => 'modFormCustomizationProfileUserGroup',
+      'local' => 'id',
+      'foreign' => 'profile',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modformcustomizationprofileusergroup.class.php
+++ b/core/model/modx/sqlite/modformcustomizationprofileusergroup.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modformcustomizationprofileusergroup.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modFormCustomizationProfileUserGroup_sqlite extends modFormCustomizationProfileUserGroup {
+}

--- a/core/model/modx/sqlite/modformcustomizationprofileusergroup.map.inc.php
+++ b/core/model/modx/sqlite/modformcustomizationprofileusergroup.map.inc.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modFormCustomizationProfileUserGroup']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'fc_profiles_usergroups',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'usergroup' => 0,
+    'profile' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'usergroup' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'profile' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'usergroup' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'profile' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'UserGroup' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'usergroup',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Profile' => 
+    array (
+      'class' => 'modFormCustomizationProfile',
+      'local' => 'profile',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modformcustomizationset.class.php
+++ b/core/model/modx/sqlite/modformcustomizationset.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modformcustomizationset.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modFormCustomizationSet_sqlite extends modFormCustomizationSet {
+}

--- a/core/model/modx/sqlite/modformcustomizationset.map.inc.php
+++ b/core/model/modx/sqlite/modformcustomizationset.map.inc.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modFormCustomizationSet']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'fc_sets',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'profile' => 0,
+    'action' => '',
+    'description' => '',
+    'active' => 0,
+    'template' => 0,
+    'constraint' => '',
+    'constraint_field' => '',
+    'constraint_class' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'profile' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'action' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'active' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'template' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'constraint' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'constraint_field' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'constraint_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'profile' => 
+    array (
+      'alias' => 'profile',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'profile' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'action' => 
+    array (
+      'alias' => 'action',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'action' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'active' => 
+    array (
+      'alias' => 'active',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'active' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'template' => 
+    array (
+      'alias' => 'template',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'template' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Rules' => 
+    array (
+      'class' => 'modActionDom',
+      'local' => 'id',
+      'foreign' => 'set',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Action' => 
+    array (
+      'class' => 'modAction',
+      'local' => 'action',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Template' => 
+    array (
+      'class' => 'modTemplate',
+      'local' => 'template',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Profile' => 
+    array (
+      'class' => 'modFormCustomizationProfile',
+      'local' => 'profile',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modjsonrpcresource.class.php
+++ b/core/model/modx/sqlite/modjsonrpcresource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modjsonrpcresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modJSONRPCResource_sqlite extends modJSONRPCResource {
+}

--- a/core/model/modx/sqlite/modjsonrpcresource.map.inc.php
+++ b/core/model/modx/sqlite/modjsonrpcresource.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modJSONRPCResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'modXMLRPCResource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sqlite/modlexiconentry.class.php
+++ b/core/model/modx/sqlite/modlexiconentry.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modlexiconentry.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modLexiconEntry_sqlite extends modLexiconEntry {
+}

--- a/core/model/modx/sqlite/modlexiconentry.map.inc.php
+++ b/core/model/modx/sqlite/modlexiconentry.map.inc.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modLexiconEntry']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'lexicon_entries',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'value' => '',
+    'topic' => 'default',
+    'namespace' => 'core',
+    'language' => 'en',
+    'createdon' => NULL,
+    'editedon' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'topic' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'default',
+      'index' => 'index',
+    ),
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '40',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+      'index' => 'index',
+    ),
+    'language' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'en',
+      'index' => 'index',
+    ),
+    'createdon' =>
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+    ),
+    'editedon' => 
+    array (
+        'dbtype' => 'bigint',
+        'phptype' => 'timestamp',
+        'null' => false,
+        'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'topic' => 
+    array (
+      'alias' => 'topic',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'topic' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'namespace' => 
+    array (
+      'alias' => 'namespace',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'namespace' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'language' => 
+    array (
+      'alias' => 'language',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'language' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Namespace' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'namespace',
+      'foreign' => 'name',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modmanagerlog.class.php
+++ b/core/model/modx/sqlite/modmanagerlog.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modmanagerlog.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modManagerLog_sqlite extends modManagerLog {
+}

--- a/core/model/modx/sqlite/modmanagerlog.map.inc.php
+++ b/core/model/modx/sqlite/modmanagerlog.map.inc.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modManagerLog']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'manager_log',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'user' => 0,
+    'occurred' => '0000-00-00 00:00:00',
+    'action' => '',
+    'classKey' => '',
+    'item' => '0',
+  ),
+  'fieldMeta' => 
+  array (
+    'user' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'occurred' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => true,
+      'default' => '0000-00-00 00:00:00',
+    ),
+    'action' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'classKey' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'item' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '0',
+    ),
+  ),
+  'indexes' =>
+  array (
+    'user_occurred' =>
+    array (
+      'alias' => 'user_occurred',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'user' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'occurred' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' =>
+  array (
+    'User' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'user',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modmenu.class.php
+++ b/core/model/modx/sqlite/modmenu.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modmenu.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modMenu_sqlite extends modMenu {
+}

--- a/core/model/modx/sqlite/modmenu.map.inc.php
+++ b/core/model/modx/sqlite/modmenu.map.inc.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modMenu']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'menus',
+  'extends' => 'modAccessibleObject',
+  'fields' => 
+  array (
+    'text' => '',
+    'parent' => '',
+    'action' => '',
+    'description' => '',
+    'icon' => '',
+    'menuindex' => 0,
+    'params' => '',
+    'handler' => '',
+    'permissions' => '',
+    'namespace' => 'core',
+  ),
+  'fieldMeta' => 
+  array (
+    'text' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'pk',
+    ),
+    'parent' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'action' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'icon' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'menuindex' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'params' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'handler' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'permissions' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'text' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'parent' => 
+    array (
+      'alias' => 'parent',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'parent' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'action' => 
+    array (
+      'alias' => 'action',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'action' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'namespace' => 
+    array (
+      'alias' => 'namespace',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'namespace' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Acls' => 
+    array (
+      'class' => 'modAccessMenu',
+      'local' => 'text',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Action' => 
+    array (
+      'class' => 'modAction',
+      'local' => 'action',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Parent' => 
+    array (
+      'class' => 'modMenu',
+      'local' => 'parent',
+      'foreign' => 'text',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Children' => 
+    array (
+      'class' => 'modMenu',
+      'local' => 'text',
+      'foreign' => 'parent',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modnamespace.class.php
+++ b/core/model/modx/sqlite/modnamespace.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modnamespace.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modNamespace_sqlite extends modNamespace {
+}

--- a/core/model/modx/sqlite/modnamespace.map.inc.php
+++ b/core/model/modx/sqlite/modnamespace.map.inc.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modNamespace']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'namespaces',
+  'extends' => 'modAccessibleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'path' => '',
+    'assets_path' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '40',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'pk',
+    ),
+    'path' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'default' => '',
+    ),
+    'assets_path' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'default' => '',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'LexiconEntries' => 
+    array (
+      'class' => 'modLexiconEntry',
+      'local' => 'name',
+      'foreign' => 'namespace',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'SystemSettings' => 
+    array (
+      'class' => 'modSystemSetting',
+      'local' => 'name',
+      'foreign' => 'namespace',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'ContextSettings' => 
+    array (
+      'class' => 'modContextSetting',
+      'local' => 'name',
+      'foreign' => 'namespace',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'UserSettings' => 
+    array (
+      'class' => 'modUserSetting',
+      'local' => 'name',
+      'foreign' => 'namespace',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'ExtensionPackages' =>
+    array (
+      'class' => 'modExtensionPackage',
+      'local' => 'name',
+      'foreign' => 'namespace',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Acls' =>
+    array (
+      'class' => 'modAccessNamespace',
+      'local' => 'name',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'Actions' =>
+    array (
+      'class' => 'modAction',
+      'local' => 'name',
+      'foreign' => 'namespace',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modplugin.class.php
+++ b/core/model/modx/sqlite/modplugin.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modplugin.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modPlugin_sqlite extends modPlugin {
+}

--- a/core/model/modx/sqlite/modplugin.map.inc.php
+++ b/core/model/modx/sqlite/modplugin.map.inc.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modPlugin']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_plugins',
+  'extends' => 'modScript',
+  'fields' => 
+  array (
+    'cache_type' => 0,
+    'plugincode' => '',
+    'locked' => 0,
+    'properties' => NULL,
+    'disabled' => 0,
+    'moduleguid' => '',
+    'static' => 0,
+    'static_file' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'cache_type' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'plugincode' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'locked' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+    'disabled' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'moduleguid' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '32',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+    'static' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'static_file' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'fieldAliases' => 
+  array (
+    'content' => 'plugincode',
+  ),
+  'indexes' => 
+  array (
+    'locked' => 
+    array (
+      'alias' => 'locked',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'locked' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'disabled' => 
+    array (
+      'alias' => 'disabled',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'disabled' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'static' =>
+    array (
+      'alias' => 'static',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'static' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'PropertySets' => 
+    array (
+      'class' => 'modElementPropertySet',
+      'local' => 'id',
+      'foreign' => 'element',
+      'owner' => 'local',
+      'cardinality' => 'many',
+      'criteria' => 
+      array (
+        'foreign' => 
+        array (
+          'element_class' => 'modPlugin',
+        ),
+      ),
+    ),
+    'PluginEvents' => 
+    array (
+      'class' => 'modPluginEvent',
+      'local' => 'id',
+      'foreign' => 'pluginid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'validation' => 
+  array (
+    'rules' => 
+    array (
+      'name' => 
+      array (
+        'invalid' => 
+        array (
+          'type' => 'preg_match',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9_-\\x7f-\\xff\\s]+(?!\\s)$/',
+          'message' => 'plugin_err_invalid_name',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modpluginevent.class.php
+++ b/core/model/modx/sqlite/modpluginevent.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modpluginevent.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modPluginEvent_sqlite extends modPluginEvent {
+}

--- a/core/model/modx/sqlite/modpluginevent.map.inc.php
+++ b/core/model/modx/sqlite/modpluginevent.map.inc.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modPluginEvent']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_plugin_events',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'pluginid' => 0,
+    'event' => '',
+    'priority' => 0,
+    'propertyset' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'pluginid' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'event' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'pk',
+    ),
+    'priority' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'propertyset' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'pluginid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'event' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'priority' => 
+    array (
+      'alias' => 'priority',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'priority' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Plugin' => 
+    array (
+      'class' => 'modPlugin',
+      'local' => 'pluginid',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Event' => 
+    array (
+      'class' => 'modEvent',
+      'local' => 'event',
+      'foreign' => 'name',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'PropertySet' => 
+    array (
+      'class' => 'modPropertySet',
+      'local' => 'propertyset',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modprincipal.class.php
+++ b/core/model/modx/sqlite/modprincipal.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modprincipal.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modPrincipal_sqlite extends modPrincipal {
+}

--- a/core/model/modx/sqlite/modprincipal.map.inc.php
+++ b/core/model/modx/sqlite/modprincipal.map.inc.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modPrincipal']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+  'composites' => 
+  array (
+    'Acls' => 
+    array (
+      'class' => 'modAccess',
+      'local' => 'id',
+      'foreign' => 'principal',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modpropertyset.class.php
+++ b/core/model/modx/sqlite/modpropertyset.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modpropertyset.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modPropertySet_sqlite extends modPropertySet {
+}

--- a/core/model/modx/sqlite/modpropertyset.map.inc.php
+++ b/core/model/modx/sqlite/modpropertyset.map.inc.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modPropertySet']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'property_set',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'category' => 0,
+    'description' => '',
+    'properties' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'category' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'category' => 
+    array (
+      'alias' => 'category',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'category' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Elements' => 
+    array (
+      'class' => 'modElementPropertySet',
+      'local' => 'id',
+      'foreign' => 'property_set',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Category' => 
+    array (
+      'class' => 'modCategory',
+      'key' => 'id',
+      'local' => 'category',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modresource.class.php
+++ b/core/model/modx/sqlite/modresource.class.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modResource_sqlite extends modResource {
+    public static function listGroups(modResource &$resource, array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+        $result = array('collection' => array(), 'total' => 0);
+        $c = $resource->xpdo->newQuery('modResourceGroup');
+        $c->leftJoin('modResourceGroupResource', 'ResourceGroupResource', array(
+            "ResourceGroupResource.document_group = modResourceGroup.id",
+            'ResourceGroupResource.document' => $resource->get('id')
+        ));
+        $result['total'] = $resource->xpdo->getCount('modResourceGroup',$c);
+        $c->select($resource->xpdo->getSelectColumns('modResourceGroup', 'modResourceGroup'));
+        $c->select(array("IFNULL(ResourceGroupResource.document,0) AS access"));
+        foreach ($sort as $sortKey => $sortDir) {
+            $c->sortby($resource->xpdo->escape('modResourceGroup') . '.' . $resource->xpdo->escape($sortKey), $sortDir);
+        }
+        if ($limit > 0) $c->limit($limit, $offset);
+        $result['collection'] = $resource->xpdo->getCollection('modResourceGroup', $c);
+        return $result;
+    }
+
+    public static function getTemplateVarCollection(modResource &$resource) {
+        $c = $resource->xpdo->newQuery('modTemplateVar');
+        $c->query['distinct'] = 'DISTINCT';
+        $c->select($resource->xpdo->getSelectColumns('modTemplateVar', 'modTemplateVar'));
+        $c->select($resource->xpdo->getSelectColumns('modTemplateVarTemplate', 'tvtpl', '', array('rank')));
+        if ($resource->isNew()) {
+            $c->select(array(
+                "modTemplateVar.default_text AS value",
+                "0 AS resourceId"
+            ));
+        } else {
+            $c->select(array(
+                "IFNULL(tvc.value,modTemplateVar.default_text) AS value",
+                "{$resource->get('id')} AS resourceId"
+            ));
+        }
+        $c->innerJoin('modTemplateVarTemplate','tvtpl',array(
+            'tvtpl.tmplvarid = modTemplateVar.id',
+            'tvtpl.templateid' => $resource->get('template'),
+        ));
+        if (!$resource->isNew()) {
+            $c->leftJoin('modTemplateVarResource','tvc',array(
+                'tvc.tmplvarid = modTemplateVar.id',
+                'tvc.contentid' => $resource->get('id'),
+            ));
+        }
+        $c->sortby('tvtpl.rank,modTemplateVar.rank');
+        return $resource->xpdo->getCollection('modTemplateVar', $c);
+    }
+}

--- a/core/model/modx/sqlite/modresource.map.inc.php
+++ b/core/model/modx/sqlite/modresource.map.inc.php
@@ -1,0 +1,868 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_content',
+  'extends' => 'modAccessibleSimpleObject',
+  'inherit' => 'single',
+  'fields' => 
+  array (
+    'type' => 'document',
+    'contentType' => 'text/html',
+    'pagetitle' => '',
+    'longtitle' => '',
+    'description' => '',
+    'alias' => '',
+    'link_attributes' => '',
+    'published' => 0,
+    'pub_date' => 0,
+    'unpub_date' => 0,
+    'parent' => 0,
+    'isfolder' => 0,
+    'introtext' => NULL,
+    'content' => NULL,
+    'richtext' => 1,
+    'template' => 0,
+    'menuindex' => 0,
+    'searchable' => 1,
+    'cacheable' => 1,
+    'createdby' => 0,
+    'createdon' => 0,
+    'editedby' => 0,
+    'editedon' => 0,
+    'deleted' => 0,
+    'deletedon' => 0,
+    'deletedby' => 0,
+    'publishedon' => 0,
+    'publishedby' => 0,
+    'menutitle' => '',
+    'donthit' => 0,
+    'privateweb' => 0,
+    'privatemgr' => 0,
+    'content_dispo' => 0,
+    'hidemenu' => 0,
+    'class_key' => 'modDocument',
+    'context_key' => 'web',
+    'content_type' => 1,
+    'uri' => NULL,
+    'uri_override' => 0,
+    'hide_children_in_tree' => 0,
+    'show_in_tree' => 1,
+    'properties' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'type' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'document',
+    ),
+    'contentType' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'text/html',
+    ),
+    'pagetitle' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fulltext',
+      'indexgrp' => 'content_ft_idx',
+    ),
+    'longtitle' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fulltext',
+      'indexgrp' => 'content_ft_idx',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fulltext',
+      'indexgrp' => 'content_ft_idx',
+    ),
+    'alias' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => true,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'link_attributes' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'published' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'pub_date' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'unpub_date' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'parent' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'isfolder' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'introtext' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'index' => 'fulltext',
+      'indexgrp' => 'content_ft_idx',
+    ),
+    'content' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'index' => 'fulltext',
+      'indexgrp' => 'content_ft_idx',
+    ),
+    'richtext' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+    ),
+    'template' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'menuindex' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'searchable' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'cacheable' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'createdby' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'createdon' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
+    'editedby' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'editedon' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
+    'deleted' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+    'deletedon' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
+    'deletedby' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'publishedon' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+      'default' => 0,
+    ),
+    'publishedby' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'menutitle' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'donthit' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+    'privateweb' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+    'privatemgr' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+    'content_dispo' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'hidemenu' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'class_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'modDocument',
+      'index' => 'index',
+    ),
+    'context_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'web',
+      'index' => 'index',
+    ),
+    'content_type' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 1,
+    ),
+    'uri' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '1000',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'uri_override' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'hide_children_in_tree' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'show_in_tree' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'json',
+      'null' => true,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'alias' => 
+    array (
+      'alias' => 'alias',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'alias' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => true,
+        ),
+      ),
+    ),
+    'published' => 
+    array (
+      'alias' => 'published',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'published' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'pub_date' => 
+    array (
+      'alias' => 'pub_date',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'pub_date' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'unpub_date' => 
+    array (
+      'alias' => 'unpub_date',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'unpub_date' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'parent' => 
+    array (
+      'alias' => 'parent',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'parent' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'isfolder' => 
+    array (
+      'alias' => 'isfolder',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'isfolder' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'template' => 
+    array (
+      'alias' => 'template',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'template' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'menuindex' => 
+    array (
+      'alias' => 'menuindex',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'menuindex' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'searchable' => 
+    array (
+      'alias' => 'searchable',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'searchable' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'cacheable' => 
+    array (
+      'alias' => 'cacheable',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'cacheable' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'hidemenu' => 
+    array (
+      'alias' => 'hidemenu',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'hidemenu' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'class_key' => 
+    array (
+      'alias' => 'class_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'class_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'context_key' => 
+    array (
+      'alias' => 'context_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'context_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'uri' => 
+    array (
+      'alias' => 'uri',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'uri' => 
+        array (
+          'length' => '1000',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'uri_override' => 
+    array (
+      'alias' => 'uri_override',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'uri_override' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'hide_children_in_tree' => 
+    array (
+      'alias' => 'hide_children_in_tree',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'hide_children_in_tree' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'show_in_tree' => 
+    array (
+      'alias' => 'show_in_tree',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'show_in_tree' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'content_ft_idx' => 
+    array (
+      'alias' => 'content_ft_idx',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'FULLTEXT',
+      'columns' => 
+      array (
+        'pagetitle' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'longtitle' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'description' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'introtext' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => true,
+        ),
+        'content' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => true,
+        ),
+      ),
+    ),
+    'cache_refresh_idx' =>
+    array (
+      'alias' => 'cache_refresh_index',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'parent' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'menuindex' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'id' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Children' =>
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'parent',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'TemplateVarResources' =>
+    array (
+      'class' => 'modTemplateVarResource',
+      'local' => 'id',
+      'foreign' => 'contentid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'ResourceGroupResources' => 
+    array (
+      'class' => 'modResourceGroupResource',
+      'local' => 'id',
+      'foreign' => 'document',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Acls' => 
+    array (
+      'class' => 'modAccessResource',
+      'local' => 'id',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+    'ContextResources' => 
+    array (
+      'class' => 'modContextResource',
+      'local' => 'id',
+      'foreign' => 'resource',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Parent' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'parent',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Children' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'parent',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'CreatedBy' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'createdby',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'EditedBy' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'editedby',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'DeletedBy' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'deletedby',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'PublishedBy' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'publishedby',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Template' => 
+    array (
+      'class' => 'modTemplate',
+      'local' => 'template',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'TemplateVars' => 
+    array (
+      'class' => 'modTemplateVar',
+      'local' => 'id:template',
+      'foreign' => 'contentid:templateid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'TemplateVarTemplates' => 
+    array (
+      'class' => 'modTemplateVarTemplate',
+      'local' => 'template',
+      'foreign' => 'templateid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'ContentType' => 
+    array (
+      'class' => 'modContentType',
+      'local' => 'content_type',
+      'foreign' => 'id',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+    'Context' => 
+    array (
+      'class' => 'modContext',
+      'local' => 'context_key',
+      'foreign' => 'key',
+      'owner' => 'foreign',
+      'cardinality' => 'one',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modresourcegroup.class.php
+++ b/core/model/modx/sqlite/modresourcegroup.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modresourcegroup.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modResourceGroup_sqlite extends modResourceGroup {
+}

--- a/core/model/modx/sqlite/modresourcegroup.map.inc.php
+++ b/core/model/modx/sqlite/modresourcegroup.map.inc.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modResourceGroup']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'documentgroup_names',
+  'extends' => 'modAccessibleSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'private_memgroup' => 0,
+    'private_webgroup' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'private_memgroup' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+    'private_webgroup' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'ResourceGroupResources' => 
+    array (
+      'class' => 'modResourceGroupResource',
+      'local' => 'id',
+      'foreign' => 'document_group',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'TemplateVarResourceGroups' => 
+    array (
+      'class' => 'modTemplateVarResourceGroup',
+      'local' => 'id',
+      'foreign' => 'documentgroup',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Acls' => 
+    array (
+      'class' => 'modAccessResourceGroup',
+      'local' => 'id',
+      'foreign' => 'target',
+      'owner' => 'local',
+      'cardinality' => 'many',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modresourcegroupresource.class.php
+++ b/core/model/modx/sqlite/modresourcegroupresource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modresourcegroupresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modResourceGroupResource_sqlite extends modResourceGroupResource {
+}

--- a/core/model/modx/sqlite/modresourcegroupresource.map.inc.php
+++ b/core/model/modx/sqlite/modresourcegroupresource.map.inc.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modResourceGroupResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'document_groups',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'document_group' => 0,
+    'document' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'document_group' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'document' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'document_group' => 
+    array (
+      'alias' => 'document_group',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'document_group' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'document' => 
+    array (
+      'alias' => 'document',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'document' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'ResourceGroup' => 
+    array (
+      'class' => 'modResourceGroup',
+      'key' => 'id',
+      'local' => 'document_group',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Resource' => 
+    array (
+      'class' => 'modResource',
+      'key' => 'id',
+      'local' => 'document',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modscript.class.php
+++ b/core/model/modx/sqlite/modscript.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modscript.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modScript_sqlite extends modScript {
+}

--- a/core/model/modx/sqlite/modscript.map.inc.php
+++ b/core/model/modx/sqlite/modscript.map.inc.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modScript']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_script',
+  'extends' => 'modElement',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => '',
+    'editor_type' => 0,
+    'category' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'editor_type' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'category' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'category' => 
+    array (
+      'alias' => 'category',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'category' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Category' => 
+    array (
+      'class' => 'modCategory',
+      'key' => 'id',
+      'local' => 'category',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modsession.class.php
+++ b/core/model/modx/sqlite/modsession.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modsession.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modSession_sqlite extends modSession {
+}

--- a/core/model/modx/sqlite/modsession.map.inc.php
+++ b/core/model/modx/sqlite/modsession.map.inc.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modSession']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'session',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'id' => '',
+    'access' => NULL,
+    'data' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'id' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+      'default' => '',
+    ),
+    'access' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+    ),
+    'data' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'id' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'access' => 
+    array (
+      'alias' => 'access',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'access' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'validation' =>
+  array (
+    'rules' =>
+    array (
+      'id' =>
+      array (
+        'invalid' =>
+        array (
+          'type' => 'preg_match',
+          'rule' => '/^[0-9a-zA-Z,-]{22,191}$/',
+          'message' => 'session_err_invalid_id',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modsnippet.class.php
+++ b/core/model/modx/sqlite/modsnippet.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modsnippet.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modSnippet_sqlite extends modSnippet {
+}

--- a/core/model/modx/sqlite/modsnippet.map.inc.php
+++ b/core/model/modx/sqlite/modsnippet.map.inc.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modSnippet']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_snippets',
+  'extends' => 'modScript',
+  'fields' => 
+  array (
+    'cache_type' => 0,
+    'snippet' => NULL,
+    'locked' => 0,
+    'properties' => NULL,
+    'moduleguid' => '',
+    'static' => 0,
+    'static_file' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'cache_type' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'snippet' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'locked' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+    'moduleguid' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '32',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'fk',
+    ),
+    'static' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'static_file' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'fieldAliases' => 
+  array (
+    'content' => 'snippet',
+  ),
+  'indexes' => 
+  array (
+    'locked' => 
+    array (
+      'alias' => 'locked',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'locked' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'moduleguid' => 
+    array (
+      'alias' => 'moduleguid',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'moduleguid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'static' =>
+    array (
+      'alias' => 'static',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'static' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'PropertySets' => 
+    array (
+      'class' => 'modElementPropertySet',
+      'local' => 'id',
+      'foreign' => 'element',
+      'owner' => 'local',
+      'cardinality' => 'many',
+      'criteria' => 
+      array (
+        'foreign' => 
+        array (
+          'element_class' => 'modSnippet',
+        ),
+      ),
+    ),
+  ),
+  'validation' => 
+  array (
+    'rules' => 
+    array (
+      'name' => 
+      array (
+        'invalid' => 
+        array (
+          'type' => 'preg_match',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?!\\s)$/',
+          'message' => 'snippet_err_invalid_name',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modstaticresource.class.php
+++ b/core/model/modx/sqlite/modstaticresource.class.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modstaticresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modStaticResource_sqlite extends modStaticResource {}

--- a/core/model/modx/sqlite/modstaticresource.map.inc.php
+++ b/core/model/modx/sqlite/modstaticresource.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modStaticResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'modResource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sqlite/modsymlink.class.php
+++ b/core/model/modx/sqlite/modsymlink.class.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modsymlink.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modSymLink_sqlite extends modSymLink {}

--- a/core/model/modx/sqlite/modsymlink.map.inc.php
+++ b/core/model/modx/sqlite/modsymlink.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modSymLink']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'modResource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sqlite/modsystemsetting.class.php
+++ b/core/model/modx/sqlite/modsystemsetting.class.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modsystemsetting.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modSystemSetting_sqlite extends modSystemSetting {
+    public static function listSettings(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+        /* build query */
+        $c = $xpdo->newQuery('modSystemSetting');
+        $c->select(array(
+            $xpdo->getSelectColumns('modSystemSetting','modSystemSetting'),
+        ));
+        $c->select(array(
+            'name_trans' => 'Entry.value',
+            'description_trans' => 'Description.value',
+        ));
+        $c->leftJoin('modLexiconEntry','Entry',"'setting_' + modSystemSetting.[key] = Entry.name");
+        $c->leftJoin('modLexiconEntry','Description',"'setting_' + modSystemSetting.[key] + '_desc' = Description.name");
+        $c->where($criteria);
+
+        $count = $xpdo->getCount('modSystemSetting',$c);
+        $c->sortby($xpdo->getSelectColumns('modSystemSetting','modSystemSetting','',array('area')),'ASC');
+        foreach($sort as $field=> $dir) {
+            $c->sortby($xpdo->getSelectColumns('modSystemSetting','modSystemSetting','',array($field)),$dir);
+        }
+        if ((int) $limit > 0) {
+            $c->limit((int) $limit, (int) $offset);
+        }
+        $c->prepare();
+        //$xpdo->log(1, "alexii: ".print_r($xpdo->getCollection('modSystemSetting',$c),1));
+        return array(
+            'count'=> $count,
+            'collection'=> $xpdo->getCollection('modSystemSetting',$c)
+        );
+    }
+}
+?>

--- a/core/model/modx/sqlite/modsystemsetting.map.inc.php
+++ b/core/model/modx/sqlite/modsystemsetting.map.inc.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modSystemSetting']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'system_settings',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'key' => '',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => '',
+    'editedon' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'pk',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'xtype' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '75',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'textfield',
+    ),
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '40',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+    ),
+    'area' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'editedon' => 
+    array (
+        'dbtype' => 'bigint',
+        'phptype' => 'timestamp',
+        'null' => false,
+        'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'ContextSetting' => 
+    array (
+      'class' => 'modContextSetting',
+      'local' => 'key',
+      'foreign' => 'key',
+      'cardinality' => 'one',
+      'owner' => 'local',
+    ),
+    'Namespace' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'namespace',
+      'foreign' => 'name',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modtemplate.class.php
+++ b/core/model/modx/sqlite/modtemplate.class.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modtemplate.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modTemplate_sqlite extends modTemplate {
+    public static function listTemplateVars(modTemplate &$template, array $sort = array('name' => 'ASC'), $limit = 0, $offset = 0,array $conditions = array()) {
+        $result = array('collection' => array(), 'total' => 0);
+        $c = $template->xpdo->newQuery('modTemplateVar');
+        $result['total'] = $template->xpdo->getCount('modTemplateVar',$c);
+        $c->select($template->xpdo->getSelectColumns('modTemplateVar','modTemplateVar'));
+        $c->leftJoin('modTemplateVarTemplate','modTemplateVarTemplate', array(
+            "modTemplateVarTemplate.tmplvarid = modTemplateVar.id",
+            'modTemplateVarTemplate.templateid' => $template->get('id'),
+        ));
+        $c->leftJoin('modCategory','Category');
+        if (!empty($conditions)) { $c->where($conditions); }
+        $c->select(array(
+            "CASE modTemplateVarTemplate.tmplvarid WHEN NULL THEN 0 ELSE 1 END AS access",
+            "IFNULL(modTemplateVarTemplate.rank, '-') AS tv_rank",
+            'category_name' => 'Category.category',
+        ));
+        foreach ($sort as $sortKey => $sortDir) {
+            $c->sortby($sortKey, $sortDir);
+        }
+        if ($limit > 0) $c->limit($limit, $offset);
+        $result['collection'] = $template->xpdo->getCollection('modTemplateVar',$c);
+        return $result;
+    }
+}

--- a/core/model/modx/sqlite/modtemplate.map.inc.php
+++ b/core/model/modx/sqlite/modtemplate.map.inc.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modTemplate']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_templates',
+  'extends' => 'modElement',
+  'fields' => 
+  array (
+    'templatename' => '',
+    'description' => 'Template',
+    'editor_type' => 0,
+    'category' => 0,
+    'icon' => '',
+    'template_type' => 0,
+    'content' => '',
+    'locked' => 0,
+    'properties' => NULL,
+    'static' => 0,
+    'static_file' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'templatename' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'Template',
+    ),
+    'editor_type' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'category' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'icon' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'template_type' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'content' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'locked' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+    'static' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'static_file' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'templatename' => 
+    array (
+      'alias' => 'templatename',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'templatename' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'category' => 
+    array (
+      'alias' => 'category',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'category' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'locked' => 
+    array (
+      'alias' => 'locked',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'locked' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'static' => 
+    array (
+      'alias' => 'static',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'static' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'PropertySets' => 
+    array (
+      'class' => 'modElementPropertySet',
+      'local' => 'id',
+      'foreign' => 'element',
+      'owner' => 'local',
+      'cardinality' => 'many',
+      'criteria' => 
+      array (
+        'foreign' => 
+        array (
+          'element_class' => 'modTemplate',
+        ),
+      ),
+    ),
+    'TemplateVarTemplates' => 
+    array (
+      'class' => 'modTemplateVarTemplate',
+      'local' => 'id',
+      'foreign' => 'templateid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Category' => 
+    array (
+      'class' => 'modCategory',
+      'local' => 'category',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Resources' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'template',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modtemplatevar.class.php
+++ b/core/model/modx/sqlite/modtemplatevar.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modtemplatevar.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modTemplateVar_sqlite extends modTemplateVar {
+}

--- a/core/model/modx/sqlite/modtemplatevar.map.inc.php
+++ b/core/model/modx/sqlite/modtemplatevar.map.inc.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modTemplateVar']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_tmplvars',
+  'extends' => 'modElement',
+  'fields' => 
+  array (
+    'type' => '',
+    'name' => '',
+    'caption' => '',
+    'description' => '',
+    'editor_type' => 0,
+    'category' => 0,
+    'locked' => 0,
+    'elements' => NULL,
+    'rank' => 0,
+    'display' => '',
+    'default_text' => NULL,
+    'properties' => NULL,
+    'input_properties' => NULL,
+    'output_properties' => NULL,
+    'static' => 0,
+    'static_file' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'type' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'caption' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '80',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'editor_type' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'category' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'locked' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'elements' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'display' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '20',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'default_text' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+    'input_properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => false,
+      'default' => '',
+    ),
+    'output_properties' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => false,
+      'default' => '',
+    ),
+    'static' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'static_file' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'fieldAliases' => 
+  array (
+    'content' => 'default_text',
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'category' => 
+    array (
+      'alias' => 'category',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'category' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'locked' => 
+    array (
+      'alias' => 'locked',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'locked' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' => 
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'rank' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'static' => 
+    array (
+      'alias' => 'static',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'static' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'PropertySets' => 
+    array (
+      'class' => 'modElementPropertySet',
+      'local' => 'id',
+      'foreign' => 'element',
+      'owner' => 'local',
+      'cardinality' => 'many',
+      'criteria' => 
+      array (
+        'foreign' => 
+        array (
+          'element_class' => 'modTemplateVar',
+        ),
+      ),
+    ),
+    'TemplateVarTemplates' => 
+    array (
+      'class' => 'modTemplateVarTemplate',
+      'local' => 'id',
+      'foreign' => 'tmplvarid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'TemplateVarResources' => 
+    array (
+      'class' => 'modTemplateVarResource',
+      'local' => 'id',
+      'foreign' => 'tmplvarid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'TemplateVarResourceGroups' => 
+    array (
+      'class' => 'modTemplateVarResourceGroup',
+      'local' => 'id',
+      'foreign' => 'tmplvarid',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Category' => 
+    array (
+      'class' => 'modCategory',
+      'local' => 'category',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+  'validation' => 
+  array (
+    'rules' => 
+    array (
+      'name' => 
+      array (
+        'invalid' => 
+        array (
+          'type' => 'preg_match',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?!\\s)$/',
+          'message' => 'tv_err_invalid_name',
+        ),
+        'reserved' => 
+        array (
+          'type' => 'preg_match',
+          'rule' => '/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree)$)/',
+          'message' => 'tv_err_reserved_name',
+        ),
+      ),
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modtemplatevarresource.class.php
+++ b/core/model/modx/sqlite/modtemplatevarresource.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modtemplatevarresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modTemplateVarResource_sqlite extends modTemplateVarResource {
+}

--- a/core/model/modx/sqlite/modtemplatevarresource.map.inc.php
+++ b/core/model/modx/sqlite/modtemplatevarresource.map.inc.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modTemplateVarResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_tmplvar_contentvalues',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'tmplvarid' => 0,
+    'contentid' => 0,
+    'value' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'tmplvarid' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'contentid' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'tmplvarid' => 
+    array (
+      'alias' => 'tmplvarid',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'tmplvarid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'contentid' => 
+    array (
+      'alias' => 'contentid',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'contentid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'tv_cnt' =>
+    array (
+      'alias' => 'tv_cnt',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'tmplvarid' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'contentid' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'TemplateVar' => 
+    array (
+      'class' => 'modTemplateVar',
+      'local' => 'tmplvarid',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Resource' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'contentid',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modtemplatevarresourcegroup.class.php
+++ b/core/model/modx/sqlite/modtemplatevarresourcegroup.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modtemplatevarresourcegroup.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modTemplateVarResourceGroup_sqlite extends modTemplateVarResourceGroup {
+}

--- a/core/model/modx/sqlite/modtemplatevarresourcegroup.map.inc.php
+++ b/core/model/modx/sqlite/modtemplatevarresourcegroup.map.inc.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modTemplateVarResourceGroup']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_tmplvar_access',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'tmplvarid' => 0,
+    'documentgroup' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'tmplvarid' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'documentgroup' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'indexes' =>
+  array (
+    'tmplvar_template' =>
+    array (
+      'alias' => 'tmplvar_template',
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'tmplvarid' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'documentgroup' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' =>
+  array (
+    'TemplateVar' => 
+    array (
+      'class' => 'modTemplateVar',
+      'local' => 'tmplvarid',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'ResourceGroup' => 
+    array (
+      'class' => 'modResourceGroup',
+      'local' => 'documentgroup',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modtemplatevartemplate.class.php
+++ b/core/model/modx/sqlite/modtemplatevartemplate.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modtemplatevartemplate.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modTemplateVarTemplate_sqlite extends modTemplateVarTemplate {
+}

--- a/core/model/modx/sqlite/modtemplatevartemplate.map.inc.php
+++ b/core/model/modx/sqlite/modtemplatevartemplate.map.inc.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modTemplateVarTemplate']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'site_tmplvar_templates',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'tmplvarid' => 0,
+    'templateid' => 0,
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'tmplvarid' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'templateid' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'tmplvarid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'templateid' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'TemplateVar' => 
+    array (
+      'class' => 'modTemplateVar',
+      'key' => 'id',
+      'local' => 'tmplvarid',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Template' => 
+    array (
+      'class' => 'modTemplate',
+      'key' => 'id',
+      'local' => 'templateid',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/moduser.class.php
+++ b/core/model/modx/sqlite/moduser.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moduser.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUser_sqlite extends modUser {
+}

--- a/core/model/modx/sqlite/moduser.map.inc.php
+++ b/core/model/modx/sqlite/moduser.map.inc.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUser']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'users',
+  'extends' => 'modPrincipal',
+  'fields' => 
+  array (
+    'username' => '',
+    'password' => '',
+    'cachepwd' => '',
+    'class_key' => 'modUser',
+    'active' => 1,
+    'remote_key' => NULL,
+    'remote_data' => NULL,
+    'hash_class' => 'hashing.modPBKDF2',
+    'salt' => '',
+    'primary_group' => 0,
+    'session_stale' => NULL,
+    'sudo' => 0,
+    'createdon' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'username' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'password' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'cachepwd' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'class_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'modUser',
+      'index' => 'index',
+    ),
+    'active' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+    ),
+    'remote_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => true,
+      'index' => 'index',
+    ),
+    'remote_data' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'json',
+      'null' => true,
+    ),
+    'hash_class' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'hashing.modPBKDF2',
+    ),
+    'salt' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'primary_group' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'session_stale' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+      'null' => true,
+    ),
+    'sudo' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+  'createdon' =>
+      array (
+          'dbtype' => 'bigint',
+          'phptype' => 'timestamp',
+          'null' => false,
+          'default' => 0,
+      ),
+  ),
+  'indexes' => 
+  array (
+    'username' => 
+    array (
+      'alias' => 'username',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'username' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'class_key' => 
+    array (
+      'alias' => 'class_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'class_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'remote_key' => 
+    array (
+      'alias' => 'remote_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'remote_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'primary_group' => 
+    array (
+      'alias' => 'primary_group',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'primary_group' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Profile' => 
+    array (
+      'class' => 'modUserProfile',
+      'local' => 'id',
+      'foreign' => 'internalKey',
+      'cardinality' => 'one',
+      'owner' => 'local',
+    ),
+    'UserSettings' => 
+    array (
+      'class' => 'modUserSetting',
+      'local' => 'id',
+      'foreign' => 'user',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'UserGroupMembers' => 
+    array (
+      'class' => 'modUserGroupMember',
+      'local' => 'id',
+      'foreign' => 'member',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'ActiveUsers' =>
+    array (
+      'class' => 'modActiveUser',
+      'local' => 'id',
+      'foreign' => 'internalKey',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'CreatedResources' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'createdby',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'EditedResources' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'editedby',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'DeletedResources' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'deletedby',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'PublishedResources' => 
+    array (
+      'class' => 'modResource',
+      'local' => 'id',
+      'foreign' => 'publishedby',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'SentMessages' => 
+    array (
+      'class' => 'modUserMessage',
+      'local' => 'id',
+      'foreign' => 'sender',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'ReceivedMessages' => 
+    array (
+      'class' => 'modUserMessage',
+      'local' => 'id',
+      'foreign' => 'recipient',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'PrimaryGroup' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'primary_group',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modusergroup.class.php
+++ b/core/model/modx/sqlite/modusergroup.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modusergroup.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUserGroup_sqlite extends modUserGroup {
+}

--- a/core/model/modx/sqlite/modusergroup.map.inc.php
+++ b/core/model/modx/sqlite/modusergroup.map.inc.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUserGroup']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'membergroup_names',
+  'extends' => 'modPrincipal',
+  'fields' => 
+  array (
+    'name' => '',
+    'description' => NULL,
+    'parent' => 0,
+    'rank' => 0,
+    'dashboard' => 1,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'text',
+      'phptype' => 'string',
+    ),
+    'parent' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'dashboard' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'parent' => 
+    array (
+      'alias' => 'parent',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'parent' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' => 
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'rank' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'dashboard' => 
+    array (
+      'alias' => 'dashboard',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'dashboard' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'UserGroupMembers' => 
+    array (
+      'class' => 'modUserGroupMember',
+      'local' => 'id',
+      'foreign' => 'user_group',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'FormCustomizationProfiles' => 
+    array (
+      'class' => 'modFormCustomizationProfileUserGroup',
+      'local' => 'id',
+      'foreign' => 'usergroup',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Parent' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'parent',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Children' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'id',
+      'foreign' => 'parent',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+    'Dashboard' => 
+    array (
+      'class' => 'modDashboard',
+      'local' => 'dashboard',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modusergroupmember.class.php
+++ b/core/model/modx/sqlite/modusergroupmember.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modusergroupmember.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUserGroupMember_sqlite extends modUserGroupMember {
+}

--- a/core/model/modx/sqlite/modusergroupmember.map.inc.php
+++ b/core/model/modx/sqlite/modusergroupmember.map.inc.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUserGroupMember']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'member_groups',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'user_group' => 0,
+    'member' => 0,
+    'role' => 1,
+    'rank' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'user_group' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'member' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'role' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'rank' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'role' => 
+    array (
+      'alias' => 'role',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'role' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'rank' => 
+    array (
+      'alias' => 'rank',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'rank' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'UserGroupRole' => 
+    array (
+      'class' => 'modUserGroupRole',
+      'local' => 'role',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'UserGroup' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'user_group',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'User' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'member',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modusergrouprole.class.php
+++ b/core/model/modx/sqlite/modusergrouprole.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modusergrouprole.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUserGroupRole_sqlite extends modUserGroupRole {
+}

--- a/core/model/modx/sqlite/modusergrouprole.map.inc.php
+++ b/core/model/modx/sqlite/modusergrouprole.map.inc.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUserGroupRole']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'user_group_roles',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => NULL,
+    'description' => NULL,
+    'authority' => 9999,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'authority' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 9999,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'authority' => 
+    array (
+      'alias' => 'authority',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'authority' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'UserGroupMembers' => 
+    array (
+      'class' => 'modUserGroupMember',
+      'local' => 'id',
+      'foreign' => 'role',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modusergroupsetting.class.php
+++ b/core/model/modx/sqlite/modusergroupsetting.class.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(__DIR__) . '/modusergroupsetting.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUserGroupSetting_sqlite extends modUserGroupSetting {
+    public static function listSettings(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+        $c = $xpdo->newQuery('modUserGroupSetting');
+        $c->select(array(
+                $xpdo->getSelectColumns('modUserGroupSetting','modUserGroupSetting'),
+            ));
+        $c->select(array(
+            'Entry.value AS name_trans',
+            'Description.value AS description_trans',
+        ));
+        $c->leftJoin('modLexiconEntry','Entry',"'setting_' + modUserGroupSetting.{$xpdo->escape('key')} = Entry.name");
+        $c->leftJoin('modLexiconEntry','Description',"'setting_' + modUserGroupSetting.{$xpdo->escape('key')} + '_desc' = Description.name");
+        $c->where($criteria);
+        //$c->groupby('modUserGroupSetting.' . $xpdo->escape('user') . ', modUserGroupSetting.' . $xpdo->escape('key')); // лечение ALEX
+        $count = $xpdo->getCount('modUserGroupSetting',$c);
+        $c->sortby($xpdo->getSelectColumns('modUserGroupSetting','modUserGroupSetting','',array('area')),'ASC');
+        foreach($sort as $field=> $dir) {
+            $c->sortby($xpdo->getSelectColumns('modUserGroupSetting','modUserGroupSetting','',array($field)),$dir);
+        }
+        if ((int) $limit > 0) {
+            $c->limit((int) $limit, (int) $offset);
+        }
+       // $c->prepare();
+        return array(
+            'count'=> $count,
+            'collection'=> $xpdo->getCollection('modUserGroupSetting',$c)
+        );
+    }
+}

--- a/core/model/modx/sqlite/modusergroupsetting.map.inc.php
+++ b/core/model/modx/sqlite/modusergroupsetting.map.inc.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUserGroupSetting']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'user_group_settings',
+  'extends' => 'xPDOObject',
+  'fields' =>
+  array (
+    'group' => 0,
+    'key' => NULL,
+    'value' => NULL,
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => '',
+    'editedon' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'group' => 
+    array (
+      'dbtype' => 'integer',
+      'attributes' => 'unsigned',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '1000',
+      'phptype' => 'string',
+      'default' => '',
+    ),
+    'xtype' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '75',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'textfield',
+    ),
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '40',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+    ),
+    'area' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '191',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'editedon' => 
+    array (
+        'dbtype' => 'bigint',
+        'phptype' => 'timestamp',
+        'null' => false,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'group' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'UserGroup' => 
+    array (
+      'class' => 'modUserGroup',
+      'local' => 'group',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Namespace' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'namespace',
+      'foreign' => 'name',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modusermessage.class.php
+++ b/core/model/modx/sqlite/modusermessage.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modusermessage.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUserMessage_sqlite extends modUserMessage {
+}

--- a/core/model/modx/sqlite/modusermessage.map.inc.php
+++ b/core/model/modx/sqlite/modusermessage.map.inc.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUserMessage']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'user_messages',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'type' => '',
+    'subject' => '',
+    'message' => '',
+    'sender' => 0,
+    'recipient' => 0,
+    'private' => 0,
+    'date_sent' => '0000-00-00 00:00:00',
+    'read' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'type' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '15',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'subject' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'message' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'sender' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'recipient' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'private' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '4',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'date_sent' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => false,
+      'default' => '0000-00-00 00:00:00',
+    ),
+    'read' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Sender' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'sender',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Recipient' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'recipient',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/moduserprofile.class.php
+++ b/core/model/modx/sqlite/moduserprofile.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/moduserprofile.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUserProfile_sqlite extends modUserProfile {
+}

--- a/core/model/modx/sqlite/moduserprofile.map.inc.php
+++ b/core/model/modx/sqlite/moduserprofile.map.inc.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUserProfile']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'user_attributes',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'internalKey' => NULL,
+    'fullname' => '',
+    'email' => '',
+    'phone' => '',
+    'mobilephone' => '',
+    'blocked' => 0,
+    'blockeduntil' => 0,
+    'blockedafter' => 0,
+    'logincount' => 0,
+    'lastlogin' => 0,
+    'thislogin' => 0,
+    'failedlogincount' => 0,
+    'sessionid' => '',
+    'dob' => 0,
+    'gender' => 0,
+    'address' => '',
+    'country' => '',
+    'city' => '',
+    'state' => '',
+    'zip' => '',
+    'fax' => '',
+    'photo' => '',
+    'comment' => '',
+    'website' => '',
+    'extended' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'internalKey' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'index' => 'unique',
+    ),
+    'fullname' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'email' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'phone' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'mobilephone' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'blocked' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+    ),
+    'blockeduntil' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'blockedafter' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'logincount' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'lastlogin' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'thislogin' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'failedlogincount' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'sessionid' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'dob' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'gender' => 
+    array (
+      'dbtype' => 'tinyint',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+    ),
+    'address' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'country' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'city' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'state' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '25',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'zip' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '25',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'fax' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'photo' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'comment' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'website' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'extended' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'json',
+      'null' => true,
+      'index' => 'fulltext',
+      'indexgrp' => 'extended',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'internalKey' => 
+    array (
+      'alias' => 'internalKey',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'internalKey' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'User' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'internalKey',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modusersetting.class.php
+++ b/core/model/modx/sqlite/modusersetting.class.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modusersetting.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modUserSetting_sqlite extends modUserSetting {
+    public static function listSettings(xPDO &$xpdo, array $criteria = array(), array $sort = array('id' => 'ASC'), $limit = 0, $offset = 0) {
+        $c = $xpdo->newQuery('modUserSetting');
+        $c->select(array(
+            $xpdo->getSelectColumns('modUserSetting','modUserSetting'),
+            'Entry.value AS name_trans',
+            'Description.value AS description_trans',
+        ));
+        $c->leftJoin('modLexiconEntry','Entry',"'setting_' + modUserSetting.{$xpdo->escape('key')} = Entry.name");
+        $c->leftJoin('modLexiconEntry','Description',"'setting_' + modUserSetting.{$xpdo->escape('key')} + '_desc' = Description.name");
+        $c->where($criteria);
+        $c->groupby('modUserSetting.' . $xpdo->escape('user') . ', modUserSetting.' . $xpdo->escape('key')); // лечение ALEX
+        $count = $xpdo->getCount('modUserSetting',$c);
+        $c->sortby($xpdo->getSelectColumns('modUserSetting','modUserSetting','',array('area')),'ASC');
+        foreach($sort as $field=> $dir) {
+            $c->sortby($xpdo->getSelectColumns('modUserSetting','modUserSetting','',array($field)),$dir);
+        }
+        if ((int) $limit > 0) {
+            $c->limit((int) $limit, (int) $offset);
+        }
+       // $c->prepare();
+        return array(
+            'count'=> $count,
+            'collection'=> $xpdo->getCollection('modUserSetting',$c)
+        );
+    }
+}
+?>

--- a/core/model/modx/sqlite/modusersetting.map.inc.php
+++ b/core/model/modx/sqlite/modusersetting.map.inc.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modUserSetting']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'user_settings',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'user' => 0,
+    'key' => '',
+    'value' => NULL,
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => '',
+    'editedon' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'user' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'pk',
+    ),
+    'key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '50',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'pk',
+    ),
+    'value' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'xtype' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '75',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'textfield',
+    ),
+    'namespace' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '40',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => 'core',
+    ),
+    'area' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+    ),
+    'editedon' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'user' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+        'key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'User' => 
+    array (
+      'class' => 'modUser',
+      'local' => 'user',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Namespace' => 
+    array (
+      'class' => 'modNamespace',
+      'local' => 'namespace',
+      'foreign' => 'name',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modweblink.class.php
+++ b/core/model/modx/sqlite/modweblink.class.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modweblink.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modWebLink_sqlite extends modWebLink {}

--- a/core/model/modx/sqlite/modweblink.map.inc.php
+++ b/core/model/modx/sqlite/modweblink.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modWebLink']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'modResource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/sqlite/modworkspace.class.php
+++ b/core/model/modx/sqlite/modworkspace.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modworkspace.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modWorkspace_sqlite extends modWorkspace {
+}

--- a/core/model/modx/sqlite/modworkspace.map.inc.php
+++ b/core/model/modx/sqlite/modworkspace.map.inc.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modWorkspace']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'table' => 'workspaces',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => '',
+    'path' => '',
+    'created' => NULL,
+    'active' => 0,
+    'attributes' => NULL,
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'path' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'unique',
+    ),
+    'created' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+      'null' => false,
+    ),
+    'active' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'attributes' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'path' => 
+    array (
+      'alias' => 'path',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'path' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'active' => 
+    array (
+      'alias' => 'active',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'active' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'composites' => 
+  array (
+    'Packages' => 
+    array (
+      'class' => 'transport.modTransportPackage',
+      'local' => 'id',
+      'foreign' => 'workspace',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/modx/sqlite/modxmlrpcresource.class.php
+++ b/core/model/modx/sqlite/modxmlrpcresource.class.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modxmlrpcresource.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modXMLRPCResource_sqlite extends modXMLRPCResource {}

--- a/core/model/modx/sqlite/modxmlrpcresource.map.inc.php
+++ b/core/model/modx/sqlite/modxmlrpcresource.map.inc.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+$xpdo_meta_map['modXMLRPCResource']= array (
+  'package' => 'modx',
+  'version' => '1.1',
+  'extends' => 'modResource',
+  'fields' => 
+  array (
+  ),
+  'fieldMeta' => 
+  array (
+  ),
+);

--- a/core/model/modx/transport/metadata.sqlite.php
+++ b/core/model/modx/transport/metadata.sqlite.php
@@ -1,0 +1,12 @@
+<?php
+
+$xpdo_meta_map = array (
+  'xPDOSimpleObject' => 
+  array (
+    0 => 'modTransportProvider',
+  ),
+  'xPDOObject' => 
+  array (
+    0 => 'modTransportPackage',
+  ),
+);

--- a/core/model/modx/transport/sqlite/modtransportpackage.class.php
+++ b/core/model/modx/transport/sqlite/modtransportpackage.class.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @package modx
+ * @subpackage transport.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modtransportpackage.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modTransportPackage_sqlite extends modTransportPackage {
+      public static function listPackages(modX &$modx, $workspace, $limit = 0, $offset = 0,$search = '') {
+        $result = array('collection' => array(), 'total' => 0);
+        $c = $modx->newQuery('transport.modTransportPackage');
+        $c->leftJoin('transport.modTransportProvider','Provider', array("modTransportPackage.provider = Provider.id"));
+        $c->where(array(
+            'workspace' => $workspace,
+        ));
+        $c->where(array(
+            "(SELECT
+                `signature`
+              FROM {$modx->getTableName('modTransportPackage')} AS `latestPackage`
+              WHERE `latestPackage`.`package_name` = `modTransportPackage`.`package_name`
+              ORDER BY
+                 `latestPackage`.`version_major` DESC,
+                 `latestPackage`.`version_minor` DESC,
+                 `latestPackage`.`version_patch` DESC,
+                 CASE WHEN `release` = '' OR `release` = 'ga' OR `release` = 'pl' THEN
+                   'z'
+                 ELSE 
+                   `release`
+                 END DESC,
+                 `latestPackage`.`release_index` DESC
+              LIMIT 1) = `modTransportPackage`.`signature`",
+        ));
+        if (!empty($search)) {
+            $c->where(array(
+                'modTransportPackage.signature:LIKE' => '%'.$search.'%',
+                'OR:modTransportPackage.package_name:LIKE' => '%'.$search.'%',
+            ));
+        }
+        $result['total'] = $modx->getCount('modTransportPackage',$c);
+        $c->select(array(
+            'modTransportPackage.*',
+        ));
+        $c->select('`Provider`.`name` AS `provider_name`');
+        $c->sortby('`modTransportPackage`.`signature`', 'ASC');
+        if ($limit > 0) $c->limit($limit, $offset);
+        $result['collection'] = $modx->getCollection('transport.modTransportPackage',$c);
+        return $result;
+    }
+
+    public static function listPackageVersions(modX &$modx, $criteria, $limit = 0, $offset = 0) {
+        $result = array('collection' => array(), 'total' => 0);
+        $c = $modx->newQuery('transport.modTransportPackage');
+        $c->select($modx->getSelectColumns('transport.modTransportPackage','modTransportPackage'));
+        $c->select(array('Provider.name AS provider_name'));
+        $c->leftJoin('transport.modTransportProvider','Provider');
+        $c->where($criteria);
+        $result['total'] = $modx->getCount('modTransportPackage',$c);
+        $c->sortby('modTransportPackage.version_major', 'DESC');
+        $c->sortby('modTransportPackage.version_minor', 'DESC');
+        $c->sortby('modTransportPackage.version_patch', 'DESC');
+        $c->sortby('CASE WHEN modTransportPackage.release = "" OR modTransportPackage.release = "ga" OR modTransportPackage.release = "pl" THEN "z" ELSE modTransportPackage.release END DESC','');
+        $c->sortby('modTransportPackage.release_index', 'DESC');
+        if((int)$limit > 0) {
+            $c->limit((int)$limit, (int)$offset);
+        }
+        $result['collection'] = $modx->getCollection('transport.modTransportPackage',$c);
+        return $result;
+    }
+}

--- a/core/model/modx/transport/sqlite/modtransportpackage.map.inc.php
+++ b/core/model/modx/transport/sqlite/modtransportpackage.map.inc.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * @package modx
+ * @subpackage transport.sqlite
+ */
+$xpdo_meta_map['modTransportPackage']= array (
+  'package' => 'modx.transport',
+  'version' => '1.1',
+  'table' => 'transport_packages',
+  'extends' => 'xPDOObject',
+  'fields' => 
+  array (
+    'signature' => NULL,
+    'created' => NULL,
+    'updated' => NULL,
+    'installed' => NULL,
+    'state' => 1,
+    'workspace' => 0,
+    'provider' => 0,
+    'disabled' => 0,
+    'source' => NULL,
+    'manifest' => NULL,
+    'attributes' => NULL,
+    'package_name' => NULL,
+    'metadata' => NULL,
+    'version_major' => 0,
+    'version_minor' => 0,
+    'version_patch' => 0,
+    'release' => '',
+    'release_index' => 0,
+  ),
+  'fieldMeta' => 
+  array (
+    'signature' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'pk',
+    ),
+    'created' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => false,
+    ),
+    'updated' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+    ),
+    'installed' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+    ),
+    'state' => 
+    array (
+      'dbtype' => 'bit',
+      'precision' => '1',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 1,
+    ),
+    'workspace' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'provider' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'fk',
+    ),
+    'disabled' => 
+    array (
+      'dbtype' => 'bit',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'source' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '512',
+      'phptype' => 'string',
+    ),
+    'manifest' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+    ),
+    'attributes' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+    ),
+    'package_name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'index',
+    ),
+    'metadata' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'array',
+    ),
+    'version_major' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'version_minor' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'version_patch' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+    'release' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '100',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'release_index' => 
+    array (
+      'dbtype' => 'integer',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 0,
+      'index' => 'index',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'PRIMARY' => 
+    array (
+      'alias' => 'PRIMARY',
+      'primary' => true,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'signature' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'workspace' => 
+    array (
+      'alias' => 'workspace',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'workspace' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'provider' => 
+    array (
+      'alias' => 'provider',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'provider' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'disabled' => 
+    array (
+      'alias' => 'disabled',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'disabled' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'package_name' => 
+    array (
+      'alias' => 'package_name',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'package_name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'version_major' => 
+    array (
+      'alias' => 'version_major',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'version_major' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'version_minor' => 
+    array (
+      'alias' => 'version_minor',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'version_minor' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'version_patch' => 
+    array (
+      'alias' => 'version_patch',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'version_patch' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'release' => 
+    array (
+      'alias' => 'release',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'release' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'release_index' => 
+    array (
+      'alias' => 'release_index',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'release_index' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Workspace' => 
+    array (
+      'class' => 'modWorkspace',
+      'local' => 'workspace',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+    'Provider' => 
+    array (
+      'class' => 'transport.modTransportProvider',
+      'local' => 'provider',
+      'foreign' => 'id',
+      'cardinality' => 'one',
+      'owner' => 'foreign',
+    ),
+  ),
+);

--- a/core/model/modx/transport/sqlite/modtransportprovider.class.php
+++ b/core/model/modx/transport/sqlite/modtransportprovider.class.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package modx
+ * @subpackage transport.sqlite
+ */
+require_once (dirname(dirname(__FILE__)) . '/modtransportprovider.class.php');
+/**
+ * @package modx
+ * @subpackage sqlite
+ */
+class modTransportProvider_sqlite extends modTransportProvider {
+}

--- a/core/model/modx/transport/sqlite/modtransportprovider.map.inc.php
+++ b/core/model/modx/transport/sqlite/modtransportprovider.map.inc.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * @package modx
+ * @subpackage transport.sqlite
+ */
+$xpdo_meta_map['modTransportProvider']= array (
+  'package' => 'modx.transport',
+  'version' => '1.1',
+  'table' => 'transport_providers',
+  'extends' => 'xPDOSimpleObject',
+  'fields' => 
+  array (
+    'name' => NULL,
+    'description' => NULL,
+    'service_url' => NULL,
+    'username' => '',
+    'api_key' => '',
+    'created' => NULL,
+    'updated' => NULL,
+    'active' => 1,
+    'priority' => 10,
+    'properties' => '',
+  ),
+  'fieldMeta' => 
+  array (
+    'name' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'index' => 'unique',
+    ),
+    'description' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+    ),
+    'service_url' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '512',
+      'phptype' => 'string',
+    ),
+    'username' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'api_key' => 
+    array (
+      'dbtype' => 'nvarchar',
+      'precision' => '255',
+      'phptype' => 'string',
+      'null' => false,
+      'default' => '',
+      'index' => 'index',
+    ),
+    'created' => 
+    array (
+      'dbtype' => 'datetime',
+      'phptype' => 'datetime',
+      'null' => false,
+    ),
+    'updated' => 
+    array (
+      'dbtype' => 'bigint',
+      'phptype' => 'timestamp',
+        'null' => false,
+        'default' => 0,
+    ),
+    'active' =>
+    array (
+      'dbtype' => 'bit',
+      'precision' => '1',
+      'phptype' => 'boolean',
+      'null' => false,
+      'default' => 1,
+      'index' => 'index',
+    ),
+    'priority' =>
+    array (
+      'dbtype' => 'integer',
+      'precision' => '4',
+      'phptype' => 'integer',
+      'null' => false,
+      'default' => 10,
+      'index' => 'index',
+    ),
+    'properties' =>
+    array (
+      'dbtype' => 'nvarchar',
+      'phptype' => 'json',
+      'null' => false,
+      'default' => '',
+    ),
+  ),
+  'indexes' => 
+  array (
+    'name' => 
+    array (
+      'alias' => 'name',
+      'primary' => false,
+      'unique' => true,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'name' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'api_key' => 
+    array (
+      'alias' => 'api_key',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'api_key' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'username' => 
+    array (
+      'alias' => 'username',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' => 
+      array (
+        'username' => 
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'active' =>
+    array (
+      'alias' => 'active',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'active' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+    'priority' =>
+    array (
+      'alias' => 'priority',
+      'primary' => false,
+      'unique' => false,
+      'type' => 'BTREE',
+      'columns' =>
+      array (
+        'priority' =>
+        array (
+          'length' => '',
+          'collation' => 'A',
+          'null' => false,
+        ),
+      ),
+    ),
+  ),
+  'aggregates' => 
+  array (
+    'Packages' => 
+    array (
+      'class' => 'transport.modTransportPackage',
+      'local' => 'id',
+      'foreign' => 'provider',
+      'cardinality' => 'many',
+      'owner' => 'local',
+    ),
+  ),
+);

--- a/core/model/schema/build.modx.php
+++ b/core/model/schema/build.modx.php
@@ -5,11 +5,11 @@ $mtime= $mtime[1] + $mtime[0];
 $tstart= $mtime;
 
 $properties = array();
-include_once (dirname(dirname(__DIR__)) . '/xpdo/xpdo.class.php');
-require_once (dirname(dirname(dirname(__DIR__))) . '/config.core.php');
-require_once (dirname(dirname(dirname(__DIR__))) . '/_build/build.properties.php');
+include_once (dirname(dirname(dirname(__FILE__))) . '/xpdo/xpdo.class.php');
+require_once (dirname(dirname(dirname(dirname(__FILE__)))) . '/config.core.php');
+require_once (dirname(dirname(dirname(dirname(__FILE__)))) . '/_build/build.properties.php');
 
-foreach (array('mysql', 'sqlsrv') as $driver) {
+foreach (array('mysql', 'sqlsrv', 'sqlite') as $driver){
     $xpdo= new xPDO(
         $properties["{$driver}_string_dsn_nodb"],
         $properties["{$driver}_string_username"],
@@ -28,8 +28,7 @@ foreach (array('mysql', 'sqlsrv') as $driver) {
 /**
  * [+phpdoc-package+]
  * [+phpdoc-subpackage+]
-*/
-
+ */
 /**
  * [+phpdoc-package+]
  * [+phpdoc-subpackage+]
@@ -43,7 +42,7 @@ EOD;
  * [+phpdoc-package+]
  * [+phpdoc-subpackage+]
  */
-require_once (dirname(__DIR__) . '/[+class-lowercase+].class.php');
+require_once (dirname(dirname(__FILE__)) . '/[+class-lowercase+].class.php');
 /**
  * [+phpdoc-package+]
  * [+phpdoc-subpackage+]

--- a/core/model/schema/modx.registry.db.sqlite.schema.xml
+++ b/core/model/schema/modx.registry.db.sqlite.schema.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*
+ * MODX CMS and PHP Application Framework ("MODX")
+ * Copyright 2006-2012 by MODX, LLC.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+ -->
+<!-- The following xPDO model represents an object-relational map structure of the MODX db registry package -->
+<model package="modx.registry.db" baseClass="xPDOObject" platform="sqlite" defaultEngine="SQLitev3" phpdoc-package="modx" phpdoc-subpackage="registry.db" version="1.1">
+    <object class="modDbRegisterQueue" table="register_queues" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="unique" />
+        <field key="options" dbtype="mediumtext" phptype="array" />
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <composite alias="Topics" class="registry.db.modDbRegisterTopic" local="id" foreign="queue" cardinality="many" owner="local" />
+    </object>
+    <object class="modDbRegisterTopic" table="register_topics" extends="xPDOSimpleObject">
+        <field key="queue" dbtype="integer" precision="10" attributes="unsigned" phptype="integer" null="false" index="fk" />
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="fk" />
+        <field key="created" dbtype="datetime" phptype="datetime" null="false" />
+        <field key="updated" dbtype="timestamp" phptype="timestamp" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="options" dbtype="mediumtext" phptype="array" />
+        <aggregate alias="Queue" class="registry.db.modDbRegisterQueue" local="queue" foreign="id" cardinality="one" owner="foreign" />
+        <composite alias="Messages" class="registry.db.modDbRegisterMessage" local="id" foreign="topic" cardinality="many" owner="local" />
+        <index alias="queue" name="queue" primary="false" unique="false" type="BTREE">
+            <column key="queue" length="" collation="A" null="false" />
+        </index>
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+    </object>
+    <object class="modDbRegisterMessage" table="register_messages" extends="xPDOObject">
+        <field key="topic" dbtype="integer" precision="10" attributes="unsigned" phptype="integer" null="false" />
+        <field key="id" dbtype="nvarchar" precision="255" phptype="string" null="false" index="pk" />
+        <field key="created" dbtype="datetime" phptype="datetime" null="false" index="index" />
+        <field key="valid" dbtype="datetime" phptype="datetime" null="false" index="index" />
+        <field key="accessed" dbtype="bigint" phptype="timestamp" index="index" />
+        <field key="accesses" dbtype="integer" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="expires" dbtype="integer" precision="20" phptype="integer" null="false" default="0" index="index" />
+        <field key="payload" dbtype="nvarchar" phptype="string" null="false" />
+        <field key="kill" dbtype="bit" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="id" length="" collation="A" null="false" />
+        </index>
+        <index alias="created" name="created" primary="false" unique="false" type="BTREE">
+            <column key="created" length="" collation="A" null="false" />
+        </index>
+        <index alias="valid" name="valid" primary="false" unique="false" type="BTREE">
+            <column key="valid" length="" collation="A" null="false" />
+        </index>
+        <index alias="accessed" name="accessed" primary="false" unique="false" type="BTREE">
+            <column key="accessed" length="" collation="A" null="false" />
+        </index>
+        <index alias="accesses" name="accesses" primary="false" unique="false" type="BTREE">
+            <column key="accesses" length="" collation="A" null="false" />
+        </index>
+        <index alias="expires" name="expires" primary="false" unique="false" type="BTREE">
+            <column key="expires" length="" collation="A" null="false" />
+        </index>
+        <aggregate alias="Topic" class="registry.db.modDbRegisterTopic" local="topic" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+</model>

--- a/core/model/schema/modx.sources.sqlite.schema.xml
+++ b/core/model/schema/modx.sources.sqlite.schema.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/*
+ * MODX CMS and PHP Application Framework ("MODX")
+ * Copyright 2006-2012 by MODX, LLC.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+ -->
+<!-- The following xPDO model represents an object-relational map structure of the MODX db registry package -->
+<model package="modx.sources" baseClass="xPDOObject" platform="sqlite" defaultEngine="SQLitev3" phpdoc-package="modx" phpdoc-subpackage="sources" version="1.1">
+
+    <object class="modAccessMediaSource" table="access_media_source" extends="modAccess">
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />
+
+        <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Target" class="sources.modMediaSource" local="target" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+
+    <object class="modMediaSource" table="media_sources" extends="modAccessibleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index"/>
+        <field key="description" dbtype="text" phptype="string" null="true" />
+        <field key="class_key" dbtype="varchar" precision="100" phptype="string" null="false" default="sources.modFileMediaSource" index="index" />
+        <field key="properties" dbtype="mediumtext" phptype="array" null="true" />
+        <field key="is_stream" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" index="index" />
+
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="class_key" name="class_key" primary="false" unique="false" type="BTREE">
+            <column key="class_key" length="" collation="A" null="false" />
+        </index>
+        <index alias="is_stream" name="is_stream" primary="false" unique="false" type="BTREE">
+            <column key="is_stream" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="SourceElement" class="sources.modMediaSourceElement" local="id" foreign="source" cardinality="one" owner="local" />
+        <aggregate alias="Chunks" class="modChunk" local="id" foreign="source" cardinality="many" owner="local" />
+        <aggregate alias="Plugins" class="modPlugin" local="id" foreign="source" cardinality="many" owner="local" />
+        <aggregate alias="Snippets" class="modSnippet" local="id" foreign="source" cardinality="many" owner="local" />
+        <aggregate alias="Templates" class="modTemplate" local="id" foreign="source" cardinality="many" owner="local" />
+        <aggregate alias="TemplateVars" class="modTemplateVar" local="id" foreign="source" cardinality="many" owner="local" />
+    </object>
+    <object class="modFileMediaSource" extends="modMediaSource" />
+    <object class="modS3MediaSource" extends="modMediaSource" />
+
+    <object class="modMediaSourceContext" table="media_sources_contexts" extends="xPDOObject">
+        <field key="source" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="pk" />
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="web" index="pk" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="source" length="" collation="A" null="false" />
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Source" class="sources.modMediaSource" local="source" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+
+    <object class="modMediaSourceElement" table="media_sources_elements" extends="xPDOObject">
+        <field key="source" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
+        <field key="object_class" dbtype="varchar" precision="100" phptype="string" null="false" default="modTemplateVar" index="pk" />
+        <field key="object" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="web" index="pk" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="source" length="" collation="A" null="false" />
+            <column key="object" length="" collation="A" null="false" />
+            <column key="object_class" length="" collation="A" null="false" />
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Source" class="sources.modMediaSource" local="source" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Element" class="modElement" local="object" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+</model>

--- a/core/model/schema/modx.sqlite.schema.xml
+++ b/core/model/schema/modx.sqlite.schema.xml
@@ -1,0 +1,1439 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*
+ * MODX CMS and PHP Application Framework ("MODX")
+ * Copyright 2006, 2007, 2008 by MODX, LLC.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have remenusceived a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+ -->
+<!-- The following xPDO model represents an object-relational map structure of MODX -->
+<model package="modx" baseClass="xPDOObject" platform="sqlite" defaultEngine="SQLitev3" phpdoc-package="modx" phpdoc-subpackage="" version="1.1">
+    <object class="modAccess" extends="xPDOSimpleObject">
+        <field key="target" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />
+        <field key="principal_class" dbtype="varchar" precision="100" phptype="string" null="false" default="modPrincipal" index="index" />
+        <field key="principal" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="fk" />
+        <field key="authority" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="9999" index="index" />
+        <field key="policy" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="fk" />
+
+        <index alias="target" name="target" primary="false" unique="false" type="BTREE">
+            <column key="target" length="" collation="A" null="false" />
+        </index>
+        <index alias="principal_class" name="principal_class" primary="false" unique="false" type="BTREE">
+            <column key="principal_class" length="" collation="A" null="false" />
+        </index>
+        <index alias="principal" name="principal" primary="false" unique="false" type="BTREE">
+            <column key="principal" length="" collation="A" null="false" />
+        </index>
+        <index alias="authority" name="authority" primary="false" unique="false" type="BTREE">
+            <column key="authority" length="" collation="A" null="false" />
+        </index>
+        <index alias="policy" name="policy" primary="false" unique="false" type="BTREE">
+            <column key="policy" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Policy" class="modAccessPolicy" local="policy" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Principal" class="modPrincipal" local="principal" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="GroupPrincipal" class="modUserGroup" local="principal" foreign="id" owner="foreign" cardinality="one">
+            <criteria target="local"><![CDATA[
+            {"principal_class":"modUserGroup"}
+            ]]></criteria>
+        </aggregate>
+        <aggregate alias="UserPrincipal" class="modUserGroup" local="principal" foreign="id" owner="foreign" cardinality="one">
+            <criteria target="local"><![CDATA[
+            {"principal_class":"modUser"}
+            ]]></criteria>
+        </aggregate>
+        <aggregate alias="MinimumRole" class="modUserGroupRole" local="authority" foreign="authority" owner="local" cardinality="one" />
+    </object>
+    
+    <object class="modAccessAction" table="access_actions" extends="modAccess">
+        <aggregate alias="Target" class="modAction" local="target" foreign="id" owner="foreign" cardinality="one" />
+    </object>
+    
+    <object class="modAccessActionDom" table="access_actiondom" extends="modAccess">
+        <aggregate alias="Target" class="modActionDom" local="target" foreign="id" owner="foreign" cardinality="one" />
+    </object>
+    
+    <object class="modAccessCategory" table="access_category" extends="modAccess">
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />
+
+        <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+        
+        <aggregate alias="Target" class="modCategory" local="target" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+
+    <object class="modAccessContext" table="access_context" extends="modAccess">
+        <aggregate alias="Target" class="modContext" local="target" foreign="key" owner="foreign" cardinality="one" />
+    </object>
+
+    <object class="modAccessElement" table="access_elements" extends="modAccess">
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />
+
+        <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Target" class="modElement" local="target" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modAccessTemplateVar" table="access_templatevars" extends="modAccessElement">
+        <aggregate alias="Target" class="modTemplateVar" local="target" foreign="id" owner="foreign" cardinality="one" />
+    </object>
+    
+    <object class="modAccessibleObject" extends="xPDOObject" />
+    
+    <object class="modAccessibleSimpleObject" extends="modAccessibleObject">
+        <field key="id" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" index="pk" generated="native" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="id" length="" collation="A" null="false" />
+        </index>
+    </object>
+    
+    <object class="modAccessMenu" table="access_menus" extends="modAccess">
+        <aggregate alias="Target" class="modMenu" local="target" foreign="text" owner="foreign" cardinality="one" />
+    </object>
+    
+    <object class="modAccessPolicy" table="access_policies" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="unique" />
+        <field key="description" dbtype="mediumtext" phptype="string" />
+        <field key="parent" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="template" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="class" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="data" dbtype="text" phptype="json" default="{}" />
+        <field key="lexicon" dbtype="varchar" precision="255" phptype="string" null="false" default="permissions" />
+
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="parent" name="parent" primary="false" unique="false" type="BTREE">
+            <column key="parent" length="" collation="A" null="false" />
+        </index>
+        <index alias="class" name="class" primary="false" unique="false" type="BTREE">
+            <column key="class" length="" collation="A" null="false" />
+        </index>
+        <index alias="template" name="template" primary="false" unique="false" type="BTREE">
+            <column key="template" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Parent" class="modAccessPolicy" local="parent" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Template" class="modAccessPolicyTemplate" local="template" foreign="id" owner="foreign" cardinality="one" />
+        <composite alias="Children" class="modAccessPolicy" local="id" foreign="parent" owner="local" cardinality="many" />
+    </object>
+
+    <object class="modAccessPolicyTemplate" table="access_policy_templates" extends="xPDOSimpleObject">
+        <field key="template_group" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="mediumtext" phptype="string" />
+        <field key="lexicon" dbtype="varchar" precision="255" phptype="string" null="false" default="permissions" />
+
+        <aggregate alias="TemplateGroup" class="modAccessPolicyTemplateGroup" local="template_group" foreign="id" owner="foreign" cardinality="one" />
+        <composite alias="Permissions" class="modAccessPermission" local="id" foreign="template" owner="local" cardinality="many" />
+        <composite alias="Policies" class="modAccessPolicy" local="id" foreign="template" owner="local" cardinality="many" />
+    </object>
+    
+    <object class="modAccessPolicyTemplateGroup" table="access_policy_template_groups" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="mediumtext" phptype="string" />
+
+        <composite alias="Templates" class="modAccessPolicyTemplate" local="id" foreign="template_group" owner="local" cardinality="many" />
+    </object>
+
+    <object class="modAccessPermission" table="access_permissions" extends="xPDOSimpleObject">
+        <field key="template" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="index" />
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="text" phptype="string" null="false" default="" />
+        <field key="value" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="false" default="1" />
+        
+        <index alias="template" name="template" primary="false" unique="false" type="BTREE">
+            <column key="template" length="" collation="A" null="false" />
+        </index>
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Template" class="modAccessPolicyTemplate" local="template" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modAccessResource" table="access_resources" extends="modAccess">
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />
+        
+        <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Target" class="modResource" local="target" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modAccessResourceGroup" table="access_resource_groups" extends="modAccess">
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="fk" />
+        
+        <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+
+        <index alias="principal_class" name="principal_class" primary="false" unique="false" type="BTREE">
+            <column key="principal_class" length="" collation="A" null="false" />
+            <column key="target" length="" collation="A" null="false" />
+            <column key="principal" length="" collation="A" null="false" />
+            <column key="authority" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Target" class="modResourceGroup" local="target" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+
+    <!-- deprecated 2.3, will be removed in 2.4/3.0 -->
+    <object class="modAction" table="actions" extends="modAccessibleSimpleObject">
+        <field key="namespace" dbtype="varchar" precision="100" phptype="string" null="false" default="core" index="index" />
+        <field key="controller" dbtype="varchar" precision="255" phptype="string" null="false" index="index" />
+        <field key="haslayout" dbtype="tinyint" precision="1" attributes="unsigned" phptype="integer" null="false" default="1" />
+        <field key="lang_topics" dbtype="text" phptype="string" null="false" />
+        <field key="assets" dbtype="text" phptype="string" null="false" default="" />
+        <field key="help_url" dbtype="text" phptype="string" null="false" default="" />
+
+        <index alias="namespace" name="namespace" primary="false" unique="false" type="BTREE">
+            <column key="namespace" length="" collation="A" null="false" />
+        </index>
+        <index alias="controller" name="controller" primary="false" unique="false" type="BTREE">
+            <column key="controller" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Namespace" class="modNamespace" local="namespace" foreign="name" owner="foreign" cardinality="one" />
+        <composite alias="Menus" class="modMenu" local="id" foreign="action" owner="local" cardinality="many" />
+        <composite alias="Acls" class="modAccessAction" local="id" foreign="target" owner="local" cardinality="many" />
+        <composite alias="Fields" class="modActionField" local="id" foreign="action" owner="local" cardinality="many" />
+        <composite alias="DOM" class="modActionDom" local="id" foreign="action" owner="local" cardinality="many" />
+    </object>
+
+    <object class="modActionDom" table="actiondom" extends="modAccessibleSimpleObject">
+        <field key="set" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
+        <field key="action" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="text" phptype="string" />
+        <field key="xtype" dbtype="varchar" precision="100" phptype="string" null="false" default="" /><!-- deprecated -->
+        <field key="container" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="rule" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="value" dbtype="text" phptype="string" null="false" default="" />
+        <field key="constraint" dbtype="varchar" precision="255" phptype="string" null="false" default="" /><!-- deprecated -->
+        <field key="constraint_field" dbtype="varchar" precision="100" phptype="string" null="false" default="" /><!-- deprecated -->
+        <field key="constraint_class" dbtype="varchar" precision="100" phptype="string" null="false" default="" /><!-- deprecated -->
+        <field key="active" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" index="index" /><!-- deprecated -->
+        <field key="for_parent" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
+
+        <index alias="set" name="set" primary="false" unique="false" type="BTREE">
+            <column key="set" length="" collation="A" null="false" />
+        </index>
+        <index alias="action" name="action" primary="false" unique="false" type="BTREE">
+            <column key="action" length="" collation="A" null="false" />
+        </index>
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="active" name="active" primary="false" unique="false" type="BTREE">
+            <column key="active" length="" collation="A" null="false" />
+        </index>
+        <index alias="for_parent" name="for_parent" primary="false" unique="false" type="BTREE">
+            <column key="for_parent" length="" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="FCSet" class="modFormCustomizationSet" local="set" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Action" class="modAction" local="action" foreign="id" cardinality="one" owner="foreign" />
+        <composite alias="Access" class="modAccessActionDom" local="id" foreign="target" cardinality="many" owner="local" />
+    </object>
+
+    <object class="modActionField" table="actions_fields" extends="xPDOSimpleObject">
+        <field key="action" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" /> <!-- name/id of field -->
+        <field key="type" dbtype="varchar" precision="100" phptype="string" null="false" default="field" index="index" /> <!-- either field/tab -->
+        <field key="tab" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" /> <!-- for fields, what tab they are on -->
+        <field key="form" dbtype="varchar" precision="255" phptype="string" null="false" default="" /> <!-- the form ID (for dom sel purposes) -->
+        <field key="other" dbtype="varchar" precision="255" phptype="string" null="false" default="" /> <!-- used on tabs to delineate TV tabs -->
+        <field key="rank" dbtype="integer" precision="11" phptype="integer" null="false" default="0" />
+
+        <index alias="action" name="action" primary="false" unique="false" type="BTREE">
+            <column key="action" length="" collation="A" null="false" />
+        </index>
+        <index alias="type" name="type" primary="false" unique="false" type="BTREE">
+            <column key="type" length="" collation="A" null="false" />
+        </index>
+        <index alias="tab" name="tab" primary="false" unique="false" type="BTREE">
+            <column key="tab" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Action" class="modAction" local="action" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+
+    <object class="modActiveUser" table="active_users" extends="xPDOObject">
+        <field key="internalKey" dbtype="int" precision="9" phptype="integer" null="false" default="0" index="pk" />
+        <field key="username" dbtype="varchar" precision="50" phptype="string" null="false" default="" />
+        <field key="lasthit" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="id" dbtype="int" precision="10" phptype="integer" null="true" />
+        <field key="action" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="ip" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
+
+        <index alias="internalKey" name="internalKey" primary="true" unique="true" type="BTREE">
+            <column key="internalKey" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="User" class="modUser" local="internalKey" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modCategory" table="categories" extends="modAccessibleSimpleObject">
+        <field key="parent" dbtype="int" precision="10" phptype="integer" attributes="unsigned" default="0" index="index" />
+        <field key="category" dbtype="varchar" precision="45" phptype="string" null="false" default="" index="unique" />
+        <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
+
+        <index alias="parent" name="parent" primary="false" unique="false" type="BTREE">
+            <column key="parent" length="" collation="A" null="false" />
+        </index>
+        <index alias="category" name="category" primary="false" unique="true" type="BTREE">
+            <column key="parent" length="" collation="A" null="false" />
+            <column key="category" length="" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="Children" class="modCategory" local="id" foreign="parent" cardinality="many" owner="local" />
+        <aggregate alias="Parent" class="modCategory" local="parent" foreign="id" cardinality="one" owner="foreign" />
+        
+        <aggregate alias="Chunks" class="modChunk" key="id" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="Snippets" class="modSnippet" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="Plugins" class="modPlugin" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="Templates" class="modTemplate" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="TemplateVars" class="modTemplateVar" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="PropertySets" class="modPropertySet" local="id" foreign="category" cardinality="many" owner="local" />
+        <composite alias="Acls" class="modAccessCategory" local="id" foreign="target" owner="local" cardinality="many" />
+
+        <composite alias="Ancestors" class="modCategoryClosure" local="id" foreign="ancestor" cardinality="many" owner="local" />
+        <composite alias="Descendants" class="modCategoryClosure" local="id" foreign="descendant" cardinality="many" owner="local" />
+
+        <!-- LEGACY RELATIONSHIPS : PLEASE USE ABOVE -->
+        <aggregate alias="modChunk" class="modChunk" key="id" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="modSnippet" class="modSnippet" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="modPlugin" class="modPlugin" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="modTemplate" class="modTemplate" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="modTemplateVar" class="modTemplateVar" local="id" foreign="category" cardinality="many" owner="local" />
+        <aggregate alias="modPropertySet" class="modPropertySet" local="id" foreign="category" cardinality="many" owner="local" />
+        <!-- END LEGACY -->
+        <validation>
+            <rule field="category" name="preventBlank" type="xPDOValidationRule" rule="xPDOMinLengthValidationRule" value="1" message="category_err_ns_name" />
+        </validation>
+    </object>
+
+    <object class="modCategoryClosure" table="categories_closure" extends="xPDOObject">
+        <field key="ancestor" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="pk" />
+        <field key="descendant" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="pk" />
+        <field key="depth" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="ancestor" length="" collation="A" null="false" />
+            <column key="descendant" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Ancestor" class="modCategory" local="ancestor" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Descendant" class="modCategory" local="descendant" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+
+    <object class="modChunk" table="site_htmlsnippets" extends="modElement">
+        <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="Chunk" />
+        <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
+        <field key="cache_type" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
+        <field key="snippet" dbtype="mediumtext" phptype="string" />
+        <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="properties" dbtype="text" phptype="array" null="true" />
+        <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+
+        <alias key="content" field="snippet" />
+
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="category" name="category" primary="false" unique="false" type="BTREE">
+            <column key="category" length="" collation="A" null="false" />
+        </index>
+        <index alias="locked" name="locked" primary="false" unique="false" type="BTREE">
+            <column key="locked" length="" collation="A" null="false" />
+        </index>
+        <index alias="static" name="static" primary="false" unique="false" type="BTREE">
+            <column key="static" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="PropertySets" class="modElementPropertySet" local="id" foreign="element" owner="local" cardinality="many">
+            <criteria target="foreign"><![CDATA[
+            {"element_class":"modChunk"}
+            ]]></criteria>
+        </composite>
+        <aggregate alias="Category" class="modCategory" key="id" local="category" foreign="id" cardinality="one" owner="foreign" />
+        <validation>
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff_-\s]+(?!\s)$/" message="chunk_err_invalid_name" />
+        </validation>
+    </object>
+
+    <object class="modClassMap" table="class_map" extends="xPDOSimpleObject">
+        <field key="class" dbtype="varchar" precision="120" phptype="string" null="false" default="" index="unique" />
+        <field key="parent_class" dbtype="varchar" precision="120" phptype="string" null="false" default="" index="index" />
+        <field key="name_field" dbtype="varchar" precision="255" phptype="string" null="false" default="name" index="index" />
+        <field key="path" dbtype="tinytext" phptype="string" default="" />
+        <field key="lexicon" dbtype="varchar" precision="255" phptype="string" null="false" default="core:resource" />
+
+        <index alias="class" name="class" primary="false" unique="true" type="BTREE">
+            <column key="class" length="" collation="A" null="false" />
+        </index>
+        <index alias="parent_class" name="parent_class" primary="false" unique="false" type="BTREE">
+            <column key="parent_class" length="" collation="A" null="false" />
+        </index>
+        <index alias="name_field" name="name_field" primary="false" unique="false" type="BTREE">
+            <column key="name_field" length="" collation="A" null="false" />
+        </index>
+    </object>
+    
+    <object class="modContentType" table="content_type" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="unique" />
+        <field key="description" dbtype="tinytext" phptype="string" null="true" />
+        <field key="mime_type" dbtype="tinytext" phptype="string" />
+        <field key="file_extensions" dbtype="tinytext" phptype="string" />
+        <field key="headers" dbtype="mediumtext" phptype="array" />
+        <field key="binary" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Resources" class="modResource" local="id" foreign="content_type" owner="local" cardinality="many" />
+        <validation>
+            <rule field="name" name="name" type="xPDOValidationRule" rule="xPDOMinLengthValidationRule" value="1" message="content_type_err_ns_name" />            
+        </validation>
+    </object>
+    
+    <object class="modContext" table="context" extends="modAccessibleObject">
+        <field key="key" dbtype="varchar" precision="100" phptype="string" null="false" index="pk" />
+        <field key="name" dbtype="varchar" precision="191" phptype="string" index="index" />
+        <field key="description" dbtype="tinytext" phptype="string" />
+        <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="key" length="" collation="A" null="false" />
+        </index>
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="ContextResources" class="modContextResource" local="key" foreign="context_key" cardinality="many" owner="local" />
+        <composite alias="ContextSettings" class="modContextSetting" local="key" foreign="context_key" cardinality="many" owner="local" />
+        <composite alias="SourceElements" class="sources.modMediaSourceElement" local="key" foreign="context_key" cardinality="many" owner="local" />
+        <composite alias="Acls" class="modAccessContext" local="key" foreign="target" owner="local" cardinality="many" />
+        <validation>
+            <rule field="key" name="key" type="preg_match" rule="/^[a-zA-Z\x7f-\xff][a-zA-Z0-9\x2d-\x2f\x7f-\xff]*$/" message="context_err_ns_key" />
+        </validation>
+    </object>
+
+    <object class="modContextSetting" table="context_setting" extends="xPDOObject">
+        <field key="context_key" dbtype="varchar" precision="255" phptype="string" null="false" index="pk" />
+        <field key="key" dbtype="varchar" precision="50" phptype="string" null="false" index="pk" />
+        <field key="value" dbtype="mediumtext" phptype="string" />
+        <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
+        <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
+        <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
+            <column key="context_key" collation="A" null="false" />
+            <column key="key" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Context" class="modContext" key="context_key" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+        <aggregate alias="SystemSetting" class="modSystemSetting" key="key" local="key" foreign="key" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modContextResource" table="context_resource" extends="xPDOObject">
+        <field key="context_key" dbtype="varchar" precision="255" phptype="string" null="false" index="pk" />
+        <field key="resource" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" index="pk" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
+            <column key="context_key" collation="A" null="false" />
+            <column key="resource" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" cardinality="one" owner="foreign" />
+        <aggregate alias="Resource" class="modResource" local="resource" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+
+    <!-- A dashboard that shows on the loading screen for a user -->
+    <object class="modDashboard" table="dashboard" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="text" phptype="string" />
+        <field key="hide_trees" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="hide_trees" name="hide_trees" primary="false" unique="false" type="BTREE">
+            <column key="hide_trees" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="UserGroups" class="modUserGroup" local="id" foreign="dashboard" cardinality="many" owner="local" />
+        <composite alias="Placements" class="modDashboardWidgetPlacement" local="id" foreign="dashboard" cardinality="many" owner="local" />
+    </object>
+
+    <!-- Widgets that can be placed on dashboards. Can be files, html, or a snippet -->
+    <object class="modDashboardWidget" table="dashboard_widget" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="text" phptype="string" />
+        <field key="type" dbtype="varchar" precision="100" phptype="string" null="false" index="index" /><!-- file/chunk/snippet -->
+        <field key="content" dbtype="mediumtext" phptype="string" />
+        <field key="namespace" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="lexicon" dbtype="varchar" precision="255" phptype="string" null="false" default="core:dashboards" index="index" />
+        <field key="size" dbtype="varchar" precision="255" phptype="string" null="false" default="half" />
+
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="type" name="type" primary="false" unique="false" type="BTREE">
+            <column key="type" length="" collation="A" null="false" />
+        </index>
+        <index alias="namespace" name="namespace" primary="false" unique="false" type="BTREE">
+            <column key="namespace" length="" collation="A" null="false" />
+        </index>
+        <index alias="lexicon" name="lexicon" primary="false" unique="false" type="BTREE">
+            <column key="lexicon" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Namespace" class="modNamespace" local="namespace" foreign="name" cardinality="one" owner="foreign" />
+        <composite alias="Placements" class="modDashboardWidgetPlacement" local="id" foreign="widget" cardinality="many" owner="local" />
+    </object>
+
+    <!-- Placements of widgets on a dashboard -->
+    <object class="modDashboardWidgetPlacement" table="dashboard_widget_placement" extends="xPDOObject">
+        <field key="dashboard" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
+        <field key="widget" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
+        <field key="rank" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
+            <column key="dashboard" collation="A" null="false" />
+            <column key="widget" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Dashboard" class="modDashboard" local="dashboard" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Widget" class="modDashboardWidget" local="widget" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modDocument" extends="modResource" />
+    
+    <object class="modElement" table="site_element" extends="modAccessibleSimpleObject">
+        <field key="source" dbtype="int" attributes="unsigned" phptype="integer" null="false" default="0" index="fk" />
+        <field key="property_preprocess" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+
+        <composite alias="Acls" class="modAccessElement" local="id" foreign="target" owner="local" cardinality="many" />
+        <aggregate alias="CategoryAcls" class="modAccessCategory" local="category" foreign="target" owner="local" cardinality="many" />
+        <aggregate alias="Source" class="sources.modMediaSource" local="source" foreign="id" owner="foreign" cardinality="one" />
+    </object>
+    
+    <object class="modElementPropertySet" table="element_property_sets" extends="xPDOObject">
+        <field key="element" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
+        <field key="element_class" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="pk" />
+        <field key="property_set" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
+            <column key="element" collation="A" null="false" />
+            <column key="element_class" collation="A" null="false" />
+            <column key="property_set" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Element" class="modElement" local="element" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="PropertySet" class="modPropertySet" local="property_set" foreign="id" owner="foreign" cardinality="one" />
+    </object>
+    
+    <object class="modEvent" table="system_eventnames" extends="xPDOObject">
+        <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" index="pk" />
+        <field key="service" dbtype="tinyint" precision="4" attributes="unsigned" phptype="integer" null="false" default="0" />
+        <field key="groupname" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="PluginEvents" class="modPluginEvent" local="name" foreign="event" cardinality="many" owner="local" />
+    </object>
+
+    <object class="modFormCustomizationProfileUserGroup" table="fc_profiles_usergroups" extends="xPDOObject">
+        <field key="usergroup" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="pk" />
+        <field key="profile" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="pk" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="usergroup" length="" collation="A" null="false" />
+            <column key="profile" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="UserGroup" class="modUserGroup" local="usergroup" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Profile" class="modFormCustomizationProfile" local="profile" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    <object class="modFormCustomizationProfile" table="fc_profiles" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="text" phptype="string" null="false" default="" />
+        <field key="active" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" index="index" />
+        <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
+
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+        <index alias="active" name="active" primary="false" unique="false" type="BTREE">
+            <column key="active" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="Sets" class="modFormCustomizationSet" local="id" foreign="profile" cardinality="many" owner="local" />
+        <composite alias="UserGroups" class="modFormCustomizationProfileUserGroup" local="id" foreign="profile" cardinality="many" owner="local" />
+    </object>
+
+    <object class="modFormCustomizationSet" table="fc_sets" extends="xPDOSimpleObject">
+        <field key="profile" dbtype="integer" precision="11" phptype="integer" null="false" default="0" index="index" />
+        <field key="action" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="text" phptype="string" null="false" default="" />
+        <field key="active" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" index="index" />
+        <field key="template" dbtype="integer" precision="11" phptype="integer" null="false" default="0" index="index" />
+        <field key="constraint" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="constraint_field" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="constraint_class" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+
+        <index alias="profile" name="profile" primary="false" unique="false" type="BTREE">
+            <column key="profile" length="" collation="A" null="false" />
+        </index>
+        <index alias="action" name="action" primary="false" unique="false" type="BTREE">
+            <column key="action" length="" collation="A" null="false" />
+        </index>
+        <index alias="active" name="active" primary="false" unique="false" type="BTREE">
+            <column key="active" length="" collation="A" null="false" />
+        </index>
+        <index alias="template" name="template" primary="false" unique="false" type="BTREE">
+            <column key="template" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Action" class="modAction" local="action" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Template" class="modTemplate" local="template" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Profile" class="modFormCustomizationProfile" local="profile" foreign="id" cardinality="one" owner="foreign" />
+        <composite alias="Rules" class="modActionDom" local="id" foreign="set" cardinality="many" owner="local" />
+    </object>
+
+    <object class="modJSONRPCResource" extends="modXMLRPCResource" />
+    
+    <object class="modLexiconEntry" table="lexicon_entries" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="value" dbtype="text" phptype="string" null="false" default="" />
+        <field key="topic" dbtype="varchar" precision="255" phptype="string" null="false" default="default" index="index" />
+        <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" index="index" />
+        <field key="language" dbtype="varchar" precision="20" phptype="string" null="false" default="en" index="index" />
+        <field key="createdon" dbtype="text" phptype="datetime" />
+        <field key="editedon" dbtype="text" phptype="timestamp" null="false" />
+        
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="topic" name="topic" primary="false" unique="false" type="BTREE">
+            <column key="topic" length="" collation="A" null="false" />
+        </index>
+        <index alias="namespace" name="namespace" primary="false" unique="false" type="BTREE">
+            <column key="namespace" length="" collation="A" null="false" />
+        </index>
+        <index alias="language" name="language" primary="false" unique="false" type="BTREE">
+            <column key="language" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Namespace" class="modNamespace" local="namespace" foreign="name" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modManagerLog" table="manager_log" extends="xPDOSimpleObject">
+        <field key="user" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
+        <field key="occurred" dbtype="datetime" phptype="datetime" null="true" default="0000-00-00 00:00:00" />
+        <field key="action" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="classKey" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="item" dbtype="varchar" precision="191" phptype="string" null="false" default="0" />
+
+        <index alias="user_occurred" name="user_occurred" primary="false" unique="false" type="BTREE">
+            <column key="user" length="" collation="A" null="false" />
+            <column key="occurred" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="User" class="modUser" local="user" foreign="id" owner="foreign" cardinality="one" />
+    </object>
+    
+    <object class="modMenu" table="menus" extends="modAccessibleObject">
+        <field key="text" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="pk" />
+        <field key="parent" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="action" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="icon" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="menuindex" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" />
+        <field key="params" dbtype="text" phptype="string" null="false" default="" />
+        <field key="handler" dbtype="text" phptype="string" null="false" default="" />
+        <field key="permissions" dbtype="text" phptype="string" null="false" default="" />
+        <field key="namespace" dbtype="varchar" precision="100" phptype="string" null="false" default="core" index="index" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="text" length="" collation="A" null="false" />
+        </index>
+        <index alias="parent" name="parent" primary="false" unique="false" type="BTREE">
+            <column key="parent" length="" collation="A" null="false" />
+        </index>
+        <index alias="action" name="action" primary="false" unique="false" type="BTREE">
+            <column key="action" length="" collation="A" null="false" />
+        </index>
+        <index alias="namespace" name="namespace" primary="false" unique="false" type="BTREE">
+            <column key="namespace" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Action" class="modAction" local="action" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Parent" class="modMenu" local="parent" foreign="text" owner="foreign" cardinality="one" />
+        <aggregate alias="Children" class="modMenu" local="text" foreign="parent" owner="local" cardinality="many" />
+        <composite alias="Acls" class="modAccessMenu" local="text" foreign="target" owner="local" cardinality="many" />
+    </object>
+
+    <!--
+        Development namespacing object by which MODX extension development is done. Provides a centralized path location
+        and grouping name for organizing development silos within MODX.
+    -->
+    <object class="modNamespace" table="namespaces" extends="modAccessibleObject">
+        <!-- A lowercase namespace name that this Namespace will be referred as -->
+        <field key="name" dbtype="varchar" precision="40" phptype="string" null="false" default="" index="pk" />
+        <!-- The core path of the Namespace, where the PHP files will reside -->
+        <field key="path" dbtype="text" phptype="string" default="" />
+        <!-- The assets path of the Namespace, where images/css/js and any public-facing files will reside -->
+        <field key="assets_path" dbtype="text" phptype="string" default="" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="LexiconEntries" class="modLexiconEntry" local="name" foreign="namespace" cardinality="many" owner="local" />
+        <composite alias="SystemSettings" class="modSystemSetting" local="name" foreign="namespace" cardinality="many" owner="local" />
+        <composite alias="ContextSettings" class="modContextSetting" local="name" foreign="namespace" cardinality="many" owner="local" />
+        <composite alias="UserSettings" class="modUserSetting" local="name" foreign="namespace" cardinality="many" owner="local" />
+        <composite alias="ExtensionPackages" class="modExtensionPackage" local="name" foreign="namespace" cardinality="many" owner="local" />
+        <composite alias="Acls" class="modAccessNamespace" local="name" foreign="target" owner="local" cardinality="many" />
+
+        <!-- @deprecated to be removed in 2.4/3.0 -->
+        <composite alias="Actions" class="modAction" local="name" foreign="namespace" cardinality="many" owner="local" />
+    </object>
+
+    <!--
+        Extension packages load xPDO models during modX instantiation, allowing for custom database tables and other
+        models to be loaded prior to modX request handling. Useful for when you want to integrate custom data and
+        extensions, such as Custom Resource Classes, into the core.
+    -->
+    <object class="modExtensionPackage" table="extension_packages" extends="xPDOSimpleObject">
+        <!-- The namespace the extension package relates to -->
+        <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" index="index" />
+        <!-- If empty, will assume the Namespace name -->
+        <field key="name" dbtype="varchar" precision="100" phptype="string" null="false" default="core" index="index" />
+        <!-- If empty, will assume the Namespace path -->
+        <field key="path" dbtype="text" phptype="string" null="true" />
+        <!-- If empty, will assume no table prefix and delegate to package schema -->
+        <field key="table_prefix" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <!-- If specified, will create an instance of the class with this name using modX.getService on the loading of this extension package -->
+        <field key="service_class" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <!-- The name to give the service on the modX object when instantiating. Only valid if service_class is not empty. -->
+        <field key="service_name" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <!-- When this extension package was made -->
+		<field key="created_at" dbtype="text" phptype="datetime" null="true" />
+		<!-- The last time this extension package was updated -->
+		<field key="updated_at" dbtype="text" phptype="datetime" null="true" />
+
+        <index alias="namespace" name="namespace" primary="false" unique="false" type="BTREE">
+            <column key="namespace" length="" collation="A" null="false" />
+        </index>
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Namespace" class="modNamespace" local="namespace" foreign="name" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modPlugin" table="site_plugins" extends="modScript">
+        <field key="cache_type" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
+        <field key="plugincode" dbtype="mediumtext" phptype="string" null="false" default="" />
+        <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="properties" dbtype="text" phptype="array" null="true" />
+        <field key="disabled" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
+        <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+
+        <alias key="content" field="plugincode" />
+
+        <index alias="locked" name="locked" primary="false" unique="false" type="BTREE">
+            <column key="locked" length="" collation="A" null="false" />
+        </index>
+        <index alias="disabled" name="disabled" primary="false" unique="false" type="BTREE">
+            <column key="disabled" length="" collation="A" null="false" />
+        </index>
+        <index alias="static" name="static" primary="false" unique="false" type="BTREE">
+            <column key="static" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="PropertySets" class="modElementPropertySet" local="id" foreign="element" owner="local" cardinality="many">
+            <criteria target="foreign"><![CDATA[
+            {"element_class":"modPlugin"}
+            ]]></criteria>
+        </composite>
+        <composite alias="PluginEvents" class="modPluginEvent" local="id" foreign="pluginid" cardinality="many" owner="local" />
+        <validation>
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9_-\x7f-\xff\s]+(?!\s)$/" message="plugin_err_invalid_name" />
+        </validation>
+    </object>
+    
+    <object class="modPluginEvent" table="site_plugin_events" extends="xPDOObject">
+        <field key="pluginid" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="pk" />
+        <field key="event" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="pk" />
+        <field key="priority" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        <field key="propertyset" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="pluginid" length="" collation="A" null="false" />
+            <column key="event" length="" collation="A" null="false" />
+        </index>
+        <index alias="priority" name="priority" primary="false" unique="false" type="BTREE">
+            <column key="priority" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Plugin" class="modPlugin" local="pluginid" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Event" class="modEvent" local="event" foreign="name" cardinality="one" owner="foreign" />
+        <aggregate alias="PropertySet" class="modPropertySet" local="propertyset" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modPrincipal" extends="xPDOSimpleObject">
+        <composite alias="Acls" class="modAccess" local="id" foreign="principal" cardinality="many" owner="local" />
+    </object>
+    
+    <object class="modPropertySet" table="property_set" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
+        <field key="category" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="fk" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="properties" dbtype="text" phptype="array" null="true" />
+    
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="category" name="category" primary="false" unique="false" type="BTREE">
+            <column key="category" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Category" class="modCategory" key="id" local="category" foreign="id" cardinality="one" owner="foreign" />
+        <composite alias="Elements" class="modElementPropertySet" local="id" foreign="property_set" cardinality="many" owner="local" />        
+    </object>
+    
+    <object class="modResource" table="site_content" extends="modAccessibleSimpleObject" inherit="single">
+        <field key="type" dbtype="varchar" precision="20" phptype="string" null="false" default="document" />
+        <field key="contentType" dbtype="varchar" precision="50" phptype="string" null="false" default="text/html" />
+        <field key="pagetitle" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
+        <field key="longtitle" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
+        <field key="alias" dbtype="varchar" precision="255" phptype="string" null="true" default="" index="index" />
+        <field key="link_attributes" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="published" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="pub_date" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" index="index" />
+        <field key="unpub_date" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" index="index" />
+        <field key="parent" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        <field key="isfolder" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="introtext" dbtype="text" phptype="string" index="fulltext" indexgrp="content_ft_idx" />
+        <field key="content" dbtype="mediumtext" phptype="string" index="fulltext" indexgrp="content_ft_idx" />
+        <field key="richtext" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" />
+        <field key="template" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        <field key="menuindex" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        <field key="searchable" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" index="index" />
+        <field key="cacheable" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" index="index" />
+        <field key="createdby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="deleted" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        <field key="deletedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="deletedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="publishedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="publishedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="menutitle" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="donthit" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        <field key="privateweb" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        <field key="privatemgr" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        <field key="content_dispo" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
+        <field key="hidemenu" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="class_key" dbtype="varchar" precision="100" phptype="string" null="false" default="modDocument" index="index" />
+        <field key="context_key" dbtype="varchar" precision="100" phptype="string" null="false" default="web" index="index" />
+        <field key="content_type" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="1" />
+        <field key="uri" dbtype="text" phptype="string" null="true" index="index" />
+        <field key="uri_override" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" index="index" />
+        <field key="hide_children_in_tree" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" index="index" />
+        <field key="show_in_tree" dbtype="tinyint" precision="1" phptype="integer" null="false" default="1" index="index" />
+        <field key="properties" dbtype="mediumtext" phptype="json" null="true" />
+        
+        <index alias="alias" name="alias" primary="false" unique="false" type="BTREE">
+            <column key="alias" length="" collation="A" null="true" />
+        </index>
+        <index alias="published" name="published" primary="false" unique="false" type="BTREE">
+            <column key="published" length="" collation="A" null="false" />
+        </index>
+        <index alias="pub_date" name="pub_date" primary="false" unique="false" type="BTREE">
+            <column key="pub_date" length="" collation="A" null="false" />
+        </index>
+        <index alias="unpub_date" name="unpub_date" primary="false" unique="false" type="BTREE">
+            <column key="unpub_date" length="" collation="A" null="false" />
+        </index>
+        <index alias="parent" name="parent" primary="false" unique="false" type="BTREE">
+            <column key="parent" length="" collation="A" null="false" />
+        </index>
+        <index alias="isfolder" name="isfolder" primary="false" unique="false" type="BTREE">
+            <column key="isfolder" length="" collation="A" null="false" />
+        </index>
+        <index alias="template" name="template" primary="false" unique="false" type="BTREE">
+            <column key="template" length="" collation="A" null="false" />
+        </index>
+        <index alias="menuindex" name="menuindex" primary="false" unique="false" type="BTREE">
+            <column key="menuindex" length="" collation="A" null="false" />
+        </index>
+        <index alias="searchable" name="searchable" primary="false" unique="false" type="BTREE">
+            <column key="searchable" length="" collation="A" null="false" />
+        </index>
+        <index alias="cacheable" name="cacheable" primary="false" unique="false" type="BTREE">
+            <column key="cacheable" length="" collation="A" null="false" />
+        </index>
+        <index alias="hidemenu" name="hidemenu" primary="false" unique="false" type="BTREE">
+            <column key="hidemenu" length="" collation="A" null="false" />
+        </index>
+        <index alias="class_key" name="class_key" primary="false" unique="false" type="BTREE">
+            <column key="class_key" length="" collation="A" null="false" />
+        </index>
+        <index alias="context_key" name="context_key" primary="false" unique="false" type="BTREE">
+            <column key="context_key" length="" collation="A" null="false" />
+        </index>
+        <index alias="uri" name="uri" primary="false" unique="false" type="BTREE">
+            <column key="uri" length="1000" collation="A" null="true" />
+        </index>
+        <index alias="uri_override" name="uri_override" primary="false" unique="false" type="BTREE">
+            <column key="uri_override" length="" collation="A" null="false" />
+        </index>
+        <index alias="hide_children_in_tree" name="hide_children_in_tree" primary="false" unique="false" type="BTREE">
+            <column key="hide_children_in_tree" length="" collation="A" null="false" />
+        </index>
+        <index alias="show_in_tree" name="show_in_tree" primary="false" unique="false" type="BTREE">
+            <column key="show_in_tree" length="" collation="A" null="false" />
+        </index>
+        <index alias="content_ft_idx" name="content_ft_idx" primary="false" unique="false" type="FULLTEXT">
+            <column key="pagetitle" length="" collation="A" null="false" />
+            <column key="longtitle" length="" collation="A" null="false" />
+            <column key="description" length="" collation="A" null="false" />
+            <column key="introtext" length="" collation="A" null="true" />
+            <column key="content" length="" collation="A" null="true" />
+        </index>
+        <index alias="cache_refresh_index" name="cache_refresh_idx" primary="false" unique="false" type="BTREE">
+            <column key="parent" length="" collation="A" null="false" />
+            <column key="menuindex" length="" collation="A" null="false" />
+            <column key="id" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Parent" class="modResource" local="parent" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Children" class="modResource" local="id" foreign="parent" cardinality="many" owner="local" />
+        <aggregate alias="CreatedBy" class="modUser" local="createdby" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="EditedBy" class="modUser" local="editedby" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="DeletedBy" class="modUser" local="deletedby" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="PublishedBy" class="modUser" local="publishedby" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Template" class="modTemplate" local="template" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="TemplateVars" class="modTemplateVar" local="id:template" foreign="contentid:templateid" cardinality="many" owner="local" />
+        <aggregate alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="template" foreign="templateid" cardinality="many" owner="local" />
+        <aggregate alias="ContentType" class="modContentType" local="content_type" foreign="id" owner="foreign" cardinality="one" />
+        <aggregate alias="Context" class="modContext" local="context_key" foreign="key" owner="foreign" cardinality="one" />
+        <composite alias="Children" class="modResource" local="id" foreign="parent" cardinality="many" owner="local" />
+        <composite alias="TemplateVarResources" class="modTemplateVarResource" local="id" foreign="contentid" cardinality="many" owner="local" />
+        <composite alias="ResourceGroupResources" class="modResourceGroupResource" local="id" foreign="document" cardinality="many" owner="local" />
+        <composite alias="Acls" class="modAccessResource" local="id" foreign="target" owner="local" cardinality="many" />
+        <composite alias="ContextResources" class="modContextResource" local="id" foreign="resource" cardinality="many" owner="local" />
+    </object>
+    
+    <object class="modResourceGroup" table="documentgroup_names" extends="modAccessibleSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="unique" />
+        <field key="private_memgroup" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        <field key="private_webgroup" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="ResourceGroupResources" class="modResourceGroupResource" local="id" foreign="document_group" cardinality="many" owner="local" />
+        <composite alias="TemplateVarResourceGroups" class="modTemplateVarResourceGroup" local="id" foreign="documentgroup" cardinality="many" owner="local" />
+        <composite alias="Acls" class="modAccessResourceGroup" local="id" foreign="target" owner="local" cardinality="many" />
+    </object>
+    
+    <object class="modResourceGroupResource" table="document_groups" extends="xPDOSimpleObject">
+        <field key="document_group" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        <field key="document" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        
+        <index alias="document_group" name="document_group" primary="false" unique="false" type="BTREE">
+            <column key="document_group" length="" collation="A" null="false" />
+        </index>
+        <index alias="document" name="document" primary="false" unique="false" type="BTREE">
+            <column key="document" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="ResourceGroup" class="modResourceGroup" key="id" local="document_group" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Resource" class="modResource" key="id" local="document" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modScript" table="site_script" extends="modElement">
+        <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
+    
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="category" name="category" primary="false" unique="false" type="BTREE">
+            <column key="category" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Category" class="modCategory" key="id" local="category" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modSession" table="session" extends="xPDOObject">
+        <field key="id" dbtype="varchar" precision="255" phptype="string" null="false" index="pk" default="" />
+        <field key="access" dbtype="int" precision="20" phptype="timestamp" null="false" attributes="unsigned" />
+        <field key="data" dbtype="mediumtext" phptype="string" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="id" length="" collation="A" null="false" />
+        </index>
+        <index alias="access" name="access" primary="false" unique="false" type="BTREE">
+            <column key="access" length="" collation="A" null="false" />
+        </index>
+    </object>
+    
+    <object class="modSnippet" table="site_snippets" extends="modScript">
+        <field key="cache_type" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
+        <field key="snippet" dbtype="mediumtext" phptype="string" />
+        <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="properties" dbtype="text" phptype="array" null="true" />
+        <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
+        <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+
+        <alias key="content" field="snippet" />
+
+        <index alias="locked" name="locked" primary="false" unique="false" type="BTREE">
+            <column key="locked" length="" collation="A" null="false" />
+        </index>
+        <index alias="moduleguid" name="moduleguid" primary="false" unique="false" type="BTREE">
+            <column key="moduleguid" length="" collation="A" null="false" />
+        </index>
+        <index alias="static" name="static" primary="false" unique="false" type="BTREE">
+            <column key="static" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="PropertySets" class="modElementPropertySet" local="id" foreign="element" owner="local" cardinality="many">
+            <criteria target="foreign"><![CDATA[
+            {"element_class":"modSnippet"}
+            ]]></criteria>
+        </composite>
+
+        <validation>
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff_-\s]+(?!\s)$/" message="snippet_err_invalid_name" />
+        </validation>
+    </object>
+
+    <object class="modStaticResource" extends="modResource" />
+    
+    <object class="modSymLink" extends="modResource" />
+    
+    <object class="modSystemSetting" table="system_settings" extends="xPDOObject">
+        <field key="key" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="pk" />
+        <field key="value" dbtype="text" phptype="string" null="false" default="" />
+        <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
+        <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
+        <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="editedon" dbtype="text" phptype="timestamp" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="ContextSetting" class="modContextSetting" local="key" foreign="key" cardinality="one" owner="local" />
+        <aggregate alias="Namespace" class="modNamespace" local="namespace" foreign="name" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modTemplate" table="site_templates" extends="modElement">
+        <field key="templatename" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="Template" />
+        <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
+        <field key="icon" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="template_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="content" dbtype="mediumtext" phptype="string" null="false" default="" />
+        <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="properties" dbtype="text" phptype="array" null="true" />
+        <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        
+        <index alias="templatename" name="templatename" primary="false" unique="true" type="BTREE">
+            <column key="templatename" length="" collation="A" null="false" />
+        </index>
+        <index alias="category" name="category" primary="false" unique="false" type="BTREE">
+            <column key="category" length="" collation="A" null="false" />
+        </index>
+        <index alias="locked" name="locked" primary="false" unique="false" type="BTREE">
+            <column key="locked" length="" collation="A" null="false" />
+        </index>
+        <index alias="static" name="static" primary="false" unique="false" type="BTREE">
+            <column key="static" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="PropertySets" class="modElementPropertySet" local="id" foreign="element" owner="local" cardinality="many">
+            <criteria target="foreign"><![CDATA[
+            {"element_class":"modTemplate"}
+            ]]></criteria>
+        </composite>
+        <aggregate alias="Category" class="modCategory" local="category" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Resources" class="modResource" local="id" foreign="template" cardinality="many" owner="local" />
+        <composite alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="id" foreign="templateid" cardinality="many" owner="local" />
+    </object>
+    
+    <object class="modTemplateVar" table="site_tmplvars" extends="modElement">
+        <field key="type" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
+        <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
+        <field key="caption" dbtype="varchar" precision="80" phptype="string" null="false" default="" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
+        <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="elements" dbtype="text" phptype="string" />
+        <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
+        <field key="display" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
+        <field key="default_text" dbtype="mediumtext" phptype="string" />
+        <field key="properties" dbtype="text" phptype="array" null="true" />
+        <field key="input_properties" dbtype="text" phptype="array" null="true" />
+        <field key="output_properties" dbtype="text" phptype="array" null="true" />
+        <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+
+        <alias key="content" field="default_text" />
+
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="category" name="category" primary="false" unique="false" type="BTREE">
+            <column key="category" length="" collation="A" null="false" />
+        </index>
+        <index alias="locked" name="locked" primary="false" unique="false" type="BTREE">
+            <column key="locked" length="" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+        <index alias="static" name="static" primary="false" unique="false" type="BTREE">
+            <column key="static" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="PropertySets" class="modElementPropertySet" local="id" foreign="element" owner="local" cardinality="many">
+            <criteria target="foreign"><![CDATA[
+            {"element_class":"modTemplateVar"}
+            ]]></criteria>
+        </composite>
+        <aggregate alias="Category" class="modCategory" local="category" foreign="id" cardinality="one" owner="foreign" />
+        <composite alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="id" foreign="tmplvarid" cardinality="many" owner="local" />
+        <composite alias="TemplateVarResources" class="modTemplateVarResource" local="id" foreign="tmplvarid" cardinality="many" owner="local" />
+        <composite alias="TemplateVarResourceGroups" class="modTemplateVarResourceGroup" local="id" foreign="tmplvarid" cardinality="many" owner="local" />
+        <validation>
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff_-\s]+(?!\s)$/" message="tv_err_invalid_name" />
+            <rule field="name" name="reserved" type="preg_match" rule="/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree)$)/" message="tv_err_reserved_name" />
+        </validation>
+    </object>
+    
+    <object class="modTemplateVarResource" table="site_tmplvar_contentvalues" extends="xPDOSimpleObject">
+        <field key="tmplvarid" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        <field key="contentid" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
+        <field key="value" dbtype="mediumtext" phptype="string" null="false" />
+
+        <index alias="tmplvarid" name="tmplvarid" primary="false" unique="false" type="BTREE">
+            <column key="tmplvarid" length="" collation="A" null="false" />
+        </index>
+        <index alias="contentid" name="contentid" primary="false" unique="false" type="BTREE">
+            <column key="contentid" length="" collation="A" null="false" />
+        </index>
+        <index alias="tv_cnt" name="tv_cnt" primary="false" unique="true" type="BTREE">
+            <column key="tmplvarid" length="" collation="A" null="false" />
+            <column key="contentid" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="TemplateVar" class="modTemplateVar" local="tmplvarid" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Resource" class="modResource" local="contentid" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modTemplateVarResourceGroup" table="site_tmplvar_access" extends="xPDOSimpleObject">
+        <field key="tmplvarid" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="documentgroup" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+
+        <index alias="tmplvar_template" name="tmplvar_template" type="BTREE">
+            <column key="tmplvarid" length="" collation="A" null="false" />
+            <column key="documentgroup" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="TemplateVar" class="modTemplateVar" local="tmplvarid" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="ResourceGroup" class="modResourceGroup" local="documentgroup" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modTemplateVarTemplate" table="site_tmplvar_templates" extends="xPDOObject">
+        <field key="tmplvarid" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="pk" />
+        <field key="templateid" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="pk" />
+        <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="tmplvarid" length="" collation="A" null="false" />
+            <column key="templateid" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="TemplateVar" class="modTemplateVar" key="id" local="tmplvarid" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Template" class="modTemplate" key="id" local="templateid" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modUser" table="users" extends="modPrincipal">
+        <field key="username" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="unique" />
+        <field key="password" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="cachepwd" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="class_key" dbtype="varchar" precision="100" phptype="string" null="false" default="modUser" index="index" />
+        <field key="active" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="false" default="1" />
+        <field key="remote_key" dbtype="varchar" precision="255" phptype="string" null="true" index="index" />
+        <field key="remote_data" dbtype="text" phptype="json" null="true" />
+        <field key="hash_class" dbtype="varchar" precision="100" phptype="string" null="false" default="hashing.modPBKDF2" />
+        <field key="salt" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="primary_group" dbtype="int" precision="10" phptype="integer" attributes="unsigned" null="false" default="0" index="index" />
+        <field key="session_stale" dbtype="text" phptype="array" null="true" />
+        <field key="sudo" dbtype="tinyint" precision="1" phptype="boolean" attributes="unsigned" null="false" default="0" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+
+        <index alias="username" name="username" primary="false" unique="true" type="BTREE">
+            <column key="username" length="" collation="A" null="false" />
+        </index>
+        <index alias="class_key" name="class_key" primary="false" unique="false" type="BTREE">
+            <column key="class_key" length="" collation="A" null="false" />
+        </index>
+        <index alias="remote_key" name="remote_key" primary="false" unique="false" type="BTREE">
+            <column key="remote_key" length="" collation="A" null="false" />
+        </index>
+        <index alias="primary_group" name="primary_group" primary="false" unique="false" type="BTREE">
+            <column key="primary_group" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="CreatedResources" class="modResource" local="id" foreign="createdby" cardinality="many" owner="local" />
+        <aggregate alias="EditedResources" class="modResource" local="id" foreign="editedby" cardinality="many" owner="local" />
+        <aggregate alias="DeletedResources" class="modResource" local="id" foreign="deletedby" cardinality="many" owner="local" />
+        <aggregate alias="PublishedResources" class="modResource" local="id" foreign="publishedby" cardinality="many" owner="local" />
+        <aggregate alias="SentMessages" class="modUserMessage" local="id" foreign="sender" cardinality="many" owner="local" />
+        <aggregate alias="ReceivedMessages" class="modUserMessage" local="id" foreign="recipient" cardinality="many" owner="local" />
+        <aggregate alias="PrimaryGroup" class="modUserGroup" local="primary_group" foreign="id" cardinality="one" owner="foreign" />
+        <composite alias="Profile" class="modUserProfile" local="id" foreign="internalKey" cardinality="one" owner="local" />
+        <composite alias="UserSettings" class="modUserSetting" local="id" foreign="user" cardinality="many" owner="local" />
+        <composite alias="UserGroupMembers" class="modUserGroupMember" local="id" foreign="member" cardinality="many" owner="local" />
+        <composite alias="ActiveUsers" class="modActiveUser" local="id" foreign="internalKey" cardinality="many" owner="local" />
+    </object>
+    
+    <object class="modUserGroup" table="membergroup_names" extends="modPrincipal">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="unique" />
+        <field key="description" dbtype="text" phptype="string" />
+        <field key="parent" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="rank" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="dashboard" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="1" index="index" />
+        
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="parent" name="parent" primary="false" unique="false" type="BTREE">
+            <column key="parent" length="" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+        <index alias="dashboard" name="dashboard" primary="false" unique="false" type="BTREE">
+            <column key="dashboard" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Parent" class="modUserGroup" local="parent" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Children" class="modUserGroup" local="id" foreign="parent" cardinality="many" owner="local" />
+        <aggregate alias="Dashboard" class="modDashboard" local="dashboard" foreign="id" cardinality="one" owner="foreign" />
+        <composite alias="UserGroupMembers" class="modUserGroupMember" local="id" foreign="user_group" cardinality="many" owner="local" />
+        <composite alias="FormCustomizationProfiles" class="modFormCustomizationProfileUserGroup" local="id" foreign="usergroup" cardinality="many" owner="local" />
+    </object>
+    
+    <object class="modUserGroupMember" table="member_groups" extends="xPDOSimpleObject">
+        <field key="user_group" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
+        <field key="member" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
+        <field key="role" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="1" index="index" />
+        <field key="rank" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        
+        <index alias="role" name="role" primary="false" unique="false" type="BTREE">
+            <column key="role" length="" collation="A" null="false" />
+        </index>
+        <index alias="rank" name="rank" primary="false" unique="false" type="BTREE">
+            <column key="rank" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="UserGroupRole" class="modUserGroupRole" local="role" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="UserGroup" class="modUserGroup" local="user_group" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="User" class="modUser" local="member" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modUserGroupRole" table="user_group_roles" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="unique" />
+        <field key="description" dbtype="mediumtext" phptype="string" />
+        <field key="authority" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="9999" index="index" />
+        
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="authority" name="authority" primary="false" unique="false" type="BTREE">
+            <column key="authority" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="UserGroupMembers" class="modUserGroupMember" local="id" foreign="role" cardinality="many" owner="local" />
+    </object>
+
+    <object class="modUserGroupSetting" table="user_group_settings" extends="xPDOObject">
+        <field key="group" dbtype="integer" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
+        <field key="key" dbtype="varchar" precision="50" phptype="string" null="false" index="pk" />
+        <field key="value" dbtype="text" phptype="string" />
+        <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
+        <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
+        <field key="area" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="group" length="" collation="A" null="false" />
+            <column key="key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="UserGroup" class="modUserGroup" local="group" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Namespace" class="modNamespace" local="namespace" foreign="name" cardinality="one" owner="foreign" />
+    </object>
+
+    <object class="modUserMessage" table="user_messages" extends="xPDOSimpleObject">
+        <field key="type" dbtype="varchar" precision="15" phptype="string" null="false" default="" />
+        <field key="subject" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="message" dbtype="text" phptype="string" null="false" default="" />
+        <field key="sender" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="recipient" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="private" dbtype="tinyint" precision="4" phptype="integer" null="false" default="0" />
+        <field key="date_sent" dbtype="datetime" phptype="datetime" null="false" default="0000-00-00 00:00:00" />
+        <field key="read" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
+
+        <aggregate alias="Sender" class="modUser" local="sender" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Recipient" class="modUser" local="recipient" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modUserProfile" table="user_attributes" extends="xPDOSimpleObject">
+        <field key="internalKey" dbtype="int" precision="10" phptype="integer" null="false" index="unique" />
+        <field key="fullname" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="email" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="phone" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="mobilephone" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="blocked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
+        <field key="blockeduntil" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="blockedafter" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="logincount" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="lastlogin" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="thislogin" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="failedlogincount" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="sessionid" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="dob" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="gender" dbtype="int" precision="1" phptype="integer" null="false" default="0" />
+        <field key="address" dbtype="text" phptype="string" null="false" default="" />
+        <field key="country" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="city" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="state" dbtype="varchar" precision="25" phptype="string" null="false" default="" />
+        <field key="zip" dbtype="varchar" precision="25" phptype="string" null="false" default="" />
+        <field key="fax" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="photo" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="comment" dbtype="text" phptype="string" null="false" default="" />
+        <field key="website" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="extended" dbtype="text" phptype="json" null="true" index="fulltext" indexgrp="extended" />
+        
+        <index alias="internalKey" name="internalKey" primary="false" unique="true" type="BTREE">
+            <column key="internalKey" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="User" class="modUser" local="internalKey" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modUserSetting" table="user_settings" extends="xPDOObject">
+        <field key="user" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="pk" />
+        <field key="key" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="pk" />
+        <field key="value" dbtype="text" phptype="string" />
+        <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
+        <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
+        <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="editedon" dbtype="timestamp" phptype="timestamp" null="false" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="user" length="" collation="A" null="false" />
+            <column key="key" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="User" class="modUser" local="user" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Namespace" class="modNamespace" local="namespace" foreign="name" cardinality="one" owner="foreign" />
+    </object>
+    
+    <object class="modWebLink" extends="modResource" />
+    
+    <object class="modWorkspace" table="workspaces" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="path" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="unique" />
+        <field key="created" dbtype="datetime" phptype="timestamp" null="false" />
+        <field key="active" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="attributes" dbtype="mediumtext" phptype="array" />
+        
+        <index alias="name" name="name" primary="false" unique="false" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="path" name="path" primary="false" unique="true" type="BTREE">
+            <column key="path" length="" collation="A" null="false" />
+        </index>
+        <index alias="active" name="active" primary="false" unique="false" type="BTREE">
+            <column key="active" length="" collation="A" null="false" />
+        </index>
+
+        <composite alias="Packages" class="transport.modTransportPackage" local="id" foreign="workspace" cardinality="many" owner="local" />
+    </object>
+    
+    <object class="modXMLRPCResource" extends="modResource" />
+
+    <!-- MOVE DEPRECATED OBJECT DEFINITIONS BELOW HERE -->
+</model>

--- a/core/model/schema/modx.transport.sqlite.schema.xml
+++ b/core/model/schema/modx.transport.sqlite.schema.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+/*
+ * MODX CMS and PHP Application Framework ("MODX")
+ * Copyright 2006, 2007, 2008 by MODX, LLC.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+ -->
+<!-- The following xPDO model represents an object-relational map structure of the MODX transport package -->
+<model package="modx.transport" baseClass="xPDOObject" platform="sqlite" defaultEngine="SQLitev3" phpdoc-package="modx" phpdoc-subpackage="transport" version="1.1">
+    <object class="modTransportProvider" table="transport_providers" extends="xPDOSimpleObject">
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" index="unique" />
+        <field key="description" dbtype="mediumtext" phptype="string" />
+        <field key="service_url" dbtype="tinytext" phptype="string" />
+        <field key="username" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="api_key" dbtype="varchar" precision="255" phptype="string" null="false" default="" index="index" />
+        <field key="created" dbtype="datetime" phptype="datetime" null="false" />
+        <field key="updated" dbtype="timestamp" phptype="timestamp" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="active" dbtype="tinyint" precision="1" phptype="boolean" null="false" default="1" index="index" />
+        <field key="priority" dbtype="tinyint" precision="4" phptype="integer" null="false" default="10" index="index" />
+        <field key="properties" dbtype="mediumtext" phptype="json" null="false" default="" />
+
+        <index alias="name" name="name" primary="false" unique="true" type="BTREE">
+            <column key="name" length="" collation="A" null="false" />
+        </index>
+        <index alias="api_key" name="api_key" primary="false" unique="false" type="BTREE">
+            <column key="api_key" length="" collation="A" null="false" />
+        </index>
+        <index alias="username" name="username" primary="false" unique="false" type="BTREE">
+            <column key="username" length="" collation="A" null="false" />
+        </index>
+        <index alias="active" name="active" primary="false" unique="false" type="BTREE">
+            <column key="active" length="" collation="A" null="false" />
+        </index>
+        <index alias="priority" name="priority" primary="false" unique="false" type="BTREE">
+            <column key="priority" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Packages" class="transport.modTransportPackage" local="id" foreign="provider" cardinality="many" owner="local" />
+    </object>
+    <object class="modTransportPackage" table="transport_packages" extends="xPDOObject">
+        <field key="signature" dbtype="varchar" precision="255" phptype="string" null="false" index="pk" />
+        <field key="created" dbtype="datetime" phptype="datetime" null="false" />
+        <field key="updated" dbtype="timestamp" phptype="timestamp" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="installed" dbtype="datetime" phptype="datetime" />
+        <field key="state" dbtype="tinyint" precision="1" attributes="unsigned" phptype="integer" null="false" default="1" />
+        <field key="workspace" dbtype="integer" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="fk" />
+        <field key="provider" dbtype="integer" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="fk" />
+        <field key="disabled" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
+        <field key="source" dbtype="tinytext" phptype="string" />
+        <field key="manifest" dbtype="text" phptype="array" />
+        <field key="attributes" dbtype="mediumtext" phptype="array" />
+        <field key="package_name" dbtype="varchar" precision="255" phptype="string" null="false" index="index" />
+        <field key="metadata" dbtype="text" phptype="array" />
+        <field key="version_major" dbtype="tinyint" precision="4" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="version_minor" dbtype="tinyint" precision="4" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="version_patch" dbtype="tinyint" precision="4" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />        
+        <field key="release" dbtype="varchar" precision="100" phptype="string" null="false" default="" index="index" />
+        <field key="release_index" dbtype="tinyint" precision="4" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        
+        <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
+            <column key="signature" length="" collation="A" null="false" />
+        </index>
+        <index alias="workspace" name="workspace" primary="false" unique="false" type="BTREE">
+            <column key="workspace" length="" collation="A" null="false" />
+        </index>
+        <index alias="provider" name="provider" primary="false" unique="false" type="BTREE">
+            <column key="provider" length="" collation="A" null="false" />
+        </index>
+        <index alias="disabled" name="disabled" primary="false" unique="false" type="BTREE">
+            <column key="disabled" length="" collation="A" null="false" />
+        </index>
+        <index alias="package_name" name="package_name" primary="false" unique="false" type="BTREE">
+            <column key="package_name" length="" collation="A" null="false" />
+        </index>
+        <index alias="version_major" name="version_major" primary="false" unique="false" type="BTREE">
+            <column key="version_major" length="" collation="A" null="false" />
+        </index>
+        <index alias="version_minor" name="version_minor" primary="false" unique="false" type="BTREE">
+            <column key="version_minor" length="" collation="A" null="false" />
+        </index>
+        <index alias="version_patch" name="version_patch" primary="false" unique="false" type="BTREE">
+            <column key="version_patch" length="" collation="A" null="false" />
+        </index>
+        <index alias="release" name="release" primary="false" unique="false" type="BTREE">
+            <column key="release" length="" collation="A" null="false" />
+        </index>
+        <index alias="release_index" name="release_index" primary="false" unique="false" type="BTREE">
+            <column key="release_index" length="" collation="A" null="false" />
+        </index>
+
+        <aggregate alias="Workspace" class="modWorkspace" local="workspace" foreign="id" cardinality="one" owner="foreign" />
+        <aggregate alias="Provider" class="transport.modTransportProvider" local="provider" foreign="id" cardinality="one" owner="foreign" />
+    </object>
+</model>

--- a/setup/assets/js/sections/database.js
+++ b/setup/assets/js/sections/database.js
@@ -1,6 +1,7 @@
 Ext.onReady(function() {
     Ext.select('#modx-testconn').on('click',MODx.DB.testConnection);
     Ext.select('#modx-testcoll').on('click',MODx.DB.testCollation);
+    Ext.select('#database-type').on('change',MODx.DB.changeTypeDB);
 
     Ext.select('#modx-db-info').hide();
     var es = Ext.select('.modx-hidden2');
@@ -133,6 +134,19 @@ MODx.DB = function() {
                ,params: p
             });
         }
+        ,changeTypeDB:function(){
+            
+            var active_db = Ext.get('database-type');
+            var objs = [  'database-server'
+                         ,'database-user'
+                         ,'database-password'
+                       ];  
+            
+            for(var i in objs)
+               document.getElementById(objs[i]).disabled = (active_db.getValue()=='sqlite');
+            
+            
+        } 
         
         ,optionTpl: new Ext.Template('<option value="{value}"{selected}>{name}</option>')
     };

--- a/setup/includes/drivers/modinstalldriver_sqlite.class.php
+++ b/setup/includes/drivers/modinstalldriver_sqlite.class.php
@@ -1,0 +1,181 @@
+<?php
+/*
+ * MODX Revolution
+ *
+ * Copyright 2006-2012 by MODX, LLC.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ */
+require_once (strtr(realpath(dirname(__FILE__)), '\\', '/') . '/modinstalldriver.class.php');
+/**
+ * Provides query abstraction for setup using the sqlite native database driver.
+ *
+ * @package setup
+ * @subpackage drivers
+ */
+class modInstallDriver_sqlite extends modInstallDriver {
+    /**
+     * Collations Support
+     */    
+    private $collations_support = array( 'utf8_general_ns','utf16_general_ns');
+    /**
+     * Collation Default
+     */            
+    private $collation_default = 'utf8_general_ci';
+    /**
+     * Charset Default
+     */        
+    private $charset_default = 'utf8';
+    /**
+     * Charsets Support
+     */    
+    private $charsets_support = array('utf8','utf16'); 
+    /**
+     * 
+     * Check for sqlite extension
+     * {@inheritDoc}
+     */
+    public function verifyExtension() {
+        return extension_loaded('sqlite');
+    }
+
+    /**
+     * Check for sqlite_pdo extension
+     * {@inheritDoc}
+     */
+    public function verifyPDOExtension() {
+        return extension_loaded('PDO_sqlite');
+    }
+
+    /**
+     * SQLite DB syntax for default collation query
+     * {@inheritDoc}
+     */
+    public function getCollation() {
+        $collation = $this->collation_default;
+        return $collation;
+    }
+
+    /**
+     * SQLite DB syntax for collation listing
+     * {@inheritDoc}
+     */
+    public function getCollations($collation = '') {        
+         
+        $collations = array();               
+        foreach($this->collations_support as $c_item) {
+           $col = array();        
+           $col['selected'] = ($c_item==$collation ? ' selected="selected"' : '');
+           $col['value'] = $c_item;
+           $col['name'] = $c_item;
+           $collations[$c_item] = $col;       
+        }
+        return $collations;
+    }
+
+    public function getCharset($collation = '') {
+        $charset = $this->charset_default;
+        if (empty($collation)) {
+            $collation = $this->getCollation();
+        }
+        $pos = strpos($collation, '_');
+        if ($pos > 0) {
+            $charset = substr($collation, 0, $pos);
+        }
+        return $charset;
+    }
+
+    /**
+     * SQLite DB syntax for charset listing
+     * {@inheritDoc}
+     */
+    public function getCharsets($charset = '') {
+        $charsets = array();               
+        foreach($this->charsets_support as $cs_item) {
+           $col = array();        
+           $col['selected'] = ($cs_item==$collation ? ' selected="selected"' : '');
+           $col['value'] = $cs_item;
+           $col['name'] = $cs_item;
+           $charsets[$cs_item] = $col;       
+        }        
+        return $charsets;
+    }
+
+    /**
+     * SQLite DB syntax for table prefix check
+     * {@inheritDoc}
+     */
+    public function testTablePrefix($database,$prefix) {
+        return 'SELECT COUNT('.$this->xpdo->escape('id').') AS '.$this->xpdo->escape('ct').' FROM '.$this->xpdo->escape($prefix.'site_content');
+    }
+
+    /**
+     * SQLite DB syntax for table truncation
+     * {@inheritDoc}
+     */
+    public function truncate($table) {
+        return 'TRUNCATE '.$this->xpdo->escape($table);
+    }
+
+    /**
+     * SQLite DB check for server version not implement
+     *
+     * @TODO Get this to actually check the server version.
+     *
+     * {@inheritDoc}
+     */
+    public function verifyServerVersion() {
+        return array('result' => 'success','message' => $this->install->lexicon('sqlite_version_success',array('version' => '')));
+    }
+
+    /**
+     * SQLite DB check for client version
+     *
+     * @TODO Get this to actually check the client version. not implement
+     *
+     * {@inheritDoc}
+     */
+    public function verifyClientVersion() {
+        return array('result' => 'success', 'message' => $this->install->lexicon('sqlite_version_client_success',array('version' => '')));
+    }
+
+    /**
+     * SQLite DB syntax to add an index
+     * {@inheritDoc}
+     */
+    public function addIndex($table,$name,$column) {
+        return 'ALTER TABLE '.$this->xpdo->escape($table).' ADD INDEX '.$this->xpdo->escape($name).' ('.$this->xpdo->escape($column).')"';
+    }
+
+    /**
+     * SQLite DB syntax to drop an index
+     * {@inheritDoc}
+     */
+    public function dropIndex($table,$index) {
+        return 'ALTER TABLE '.$this->xpdo->escape($table).' DROP INDEX '.$this->xpdo->escape($index);
+    }
+
+
+    /**
+     * Cleans a sqlite version string that often has extra junk in certain distros
+     *
+     * @param string $sqliteVersion The version note to sanitize
+     * @return string The sanitized version
+     */
+    protected function _sanitizeVersion($sqliteVersion) {
+        return $sqliteVersion;
+    }
+}

--- a/setup/includes/modinstallsettings.class.php
+++ b/setup/includes/modinstallsettings.class.php
@@ -1,13 +1,4 @@
 <?php
-/*
- * This file is part of MODX Revolution.
- *
- * Copyright (c) MODX, LLC. All Rights Reserved.
- *
- * For complete copyright and license information, see the COPYRIGHT and LICENSE
- * files found in the top-level directory of this distribution.
- */
-
 /**
  * @package setup
  */
@@ -43,11 +34,16 @@ class modInstallSettings {
                     $server_dsn = "{$this->settings['database_type']}:server={$this->settings['database_server']}";
                     break;
                 case 'mysql':
-                    $server = explode(':', $this->settings['database_server']);
-                    $port = !empty($server[1]) ? "port={$server[1]};" : '';
-                    $database_dsn = "{$this->settings['database_type']}:host={$server[0]};{$port}dbname={$this->settings['dbase']};charset={$this->settings['database_connection_charset']}";
-                    $server_dsn = "{$this->settings['database_type']}:host={$server[0]};{$port}charset={$this->settings['database_connection_charset']}";
+                    $database_dsn = "{$this->settings['database_type']}:host={$this->settings['database_server']};dbname={$this->settings['dbase']};charset={$this->settings['database_connection_charset']}";
+                    $server_dsn = "{$this->settings['database_type']}:host={$this->settings['database_server']};charset={$this->settings['database_connection_charset']}";
                     break;
+                case 'sqlite':
+                    $database_name = explode('.',preg_replace('[^A-Za-z0-9.]', '', $this->settings['dbase']));
+                    $this->settings['dbase'] = $database_name[0];
+                    $database_fullpath = MODX_CORE_PATH.'data/'.$this->settings['dbase'].'.db3';
+                    $database_dsn = "{$this->settings['database_type']}:{$database_fullpath}";
+                    $server_dsn = "{$this->settings['database_type']}:charset={$this->settings['database_connection_charset']}"; /*NOT IMPLEMENT*/                   
+                    break;                  
                 default:
                     $database_dsn = '';
                     $server_dsn = '';
@@ -91,7 +87,7 @@ class modInstallSettings {
             $this->settings[$k] = $v;
         }
     }
-
+    
     /**
      * @return void
      */

--- a/setup/templates/database.tpl
+++ b/setup/templates/database.tpl
@@ -10,12 +10,13 @@
     <p>{$_lang.connection_connection_note}</p>
 
     <p class="error">{$error_message|default}</p>
-    
+
     <div class="labelHolder">
         <label for="database-type">{$_lang.connection_database_type}</label>
         <select id="database-type" name="database_type" autofocus="autofocus">
             <option value="mysql"{if $config.database_type|default EQ "mysql"} selected="selected"{/if}>mysql</option>
             <option value="sqlsrv"{if $config.database_type|default EQ "sqlsrv"} selected="selected"{/if}>sqlsrv</option>
+            <option value="sqlite"{if $config.database_type|default EQ "sqlite"} selected="selected"{/if}>sqlite</option>
         </select>
         &nbsp;<span class="version-msg" id="database-type-error"></span>
     </div>


### PR DESCRIPTION
### What does it do?
Make MODX Revolution to work whith SqLite v3.

### Why is it needed?
Using MODX Revolution whithout mysql server.
## Information
It is still necessary to test, because there are errors in the logs.
(I have successfully installed on version 2.8.)
**Install as usual /setup.**

- When setting up the database, select - sqlite.
- Do not enter anything into the connections - click to check the connection.
test the connection in the database.
- If everything is successful, enter the data for the admin as usual and set it to the end.
- Log in to the admin panel if there are no errors.
- the database file will be located in the core/data/ folder and be closed from unexpected guests through htpasswd. Or move this file outside of www. The path of the file is written in the core/config config.

