### PR TITLE
Prevent path traversal when sending registry message

### DIFF
--- a/_build/test/Tests/Model/Registry/modFileRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modFileRegisterTest.php
@@ -124,6 +124,12 @@ class modFileRegisterTest extends MODxTestCase {
                 array('a' => 1, 'b' => 2.0, 'c' => 3.25, 'd' => 4.1390, 'e' => 5),
                 array()
             ),
+            array(
+                false,
+                '/topic5/',
+                array('../../invalidMessageKey' => 'invalid'),
+                array()
+            ),
         );
     }
 
@@ -199,6 +205,13 @@ class modFileRegisterTest extends MODxTestCase {
             array(
                 array(1, 2.0, 3.25, 4.1390, 5),
                 '/topic4/',
+                array(
+                    'poll_limit' => 1,
+                )
+            ),
+            array(
+                array(),
+                '/topic5/',
                 array(
                     'poll_limit' => 1,
                 )

--- a/core/model/modx/registry/modfileregister.class.php
+++ b/core/model/modx/registry/modfileregister.class.php
@@ -253,6 +253,10 @@ class modFileRegister extends modRegister {
                             $expires = isset($options['ttl']) && !empty($options['ttl']) ? time() + intval($options['ttl']) : 0;
                             $kill = isset($options['kill']) ? (boolean) $options['kill'] : false;
                             if (!is_int($msgIdx)) {
+                                if (strpos($msgIdx, '../') !== false) {
+                                    $this->modx->log(modX::LOG_LEVEL_ERROR, "Directory traversal attempt in register message key; message skipped with key {$msgIdx}");
+                                    break;
+                                }
                                 $msgKey = $msgIdx;
                             } else {
                                 $msgKey = strftime('%Y%m%dT%H%M%S', $timestamp) . '-' . sprintf("%03d", $msgIdx);


### PR DESCRIPTION
### What does it do?
Prevents a carefully crafted message key provided to the modFileRegister->send() method from writing files above the registry directory location if the message key contains path traversal syntax.

### Why is it needed?
modFileRegister will write a file above the registry directory when a message key is provided that includes path traversal syntax, i.e. `../`. This can result in PHP files written anywhere on a file system that is permissible by the PHP process. Though it is not likely this could be exploited for anything beyond annoyance, it still needs to be prevented.

### Related issue(s)/PR(s)
N/A