### PR TITLE
Fix the name of the create tv action

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -75,7 +75,7 @@ MODx.panel.TV = function(config) {
                             'keyup': {scope:this,fn:function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
                                 title = _('tv')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'Element/TemplateVar/Create' && MODx.perm.tree_show_element_ids === true) {
+                                if (MODx.request.a !== 'element/tv/create' && MODx.perm.tree_show_element_ids === true) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
 


### PR DESCRIPTION
### What does it do?
Uses correct name of the create TV action in the condition

### Why is it needed?
Without the change, it tries to display TV's ID, even though it's unavailable.

### Related issue(s)/PR(s)
Resolves #15003