### PR TITLE
Fixed allowBlank for TV with URL, RichText, Image & File types

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/inputproperties/richtext.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/inputproperties/richtext.php
@@ -1,0 +1,16 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+/**
+ * @package modx
+ * @subpackage processors.element.tv.renders.mgr.inputproperties
+ */
+
+return $modx->controller->fetchTemplate('element/tv/renders/inputproperties/richtext.tpl');

--- a/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
@@ -1,6 +1,6 @@
 /**
  * Renders an input for an image TV
- * 
+ *
  * @class MODx.panel.ImageTV
  * @extends MODx.Panel
  * @param {Object} config An object of configuration properties
@@ -23,6 +23,7 @@ MODx.panel.ImageTV = function(config) {
             ,name: 'tv'+config.tv
             ,id: 'tv'+config.tv
             ,value: config.value
+            ,allowBlank: config.allowBlank
         },{
             xtype: 'modx-combo-browser'
             ,browserEl: 'tvbrowser'+config.tv
@@ -32,7 +33,9 @@ MODx.panel.ImageTV = function(config) {
             ,value: config.relativeValue
             // ,hideFiles: true
             ,source: config.source || 1
+            ,allowBlank: config.allowBlank
             ,allowedFileTypes: config.allowedFileTypes || ''
+            ,msgTarget: config.msgTarget
             ,openTo: config.openTo || ''
             ,hideSourceCombo: true
             ,listeners: {
@@ -49,7 +52,7 @@ MODx.panel.ImageTV = function(config) {
                     });
                 },scope:this}
             }
-        }] 
+        }]
     });
     MODx.panel.ImageTV.superclass.constructor.call(this,config);
     this.addEvents({select: true});
@@ -57,6 +60,14 @@ MODx.panel.ImageTV = function(config) {
 Ext.extend(MODx.panel.ImageTV,MODx.Panel);
 Ext.reg('modx-panel-tv-image',MODx.panel.ImageTV);
 
+/**
+ * Renders an input for an file TV
+ *
+ * @class MODx.panel.FileTV
+ * @extends MODx.Panel
+ * @param {Object} config An object of configuration properties
+ * @xtype panel-tv-file
+ */
 MODx.panel.FileTV = function(config) {
     config = config || {};
     config.filemanager_url = MODx.config.filemanager_url;
@@ -74,6 +85,7 @@ MODx.panel.FileTV = function(config) {
             ,name: 'tv'+config.tv
             ,id: 'tv'+config.tv
             ,value: config.value
+            ,allowBlank: config.allowBlank
         },{
             xtype: 'modx-combo-browser'
             ,browserEl: 'tvbrowser'+config.tv
@@ -82,7 +94,9 @@ MODx.panel.FileTV = function(config) {
             ,value: config.relativeValue
             // ,hideFiles: true
             ,source: config.source || 1
+            ,allowBlank: config.allowBlank
             ,allowedFileTypes: config.allowedFileTypes || ''
+            ,msgTarget: config.msgTarget
             ,wctx: config.wctx || 'web'
             ,openTo: config.openTo || ''
             ,hideSourceCombo: true
@@ -100,7 +114,7 @@ MODx.panel.FileTV = function(config) {
                     });
                 },scope:this}
             }
-        }] 
+        }]
     });
     MODx.panel.FileTV.superclass.constructor.call(this,config);
     this.addEvents({select: true});
@@ -110,5 +124,5 @@ Ext.reg('modx-panel-tv-file',MODx.panel.FileTV);
 
 MODx.checkTV = function(id) {
     var cb = Ext.get('tv'+id);
-    Ext.get('tvh'+id).dom.value = cb.dom.checked ? cb.dom.value : '';     
+    Ext.get('tvh'+id).dom.value = cb.dom.checked ? cb.dom.value : '';
 };

--- a/manager/templates/default/element/tv/renders/input/file.tpl
+++ b/manager/templates/default/element/tv/renders/input/file.tpl
@@ -41,7 +41,13 @@ Ext.onReady(function() {
         {if $params.openTo|default},openTo: '{$params.openTo|replace:"'":"\\'"}'{/if}
 
     {literal}
-        ,listeners: { 'select': { fn:MODx.fireResourceFormChange, scope:this}}
+        ,listeners: {'select': {fn:MODx.fireResourceFormChange, scope:this}}
+        ,validate: function () {
+            var value = Ext.getCmp('tv{/literal}{$tv->id}{literal}').value;
+            return !(!this.allowBlank && (value.length < 1));
+        }
+        ,markInvalid : Ext.emptyFn
+        ,clearInvalid : Ext.emptyFn
     });
     MODx.makeDroppable(Ext.get('tvpanel{/literal}{$tv->id}{literal}'),function(v) {
         var cb = Ext.getCmp('tvbrowser{/literal}{$tv->id}{literal}');
@@ -51,6 +57,7 @@ Ext.onReady(function() {
         }
         return '';
     });
+    Ext.getCmp('modx-panel-resource').getForm().add(fld{/literal}{$tv->id}{literal});
 });
 {/literal}
 // ]]>

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -53,6 +53,12 @@ Ext.onReady(function() {
                 }
             }}
         }
+        ,validate: function () {
+            var value = Ext.getCmp('tv{/literal}{$tv->id}{literal}').value;
+            return !(!this.allowBlank && (value.length < 1));
+        }
+        ,markInvalid : Ext.emptyFn
+        ,clearInvalid : Ext.emptyFn
     });
     MODx.makeDroppable(Ext.get('tv-image-{/literal}{$tv->id}{literal}'),function(v) {
         var cb = Ext.getCmp('tvbrowser{/literal}{$tv->id}{literal}');
@@ -62,6 +68,7 @@ Ext.onReady(function() {
         }
         return '';
     });
+    Ext.getCmp('modx-panel-resource').getForm().add(fld{/literal}{$tv->id}{literal});
 });
 {/literal}
 // ]]>

--- a/manager/templates/default/element/tv/renders/input/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/input/richtext.tpl
@@ -1,10 +1,25 @@
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" class="modx-richtext" {literal}onchange="MODx.fireResourceFormChange();"{/literal}>{$tv->get('value')|escape}</textarea>
 
 <script type="text/javascript">
+// <![CDATA[
 {literal}
 Ext.onReady(function() {
+    var fld = MODx.load({
     {/literal}
-    MODx.makeDroppable(Ext.get('tv{$tv->id}'));
+        xtype: 'textarea'
+        ,applyTo: 'tv{$tv->id}'
+        ,value: '{$tv->get('value')|escape:'javascript'}'
+        ,height: 140
+        ,width: '99%'
+        ,enableKeyEvents: true
+        ,msgTarget: 'under'
+        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
     {literal}
-});{/literal}
+        ,listeners: {'keydown': {fn:MODx.fireResourceFormChange, scope:this}}
+    });
+    MODx.makeDroppable(fld);
+    Ext.getCmp('modx-panel-resource').getForm().add(fld);
+});
+{/literal}
+// ]]>
 </script>

--- a/manager/templates/default/element/tv/renders/input/url.tpl
+++ b/manager/templates/default/element/tv/renders/input/url.tpl
@@ -1,19 +1,19 @@
 <select id="tv{$tv->id}_prefix" name="tv{$tv->id}_prefix" onchange="MODx.fireResourceFormChange();">
 {foreach from=$urls item=url}
-	<option value="{$url}" {if $url == $selected|default}selected="selected"{/if}>{$url}</option>
+    <option value="{$url}" {if $url == $selected|default}selected="selected"{/if}>{$url}</option>
 {/foreach}
 </select>
 <input id="tv{$tv->id}" name="tv{$tv->id}"
-	type="text"
-	value="{$tv->get('processedValue')}"
-	onchange="MODx.fireResourceFormChange();"
-	class="textfield x-form-text x-form-field"
-	style="width: 283px;"
+    type="text"
+    value="{$tv->get('processedValue')}"
+    onchange="MODx.fireResourceFormChange();"
+    class="textfield x-form-text x-form-field"
+    style="width: 283px;"
 />
 <script type="text/javascript">
 // <![CDATA[
 Ext.onReady(function() {
-	MODx.makeDroppable(Ext.get('tv{$tv->id}'));
+    MODx.makeDroppable(Ext.get('tv{$tv->id}'));
 
     var fld = MODx.load({
         xtype: 'combo'
@@ -21,7 +21,7 @@ Ext.onReady(function() {
         ,id: 'tv{$tv->id}_prefix'
         ,triggerAction: 'all'
         ,width: 100
-        ,allowBlank: false
+        ,allowBlank: true
         ,maxHeight: 300
         ,typeAhead: false
         ,forceSelection: false
@@ -29,9 +29,20 @@ Ext.onReady(function() {
         ,listeners: { 'select': { fn:MODx.fireResourceFormChange, scope:this}}
     });
 
-	fld.wrap.applyStyles({
-		display: "inline-block"
-	});
+    fld.wrap.applyStyles({
+        display: "inline-block"
+    });
+
+    var fld = MODx.load({
+        xtype: 'textfield'
+        ,applyTo: 'tv{$tv->id}'
+        ,enableKeyEvents: true
+        ,msgTarget: 'under'
+        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
+        ,listeners: {'keydown': {fn:MODx.fireResourceFormChange, scope:this}}
+    });
+    MODx.makeDroppable(fld);
+    Ext.getCmp('modx-panel-resource').getForm().add(fld);
 });
 // ]]>
 </script>

--- a/manager/templates/default/element/tv/renders/inputproperties/file.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/file.tpl
@@ -22,7 +22,22 @@ MODx.load({
     ,cls: 'form-with-labels'
     ,labelAlign: 'top'
     ,border: false
-    ,items: []
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });
 // ]]>

--- a/manager/templates/default/element/tv/renders/inputproperties/image.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/image.tpl
@@ -22,7 +22,22 @@ MODx.load({
     ,cls: 'form-with-labels'
     ,labelAlign: 'top'
     ,border: false
-    ,items: []
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });
 // ]]>

--- a/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
@@ -1,0 +1,45 @@
+<div id="tv-input-properties-form{$tv|default}"></div>
+{literal}
+
+<script type="text/javascript">
+// <![CDATA[
+var params = {
+{/literal}{foreach from=$params key=k item=v name='p'}
+ '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}{literal}
+};
+var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
+var element = Ext.getCmp('modx-tv-elements');
+if (element) {
+  element.hide();
+}
+
+MODx.load({
+    xtype: 'panel'
+    ,layout: 'form'
+    ,autoHeight: true
+    ,cls: 'form-with-labels'
+    ,labelAlign: 'top'
+    ,border: false
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
+    ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
+});
+// ]]>
+</script>
+{/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/url.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/url.tpl
@@ -1,0 +1,39 @@
+<div id="tv-input-properties-form{$tv|default}"></div>
+{literal}
+
+<script type="text/javascript">
+// <![CDATA[
+var params = {
+{/literal}{foreach from=$params key=k item=v name='p'}
+ '{$k}': '{$v|escape:"javascript"}'{if NOT $smarty.foreach.p.last},{/if}
+{/foreach}{literal}
+};
+var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+MODx.load({
+    xtype: 'panel'
+    ,layout: 'form'
+    ,autoHeight: true
+    ,cls: 'form-with-labels'
+    ,labelAlign: 'top'
+    ,border: false
+    ,items: [{
+        xtype: 'combo-boolean'
+        ,fieldLabel: _('required')
+        ,description: MODx.expandHelp ? '' : _('required_desc')
+        ,name: 'inopt_allowBlank'
+        ,hiddenName: 'inopt_allowBlank'
+        ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,width: 200
+        ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
+        ,listeners: oc
+    },{
+        xtype: MODx.expandHelp ? 'label' : 'hidden'
+        ,forId: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
+        ,html: _('required_desc')
+        ,cls: 'desc-under'
+    }]
+    ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
+});
+// ]]>
+</script>
+{/literal}


### PR DESCRIPTION
### What does it do?
Fixed allowBlank for TV with URL, RichText, Image & File types:

**URL** (for 3.x - https://github.com/modxcms/revolution/pull/15073):

![url-req](https://user-images.githubusercontent.com/12523676/81088513-b2766980-8f03-11ea-97a6-2ff761285368.png)

**RichText** (for 3.x - https://github.com/modxcms/revolution/pull/15074):

![richtext-req](https://user-images.githubusercontent.com/12523676/81093480-de491d80-8f0a-11ea-8ccd-709fd5305dd2.png)

**Image & File** (for 3.x - https://github.com/modxcms/revolution/pull/15075):

![tv-files-req](https://user-images.githubusercontent.com/12523676/82463534-9f4bc800-9ac5-11ea-8ec7-a77c5b87f5ae.gif)

_p.s. Because corrections are already tested and merged in 3.x, I did not make commits detailed._

### Why is it needed?
For some reason, allowBlank setting is not for all TVs, which is strange.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/6521