### PR TITLE
Fix title of edit content type window

### DIFF
--- a/core/lexicon/en/content_type.inc.php
+++ b/core/lexicon/en/content_type.inc.php
@@ -23,6 +23,7 @@ $_lang['content_type_main_tab'] = 'Main';
 $_lang['content_type_header_tab'] = 'Custom headers';
 $_lang['content_type_header_title'] = 'Create/edit header';
 $_lang['content_type_new'] = 'New Content Type';
+$_lang['content_type_edit'] = 'Edit Content Type';
 $_lang['content_type_remove'] = 'Delete Content Type';
 $_lang['content_type_remove_confirm'] = 'Are you sure you want to delete this Content Type?';
 $_lang['content_types'] = 'Content Types';

--- a/manager/assets/modext/widgets/system/modx.grid.content.type.js
+++ b/manager/assets/modext/widgets/system/modx.grid.content.type.js
@@ -111,10 +111,11 @@ Ext.extend(MODx.grid.ContentType,MODx.grid.Grid,{
     getMenu: function() {
         var m = [];
         m.push({
-            text: _('edit')
+            text: _('content_type_edit')
             ,handler: function(btn, e) {
                 var window = new MODx.window.CreateContentType({
                     record: this.menu.record
+                    ,title: _('content_type_edit')
                     ,action: 'System/ContentType/Update'
                     ,listeners: {
                         success: {


### PR DESCRIPTION
### What does it do?
Adds a new lexicon for edit content type window title and uses it.

### Why is it needed?
Current title of edit content type window is wrong.

### Related issue(s)/PR(s)
Resolves #15089
