### PR TITLE
Corrected TV form with the Listbox (Single Select) type

### DIFF
--- a/manager/templates/default/element/tv/renders/input/listbox-single.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-single.tpl
@@ -1,9 +1,8 @@
 <select id="tv{$tv->id}" name="tv{$tv->id}">
-{foreach from=$opts item=item}
-	<option value="{$item.value}" {if $item.selected} selected="selected"{/if}>{$item.text}</option>
-{/foreach}
+    {foreach from=$opts item=item}
+        <option value="{$item.value}" {if $item.selected} selected="selected"{/if}>{$item.text}</option>
+    {/foreach}
 </select>
-
 
 <script type="text/javascript">
 // <![CDATA[
@@ -16,24 +15,24 @@ Ext.onReady(function() {
         ,id: 'tv{$tv->id}'
         ,triggerAction: 'all'
         ,width: 400
+        ,maxHeight: 300
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
-
-        {if $params.title|default},title: '{$params.title|default}'{/if}
-        {if $params.listWidth|default},listWidth: {$params.listWidth|default}{/if}
-        ,maxHeight: {if $params.maxHeight|default}{$params.maxHeight|default}{else}300{/if}
         {if $params.typeAhead == 1 || $params.typeAhead == 'true'}
+            ,editable: true
             ,typeAhead: true
             ,typeAheadDelay: {if $params.typeAheadDelay|default && $params.typeAheadDelay|default != ''}{$params.typeAheadDelay|default}{else}250{/if}
         {else}
             ,editable: false
             ,typeAhead: false
         {/if}
+        {if $params.title|default}
+            ,title: '{$params.title|default}'
+        {/if}
         {if $params.listEmptyText|default}
             ,listEmptyText: '{$params.listEmptyText|default}'
         {/if}
         ,forceSelection: {if $params.forceSelection|default && $params.forceSelection|default != 'false'}true{else}false{/if}
         ,msgTarget: 'under'
-
     {literal}
         ,listeners: { 'select': { fn:MODx.fireResourceFormChange, scope:this}}
     });

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
@@ -33,7 +33,7 @@ MODx.load({
         ,name: 'inopt_allowBlank'
         ,hiddenName: 'inopt_allowBlank'
         ,id: 'inopt_allowBlank{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['allowBlank']) ? !(params['allowBlank'] === 0 || params['allowBlank'] === 'false') : true
         ,listeners: oc
     },{
@@ -42,63 +42,51 @@ MODx.load({
         ,html: _('required_desc')
         ,cls: 'desc-under'
     },{
-        xtype: 'textfield'
-        ,fieldLabel: _('combo_listwidth')
-        ,description: MODx.expandHelp ? '' : _('combo_listwidth_desc')
-        ,name: 'inopt_listWidth'
-        ,id: 'inopt_listWidth{/literal}{$tv|default}{literal}'
-        ,value: params['listWidth'] || ''
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_listWidth{/literal}{$tv|default}{literal}'
-        ,html: _('combo_listwidth_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('combo_title')
-        ,description: MODx.expandHelp ? '' : _('combo_title_desc')
-        ,name: 'inopt_title'
-        ,id: 'inopt_title{/literal}{$tv|default}{literal}'
-        ,value: params['title'] || ''
-        ,anchor: '100%'
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_title{/literal}{$tv|default}{literal}'
-        ,html: _('combo_title_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'combo-boolean'
-        ,fieldLabel: _('combo_typeahead')
-        ,description: MODx.expandHelp ? '' : _('combo_typeahead_desc')
-        ,name: 'inopt_typeAhead'
-        ,hiddenName: 'inopt_typeAhead'
-        ,id: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
-        ,width: 200
-        ,value: (params['typeAhead']) ? !(params['typeAhead'] === 0 || params['typeAhead'] === 'false') : false
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
-        ,html: _('combo_typeahead_desc')
-        ,cls: 'desc-under'
-    },{
-        xtype: 'textfield'
-        ,fieldLabel: _('combo_typeahead_delay')
-        ,description: MODx.expandHelp ? '' : _('combo_typeahead_delay_desc')
-        ,name: 'inopt_typeAheadDelay'
-        ,id: 'inopt_typeAheadDelay{/literal}{$tv|default}{literal}'
-        ,value: params['typeAheadDelay'] || 250
-        ,width: 200
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_typeAheadDelay{/literal}{$tv|default}{literal}'
-        ,html: _('combo_typeahead_delay_desc')
-        ,cls: 'desc-under'
-
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'combo-boolean'
+                ,fieldLabel: _('combo_typeahead')
+                ,description: MODx.expandHelp ? '' : _('combo_typeahead_desc')
+                ,name: 'inopt_typeAhead'
+                ,hiddenName: 'inopt_typeAhead'
+                ,id: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
+                ,anchor: '100%'
+                ,value: (params['typeAhead']) ? !(params['typeAhead'] === 0 || params['typeAhead'] === 'false') : false
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
+                ,html: _('combo_typeahead_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('combo_typeahead_delay')
+                ,description: MODx.expandHelp ? '' : _('combo_typeahead_delay_desc')
+                ,name: 'inopt_typeAheadDelay'
+                ,id: 'inopt_typeAheadDelay{/literal}{$tv|default}{literal}'
+                ,value: params['typeAheadDelay'] || 250
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_typeAheadDelay{/literal}{$tv|default}{literal}'
+                ,html: _('combo_typeahead_delay_desc')
+                ,cls: 'desc-under'
+            }]
+        }]
     },{
         xtype: 'combo-boolean'
         ,fieldLabel: _('combo_forceselection')
@@ -106,7 +94,7 @@ MODx.load({
         ,name: 'inopt_forceSelection'
         ,hiddenName: 'inopt_forceSelection'
         ,id: 'inopt_forceSelection{/literal}{$tv|default}{literal}'
-        ,width: 200
+        ,anchor: '100%'
         ,value: (params['forceSelection']) ? !(params['forceSelection'] === 0 || params['forceSelection'] === 'false') : false
         ,listeners: oc
     },{
@@ -114,21 +102,51 @@ MODx.load({
         ,forId: 'inopt_forceSelection{/literal}{$tv|default}{literal}'
         ,html: _('combo_forceselection_desc')
         ,cls: 'desc-under'
-
     },{
-        xtype: 'textfield'
-        ,fieldLabel: _('combo_listempty_text')
-        ,description: MODx.expandHelp ? '' : _('combo_listempty_text_desc')
-        ,name: 'inopt_listEmptyText'
-        ,id: 'inopt_listEmptyText{/literal}{$tv|default}{literal}'
-        ,value: params['listEmptyText'] || ''
-        ,anchor: '100%'
-        ,listeners: oc
-    },{
-        xtype: MODx.expandHelp ? 'label' : 'hidden'
-        ,forId: 'inopt_listEmptyText{/literal}{$tv|default}{literal}'
-        ,html: _('combo_listempty_text_desc')
-        ,cls: 'desc-under'
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('combo_title')
+                ,description: MODx.expandHelp ? '' : _('combo_title_desc')
+                ,name: 'inopt_title'
+                ,id: 'inopt_title{/literal}{$tv|default}{literal}'
+                ,value: params['title'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_title{/literal}{$tv|default}{literal}'
+                ,html: _('combo_title_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('combo_listempty_text')
+                ,description: MODx.expandHelp ? '' : _('combo_listempty_text_desc')
+                ,name: 'inopt_listEmptyText'
+                ,id: 'inopt_listEmptyText{/literal}{$tv|default}{literal}'
+                ,value: params['listEmptyText'] || ''
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_listEmptyText{/literal}{$tv|default}{literal}'
+                ,html: _('combo_listempty_text_desc')
+                ,cls: 'desc-under'
+            }]
+        }]
     }]
     ,renderTo: 'tv-input-properties-form{/literal}{$tv|default}{literal}'
 });


### PR DESCRIPTION
### What does it do?
Corrected TV form with the Listbox (Single Select) type:
- Changed the order
- Related items grouped
- **Removed not working params in TV render in resource**: `listWidth` and `maxHeight`

**Before:**
![tv-list-1](https://user-images.githubusercontent.com/12523676/86519080-06d49180-be40-11ea-8ea0-fa1ebce7c283.png)

**After:**
![tv-list-2](https://user-images.githubusercontent.com/12523676/86519082-076d2800-be40-11ea-80e9-8c339d2a4d70.png)

### Why is it needed?
Improves UI / UX

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15044
https://github.com/modxcms/revolution/pull/15043
https://github.com/modxcms/revolution/pull/15042
https://github.com/modxcms/revolution/pull/15009