### PR TITLE
Register webp format in system settings

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1904,7 +1904,7 @@ $settings['unauthorized_page']->fromArray(array (
 $settings['upload_files']= $xpdo->newObject('modSystemSetting');
 $settings['upload_files']->fromArray(array (
   'key' => 'upload_files',
-  'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot,scss,less,css.map',
+  'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot,scss,less,css.map,webp',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
@@ -1922,7 +1922,7 @@ $settings['upload_flash']->fromArray(array (
 $settings['upload_images']= $xpdo->newObject('modSystemSetting');
 $settings['upload_images']->fromArray(array (
   'key' => 'upload_images',
-  'value' => 'jpg,jpeg,png,gif,psd,ico,bmp,tiff,svg,svgz',
+  'value' => 'jpg,jpeg,png,gif,psd,ico,bmp,tiff,svg,svgz,webp',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',

--- a/setup/includes/upgrades/common/2.8.0-update-upload_files-upload_images.php
+++ b/setup/includes/upgrades/common/2.8.0-update-upload_files-upload_images.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Common upgrade script for modify upload_files, upload_images System Setting
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+$keys = ['upload_files','upload_images'];
+
+foreach ($keys as $key) {
+    $success = false;
+
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject('modSystemSetting', array('key' => $key));
+    if ($setting) {
+        $value = $setting->get('value');
+        $tmp = explode(',', $value);
+        if (in_array('webp', $tmp)) {
+            continue;
+        } else {
+            $setting->set('value', $value . ',webp');
+            if ($setting->save()) {
+                $success = true;
+            }
+        }
+    }
+
+    if ($success) {
+        $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+            sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_update_success', ['key' => $key])));
+    } else {
+        $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+            sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_update_failed', ['key' => $key])));
+    }
+}

--- a/setup/includes/upgrades/mysql/2.8.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.8.0-pl.php
@@ -1,0 +1,3 @@
+<?php
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/2.8.0-update-upload_files-upload_images.php';

--- a/setup/includes/upgrades/sqlsrv/2.8.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.8.0-pl.php
@@ -1,0 +1,3 @@
+<?php
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/2.8.0-update-upload_files-upload_images.php';

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -44,3 +44,5 @@ $_lang['update_table_column_data'] = 'Updated data in column [[+column]] of tabl
 $_lang['iso_country_code_converted'] = 'Successfully converted user profile country names to ISO codes.';
 $_lang['legacy_cleanup_complete'] = 'Legacy file clean up complete.';
 $_lang['legacy_cleanup_count'] = 'Removed [[+files]] file(s) and [[+folders]] folder(s).';
+$_lang['system_setting_update_success'] = 'System Setting `[[+key]]` updated.';
+$_lang['system_setting_update_failed'] = 'System Setting `[[+key]]` could not be updated.';


### PR DESCRIPTION
**What does it do?**
Registers the webp format in the default settings to allow downloads.

**Why is it needed?**
Registration of web format in the Types of downloaded images setting upload_files and upload_images for working with formats out of the "box"

**Related issue(s)/PR(s)**
#14366