### PR TITLE
Clean up JS files

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -457,7 +457,7 @@ Ext.extend(MODx,Ext.Component,{
 					}
 				}]
 			}]
-        });w
+        });
         MODx.helpWindow.show(b);
         return true;
     }

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -98,8 +98,8 @@ Ext.extend(MODx,Ext.Component,{
 
     ,initMarkRequiredFields: function() {
         var markdom = '<span class=\"field-required-mark\">*</span> ';
-            
-        var MarkRequiredFieldPlugin = function (config) { 
+
+        var MarkRequiredFieldPlugin = function (config) {
             config = config || {};
             Ext.apply(config, {
                 init: function(cmp) {
@@ -120,11 +120,11 @@ Ext.extend(MODx,Ext.Component,{
                     }
                 }
             });
-            MarkRequiredFieldPlugin.superclass.constructor.call(this, config); 
+            MarkRequiredFieldPlugin.superclass.constructor.call(this, config);
         }
-        Ext.extend(MarkRequiredFieldPlugin, Ext.BoxComponent); 
+        Ext.extend(MarkRequiredFieldPlugin, Ext.BoxComponent);
         Ext.ComponentMgr.registerPlugin('markrequiredfields',MarkRequiredFieldPlugin);
-        
+
         if (!Array.isArray(Ext.form.Field.prototype.plugins)) {
             Ext.form.Field.prototype.plugins = [];
         }
@@ -275,23 +275,23 @@ Ext.extend(MODx,Ext.Component,{
 			,listeners: {
 				'success': {
 					fn:function() {
-						var tree = Ext.getCmp("modx-resource-tree"); 
-						
+						var tree = Ext.getCmp("modx-resource-tree");
+
 						if (tree && tree.rendered) {
 							tree.refresh();
 						}
 
 						var cmp = Ext.getCmp("modx-panel-resource");
-						
+
 						if (cmp) {
 							Ext.getCmp('modx-abtn-locked').hide();
-							Ext.getCmp('modx-abtn-save').show();	
+							Ext.getCmp('modx-abtn-save').show();
 						}
 					},
 					scope:this
 				}
 			}
-		});  
+		});
     }
 
     ,sleep: function(ms) {
@@ -457,8 +457,7 @@ Ext.extend(MODx,Ext.Component,{
 					}
 				}]
 			}]
-			//,html: '<iframe src="' + url + '" width="100%" height="100%" frameborder="0"></iframe>'
-        });
+        });w
         MODx.helpWindow.show(b);
         return true;
     }
@@ -924,7 +923,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
     initState: function(state) {
         if (state instanceof Object) {
             Ext.iterate(state, function(name, value, o) {
-                this.state[name] = value;//this.decodeValue(value);
+                this.state[name] = value;
             }, this)
         } else {
             this.state = {};

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -330,7 +330,6 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                 }
                 if (animate && window.innerWidth > 640) {
                     var tree = Ext.getCmp('modx-leftbar-tabpanel').getEl();
-                    // tree.dom.style.visibility = 'hidden';
                     tree.dom.style.opacity = 0;
                     this.el.dom.style.left = '-' + this.el.dom.style.width;
                 } else {

--- a/manager/assets/modext/sections/context/update.js
+++ b/manager/assets/modext/sections/context/update.js
@@ -20,7 +20,6 @@ MODx.page.UpdateContext = function(config) {
             ,id: 'modx-abtn-save'
             ,cls:'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || "s"
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/chunk/create.js
+++ b/manager/assets/modext/sections/element/chunk/create.js
@@ -46,7 +46,6 @@ MODx.page.CreateChunk = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/chunk/update.js
+++ b/manager/assets/modext/sections/element/chunk/update.js
@@ -116,7 +116,6 @@ Ext.extend(MODx.page.UpdateChunk,MODx.Component, {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/plugin/create.js
+++ b/manager/assets/modext/sections/element/plugin/create.js
@@ -46,7 +46,6 @@ MODx.page.CreatePlugin = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/plugin/update.js
+++ b/manager/assets/modext/sections/element/plugin/update.js
@@ -116,7 +116,6 @@ Ext.extend(MODx.page.UpdatePlugin,MODx.Component, {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/snippet/create.js
+++ b/manager/assets/modext/sections/element/snippet/create.js
@@ -1,6 +1,6 @@
 /**
  * Loads the create snippet page
- * 
+ *
  * @class MODx.page.CreateSnippet
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -46,7 +46,6 @@ MODx.page.CreateSnippet = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/snippet/update.js
+++ b/manager/assets/modext/sections/element/snippet/update.js
@@ -116,7 +116,6 @@ Ext.extend(MODx.page.UpdateSnippet,MODx.Component, {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/template/create.js
+++ b/manager/assets/modext/sections/element/template/create.js
@@ -46,7 +46,6 @@ MODx.page.CreateTemplate = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/template/update.js
+++ b/manager/assets/modext/sections/element/template/update.js
@@ -116,7 +116,6 @@ Ext.extend(MODx.page.UpdateTemplate,MODx.Component, {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/tv/create.js
+++ b/manager/assets/modext/sections/element/tv/create.js
@@ -46,7 +46,6 @@ MODx.page.CreateTV = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/element/tv/update.js
+++ b/manager/assets/modext/sections/element/tv/update.js
@@ -117,7 +117,6 @@ Ext.extend(MODx.page.UpdateTV,MODx.Component, {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/fc/profile/update.js
+++ b/manager/assets/modext/sections/fc/profile/update.js
@@ -21,7 +21,6 @@ MODx.page.UpdateFCProfile = function(config) {
             ,id: 'modx-abtn-save'
             ,cls:'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
@@ -39,7 +38,6 @@ MODx.page.UpdateFCProfile = function(config) {
         ,components: [{
             xtype: 'modx-panel-fc-profile'
             ,record: config.record || {}
-            //,baseParams: { action: 'update' ,id: config.id }
         }]
 	});
 	MODx.page.UpdateFCProfile.superclass.constructor.call(this,config);

--- a/manager/assets/modext/sections/fc/set/update.js
+++ b/manager/assets/modext/sections/fc/set/update.js
@@ -21,7 +21,6 @@ MODx.page.UpdateFCSet = function(config) {
             ,id: 'modx-abtn-save'
             ,cls:'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
@@ -39,7 +38,6 @@ MODx.page.UpdateFCSet = function(config) {
         ,components: [{
             xtype: 'modx-panel-fc-set'
             ,record: config.record || {}
-            //,baseParams: { action: 'update' ,id: config.id }
         }]
 	});
 	MODx.page.UpdateFCSet.superclass.constructor.call(this,config);

--- a/manager/assets/modext/sections/resource/create.js
+++ b/manager/assets/modext/sections/resource/create.js
@@ -64,7 +64,6 @@ Ext.extend(MODx.page.CreateResource,MODx.Component,{
             ,id: 'modx-abtn-save'
             ,cls:'primary-button'
             ,method: 'remote'
-            //,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/resource/update.js
+++ b/manager/assets/modext/sections/resource/update.js
@@ -106,7 +106,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('Resource/Update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(true);
@@ -126,7 +125,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             }
             ,listeners: {
                 success: {fn:function(r) {
-                    //MODx.loadPage('Resource/Update', 'id='+r.object.id);
                     var panel = Ext.getCmp('modx-panel-resource');
                     if (panel) {
                         panel.handlePreview(false);
@@ -236,7 +234,6 @@ Ext.extend(MODx.page.UpdateResource,MODx.Component,{
             ,cls: 'primary-button'
             ,method: 'remote'
             ,hidden: !(config.canSave == 1)
-            //,checkDirty: MODx.request.reload ? false : true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/security/access/policy/template/update.js
+++ b/manager/assets/modext/sections/security/access/policy/template/update.js
@@ -21,7 +21,6 @@ MODx.page.UpdateAccessPolicyTemplate = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
@@ -36,7 +35,7 @@ MODx.page.UpdateAccessPolicyTemplate = function(config) {
             ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
-        ,components: [{ 
+        ,components: [{
             xtype: 'modx-panel-access-policy-template'
             ,template: config.template
             ,record: config.record || {}

--- a/manager/assets/modext/sections/security/access/policy/update.js
+++ b/manager/assets/modext/sections/security/access/policy/update.js
@@ -21,7 +21,6 @@ MODx.page.UpdateAccessPolicy = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true
@@ -36,7 +35,7 @@ MODx.page.UpdateAccessPolicy = function(config) {
             ,id: 'modx-abtn-help'
             ,handler: MODx.loadHelpPane
         }]
-        ,components: [{ 
+        ,components: [{
             xtype: 'modx-panel-access-policy'
             ,policy: config.policy
             ,record: config.record || {}

--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -18,7 +18,6 @@ MODx.page.Profile = function(config) {
             ,cls: 'primary-button'
             ,redirect: false
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/security/user/create.js
+++ b/manager/assets/modext/sections/security/user/create.js
@@ -1,6 +1,6 @@
 /**
- * Loads the create user page 
- * 
+ * Loads the create user page
+ *
  * @class MODx.page.CreateUser
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -18,7 +18,6 @@ MODx.page.CreateUser = function(config) {
             ,cls: 'primary-button'
             ,redirect: false
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/security/user/update.js
+++ b/manager/assets/modext/sections/security/user/update.js
@@ -1,6 +1,6 @@
 /**
  * Loads the update user page
- * 
+ *
  * @class MODx.page.UpdateUser
  * @extends MODx.Component
  * @param {Object} config An object of config properties
@@ -21,7 +21,6 @@ MODx.page.UpdateUser = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/security/usergroup/update.js
+++ b/manager/assets/modext/sections/security/usergroup/update.js
@@ -17,7 +17,6 @@ MODx.page.UpdateUserGroup = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/source/update.js
+++ b/manager/assets/modext/sections/source/update.js
@@ -13,7 +13,6 @@ MODx.page.UpdateSource = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/system/dashboards/create.js
+++ b/manager/assets/modext/sections/system/dashboards/create.js
@@ -14,7 +14,6 @@ MODx.page.CreateDashboard = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/system/dashboards/update.js
+++ b/manager/assets/modext/sections/system/dashboards/update.js
@@ -13,7 +13,6 @@ MODx.page.UpdateDashboard = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/system/dashboards/widget/create.js
+++ b/manager/assets/modext/sections/system/dashboards/widget/create.js
@@ -14,7 +14,6 @@ MODx.page.CreateDashboardWidget = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/sections/system/dashboards/widget/update.js
+++ b/manager/assets/modext/sections/system/dashboards/widget/update.js
@@ -13,7 +13,6 @@ MODx.page.UpdateDashboardWidget = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: false
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,ctrl: true

--- a/manager/assets/modext/util/datetime.js
+++ b/manager/assets/modext/util/datetime.js
@@ -80,7 +80,6 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
     ,hideTime: false
 
 
-    // {{{
     /**
      * @private
      * creates DateField and TimeField and installs the necessary event handlers
@@ -156,9 +155,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
 
         this.on('specialkey', this.onSpecialKey, this);
 
-    } // eo function initComponent
-    // }}}
-    // {{{
+    }
     /**
      * @private
      * Renders underlying DateField and TimeField and provides a workaround for side error icon bug
@@ -191,18 +188,11 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
 
         this.tableEl = t;
         this.wrap = t.wrap({cls:'x-form-field-wrap x-datetime-wrap'});
-//        this.wrap = t.wrap();
         this.wrap.on("mousedown", this.onMouseDown, this, {delay:10});
 
         // render DateField & TimeField
         this.df.render(t.child('td.ux-datetime-date'));
         this.tf.render(t.child('td.ux-datetime-time'));
-
-        // workaround for IE trigger misalignment bug
-        // see http://extjs.com/forum/showthread.php?p=341075#post341075
-//        if(Ext.isIE && Ext.isStrict) {
-//            t.select('input').applyStyles({top:0});
-//        }
 
         this.df.el.swallowEvent(['keydown', 'keypress']);
         this.tf.el.swallowEvent(['keydown', 'keypress']);
@@ -221,8 +211,6 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             };
             Ext.apply(this.df, o);
             Ext.apply(this.tf, o);
-//            this.df.errorIcon = this.errorIcon;
-//            this.tf.errorIcon = this.errorIcon;
         }
 
         // setup name for submit
@@ -238,40 +226,30 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         // update hidden field
         this.updateHidden();
 
-    } // eo function onRender
-    // }}}
-    // {{{
+    }
     /**
      * @private
      */
     ,adjustSize:Ext.BoxComponent.prototype.adjustSize
-    // }}}
-    // {{{
     /**
      * @private
      */
     ,alignErrorIcon:function() {
         this.errorIcon.alignTo(this.tableEl, 'tl-tr', [2, 0]);
     }
-    // }}}
-    // {{{
     /**
      * @private initializes internal dateValue
      */
     ,initDateValue:function() {
         this.dateValue = this.otherToNow ? new Date() : new Date(1970, 0, 1, 0, 0, 0);
     }
-    // }}}
-    // {{{
     /**
      * Calls clearInvalid on the DateField and TimeField
      */
     ,clearInvalid:function(){
         this.df.clearInvalid();
         this.tf.clearInvalid();
-    } // eo function clearInvalid
-    // }}}
-    // {{{
+    }
     /**
      * Calls markInvalid on both DateField and TimeField
      * @param {String} msg Invalid message to display
@@ -279,9 +257,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
     ,markInvalid:function(msg){
         this.df.markInvalid(msg);
         this.tf.markInvalid(msg);
-    } // eo function markInvalid
-    // }}}
-    // {{{
+    }
     /**
      * @private
      * called from Component::destroy.
@@ -289,16 +265,13 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
      */
     ,beforeDestroy:function() {
         if(this.isRendered) {
-//            this.removeAllListeners();
             this.wrap.removeAllListeners();
             this.wrap.remove();
             this.tableEl.remove();
             this.df.destroy();
             this.tf.destroy();
         }
-    } // eo function beforeDestroy
-    // }}}
-    // {{{
+    }
     /**
      * Disable this component.
      * @return {Ext.Component} this
@@ -314,9 +287,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         this.tf.disabled = true;
         this.fireEvent("disable", this);
         return this;
-    } // eo function disable
-    // }}}
-    // {{{
+    }
     /**
      * Enable this component.
      * @return {Ext.Component} this
@@ -331,60 +302,46 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         this.tf.disabled = false;
         this.fireEvent("enable", this);
         return this;
-    } // eo function enable
-    // }}}
-    // {{{
+    }
     /**
      * @private Focus date filed
      */
     ,focus:function() {
         this.df.focus();
-    } // eo function focus
-    // }}}
-    // {{{
+    }
     /**
      * @private
      */
     ,getPositionEl:function() {
         return this.wrap;
     }
-    // }}}
-    // {{{
     /**
      * @private
      */
     ,getResizeEl:function() {
         return this.wrap;
     }
-    // }}}
-    // {{{
     /**
      * @return {Date/String} Returns value of this field
      */
     ,getValue:function() {
         // create new instance of date
         return this.dateValue ? new Date(this.dateValue) : '';
-    } // eo function getValue
-    // }}}
-    // {{{
+    }
     /**
      * @return {Boolean} true = valid, false = invalid
      * @private Calls isValid methods of underlying DateField and TimeField and returns the result
      */
     ,isValid:function() {
         return this.df.isValid() && this.tf.isValid();
-    } // eo function isValid
-    // }}}
-    // {{{
+    }
     /**
      * Returns true if this component is visible
      * @return {boolean}
      */
     ,isVisible : function(){
         return this.df.rendered && this.df.getActionEl().isVisible();
-    } // eo function isVisible
-    // }}}
-    // {{{
+    }
     /**
      * @private Handles blur event
      */
@@ -420,9 +377,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             }
         }).defer(100, this);
 
-    } // eo function onBlur
-    // }}}
-    // {{{
+    }
     /**
      * @private Handles focus event
      */
@@ -433,8 +388,6 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             this.fireEvent("focus", this);
         }
     }
-    // }}}
-    // {{{
     /**
      * @private Just to prevent blur event when clicked in the middle of fields
      */
@@ -443,8 +396,6 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             this.wrapClick = 'td' === e.target.nodeName.toLowerCase();
         }
     }
-    // }}}
-    // {{{
     /**
      * @private
      * Handles Tab and Shift-Tab events
@@ -467,9 +418,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             this.updateValue();
         }
 
-    } // eo function onSpecialKey
-    // }}}
-    // {{{
+    }
     /**
      * Resets the current field value to the originally loaded value
      * and clears any validation messages. See Ext.form.BasicForm.trackResetOnLoad
@@ -477,9 +426,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
     ,reset:function() {
         this.df.setValue(this.originalValue);
         this.tf.setValue(this.originalValue);
-    } // eo function reset
-    // }}}
-    // {{{
+    }
     /**
      * @private Sets the value of DateField
      */
@@ -488,9 +435,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             date = date.add(Date.MINUTE, 60 * new Number(this.offset_time));
         }
         this.df.setValue(date);
-    } // eo function setDate
-    // }}}
-    // {{{
+    }
     /**
      * @private Sets the value of TimeField
      */
@@ -499,9 +444,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             date = date.add(Date.MINUTE, 60 * new Number(this.offset_time));
         }
         this.tf.setValue(date);
-    } // eo function setTime
-    // }}}
-    // {{{
+    }
     /**
      * @private
      * Sets correct sizes of underlying DateField and TimeField
@@ -528,9 +471,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
                 this.tf.el.up('td').setWidth(this.timeWidth);
             }
         }
-    } // eo function setSize
-    // }}}
-    // {{{
+    }
     /**
      * @param {Mixed} val Value to set
      * Sets the value of this field
@@ -571,9 +512,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             }
         }
         this.updateValue();
-    } // eo function setValue
-    // }}}
-    // {{{
+    }
     /**
      * Hide or show this component by boolean
      * @return {Ext.Component} this
@@ -587,19 +526,13 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             this.tf.hide();
         }
         return this;
-    } // eo function setVisible
-    // }}}
-    //{{{
+    }
     ,show:function() {
         return this.setVisible(true);
-    } // eo function show
-    //}}}
-    //{{{
+    }
     ,hide:function() {
         return this.setVisible(false);
-    } // eo function hide
-    //}}}
-    // {{{
+    }
     /**
      * @private Updates the date part
      */
@@ -616,15 +549,12 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             this.dateValue.setMonth(0); // because of leap years
             this.dateValue.setFullYear(d.getFullYear());
             this.dateValue.setMonth(d.getMonth(), d.getDate());
-//            this.dateValue.setDate(d.getDate());
         }
         else {
             this.dateValue = '';
             this.setTime('');
         }
-    } // eo function updateDate
-    // }}}
-    // {{{
+    }
     /**
      * @private
      * Updates the time part
@@ -650,9 +580,7 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
                 this.dateValue.setSeconds(0);
             }
         }
-    } // eo function updateTime
-    // }}}
-    // {{{
+    }
     /**
      * @private Updates the underlying hidden field value
      */
@@ -665,8 +593,6 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
             this.el.dom.value = value;
         }
     }
-    // }}}
-    // {{{
     /**
      * @private Updates all of Date, Time and Hidden
      */
@@ -674,18 +600,14 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         this.updateDate();
         this.updateTime();
         this.updateHidden();
-    } // eo function updateValue
-    // }}}
-    // {{{
+    }
     /**
      * @return {Boolean} true = valid, false = invalid
      * calls validate methods of DateField and TimeField
      */
     ,validate:function() {
         return this.df.validate() && this.tf.validate();
-    } // eo function validate
-    // }}}
-    // {{{
+    }
     /**
      * Returns renderer suitable to render this field
      * @param {Object} Column model config
@@ -697,10 +619,9 @@ Ext.ux.form.DateTime = Ext.extend(Ext.form.Field, {
         return function(val) {
             return Ext.util.Format.date(val, format);
         };
-    } // eo function renderer
-    // }}}
+    }
 
-}); // eo extend
+});
 
 // register xtype
 Ext.reg('xdatetime', Ext.ux.form.DateTime);

--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -247,18 +247,6 @@
                 style: "cursor: pointer; display: inline-block; opacity: 0; position: absolute; top: 0; left: 0; width: 100%; height: 100%;",
                 multiple: true
             });
-            // this can all be done via the inline css above
-            // doing it like this prevents a too big hidden file field creating weird hover behavoir on the buttons
-            // this.input_file.setOpacity(0.0);
-
-            // var button_box = this.el.getBox();
-            // this.input_file.setStyle('font-size', (button_box.height * 1) + 'px');
-
-            // var adj = {x: -3, y: -3};
-
-            // this.input_file.setLeft(adj.x + 'px');
-            // this.input_file.setTop(adj.y + 'px');
-            // this.input_file.setOpacity(0.0);
 
             if (this.handleMouseEvents) {
                 this.input_file.on('mouseover', this.onMouseOver, this);

--- a/manager/assets/modext/util/uploaddialog.js
+++ b/manager/assets/modext/util/uploaddialog.js
@@ -18,10 +18,10 @@ Ext.ux.Utils.EventQueue = function(handler, scope) {
   this.scope = scope || window;
   this.queue = [];
   this.is_processing = false;
-  
+
   /**
    * Posts event into the queue.
-   * 
+   *
    * @access public
    * @param mixed event Event identificator.
    * @param mixed data  Event data.
@@ -33,11 +33,11 @@ Ext.ux.Utils.EventQueue = function(handler, scope) {
       this.process();
     }
   }
-  
+
   this.flushEventQueue = function() {
     this.queue = [];
   },
-  
+
   /**
    * @access private
    */
@@ -53,7 +53,7 @@ Ext.ux.Utils.EventQueue = function(handler, scope) {
 
 /**
  * This class implements Mili's finite state automata behaviour.
- *  
+ *
  *  Transition / output table format:
  *  {
  *    'state_1' : {
@@ -65,9 +65,9 @@ Ext.ux.Utils.EventQueue = function(handler, scope) {
  *          a|action: function|array, // Transition action, optional, default to Ext.emptyFn.
  *                                    // If array then methods will be called sequentially.
  *                                    // Action signature is (data, event, this).
- *          s|state: 'state_x',       // New state - transition destination, optional, default to 
+ *          s|state: 'state_x',       // New state - transition destination, optional, default to
  *                                    // current state.
- *          scope: object             // Predicate and action scope, optional, default to 
+ *          scope: object             // Predicate and action scope, optional, default to
  *                                    // trans_table_scope or window.
  *        }
  *      ]
@@ -91,19 +91,19 @@ Ext.ux.Utils.FSA = function(initial_state, trans_table, trans_table_scope) {
 };
 Ext.extend(Ext.ux.Utils.FSA, Ext.ux.Utils.EventQueue,{
   current_state : null,
-  trans_table : null,  
+  trans_table : null,
   trans_table_scope : null,
-  
+
   /**
    * Returns current state
-   * 
+   *
    * @access public
    * @return mixed Current state.
    */
   state : function() {
     return this.current_state;
   },
-  
+
   /**
    * @access public
    */
@@ -119,33 +119,33 @@ Ext.extend(Ext.ux.Utils.FSA, Ext.ux.Utils.EventQueue,{
       var action = transition.action || transition.a || Ext.emptyFn;
       var new_state = transition.state || transition.s || this.current_state;
       var scope = transition.scope || this.trans_table_scope;
-      
+
       if (this.computePredicate(predicate, scope, data, event)) {
         this.callAction(action, scope, data, event);
-        this.current_state = new_state; 
+        this.current_state = new_state;
         return;
       }
     }
-    
+
     throw "State '" + this.current_state + "' has no transition for event '" + event + "' in current context";
   },
-  
+
   /**
    * @access private
    */
   currentStateEventTransitions : function(event) {
-    return this.trans_table[this.current_state] ? 
+    return this.trans_table[this.current_state] ?
       this.trans_table[this.current_state][event] || false
       :
       false;
   },
-  
+
   /**
    * @access private
    */
   computePredicate : function(predicate, scope, data, event) {
-    var result = false; 
-    
+    var result = false;
+
     switch (Ext.type(predicate)) {
      case 'function':
        result = predicate.call(scope, data, event, this);
@@ -183,7 +183,7 @@ Ext.extend(Ext.ux.Utils.FSA, Ext.ux.Utils.EventQueue,{
     }
     return result;
   },
-  
+
   /**
    * @access private
    */
@@ -223,8 +223,6 @@ Ext.extend(Ext.ux.Utils.FSA, Ext.ux.Utils.EventQueue,{
   }
 });
 
-// ---------------------------------------------------------------------------------------------- //
-
 /**
  * Ext.ux.UploadDialog namespace.
  */
@@ -234,16 +232,16 @@ Ext.namespace('Ext.ux.UploadDialog');
  * File upload browse button.
  *
  * @class Ext.ux.UploadDialog.BrowseButton
- */ 
+ */
 Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
   input_name : 'file',
-  
+
   input_file : null,
-  
+
   original_handler : null,
-  
+
   original_scope : null,
-  
+
   /**
    * @access private
    */
@@ -255,7 +253,7 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
     this.handler = null;
     this.scope = null;
   },
-  
+
   /**
    * @access private
    */
@@ -264,7 +262,7 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
     Ext.ux.UploadDialog.BrowseButton.superclass.onRender.call(this, ct, position);
     this.createInputFile();
   },
-  
+
   /**
    * @access private
    */
@@ -272,7 +270,7 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
   {
     var button_container = this.el;
         button_container.position('relative');
-       this.wrap = this.el.wrap({cls:'tbody'});    
+       this.wrap = this.el.wrap({cls:'tbody'});
        this.input_file = this.wrap.createChild({
            tag: 'input',
             type: 'file',
@@ -281,7 +279,7 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
             style: "position: absolute; display: block; border: none; cursor: pointer"
         });
         this.input_file.setOpacity(0.0);
-    
+
     var button_box = button_container.getBox();
     this.input_file.setStyle('font-size', (button_box.width * 0.5) + 'px');
 
@@ -290,38 +288,38 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
     if (Ext.isIE) {
       adj = {x: 0, y: 3}
     }
-    
+
     this.input_file.setLeft(button_box.width - input_box.width + adj.x + 'px');
     this.input_file.setTop(button_box.height - input_box.height + adj.y + 'px');
     this.input_file.setOpacity(0.0);
-        
+
     if (this.handleMouseEvents) {
       this.input_file.on('mouseover', this.onMouseOver, this);
         this.input_file.on('mousedown', this.onMouseDown, this);
     }
-    
+
     if(this.tooltip){
       if(typeof this.tooltip == 'object'){
         Ext.QuickTips.register(Ext.apply({target: this.input_file}, this.tooltip));
-      } 
+      }
       else {
         this.input_file.dom[this.tooltipType] = this.tooltip;
         }
       }
-    
+
     this.input_file.on('change', this.onInputFileChange, this);
-    this.input_file.on('click', function(e) { e.stopPropagation(); }); 
+    this.input_file.on('click', function(e) { e.stopPropagation(); });
   },
-  
+
   /**
    * @access public
    */
   detachInputFile : function(no_create)
   {
     var result = this.input_file;
-    
+
     no_create = no_create || false;
-    
+
     if (typeof this.tooltip == 'object') {
       Ext.QuickTips.unregister(this.input_file);
     }
@@ -330,13 +328,13 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
     }
     this.input_file.removeAllListeners();
     this.input_file = null;
-    
+
     if (!no_create) {
       this.createInputFile();
     }
     return result;
   },
-  
+
   /**
    * @access public
    */
@@ -344,16 +342,16 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
   {
     return this.input_file;
   },
-  
+
   /**
    * @access public
    */
   disable : function()
   {
-    Ext.ux.UploadDialog.BrowseButton.superclass.disable.call(this);  
+    Ext.ux.UploadDialog.BrowseButton.superclass.disable.call(this);
     this.input_file.dom.disabled = true;
   },
-  
+
   /**
    * @access public
    */
@@ -362,7 +360,7 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
     Ext.ux.UploadDialog.BrowseButton.superclass.enable.call(this);
     this.input_file.dom.disabled = false;
   },
-  
+
   /**
    * @access public
    */
@@ -371,9 +369,9 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
     var input_file = this.detachInputFile(true);
     input_file.remove();
     input_file = null;
-    Ext.ux.UploadDialog.BrowseButton.superclass.destroy.call(this);      
+    Ext.ux.UploadDialog.BrowseButton.superclass.destroy.call(this);
   },
-  
+
   /**
    * @access private
    */
@@ -382,7 +380,7 @@ Ext.ux.UploadDialog.BrowseButton = Ext.extend(Ext.Button,{
     if (this.original_handler) {
       this.original_handler.call(this.original_scope, this);
     }
-  }  
+  }
 });
 
 /**
@@ -403,7 +401,7 @@ Ext.ux.UploadDialog.TBBrowseButton = Ext.extend(Ext.ux.UploadDialog.BrowseButton
 /**
  * Record type for dialogs grid.
  *
- * @class Ext.ux.UploadDialog.FileRecord 
+ * @class Ext.ux.UploadDialog.FileRecord
  */
 Ext.ux.UploadDialog.FileRecord = Ext.data.Record.create([
   {name: 'filename'},
@@ -427,7 +425,6 @@ Ext.ux.UploadDialog.Dialog = function(config) {
     border: false,
     width: 600,
     height: 350,
-    // minWidth: 450,
     minHeight: 350,
     plain: true,
     constrainHeader: true,
@@ -436,14 +433,13 @@ Ext.ux.UploadDialog.Dialog = function(config) {
     maximizable: false,
     minimizable: false,
     resizable: true,
-    
+
         layout:'fit',
         region:'center',
     autoDestroy: true,
     closeAction: 'hide',
     title: this.i18n.title,
     cls: 'ext-ux-uploaddialog-dialog',
-    // --------
     url: '',
     base_params: {},
     permitted_extensions: [],
@@ -455,39 +451,36 @@ Ext.ux.UploadDialog.Dialog = function(config) {
   };
   config = Ext.applyIf(config || {}, default_config);
   config.layout = 'absolute';
-  
+
   Ext.ux.UploadDialog.Dialog.superclass.constructor.call(this, config);
 };
 
 Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
   fsa : null,
-  
+
   state_tpl : null,
-  
+
   form : null,
-  
+
   grid_panel : null,
-  
+
   progress_bar : null,
-  
+
   is_uploading : false,
-  
+
   initial_queued_count : 0,
-  
+
   upload_frame : null,
-  
+
   /**
    * @access private
    */
-  //--------------------------------------------------------------------------------------------- //
   initComponent : function() {
     Ext.ux.UploadDialog.Dialog.superclass.initComponent.call(this);
-    
+
     // Setting automata protocol
     var tt = {
-      // --------------
       'created' : {
-      // --------------
         'window-render' : [
           {
             action: [this.createForm, this.createProgressBar, this.createGrid],
@@ -501,9 +494,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           }
         ]
       },
-      // --------------
       'rendering' : {
-      // --------------
         'grid-render' : [
           {
             action: [this.fillToolbar, this.updateToolbar],
@@ -517,9 +508,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           }
         ]
       },
-      // --------------
       'ready' : {
-      // --------------
         'file-selected' : [
           {
             predicate: [this.fireFileTestEvent, this.isPermittedFile],
@@ -549,7 +538,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           {
             predicate: this.hasUnuploadedFiles,
             action: [
-              this.setUploadingFlag, this.saveInitialQueuedCount, this.updateToolbar, 
+              this.setUploadingFlag, this.saveInitialQueuedCount, this.updateToolbar,
               this.updateProgressBar, this.prepareNextUploadTask, this.fireUploadStartEvent
             ],
             state: 'uploading'
@@ -560,7 +549,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
         ],
         'stop-upload' : [
           {
-            // We are not uploading, do nothing. Can be posted by user only at this state. 
+            // We are not uploading, do nothing. Can be posted by user only at this state.
           }
         ],
         'hide' : [
@@ -579,14 +568,12 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           }
         ]
       },
-      // --------------
       'adding-file' : {
-      // --------------
         'file-added' : [
           {
             predicate: this.isUploading,
             action: [this.incInitialQueuedCount, this.updateProgressBar, this.fireFileAddEvent],
-            state: 'uploading' 
+            state: 'uploading'
           },
           {
             predicate: this.getUploadAutostart,
@@ -599,9 +586,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           }
         ]
       },
-      // --------------
       'uploading' : {
-      // --------------
         'file-selected' : [
           {
             predicate: [this.fireFileTestEvent, this.isPermittedFile],
@@ -619,21 +604,21 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
         ],
         'start-upload' : [
           {
-            // Can be posted only by user in this state. 
+            // Can be posted only by user in this state.
           }
         ],
         'stop-upload' : [
           {
             predicate: this.hasUnuploadedFiles,
             action: [
-              this.resetUploadingFlag, this.abortUpload, this.updateToolbar, 
+              this.resetUploadingFlag, this.abortUpload, this.updateToolbar,
               this.updateProgressBar, this.fireUploadStopEvent
             ],
             state: 'ready'
           },
           {
             action: [
-              this.resetUploadingFlag, this.abortUpload, this.updateToolbar, 
+              this.resetUploadingFlag, this.abortUpload, this.updateToolbar,
               this.updateProgressBar, this.fireUploadStopEvent, this.fireUploadCompleteEvent
             ],
             state: 'ready'
@@ -648,14 +633,14 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           {
             predicate: this.hasUnuploadedFiles,
             action: [
-              this.resetUploadFrame, this.updateRecordState, this.updateProgressBar, 
+              this.resetUploadFrame, this.updateRecordState, this.updateProgressBar,
               this.prepareNextUploadTask, this.fireUploadSuccessEvent
             ]
           },
           {
             action: [
-              this.resetUploadFrame, this.resetUploadingFlag, this.updateRecordState, 
-              this.updateToolbar, this.updateProgressBar, this.fireUploadSuccessEvent, 
+              this.resetUploadFrame, this.resetUploadingFlag, this.updateRecordState,
+              this.updateToolbar, this.updateProgressBar, this.fireUploadSuccessEvent,
               this.fireUploadCompleteEvent
             ],
             state: 'ready'
@@ -665,14 +650,14 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           {
             predicate: this.hasUnuploadedFiles,
             action: [
-              this.resetUploadFrame, this.updateRecordState, this.updateProgressBar, 
+              this.resetUploadFrame, this.updateRecordState, this.updateProgressBar,
               this.prepareNextUploadTask, this.fireUploadErrorEvent
             ]
           },
           {
             action: [
-              this.resetUploadFrame, this.resetUploadingFlag, this.updateRecordState, 
-              this.updateToolbar, this.updateProgressBar, this.fireUploadErrorEvent, 
+              this.resetUploadFrame, this.resetUploadingFlag, this.updateRecordState,
+              this.updateToolbar, this.updateProgressBar, this.fireUploadErrorEvent,
               this.fireUploadCompleteEvent
             ],
             state: 'ready'
@@ -682,14 +667,14 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
           {
             predicate: this.hasUnuploadedFiles,
             action: [
-              this.resetUploadFrame, this.updateRecordState, this.updateProgressBar, 
+              this.resetUploadFrame, this.updateRecordState, this.updateProgressBar,
               this.prepareNextUploadTask, this.fireUploadFailedEvent
             ]
           },
           {
             action: [
-              this.resetUploadFrame, this.resetUploadingFlag, this.updateRecordState, 
-              this.updateToolbar, this.updateProgressBar, this.fireUploadFailedEvent, 
+              this.resetUploadFrame, this.resetUploadingFlag, this.updateRecordState,
+              this.updateToolbar, this.updateProgressBar, this.fireUploadFailedEvent,
               this.fireUploadCompleteEvent
             ],
             state: 'ready'
@@ -717,18 +702,16 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
             action: [
               this.resetUploadingFlag, this.abortUpload,
               this.fireUploadStopEvent, this.fireUploadCompleteEvent, this.flushEventQueue
-            ], 
+            ],
             state: 'destroyed'
           }
         ]
       },
-      // --------------
       'destroyed' : {
-      // --------------
       }
     };
     this.fsa = new Ext.ux.Utils.FSA('created', tt, this);
-    
+
     // Registering dialog events.
     this.addEvents({
       'filetest': true
@@ -743,19 +726,19 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       ,'uploadcomplete' : true
       ,'fileuploadstart' : true
     });
-    
+
     // Attaching to window events.
     this.on('render', this.onWindowRender, this);
     this.on('beforehide', this.onWindowBeforeHide, this);
     this.on('hide', this.onWindowHide, this);
     this.on('destroy', this.onWindowDestroy, this);
-    
+
     // Compiling state template.
     this.state_tpl = new Ext.Template(
       "<div class='ext-ux-uploaddialog-state ext-ux-uploaddialog-state-{state}'> </div>"
     ).compile();
   },
-  
+
   createForm : function()
   {
     this.form = Ext.DomHelper.append(this.body, {
@@ -765,7 +748,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       style: 'position: absolute; left: -100px; top: -100px; width: 100px; height: 100px; clear: both;'
     });
   },
-  
+
   createProgressBar : function()
   {
     this.progress_bar = this.add(
@@ -778,7 +761,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       })
     );
   },
-  
+
   createGrid : function()
   {
     var store = new Ext.data.Store({
@@ -787,7 +770,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       sortInfo: {field: 'state', direction: 'DESC'},
       pruneModifiedRecords: true
     });
-    
+
     var cm = new Ext.grid.ColumnModel([
       {
         header: this.i18n.state_col_title,
@@ -806,7 +789,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       },
       {
         header: this.i18n.note_col_title,
-        width: this.i18n.note_col_width, 
+        width: this.i18n.note_col_width,
         dataIndex: 'note',
         sortable: true,
         renderer: this.renderNoteCell.createDelegate(this)
@@ -821,26 +804,26 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       x: 0,
       y: 22,
       border: true,
-      
+
         viewConfig: {
         autoFill: true,
           forceFit: true
         },
-      
+
       bbar : new Ext.Toolbar()
     });
     this.grid_panel.on('render', this.onGridRender, this);
-    
+
     this.add(this.grid_panel);
-    
+
     this.grid_panel.getSelectionModel().on('selectionchange', this.onGridSelectionChange, this);
   },
-  
+
   fillToolbar : function()
   {
     var tb = this.grid_panel.getBottomToolbar();
     tb.x_buttons = {}
-    
+
     tb.x_buttons.add = tb.addItem(new Ext.ux.UploadDialog.TBBrowseButton({
       input_name: this.post_var_name,
       text: this.i18n.add_btn_text,
@@ -855,7 +838,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       iconCls: 'ext-ux-uploaddialog-removebtn',
       handler: this.onRemoveButtonClick,
       scope: this
-    }); 
+    });
     tb.x_buttons.reset = tb.addButton({
       text: this.i18n.reset_btn_text,
       tooltip: this.i18n.reset_btn_tip,
@@ -877,12 +860,12 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       scope: this
     });
   },
-  
+
   renderStateCell : function(data, cell, record, row_index, column_index, store)
   {
     return this.state_tpl.apply({state: data});
   },
-  
+
   renderFilenameCell : function(data, cell, record, row_index, column_index, store)
   {
     var view = this.grid_panel.getView();
@@ -898,7 +881,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     f.defer(1000);
     return data;
   },
-  
+
   renderNoteCell : function(data, cell, record, row_index, column_index, store)
   {
     var view = this.grid_panel.getView();
@@ -914,7 +897,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     f.defer(1000);
     return data;
   },
-  
+
   getFileExtension : function(filename)
   {
     var result = null;
@@ -924,7 +907,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     }
     return result;
   },
-  
+
   isPermittedFileType : function(filename)
   {
     var result = true;
@@ -938,13 +921,13 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
   {
     var result = false;
     var filename = browse_btn.getInputFile().dom.value;
-    
+
     if (this.isPermittedFileType(filename)) {
       result = true;
     }
     else {
       Ext.Msg.alert(
-        this.i18n.error_msgbox_title, 
+        this.i18n.error_msgbox_title,
         String.format(
           this.i18n.err_file_type_not_permitted,
           filename,
@@ -953,23 +936,23 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       );
       result = false;
     }
-    
+
     return result;
   },
-  
+
   fireFileTestEvent : function(browse_btn)
   {
     return this.fireEvent('filetest', this, browse_btn.getInputFile().dom.value) !== false;
   },
-  
+
   addFileToUploadQueue : function(browse_btn)
   {
     var input_file = browse_btn.detachInputFile();
-    
+
     input_file.appendTo(this.form);
     input_file.setStyle('width', '100px');
     input_file.dom.disabled = true;
-    
+
     var store = this.grid_panel.getStore();
     var fileApi = input_file.dom.files;
     var filename = (typeof fileApi != 'undefined') ? fileApi[0].name : input_file.dom.value.replace("C:\\fakepath\\", "");
@@ -981,12 +964,12 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     }));
     this.fsa.postEvent('file-added', input_file.dom.value);
   },
-  
+
   fireFileAddEvent : function(filename)
   {
     this.fireEvent('fileadd', this, filename);
   },
-  
+
   updateProgressBar : function()
   {
     if (this.is_uploading) {
@@ -998,7 +981,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       this.progress_bar.updateProgress(0, this.i18n.progress_waiting_text);
     }
   },
-  
+
   updateToolbar : function() {
     var tb = this.grid_panel.getBottomToolbar();
     if (this.is_uploading) {
@@ -1020,21 +1003,21 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       tb.x_buttons.close.enable();
       tb.x_buttons.upload.setIconClass('ext-ux-uploaddialog-uploadstartbtn');
       tb.x_buttons.upload.setText(this.i18n.upload_btn_start_text);
-      
+
       if (this.getQueuedCount() > 0) {
         tb.x_buttons.upload.enable();
       }
       else {
-        tb.x_buttons.upload.disable();      
+        tb.x_buttons.upload.disable();
       }
-      
+
       if (this.grid_panel.getSelectionModel().hasSelection()) {
         tb.x_buttons.remove.enable();
       }
       else {
         tb.x_buttons.remove.disable();
       }
-      
+
       if (this.grid_panel.getStore().getCount() > 0) {
         tb.x_buttons.reset.enable();
       }
@@ -1043,22 +1026,22 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       }
     }
   },
-  
+
   saveInitialQueuedCount : function()
   {
     this.initial_queued_count = this.getQueuedCount();
   },
-  
+
   incInitialQueuedCount : function()
   {
     this.initial_queued_count++;
   },
-  
+
   setUploadingFlag : function()
   {
     this.is_uploading = true;
-  }, 
-  
+  },
+
   resetUploadingFlag : function()
   {
     this.is_uploading = false;
@@ -1069,7 +1052,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     // Searching for first unuploaded file.
     var store = this.grid_panel.getStore();
     var record = null;
-    
+
     store.each(function(r) {
       if (!record && r.get('state') == Ext.ux.UploadDialog.FileRecord.STATE_QUEUE) {
         record = r;
@@ -1078,20 +1061,20 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
         r.get('input_element').dom.disabled = true;
       }
     });
-    
+
     record.get('input_element').dom.disabled = false;
     record.set('state', Ext.ux.UploadDialog.FileRecord.STATE_PROCESSING);
     record.set('note', this.i18n.note_processing);
     record.commit();
-    
+
     this.fsa.postEvent('file-upload-start', record);
   },
-   
+
   fireUploadStartEvent : function()
   {
     this.fireEvent('uploadstart', this);
   },
-  
+
   removeFiles : function(file_records)
   {
     var store = this.grid_panel.getStore();
@@ -1101,14 +1084,14 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       store.remove(r);
     }
   },
-  
+
   fireFileRemoveEvent : function(file_records)
   {
     for (var i = 0, len = file_records.length; i < len; i++) {
       this.fireEvent('fileremove', this, file_records[i].get('filename'));
     }
   },
-  
+
   resetQueue : function() {
     var store = this.grid_panel.getStore();
     store.each(function(r) {
@@ -1116,11 +1099,11 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     });
     store.removeAll();
   },
-  
+
   fireResetQueueEvent : function() {
     this.fireEvent('resetqueue', this);
   }
-  
+
   ,uploadFile : function(record) {
     Ext.Ajax.request({
       url: this.url
@@ -1134,12 +1117,12 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       ,record: record
     });
   },
-   
+
   fireFileUploadStartEvent : function(record)
   {
     this.fireEvent('fileuploadstart', this, record.get('filename'));
   },
-  
+
   updateRecordState : function(data)
   {
     if ('success' in data.response && data.response.success) {
@@ -1154,40 +1137,40 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
         'note', data.response.message || data.response.error || this.i18n.note_upload_error
       );
     }
-    
+
     data.record.commit();
   },
-  
+
   fireUploadSuccessEvent : function(data)
   {
     this.fireEvent('uploadsuccess', this, data.record.get('filename'), data.response);
   },
-  
+
   fireUploadErrorEvent : function(data)
   {
     this.fireEvent('uploaderror', this, data.record.get('filename'), data.response);
   },
-  
+
   fireUploadFailedEvent : function(data)
   {
     this.fireEvent('uploadfailed', this, data.record.get('filename'));
   },
-  
+
   fireUploadCompleteEvent : function()
   {
     this.fireEvent('uploadcomplete', this);
   },
-  
-  findUploadFrame : function() 
+
+  findUploadFrame : function()
   {
     this.upload_frame = Ext.getBody().child('iframe.x-hidden:last');
   },
-  
+
   resetUploadFrame : function()
   {
     this.upload_frame = null;
   },
-  
+
   removeUploadFrame : function()
   {
     if (this.upload_frame) {
@@ -1197,11 +1180,11 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     }
     this.upload_frame = null;
   },
-  
+
   abortUpload : function()
   {
     this.removeUploadFrame();
-    
+
     var store = this.grid_panel.getStore();
     var record = null;
     store.each(function(r) {
@@ -1210,66 +1193,65 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
         return false;
       }
     });
-    
+
     record.set('state', Ext.ux.UploadDialog.FileRecord.STATE_FAILED);
     record.set('note', this.i18n.note_aborted);
     record.commit();
   },
-  
+
   fireUploadStopEvent : function()
   {
     this.fireEvent('uploadstop', this);
   },
-  
+
   repostHide : function()
   {
     this.fsa.postEvent('hide');
   },
-  
+
   flushEventQueue : function()
   {
     this.fsa.flushEventQueue();
   },
-  
+
   /**
    * @access private
    */
-  // -------------------------------------------------------------------------------------------- //
   onWindowRender : function()
   {
     this.fsa.postEvent('window-render');
   },
-  
+
   onWindowBeforeHide : function()
   {
     return this.isUploading() ? this.getAllowCloseOnUpload() : true;
   },
-  
+
   onWindowHide : function()
   {
     this.fsa.postEvent('hide');
   },
-  
+
   onWindowDestroy : function()
   {
     this.fsa.postEvent('destroy');
   },
-  
+
   onGridRender : function()
   {
     this.fsa.postEvent('grid-render');
   },
-  
+
   onGridSelectionChange : function()
   {
     this.fsa.postEvent('grid-selection-change');
   },
-  
+
   onAddButtonFileSelected : function(btn)
   {
     this.fsa.postEvent('file-selected', btn);
   },
-  
+
   onUploadButtonClick : function()
   {
     if (this.is_uploading) {
@@ -1279,18 +1261,18 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       this.fsa.postEvent('start-upload');
     }
   },
-  
+
   onRemoveButtonClick : function()
   {
     var selections = this.grid_panel.getSelectionModel().getSelections();
     this.fsa.postEvent('remove-files', selections);
   },
-  
+
   onResetButtonClick : function()
   {
     this.fsa.postEvent('reset-queue');
   },
-  
+
   onCloseButtonClick : function()
   {
     this[this.closeAction].call(this);
@@ -1298,27 +1280,27 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
         document.location.reload();
    }
   },
-  
+
   onAjaxSuccess : function(response, options) {
     var json_response = {
       'success' : false,
       'error' : this.i18n.note_upload_error
     }
-    try { 
+    try {
         var rt = response.responseText;
         var filter = rt.match(/^<pre>((?:.|\n)*)<\/pre>$/i);
         if (filter) {
             rt = filter[1];
         }
-        json_response = Ext.util.JSON.decode(rt); 
-    } 
+        json_response = Ext.util.JSON.decode(rt);
+    }
     catch (e) {}
-    
+
     var data = {
       record: options.record,
       response: json_response
     }
-    
+
     if ('success' in json_response && json_response.success) {
       this.fsa.postEvent('file-upload-success', data);
     }
@@ -1326,7 +1308,7 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
       this.fsa.postEvent('file-upload-error', data);
     }
   },
-  
+
   onAjaxFailure : function(response, options)
   {
     var data = {
@@ -1339,97 +1321,96 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
 
     this.fsa.postEvent('file-upload-failed', data);
   },
-  
+
   /**
    * @access public
    */
-  // -------------------------------------------------------------------------------------------- //
   startUpload : function()
   {
     this.fsa.postEvent('start-upload');
   },
-  
+
   stopUpload : function()
   {
     this.fsa.postEvent('stop-upload');
   },
-  
+
   getUrl : function()
   {
     return this.url;
   },
-  
+
   setUrl : function(url)
   {
     this.url = url;
   },
-  
+
   getBaseParams : function()
   {
     return this.base_params;
   },
-  
+
   setBaseParams : function(params)
   {
     this.base_params = params;
   },
-  
+
   getUploadAutostart : function()
   {
     return this.upload_autostart;
   },
-  
+
   setUploadAutostart : function(value)
   {
     this.upload_autostart = value;
   },
-  
+
   ///////////EIGENE ERWEITERUNG RELOAD EXT//////////////////////
-  
+
   getMakeReload : function()
   {
     return this.Make_Reload;
   },
-  
+
   setMakeReload : function(value)
   {
     this.Make_Reload = value;
   }
-  
+
   ///////////EIGENE ERWEITERUNG RELOAD EXT//////////////////////
-   
+
   ,getAllowCloseOnUpload : function() {
     return this.allow_close_on_upload;
   }
-  
+
   ,setAllowCloseOnUpload : function(value) {
     this.allow_close_on_upload;
   }
-  
+
   ,getResetOnHide : function() {
     return this.reset_on_hide;
   }
-  
+
   ,setResetOnHide : function(value) {
     this.reset_on_hide = value;
   }
-  
+
   ,getPermittedExtensions : function() {
     return this.permitted_extensions;
   }
-  
+
   ,setPermittedExtensions : function(value) {
     this.permitted_extensions = value;
   }
-  
+
   ,isUploading : function() {
     return this.is_uploading;
   }
-  
+
   ,isNotEmptyQueue : function() {
     return this.grid_panel.getStore().getCount() > 0;
   }
-  
+
   ,getQueuedCount : function(count_processing) {
     var count = 0;
     var store = this.grid_panel.getStore();
@@ -1443,13 +1424,11 @@ Ext.extend(Ext.ux.UploadDialog.Dialog, Ext.Window,{
     });
     return count;
   }
-  
+
   ,hasUnuploadedFiles : function() {
     return this.getQueuedCount() > 0;
   }
 });
-
-// ---------------------------------------------------------------------------------------------- //
 
 var p = Ext.ux.UploadDialog.Dialog.prototype;
 p.i18n = {

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -289,7 +289,6 @@ Ext.override(Ext.tree.TreeNodeUI,{
             iconMarkup = '<i class="icon'+(a.icon ? " x-tree-node-inline-icon" : "")+(a.iconCls ? " "+a.iconCls : "")+'" unselectable="on"></i>',
             elbowMarkup = n.attributes.pseudoroot ?
                 '<i class="icon-sort-down expanded-icon"></i>' :
-                //'<img alt="" src="'+ this.emptyIcon+ '" class="x-tree-ec-icon x-tree-elbow" />',
                 '<i class="x-tree-ec-icon x-tree-elbow"></i>',
 
             buf =  ['<li class="x-tree-node"><div ext:tree-node-id="',n.id,'" class="x-tree-node-el x-tree-node-leaf x-unselectable ', a.cls,'" unselectable="on">',

--- a/manager/assets/modext/widgets/core/modx.button.js
+++ b/manager/assets/modext/widgets/core/modx.button.js
@@ -19,7 +19,6 @@ MODx.Button = function(config) {
     Ext.applyIf(config,{
         template: new Ext.XTemplate('<span id="{4}" class="x-btn icon {1} {3}" unselectable="on">'+
                                     '   <i class="{2}">'+
-                                //    '       <button type="{0}"></button>'+
                                     '   </i>'+
                                     '</span>').compile()
     });

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -62,7 +62,6 @@ MODx.combo.ComboBox = function(config,getStore) {
             action: 'GetList'
         }
         ,width: 150
-        // ,listWidth: 300
         ,editable: false
         ,resizable: true
         ,typeAhead: false
@@ -257,7 +256,6 @@ MODx.combo.UserGroup = function(config) {
         ,displayField: 'name'
         ,valueField: 'id'
         ,fields: ['name','id','description']
-        // ,listWidth: 300
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -388,7 +386,6 @@ MODx.combo.Template = function(config) {
             action: 'Element/Template/GetList'
             ,combo: 1
         }
-        // ,listWidth: 350
         ,allowBlank: true
     });
     MODx.combo.Template.superclass.constructor.call(this,config);
@@ -441,7 +438,6 @@ MODx.combo.Language = function(config) {
         ,minChars: 1
         ,editable: true
         ,allowBlank: true
-        // ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'System/Language/GetList'
@@ -464,7 +460,6 @@ MODx.combo.Charset = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'System/Charset/GetList'
@@ -487,7 +482,6 @@ MODx.combo.RTE = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'System/Rte/GetList'
@@ -507,7 +501,6 @@ MODx.combo.Role = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -529,7 +522,6 @@ MODx.combo.ContentType = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -601,7 +593,6 @@ MODx.combo.ClassDerivatives = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,pageSize: 20
     });
     MODx.combo.ClassDerivatives.superclass.constructor.call(this,config);
@@ -620,7 +611,6 @@ MODx.combo.Namespace = function(config) {
         ,editable: true
         ,allowBlank: true
         ,preselectValue: false
-        // ,listWidth: 300
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -682,7 +672,6 @@ Ext.extend(MODx.combo.Browser,Ext.form.TriggerField,{
             return false;
         }
 
-        //if (this.browser === null) {
             this.browser = MODx.load({
                 xtype: 'modx-browser'
                 ,closeAction: 'close'
@@ -703,7 +692,6 @@ Ext.extend(MODx.combo.Browser,Ext.form.TriggerField,{
                     },scope:this}
                 }
             });
-        //}
         this.browser.show(btn);
         return true;
     }
@@ -946,7 +934,6 @@ MODx.combo.Dashboard = function(config) {
         ,displayField: 'name'
         ,valueField: 'id'
         ,fields: ['id','name','description']
-        // ,listWidth: 400
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -971,7 +958,6 @@ MODx.combo.MediaSource = function(config) {
         ,displayField: 'name'
         ,valueField: 'id'
         ,fields: ['id','name','description']
-        // ,listWidth: 400
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -996,7 +982,6 @@ MODx.combo.MediaSourceType = function(config) {
         ,displayField: 'name'
         ,valueField: 'class'
         ,fields: ['id','class','name','description']
-        // ,listWidth: 400
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -1023,7 +1008,6 @@ MODx.combo.Authority = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {

--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -5,7 +5,6 @@ MODx.Console = function(config) {
         title: _('console')
         ,modal: Ext.isIE ? false : true
         ,closeAction: 'hide'
-        // ,shadow: true
         ,resizable: false
         ,collapsible: false
         ,closable: true
@@ -62,7 +61,6 @@ MODx.Console = function(config) {
             } catch (e) {}
         }
         this.fireEvent('shutdown');
-        //this.getComponent('body').el.update('');
         this.destroy();
     });
     this.on('complete',this.onComplete,this);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -407,8 +407,6 @@ Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
 
         // Return formatted date (server side)
         return value;
-        // JavaScripts time is in milliseconds
-        //return new Date(value*1000).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);
     }
 });
 Ext.reg('modx-grid-settings',MODx.grid.SettingsGrid);

--- a/manager/assets/modext/widgets/core/modx.orm.js
+++ b/manager/assets/modext/widgets/core/modx.orm.js
@@ -130,7 +130,7 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
     ,addContainer: function(btn,e,node) {
         var r = {};
         if (node) { r.parent = node.id; }
-        
+
         if (!this.windows.addContainer) {
             this.windows.addContainer = MODx.load({
                 xtype: 'modx-orm-window-container-add'
@@ -141,7 +141,7 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
                         if (typeof(r.name) !== 'undefined') {
                             r.name = r.name.replace(/"/g, '');
                         }
-                        
+
                         var n = new Ext.tree.TreeNode({
                             text: r.name
                             ,id: r.name
@@ -166,7 +166,7 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
     ,renameContainer: function(btn,e,node) {
         var r = {};
         if (node) { r.parent = node.id; }
-        
+
         if (!this.windows.renameContainer) {
             this.windows.renameContainer = MODx.load({
                 xtype: 'modx-orm-window-container-rename'
@@ -176,7 +176,7 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
                         if (typeof(r.name) !== 'undefined') {
                             r.name = r.name.replace(/"/g, '');
                         }
-                        
+
                         var nd = this.getSelectedNode();
                         nd.setId(r.name);
                         nd.setText(r.name);
@@ -202,7 +202,7 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
                         if (typeof(r.name) !== 'undefined') {
                             r.name = r.name.replace(/"/g, '');
                         }
-                        
+
                         var n = new Ext.tree.TreeNode({
                             text: r.name+' - <i>'+r.value+'</i>'
                             ,id: r.id
@@ -332,8 +332,6 @@ MODx.window.AddOrmAttribute = function(config) {
     Ext.applyIf(config,{
         title: _('orm_attribute_add')
         ,id: this.ident
-        // ,height: 150
-        // ,width: 350
         ,fields: [{
             xtype: 'hidden'
             ,name: 'parent'
@@ -385,8 +383,6 @@ MODx.window.AddOrmContainer = function(config) {
     Ext.applyIf(config,{
         title: _('orm_container_add')
         ,id: this.ident
-        // ,height: 150
-        // ,width: 350
         ,fields: [{
             xtype: 'hidden'
             ,name: 'parent'
@@ -431,8 +427,6 @@ MODx.window.RenameOrmContainer = function(config) {
     Ext.applyIf(config,{
         title: _('orm_container_rename')
         ,id: this.ident
-        // ,height: 150
-        // ,width: 350
         ,fields: [{
             xtype: 'hidden'
             ,name: 'parent'

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -145,19 +145,6 @@ Ext.extend(MODx.SearchBar, Ext.form.ComboBox, {
 
     // Initialize the keyboard shortcuts to focus the bar (ctrl + alt + /) and hide it (esc)
     setKeyMap: function() {
-        // This keymap is conflicting with typing certain characters, see #11974
-        /*new Ext.KeyMap(document, {
-            key: [191, 0]
-            ,ctrl: true
-            ,alt: true
-            ,handler: function() {
-                this.hideBar();
-                this.toggle();
-            }
-            ,scope: this
-            ,stopEvent: true
-        });*/
-
         // Escape to hide SearchBar
         new Ext.KeyMap(document, {
             key: 27
@@ -232,12 +219,6 @@ Ext.extend(MODx.SearchBar, Ext.form.ComboBox, {
                 deferEmptyText: false
             });
 
-            // Original view listeners
-            // this.mon(this.view, {
-            //    containerclick : this.onViewClick,
-            //    click : this.onViewClick,
-            //    scope :this
-            // });
             this.view.on('click', function(view, index, node, vent) {
                 /**
                  * Force node selection to make sure it is available in onViewClick
@@ -291,44 +272,13 @@ Ext.extend(MODx.SearchBar, Ext.form.ComboBox, {
 
         MODx.loadPage(target);
     }
-    /**
-     * Toggle the search drawer visibility
-     *
-     * @param {Boolean} hide Whether or not to force-hide MODx.SearchBar
-     */
-    /*
-    ,toggle: function(hide) {
-        var uberbar = Ext.get( this.container.id );
-        if (uberbar.hasClass('visible') || hide) {
-            this.blurBar();
-            uberbar.removeClass('visible');
-        } else {
-            uberbar.addClass('visible');
-            this.focusBar();
-        }
-    }
-    */
     ,hideBar: function() {
-        // this.toggle(true);
     }
     ,focusBar: function() {
         this.selectText();
-        // this.animate();
     }
     ,blurBar: function() {
-        // this.animate(true);
     }
-    /**
-     * Animate the input "grow"
-     *
-     * @param {Boolean} blur Whether or not the input loses focus (to "minimize" the input width)
-     */
-    /*
-    ,animate: function(blur) {
-        var to = blur ? this.width : this.maxWidth;
-        this.wrap.setWidth(to, true);
-        this.el.setWidth(to - this.getTriggerWidth(), true);
-    }*/
     /**
      * Compute the available max height so results could be scrollable if required
      *

--- a/manager/assets/modext/widgets/core/modx.tree.asynctreenode.js
+++ b/manager/assets/modext/widgets/core/modx.tree.asynctreenode.js
@@ -11,6 +11,5 @@ MODx.tree.AsyncTreeNode = function(config) {
 Ext.extend(MODx.tree.AsyncTreeNode,Ext.tree.AsyncTreeNode,{
 
 });
-//Ext.tree.AsyncTreeNode = MODx.tree.AsyncTreeNode;
 Ext.reg('modx-tree-asynctreenode',MODx.tree.AsyncTreeNode);
 

--- a/manager/assets/modext/widgets/core/modx.tree.column.js
+++ b/manager/assets/modext/widgets/core/modx.tree.column.js
@@ -10,7 +10,7 @@ Ext.ns('Ext.ux.tree');Ext.ux.tree.ColumnTree=Ext.extend(Ext.tree.TreePanel,{line
 MODx.tree.ColumnTree = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        
+
         rootVisible: false
         ,autoScroll: true
         ,autoHeight: true
@@ -48,17 +48,16 @@ MODx.tree.ColumnTree = function(config) {
 };
 Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
     windows: {}
-    
+
     /**
      * Shows the current context menu.
-     * @param {Ext.tree.TreeNode} node The 
+     * @param {Ext.tree.TreeNode} node The
      * @param {Ext.EventObject} e The event object run.
      */
     ,_showContextMenu: function(node,e) {
         node.select();
         this.cm.activeNode = node;
         this.cm.record = node.attributes;
-        /*this.cm.record.id = node.attributes.pk;*/
         this.cm.removeAll();
         if (node.attributes.menu && node.attributes.menu.items) {
             this._addContextMenuItem(node.attributes.menu.items);
@@ -67,7 +66,7 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
     }
     /**
      * Add context menu items to the tree.
-     * @param {Object, Array} items Either an Object config or array of Object configs.  
+     * @param {Object, Array} items Either an Object config or array of Object configs.
      */
     ,_addContextMenuItem: function(items) {
         var a = items, l = a.length;
@@ -76,8 +75,8 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
             this.cm.add(a[i]);
         }
     }
-    
-    
+
+
     /**
      * Handles all drag events into the tree.
      * @param {Object} dropEvent The node dropped on the parent node.
@@ -90,12 +89,12 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
             ,progress:true
             ,closable:false
         });
-        
+
         MODx.util.Progress.reset();
         for(var i = 1; i < 20; i++) {
             setTimeout('MODx.util.Progress.time('+i+','+MODx.util.Progress.id+')',i*1000);
         }
-        
+
         /**
          * Simplify nodes into JSON format.
          * @param {Object} node
@@ -131,20 +130,20 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
             }
         });
     }
-    
+
     ,reloadNode: function(n) {
         this.getLoader().load(n);
         n.expand();
     }
-    
+
     /**
      * Abstract definition to handle drop events.
      */
     ,_handleDrop: function() { }
-    
+
     ,loadWindow: function(btn,e,win) {
         var r = win.record || this.cm.record;
-        if (!this.windows[win.xtype]) {  
+        if (!this.windows[win.xtype]) {
             Ext.applyIf(win,{
                 record: win.blankValues ? {} : r
                 ,grid: this
@@ -159,8 +158,8 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
         }
         this.windows[win.xtype].show(e.target);
     }
-    
-    
+
+
     ,refresh: function(func,scope,args) {
         this.getLoader().baseParams = this.config.baseParams;
         this.getRootNode().reload();
@@ -172,7 +171,7 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
         }
         return true;
     }
-    
+
     ,refreshActiveNode: function() {
         if (this.cm.activeNode) {
             this.getLoader().load(this.cm.activeNode);
@@ -188,9 +187,9 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
             n.expand();
         }
     }
-    
-    
-    
+
+
+
     ,_getToolbar: function() {
         var iu = MODx.config.template_url+'images/restyle/icons/';
         return [{
@@ -201,10 +200,10 @@ Ext.extend(MODx.tree.ColumnTree,Ext.tree.ColumnTree,{
             ,scope: this
         }];
     }
-    
+
     /**
      * Render the row to a colored Yes/No value.
-     * 
+     *
      * @access public
      * @param {Object} d The data record
      * @param {Object} c The dom properties

--- a/manager/assets/modext/widgets/core/modx.window.js
+++ b/manager/assets/modext/widgets/core/modx.window.js
@@ -32,7 +32,6 @@ Ext.override(Ext.Window, {
         }, 300);
     }
     ,animHide: function() {
-        //this.el.hide(); // dont hide the window here, we'll do that onHide when the animation is finished!
         this.afterHide();
 
     }
@@ -123,7 +122,6 @@ MODx.Window = function(config) {
         ,resizable: true
         ,collapsible: true
         ,maximizable: true
-        // ,autoHeight: true // this messes up many windows on smaller screens (e.g. too much height), ex. macbook air 11"
         ,autoHeight: false
         ,autoScroll: true
         ,allowDrop: true

--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -226,7 +226,6 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
         if (Ext.isEmpty(treeState) && this.root) {
             this.root.expand();
             if (this.root.firstChild && this.config.expandFirst) {
-                //this.root.firstChild.select();
                 this.root.firstChild.expand();
             }
         } else {
@@ -595,7 +594,6 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
 
         var encNodes = Ext.encode(simplifyNodes(dropEvent.tree.root))
             ,source = dropEvent.dropNode;
-        //var target = dropEvent.target;
 
         this.fireEvent('beforeSort',encNodes);
         MODx.Ajax.request({

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -607,7 +607,6 @@ MODx.window.CreateElementProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_create')
         ,id: 'modx-window-element-property-create'
-        // ,height: 250
         ,width: 600
         ,saveBtnText: _('done')
         ,fields: [{
@@ -759,7 +758,6 @@ MODx.window.UpdateElementProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_update')
         ,id: 'modx-window-element-property-update'
-        // ,height: 250
         ,width: 600
         ,saveBtnText: _('done')
         ,forceLayout: true
@@ -932,8 +930,6 @@ MODx.window.CreateElementPropertyOption = function(config) {
     Ext.applyIf(config,{
         title: _('property_option_create')
         ,id: 'modx-window-element-property-option-create'
-        // ,height: 250
-        // ,width: 450
         ,saveBtnText: _('done')
         ,fields: [{
             fieldLabel: _('name')
@@ -1157,7 +1153,6 @@ MODx.window.ImportProperties = function(config) {
             ,name: 'file'
             ,id: 'modx-impp-file'
             ,anchor: '100%'
-            // ,inputType: 'file'
         }]
     });
     MODx.window.ImportProperties.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -330,8 +330,6 @@ MODx.window.AddPluginToEvent = function(config) {
         ,url: MODx.config.connector_url
         ,action: 'element/plugin/event/addplugin'
         ,autoHeight: true
-        // ,height: 250
-        // ,width: 600
         ,fields: [{
             xtype: 'modx-combo-plugin'
             ,fieldLabel: _('plugin')

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -167,7 +167,6 @@ Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
     ,filterByCategory: function(cb,rec,ri) {
         this.getStore().baseParams['category'] = cb.getValue();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,search: function(tf,newValue,oldValue) {
@@ -175,7 +174,6 @@ Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         Ext.getCmp('modx-temptv-filter-category').setValue('');
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -187,7 +185,6 @@ Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
         Ext.getCmp('modx-temptv-filter-category').reset();
         Ext.getCmp('modx-temptv-search').setValue('');
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,prepareDDSort: function(grid) {

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -96,7 +96,6 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
     filterByCategory: function(cb,rec,ri) {
         this.getStore().baseParams['category'] = cb.getValue();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,search: function(tf,newValue,oldValue) {
@@ -104,7 +103,6 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         Ext.getCmp('modx-tvtemp-filter-category').setValue('');
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -115,7 +113,6 @@ Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid,{
         Ext.getCmp('modx-tvtemp-filter-category').reset();
         Ext.getCmp('modx-tvtemp-search').setValue('');
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 });
 Ext.reg('modx-grid-tv-template',MODx.grid.TemplateVarTemplate);

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -105,7 +105,6 @@ MODx.panel.Chunk = function(config) {
                         ,fieldLabel: _('static_file')
                         ,description: MODx.expandHelp ? '' : _('static_file_msg')
                         ,name: 'static_file'
-                        // ,hideFiles: true
                         ,source: config.record.source != null ? config.record.source : MODx.config.default_media_source
                         ,openTo: config.record.openTo || ''
                         ,id: 'modx-chunk-static-file'

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -107,7 +107,6 @@ MODx.panel.Plugin = function(config) {
                         ,fieldLabel: _('static_file')
                         ,description: MODx.expandHelp ? '' : _('static_file_msg')
                         ,name: 'static_file'
-                        // ,hideFiles: true
                         ,source: config.record.source != null ? config.record.source : MODx.config.default_media_source
                         ,openTo: config.record.openTo || ''
                         ,id: 'modx-plugin-static-file'

--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -309,7 +309,6 @@ MODx.window.AddElementToPropertySet = function(config) {
         ,baseParams: {
             action: 'Element/PropertySet/AddElement'
         }
-        // ,width: 400
         ,fields: [{
             xtype: 'hidden'
             ,name: 'propertyset'
@@ -372,7 +371,6 @@ MODx.combo.ElementClass = function(config) {
         ,displayField: 'name'
         ,valueField: 'name'
         ,fields: ['name']
-        // ,listWidth: 300
         ,pageSize: 20
         ,editable: false
         ,url: MODx.config.connector_url
@@ -399,7 +397,6 @@ MODx.combo.Elements = function(config) {
         ,displayField: 'name'
         ,valueField: 'id'
         ,fields: ['id','name']
-        // ,listWidth: 300
         ,pageSize: 20
         ,editable: false
         ,url: MODx.config.connector_url
@@ -428,7 +425,6 @@ MODx.window.CreatePropertySet = function(config) {
             action: 'Element/PropertySet/Create'
         }
         ,autoHeight: true
-        // ,width: 550
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -498,7 +494,6 @@ MODx.window.DuplicatePropertySet = function(config) {
             action: 'Element/PropertySet/Duplicate'
         }
         ,autoHeight: true
-        // ,width: 550
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'
@@ -513,7 +508,6 @@ MODx.window.DuplicatePropertySet = function(config) {
         },{
             xtype: 'xcheckbox'
             ,boxLabel: _('propertyset_duplicate_copyels')
-            // ,labelSeparator: ''
             ,hideLabel: true
             ,name: 'copyels'
             ,id: 'modx-dpropset-copyels'

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -106,7 +106,6 @@ MODx.panel.Snippet = function(config) {
                         ,fieldLabel: _('static_file')
                         ,description: MODx.expandHelp ? '' : _('static_file_msg')
                         ,name: 'static_file'
-                        // ,hideFiles: true
                         ,source: config.record.source != null ? config.record.source : MODx.config.default_media_source
                         ,openTo: config.record.openTo || ''
                         ,id: 'modx-snippet-static-file'

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -122,7 +122,6 @@ MODx.panel.TV = function(config) {
                         ,fieldLabel: _('static_file')
                         ,description: MODx.expandHelp ? '' : _('static_file_msg')
                         ,name: 'static_file'
-                        // ,hideFiles: true
                         ,openTo: config.record.openTo || ''
                         ,id: 'modx-tv-static-file'
                         ,triggerClass: 'x-form-code-trigger'

--- a/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
@@ -32,7 +32,6 @@ MODx.panel.ImageTV = function(config) {
             ,caption: 'tv'+config.tv+'-caption'
             ,triggerClass: 'x-form-image-trigger'
             ,value: config.relativeValue
-            // ,hideFiles: true
             ,source: config.source || 1
             ,allowBlank: config.allowBlank
             ,allowedFileTypes: config.allowedFileTypes || ''
@@ -94,7 +93,6 @@ MODx.panel.FileTV = function(config) {
             ,id: 'tvbrowser'+config.tv
             ,caption: 'tv'+config.tv+'-caption'
             ,value: config.relativeValue
-            // ,hideFiles: true
             ,source: config.source || 1
             ,allowBlank: config.allowBlank
             ,allowedFileTypes: config.allowedFileTypes || ''

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -16,60 +16,10 @@ MODx.tree.Element = function(config) {
         ,url: MODx.config.connector_url
         ,action: 'Element/GetNodes'
         ,sortAction: 'Element/Sort'
-        // ,useDefaultToolbar: false
         ,baseParams: {
             currentElement: MODx.request.id || 0
             ,currentAction: MODx.request.a || 0
-        }/*
-        ,tbar: [{
-            cls: 'tree-new-template'
-            ,tooltip: {text: _('new')+' '+_('template')}
-            ,handler: function() {
-                this.redirect('?a=Element/Template/Create');
-            }
-            ,scope: this
-            ,hidden: MODx.perm.new_template ? false : true
-        },{
-            cls: 'tree-new-tv'
-            ,tooltip: {text: _('new')+' '+_('tv')}
-            ,handler: function() {
-                this.redirect('?a=Element/TemplateVar/Create');
-            }
-            ,scope: this
-            ,hidden: MODx.perm.new_tv ? false : true
-        },{
-            cls: 'tree-new-chunk'
-            ,tooltip: {text: _('new')+' '+_('chunk')}
-            ,handler: function() {
-                this.redirect('?a=Element/Chunk/Create');
-            }
-            ,scope: this
-            ,hidden: MODx.perm.new_chunk ? false : true
-        },{
-            cls: 'tree-new-snippet'
-            ,tooltip: {text: _('new')+' '+_('snippet')}
-            ,handler: function() {
-                this.redirect('?a=Element/Snippet/Create');
-            }
-            ,scope: this
-            ,hidden: MODx.perm.new_snippet ? false : true
-        },{
-            cls: 'tree-new-plugin'
-            ,tooltip: {text: _('new')+' '+_('plugin')}
-            ,handler: function() {
-                this.redirect('?a=Element/Plugin/Create');
-            }
-            ,scope: this
-            ,hidden: MODx.perm.new_plugin ? false : true
-        },{
-            cls: 'tree-new-category'
-            ,tooltip: {text: _('new_category')}
-            ,handler: function() {
-                this.createCategory(null,{target: this.getEl()});
-            }
-            ,scope: this
-            ,hidden: MODx.perm.new_category ? false : true
-        }]*/
+        }
     });
     MODx.tree.Element.superclass.constructor.call(this,config);
     this.on('afterSort',this.afterSort);
@@ -568,7 +518,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
 
             if (childNodes.some(function(child) { return !child.leaf; })) { // If any childNode has own children
                 m.push('-');
-    
+
                 if (n.isExpanded() && childNodes.some(function(child) { return child.isExpanded(); })) { // If any childNode is expanded
                     m.push({
                         text: _('collapse_all')
@@ -577,7 +527,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                         }
                     });
                 }
-    
+
                 m.push({
                     text: _('expand_all')
                     ,handler: function() {

--- a/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcprofile.js
@@ -329,7 +329,6 @@ Ext.extend(MODx.grid.FCProfile,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -355,8 +354,6 @@ MODx.window.CreateFCProfile = function(config) {
         title: _('profile_create')
         ,url: MODx.config.connector_url
         ,action: 'Security/Forms/Profile/Create'
-        // ,height: 150
-        // ,width: 375
         ,fields: [{
             xtype: 'textfield'
             ,name: 'name'

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -201,7 +201,6 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
     ,clearFilter: function() {
@@ -211,7 +210,6 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
     	};
         Ext.getCmp('modx-fcs-search').reset();
     	this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,exportSet: function(btn,e) {
@@ -382,7 +380,6 @@ MODx.window.CreateFCSet = function(config) {
         title: _('set_create')
         ,url: MODx.config.connector_url
         ,action: 'Security/Forms/Set/Create'
-        // ,height: 150
         ,width: 600
         ,fields: [{
             xtype: 'hidden'
@@ -513,7 +510,6 @@ MODx.window.ImportFCSet = function(config) {
             ,name: 'file'
             ,id: 'modx-impset-file'
             ,anchor: '100%'
-            // ,inputType: 'file'
         }]
     });
     MODx.window.ImportFCSet.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -215,8 +215,6 @@ MODx.window.AddGroupToProfile = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('usergroup_create')
-        // ,height: 150
-        // ,width: 375
         ,fields: [{
             fieldLabel: _('user_group')
             ,name: 'usergroup'

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -471,8 +471,6 @@ MODx.window.AddTabToSet = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('tab_create')
-        // ,height: 150
-        // ,width: 375
         ,fields: [{
             xtype: 'hidden'
             ,name: 'container'

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -627,7 +627,6 @@ MODx.browser.Window = function(config) {
             ,cls: 'modx-browser-view-ct'
             ,region: 'center'
             ,autoScroll: true
-            //,width: 635
             ,border: false
             ,items: this.view
             ,tbar: this.getToolbar()
@@ -1015,7 +1014,6 @@ MODx.Media = function(config) {
             ,id: this.ident+'-img-detail-panel'
             ,cls: 'modx-browser-details-ct'
             ,split: true
-            //,collapsed: true
         }]
     });
     MODx.Media.superclass.constructor.call(this, config);
@@ -1379,7 +1377,6 @@ MODx.browser.RTE = function(config) {
                 ,minWidth: 75
                 ,handler: this.onCancel
                 ,scope: this
-                // ,width: 200
             },{
                 xtype: 'button'
                 ,id: this.ident+'-ok-btn'
@@ -1388,7 +1385,6 @@ MODx.browser.RTE = function(config) {
                 ,minWidth: 75
                 ,handler: this.onSelect
                 ,scope: this
-                // ,width: 200
             }]
         }]
     });

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -9,7 +9,6 @@ MODx.panel.Welcome = function (config) {
     Ext.applyIf(config, {
         id: 'modx-panel-welcome',
         cls: 'container',
-        // baseCls: 'modx-formpanel',
         layout: 'auto',
         defaults: {
             collapsible: false,
@@ -133,7 +132,6 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
                         to: e.newIndex,
                     },
                     listeners: {
-                        //failure: {fn: function() {}, scope: this}
                     }
                 });
             },
@@ -209,7 +207,6 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
                                         }
                                     }, scope: this
                                 },
-                                //failure: {fn: function() {}, scope: this}
                             }
                         });
                     }

--- a/manager/assets/modext/widgets/modx.treedrop.js
+++ b/manager/assets/modext/widgets/modx.treedrop.js
@@ -264,15 +264,12 @@ MODx.window.InsertElement = function(config) {
         },{
             xtype: 'fieldset'
             ,title: _('properties')
-            // ,autoHeight: true
             ,height: Ext.getBody().getViewSize().height * 0.6
             ,collapsible: true
             ,autoScroll: true
             ,items: [{
                 html: '<div id="modx-iprops-form"></div>'
                 ,id: 'modx-iprops-container'
-                // ,height: 400
-                // ,autoScroll: true
             }]
         }]
         ,modps: []

--- a/manager/assets/modext/widgets/resource/modx.grid.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.trash.js
@@ -457,7 +457,6 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
         var selections = this.getSelectionModel().getSelections();
         var text = [], t;
         selections.forEach(function (selection) {
-            //t = selection.data.pagetitle + " (" + selection.data.id + ")";
             t = selection.data.parentPath + "<strong>" + selection.data.pagetitle + " (" + selection.data.id + ")" + "</strong>";
             if (selection.data.published) {
                 t = '<em>' + t + '</em>';

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.data.js
@@ -245,7 +245,6 @@ Ext.extend(MODx.panel.ResourceData,MODx.FormPanel,{
                 } else {
                     trail.push({
                         text: '<i class="icon icon-globe"></i> ' + (parents[i].name || parents[i].key)
-                        //,href: MODx.config.manager_url + '?a=Context/Update&key=' + parents[i].key
                         ,href: false
                     });
                 }

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -90,8 +90,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     if (panel.warnUnsavedChanges) return _('unsaved_changes');
                 };
             }
-            //this.handlePreview(this.config.record.deleted);
-            //this.handleDeleted(this.config.record.deleted);
         }
         if (MODx.config.use_editor && MODx.loadRTE) {
             var f = this.getForm().findField('richtext');
@@ -488,7 +486,6 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 } else {
                     trail.push({
                         text: parents[i].name || parents[i].key
-                        //,href: MODx.config.manager_url + '?a=Context/Update&key=' + parents[i].key
                         ,href: false
                     });
                 }

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.schedule.js
@@ -125,7 +125,6 @@ Ext.extend(MODx.grid.ResourceSchedule,MODx.grid.Grid,{
         }
         this.getBottomToolbar().changePage(1);
         s.removeAll();
-      //  this.refresh();
     }
 });
 Ext.reg('modx-grid-resource-schedule',MODx.grid.ResourceSchedule);

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
@@ -27,7 +27,6 @@ Ext.extend(MODx.panel.Static,MODx.panel.Resource,{
             ,browserEl: 'modx-browser'
             ,prependPath: false
             ,prependUrl: false
-            // ,hideFiles: true
             ,fieldLabel: _('static_resource')
             ,description: '<b>[[*content]]</b>'
             ,name: 'content'

--- a/manager/assets/modext/widgets/resource/modx.tree.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.tree.resource.js
@@ -16,12 +16,9 @@ MODx.tree.Resource = function(config) {
         ,expandFirst: true
         ,enableDD: (MODx.config.enable_dragdrop != '0') ? true : false
         ,ddGroup: 'modx-treedrop-dd'
-        // ,remoteToolbar: true
-        // ,remoteToolbarAction: 'Resource/GetToolbar'
         ,sortAction: 'Resource/Sort'
         ,sortBy: this.getDefaultSortBy(config)
         ,tbarCfg: {
-        //    hidden: true
             id: config.id ? config.id+'-tbar' : 'modx-tree-resource-tbar'
         }
         ,baseParams: {
@@ -68,43 +65,6 @@ Ext.extend(MODx.tree.Resource,MODx.tree.Tree,{
             }
         }
     }
-
-    /*,addSearchToolbar: function() {
-        this.searchField = new Ext.form.TextField({
-            emptyText: _('search_ellipsis')
-            ,listeners: {
-                'change': {fn: this.search,scope:this}
-                ,'render': {fn: function(cmp) {
-                    new Ext.KeyMap(cmp.getEl(), {
-                        key: Ext.EventObject.ENTER
-                        ,fn: function() {
-                            this.fireEvent('change',this.getValue());
-                            this.blur();
-                            return true;}
-                        ,scope: cmp
-                    });
-                },scope:this}
-            }
-        });
-        this.searchBar = new Ext.Toolbar({
-            renderTo: this.tbar
-            ,id: 'modx-resource-searchbar'
-            ,items: [this.searchField]
-        });
-        this.on('resize', function(){
-            this.searchField.setWidth(this.getWidth() - 12);
-        }, this);
-    }
-
-    ,search: function(nv) {
-        Ext.state.Manager.set(this.treestate_id+'-search',nv);
-        this.config.search = nv;
-        this.getLoader().baseParams = {
-            action: this.config.action
-            ,search: this.config.search
-        };
-        this.refresh();
-    }*/
 
     /**
      * Shows the current context menu.
@@ -880,12 +840,9 @@ MODx.window.QuickCreateResource = function(config) {
         ,id: this.ident
         ,bwrapCssClass: 'x-window-with-tabs'
         ,width: 700
-        //,height: ['modSymLink', 'modWebLink', 'modStaticResource'].indexOf(config.record.class_key) == -1 ? 640 : 498
-        // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'Resource/Create'
-        // ,shadow: false
         ,fields: [{
             xtype: 'modx-tabs'
             ,bodyStyle: { background: 'transparent' }
@@ -898,7 +855,6 @@ MODx.window.QuickCreateResource = function(config) {
                 title: _('resource')
                 ,layout: 'form'
                 ,cls: 'modx-panel'
-                // ,bodyStyle: { background: 'transparent', padding: '10px' } // we handle this in CSS
                 ,autoHeight: false
                 ,anchor: '100% 100%'
                 ,labelWidth: 100
@@ -1027,7 +983,6 @@ MODx.window.QuickCreateResource = function(config) {
                     autoHeight: true
                     ,border: false
                 }
-                // ,bodyStyle: { padding: '10px' } // we handle this in CSS
                 ,items: MODx.getQRSettings(this.ident,config.record)
             }]
         }]
@@ -1104,7 +1059,6 @@ MODx.getQRContentField = function(id,cls) {
                 ,browserEl: 'modx-browser'
                 ,prependPath: false
                 ,prependUrl: false
-                // ,hideFiles: true
                 ,fieldLabel: _('static_resource')
                 ,name: 'content'
                 ,id: 'modx-'+id+'-content'
@@ -1127,7 +1081,6 @@ MODx.getQRContentField = function(id,cls) {
                 xtype: 'textarea'
                 ,name: 'content'
                 ,id: 'modx-'+id+'-content'
-                // ,hideLabel: true
                 ,fieldLabel: _('content')
                 ,labelSeparator: ''
                 ,anchor: '100%'

--- a/manager/assets/modext/widgets/security/modx.grid.access.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.context.js
@@ -166,8 +166,6 @@ MODx.window.CreateAccessContext = function(config) {
             action: 'Security/Access/AddAcl'
             ,type: config.type || 'modAccessContext'
         }
-        // ,height: 250
-        // ,width: 350
         ,type: 'modAccessContext'
         ,acl: 0
         ,fields: [{
@@ -204,7 +202,6 @@ MODx.window.CreateAccessContext = function(config) {
             xtype: 'textfield'
             ,fieldLabel: _('authority')
             ,name: 'authority'
-            // ,width: 75
             ,anchor: '100%'
             ,value: r.authority || ''
         }]

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -144,7 +144,6 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
     ,clearFilter: function() {
@@ -153,7 +152,6 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
         };
         Ext.getCmp('modx-policy-search').reset();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,editPolicy: function(itm,e) {
@@ -287,7 +285,6 @@ MODx.window.CreateAccessPolicy = function(config) {
     config = config || {};
     this.ident = config.ident || 'cacp'+Ext.id();
     Ext.applyIf(config,{
-        // width: 500
         title: _('policy_create')
         ,url: MODx.config.connector_url
         ,action: 'Security/Access/Policy/Create'
@@ -362,7 +359,6 @@ MODx.combo.AccessPolicyTemplate = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {
@@ -404,7 +400,6 @@ MODx.window.ImportPolicy = function(config) {
             ,name: 'file'
             ,id: this.ident+'-file'
             ,anchor: '100%'
-            // ,inputType: 'file'
         }]
     });
     MODx.window.ImportPolicy.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -261,7 +261,6 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-       // this.refresh();
         return true;
     }
 
@@ -271,7 +270,6 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
         };
         Ext.getCmp('modx-policy-template-search').reset();
         this.getBottomToolbar().changePage(1);
-       // this.refresh();
     }
 });
 Ext.reg('modx-grid-access-policy-templates',MODx.grid.AccessPolicyTemplate);
@@ -292,7 +290,6 @@ MODx.combo.AccessPolicyTemplateGroups = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'Security/Access/Policy/Template/Group/GetList'
@@ -317,7 +314,6 @@ MODx.window.CreateAccessPolicyTemplate = function(config) {
     config = config || {};
     this.ident = config.ident || 'cacpt'+Ext.id();
     Ext.applyIf(config,{
-        // width: 500
         title: _('policy_template_create')
         ,url: MODx.config.connector_url
         ,action: 'Security/Access/Policy/Template/Create'
@@ -392,7 +388,6 @@ MODx.window.ImportPolicyTemplate = function(config) {
             ,name: 'file'
             ,id: this.ident+'-file'
             ,anchor: '100%'
-            // ,inputType: 'file'
         }]
     });
     MODx.window.ImportPolicyTemplate.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/security/modx.grid.message.js
+++ b/manager/assets/modext/widgets/security/modx.grid.message.js
@@ -133,7 +133,6 @@ MODx.grid.Message = function(config) {
             ,editable: false
             ,typeAhead: false
             ,forceSelection: true
-            // ,value: 'inbox'
             ,width: 200
             ,listeners: {
                 'select': {fn: this.filterByType, scope: this}

--- a/manager/assets/modext/widgets/security/modx.grid.role.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.js
@@ -96,8 +96,6 @@ MODx.window.CreateRole = function(config) {
     this.ident = config.ident || 'crole'+Ext.id();
     Ext.applyIf(config,{
         title: _('role_create')
-        // ,height: 150
-        // ,width: 400
         ,url: MODx.config.connector_url
         ,action: 'Security/Role/Create'
         ,fields: [{
@@ -120,7 +118,6 @@ MODx.window.CreateRole = function(config) {
             ,allowBlank: false
             ,allowNegative: false
             ,value: 0
-            // ,width: 75
             ,anchor: '100%'
         },{
             xtype: MODx.expandHelp ? 'label' : 'hidden'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
@@ -115,7 +115,6 @@ Ext.extend(MODx.grid.UserGroupCategory,MODx.grid.Grid,{
     ,filterPolicy: function(cb,rec,ri) {
         this.getStore().baseParams['policy'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,clearFilter: function(btn,e) {
@@ -124,7 +123,6 @@ Ext.extend(MODx.grid.UserGroupCategory,MODx.grid.Grid,{
         Ext.getCmp('modx-ugcat-policy-filter').setValue('');
         this.getStore().baseParams['policy'] = '';
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,createAcl: function(itm,e) {
@@ -181,8 +179,6 @@ MODx.window.CreateUGCat = function(config) {
         title: _('category_add')
         ,url: MODx.config.connector_url
         ,action: 'Security/Access/UserGroup/Category/Create'
-        // ,height: 250
-        // ,width: 500
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -133,13 +133,11 @@ Ext.extend(MODx.grid.UserGroupContext,MODx.grid.Grid,{
     ,filterContext: function(cb,rec,ri) {
         this.getStore().baseParams['context'] = rec.data['key'];
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,filterPolicy: function(cb,rec,ri) {
         this.getStore().baseParams['policy'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,clearFilter: function(btn,e) {
@@ -148,7 +146,6 @@ Ext.extend(MODx.grid.UserGroupContext,MODx.grid.Grid,{
         Ext.getCmp('modx-ugc-policy-filter').setValue('');
         this.getStore().baseParams['policy'] = '';
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,createAcl: function(itm,e) {
@@ -205,7 +202,6 @@ MODx.window.CreateUGAccessContext = function(config) {
         title: _('ugc_mutate')
         ,url: MODx.config.connector_url
         ,action: 'Security/Access/UserGroup/Context/Create'
-        // ,width: 600
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.js
@@ -172,8 +172,6 @@ MODx.window.AddGroupToUser = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('user_group_user_add')
-        // ,height: 150
-        // ,width: 375
         ,url: MODx.config.connector_url
         ,action: 'Security/Group/User/Create'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
@@ -117,7 +117,6 @@ Ext.extend(MODx.grid.UserGroupNamespace,MODx.grid.Grid,{
         Ext.getCmp('modx-ugnamespace-policy-filter').setValue('');
         this.getStore().baseParams['policy'] = '';
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,createAcl: function(itm,e) {
@@ -174,8 +173,6 @@ MODx.window.CreateUGNamespace = function(config) {
         title: _('namespace_add')
         ,url: MODx.config.connector_url
         ,action: 'Security/Access/UserGroup/AccessNamespace/Create'
-        // ,height: 250
-        // ,width: 500
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.resource.js
@@ -115,12 +115,10 @@ Ext.extend(MODx.grid.UserGroupResourceGroup,MODx.grid.Grid,{
     ,filterResourceGroup: function(cb,rec,ri) {
         this.getStore().baseParams['resourceGroup'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
     ,filterPolicy: function(cb,rec,ri) {
         this.getStore().baseParams['policy'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,clearFilter: function(btn,e) {
@@ -129,7 +127,6 @@ Ext.extend(MODx.grid.UserGroupResourceGroup,MODx.grid.Grid,{
         Ext.getCmp('modx-ugrg-policy-filter').setValue('');
         this.getStore().baseParams['policy'] = '';
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,createAcl: function(itm,e) {
@@ -186,8 +183,6 @@ MODx.window.CreateUGRG = function(config) {
         title: _('resource_group_add')
         ,url: MODx.config.connector_url
         ,action: 'Security/Access/UserGroup/ResourceGroup/Create'
-        // ,height: 250
-        // ,width: 600
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.source.js
@@ -104,13 +104,11 @@ Ext.extend(MODx.grid.UserGroupSource,MODx.grid.Grid,{
     ,filterSource: function(cb,rec,ri) {
         this.getStore().baseParams['source'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,filterPolicy: function(cb,rec,ri) {
         this.getStore().baseParams['policy'] = rec.data['id'];
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,clearFilter: function(btn,e) {
@@ -119,7 +117,6 @@ Ext.extend(MODx.grid.UserGroupSource,MODx.grid.Grid,{
         Ext.getCmp('modx-ugsource-policy-filter').setValue('');
         this.getStore().baseParams['policy'] = '';
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,createAcl: function(itm,e) {
@@ -176,8 +173,6 @@ MODx.window.CreateUGSource = function(config) {
         title: _('source_add')
         ,url: MODx.config.connector_url
         ,action: 'Security/Access/UserGroup/Source/Create'
-        // ,height: 250
-        // ,width: 500
         ,fields: [{
             xtype: 'hidden'
             ,name: 'id'

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.js
@@ -231,7 +231,6 @@ MODx.combo.AccessPolicyTemplate = function(config) {
         ,typeAhead: false
         ,editable: false
         ,allowBlank: false
-        // ,listWidth: 300
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
@@ -252,8 +252,6 @@ MODx.window.NewTemplatePermission = function(config) {
     this.ident = config.ident || 'polpc'+Ext.id();
     Ext.applyIf(config,{
         title: _('permission_add_template')
-        // ,height: 150
-        // ,width: 475
         ,url: MODx.config.connector_url
         ,action: 'security/access/policy/addProperty'
         ,saveBtnText: _('add')

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -164,9 +164,6 @@ MODx.panel.UserGroup = function(config) {
                     ,group: config.record.id
                     ,autoHeight: true
                     ,width: '97%'
-//                    ,listeners: {
-//                        'afterAutoSave':{fn:this.markDirty,scope:this}
-//                    }
                 }]
             },{
                 title: _('permissions')
@@ -277,12 +274,6 @@ MODx.panel.UserGroup = function(config) {
                             ,usergroup: config.record.id
                             ,autoHeight: true
                             ,width: '97%'
-                            //,listeners: {
-                            //    'afterRemoveRow': {fn:this.markDirty,scope:this}
-                            //    ,'afteredit': {fn:this.markDirty,scope:this}
-                            //    ,'updateAcl': {fn:this.markDirty,scope:this}
-                            //    ,'createAcl': {fn:this.markDirty,scope:this}
-                            //}
                         }]
                     }]
                 }]
@@ -430,14 +421,12 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
     ,searchUser: function(tf,nv,ov) {
         this.getStore().baseParams['username'] = Ext.getCmp('modx-ugu-filter-username').getValue();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,clearFilter: function(btn,e) {
         Ext.getCmp('modx-ugu-filter-username').setValue('');
         this.getStore().baseParams['username'] = '';
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,updateRole: function(btn,e) {
@@ -541,8 +530,6 @@ MODx.window.AddUserToUserGroup = function(config) {
     this.ident = config.ident || 'auug'+Ext.id();
     Ext.applyIf(config,{
         title: _('user_group_user_add')
-        // ,height: 150
-        // ,width: 500
         ,url: MODx.config.connector_url
         ,action: 'Security/Group/User/Create'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.tree.resource.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.resource.group.js
@@ -220,7 +220,6 @@ MODx.window.CreateResourceGroup = function(config) {
     Ext.applyIf(config,{
         title: _('resource_group_create')
         ,id: this.ident
-        // ,height: 150
         ,width: 600
         ,stateful: false
         ,url: MODx.config.connector_url
@@ -337,8 +336,6 @@ MODx.window.UpdateResourceGroup = function(config) {
     Ext.applyIf(config,{
         title: _('resource_group_update')
         ,id: this.ident
-        // ,height: 150
-        // ,width: 350
         ,url: MODx.config.connector_url
         ,action: 'Security/ResourceGroup/Update'
         ,fields: [{

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -41,12 +41,12 @@ Ext.extend(MODx.tree.UserGroup,MODx.tree.Tree,{
     ,_handleClick: function (n,e) {
         e.stopEvent();
         e.preventDefault();
-        
+
         if (this.disableHref) {return true;}
         if (e.ctrlKey) {return true;}
         return true;
     }
-    
+
     ,addUser: function(item,e) {
         var n = this.cm.activeNode;
         var ug = n.id.substr(2).split('_');ug = ug[1];
@@ -201,7 +201,6 @@ MODx.window.CreateUserGroup = function(config) {
     Ext.applyIf(config,{
         title: _('create_user_group')
         ,id: this.ident
-        // ,height: 150
         ,width: 700
         ,stateful: false
         ,url: MODx.config.connector_url
@@ -363,8 +362,6 @@ MODx.window.AddUserToUserGroup = function(config) {
     Ext.applyIf(config,{
         title: _('user_group_user_add')
         ,id: this.ident
-        // ,height: 150
-        // ,width: 375
         ,url: MODx.config.connector_url
         ,action: 'Security/Group/User/Create'
         ,fields: [{

--- a/manager/assets/modext/widgets/source/modx.grid.source.access.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.access.js
@@ -162,8 +162,6 @@ MODx.window.CreateSourceAccess = function(config) {
 
     Ext.applyIf(config,{
         title: _('source_access_add')
-        // ,height: 250
-        // ,width: 350
         ,type: 'modAccessMediaSource'
         ,acl: 0
         ,fields: [{

--- a/manager/assets/modext/widgets/source/modx.grid.source.properties.js
+++ b/manager/assets/modext/widgets/source/modx.grid.source.properties.js
@@ -334,8 +334,6 @@ MODx.window.CreateSourceProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_create')
         ,id: 'modx-window-source-property-create'
-        // ,height: 250
-        // ,width: 450
         ,saveBtnText: _('done')
         ,fields: [{
             fieldLabel: _('name')
@@ -430,8 +428,6 @@ MODx.window.UpdateSourceProperty = function(config) {
     Ext.applyIf(config,{
         title: _('property_update')
         ,id: 'modx-window-source-property-update'
-        // ,height: 250
-        // ,width: 450
         ,saveBtnText: _('done')
         ,forceLayout: true
         ,fields: [{
@@ -548,8 +544,6 @@ MODx.window.CreateSourcePropertyOption = function(config) {
     Ext.applyIf(config,{
         title: _('property_option_create')
         ,id: 'modx-window-source-property-option-create'
-        // ,height: 250
-        // ,width: 450
         ,saveBtnText: _('done')
         ,fields: [{
             fieldLabel: _('name')

--- a/manager/assets/modext/widgets/source/modx.panel.sources.js
+++ b/manager/assets/modext/widgets/source/modx.panel.sources.js
@@ -243,7 +243,6 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -253,7 +252,6 @@ Ext.extend(MODx.grid.Sources,MODx.grid.Grid,{
         };
         Ext.getCmp('modx-source-search').reset();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 });
 Ext.reg('modx-grid-sources',MODx.grid.Sources);

--- a/manager/assets/modext/widgets/system/modx.grid.context.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.js
@@ -223,7 +223,6 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -233,7 +232,6 @@ Ext.extend(MODx.grid.Context,MODx.grid.Grid,{
         };
         Ext.getCmp('modx-ctx-search').reset();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
     ,afterAction: function() {

--- a/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
+++ b/manager/assets/modext/widgets/system/modx.grid.dashboard.widgets.js
@@ -175,7 +175,6 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -185,7 +184,6 @@ Ext.extend(MODx.grid.DashboardWidgets,MODx.grid.Grid,{
         };
         Ext.getCmp('modx-dashboard-widget-search').reset();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 });
 Ext.reg('modx-grid-dashboard-widgets',MODx.grid.DashboardWidgets);

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.js
@@ -154,13 +154,6 @@ Ext.extend(MODx.panel.Dashboard,MODx.FormPanel,{
         this.getForm().setValues(this.config.record);
         Ext.getCmp('modx-header-breadcrumbs').updateHeader(Ext.util.Format.htmlEncode(this.config.record.name));
 
-        /*
-        var d = this.config.record.usergroups;
-        var g = Ext.getCmp('modx-grid-dashboard-usergroups');
-        if (d && g) {
-            g.getStore().loadData(d);
-        }*/
-
         var d = this.config.record.widgets;
         var g = Ext.getCmp('modx-grid-dashboard-widget-placements');
         if (d && g) {
@@ -333,7 +326,6 @@ MODx.window.DashboardWidgetPlace = function(config) {
     this.ident = config.ident || 'dbugadd'+Ext.id();
     Ext.applyIf(config,{
         title: _('widget_place')
-        // ,frame: true
         ,id: 'modx-window-dashboard-widget-place'
         ,fields: [{
             xtype: 'modx-combo-dashboard-widgets'
@@ -503,7 +495,6 @@ MODx.combo.DashboardWidgets = function(config) {
         ,editable: true
         ,valueField: 'id'
         ,fields: ['id','name','name_trans','description','description_trans']
-        // ,listWidth: 400
         ,pageSize: 20
         ,url: MODx.config.connector_url
         ,baseParams: {

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -23,7 +23,6 @@ MODx.panel.DashboardWidget = function(config) {
                 ,labelAlign: 'top'
                 ,anchor: '100%'
                 ,border: false
-                // ,cls:'main-wrapper'
                 ,labelSeparator: ''
             }
             ,items: [{
@@ -166,18 +165,12 @@ MODx.panel.DashboardWidget = function(config) {
             xtype: 'panel'
             ,border: false
             ,layout: 'form'
-            // ,cls:'main-wrapper'
             ,style: 'padding-top: 15px' // new form panel, first label is not gonna have top padding
             ,labelAlign: 'top'
-            ,items: [/*{
-                html: '<h4>'+_('widget_content')+'</h4>'
-                ,border: false
-                ,anchor: '100%'
-            },*/{
+            ,items: [{
                 xtype: 'textarea'
                 ,name: 'content'
                 ,fieldLabel: _('widget_content')
-                // ,hideLabel: true
                 ,anchor: '100%'
                 ,height: 400
             }]
@@ -252,7 +245,6 @@ MODx.panel.DashboardWidget = function(config) {
                 autoHeight: true
                 ,border: false
             }
-            //,border: true
             ,id: 'modx-dashboard-widget-tabs'
             ,forceLayout: true
             ,deferredRender: false
@@ -382,7 +374,6 @@ MODx.window.WidgetAddDashboard = function(config) {
     this.ident = config.ident || 'dbugadd'+Ext.id();
     Ext.applyIf(config,{
         title: _('widget_place')
-        // ,frame: true
         ,id: 'modx-window-widget-add-dashboard'
         ,fields: [{
             xtype: 'modx-combo-dashboard'

--- a/manager/assets/modext/widgets/system/modx.panel.dashboards.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboards.js
@@ -255,7 +255,6 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
     ,filterUsergroup: function(cb,nv,ov) {
         this.getStore().baseParams.usergroup = Ext.isEmpty(nv) || Ext.isObject(nv) ? cb.getValue() : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -263,7 +262,6 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.query = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -274,7 +272,6 @@ Ext.extend(MODx.grid.Dashboards,MODx.grid.Grid,{
         Ext.getCmp('modx-dashboard-search').reset();
         Ext.getCmp('modx-user-filter-usergroup').reset();
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 });
 Ext.reg('modx-grid-dashboards',MODx.grid.Dashboards);

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -15,7 +15,6 @@ MODx.panel.ErrorLog = function(config) {
         ,baseParams: {
             action: 'System/ErrorLog/Clear'
         }
-        // ,layout: 'form' // unnecessary and creates a wrong box shadow
         ,items: [{
             html: _('error_log')
             ,id: 'modx-error-log-header'

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -80,11 +80,8 @@ MODx.tree.Directory = function(config) {
         el.createChild({tag: 'div', id: this.config.id+'_filter'});
         this.addSourceToolbar();
 
-//        this.getRootNode().pseudoroot = true
-//        console.log(this.getRootNode())
 
     },this);
-    //this.addSourceToolbar();
     this.on('show',function() {
         if (!this.config.hideSourceCombo) {
             try { this.sourceCombo.show(); } catch (e) {}
@@ -161,14 +158,6 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 }
             ])
         }
-
-//        if (MODx.perm.file_manager) {
-//            menu.push({
-//                text: _('modx_browser')
-//                ,handler: this.loadFileManager
-//                ,scope: this
-//            });
-//        }
 
         return menu;
     }
@@ -356,7 +345,6 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 'success': {fn:function(r) {
                     var el = dropEvent.dropNode.getUI().getTextEl();
                     if (el) {Ext.get(el).frame();}
-                    // this.refreshParentNode();
                     this.fireEvent('afterSort',{event:dropEvent,result:r});
                 },scope:this}
                 ,'failure': {fn:function(r) {
@@ -490,7 +478,6 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                 xtype: 'modx-browser'
                 ,hideFiles: MODx.config.modx_browser_tree_hide_files
                 ,rootId: '/' // prevent JS error because ui.node.elNode is undefined when this is
-                // ,rootVisible: false
                 ,wctx: MODx.ctx
                 ,source: this.config.baseParams.source
                 ,listeners: {
@@ -564,7 +551,6 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             xtype: 'modx-window-file-rename'
             ,record: r
             ,listeners: {
-                // 'success':{fn:this.refreshParentNode,scope:this}
                 'success': {fn:function(r) {
                     this.fireEvent('afterRename');
                     this.refreshParentNode();
@@ -791,8 +777,6 @@ MODx.window.CreateDirectory = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('file_folder_create')
-        // width: 430
-        // ,height: 200
         ,url: MODx.config.connector_url
         ,action: 'Browser/Directory/Create'
         ,fields: [{
@@ -879,8 +863,6 @@ MODx.window.RenameDirectory = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('rename')
-        // ,width: 430
-        // ,height: 200
         ,url: MODx.config.connector_url
         ,action: 'Browser/Directory/Rename'
         ,fields: [{
@@ -926,8 +908,6 @@ MODx.window.RenameFile = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('rename')
-        // ,width: 430
-        // ,height: 200
         ,url: MODx.config.connector_url
         ,action: 'Browser/File/Rename'
         ,fields: [{
@@ -977,8 +957,6 @@ MODx.window.QuickUpdateFile = function(config) {
     Ext.applyIf(config,{
         title: _('file_quick_update')
         ,width: 600
-        // ,height: 640
-        // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'Browser/File/Update'
@@ -1048,8 +1026,6 @@ MODx.window.QuickCreateFile = function(config) {
     Ext.applyIf(config,{
         title: _('file_quick_create')
         ,width: 600
-        // ,height: 640
-        // ,autoHeight: false
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'Browser/File/Create'
@@ -1085,16 +1061,6 @@ MODx.window.QuickCreateFile = function(config) {
             ,fn: this.submit
             ,scope: this
         }]
-        /* this is the default config found also in widgets/core/modx.window.js, no need to redeclare here */
-        /*,buttons: [{
-            text: config.cancelBtnText || _('cancel')
-            ,scope: this
-            ,handler: function() { this.hide(); }
-        },{
-            text: config.saveBtnText || _('save')
-            ,scope: this
-            ,handler: this.submit
-        }]*/
     });
     MODx.window.QuickCreateFile.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/widgets/system/modx.tree.menu.js
+++ b/manager/assets/modext/widgets/system/modx.tree.menu.js
@@ -134,7 +134,6 @@ MODx.window.CreateMenu = function(config) {
     Ext.applyIf(config,{
         title: _('menu_create')
         ,width: 600
-        // ,height: 400
         ,url: MODx.config.connector_url
         ,action: 'System/Menu/Create'
         ,fields: [{
@@ -167,7 +166,6 @@ MODx.window.CreateMenu = function(config) {
                     ,allowBlank: false
                     ,anchor: '100%'
                     ,id: this.ident+'-text'
-                    //,readOnly: config.update ? true : false
                 },{
                     xtype: MODx.expandHelp ? 'label' : 'hidden'
                     ,forId: this.ident+'-text'
@@ -222,7 +220,6 @@ MODx.window.CreateMenu = function(config) {
                     ,xtype: 'textfield'
                     ,anchor: '100%'
                     ,id: this.ident+'-action-id'
-                    //,allowBlank: false
                 },{
                     xtype: MODx.expandHelp ? 'label' : 'hidden'
                     ,forId: this.ident+'-action-id'
@@ -317,7 +314,6 @@ MODx.combo.Menu = function(config) {
         ,fields: ['text','text_lex']
         ,displayField: 'text_lex'
         ,valueField: 'text'
-        // ,listWidth: 300
         ,editable: false
     });
     MODx.combo.Menu.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/windows.js
+++ b/manager/assets/modext/widgets/windows.js
@@ -12,7 +12,6 @@ MODx.window.DuplicateResource = function(config) {
     Ext.applyIf(config,{
         title: config.pagetitle ? _('duplicate') + ' ' + config.pagetitle : _('duplication_options')
         ,id: this.ident
-        // ,width: 500
     });
     MODx.window.DuplicateResource.superclass.constructor.call(this,config);
 };
@@ -238,8 +237,6 @@ MODx.window.CreateCategory = function(config) {
     Ext.applyIf(config,{
         title: _('new_category')
         ,id: this.ident
-        // ,height: 150
-        // ,width: 350
         ,url: MODx.config.connector_url
         ,action: 'Element/Category/Create'
         ,fields: [{
@@ -281,8 +278,6 @@ MODx.window.RenameCategory = function(config) {
     this.ident = config.ident || 'rencat-'+Ext.id();
     Ext.applyIf(config,{
         title: _('category_rename')
-        // ,height: 150
-        // ,width: 350
         ,url: MODx.config.connector_url
         ,action: 'Element/Category/Update'
         ,fields: [{
@@ -389,8 +384,6 @@ MODx.window.QuickCreateChunk = function(config) {
     Ext.applyIf(config,{
         title: _('quick_create_chunk')
         ,width: 600
-        //,height: 640
-        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'Element/Chunk/Create'
@@ -412,7 +405,6 @@ MODx.window.QuickCreateChunk = function(config) {
             ,name: 'description'
             ,fieldLabel: _('description')
             ,anchor: '100%'
-            //,rows: 2
         },{
             xtype: 'textarea'
             ,name: 'snippet'
@@ -473,7 +465,6 @@ MODx.window.QuickCreateTemplate = function(config) {
     Ext.applyIf(config,{
         title: _('quick_create_template')
         ,width: 600
-        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'Element/Template/Create'
@@ -556,7 +547,6 @@ MODx.window.QuickCreateSnippet = function(config) {
     Ext.applyIf(config,{
         title: _('quick_create_snippet')
         ,width: 600
-        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'Element/Snippet/Create'
@@ -640,7 +630,6 @@ MODx.window.QuickCreatePlugin = function(config) {
     Ext.applyIf(config,{
         title: _('quick_create_plugin')
         ,width: 600
-        // ,autoHeight: true
         ,layout: 'anchor'
         ,url: MODx.config.connector_url
         ,action: 'Element/Plugin/Create'
@@ -862,7 +851,6 @@ MODx.window.DuplicateContext = function(config) {
         ,id: this.ident
         ,url: MODx.config.connector_url
         ,action: 'Context/Duplicate'
-        // ,width: 400
         ,fields: [{
             xtype: 'statictextfield'
             ,id: 'modx-'+this.ident+'-key'
@@ -929,7 +917,6 @@ MODx.window.Login = function(config) {
         ,id: this.ident
         ,url: MODx.config.connectors_url
         ,action: 'Security/Login'
-        // ,width: 400
         ,fields: [{
             html: '<p>'+_('session_logging_out')+'</p>'
             ,xtype: 'modx-description'

--- a/manager/assets/modext/workspace/lexicon/combos.js
+++ b/manager/assets/modext/workspace/lexicon/combos.js
@@ -1,6 +1,6 @@
 /**
  * Displays a dropdown list of available Lexicon Topics. Requires a namespace.
- * 
+ *
  * @class MODx.combo.LexiconTopic
  * @extends MODx.combo.ComboBox
  * @param {Object} config An object of config properties
@@ -16,7 +16,6 @@ MODx.combo.LexiconTopic = function(config) {
         ,minChars: 1
         ,editable: true
         ,allowBlank: true
-        // ,listWidth: 300
         ,url: MODx.config.connector_url
         ,fields: ['name']
         ,displayField: 'name'
@@ -26,7 +25,6 @@ MODx.combo.LexiconTopic = function(config) {
             ,'namespace': 'core'
             ,'language': 'en'
         }
-        // ,pageSize: 20
     });
     MODx.combo.LexiconTopic.superclass.constructor.call(this,config);
 };

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -130,58 +130,7 @@ MODx.grid.Lexicon = function(config) {
             text: _('reload_from_base')
             ,handler: this.reloadFromBase
             ,scope: this
-        }
-        /*
-        ,{
-            xtype: 'button'
-            ,id: 'modx-lexicon-import-btn'
-            ,text: _('lexicon_import')
-            ,handler: function(btn,e) {
-                this.loadWindow2(btn,e,{
-                    xtype: 'modx-window-lexicon-import'
-                    ,listeners: {
-                        'success': {fn:function(o) {
-                            var r = o.a.result.object;
-                            this.setFilterParams(r['namespace'],r.topic);
-                        },scope:this}
-                        ,'show': {fn:function() {
-                            var w = this.windows['modx-window-lexicon-import'];
-                            if (w) {
-                                var tf = w.fp.getComponent('topic');
-                                var tb = this.getTopToolbar();
-                                if (tf && tb) {
-                                    tf.setValue(tb.getComponent('topic').getRawValue());
-                                }
-                            }
-                        },scope: this}
-                    }
-                });
-            }
-            ,scope: this
-        },{
-            xtype: 'button'
-            ,id: 'modx-lexicon-export-btn'
-            ,text: _('lexicon_export')
-            ,handler: function(btn,e) {
-                this.loadWindow2(btn,e,{
-                    xtype: 'modx-window-lexicon-export'
-                    ,listeners: {
-                        'success': {fn:function(o) {
-                            location.href = MODx.config.connector_url+'?action=workspace/lexicon/export&HTTP_MODAUTH='+MODx.siteId+'&download='+o.a.result.message;
-                        },scope:this}
-                        ,'show': {fn:function() {
-                            var w = this.windows['modx-window-lexicon-export'];
-                            var cb = w.fp.getComponent('topic');
-                            if (cb) {
-                                var tb = this.getTopToolbar();
-                                cb.setNamespace(tb.getComponent('namespace').getValue(),tb.getComponent('topic').getValue());
-                            }
-                        },scope: this}
-                    }
-                });
-            }
-            ,scope: this
-        }*/]
+        }]
     });
     MODx.grid.Lexicon.superclass.constructor.call(this,config);
 };
@@ -211,7 +160,6 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
     	if (!name) {return false;}
     	this.store.baseParams[name] = cb.getValue();
     	this.getBottomToolbar().changePage(1);
-    	//this.refresh();
         return true;
     }
     ,clearFilter: function() {
@@ -236,7 +184,6 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
         tcl.setValue('en');
 
         tb.getComponent('search').setValue('');
-    	//this.refresh();
     }
     ,changeNamespace: function(cb,nv,ov) {
         this.setFilterParams(cb.getValue(),'default','en');
@@ -288,7 +235,6 @@ Ext.extend(MODx.grid.Lexicon,MODx.grid.Grid,{
             s.removeAll();
         }
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
     ,loadWindow2: function(btn,e,o) {
         var tb = this.getTopToolbar();

--- a/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
+++ b/manager/assets/modext/workspace/namespace/modx.namespace.panel.js
@@ -159,7 +159,6 @@ Ext.extend(MODx.grid.Namespace,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
     ,clearFilter: function() {
@@ -168,7 +167,6 @@ Ext.extend(MODx.grid.Namespace,MODx.grid.Grid,{
     	};
         Ext.getCmp('modx-namespace-search').reset();
     	this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
     ,removeSelected: function() {
         var cs = this.getSelectedAsList();

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -181,7 +181,6 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
         var nv = newValue || tf;
         this.getStore().baseParams.search = Ext.isEmpty(nv) || Ext.isObject(nv) ? '' : nv;
         this.getBottomToolbar().changePage(1);
-        //this.refresh();
         return true;
     }
 
@@ -191,7 +190,6 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
     	};
         Ext.getCmp('modx-package-search').reset();
     	this.getBottomToolbar().changePage(1);
-        //this.refresh();
     }
 
 
@@ -501,8 +499,6 @@ MODx.window.PackageUpdate = function(config) {
         title: _('package_update')
         ,url: MODx.config.connector_url
         ,action: 'Workspace/Packages/Rest/Download'
-        // ,height: 400
-        // ,width: 400
         ,id: 'modx-window-package-update'
         ,saveBtnText: _('update')
         ,fields: this.setupOptions(config.packages,config.record)

--- a/manager/assets/modext/workspace/package.panels.js
+++ b/manager/assets/modext/workspace/package.panels.js
@@ -11,24 +11,6 @@ MODx.panel.PackageMetaPanel = function(config) {
 
 	Ext.applyIf(config,{
 		cls: 'vertical-tabs-panel wrapped'
-		// same as in parent class
-		// ,headerCfg: { tag: 'div', cls: 'x-tab-panel-header vertical-tabs-header' }
-		// ,bwrapCfg: { tag: 'div', cls: 'x-tab-panel-bwrap vertical-tabs-bwrap' }
-		// ,defaults: {
-		// 	bodyCssClass: 'vertical-tabs-body'
-		// 	,autoScroll: true
-		// 	,autoHeight: true
-		// 	,autoWidth: true
-		// }
-		// ,layoutOnTabChange: true
-		// ,listeners:{
-			// tabchange: function(tb, pnl){
-			// 	w = this.bwrap.getWidth();
-			// 	this.body.setWidth(w);
-			// 	this.doLayout();
-			// }
-			// ,scope: this
-		// }
 		,items: []
 	});
 	MODx.panel.PackageMetaPanel.superclass.constructor.call(this,config);

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -10,16 +10,12 @@ MODx.window.PackageUninstall = function(config) {
         title: _('package_uninstall')
         ,url: MODx.config.connector_url
         ,action: 'Workspace/Packages/Uninstall'
-        // ,height: 400
-        // ,width: 400
         ,id: 'modx-window-package-uninstall'
         ,cls: 'modx-confirm'
         ,saveBtnText: _('uninstall')
         ,fields: [{
             html: _('preexisting_mode_select')
             ,cls: 'win-desc panel-desc'
-            // ,border: false
-            // ,autoHeight: true
         },{
             xtype: 'radio'
             ,name: 'preexisting_mode'
@@ -270,7 +266,6 @@ MODx.window.ChangeProvider = function(config) {
 			xtype: 'form'
 			,id: 'change-provider-form'
 			,border: false
-			// ,bodyCssClass: 'main-wrapper'
 			,items:[{
 				fieldLabel: _('provider')
 				,xtype: 'modx-combo-provider'

--- a/manager/assets/modext/workspace/package/index.js
+++ b/manager/assets/modext/workspace/package/index.js
@@ -13,7 +13,6 @@ MODx.page.Package = function(config) {
             ,id: 'modx-abtn-save'
             ,cls: 'primary-button'
             ,method: 'remote'
-            // ,checkDirty: true
             ,keys: [{
                 key: MODx.config.keymap_save || 's'
                 ,alt: true

--- a/manager/assets/modext/workspace/provider.grid.js
+++ b/manager/assets/modext/workspace/provider.grid.js
@@ -58,7 +58,6 @@ MODx.window.CreateProvider = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         title: _('provider_add')
-        // ,width: 400
         ,url: MODx.config.connector_url
         ,action: 'Workspace/Providers/Create'
         ,fields: [{


### PR DESCRIPTION
### What does it do?
Remove unnecessary comments and uncommented code in JS files and remove some extra whitespaces at some places.

### Why is it needed?
Currently contributors remove unnecessary comments and uncommented code when they encounter it when fixing/changing the file. This is great and but creates unnecessary noise and/or make it difficult to see actual changes in a PR.

Doing it all at once cleans up the code base and reduces the noise. 

### Related issue(s)/PR(s)
n/a