### PR TITLE
Register woff2 format in system settings

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1904,7 +1904,7 @@ $settings['unauthorized_page']->fromArray(array (
 $settings['upload_files']= $xpdo->newObject('modSystemSetting');
 $settings['upload_files']->fromArray(array (
   'key' => 'upload_files',
-  'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot,scss,less,css.map,webp,woff2',
+  'value' => 'txt,html,htm,xml,js,js.map,css,scss,less,css.map,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,webp,odt,ods,odp,odb,odg,odf,md,ttf,woff,woff2,eot',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1904,7 +1904,7 @@ $settings['unauthorized_page']->fromArray(array (
 $settings['upload_files']= $xpdo->newObject('modSystemSetting');
 $settings['upload_files']->fromArray(array (
   'key' => 'upload_files',
-  'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot,scss,less,css.map,webp',
+  'value' => 'txt,html,htm,xml,js,css,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,odt,ods,odp,odb,odg,odf,md,ttf,woff,eot,scss,less,css.map,webp,woff2',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',

--- a/setup/includes/upgrades/common/2.8.0-update-upload_files-woff2.php
+++ b/setup/includes/upgrades/common/2.8.0-update-upload_files-woff2.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Common upgrade script for modify upload_files System Setting
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+$keys = ['upload_files'];
+
+foreach ($keys as $key) {
+    $success = false;
+
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject('modSystemSetting', array('key' => $key));
+    if ($setting) {
+        $value = $setting->get('value');
+        $tmp = explode(',', $value);
+        if (in_array('woff2', $tmp)) {
+            continue;
+        } else {
+            $setting->set('value', $value . ',woff2');
+            if ($setting->save()) {
+                $success = true;
+            }
+        }
+    }
+
+    if ($success) {
+        $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+            sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_update_success', ['key' => $key])));
+    } else {
+        $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+            sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_update_failed', ['key' => $key])));
+    }
+}

--- a/setup/includes/upgrades/mysql/2.8.0-pl.php
+++ b/setup/includes/upgrades/mysql/2.8.0-pl.php
@@ -1,3 +1,4 @@
 <?php
 /* run upgrades common to all db platforms */
 include dirname(__DIR__) . '/common/2.8.0-update-upload_files-upload_images.php';
+include dirname(__DIR__) . '/common/2.8.0-update-upload_files-woff2.php';

--- a/setup/includes/upgrades/sqlsrv/2.8.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/2.8.0-pl.php
@@ -1,3 +1,4 @@
 <?php
 /* run upgrades common to all db platforms */
 include dirname(__DIR__) . '/common/2.8.0-update-upload_files-upload_images.php';
+include dirname(__DIR__) . '/common/2.8.0-update-upload_files-woff2.php';


### PR DESCRIPTION
### What does it do?
Registers the woff2 format in the default settings to allow downloads.

### Why is it needed?
Registration of woff2 format in the Types of upload files setting upload_files for working with formats out of the "box"

### Related issue(s)/PR(s)
NA