### PR TITLE
Corrected styles in manager panel

### DIFF
--- a/_build/templates/default/sass/_breadcrumbs.scss
+++ b/_build/templates/default/sass/_breadcrumbs.scss
@@ -36,10 +36,14 @@
           line-height: 34px;
           position: absolute;
           top: 0;
-          left: 6px;
+          left: 0;
           text-align: center;
           text-indent: 0;
           z-index: 2; /* put the icon above the triangle :after element */
+        }
+
+        #packages-breadcrumbs &:before {
+          content: fa-content($fa-var-cube);
         }
 
         &:hover:before {
@@ -56,9 +60,9 @@
           display: inline-block;
           line-height: 12px;
           margin: 0; /* neutralize the normal li margin */
-          padding: 11px 13px 11px 20px;
+          padding: 12px;
           text-indent: -999em;
-          width: 20px;
+          width: 35px;
           z-index: 3;
 
           /* do not display the cover element here */
@@ -72,10 +76,7 @@
         }
       }
 
-
-
       &:hover {
-
         button,
         span,
         span:after {

--- a/_build/templates/default/sass/_browser.scss
+++ b/_build/templates/default/sass/_browser.scss
@@ -35,8 +35,12 @@
   text-align: center;
 
   &.x-view-over {
+    .modx-browser-placeholder {
+      color: $darkGray;
+    }
+
     .modx-browser-thumb {
-    border: 1px solid $brandSelectedColor;
+      border: 1px dotted $darkGray;
     }
   }
 
@@ -46,7 +50,7 @@
     }
 
     .modx-browser-thumb {
-    border: 1px solid $brandSelectedColor;
+      border: 1px solid $brandSelectedColor;
     }
   }
 }
@@ -86,20 +90,6 @@
 .modx-browser-list-item {
   padding: 0 5px 0 5px;
 
-  .x-view-over {
-    >span {
-      background: $brandHover;
-    }
-  }
-
-  .x-view-selected {
-    >span {
-      background: $brandSelectedBg;
-      border-bottom: 1px solid $brandSelectedColor;
-      color: $brandSelectedColor;
-    }
-  }
-
   >span {
     background-position: center left !important;
     border-bottom: 1px solid $borderColor;
@@ -118,7 +108,6 @@
     span {
       display: inline-block;
       font: $fontSmall;
-      padding-top: 2px;
     }
 
     span.file-size {
@@ -129,6 +118,19 @@
     span.image-size {
       float: right;
       width: 13%;
+    }
+  }
+
+  &.x-view-over {
+    >span {
+      background: $lightestGray;
+    }
+  }
+
+  &.x-view-selected {
+    >span {
+      background: $lightestGray;
+      color: $brandSelectedColor;
     }
   }
 }

--- a/_build/templates/default/sass/_forms.scss
+++ b/_build/templates/default/sass/_forms.scss
@@ -569,7 +569,7 @@ input::-moz-focus-inner {
     display: inline-block; /* make line-height apply */
     font-weight: normal;
     margin: 0;
-    padding-left: 20px;
+    padding-left: 1.9em;
     position: relative;
     top: 0; /* override extjs default style */
 
@@ -681,7 +681,7 @@ input::-moz-focus-inner {
       &+.x-form-cb-label,
       &+.x-fieldset-header-text {
         position: relative;
-        padding-left: 4em;
+        padding-left: 3.6em;
         padding-top: .2em;
         margin-left: 0;
         cursor: pointer;
@@ -769,10 +769,6 @@ input::-moz-focus-inner {
     .x-form-item {
       &:first-child {
         padding: 4px 0 0 0;
-      }
-
-      &:last-child {
-        padding: 0 0 4px 0;
       }
     }
   }

--- a/_build/templates/default/sass/_tabs.scss
+++ b/_build/templates/default/sass/_tabs.scss
@@ -360,11 +360,16 @@ ul.x-tab-strip-bottom {
 .tvs-wrapper {
   &.below-content {
     border-radius: $borderRadius;
-    margin-top: 20px;
+    margin: 1rem;
 
     .vertical-tabs-panel {
       border-radius: $borderRadius;
-      box-shadow: $boxShadow;
+    }
+  }
+
+  @include grid-media($desktop) {
+    &.below-content {
+      margin: 0;
     }
   }
 }

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -528,6 +528,10 @@ textarea.x-form-field {
   font-size: 12px !important;
 }
 
+.x-small-editor .x-form-num-field {
+  text-align: left;
+}
+
 .grid-row-inactive {
   color: #999 !important;
 }


### PR DESCRIPTION
### What does it do?
Corrected some styles in manager panel.

**TV, if located below**
Before:
![tv_bottom_1](https://user-images.githubusercontent.com/12523676/84918337-255d2d80-b0c9-11ea-82ed-f6b888827477.png)

After:
![tv_bottom_2](https://user-images.githubusercontent.com/12523676/84918339-25f5c400-b0c9-11ea-831e-b755d8098b61.png)

**Checkboxes**
Before:
![tv_radios_1](https://user-images.githubusercontent.com/12523676/84918342-25f5c400-b0c9-11ea-980d-3e500cd849b6.png)

After:
![tv_radios_2](https://user-images.githubusercontent.com/12523676/84918345-268e5a80-b0c9-11ea-9110-215a3ac7b13f.png)

**Number fields in grid**
Before:
![num_field_1](https://user-images.githubusercontent.com/12523676/85117603-c6fa9100-b227-11ea-98b1-c41960801c68.gif)

After:
![num_field_2](https://user-images.githubusercontent.com/12523676/85117607-c7932780-b227-11ea-919f-553d03029160.png)

**Added hover styles for files in file browser**
![file_browser](https://user-images.githubusercontent.com/12523676/85458495-dcfead80-b5a9-11ea-809c-ae2476912a99.gif)

Previously, hover styles coincided with the styles of the selected file, which can be confusing.

**Changed the breadcrumbs icon in the package manager**

![bc_icon](https://user-images.githubusercontent.com/12523676/85954382-a2b55780-b97f-11ea-80f9-610ae9e5a887.png)


### Why is it needed?
UI fix

### Related issue(s)/PR(s)
None