### PR TITLE
[3.x] Add numberfield as Field Type option for system settings

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -294,6 +294,7 @@ $_lang['no_action'] = 'No Action';
 $_lang['no_category'] = 'uncategorized';
 $_lang['no_records_found'] = 'No records found.';
 $_lang['no_results'] = 'No results found';
+$_lang['numberfield'] = 'Numberfield';
 $_lang['offline'] = 'Offline';
 $_lang['ok'] = 'OK';
 $_lang['old_key'] = 'Old Key';

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -520,6 +520,7 @@ MODx.combo.xType = function(config) {
             fields: ['d','v']
             ,data: [[_('textfield'),'textfield']
                 ,[_('textarea'),'textarea']
+                ,[_('numberfield'),'numberfield']
                 ,[_('yesno'),'combo-boolean']
                 ,[_('password'),'text-password']
                 ,[_('category'),'modx-combo-category']


### PR DESCRIPTION
### What does it do?
Adds number field as possible Field Type when creating/updating system settings.

### Why is it needed?
To create system settings that allow numeric values only.

### Related issue(s)/PR(s)
Fixes issue #15091