### PR TITLE
Remember filter properties of packages grid in browser url 

### DIFF
--- a/manager/assets/modext/workspace/package.containers.js
+++ b/manager/assets/modext/workspace/package.containers.js
@@ -9,33 +9,34 @@
 MODx.panel.Packages = function(config) {
     config = config || {};
 
-	Ext.applyIf(config,{
-		layout:'card'
-		,border:false
-		,layoutConfig:{ deferredRender: true }
-		,defaults:{
-			autoHeight: true
-			,autoWidth: true
-			,border: false
-		}
-		,activeItem: 0
-		,items:[{
-			xtype:'modx-package-grid'
-			,id:'modx-package-grid'
-			,bodyCssClass: 'grid-with-buttons'
-		},{
-			xtype: 'modx-package-beforeinstall'
-			,id:'modx-package-beforeinstall'
-		},{
-			xtype: 'modx-package-details'
-			,id:'modx-package-details'
-			,bodyCssClass: 'modx-template-detail'
-		}]
-		,buttons: [{
-			text: _('cancel')
-			,id:'package-list-reset'
-			,hidden: true
-			,handler: function(btn, e){
+    Ext.applyIf(config,{
+        layout:'card'
+        ,border:false
+        ,layoutConfig:{ deferredRender: true }
+        ,defaults:{
+            autoHeight: true
+            ,autoWidth: true
+            ,border: false
+        }
+        ,activeItem: 0
+        ,items:[{
+            xtype:'modx-package-grid'
+            ,urlFilters: ['search']
+            ,id:'modx-package-grid'
+            ,bodyCssClass: 'grid-with-buttons'
+        },{
+            xtype: 'modx-package-beforeinstall'
+            ,id:'modx-package-beforeinstall'
+        },{
+            xtype: 'modx-package-details'
+            ,id:'modx-package-details'
+            ,bodyCssClass: 'modx-template-detail'
+        }]
+        ,buttons: [{
+            text: _('cancel')
+            ,id:'package-list-reset'
+            ,hidden: true
+            ,handler: function(btn, e){
                 var bc = Ext.getCmp('packages-breadcrumbs');
                 var last = bc.data.trail[bc.data.trail.length - 2];
                 if (last != undefined && last.rec != undefined) {
@@ -48,31 +49,31 @@ MODx.panel.Packages = function(config) {
                     grid.install(last.rec);
                     return;
                 }
-				Ext.getCmp('modx-panel-packages').activate();
-			}
-			,scope: this
-		},{
-			text: _('continue')
-			,id:'package-install-btn'
-			,cls:'primary-button'
-			,hidden: true
-			,handler: this.install
+                Ext.getCmp('modx-panel-packages').activate();
+            }
+            ,scope: this
+        },{
+            text: _('continue')
+            ,id:'package-install-btn'
+            ,cls:'primary-button'
+            ,hidden: true
+            ,handler: this.install
             ,disabled: false
-			,scope: this
-			,autoWidth: true
-			,autoHeight: true
-		},{
-			text: _('setup_options')
-			,id:'package-show-setupoptions-btn'
-			,cls:'primary-button'
-			,hidden: true
-			,handler: this.onSetupOptions
-			,scope: this
-			,autoWidth: true
-			,autoHeight: true
-		}]
-	});
-	MODx.panel.Packages.superclass.constructor.call(this,config);
+            ,scope: this
+            ,autoWidth: true
+            ,autoHeight: true
+        },{
+            text: _('setup_options')
+            ,id:'package-show-setupoptions-btn'
+            ,cls:'primary-button'
+            ,hidden: true
+            ,handler: this.onSetupOptions
+            ,scope: this
+            ,autoWidth: true
+            ,autoHeight: true
+        }]
+    });
+    MODx.panel.Packages.superclass.constructor.call(this,config);
 };
 Ext.extend(MODx.panel.Packages,MODx.Panel,{
     activate: function() {
@@ -82,14 +83,14 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
     }
 
     /**
-	 *
+     *
      * @param va ExtJS instance of the button that was clicked
      * @param event The Ext.EventObjectImpl from clicking the button
      * @param options Object containing the setup options if available, or undefined.
      * @returns {boolean}
      */
-	,install: function(va, event, options){
-    	options = options || {};
+    ,install: function(va, event, options){
+        options = options || {};
         var r;
         var g = Ext.getCmp('modx-package-grid');
         if (!g) return false;
@@ -102,7 +103,7 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
         }
 
         // Load up the installation console
-		var topic = '/workspace/package/install/'+r.signature+'/';
+        var topic = '/workspace/package/install/'+r.signature+'/';
         g.loadConsole(Ext.getBody(),topic);
 
         // Grab the params to send to the install processor
@@ -140,7 +141,7 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
                     }
 
                     this.activate();
-					Ext.getCmp('modx-package-grid').refresh();
+                    Ext.getCmp('modx-package-grid').refresh();
                 },scope:this}
                 ,'failure': {fn:function() {
                     this.activate();
@@ -149,22 +150,22 @@ Ext.extend(MODx.panel.Packages,MODx.Panel,{
         });
 
         return true;
-	}
+    }
 
-	,onSetupOptions: function(btn){
-		if(this.win == undefined){
-			this.win = new MODx.window.SetupOptions({
-				id: 'modx-window-setupoptions'
-				,signature: btn.signature || ''
-			});
-		} else {
-			this.win.signature = btn.signature || '';
+    ,onSetupOptions: function(btn){
+        if(this.win == undefined){
+            this.win = new MODx.window.SetupOptions({
+                id: 'modx-window-setupoptions'
+                ,signature: btn.signature || ''
+            });
+        } else {
+            this.win.signature = btn.signature || '';
             this.win.title = _('setup_options');
-		}
-		this.win.show(btn);
-		var opts = Ext.getCmp('modx-package-beforeinstall').getOptions();
-		this.win.fetch(opts);
-	}
+        }
+        this.win.show(btn);
+        var opts = Ext.getCmp('modx-package-beforeinstall').getOptions();
+        this.win.fetch(opts);
+    }
 });
 Ext.reg('modx-panel-packages',MODx.panel.Packages);
 
@@ -179,58 +180,58 @@ Ext.reg('modx-panel-packages',MODx.panel.Packages);
 MODx.panel.PackagesBrowser = function(config) {
     config = config || {};
 
-	Ext.applyIf(config,{
-		layout: 'column'
-		,border: false
-		,items:[{
-			xtype: 'modx-package-browser-tree'
-			,id: 'modx-package-browser-tree'
-			,width: 250
-		},{
-			layout:'card'
-			,columnWidth: 1
-			,defaults:{ border: false }
-			,border:false
-			,id:'package-browser-card-container'
-			,layoutConfig:{ deferredRender:true }
-			,items:[{
-				xtype:'modx-package-browser-home'
-				,id:'modx-package-browser-home'
-			},{
-				xtype: 'modx-package-browser-repositories'
-				,id: 'modx-package-browser-repositories'
-			},{
-				xtype:'modx-package-browser-grid'
-				,id:'modx-package-browser-grid'
-				,bodyCssClass: 'grid-with-buttons'
-			},{
-				xtype: 'modx-package-browser-details'
-				,id: 'modx-package-browser-details'
-				,bodyCssClass: 'modx-template-detail'
-			},{
-				xtype: 'modx-package-browser-view'
-				,id: 'modx-package-browser-view'
-				,bodyCssClass: 'modx-template-detail'
-			}]
-		}]
-	});
-	MODx.panel.PackagesBrowser.superclass.constructor.call(this,config);
+    Ext.applyIf(config,{
+        layout: 'column'
+        ,border: false
+        ,items:[{
+            xtype: 'modx-package-browser-tree'
+            ,id: 'modx-package-browser-tree'
+            ,width: 250
+        },{
+            layout:'card'
+            ,columnWidth: 1
+            ,defaults:{ border: false }
+            ,border:false
+            ,id:'package-browser-card-container'
+            ,layoutConfig:{ deferredRender:true }
+            ,items:[{
+                xtype:'modx-package-browser-home'
+                ,id:'modx-package-browser-home'
+            },{
+                xtype: 'modx-package-browser-repositories'
+                ,id: 'modx-package-browser-repositories'
+            },{
+                xtype:'modx-package-browser-grid'
+                ,id:'modx-package-browser-grid'
+                ,bodyCssClass: 'grid-with-buttons'
+            },{
+                xtype: 'modx-package-browser-details'
+                ,id: 'modx-package-browser-details'
+                ,bodyCssClass: 'modx-template-detail'
+            },{
+                xtype: 'modx-package-browser-view'
+                ,id: 'modx-package-browser-view'
+                ,bodyCssClass: 'modx-template-detail'
+            }]
+        }]
+    });
+    MODx.panel.PackagesBrowser.superclass.constructor.call(this,config);
 };
 Ext.extend(MODx.panel.PackagesBrowser,MODx.Panel,{
-	activate: function(){
-		Ext.getCmp('modx-layout').hideLeftbar(true, false);
-		Ext.getCmp('card-container').getLayout().setActiveItem(this.id);
-		Ext.getCmp('modx-package-browser-home').activate();
-		this.updateBreadcrumbs(_('provider_home_msg'));
-	}
+    activate: function(){
+        Ext.getCmp('modx-layout').hideLeftbar(true, false);
+        Ext.getCmp('card-container').getLayout().setActiveItem(this.id);
+        Ext.getCmp('modx-package-browser-home').activate();
+        this.updateBreadcrumbs(_('provider_home_msg'));
+    }
 
-	,updateBreadcrumbs: function(msg, highlight){
-		var bd = { text: msg };
+    ,updateBreadcrumbs: function(msg, highlight){
+        var bd = { text: msg };
         if(highlight){ bd.className = 'highlight'; }
 
-		bd.trail = [{ text : _('package_browser') }];
-		Ext.getCmp('packages-breadcrumbs').updateDetail(bd);
-	}
+        bd.trail = [{ text : _('package_browser') }];
+        Ext.getCmp('packages-breadcrumbs').updateDetail(bd);
+    }
 
     ,showWait: function(){
         if (!this.wait) {


### PR DESCRIPTION
### What does it do?
Added the selected filter properties in the browser url.

![packages_search](https://user-images.githubusercontent.com/12523676/89510129-dbdfb380-d7d8-11ea-9cad-02d5a56e72b1.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086
