### PR TITLE
Add renderEditableColumn to LocalGrid

### DIFF
--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -680,11 +680,11 @@ MODx.grid.ComboColumn = Ext.extend(Ext.grid.Column,{
     gridId: undefined
     ,constructor: function(cfg){
         MODx.grid.ComboColumn.superclass.constructor.call(this, cfg);
-        this.renderer = (this.editor && this.editor.triggerAction) ? MODx.grid.ComboBoxRenderer(this.editor,this.gridId) : function(value) {return value;};
+        this.renderer = (this.editor && this.editor.triggerAction) ? MODx.grid.ComboBoxRenderer(this.editor,this.gridId, cfg.renderer) : function(value) {return value;};
     }
 });
 Ext.grid.Column.types['combocolumn'] = MODx.grid.ComboColumn;
-MODx.grid.ComboBoxRenderer = function(combo, gridId) {
+MODx.grid.ComboBoxRenderer = function(combo, gridId, currentRenderer) {
     var getValue = function(value) {
         var idx = combo.store.find(combo.valueField, value);
         var rec = combo.store.getAt(idx);
@@ -694,7 +694,18 @@ MODx.grid.ComboBoxRenderer = function(combo, gridId) {
         return value;
     };
 
-    return function(value) {
+    return function(value, metaData, record, rowIndex, colIndex, store) {
+        if (currentRenderer) {
+            if (typeof currentRenderer.fn === 'function') {
+                var scope = (currentRenderer.scope) ? currentRenderer.scope : false;
+                currentRenderer = currentRenderer.fn.bind(scope);
+            }
+
+            if (typeof currentRenderer === 'function') {
+                value = currentRenderer(value, metaData, record, rowIndex, colIndex, store);
+            }
+        }
+
         if (combo.store.getCount() == 0 && gridId) {
             combo.store.on(
                 'load',

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -868,8 +868,35 @@ Ext.extend(MODx.grid.LocalGrid,Ext.grid.EditorGridPanel,{
                 if (Ext.isEmpty(c[i].renderer)) {
                     c[i].renderer = Ext.util.Format.htmlEncode;
                 }
+
+                /**
+                 * When the field has an editor defined, wrap the (optional) renderer with
+                 * a special renderer that applies a class and tooltip to indicate the
+                 * column is editable.
+                 */
+                if (c[i].editor) {
+                    c[i].renderer = this.renderEditableColumn(c[i].renderer);
+                }
             }
             this.cm = new Ext.grid.ColumnModel(c);
+        }
+    }
+
+    ,renderEditableColumn: function(renderer) {
+        return function(value, metaData, record, rowIndex, colIndex, store) {
+            if (renderer) {
+                if (typeof renderer.fn === 'function') {
+                    var scope = (renderer.scope) ? renderer.scope : false;
+                    renderer = renderer.fn.bind(scope);
+                }
+
+                if (typeof renderer === 'function') {
+                    value = renderer(value, metaData, record, rowIndex, colIndex, store);
+                }
+            }
+            metaData.css = ['x-editable-column', metaData.css || ''].join(' ');
+
+            return value;
         }
     }
 

--- a/manager/assets/modext/widgets/core/modx.grid.local.property.js
+++ b/manager/assets/modext/widgets/core/modx.grid.local.property.js
@@ -48,13 +48,13 @@ Ext.extend(MODx.grid.LocalProperty,MODx.grid.LocalGrid,{
         var xtype = this.config.dynProperty;
         if (!r[xtype] || r[xtype] == 'combo-boolean') {
             f = MODx.grid.Grid.prototype.rendYesNo;
-            oz = f(v == 1,md);
+            return this.renderEditableColumn(f)(Ext.util.Format.htmlEncode(v),md,rec,ri,ci,s,g);
         } else if (r[xtype] === 'datefield') {
             f = Ext.util.Format.dateRenderer('Y-m-d');
-            oz = f(v);
+            return this.renderEditableColumn(f)(Ext.util.Format.htmlEncode(v),md,rec,ri,ci,s,g);
         } else if (r[xtype] === 'password') {
             f = this.rendPassword;
-            oz = f(v,md);
+            return this.renderEditableColumn(f)(Ext.util.Format.htmlEncode(v),md,rec,ri,ci,s,g);
         } else if (r[xtype].substr(0,5) == 'combo' || r[xtype] == 'list' || r[xtype].substr(0,9) == 'modx-combo') {
             var cm = g.getColumnModel();
             var ed = cm.getCellEditor(ci,ri);
@@ -69,7 +69,7 @@ Ext.extend(MODx.grid.LocalProperty,MODx.grid.LocalGrid,{
             }
             if (r[xtype] != 'list') {
                 f = Ext.util.Format.comboRenderer(ed.field);
-                oz = f(v);
+                return this.renderEditableColumn(f)(Ext.util.Format.htmlEncode(v),md,rec,ri,ci,s,g);
             } else if (cb) {
                 idx = cb.getStore().find(cb.valueField,v);
                 rec = cb.getStore().getAt(idx);
@@ -81,7 +81,7 @@ Ext.extend(MODx.grid.LocalProperty,MODx.grid.LocalGrid,{
             }
         }
 
-        return this.renderEditableColumn(f)(Ext.util.Format.htmlEncode(oz),md,rec,ri,ci,s,g);
+        return this.renderEditableColumn()(Ext.util.Format.htmlEncode(oz),md,rec,ri,ci,s,g);
     }
 
     ,createCombo: function(p) {

--- a/manager/assets/modext/widgets/core/modx.grid.local.property.js
+++ b/manager/assets/modext/widgets/core/modx.grid.local.property.js
@@ -19,7 +19,7 @@ Ext.extend(MODx.grid.LocalProperty,MODx.grid.LocalGrid,{
             this.startEditing(ri,ci);
         }
     }
-    
+
     ,initEditor: function(cm,ci,ri,r) {
         cm.setEditable(ci,true);
         var xtype = this.config.dynProperty;
@@ -40,7 +40,7 @@ Ext.extend(MODx.grid.LocalProperty,MODx.grid.LocalGrid,{
         cm.setEditor(ci,ed);
         return ed;
     }
-    
+
     ,renderDynField: function(v,md,rec,ri,ci,s,g) {
         var r = s.getAt(ri).data;
         var f,idx;
@@ -80,9 +80,10 @@ Ext.extend(MODx.grid.LocalProperty,MODx.grid.LocalGrid,{
                 }
             }
         }
-        return Ext.util.Format.htmlEncode(oz);
+
+        return this.renderEditableColumn(f)(Ext.util.Format.htmlEncode(oz),md,rec,ri,ci,s,g);
     }
-    
+
     ,createCombo: function(p) {
         var obj;
         try {


### PR DESCRIPTION
### What does it do?
Adds functionality to display the pencil icon in editable columns to the LocalGrid.

### Why is it needed?
Right now is the functionality only in the Grid, so in LocalGrid the pencil icon won't show up.

### Related issue(s)/PR(s)
Closes #14939
