### PR TITLE
Set error message by the name of the field instead of id

### DIFF
--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -536,18 +536,18 @@ class Update extends UpdateProcessor
         }
 
         if (filter_var($target, FILTER_VALIDATE_INT) === false) {
-            $this->addFieldError('modx-symlink-content', $this->modx->lexicon('resource_err_symlink_target_invalid'));
+            $this->addFieldError('content', $this->modx->lexicon('resource_err_symlink_target_invalid'));
             return false;
         }
 
         $targetResource = $this->modx->getObject(modResource::class, $target);
         if (!$targetResource) {
-            $this->addFieldError('modx-symlink-content', $this->modx->lexicon('resource_err_symlink_target_nf'));
+            $this->addFieldError('content', $this->modx->lexicon('resource_err_symlink_target_nf'));
             return false;
         }
 
         if ($targetResource->get('id') === $this->object->get('id')) {
-            $this->addFieldError('modx-symlink-content', $this->modx->lexicon('resource_err_symlink_target_self'));
+            $this->addFieldError('content', $this->modx->lexicon('resource_err_symlink_target_self'));
             return false;
         }
 
@@ -572,12 +572,12 @@ class Update extends UpdateProcessor
         if (filter_var($target, FILTER_VALIDATE_INT) !== false) {
             $targetResource = $this->modx->getObject(modResource::class, $target);
             if (!$targetResource) {
-                $this->addFieldError('modx-weblink-content', $this->modx->lexicon('resource_err_weblink_target_nf'));
+                $this->addFieldError('content', $this->modx->lexicon('resource_err_weblink_target_nf'));
                 return false;
             }
 
             if ($targetResource->get('id') === $this->object->get('id')) {
-                $this->addFieldError('modx-weblink-content', $this->modx->lexicon('resource_err_weblink_target_self'));
+                $this->addFieldError('content', $this->modx->lexicon('resource_err_weblink_target_self'));
                 return false;
             }
         }


### PR DESCRIPTION
### What does it do?
Set field error message for the content field by the field name instead of the id.

### Why is it needed?
In the resource quick edit window, the field ID is always different and based on the window's id, so the error won't show up.

### Related issue(s)/PR(s)
Closes #14982
