### PR TITLE
Prevent XSS in template name in TVs grid of template access

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -34,6 +34,7 @@ MODx.grid.TemplateVarTemplate = function(config) {
             ,dataIndex: 'templatename'
             ,width: 150
             ,sortable: true
+            ,renderer: Ext.util.Format.htmlEncode
         },{
             header: _('category')
             ,dataIndex: 'category_name'


### PR DESCRIPTION
### What does it do?
Prevent XSS in template name in TVs grid of template access

### Why is it needed?
Prevent XSS

### Related issue(s)/PR(s)
#15133 