### PR TITLE
Improve Navigation for Access Control Lists > User Groups & Users

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Improve Navigation for Access Control Lists > User Groups & Users [#15159]
 - Various quick search improvements [#15158]
 - Improve layout of additional options for TV List Box (Single Select) type [#15150]
 - Remove allowNegative parameter for TV with number type [#15119]

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -367,11 +367,16 @@ MODx.grid.UserGroupUsers = function(config) {
             }, scope: this }
         }]
         ,tbar: [{
+            text: _('user_group_update')
+            ,cls:'primary-button'
+            ,handler: this.updateUserGroup
+            ,hidden: (MODx.perm.usergroup_edit == 0 || config.ownerCt.id != 'modx-tree-panel-usergroup')
+        },'->',{
             text: _('user_group_user_add')
             ,cls:'primary-button'
             ,handler: this.addMember
             ,hidden: MODx.perm.usergroup_user_edit == 0
-        },'->',{
+        },{
             xtype: 'textfield'
             ,id: 'modx-ugu-filter-username'
             ,cls: 'x-form-filter'
@@ -444,6 +449,11 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
                 },scope:this}
             }
         });
+    }
+
+    ,updateUserGroup: function() {
+        var id = this.config.usergroup;
+        MODx.loadPage('security/usergroup/update', 'id=' + id);
     }
 
     ,addMember: function(btn,e) {

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -40,7 +40,7 @@ MODx.panel.UserGroup = function(config) {
                 ,items: [{
                     xtype: 'panel'
                     ,border: false
-                    ,cls:'main-wrapper'
+                    ,cls: 'main-wrapper'
                     ,layout: 'form'
                     ,items: [{
                         layout: 'column'
@@ -137,7 +137,7 @@ MODx.panel.UserGroup = function(config) {
                     ,xtype: 'modx-description'
                 },{
                     xtype: 'modx-grid-user-group-users'
-                    ,cls:'main-wrapper'
+                    ,cls: 'main-wrapper'
                     ,preventRender: true
                     ,usergroup: config.record.id
                     ,autoHeight: true
@@ -185,7 +185,7 @@ MODx.panel.UserGroup = function(config) {
                             ,preventRender: true
                             ,usergroup: config.record.id
                             ,autoHeight: true
-                            ,cls:'main-wrapper'
+                            ,cls: 'main-wrapper'
                             ,listeners: {
                                 'afterRemoveRow': {fn:this.markDirty,scope:this}
                                 ,'afteredit': {fn:this.markDirty,scope:this}
@@ -203,7 +203,7 @@ MODx.panel.UserGroup = function(config) {
                             ,xtype: 'modx-description'
                         },{
                             xtype: 'modx-grid-user-group-resource-group'
-                            ,cls:'main-wrapper'
+                            ,cls: 'main-wrapper'
                             ,preventRender: true
                             ,usergroup: config.record.id
                             ,autoHeight: true
@@ -225,7 +225,7 @@ MODx.panel.UserGroup = function(config) {
                             ,xtype: 'modx-description'
                         },{
                             xtype: 'modx-grid-user-group-category'
-                            ,cls:'main-wrapper'
+                            ,cls: 'main-wrapper'
                             ,preventRender: true
                             ,usergroup: config.record.id
                             ,autoHeight: true
@@ -247,7 +247,7 @@ MODx.panel.UserGroup = function(config) {
                             ,xtype: 'modx-description'
                         },{
                             xtype: 'modx-grid-user-group-source'
-                            ,cls:'main-wrapper'
+                            ,cls: 'main-wrapper'
                             ,preventRender: true
                             ,usergroup: config.record.id
                             ,autoHeight: true
@@ -269,7 +269,7 @@ MODx.panel.UserGroup = function(config) {
                             ,xtype: 'modx-description'
                         },{
                             xtype: 'modx-grid-user-group-namespace'
-                            ,cls:'main-wrapper'
+                            ,cls: 'main-wrapper'
                             ,preventRender: true
                             ,usergroup: config.record.id
                             ,autoHeight: true
@@ -368,12 +368,12 @@ MODx.grid.UserGroupUsers = function(config) {
         }]
         ,tbar: [{
             text: _('user_group_update')
-            ,cls:'primary-button'
+            ,cls: 'primary-button'
             ,handler: this.updateUserGroup
             ,hidden: (MODx.perm.usergroup_edit == 0 || config.ownerCt.id != 'modx-tree-panel-usergroup')
         },'->',{
             text: _('user_group_user_add')
-            ,cls:'primary-button'
+            ,cls: 'primary-button'
             ,handler: this.addUser
             ,hidden: MODx.perm.usergroup_user_edit == 0
         },{
@@ -423,15 +423,9 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
         return m;
     }
 
-    ,searchUser: function(tf,nv,ov) {
-        this.getStore().baseParams['username'] = Ext.getCmp('modx-ugu-filter-username').getValue();
-        this.getBottomToolbar().changePage(1);
-    }
-
-    ,clearFilter: function(btn,e) {
-        Ext.getCmp('modx-ugu-filter-username').setValue('');
-        this.getStore().baseParams['username'] = '';
-        this.getBottomToolbar().changePage(1);
+    ,updateUserGroup: function() {
+        var id = this.config.usergroup;
+        MODx.loadPage('security/usergroup/update', 'id=' + id);
     }
 
     ,updateRole: function(btn,e) {
@@ -449,11 +443,6 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
                 },scope:this}
             }
         });
-    }
-
-    ,updateUserGroup: function() {
-        var id = this.config.usergroup;
-        MODx.loadPage('security/usergroup/update', 'id=' + id);
     }
 
     ,addUser: function(btn,e) {
@@ -492,6 +481,17 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
                 'success': {fn:this.refresh,scope:this}
             }
         });
+    }
+
+    ,searchUser: function(tf,nv,ov) {
+        this.getStore().baseParams['username'] = Ext.getCmp('modx-ugu-filter-username').getValue();
+        this.getBottomToolbar().changePage(1);
+    }
+
+    ,clearFilter: function(btn,e) {
+        Ext.getCmp('modx-ugu-filter-username').setValue('');
+        this.getStore().baseParams['username'] = '';
+        this.getBottomToolbar().changePage(1);
     }
 });
 Ext.reg('modx-grid-user-group-users',MODx.grid.UserGroupUsers);

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -145,7 +145,7 @@ MODx.panel.UserGroup = function(config) {
                     ,listeners: {
                         'afterRemoveRow': {fn:this.markDirty,scope:this}
                         ,'updateRole': {fn:this.markDirty,scope:this}
-                        ,'addMember': {fn:this.markDirty,scope:this}
+                        ,'addUser': {fn:this.markDirty,scope:this}
                     }
                 }]
             },{
@@ -374,7 +374,7 @@ MODx.grid.UserGroupUsers = function(config) {
         },'->',{
             text: _('user_group_user_add')
             ,cls:'primary-button'
-            ,handler: this.addMember
+            ,handler: this.addUser
             ,hidden: MODx.perm.usergroup_user_edit == 0
         },{
             xtype: 'textfield'
@@ -404,7 +404,7 @@ MODx.grid.UserGroupUsers = function(config) {
         }]
     });
     MODx.grid.UserGroupUsers.superclass.constructor.call(this,config);
-    this.addEvents('updateRole','addMember');
+    this.addEvents('updateRole','addUser');
 };
 Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
     getMenu: function() {
@@ -456,7 +456,7 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
         MODx.loadPage('security/usergroup/update', 'id=' + id);
     }
 
-    ,addMember: function(btn,e) {
+    ,addUser: function(btn,e) {
         var r = {usergroup:this.config.usergroup};
 
         if (!this.windows['modx-window-user-group-adduser']) {
@@ -467,7 +467,7 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
                 ,listeners: {
                     'success': {fn:function(r) {
                         this.refresh();
-                        this.fireEvent('addMember',r);
+                        this.fireEvent('addUser',r);
                     },scope:this}
                 }
             });


### PR DESCRIPTION
### What does it do?
Added a button "Update User Group" for "ACL" section.
As suggested in https://github.com/modxcms/revolution/issues/15148#issuecomment-659629172 added a button, this option is easier.
After discussion and merging into the 3.0 branch I will add for the 2.0 branch as well.

And in the future, it is worth completely rewriting the section in the form of a grid.

Before:
![user_groups_1](https://user-images.githubusercontent.com/12523676/87782598-80ef1800-c83b-11ea-89da-6251aa895ce3.png)

After:
![users_groups_2](https://user-images.githubusercontent.com/12523676/87782602-82204500-c83b-11ea-85e6-13cb582c1964.gif)

### Why is it needed?
In the current version, it’s almost impossible to understand where to edit a specific “User Group”, because the editing link is hidden in the context menu.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/15148
