### PR TITLE
Added remembering filter properties of contexts grid in browser url

### DIFF
--- a/_build/templates/default/sass/_buttons.scss
+++ b/_build/templates/default/sass/_buttons.scss
@@ -194,6 +194,14 @@ button {
     .x-form-filter {
       border-radius: $borderRadius 0 0 $borderRadius;
       z-index: 1; /* prevent clear filter button from overlapping the textfield */
+
+      &:not(.x-form-empty-field) {
+        border-color: $darkBlack;
+      }
+
+      &.x-form-focus {
+        border-color: $mediumGray;
+      }
     }
 
     .x-form-filter-clear {


### PR DESCRIPTION
### What does it do?
- Added the selected filter properties in the browser url.
- Added styles for not empty search input, so that the user can see that the filter is active.

![ctx_search](https://user-images.githubusercontent.com/12523676/89536053-fb3e0700-d7ff-11ea-9f0e-338ac194f705.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15182
https://github.com/modxcms/revolution/pull/15181
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086