### PR TITLE
Changed the width of input fields for "Edit File" form

### DIFF
--- a/manager/assets/modext/sections/system/file/edit.js
+++ b/manager/assets/modext/sections/system/file/edit.js
@@ -40,6 +40,7 @@ MODx.page.EditFile = function(config) {
 };
 Ext.extend(MODx.page.EditFile,MODx.Component);
 Ext.reg('modx-page-file-edit',MODx.page.EditFile);
+
 /**
  * Loads the EditFile panel
  *
@@ -59,7 +60,7 @@ MODx.panel.EditFile = function(config) {
             ,file: config.file
             ,wctx: MODx.request.wctx
         }
-    	,cls: 'container form-with-labels'
+        ,cls: 'container form-with-labels'
         ,class_key: 'modTemplate'
         ,template: ''
         ,bodyStyle: ''
@@ -74,10 +75,10 @@ MODx.panel.EditFile = function(config) {
             ,layout: 'form'
             ,labelWidth: 150
             ,items: [{
-				xtype: 'panel'
-				,border: false
-				,layout: 'form'
-				,cls:'main-wrapper'
+                xtype: 'panel'
+                ,border: false
+                ,layout: 'form'
+                ,cls:'main-wrapper'
                 ,items: [{
                     xtype: 'hidden'
                     ,name: 'source'
@@ -87,7 +88,7 @@ MODx.panel.EditFile = function(config) {
                     ,fieldLabel: _('file_name')
                     ,name: 'basename'
                     ,id: 'modx-file-basename'
-                    ,anchor: '98%'
+                    ,anchor: '100%'
                     ,value: config.record.basename || ''
                 },{
                     xtype: 'statictextfield'
@@ -95,37 +96,37 @@ MODx.panel.EditFile = function(config) {
                     ,name: 'name'
                     ,id: 'modx-file-name'
                     ,value: config.record.name || ''
-                    ,anchor: '98%'
+                    ,anchor: '100%'
                     ,submitValue: true
                 },{
                     xtype: 'statictextfield'
                     ,fieldLabel: _('file_size')
                     ,name: 'size'
                     ,id: 'modx-file-size'
-                    ,anchor: '98%'
+                    ,anchor: '100%'
                     ,value: (config.record.size || 0) + ' B'
                 },{
                     xtype: 'statictextfield'
                     ,fieldLabel: _('file_last_accessed')
                     ,name: 'last_accessed'
                     ,id: 'modx-file-last-accessed'
-                    ,anchor: '98%'
+                    ,anchor: '100%'
                     ,value: MODx.util.Format.dateFromTimestamp(config.record.last_accessed)
                 },{
                     xtype: 'statictextfield'
                     ,fieldLabel: _('file_last_modified')
                     ,name: 'last_modified'
                     ,id: 'modx-file-last-modified'
-                    ,anchor: '98%'
+                    ,anchor: '100%'
                     ,value: MODx.util.Format.dateFromTimestamp(config.record.last_modified)
                 },{
                     xtype: 'textarea'
                     ,hideLabel: true
                     ,name: 'content'
                     ,id: 'modx-file-content'
-                    ,anchor: '98%'
-                    ,grow: false
+                    ,anchor: '100%'
                     ,height: 400
+                    ,grow: false
                     ,value: config.record.content || ''
                 }]
             }]


### PR DESCRIPTION
### What does it do?
Changed the width of input fields for "Edit File" form. Made the width 100%.

Before:
![file_edit_1](https://user-images.githubusercontent.com/12523676/90005157-7b9cb600-dc9f-11ea-9284-f84b971a9aab.png)

After:
![file_edit_2](https://user-images.githubusercontent.com/12523676/90005161-7c354c80-dc9f-11ea-854e-aa9e387f9b31.png)

### Why is it needed?
For unification in design.

### Related issue(s)/PR(s)
N/A