### PR TITLE
Changed header to a more specific in user grid

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.user.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.js
@@ -6,7 +6,7 @@
  * @param {Object} config An object of configuration options
  * @xtype modx-panel-users
  */
-MODx.panel.Users = function(config) {
+MODx.panel.Users = function(config) { 
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-users'
@@ -76,7 +76,7 @@ MODx.grid.User = function(config) {
             ,width: 50
             ,sortable: true
         },{
-            header: _('name')
+            header: _('username')
             ,dataIndex: 'username'
             ,width: 150
             ,sortable: true


### PR DESCRIPTION
### What does it do?
Changed header to a more specific in user grid:

![users_1](https://user-images.githubusercontent.com/12523676/84515801-9d94af00-acd5-11ea-8845-7e0f9d4c51f9.png)

![users_2](https://user-images.githubusercontent.com/12523676/84515804-9e2d4580-acd5-11ea-9542-572155a87a6e.png)

### Why is it needed?
Firstly, there is a specific lexicon for the username.
Secondly, in other languages, for example, the Russian lexicon "name" is more widely translated and we can make a mistake when translating.

### Related issue(s)/PR(s)
None
