### PR TITLE
Added character limit for 'site_name' in header link

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -907,6 +907,14 @@
     &:focus {
       color: $colorSplash;
     }
+
+    &:after {
+      @extend %pseudo-font;
+      content: fa-content($fa-var-eye);
+      margin-left: 5px;
+      font-size: 14px;
+      opacity: 0.5;
+    }
   }
 
   img+a {

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -298,7 +298,7 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                             var el = document.createElement('a');
                             el.href = MODx.config.default_site_url || MODx.config.site_url;
                             el.title = MODx.config.site_name;
-                            el.innerText = MODx.config.site_name;
+                            el.innerText = Ext.util.Format.ellipsis(MODx.config.site_name, 45, true);
                             el.target = '_blank';
 
                             html += el.outerHTML;

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -41,7 +41,7 @@
             <ul id="modx-headnav">
                 <li id="modx-home-dashboard">
                     <a href="?" title="{$_config.site_name|strip_tags|escape}">
-                        <img src="{$_config.manager_url}templates/{$_config.manager_theme}/images/modx-icon-color.svg" title="{$_config.site_name}">
+                        <img src="{$_config.manager_url}templates/{$_config.manager_theme}/images/modx-icon-color.svg" title="{$_config.site_name|strip_tags|escape}">
                     </a>
                 </li>
                 <li id="modx-site-info">


### PR DESCRIPTION
### What does it do?
Added character limit for `site_name` and **icon** for link in header.

**Before:**
![site_name_1](https://user-images.githubusercontent.com/12523676/89281907-6e564a80-d653-11ea-81c8-ee1e7ad3495d.png)

**After:**
![site_name_2](https://user-images.githubusercontent.com/12523676/89505343-1f82ef00-d7d2-11ea-8ff6-1bbf6ee090ab.gif)

### Why is it needed?
UI/UX fixes

### Related issue(s)/PR(s)
N/A
