### PR TITLE
[3.x] Add node@12 as dev dependencies fixing node-sass errors

### DIFF
--- a/_build/templates/default/package-lock.json
+++ b/_build/templates/default/package-lock.json
@@ -1530,6 +1530,21 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
     },
+    "node": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-12.18.0.tgz",
+      "integrity": "sha512-MTQnAT0iOy3tYTrXc3SfJU9SKgO7gfvKkktsctRYU/J9T/cCQG1z9whT2+/lxDb0YPMYxjK2l+8z2abXDIpv7Q==",
+      "dev": true,
+      "requires": {
+        "node-bin-setup": "^1.0.0"
+      }
+    },
+    "node-bin-setup": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
+      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==",
+      "dev": true
+    },
     "node-gyp": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",

--- a/_build/templates/default/package.json
+++ b/_build/templates/default/package.json
@@ -16,6 +16,7 @@
     "grunt-imageoptim": "^1.4.4",
     "grunt-notify": "^0.4.5",
     "grunt-sass": "^3.0.2",
+    "node": "^12.18.0",
     "node-sass": "^4.13.0"
   },
   "dependencies": {


### PR DESCRIPTION
### What does it do?
Add node@12 as dev dependencies

### Why is it needed?
The version of node-sass we use doesn't work with newer node versions (e.g 14).

### Related issue(s)/PR(s)
None

### Note
We need this for 2.x as well. 
Also the README in the `_build/templates/default` folder needs to be updated since the process is much easier nowadays. 