### PR TITLE
Fix fatal error when deleting resources in trash manager

### DIFF
--- a/core/src/Revolution/Processors/Resource/Trash/Purge.php
+++ b/core/src/Revolution/Processors/Resource/Trash/Purge.php
@@ -115,7 +115,6 @@ class Purge extends Processor
         // fire before empty trash event
         $this->modx->invokeEvent('OnBeforeEmptyTrash', [
             'ids' => &$this->ids,
-            'resources' => &$this->resources,
         ]);
 
         // we track success and failure independently, as we don't want
@@ -162,9 +161,8 @@ class Purge extends Processor
         }
 
         $this->modx->invokeEvent('OnEmptyTrash', [
+	        'ids' => &$success,
             'num_deleted' => count($success),
-            'resources' => &$this->resources,
-            'ids' => &$success,
         ]);
 
         $this->modx->logManagerAction('empty_trash', modResource::class, implode(',', $success));


### PR DESCRIPTION
### What does it do?
Correct parameters for the invokeEvent calls: OnBeforeEmptyTrash and OnEmptyTrash as stated in the docs https://docs.modx.com/3.x/en/extending-modx/plugins/system-events/onemptytrash

### Why is it needed?
OnBeforeEmptyTrash with old parameters resulted in: 
PHP Fatal error: Uncaught Exception: Serialization of 'Closure' is not allowed in /core/src/Revolution/modElement.php on line 278