### PR TITLE
Created a second media source to /assets/ folder and set it by default

### DIFF
--- a/_build/data/transport.core.media_sources.php
+++ b/_build/data/transport.core.media_sources.php
@@ -14,3 +14,28 @@ $collection[1]->fromArray([
   'class_key' => 'MODX\Revolution\Sources\modFileMediaSource',
   'properties' => [],
 ], '', true, true);
+$collection[2]= $xpdo->newObject(modMediaSource::class);
+$collection[2]->fromArray([
+  'id' => 2,
+  'name' => 'Assets',
+  'description' => '',
+  'class_key' => 'MODX\Revolution\Sources\modFileMediaSource',
+  'properties' => [
+    'basePath' => [
+        'name' => 'basePath',
+        'desc' => 'prop_file.basePath_desc',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '[[++assets_url]]',
+        'lexicon' => 'core:source',
+    ],
+    'baseUrl' => [
+        'name' => 'baseUrl',
+        'desc' => 'prop_file.baseUrl_desc',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '[[++assets_url]]',
+        'lexicon' => 'core:source',
+    ],
+  ],
+], '', true, true);

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -418,7 +418,7 @@ $settings['default_duplicate_publish_option']->fromArray([
 $settings['default_media_source']= $xpdo->newObject(modSystemSetting::class);
 $settings['default_media_source']->fromArray([
   'key' => 'default_media_source',
-  'value' => 1,
+  'value' => 2,
   'xtype' => 'modx-combo-source',
   'namespace' => 'core',
   'area' => 'manager',


### PR DESCRIPTION
### What does it do?
Created a second media source and linked it to the `/assets/` folder and set it by default.
This is relevant for the new MODX3 installation.

### Why is it needed?
In MODX, the FIlesystem source is set by default, but any user can see the system files in the file viewer, which is not correct (if user access is not set).
And also, if the sources for TV are incorrectly set, then all uploaded files will go to the root folder, cluttering up the root, and here you can, by mistake, delete the system files with the uploaded ones.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14307