### PR TITLE
Fix issues with fileHandler service

### DIFF
--- a/core/src/Revolution/File/modFileHandler.php
+++ b/core/src/Revolution/File/modFileHandler.php
@@ -65,9 +65,9 @@ class modFileHandler {
         } else {
             if (is_dir($path)) {
                 $path = $this->postfixSlash($path);
-                $class = 'modDirectory';
+                $class = modDirectory::class;
             } else {
-                $class = 'modFile';
+                $class = modFile::class;
             }
         }
 

--- a/core/src/Revolution/File/modFileSystemResource.php
+++ b/core/src/Revolution/File/modFileSystemResource.php
@@ -249,7 +249,7 @@ abstract class modFileSystemResource
             return $ppath;
         }
 
-        $directory = $this->fileHandler->make($ppath, [], 'modDirectory');
+        $directory = $this->fileHandler->make($ppath, [], modDirectory::class);
 
         return $directory;
     }

--- a/core/src/Revolution/Processors/Element/ExportProperties.php
+++ b/core/src/Revolution/Processors/Element/ExportProperties.php
@@ -57,7 +57,7 @@ class ExportProperties extends Processor
         }
 
         /** @var modFileHandler $fileHandler */
-        $fileHandler = $this->modx->getService('fileHandler', 'modFileHandler');
+        $fileHandler = $this->modx->getService('fileHandler', modFileHandler::class);
 
         $fileName = strtolower(str_replace(' ', '-', $this->getProperty('id'))) . '.export.js';
 

--- a/core/src/Revolution/Processors/Model/ExportProcessor.php
+++ b/core/src/Revolution/Processors/Model/ExportProcessor.php
@@ -95,7 +95,7 @@ abstract class ExportProcessor extends GetProcessor
                 MODX_CORE_PATH) . 'export/' . $this->objectType . '/' . $fileName;
 
         /** @var modFileHandler $fileHandler */
-        $fileHandler = $this->modx->getService('fileHandler', 'modFileHandler');
+        $fileHandler = $this->modx->getService('fileHandler', modFileHandler::class);
         $fileObj = $fileHandler->make($file);
         $name = strtolower(str_replace([' ', '/'], '-', $this->object->get($this->nameField)));
 

--- a/manager/controllers/default/resource/staticresource/update.class.php
+++ b/manager/controllers/default/resource/staticresource/update.class.php
@@ -8,6 +8,8 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\File\modFileHandler;
+
 /**
  * @package modx
  * @subpackage manager.controllers
@@ -73,7 +75,7 @@ class StaticResourceUpdateManagerController extends ResourceUpdateManagerControl
         }
 
         /** @var modFileHandler $fileHandler */
-        if ($fileHandler = $this->modx->getService('fileHandler', 'modFileHandler', '', ['context' => $workingContext->get('key')])) {
+        if ($fileHandler = $this->modx->getService('fileHandler', modFileHandler::class, '', ['context' => $workingContext->get('key')])) {
             $baseUrl = $fileHandler->getBaseUrl();
             if (!empty($this->resourceArray['content'])) {
                 $this->resourceArray['openTo'] = str_replace($baseUrl, '', dirname($this->resourceArray['content']) . '/');


### PR DESCRIPTION
### What does it do?
Use fully qualified class names when loading the `fileHandler` service.

### Why is it needed?
Make sure we can load the fileHandler service and prevent errors in export processors. 

### Related issue(s)/PR(s)
fixes #15194 