### PR TITLE
Remember the filter properties of the system setting grid in the browser url

### DIFF
--- a/core/src/Revolution/Processors/Context/Setting/GetList.php
+++ b/core/src/Revolution/Processors/Context/Setting/GetList.php
@@ -58,17 +58,17 @@ class GetList extends GetListProcessor
      */
     public function getData()
     {
-        $key = $this->getProperty('key', false);
+        $query = $this->getProperty('query', false);
         $data = [];
 
         $criteria = [];
         $criteria[] = ['context_key' => $this->getProperty('context_key')];
-        if (!empty($key)) {
+        if (!empty($query)) {
             $criteria[] = [
-                'modContextSetting.key:LIKE' => '%' . $key . '%',
-                'OR:Entry.value:LIKE' => '%' . $key . '%',
-                'OR:modContextSetting.value:LIKE' => '%' . $key . '%',
-                'OR:Description.value:LIKE' => '%' . $key . '%',
+                'modContextSetting.key:LIKE' => '%' . $query . '%',
+                'OR:Entry.value:LIKE' => '%' . $query . '%',
+                'OR:modContextSetting.value:LIKE' => '%' . $query . '%',
+                'OR:Description.value:LIKE' => '%' . $query . '%',
             ];
         }
 

--- a/core/src/Revolution/Processors/System/Settings/GetList.php
+++ b/core/src/Revolution/Processors/System/Settings/GetList.php
@@ -60,17 +60,17 @@ class GetList extends GetListProcessor
      */
     public function getData()
     {
-        $key = $this->getProperty('key', false);
+        $query = $this->getProperty('query', false);
         $data = [];
 
         /** @var xPDOQuery $criteria */
         $criteria = $this->prepareCriteria();
-        if (!empty($key)) {
+        if (!empty($query)) {
             $criteria[] = [
-                $this->modx->getAlias($this->classKey) . '.key:LIKE' => '%' . $key . '%',
-                'OR:Entry.value:LIKE' => '%' . $key . '%',
-                'OR:' . $this->modx->getAlias($this->classKey) . '.value:LIKE' => '%' . $key . '%',
-                'OR:Description.value:LIKE' => '%' . $key . '%',
+                $this->modx->getAlias($this->classKey) . '.key:LIKE' => '%' . $query . '%',
+                'OR:Entry.value:LIKE' => '%' . $query . '%',
+                'OR:' . $this->modx->getAlias($this->classKey) . '.value:LIKE' => '%' . $query . '%',
+                'OR:Description.value:LIKE' => '%' . $query . '%',
             ];
         }
 

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -715,6 +715,39 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     actionContextMenu: function(record, recordIndex, e) {
         this._showMenu(this, recordIndex, e);
     }
+
+    ,makeUrl: function () {
+        if (typeof this.config.urlFilters !== "undefined" && this.config.urlFilters !== null && this.config.urlFilters.length !== null && this.config.urlFilters.length > 0) {
+            var s = this.getStore();
+            var p = {
+                a: MODx.request.a
+            }
+            if (MODx.request.id) {
+                p['id'] = MODx.request.id;
+            }
+            if (MODx.request.key) {
+                p['key'] = MODx.request.key;
+            }
+            for (var i = 0; i < this.config.urlFilters.length; ++i) {
+                if (s.baseParams.hasOwnProperty(this.config.urlFilters[i]) && s.baseParams[this.config.urlFilters[i]]) {
+                    if (this.config.urlFilters[i] === 'namespace') {
+                        p['ns'] = s.baseParams[this.config.urlFilters[i]];
+                    } else {
+                        p[this.config.urlFilters[i]] = s.baseParams[this.config.urlFilters[i]];
+                    }
+                }
+            }
+            return Ext.urlAppend(MODx.config.manager_url, Ext.urlEncode(p).replace(/%2F/g, '/'));
+        }
+    }
+
+    ,replaceState: function () {
+        if (typeof window.history.replaceState !== 'undefined' &&
+            typeof this.config.urlFilters !== "undefined" && this.config.urlFilters !== null && this.config.urlFilters.length !== null && this.config.urlFilters.length > 0
+        ) {
+            window.history.replaceState(this.getStore().baseParams, document.title, this.makeUrl());
+        }
+    }
 });
 
 /* local grid */

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -717,7 +717,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     }
 
     ,makeUrl: function () {
-        if (typeof this.config.urlFilters !== "undefined" && this.config.urlFilters !== null && this.config.urlFilters.length !== null && this.config.urlFilters.length > 0) {
+        if (Array.isArray(this.config.urlFilters) && this.config.urlFilters.length > 0) {
             var s = this.getStore();
             var p = {
                 a: MODx.request.a
@@ -743,7 +743,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
 
     ,replaceState: function () {
         if (typeof window.history.replaceState !== 'undefined' &&
-            typeof this.config.urlFilters !== "undefined" && this.config.urlFilters !== null && this.config.urlFilters.length !== null && this.config.urlFilters.length > 0
+            Array.isArray(this.config.urlFilters) && this.config.urlFilters.length > 0
         ) {
             window.history.replaceState(this.getStore().baseParams, document.title, this.makeUrl());
         }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -30,7 +30,6 @@ MODx.grid.SettingsGrid = function(config) {
     '->'
     ,{
         xtype: 'modx-combo-namespace'
-        ,name: 'namespace'
         ,id: 'modx-filter-namespace'
         ,emptyText: _('namespace_filter')
         ,preselectValue: (MODx.request.ns) ? MODx.request.ns : 'core'
@@ -43,7 +42,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,listeners: {
             'select': {
                 fn: function (cb, rec, ri) {
-                    if (!MODx.request.key) {
+                    if (!MODx.request.query) {
                         this.filterByNamespace(cb, rec, ri)
                     }
                 }
@@ -52,7 +51,6 @@ MODx.grid.SettingsGrid = function(config) {
         }
     },{
         xtype: 'modx-combo-area'
-        ,name: 'area'
         ,id: 'modx-filter-area'
         ,emptyText: _('area_filter')
         ,value: MODx.request.area
@@ -68,7 +66,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,listeners: {
             'select': {
                 fn: function (cb, rec, ri) {
-                    if (!MODx.request.key) {
+                    if (!MODx.request.query) {
                         this.filterByArea(cb, rec, ri);
                     }
                 }
@@ -77,23 +75,22 @@ MODx.grid.SettingsGrid = function(config) {
         }
     },{
         xtype: 'textfield'
-        ,name: 'filter_key'
-        ,id: 'modx-filter-key'
+        ,id: 'modx-filter-query'
         ,cls: 'x-form-filter'
         ,emptyText: _('search_by_key')
-        ,value: MODx.request.key
+        ,value: MODx.request.query
         ,listeners: {
             'change': {
                 fn: function (cb, rec, ri) {
-                    this.filterByKey(cb, rec, ri);
+                    this.filterByQuery(cb, rec, ri);
                 }
                 ,scope: this
             },
             'afterrender': {
                 fn: function (cb){
-                    if (MODx.request.key) {
-                        this.filterByKey(cb, cb.value);
-                        MODx.request.key = '';
+                    if (MODx.request.query) {
+                        this.filterByQuery(cb, cb.value);
+                        MODx.request.query = '';
                     }
                 }
                 ,scope: this
@@ -297,22 +294,20 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
     ,clearFilter: function() {
         var s = this.getStore();
         var filterNs = Ext.getCmp('modx-filter-namespace');
-        var filterKey = Ext.getCmp('modx-filter-key');
+        var filterQuery = Ext.getCmp('modx-filter-query');
         var ns = MODx.request.ns ? MODx.request.ns : 'core';
         s.baseParams = this.initialConfig.baseParams;
 
         s.baseParams.namespace = ns;
         s.baseParams.area = '';
-        s.baseParams.key = '';
+        s.baseParams.query = '';
         MODx.request.ns = '';
-        MODx.request.key = '';
+        MODx.request.query = '';
         filterNs.preselectValue = ns;
         filterNs.setValue(ns);
-        filterKey.setValue('');
+        filterQuery.setValue('');
         this.clearArea();
-        if (typeof window.history.replaceState !== 'undefined') {
-            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
-        }
+        this.replaceState();
         this.getBottomToolbar().changePage(1);
     }
 
@@ -326,22 +321,20 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         }
     }
 
-    ,filterByKey: function(tf,newValue,oldValue) {
+    ,filterByQuery: function(tf,newValue,oldValue) {
         var s = this.getStore();
         var filterNs = Ext.getCmp('modx-filter-namespace');
         var ns = MODx.request.ns ? MODx.request.ns : 'core';
         if (newValue) {
             ns = '';
         }
-        s.baseParams.key = newValue;
+        s.baseParams.query = newValue;
         s.baseParams.namespace = ns;
         s.baseParams.area = '';
         filterNs.preselectValue = (ns) ? ns : false;
         filterNs.setValue(ns);
         this.clearArea();
-        if (typeof window.history.replaceState !== 'undefined') {
-            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
-        }
+        this.replaceState();
         this.getBottomToolbar().changePage(1);
     }
 
@@ -357,18 +350,14 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
             s.baseParams.area = MODx.request.area;
             MODx.request.area = '';
         }
-        if (typeof window.history.replaceState !== 'undefined') {
-            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
-        }
+        this.replaceState();
     }
 
     ,filterByArea: function(cb,rec,ri) {
         var s = this.getStore();
         s.baseParams.area = rec.data.v;
         this.getBottomToolbar().changePage(1);
-        if (typeof window.history.replaceState !== 'undefined') {
-            window.history.replaceState(s.baseParams, document.title, this.makeUrl());
-        }
+        this.replaceState();
     }
 
     ,renderDynField: function(v,md,rec,ri,ci,s,g) {
@@ -420,23 +409,6 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
         return value;
         // JavaScripts time is in milliseconds
         //return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);
-    }
-    ,makeUrl : function () {
-        var s = this.getStore();
-        var p = {
-            a: MODx.request.a
-        }
-        if (s.baseParams.namespace) {
-            p.ns = s.baseParams.namespace;
-        }
-        if (s.baseParams.area) {
-            p.area = s.baseParams.area;
-        }
-        if (s.baseParams.key) {
-            p.key = s.baseParams.key;
-        }
-        return Ext.urlAppend(MODx.config.manager_url, Ext.urlEncode(p).replace('%2F','/'));
-
     }
 });
 Ext.reg('modx-grid-settings',MODx.grid.SettingsGrid);

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -158,6 +158,7 @@ MODx.panel.UserGroup = function(config) {
                     ,xtype: 'modx-description'
                 },{
                     xtype: 'modx-grid-group-settings'
+                    ,urlFilters: ['namespace', 'area', 'query']
                     ,cls: 'main-wrapper'
                     ,preventRender: true
                     ,group: config.record.id

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -136,6 +136,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,xtype: 'modx-description'
                 },{
                     xtype: 'modx-grid-user-settings'
+                    ,urlFilters: ['namespace', 'area', 'query']
                     ,cls: 'main-wrapper'
                     ,preventRender: true
                     ,user: config.user

--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -69,6 +69,7 @@ MODx.panel.Context = function(config) {
                 ,xtype: 'modx-description'
             },{
                 xtype: 'modx-grid-context-settings'
+                ,urlFilters: ['namespace', 'area', 'query']
                 ,cls:'main-wrapper'
                 ,title: ''
                 ,preventRender: true

--- a/manager/assets/modext/widgets/system/modx.panel.system.settings.js
+++ b/manager/assets/modext/widgets/system/modx.panel.system.settings.js
@@ -31,6 +31,7 @@ MODx.panel.SystemSettings = function(config) {
                     ,xtype: 'modx-description'
 				},{
 					xtype: 'modx-grid-system-settings'
+                    ,urlFilters: ['namespace', 'area', 'query']
 					,cls: 'main-wrapper'
 					,preventSaveRefresh: true
 				},{


### PR DESCRIPTION
### What does it do?
Global approach for #15086 in MODx.grid.Grid with a replaceState method and a makeUrl method triggered by an urlFilters config array. Since the key request parameter is used in the context window, the filter 'key' is renamed to 'query'

### Why is it needed?
Since #15086 the user settings page was broken.

### Related issue(s)/PR(s)
#15086
