### PR TITLE
Fix PHP error with absent array index

### DIFF
--- a/core/model/modx/processors/element/getnodes.class.php
+++ b/core/model/modx/processors/element/getnodes.class.php
@@ -294,8 +294,10 @@ class modElementGetNodesProcessor extends modProcessor {
             );
         }
 
-        foreach (array_keys($this->actionMap) as $type) {
-            $nodes = array_merge($nodes, $this->getInCategoryElements(array($type, $map[1])));
+        if (isset($map[1])) {
+            foreach (array_keys($this->actionMap) as $type) {
+                $nodes = array_merge($nodes, $this->getInCategoryElements([$type, $map[1]]));
+            }
         }
 
         return $nodes;


### PR DESCRIPTION
### What does it do?
Fix PHP error with absent array index in the category tree.
```
(.../processors/mgr/element/getnodes.class.php : 298) PHP notice: Undefined offset: 1
```

### Why is it needed?
If expand the category list (only the first level) in the element tree, `$map` contains only one element with index 0.  And `$map[1]` is not set. To see this error the system setting "log_level"must be set to 2.
