### PR TITLE
Changed hiding/showing "Input Option Values" and added allowBlank check

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -561,10 +561,24 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
     }
 
     ,showInputProperties: function(cb,rc,i) {
-        var element = Ext.getCmp('modx-tv-elements');
-        if (element) {
-            element.show();
+        var tvTypesWithOptions = ['checkbox', 'list-multiple-legacy', 'listbox-multiple', 'listbox', 'option', 'tag'],
+            tvType = Ext.getCmp('modx-tv-type').value,
+            tvOptions = Ext.getCmp('modx-tv-elements'),
+            tvOptionsLabel = Ext.select('label[for="' + tvOptions.id + '"]'),
+            tvOptionsBlank = true;
+
+        if (tvTypesWithOptions.indexOf(tvType) === -1) {
+            tvOptions.hide();
+            tvOptionsLabel.hide();
+        } else {
+            tvOptionsBlank = false;
+            tvOptions.show();
+            tvOptionsLabel.show();
         }
+
+        Ext.apply(tvOptions, {
+            allowBlank: tvOptionsBlank,
+        });
 
         this.markPanelDirty();
         var pu = Ext.get('modx-input-props').getUpdater();

--- a/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
@@ -11,13 +11,6 @@ var params = {
 {literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-// Show "Input Option Values"
-var element = Ext.getCmp('modx-tv-elements');
-var element_label = Ext.select('label[for="' + element.id + '"]');
-if (element) {
-    element.show();
-    element_label.show();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
@@ -11,13 +11,6 @@ var params = {
 {literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-// Show "Input Option Values"
-var element = Ext.getCmp('modx-tv-elements');
-var element_label = Ext.select('label[for="' + element.id + '"]');
-if (element) {
-    element.show();
-    element_label.show();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
@@ -11,13 +11,6 @@ var params = {
 {literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-// Show "Input Option Values"
-var element = Ext.getCmp('modx-tv-elements');
-var element_label = Ext.select('label[for="' + element.id + '"]');
-if (element) {
-    element.show();
-    element_label.show();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
@@ -11,13 +11,6 @@ var params = {
 {literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-// Show "Input Option Values"
-var element = Ext.getCmp('modx-tv-elements');
-var element_label = Ext.select('label[for="' + element.id + '"]');
-if (element) {
-    element.show();
-    element_label.show();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
@@ -11,13 +11,6 @@ var params = {
 {literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-// Show "Input Option Values"
-var element = Ext.getCmp('modx-tv-elements');
-var element_label = Ext.select('label[for="' + element.id + '"]');
-if (element) {
-    element.show();
-    element_label.show();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
@@ -10,11 +10,6 @@ var params = {
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
 
-var element = Ext.getCmp('modx-tv-elements');
-if (element) {
-  element.hide();
-}
-
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'

--- a/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
@@ -11,13 +11,6 @@ var params = {
 {literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
-// Show "Input Option Values"
-var element = Ext.getCmp('modx-tv-elements');
-var element_label = Ext.select('label[for="' + element.id + '"]');
-if (element) {
-    element.show();
-    element_label.show();
-}
 
 MODx.load({
     xtype: 'panel'

--- a/manager/templates/default/element/tv/renders/inputproperties/url.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/url.tpl
@@ -9,6 +9,7 @@ var params = {
 {/foreach}{literal}
 };
 var oc = {'change':{fn:function(){Ext.getCmp('modx-panel-tv').markDirty();},scope:this}};
+
 MODx.load({
     xtype: 'panel'
     ,layout: 'form'


### PR DESCRIPTION
### What does it do?
Changed hiding/showing "Input Option Values" and added allowBlank check.
- Now "Input Option Values" check in one place, no code in TV renders.
- Added allowBlank check for "Input Option Values". Previously, it was possible to create, for example, checkboxes, but not set "Input Option Values" and there was an empty TV in resource form.

![tv_input_options](https://user-images.githubusercontent.com/12523676/85704352-e17db000-b6e8-11ea-9a37-c864e4af703d.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15016
