### PR TITLE
Language switcher now remembers the page

### DIFF
--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -94,6 +94,11 @@ class modMenu extends modAccessibleObject
 
         $this->xpdo->lexicon->load('core:languages');
 
+        $currentPage = '';
+        if (!empty($_SERVER['REQUEST_URI'])) {
+            $currentPage = '&page=' . urlencode($_SERVER['REQUEST_URI']);
+        }
+
         foreach ($languages as $code => &$language) {
             $language = [
                 'id' => $code,
@@ -104,7 +109,7 @@ class modMenu extends modAccessibleObject
                 ),
                 'parent' => 'language',
                 'action' => 'language',
-                'params' => '&switch=' . $code,
+                'params' => '&switch=' . $code . $currentPage,
                 'namespace' => 'core',
                 'permissions' => ''
             ];

--- a/manager/controllers/default/language.class.php
+++ b/manager/controllers/default/language.class.php
@@ -18,13 +18,18 @@ class LanguageManagerController extends modParsedManagerController
     {
         $targetLanguage = $this->modx->getOption('switch', $scriptProperties, 'en');
 
+        $targetPage = MODX_MANAGER_URL;
+        if (!empty($scriptProperties['page'])) {
+            $targetPage = urldecode($scriptProperties['page']);
+        }
+
         if (!in_array($targetLanguage, $this->modx->lexicon->getLanguageList())) {
             return;
         }
 
         $_SESSION['manager_language'] = $targetLanguage;
 
-        $this->modx->sendRedirect(MODX_MANAGER_URL);
+        $this->modx->sendRedirect($targetPage);
     }
 
     public function getPageTitle()


### PR DESCRIPTION
### What does it do?
When changing the language, the language switch opened the manager home page, which is inconvenient. The language switcher now remembers the page.

**Unfortunately, caching does not update the `&page` (switch language page) parameter and I have no idea how to fix this problem.**

If you comment out this line - https://github.com/Ruslan-Aleev/revolution/blob/20eb1adb899a43d52fa8a7888e3bec564ee1b60f/core/src/Revolution/modMenu.php#L69, then the switch works as desired.

![switch_lang](https://user-images.githubusercontent.com/12523676/88840454-2794ca80-d1e5-11ea-89e5-9823c8eb9b18.gif)

p.s. Most likely there is a more competent solution, without using `_SERVER`.

### Why is it needed?
Now the language switcher remembers the page on which the language was changed.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/14046