### PR TITLE
Load tree_show_resource_ids permission

### DIFF
--- a/manager/controllers/default/resource/staticresource/update.class.php
+++ b/manager/controllers/default/resource/staticresource/update.class.php
@@ -42,6 +42,7 @@ Ext.onReady(function() {
         ,show_tvs: '.(!empty($this->tvCounts) ? 1 : 0).'
     });
 });
+MODx.perm.tree_show_resource_ids = '.($this->modx->hasPermission('tree_show_resource_ids') ? 1 : 0).';
 // ]]>
 </script>');
         /* load RTE */

--- a/manager/controllers/default/resource/symlink/update.class.php
+++ b/manager/controllers/default/resource/symlink/update.class.php
@@ -45,12 +45,13 @@ class SymlinkUpdateManagerController extends ResourceUpdateManagerController {
                 ,show_tvs: '.(!empty($this->tvCounts) ? 1 : 0).'
             });
         });
+        MODx.perm.tree_show_resource_ids = '.($this->modx->hasPermission('tree_show_resource_ids') ? 1 : 0).';
         // ]]>
         </script>');
         /* load RTE */
         $this->loadRichTextEditor();
     }
-    
+
     /**
      * Return the location of the template file
      * @return string

--- a/manager/controllers/default/resource/weblink/update.class.php
+++ b/manager/controllers/default/resource/weblink/update.class.php
@@ -45,6 +45,7 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController {
                 ,show_tvs: '.(!empty($this->tvCounts) ? 1 : 0).'
             });
         });
+        MODx.perm.tree_show_resource_ids = '.($this->modx->hasPermission('tree_show_resource_ids') ? 1 : 0).';
         // ]]>
         </script>');
         /* load RTE */


### PR DESCRIPTION
### What does it do?
Loads tree_show_resource_ids permission for symlinks, weblinks and static resources.

### Why is it needed?
It's required to show ID after the pagetitle, if it's not loaded the id will never show up.

### Related issue(s)/PR(s)
Closes #14973
