### PR TITLE
Fix combocolumn grid refresh

### DIFF
--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -591,7 +591,7 @@ MODx.grid.ComboBoxRenderer = function(combo, gridId) {
                     if (grid) {
                         grid.getView().refresh();
                     }
-                },{single: true}
+                }, this, {single: true}
             );
             return value;
         }


### PR DESCRIPTION
### What does it do?
Fix a second refresh of the grid when opening the combo box reloads the store.

### Why is it needed?
During editing a combo box in the grid the combobox currently has to be opened twice. This happens because the 'load' handler was missing the scope property and the options property was used as scope and the option single: true was not used.

### Related issue(s)/PR(s)
#14966 