### PR TITLE
Unify manager actions to lowercase

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -619,7 +619,7 @@ MODx.LayoutMgr = function() {
                 if (isNaN(parseInt(action)) && (action.substr(0,1) == '?' || (action.substr(0, "index.php?".length) == 'index.php?'))) {
                     parts.push(action);
                 } else {
-                    parts.push('?a=' + action);
+                    parts.push('?a=' + ("" + action).toLowerCase());
                 }
             }
             if (parameters) {

--- a/manager/assets/modext/sections/resource/data.js
+++ b/manager/assets/modext/sections/resource/data.js
@@ -33,7 +33,7 @@ Ext.extend(MODx.page.ResourceData,MODx.Component,{
     }
 
     ,editResource: function() {
-        MODx.loadPage('Resource/Update', 'id='+this.config.record.id);
+        MODx.loadPage('resource/update', 'id='+this.config.record.id);
     }
 
     ,cancel: function() {

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -106,7 +106,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('resource/update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(true);
@@ -126,7 +125,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('resource/update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(false);

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -83,7 +83,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
                 success: {fn:function(r) {
                     var response = Ext.decode(r.a.response.responseText);
                     if (response.object.redirect) {
-                        MODx.loadPage('Resource/Update', 'id='+response.object.id);
+                        MODx.loadPage('resource/update', 'id='+response.object.id);
                     } else if (node) {
                         node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
                         t.refreshNode(node.id);
@@ -106,7 +106,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('Resource/Update', 'id='+r.object.id);
+                    //MODx.loadPage('resource/update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(true);
@@ -126,7 +126,7 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('Resource/Update', 'id='+r.object.id);
+                    //MODx.loadPage('resource/update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(false);

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -451,35 +451,17 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
     }
 
     ,toggleStaticFile: function(cb) {
-        var flds = ['modx-tv-static-file','modx-tv-static-source'];
-        var fld;
-        var i;
-        var fldHelp;
+        var flds = ['modx-tv-static-file','modx-tv-static-file-help','modx-tv-static-source','modx-tv-static-source-help'];
+        var fld,i;
         if (cb.checked) {
             for (i in flds) {
                 fld = Ext.getCmp(flds[i]);
-                if (fld) {
-                    fld.show();
-                    fld.updateBox(fld.getResizeEl().parent().getBox());
-
-                    fldHelp = Ext.getCmp(flds[i] + '-help');
-                    if (fldHelp) {
-                        fldHelp.show();
-                    }
-
-                }
+                if (fld) { fld.show(); }
             }
         } else {
             for (i in flds) {
                 fld = Ext.getCmp(flds[i]);
-                if (fld) {
-                    fld.hide();
-
-                    fldHelp = Ext.getCmp(flds[i] + '-help');
-                    if (fldHelp) {
-                        fldHelp.hide();
-                    }
-                }
+                if (fld) { fld.hide(); }
             }
         }
     }
@@ -580,14 +562,9 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
     }
 
     ,showInputProperties: function(cb,rc,i) {
-        /**
-         * Hide "Input Option Values" by default
-         */
         var element = Ext.getCmp('modx-tv-elements');
-        var element_label = Ext.select('label[for="' + element.id + '"]');
         if (element) {
-            element.hide();
-            element_label.hide();
+            element.show();
         }
 
         this.markPanelDirty();

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -542,7 +542,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 text: _('edit_context')
                 ,handler: function() {
                     var at = this.cm.activeNode.attributes;
-                    this.loadAction('a=Context/Update&key='+at.pk);
+                    this.loadAction('a=context/update&key='+at.pk);
                 }
             });
         }
@@ -578,13 +578,13 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         return m;
     }
 
-    ,overviewResource: function() {this.loadAction('a=Resource/Data')}
+    ,overviewResource: function() {this.loadAction('a=resource/data')}
 
     ,quickUpdateResource: function(itm,e) {
         this.quickUpdate(itm,e,itm.classKey);
     }
 
-    ,editResource: function() {this.loadAction('a=Resource/Update');}
+    ,editResource: function() {this.loadAction('a=resource/update');}
 
     ,_getModResourceMenu: function(n) {
         var a = n.attributes;
@@ -681,7 +681,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
         var at = this.cm.activeNode.attributes;
         var p = itm.usePk ? itm.usePk : at.pk;
         this.loadAction(
-            'a=Resource/Create&class_key=' + itm.classKey + '&parent=' + p + (at.ctx ? '&context_key='+at.ctx : '')
+            'a=resource/create&class_key=' + itm.classKey + '&parent=' + p + (at.ctx ? '&context_key='+at.ctx : '')
         );
     }
 

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -154,7 +154,7 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
                 'success': {fn:function(r) {
                     var response = Ext.decode(r.a.response.responseText);
                     if (response.object.redirect) {
-                        MODx.loadPage('Resource/Update', 'id='+response.object.id);
+                        MODx.loadPage('resource/update', 'id='+response.object.id);
                     } else {
                         node.parentNode.attributes.childCount = parseInt(node.parentNode.attributes.childCount) + 1;
                         this.refreshNode(node.id);

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -157,7 +157,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
     }
 
     ,editPolicy: function(itm,e) {
-        MODx.loadPage('Security/Access/Policy/Update', 'id='+this.menu.record.id);
+        MODx.loadPage('security/access/policy/update', 'id='+this.menu.record.id);
     }
 
     ,createPolicy: function(btn,e) {

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -232,7 +232,7 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
     }
 
     ,editPolicyTemplate: function(itm,e) {
-        MODx.loadPage('Security/Access/Policy/Template/Update', 'id='+this.menu.record.id);
+        MODx.loadPage('security/access/policy/template/update', 'id='+this.menu.record.id);
     }
 
     ,removeSelected: function() {

--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -229,11 +229,11 @@ Ext.extend(MODx.grid.User,MODx.grid.Grid,{
     }
 
     ,createUser: function() {
-        MODx.loadPage('Security/User/Create');
+        MODx.loadPage('security/user/create');
     }
 
     ,updateUser: function() {
-        MODx.loadPage('Security/User/Update', 'id='+this.menu.record.id);
+        MODx.loadPage('security/user/update', 'id='+this.menu.record.id);
     }
 
     ,duplicateUser: function() {

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -97,14 +97,14 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                 ,buttons: Ext.Msg.OK
                 ,fn: function(btn) {
                     if (userId == 0) {
-                        MODx.loadPage('Security/User/Update', 'id='+o.result.object.id);
+                        MODx.loadPage('security/user/update', 'id='+o.result.object.id);
                     }
                     return false;
                 }
             });
             this.clearDirty();
         } else if (userId == 0) {
-            MODx.loadPage('Security/User/Update', 'id='+o.result.object.id);
+            MODx.loadPage('security/user/update', 'id='+o.result.object.id);
         }
     }
 

--- a/manager/assets/modext/widgets/source/modx.panel.source.js
+++ b/manager/assets/modext/widgets/source/modx.panel.source.js
@@ -206,7 +206,7 @@ Ext.extend(MODx.panel.Source,MODx.FormPanel,{
 
     ,success: function(o) {
         if (Ext.isEmpty(this.config.record) || Ext.isEmpty(this.config.record.id)) {
-            MODx.loadPage('Source/Update', 'id='+o.result.object.id);
+            MODx.loadPage('source/update', 'id='+o.result.object.id);
         } else {
             Ext.getCmp('modx-abtn-save').setDisabled(false);
             var wg = Ext.getCmp('modx-grid-source-properties');

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -182,11 +182,11 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
     }
 
     ,createSource: function() {
-        MODx.loadPage('system/Source/Create');
+        MODx.loadPage('system/source/create');
     }
 
     ,updateSource: function() {
-        MODx.loadPage('Source/Update', 'id='+this.menu.record.id);
+        MODx.loadPage('source/update', 'id='+this.menu.record.id);
     }
 
     ,duplicateSource: function(btn,e) {

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -175,7 +175,7 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
     }
 
     ,updateContext: function(itm,e) {
-        MODx.loadPage('Context/Update', 'key='+this.menu.record.key);
+        MODx.loadPage('context/update', 'key='+this.menu.record.key);
     }
 
     ,duplicateContext: function() {

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -156,7 +156,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 ,{
                     text: _('update')
                     ,handler: function() {
-                        MODx.loadPage('Source/Update', 'id=' + node.ownerTree.source);
+                        MODx.loadPage('source/update', 'id=' + node.ownerTree.source);
                     }
                 }
             ])


### PR DESCRIPTION
### What does it do?
Tries to normalize manager actions to be lower cased. I tried to find as many CamelCase usages as I could and replace them with lower cased version, but not really sure I got them all.

Also the MODx.getPage / MODx.loadPage now should return only lower case action, which should help keeping this as a standard.

### Why is it needed?
As described in #14744, currently lower case and Camel Case versions are mixed and not all conditions works because they are checking wrong case.

### Related issue(s)/PR(s)
Closes #14744
