### PR TITLE
Update htaccess delete rules for win xp and IE

### DIFF
--- a/ht.access
+++ b/ht.access
@@ -48,37 +48,13 @@ RewriteRule "/\.|^\.(?!well-known/)" - [F]
 #RewriteRule ^(.*)$ https://example.com/$1 [R=301,L]
 
 
-
 # The Friendly URLs part
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ index.php?q=$1 [L,QSA]
 
 
-
-# Make sure .htc files are served with the proper MIME type, which is critical
-# for XP SP2. Un-comment if your host allows htaccess MIME type overrides.
-
-#AddType text/x-component .htc
-
-
 # For servers that support output compression, you should pick up a bit of
 # speed by un-commenting the following lines.
-
 #php_flag zlib.output_compression On
 #php_value zlib.output_compression_level 5
-
-
-
-# The following directives stop screen flicker in IE on CSS rollovers. If
-# needed, un-comment the following rules. When they're in place, you may have
-# to do a force-refresh in order to see changes in your designs.
-
-#ExpiresActive On
-#ExpiresByType image/gif A2592000
-#ExpiresByType image/jpeg A2592000
-#ExpiresByType image/png A2592000
-#BrowserMatch "MSIE" brokenvary=1
-#BrowserMatch "Mozilla/4.[0-9]{2}" brokenvary=1
-#BrowserMatch "Opera" !brokenvary
-#SetEnvIf brokenvary 1 force-no-vary


### PR DESCRIPTION
### What does it do?
Delete rules for win xp and IE

### Why is it needed?
These rules are no longer valid

### Related issue(s)/PR(s)
#14244
