### PR TITLE
Changed xtype for description in grids

### DIFF
--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -97,7 +97,7 @@ MODx.grid.Sources = function(config) {
             ,dataIndex: 'description'
             ,width: 300
             ,sortable: false
-            ,editor: { xtype: 'textarea' }
+            ,editor: { xtype: 'textfield' }
             ,renderer: Ext.util.Format.htmlEncode
         }]
         ,tbar: [{

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -92,7 +92,7 @@ MODx.grid.Dashboards = function(config) {
             ,dataIndex: 'description'
             ,width: 300
             ,sortable: false
-            ,editor: { xtype: 'textarea' }
+            ,editor: { xtype: 'textfield' }
         }]
         ,tbar: [{
             text: _('dashboard_create')

--- a/manager/assets/modext/workspace/provider.grid.js
+++ b/manager/assets/modext/workspace/provider.grid.js
@@ -32,7 +32,7 @@ MODx.grid.Provider = function(config) {
             header: _('description')
             ,dataIndex: 'description'
             ,width: 300
-            ,editor: { xtype: 'textarea' }
+            ,editor: { xtype: 'textfield' }
         }]
         ,tbar: [{
             text: _('provider_add')


### PR DESCRIPTION
### What does it do?
Changed xtype for description in **sources, widgets & providers grids**
For all grids, for example, contexts, settings, etc., the description basically has `xtype: textfield`, for sources, widgets & providers grids for some reason `xtype: textarea` - it looks strange.

A grid of sources, for example. Before:
![sources_grid_1](https://user-images.githubusercontent.com/12523676/85140604-27042e00-b24e-11ea-9954-04850567f119.gif)

After:
![sources_grid_2](https://user-images.githubusercontent.com/12523676/85140607-279cc480-b24e-11ea-9bbc-5c47b317ca75.png)

A grid of contexts, for example:
![sources_grid_3](https://user-images.githubusercontent.com/12523676/85140834-85311100-b24e-11ea-8a7e-362c303793ef.png)

p.s. `xtype: textarea` is also set for the lexicons grid, but this is appropriate here.

### Why is it needed?
UI / UX Improvement

### Related issue(s)/PR(s)
None