### PR TITLE
Remember the filter properties of the system setting grid in the browser url

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -296,7 +296,9 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
 
     ,clearFilter: function() {
         var s = this.getStore();
-        var ns = MODx.request.ns ? MODx.request.ns : Ext.getCmp('modx-filter-namespace').getValue();
+        var filterNs = Ext.getCmp('modx-filter-namespace');
+        var filterKey = Ext.getCmp('modx-filter-key');
+        var ns = MODx.request.ns ? MODx.request.ns : 'core';
         s.baseParams = this.initialConfig.baseParams;
 
         s.baseParams.namespace = ns;
@@ -304,8 +306,9 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         s.baseParams.key = '';
         MODx.request.ns = '';
         MODx.request.key = '';
-        Ext.getCmp('modx-filter-namespace').setValue(ns);
-        Ext.getCmp('modx-filter-key').setValue('');
+        filterNs.preselectValue = ns;
+        filterNs.setValue(ns);
+        filterKey.setValue('');
         this.clearArea();
         if (history.replaceState) {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
@@ -325,9 +328,16 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
 
     ,filterByKey: function(tf,newValue,oldValue) {
         var s = this.getStore();
+        var filterNs = Ext.getCmp('modx-filter-namespace');
+        var ns = MODx.request.ns ? MODx.request.ns : 'core';
+        if (newValue) {
+            ns = '';
+        }
         s.baseParams.key = newValue;
-        s.baseParams.namespace = '';
+        s.baseParams.namespace = ns;
         s.baseParams.area = '';
+        filterNs.preselectValue = (ns) ? ns : false;
+        filterNs.setValue(ns);
         this.clearArea();
         if (history.replaceState) {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -335,10 +335,15 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
     ,filterByNamespace: function(cb,rec,ri) {
         var s = this.getStore();
         s.baseParams.namespace = rec.data.name;
-        s.baseParams.area = '';
-        this.getBottomToolbar().changePage(1);
+        if (!MODx.request['area']) {
+            s.baseParams.area = '';
+            this.getBottomToolbar().changePage(1);
 
-        this.clearArea();
+            this.clearArea();
+        } else {
+            s.baseParams.area = MODx.request['area'];
+            MODx.request['area'] = '';
+        }
         if (history.replaceState) {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
         }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -33,7 +33,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,name: 'namespace'
         ,id: 'modx-filter-namespace'
         ,emptyText: _('namespace_filter')
-        ,preselectValue: MODx.request['ns'] ? MODx.request['ns'] : 'core'
+        ,preselectValue: (MODx.request.ns) ? MODx.request.ns : 'core'
         ,allowBlank: false
         ,editable: true
         ,typeAhead: true
@@ -43,7 +43,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,listeners: {
             'select': {
                 fn: function (cb, rec, ri) {
-                    if (!MODx.request['key']) {
+                    if (!MODx.request.key) {
                         this.filterByNamespace(cb, rec, ri)
                     }
                 }
@@ -55,10 +55,10 @@ MODx.grid.SettingsGrid = function(config) {
         ,name: 'area'
         ,id: 'modx-filter-area'
         ,emptyText: _('area_filter')
-        ,value: MODx.request['area']
+        ,value: MODx.request.area
         ,baseParams: {
             action: 'System/Settings/GetAreas'
-            ,namespace: MODx.request['ns'] ? MODx.request['ns'] : 'core'
+            ,namespace: MODx.request.ns ? MODx.request.ns : 'core'
         }
         ,width: 250
         ,allowBlank: true
@@ -68,7 +68,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,listeners: {
             'select': {
                 fn: function (cb, rec, ri) {
-                    if (!MODx.request['key']) {
+                    if (!MODx.request.key) {
                         this.filterByArea(cb, rec, ri);
                     }
                 }
@@ -81,7 +81,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,id: 'modx-filter-key'
         ,cls: 'x-form-filter'
         ,emptyText: _('search_by_key')
-        ,value: MODx.request['key']
+        ,value: MODx.request.key
         ,listeners: {
             'change': {
                 fn: function (cb, rec, ri) {
@@ -91,7 +91,7 @@ MODx.grid.SettingsGrid = function(config) {
             },
             'afterrender': {
                 fn: function (cb){
-                    if (MODx.request['key']) {
+                    if (MODx.request.key) {
                         this.filterByKey(cb, cb.value);
                         MODx.request.key = '';
                     }
@@ -198,8 +198,8 @@ MODx.grid.SettingsGrid = function(config) {
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'System/Settings/GetList'
-            ,namespace: MODx.request['ns'] ? MODx.request['ns'] : 'core'
-            ,area: MODx.request['area']
+            ,namespace: MODx.request.ns ? MODx.request.ns : 'core'
+            ,area: MODx.request.area
         }
         ,clicksToEdit: 2
         ,grouping: true
@@ -296,12 +296,14 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
 
     ,clearFilter: function() {
         var s = this.getStore();
-        var ns = MODx.request['ns'] ? MODx.request['ns'] : Ext.getCmp('modx-filter-namespace').getValue();
+        var ns = MODx.request.ns ? MODx.request.ns : Ext.getCmp('modx-filter-namespace').getValue();
         s.baseParams = this.initialConfig.baseParams;
 
         s.baseParams.namespace = ns;
         s.baseParams.area = '';
         s.baseParams.key = '';
+        MODx.request.ns = '';
+        MODx.request.key = '';
         Ext.getCmp('modx-filter-namespace').setValue(ns);
         Ext.getCmp('modx-filter-key').setValue('');
         this.clearArea();
@@ -336,14 +338,14 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
     ,filterByNamespace: function(cb,rec,ri) {
         var s = this.getStore();
         s.baseParams.namespace = rec.data.name;
-        if (!MODx.request['area']) {
+        if (!MODx.request.area) {
             s.baseParams.area = '';
             this.getBottomToolbar().changePage(1);
 
             this.clearArea();
         } else {
-            s.baseParams.area = MODx.request['area'];
-            MODx.request['area'] = '';
+            s.baseParams.area = MODx.request.area;
+            MODx.request.area = '';
         }
         if (history.replaceState) {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
@@ -352,7 +354,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
 
     ,filterByArea: function(cb,rec,ri) {
         var s = this.getStore();
-        s.baseParams['area'] = rec.data['v'];
+        s.baseParams.area = rec.data.v;
         this.getBottomToolbar().changePage(1);
         if (history.replaceState) {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
@@ -412,16 +414,16 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
     ,makeUrl : function () {
         var s = this.getStore();
         var p = {
-            a: MODx.request['a']
+            a: MODx.request.a
         }
-        if (s.baseParams['namespace']) {
-            p.ns = s.baseParams['namespace'];
+        if (s.baseParams.namespace) {
+            p.ns = s.baseParams.namespace;
         }
-        if (s.baseParams['area']) {
-            p.area = s.baseParams['area'];
+        if (s.baseParams.area) {
+            p.area = s.baseParams.area;
         }
-        if (s.baseParams['key']) {
-            p.key = s.baseParams['key'];
+        if (s.baseParams.key) {
+            p.key = s.baseParams.key;
         }
         return Ext.urlAppend(MODx.config.manager_url, Ext.urlEncode(p).replace('%2F','/'));
 

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -263,56 +263,63 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
     }
 
     ,clearFilter: function() {
+        var s = this.getStore();
         var ns = MODx.request['ns'] ? MODx.request['ns'] : Ext.getCmp('modx-filter-namespace').getValue();
-        var area = MODx.request['area'] ? MODx.request['area'] : '';
+        s.baseParams = this.initialConfig.baseParams;
 
-        this.getStore().baseParams = this.initialConfig.baseParams;
-
-        var acb = Ext.getCmp('modx-filter-area');
-        if (acb) {
-            acb.store.baseParams['namespace'] = ns;
-            acb.store.load();
-            acb.reset();
-        }
-
+        s.baseParams.namespace = ns;
+        s.baseParams.area = '';
+        s.baseParams.key = '';
         Ext.getCmp('modx-filter-namespace').setValue(ns);
         Ext.getCmp('modx-filter-key').reset();
-
-        this.getStore().baseParams.namespace = ns;
-        this.getStore().baseParams.area = area;
-        this.getStore().baseParams.key = '';
-
+        this.clearArea();
+        if (history.replaceState) {
+            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
+        }
         this.getBottomToolbar().changePage(1);
-       // this.refresh();
-    }
-    ,filterByKey: function(tf,newValue,oldValue) {
-        this.getStore().baseParams.key = newValue;
-        this.getStore().baseParams.namespace = '';
-        this.getBottomToolbar().changePage(1);
-        //this.refresh();
-        return true;
     }
 
-    ,filterByNamespace: function(cb,rec,ri) {
-        this.getStore().baseParams['namespace'] = rec.data['name'];
-        this.getStore().baseParams['area'] = '';
-        this.getBottomToolbar().changePage(1);
-        //this.refresh();
-
+    ,clearArea: function () {
         var acb = Ext.getCmp('modx-filter-area');
         if (acb) {
-            var s = acb.store;
-            s.baseParams['namespace'] = rec.data.name;
-            s.removeAll();
-            s.load();
+            acb.store.baseParams.namespace = this.getStore().baseParams.namespace;
+            acb.store.removeAll();
+            acb.store.load();
             acb.setValue('');
         }
     }
 
-    ,filterByArea: function(cb,rec,ri) {
-        this.getStore().baseParams['area'] = rec.data['v'];
+    ,filterByKey: function(tf,newValue,oldValue) {
+        var s = this.getStore();
+        s.baseParams.key = newValue;
+        s.baseParams.namespace = '';
+        s.baseParams.area = '';
+        this.clearArea();
+        if (history.replaceState) {
+            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
+        }
         this.getBottomToolbar().changePage(1);
-       // this.refresh();
+    }
+
+    ,filterByNamespace: function(cb,rec,ri) {
+        var s = this.getStore();
+        s.baseParams.namespace = rec.data.name;
+        s.baseParams.area = '';
+        this.getBottomToolbar().changePage(1);
+
+        this.clearArea();
+        if (history.replaceState) {
+            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
+        }
+    }
+
+    ,filterByArea: function(cb,rec,ri) {
+        var s = this.getStore();
+        s.baseParams['area'] = rec.data['v'];
+        this.getBottomToolbar().changePage(1);
+        if (history.replaceState) {
+            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
+        }
     }
 
     ,renderDynField: function(v,md,rec,ri,ci,s,g) {
@@ -364,6 +371,23 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         return value;
         // JavaScripts time is in milliseconds
         //return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);
+    }
+    ,makeUrl : function () {
+        var s = this.getStore();
+        var p = {
+            a: MODx.request['a']
+        }
+        if (s.baseParams['namespace']) {
+            p.ns = s.baseParams['namespace'];
+        }
+        if (s.baseParams['area']) {
+            p.area = s.baseParams['area'];
+        }
+        if (s.baseParams['key']) {
+            p.key = s.baseParams['key'];
+        }
+        return Ext.urlAppend(MODx.config.manager_url, Ext.urlEncode(p).replace('%2F','/'));
+
     }
 });
 Ext.reg('modx-grid-settings',MODx.grid.SettingsGrid);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -317,12 +317,12 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
     }
 
     ,clearArea: function () {
-        var acb = Ext.getCmp('modx-filter-area');
-        if (acb) {
-            acb.store.baseParams.namespace = this.getStore().baseParams.namespace;
-            acb.store.removeAll();
-            acb.store.load();
-            acb.setValue('');
+        var filterArea = Ext.getCmp('modx-filter-area');
+        if (filterArea) {
+            filterArea.store.baseParams.namespace = this.getStore().baseParams.namespace;
+            filterArea.store.removeAll();
+            filterArea.store.load();
+            filterArea.setValue('');
         }
     }
 

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -93,6 +93,7 @@ MODx.grid.SettingsGrid = function(config) {
                 fn: function (cb){
                     if (MODx.request['key']) {
                         this.filterByKey(cb, cb.value);
+                        MODx.request.key = '';
                     }
                 }
                 ,scope: this

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -41,7 +41,14 @@ MODx.grid.SettingsGrid = function(config) {
         ,queryParam: 'search'
         ,width: 150
         ,listeners: {
-            'select': {fn: this.filterByNamespace, scope:this}
+            'select': {
+                fn: function (cb, rec, ri) {
+                    if (!MODx.request['key']) {
+                        this.filterByNamespace(cb, rec, ri)
+                    }
+                }
+                ,scope:this
+            }
         }
     },{
         xtype: 'modx-combo-area'
@@ -59,7 +66,14 @@ MODx.grid.SettingsGrid = function(config) {
         ,typeAhead: true
         ,forceSelection: true
         ,listeners: {
-            'select': {fn: this.filterByArea, scope:this}
+            'select': {
+                fn: function (cb, rec, ri) {
+                    if (!MODx.request['key']) {
+                        this.filterByArea(cb, rec, ri);
+                    }
+                }
+                ,scope:this
+            }
         }
     },{
         xtype: 'textfield'
@@ -67,15 +81,32 @@ MODx.grid.SettingsGrid = function(config) {
         ,id: 'modx-filter-key'
         ,cls: 'x-form-filter'
         ,emptyText: _('search_by_key')
+        ,value: MODx.request['key']
         ,listeners: {
-            'change': {fn: this.filterByKey, scope: this}
-            ,'render': {fn: function(cmp) {
-                new Ext.KeyMap(cmp.getEl(), {
-                    key: Ext.EventObject.ENTER
-                    ,fn: this.blur
-                    ,scope: cmp
-                });
-            },scope:this}
+            'change': {
+                fn: function (cb, rec, ri) {
+                    this.filterByKey(cb, rec, ri);
+                }
+                ,scope: this
+            },
+            'afterrender': {
+                fn: function (cb){
+                    if (MODx.request['key']) {
+                        this.filterByKey(cb, cb.value);
+                    }
+                }
+                ,scope: this
+            }
+            ,'render': {
+                fn: function(cmp) {
+                    new Ext.KeyMap(cmp.getEl(), {
+                        key: Ext.EventObject.ENTER
+                        ,fn: this.blur
+                        ,scope: cmp
+                    });
+                }
+                ,scope: this
+            }
         }
     },{
         xtype: 'button'
@@ -83,8 +114,8 @@ MODx.grid.SettingsGrid = function(config) {
         ,cls: 'x-form-filter-clear'
         ,text: _('filter_clear')
         ,listeners: {
-            'click': {fn: this.clearFilter, scope: this},
-            'mouseout': { fn: function(evt){
+            'click': { fn: this.clearFilter, scope: this },
+            'mouseout': { fn: function(evt) {
                     this.removeClass('x-btn-focus');
                 }
             }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -310,7 +310,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         filterNs.setValue(ns);
         filterKey.setValue('');
         this.clearArea();
-        if (history.replaceState) {
+        if (typeof window.history.replaceState !== 'undefined') {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
         }
         this.getBottomToolbar().changePage(1);
@@ -339,7 +339,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         filterNs.preselectValue = (ns) ? ns : false;
         filterNs.setValue(ns);
         this.clearArea();
-        if (history.replaceState) {
+        if (typeof window.history.replaceState !== 'undefined') {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
         }
         this.getBottomToolbar().changePage(1);
@@ -357,7 +357,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
             s.baseParams.area = MODx.request.area;
             MODx.request.area = '';
         }
-        if (history.replaceState) {
+        if (typeof window.history.replaceState !== 'undefined') {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
         }
     }
@@ -366,7 +366,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         var s = this.getStore();
         s.baseParams.area = rec.data.v;
         this.getBottomToolbar().changePage(1);
-        if (history.replaceState) {
+        if (typeof window.history.replaceState !== 'undefined') {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());
         }
     }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -302,7 +302,7 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         s.baseParams.area = '';
         s.baseParams.key = '';
         Ext.getCmp('modx-filter-namespace').setValue(ns);
-        Ext.getCmp('modx-filter-key').reset();
+        Ext.getCmp('modx-filter-key').setValue('');
         this.clearArea();
         if (history.replaceState) {
             window.history.replaceState(s.baseParams, document.title, this.makeUrl());


### PR DESCRIPTION
### What does it do?
Add the selected settings filter properties in the browser url

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url i.e. for support sessions 

### Related issue(s)/PR(s)
#14086 