### PR TITLE
Make sure the tree node is visible before drop animation

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -611,6 +611,8 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
                     fn: function (r) {
                         var el = dropEvent.dropNode.getUI().getTextEl();
                         if (el) {
+                            if(dropEvent.target.childNodes.length === 1) dropEvent.dropNode.ensureVisible();
+
                             Ext.get(el).frame();
                         }
                         this.fireEvent('afterSort',{event: dropEvent,result: r});


### PR DESCRIPTION
### What does it do?
If the category has just a single children, make sure it's visible before animating the drop.

### Why is it needed?
The drop animation appears on a wrong location.

### Related issue(s)/PR(s)
Closes #15017
