### PR TITLE
Changed the lexicon to be more specific

### DIFF
--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -92,7 +92,6 @@ $_lang['create'] = 'Create';
 $_lang['create_document_here'] = 'Create document here';
 $_lang['create_document_inside'] = 'Create document inside';
 $_lang['create_folder_here'] = 'Create folder here';
-$_lang['create_new'] = 'Create New';
 $_lang['create_user_group'] = 'Create User Group';
 $_lang['created'] = 'Created';
 $_lang['createdon'] = 'Creation date';

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.settings.js
@@ -22,7 +22,7 @@ MODx.grid.GroupSettings = function(config) {
         ,save_action: 'Security/Group/Setting/UpdateFromGrid'
         ,fk: config.group
         ,tbar: [{
-            text: _('create_new')
+            text: _('setting_create')
             ,cls:'primary-button'
             ,scope: this
             ,handler: {

--- a/manager/assets/modext/widgets/security/modx.grid.user.settings.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.settings.js
@@ -22,10 +22,10 @@ MODx.grid.UserSettings = function(config) {
         ,save_action: 'Security/User/Setting/UpdateFromGrid'
         ,fk: config.user
         ,tbar: [{
-            text: _('create_new')
+            text: _('setting_create')
             ,cls: 'primary-button'
             ,scope: this
-            ,handler: { 
+            ,handler: {
                 xtype: 'modx-window-setting-create'
                 ,url: MODx.config.connector_url
                 ,baseParams: {

--- a/manager/assets/modext/widgets/system/modx.grid.context.settings.js
+++ b/manager/assets/modext/widgets/system/modx.grid.context.settings.js
@@ -22,7 +22,7 @@ MODx.grid.ContextSettings = function(config) {
         ,fk: config.context_key
         ,save_action: 'Context/Setting/UpdateFromGrid'
         ,tbar: [{
-            text: _('create_new')
+            text: _('setting_create')
             ,scope: this
             ,cls:'primary-button'
             ,handler: {


### PR DESCRIPTION
### What does it do?
In the "Contexts", "User groups" and "Users" sections there is a button for creating a setting. However, it is more correct to specify a more specific lexicon, which is also used in the "System settings" section, especially since the `create_new` lexicon is no longer used in the code.

![create_setting_1](https://user-images.githubusercontent.com/12523676/89204181-5680b700-d5be-11ea-8dad-89613fbfa65d.png)

![create_setting_2](https://user-images.githubusercontent.com/12523676/89204183-57194d80-d5be-11ea-9a6a-d2df65dca47c.png)

### Why is it needed?
- Changed the lexicon to be more specific
- Removed unnecessary lexicon

### Related issue(s)/PR(s)
N/A