### PR TITLE
Corrected position of context menu in media browser

### DIFF
--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -485,7 +485,7 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
                 return false;
             }
             this._addContextMenuItem(menu);
-            m.show(n,'tl-c?');
+            m.showAt(e.xy);
         }
         m.activeNode = n;
     }


### PR DESCRIPTION
### What does it do?
Corrected the position of the context menu in MODX media browser.
The position of the context menu is always set relative to the center of the element. But this is not convenient, especially if the items are displayed in a list.

Before:
![browser_menu_1](https://user-images.githubusercontent.com/12523676/85528306-621eac80-b614-11ea-8a12-43733d0a1cbc.gif)

After:
![browser_menu_2](https://user-images.githubusercontent.com/12523676/85528310-634fd980-b614-11ea-9b38-2fe36f2a305a.gif)

### Why is it needed?
UI/UX

### Related issue(s)/PR(s)
None
