### PR TITLE
Recreate form customization menu entry

### DIFF
--- a/setup/includes/upgrades/common/3.0.0-update-menu-entries.php
+++ b/setup/includes/upgrades/common/3.0.0-update-menu-entries.php
@@ -16,10 +16,17 @@ if ($formCustomization) {
     $newData['text'] = 'form_customization';
     $newData['description'] = 'form_customization_desc';
 
-    $formCustomization->remove();
+    $created = true;
+    $newFormCustomization = $modx->getObject(modMenu::class, ['text' => 'form_customization']);
+    if (!$newFormCustomization) {
+        $newFormCustomization = $modx->newObject(modMenu::class);
+        $newFormCustomization->fromArray($newData, '', true, true);
 
-    $newFormCustomization = $modx->newObject(modMenu::class);
-    $newFormCustomization->fromArray($newData, '', true, true);
-    $newFormCustomization->save();
+        $created = $newFormCustomization->save();
+    }
+
+    if ($created) {
+        $formCustomization->remove();
+    }
 }
 

--- a/setup/includes/upgrades/common/3.0.0-update-menu-entries.php
+++ b/setup/includes/upgrades/common/3.0.0-update-menu-entries.php
@@ -10,8 +10,16 @@ use MODX\Revolution\modMenu;
 
 /** @var modMenu $formCustomization */
 $formCustomization = $modx->getObject(modMenu::class, ['text' => 'bespoke_manager']);
+
 if ($formCustomization) {
-    $formCustomization->set('text', 'form_customization');
-    $formCustomization->set('description', 'form_customization_desc');
-    $formCustomization->save();
+    $newData = $formCustomization->toArray();
+    $newData['text'] = 'form_customization';
+    $newData['description'] = 'form_customization_desc';
+
+    $formCustomization->remove();
+
+    $newFormCustomization = $modx->newObject(modMenu::class);
+    $newFormCustomization->fromArray($newData, '', true, true);
+    $newFormCustomization->save();
 }
+


### PR DESCRIPTION
### What does it do?
Deletes the current menu entry named `bespoke_manager` and creates a new one with text `form_customization`.

### Why is it needed?
The `text` is a PK of the modMenu and can't change the way I did it last time.

### Related issue(s)/PR(s)
Closes #14953
