### PR TITLE
Changed styles for widgets

### DIFF
--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -202,6 +202,36 @@
     }
   }
 
+  /* news articles */
+  .news_article {
+    border-bottom: 1px solid $alto;
+    padding: 10px 0 33px;
+  }
+
+  .news_article h2 {
+    font-size: 17px;
+  }
+
+  .news_article .content {
+    color: $tundora;
+  }
+
+  .news_article a {
+    color: #535d6c;
+    text-decoration: none;
+  }
+
+  .news_article a:hover {
+    color: #90b1b9;
+  }
+
+  .news_article .date_stamp {
+    color: #535d6c;
+    float: right;
+    font-size: 11px;
+    font-style: italic;
+  }
+
   .table-wrapper {
     width: 100%;
     overflow: auto;

--- a/_build/templates/default/sass/_dashboard.scss
+++ b/_build/templates/default/sass/_dashboard.scss
@@ -149,6 +149,7 @@
     }
 
     .title-wrapper {
+      border-bottom: 1px solid $lighterGray;
       display: flex;
       flex-wrap: nowrap;
       align-items: center;
@@ -202,34 +203,36 @@
     }
   }
 
-  /* news articles */
   .news_article {
+    overflow: hidden;
     border-bottom: 1px solid $alto;
-    padding: 10px 0 33px;
+    padding: 15px 0;
   }
 
   .news_article h2 {
-    font-size: 17px;
+    font-size: 18px;
+
+    & a {
+      text-decoration: none;
+    }
   }
 
-  .news_article .content {
-    color: $tundora;
-  }
-
-  .news_article a {
-    color: #535d6c;
-    text-decoration: none;
-  }
-
-  .news_article a:hover {
-    color: #90b1b9;
+  .news_article h2 {
+    font-size: 18px;
   }
 
   .news_article .date_stamp {
-    color: #535d6c;
     float: right;
-    font-size: 11px;
+    font-size: 12px;
     font-style: italic;
+  }
+
+  .configcheck a, .news_article a {
+    text-decoration: underline;
+  }
+
+  .configcheck a:hover, .news_article a:hover {
+    text-decoration: none;
   }
 
   .table-wrapper {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -684,36 +684,6 @@ a.x-grid-link:focus {
   position: relative;
 }
 
-/* news articles */
-.news_article {
-  border-bottom: 1px solid $alto;
-  padding: 10px 0 33px;
-}
-
-.news_article h2 {
-  font-size: 17px;
-}
-
-.news_article .content {
-  color: $tundora;
-}
-
-.news_article a {
-  color: #535d6c;
-  text-decoration: none;
-}
-
-.news_article a:hover {
-  color: #90b1b9;
-}
-
-.news_article .date_stamp {
-  color: #535d6c;
-  float: right;
-  font-size: 11px;
-  font-style: italic;
-}
-
 /* portlets */
 .x-portal .x-panel-dd-spacer {
   margin-bottom: 10px;

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -92,6 +92,10 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
                             else if (response.message.length > 0) {
                                 container.innerHTML = '<p class="error">' + MODx.util.safeHtml(response.message) + '</p>';
                             }
+                            var datestamps = Ext.select(".date_stamp", container);
+                            datestamps.each(function (el) {
+                                el.dom.innerText = new Date(el.dom.innerText).format(MODx.config.manager_date_format);
+                            });
                         }, scope: this
                     }
                     ,failure: {

--- a/manager/templates/default/dashboard/rssitem.tpl
+++ b/manager/templates/default/dashboard/rssitem.tpl
@@ -1,5 +1,5 @@
 <div class="news_article">
     <h2><a href="[[+link]]" target="_blank">[[+title]]</a></h2>
     <div class="content">[[+description]]</div>
-    <div class="date_stamp">[[+pubdate:strtotime:date=`%Y-%m-%d`]]</div>
+    <div class="date_stamp">[[+pubdate]]</div>
 </div>

--- a/manager/templates/default/dashboard/rssitem.tpl
+++ b/manager/templates/default/dashboard/rssitem.tpl
@@ -1,5 +1,5 @@
 <div class="news_article">
     <h2><a href="[[+link]]" target="_blank">[[+title]]</a></h2>
-    <span class="content">[[+description]]</span>
-    <span class="date_stamp">[[+pubdate]]</span>
+    <div class="content">[[+description]]</div>
+    <div class="date_stamp">[[+pubdate:strtotime:date=`%Y-%m-%d`]]</div>
 </div>


### PR DESCRIPTION
### What does it do?
Changed the styles for widgets, basically made the links more visible.
In the current version, the links are not visible at all.
Which is strange, especially for a MODX Security Feed widget.

Before:
![widgets_1](https://user-images.githubusercontent.com/12523676/84922177-2b094200-b0ce-11ea-8939-29de42655c61.png)

After:
![widgets_2](https://user-images.githubusercontent.com/12523676/84922180-2c3a6f00-b0ce-11ea-9789-9ef38100d5eb.png)


### Why is it needed?
UI/UX improvements

### Related issue(s)/PR(s)
None
