### PR TITLE
Changed xtype for description in grids

### DIFF
--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -78,7 +78,7 @@ MODx.grid.FCProfile = function(config) {
             ,dataIndex: 'description'
             ,width: 250
             ,sortable: true
-            ,editor: { xtype: 'textfield' }
+            ,editor: { xtype: 'textarea' }
         },{
             header: _('usergroups')
             ,dataIndex: 'usergroups'

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -36,7 +36,7 @@ MODx.grid.FCSet = function(config) {
             ,editable: true
             ,sortable: true
             ,editor: {
-                xtype: 'textfield',
+                xtype: 'textarea',
                 renderer: true
             }
         },{

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -71,7 +71,7 @@ MODx.grid.AccessPolicy = function(config) {
             header: _('description')
             ,dataIndex: 'description'
             ,width: 375
-            ,editor: { xtype: 'textfield' }
+            ,editor: { xtype: 'textarea' }
         },{
             header: _('policy_template')
             ,dataIndex: 'template_name'

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -71,7 +71,7 @@ MODx.grid.AccessPolicyTemplate = function(config) {
             header: _('description')
             ,dataIndex: 'description'
             ,width: 375
-            ,editor: { xtype: 'textfield' }
+            ,editor: { xtype: 'textarea' }
             ,sortable: true
         },{
             header: _('template_group')

--- a/manager/assets/modext/widgets/security/modx.grid.role.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.js
@@ -35,7 +35,7 @@ MODx.grid.Role = function(config) {
             header: _('description')
             ,dataIndex: 'description'
             ,width: 350
-            ,editor: { xtype: 'textfield' }
+            ,editor: { xtype: 'textarea' }
         },{
             header: _('authority')
             ,dataIndex: 'authority'

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -79,7 +79,7 @@ MODx.grid.Context = function(config) {
             ,dataIndex: 'description'
             ,width: 575
             ,sortable: false
-            ,editor: { xtype: 'textfield' }
+            ,editor: { xtype: 'textarea' }
         },{
             header: _('rank')
             ,dataIndex: 'rank'


### PR DESCRIPTION
### What does it do?
Changed xtype for description in grids.

A large text can be specified in the description (the field has a text or tinytext in the database), so that it is more convenient to edit it in the grid, I changed `xtype` to `textarea`.

For some grids, xtype is already set to textarea: sources, widgets & providers.
p.s. This is just the output of the description in the grid. It does not affect the description itself. 

A grid of contexts, for example:
Before:
![sources_grid_3](https://user-images.githubusercontent.com/12523676/85140834-85311100-b24e-11ea-8a7e-362c303793ef.png)

After:
![grid_desc_2](https://user-images.githubusercontent.com/12523676/85416981-c8092680-b577-11ea-89a9-ac603253014f.png)

### Why is it needed?
UI / UX Improvement

### Related issue(s)/PR(s)
None