### PR TITLE
[3x] Enable GitHub Dependabot version updates for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### What does it do?
Create dependabot.yml with configuration for the composer package ecosystem.

### Why is it needed?
We can use [GitHub Dependabot](https://help.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically) to keep the packages MODX use updated to the latest versions.

### Related issue(s)/PR(s)
None

### Note
Dependabot alerts for dependencies on the default branch, this means it will work once 3.x becomes the default branch.