### PR TITLE
Fix a fatal error when calling runProcessor in a connector

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1730,7 +1730,7 @@ class modX extends xPDO {
             $this->services->get('lexicon');
         }
         if (!$this->error) {
-            $this->services->get('error');
+            $this->getService('error', 'error.modError');
         }
 
         // First check if the processor can be found directly as a class name provided to $action

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1727,10 +1727,16 @@ class modX extends xPDO {
 
         // Make sure the required services are loaded before initialising a processor
         if (!$this->lexicon) {
-            $this->services->get('lexicon');
+            if (!$this->services->has('lexicon')) {
+                $this->services->add('lexicon', new modLexicon($this));
+            }
+            $this->lexicon = $this->services->get('lexicon');
         }
         if (!$this->error) {
-            $this->getService('error', 'error.modError');
+            if (!$this->services->has('error')) {
+                $this->services->add('error', new modError($this));
+            }
+            $this->error = $this->services->get('error');
         }
 
         // First check if the processor can be found directly as a class name provided to $action


### PR DESCRIPTION
### What does it do?
Use the deprecated `getService` to load `modError`.

### Why is it needed?
To fix a fatal error when calling runProcessor in a connector.

### Related issue(s)/PR(s)
Fixes #15001

### Note
We definitely need to fix it the proper way, however doing it this way it will give us a bit more time without blocking a 3.0 release.
