### PR TITLE
Fix bug in the resource trash interface

### DIFF
--- a/core/model/modx/processors/resource/trash/getlist.class.php
+++ b/core/model/modx/processors/resource/trash/getlist.class.php
@@ -59,7 +59,11 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
         if (!empty($context)) {
             $c->where(array('modResource.context_key' => $context));
         }
-        $c->where(array('modResource.id:IN' => $this->getDeleted()));
+        if ($deleted = $this->getDeleted()) {
+            $c->where(array('modResource.id:IN' => $deleted));
+        } else {
+            $c->where(array('modResource.deleted' => true));
+        }
 
         return $c;
     }
@@ -67,7 +71,6 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
     public function getDeleted()
     {
         $c = $this->modx->newQuery($this->classKey);
-        $c->leftJoin($this->classKey, 'Children');
         $c->select($this->modx->getSelectColumns($this->classKey, $this->classKey, '', array('id', 'context_key')));
         $c->where(array(
             $this->classKey . '.deleted' => true

--- a/core/model/modx/processors/resource/trash/getlist.class.php
+++ b/core/model/modx/processors/resource/trash/getlist.class.php
@@ -62,7 +62,7 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
         if ($deleted = $this->getDeleted()) {
             $c->where(array('modResource.id:IN' => $deleted));
         } else {
-            $c->where(array('modResource.deleted' => true));
+            $c->where(array('modResource.id' => 0));
         }
 
         return $c;


### PR DESCRIPTION
### What does it do?
1. Fix SQL query bug if there are no deleted resources. This query causes an error "Encountered empty IN condition with key id".
2. Remove JOIN subquery because it's redundant.

### Why is it needed?
A quick way to check
1. Move to "manager/index.php?a=resource/trash" page.
2. Look at the MODX error log.
