### PR TITLE
Added remembering filter properties of fcsets grid in browser url

### DIFF
--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -71,6 +71,7 @@ MODx.panel.FCProfile = function(config) {
                 }]
             },{
                 xtype: 'modx-grid-fc-set'
+                ,urlFilters: ['search']
                 ,cls:'main-wrapper'
                 ,baseParams: {
                     action: 'Security/Forms/Set/GetList'
@@ -173,7 +174,15 @@ MODx.grid.FCProfileUserGroups = function(config) {
     this.fcugRecord = Ext.data.Record.create(config.fields);
 };
 Ext.extend(MODx.grid.FCProfileUserGroups,MODx.grid.LocalGrid,{
-    addUserGroup: function(btn,e) {
+    getMenu: function(g,ri) {
+        return [{
+            text: _('usergroup_remove')
+            ,handler: this.removeUserGroup
+            ,scope: this
+        }];
+    }
+
+    ,addUserGroup: function(btn,e) {
         this.loadWindow(btn,e,{
             xtype: 'modx-window-fc-profile-add-usergroup'
             ,listeners: {
@@ -184,14 +193,6 @@ Ext.extend(MODx.grid.FCProfileUserGroups,MODx.grid.LocalGrid,{
                 },scope:this}
             }
         });
-    }
-
-    ,getMenu: function(g,ri) {
-        return [{
-            text: _('usergroup_remove')
-            ,handler: this.removeUserGroup
-            ,scope: this
-        }];
     }
 
     ,removeUserGroup: function(btn,e) {


### PR DESCRIPTION
### What does it do?
- Added the selected filter properties in the browser url.
- Fixed code: indentation, changed the order of functions to logical.

![fcs_search](https://user-images.githubusercontent.com/12523676/89543026-195c3500-d809-11ea-8c5b-8c89ff25d189.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15185
https://github.com/modxcms/revolution/pull/15184
https://github.com/modxcms/revolution/pull/15183
https://github.com/modxcms/revolution/pull/15182
https://github.com/modxcms/revolution/pull/15181
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086