### PR TITLE
Corrected output of resource data in "Overview" form

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -60,10 +60,6 @@ MODx.panel.ResourceData = function(config) {
                 ,fieldLabel: _('context')
                 ,xtype: 'statictextfield'
             },{
-                name: 'status'
-                ,fieldLabel: _('resource_status')
-                ,description: _('resource_status_help')
-            },{
                 name: 'deleted'
                 ,fieldLabel: _('deleted')
                 ,xtype: 'staticboolean'
@@ -71,10 +67,12 @@ MODx.panel.ResourceData = function(config) {
                 name: 'pub_date'
                 ,fieldLabel: _('resource_publishdate')
                 ,description: _('resource_publishdate_help')
+                ,xtype: 'statictextfield'
             },{
                 name: 'unpub_date'
                 ,fieldLabel: _('resource_unpublishdate')
                 ,description: _('resource_unpublishdate_help')
+                ,xtype: 'statictextfield'
             },{
                 name: 'cacheable'
                 ,fieldLabel: _('resource_cacheable')
@@ -94,10 +92,12 @@ MODx.panel.ResourceData = function(config) {
                 name: 'menutitle'
                 ,fieldLabel: _('resource_menutitle')
                 ,description: _('resource_menutitle_help')
+                ,xtype: 'statictextfield'
             },{
                 name: 'menuindex'
                 ,fieldLabel: _('resource_menuindex')
                 ,description: _('resource_menuindex_help')
+                ,xtype: 'statictextfield'
             },{
                 name: 'richtext'
                 ,fieldLabel: _('resource_richtext')

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -24,13 +24,22 @@ MODx.panel.ResourceData = function(config) {
             ,labelWidth: 150
             ,defaults: df
             ,items: [{
-                name: 'pagetitle'
-                ,fieldLabel: _('resource_pagetitle')
-                ,description: _('resource_pagetitle_help')
+                name: 'context_key'
+                ,fieldLabel: _('context')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'alias'
+                ,fieldLabel: _('resource_alias')
+                ,description: _('resource_alias_help')
                 ,xtype: 'statictextfield'
             },{
                 name: 'template_name'
                 ,fieldLabel: _('resource_template')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'pagetitle'
+                ,fieldLabel: _('resource_pagetitle')
+                ,description: _('resource_pagetitle_help')
                 ,xtype: 'statictextfield'
             },{
                 name: 'longtitle'
@@ -46,20 +55,6 @@ MODx.panel.ResourceData = function(config) {
                 ,xtype: 'statictextfield'
                 ,width: 500
             },{
-                name: 'class_key'
-                ,fieldLabel: _('class_key')
-                ,description: _('resource_class_key_help')
-                ,xtype: 'statictextfield'
-            },{
-                name: 'alias'
-                ,fieldLabel: _('resource_alias')
-                ,description: _('resource_alias_help')
-                ,xtype: 'statictextfield'
-            },{
-                name: 'context_key'
-                ,fieldLabel: _('context')
-                ,xtype: 'statictextfield'
-            },{
                 name: 'deleted'
                 ,fieldLabel: _('deleted')
                 ,xtype: 'staticboolean'
@@ -73,16 +68,6 @@ MODx.panel.ResourceData = function(config) {
                 ,fieldLabel: _('resource_unpublishdate')
                 ,description: _('resource_unpublishdate_help')
                 ,xtype: 'statictextfield'
-            },{
-                name: 'cacheable'
-                ,fieldLabel: _('resource_cacheable')
-                ,description: _('resource_cacheable_help')
-                ,xtype: 'staticboolean'
-            },{
-                name: 'searchable'
-                ,fieldLabel: _('resource_searchable')
-                ,description: _('resource_searchable_help')
-                ,xtype: 'staticboolean'
             },{
                 name: 'hidemenu'
                 ,fieldLabel: _('resource_hide_from_menus')
@@ -99,14 +84,29 @@ MODx.panel.ResourceData = function(config) {
                 ,description: _('resource_menuindex_help')
                 ,xtype: 'statictextfield'
             },{
+                name: 'class_key'
+                ,fieldLabel: _('class_key')
+                ,description: _('resource_class_key_help')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'isfolder'
+                ,fieldLabel: _('resource_folder')
+                ,description: _('resource_folder_help')
+                ,xtype: 'staticboolean'
+            },{
                 name: 'richtext'
                 ,fieldLabel: _('resource_richtext')
                 ,description: _('resource_richtext_help')
                 ,xtype: 'staticboolean'
             },{
-                name: 'isfolder'
-                ,fieldLabel: _('resource_folder')
-                ,description: _('resource_folder_help')
+                name: 'searchable'
+                ,fieldLabel: _('resource_searchable')
+                ,description: _('resource_searchable_help')
+                ,xtype: 'staticboolean'
+            },{
+                name: 'cacheable'
+                ,fieldLabel: _('resource_cacheable')
+                ,description: _('resource_cacheable_help')
                 ,xtype: 'staticboolean'
             }]
         },{
@@ -125,17 +125,17 @@ MODx.panel.ResourceData = function(config) {
                 name: 'createdon_by'
                 ,fieldLabel: _('resource_createdby')
             },{
-                name: 'editedon_adjusted'
-                ,fieldLabel: _('resource_editedon')
-            },{
-                name: 'editedon_by'
-                ,fieldLabel: _('resource_editedby')
-            },{
                 name: 'publishedon_adjusted'
                 ,fieldLabel: _('resource_publishedon')
             },{
                 name: 'publishedon_by'
                 ,fieldLabel: _('resource_publishedby')
+            },{
+                name: 'editedon_adjusted'
+                ,fieldLabel: _('resource_editedon')
+            },{
+                name: 'editedon_by'
+                ,fieldLabel: _('resource_editedby')
             },{
                 xtype: 'modx-grid-manager-log'
                 ,anchor: '100%'

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -27,151 +27,179 @@ MODx.panel.ResourceData = function(config) {
                 name: 'context_key'
                 ,fieldLabel: _('context')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'alias'
                 ,fieldLabel: _('resource_alias')
                 ,description: _('resource_alias_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'template_name'
                 ,fieldLabel: _('resource_template')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'pagetitle'
                 ,fieldLabel: _('resource_pagetitle')
                 ,description: _('resource_pagetitle_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'longtitle'
                 ,fieldLabel: _('resource_longtitle')
                 ,description: _('resource_longtitle_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
                 ,value: _('notset')
-                ,width: 500
             },{
                 name: 'description'
                 ,fieldLabel: _('resource_description')
                 ,description: _('resource_description_help')
                 ,xtype: 'statictextfield'
-                ,width: 500
+                ,anchor: '100%'
             },{
                 name: 'introtext'
                 ,fieldLabel: _('resource_summary')
                 ,description: _('resource_summary_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'content'
                 ,fieldLabel: _('resource_content')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'published'
                 ,fieldLabel: _('resource_published')
                 ,description: _('resource_published_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'deleted'
                 ,fieldLabel: _('deleted')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'publishedon'
                 ,fieldLabel: _('resource_publishedon')
                 ,description: _('resource_publishedon_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'pub_date'
                 ,fieldLabel: _('resource_publishdate')
                 ,description: _('resource_publishdate_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'unpub_date'
                 ,fieldLabel: _('resource_unpublishdate')
                 ,description: _('resource_unpublishdate_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'hidemenu'
                 ,fieldLabel: _('resource_hide_from_menus')
                 ,description: _('resource_hide_from_menus_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'menutitle'
                 ,fieldLabel: _('resource_menutitle')
                 ,description: _('resource_menutitle_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'menuindex'
                 ,fieldLabel: _('resource_menuindex')
                 ,description: _('resource_menuindex_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'link_attributes'
                 ,fieldLabel: _('resource_link_attributes')
                 ,description: _('resource_link_attributes_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'class_key'
                 ,fieldLabel: _('class_key')
                 ,description: _('resource_class_key_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'content_type'
                 ,fieldLabel: _('resource_content_type')
                 ,description: _('resource_content_type_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'isfolder'
                 ,fieldLabel: _('resource_folder')
                 ,description: _('resource_folder_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'show_in_tree'
                 ,fieldLabel: _('resource_show_in_tree')
                 ,description: _('resource_show_in_tree_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'hide_children_in_tree'
                 ,fieldLabel: _('resource_hide_children_in_tree')
                 ,description: _('resource_hide_children_in_tree_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'alias_visible'
                 ,fieldLabel: _('resource_alias_visible')
                 ,description: _('resource_alias_visible_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'uri_override'
                 ,fieldLabel: _('resource_uri_override')
                 ,description: _('resource_uri_override_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'uri'
                 ,fieldLabel: _('resource_uri')
                 ,description: _('resource_uri_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'parent'
                 ,fieldLabel: _('resource_parent')
                 ,description: _('resource_parent_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'content_dispo'
                 ,fieldLabel: _('resource_contentdispo')
                 ,description: _('resource_contentdispo_help')
                 ,xtype: 'statictextfield'
+                ,anchor: '100%'
             },{
                 name: 'richtext'
                 ,fieldLabel: _('resource_richtext')
                 ,description: _('resource_richtext_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'searchable'
                 ,fieldLabel: _('resource_searchable')
                 ,description: _('resource_searchable_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             },{
                 name: 'cacheable'
                 ,fieldLabel: _('resource_cacheable')
                 ,description: _('resource_cacheable_help')
                 ,xtype: 'staticboolean'
+                ,anchor: '100%'
             }]
         },{
             title: _('changes')
@@ -181,25 +209,31 @@ MODx.panel.ResourceData = function(config) {
             ,autoHeight: true
             ,bodyCssClass: 'main-wrapper'
             ,defaultType: 'statictextfield'
-            ,anchor: '100%'
+            ,labelWidth: 150
             ,items: [{
                 name: 'createdon_adjusted'
                 ,fieldLabel: _('resource_createdon')
+                ,anchor: '100%'
             },{
                 name: 'createdon_by'
                 ,fieldLabel: _('resource_createdby')
+                ,anchor: '100%'
             },{
                 name: 'publishedon_adjusted'
                 ,fieldLabel: _('resource_publishedon')
+                ,anchor: '100%'
             },{
                 name: 'publishedon_by'
                 ,fieldLabel: _('resource_publishedby')
+                ,anchor: '100%'
             },{
                 name: 'editedon_adjusted'
                 ,fieldLabel: _('resource_editedon')
+                ,anchor: '100%'
             },{
                 name: 'editedon_by'
                 ,fieldLabel: _('resource_editedby')
+                ,anchor: '100%'
             },{
                 xtype: 'modx-grid-manager-log'
                 ,anchor: '100%'
@@ -248,7 +282,7 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
 
         if (this.config.resource === '' || this.config.resource === 0) {
             this.fireEvent('ready');
-        	return false;
+            return false;
         }
         var g = Ext.getCmp('modx-grid-manager-log');
         g.getStore().baseParams.item = this.config.resource;
@@ -262,13 +296,13 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
                 ,class_key: this.config.class_key
             }
             ,listeners: {
-            	'success': {fn:function(r) {
+                'success': {fn:function(r) {
                     if (r.object.pub_date == '0') { r.object.pub_date = ''; }
                     if (r.object.unpub_date == '0') { r.object.unpub_date = ''; }
                     Ext.get('modx-resource-header').update(r.object.pagetitle);
                     this.getForm().setValues(r.object);
                     this.fireEvent('ready');
-            	},scope:this}
+                },scope:this}
             }
         });
     },

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -55,9 +55,28 @@ MODx.panel.ResourceData = function(config) {
                 ,xtype: 'statictextfield'
                 ,width: 500
             },{
+                name: 'introtext'
+                ,fieldLabel: _('resource_summary')
+                ,description: _('resource_summary_help')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'content'
+                ,fieldLabel: _('resource_content')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'published'
+                ,fieldLabel: _('resource_published')
+                ,description: _('resource_published_help')
+                ,xtype: 'staticboolean'
+            },{
                 name: 'deleted'
                 ,fieldLabel: _('deleted')
                 ,xtype: 'staticboolean'
+            },{
+                name: 'publishedon'
+                ,fieldLabel: _('resource_publishedon')
+                ,description: _('resource_publishedon_help')
+                ,xtype: 'statictextfield'
             },{
                 name: 'pub_date'
                 ,fieldLabel: _('resource_publishdate')
@@ -84,15 +103,60 @@ MODx.panel.ResourceData = function(config) {
                 ,description: _('resource_menuindex_help')
                 ,xtype: 'statictextfield'
             },{
+                name: 'link_attributes'
+                ,fieldLabel: _('resource_link_attributes')
+                ,description: _('resource_link_attributes_help')
+                ,xtype: 'statictextfield'
+            },{
                 name: 'class_key'
                 ,fieldLabel: _('class_key')
                 ,description: _('resource_class_key_help')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'content_type'
+                ,fieldLabel: _('resource_content_type')
+                ,description: _('resource_content_type_help')
                 ,xtype: 'statictextfield'
             },{
                 name: 'isfolder'
                 ,fieldLabel: _('resource_folder')
                 ,description: _('resource_folder_help')
                 ,xtype: 'staticboolean'
+            },{
+                name: 'show_in_tree'
+                ,fieldLabel: _('resource_show_in_tree')
+                ,description: _('resource_show_in_tree_help')
+                ,xtype: 'staticboolean'
+            },{
+                name: 'hide_children_in_tree'
+                ,fieldLabel: _('resource_hide_children_in_tree')
+                ,description: _('resource_hide_children_in_tree_help')
+                ,xtype: 'staticboolean'
+            },{
+                name: 'alias_visible'
+                ,fieldLabel: _('resource_alias_visible')
+                ,description: _('resource_alias_visible_help')
+                ,xtype: 'staticboolean'
+            },{
+                name: 'uri_override'
+                ,fieldLabel: _('resource_uri_override')
+                ,description: _('resource_uri_override_help')
+                ,xtype: 'staticboolean'
+            },{
+                name: 'uri'
+                ,fieldLabel: _('resource_uri')
+                ,description: _('resource_uri_help')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'parent'
+                ,fieldLabel: _('resource_parent')
+                ,description: _('resource_parent_help')
+                ,xtype: 'statictextfield'
+            },{
+                name: 'content_dispo'
+                ,fieldLabel: _('resource_contentdispo')
+                ,description: _('resource_contentdispo_help')
+                ,xtype: 'statictextfield'
             },{
                 name: 'richtext'
                 ,fieldLabel: _('resource_richtext')


### PR DESCRIPTION
### What does it do?
Corrected output of resource data in "Overview" form.
Changed the order and added the missing fields.

![res-data_2](https://user-images.githubusercontent.com/12523676/84545602-37754f80-ad08-11ea-9f7d-3f939eb41250.png)

### Why is it needed?
- Not all fields were shown.
- Some fields did not display anything.

### Related issue(s)/PR(s)
None
