### PR TITLE
Added an icon for "Resource Groups", "User Groups" & "Property Sets" sections tree

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -8,7 +8,7 @@ MODx.panel.PropertySet = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-property-sets'
-		,cls: 'container'
+        ,cls: 'container'
         ,items: [{
             html: _('propertysets')
             ,xtype: 'modx-header'
@@ -24,7 +24,7 @@ MODx.panel.PropertySet = function(config) {
             },{
                 layout: 'column'
                 ,border: false
-				,cls: 'main-wrapper'
+                ,cls: 'main-wrapper'
                 ,items: [{
                     columnWidth: .3
                     ,cls: 'left-col'
@@ -111,11 +111,12 @@ Ext.reg('modx-grid-property-set-properties',MODx.grid.PropertySetProperties);
 MODx.tree.PropertySets = function(config) {
     config = config || {};
     Ext.applyIf(config,{
-        rootVisible: false
-        ,enableDD: false
-        ,title: ''
+        title: _('propertysets')
         ,url: MODx.config.connector_url
         ,action: 'Element/PropertySet/GetNodes'
+        ,rootIconCls: 'icon-sitemap'
+        ,root_name: _('propertysets')
+        ,enableDD: false
         ,tbar: ['->', {
             text: _('propertyset_new')
             ,cls: 'primary-button'
@@ -215,6 +216,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
         this.winDupeSet.setValues(r);
         this.winDupeSet.show(e.target);
     }
+
     ,updateSet: function(btn,e) {
         var id = this.cm.activeNode.id.split('_');
         var r = this.cm.activeNode.attributes.data;
@@ -234,6 +236,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
         this.winUpdateSet.setValues(r);
         this.winUpdateSet.show(e.target);
     }
+
     ,removeSet: function(btn,e) {
         var id = this.cm.activeNode.id.split('_');
         id = id[1];
@@ -255,6 +258,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
             }
         });
     }
+
     ,addElement: function(btn,e) {
         var id = this.cm.activeNode.id.split('_'); id = id[1];
         var t = this.cm.activeNode.text;
@@ -276,6 +280,7 @@ Ext.extend(MODx.tree.PropertySets,MODx.tree.Tree,{
         this.winPSEA.fp.getForm().setValues(r);
         this.winPSEA.show(e.target);
     }
+
     ,removeElement: function(btn,e) {
         var d = this.cm.activeNode.attributes;
         MODx.msg.confirm({
@@ -355,7 +360,6 @@ Ext.extend(MODx.window.AddElementToPropertySet,MODx.Window,{
     }
 });
 Ext.reg('modx-window-propertyset-element-add',MODx.window.AddElementToPropertySet);
-
 
 /**
  * @class MODx.combo.ElementClass
@@ -456,7 +460,6 @@ MODx.window.CreatePropertySet = function(config) {
 Ext.extend(MODx.window.CreatePropertySet,MODx.Window);
 Ext.reg('modx-window-property-set-create',MODx.window.CreatePropertySet);
 
-
 /**
  * @class MODx.window.UpdatePropertySet
  * @extends MODx.Window
@@ -476,8 +479,6 @@ MODx.window.UpdatePropertySet = function(config) {
 };
 Ext.extend(MODx.window.UpdatePropertySet,MODx.window.CreatePropertySet);
 Ext.reg('modx-window-property-set-update',MODx.window.UpdatePropertySet);
-
-
 
 /**
  * @class MODx.window.DuplicatePropertySet

--- a/manager/assets/modext/widgets/security/modx.tree.resource.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.resource.group.js
@@ -12,6 +12,7 @@ MODx.tree.ResourceGroup = function(config) {
         title: _('resource_groups')
         ,url: MODx.config.connector_url
         ,action: 'Security/ResourceGroup/GetNodes'
+        ,rootIconCls: 'icon-files-o'
         ,root_id: '0'
         ,root_name: _('resource_groups')
         ,enableDrag: false
@@ -213,7 +214,12 @@ Ext.extend(MODx.tree.ResourceGroup,MODx.tree.Tree,{
 });
 Ext.reg('modx-tree-resource-group',MODx.tree.ResourceGroup);
 
-
+/**
+ * @class MODx.window.CreateResourceGroup
+ * @extends MODx.Window
+ * @param {Object} config An object of configuration resource groups
+ * @xtype modx-window-resourcegroup-create
+ */
 MODx.window.CreateResourceGroup = function(config) {
     config = config || {};
     this.ident = config.ident || 'modx-crgrp'+Ext.id();
@@ -330,6 +336,12 @@ MODx.window.CreateResourceGroup = function(config) {
 Ext.extend(MODx.window.CreateResourceGroup,MODx.Window);
 Ext.reg('modx-window-resourcegroup-create',MODx.window.CreateResourceGroup);
 
+/**
+ * @class MODx.window.UpdateResourceGroup
+ * @extends MODx.Window
+ * @param {Object} config An object of configuration resource groups
+ * @xtype modx-window-resourcegroup-update
+ */
 MODx.window.UpdateResourceGroup = function(config) {
     config = config || {};
     this.ident = config.ident || 'urgrp'+Ext.id();

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -14,6 +14,7 @@ MODx.tree.UserGroup = function(config) {
         ,url: MODx.config.connector_url
         ,action: 'Security/Group/GetNodes'
         ,sortAction: 'Security/Group/Sort'
+        ,rootIconCls: 'icon-group'
         ,root_id: 'n_ug_0'
         ,root_name: _('user_groups')
         ,enableDrag: true
@@ -195,6 +196,12 @@ Ext.extend(MODx.tree.UserGroup,MODx.tree.Tree,{
 });
 Ext.reg('modx-tree-usergroup',MODx.tree.UserGroup);
 
+/**
+ * @class MODx.window.CreateUserGroup
+ * @extends MODx.Window
+ * @param {Object} config An object of configuration user groups
+ * @xtype modx-window-usergroup-create
+ */
 MODx.window.CreateUserGroup = function(config) {
     config = config || {};
     this.ident = config.ident || 'cugrp'+Ext.id();
@@ -280,7 +287,6 @@ MODx.window.CreateUserGroup = function(config) {
                         ,forId: this.ident+'-aw-resource-groups'
                         ,html: _('user_group_aw_resource_groups_desc')
                         ,cls: 'desc-under'
-
                     },{
                         boxLabel: _('user_group_aw_parallel')
                         ,description: _('user_group_aw_parallel_desc')
@@ -311,7 +317,6 @@ MODx.window.CreateUserGroup = function(config) {
                         ,forId: this.ident+'-aw-contexts'
                         ,html: _('user_group_aw_contexts_desc')
                         ,cls: 'desc-under'
-
                     },{
                         xtype: 'modx-combo-policy'
                         ,baseParams: {
@@ -330,7 +335,6 @@ MODx.window.CreateUserGroup = function(config) {
                         ,forId: this.ident+'-aw-manager-policy'
                         ,html: _('user_group_aw_manager_policy_desc')
                         ,cls: 'desc-under'
-
                     },{
                         fieldLabel: _('user_group_aw_categories')
                         ,description: _('user_group_aw_categories_desc')
@@ -344,7 +348,6 @@ MODx.window.CreateUserGroup = function(config) {
                         ,forId: this.ident+'-aw-categories'
                         ,html: _('user_group_aw_categories_desc')
                         ,cls: 'desc-under'
-
                     }]
                 }]
             }]
@@ -356,6 +359,12 @@ MODx.window.CreateUserGroup = function(config) {
 Ext.extend(MODx.window.CreateUserGroup,MODx.Window);
 Ext.reg('modx-window-usergroup-create',MODx.window.CreateUserGroup);
 
+/**
+ * @class MODx.window.AddUserToUserGroup
+ * @extends MODx.Window
+ * @param {Object} config An object of configuration user groups
+ * @xtype modx-window-usergroup-adduser
+ */
 MODx.window.AddUserToUserGroup = function(config) {
     config = config || {};
     this.ident = config.ident || 'adtug'+Ext.id();


### PR DESCRIPTION
### What does it do?
Added an icon for "Resource Groups", "User Groups" & "Property Sets" sections tree.

Before:
![rg_1](https://user-images.githubusercontent.com/12523676/90513718-c0759080-e168-11ea-88c1-fddd8c674058.png)
![ug_1](https://user-images.githubusercontent.com/12523676/90513723-c23f5400-e168-11ea-8ef9-2f3c5c68afd6.png)
![ps_1](https://user-images.githubusercontent.com/12523676/90516733-177d6480-e16d-11ea-9b03-d7740df0d078.png)

After:
![rg_2](https://user-images.githubusercontent.com/12523676/90513721-c1a6bd80-e168-11ea-9ba9-90533f5957fa.png)
![ug_2](https://user-images.githubusercontent.com/12523676/90513725-c23f5400-e168-11ea-9101-d92b2125c78e.png)
![ps_2](https://user-images.githubusercontent.com/12523676/90516735-1815fb00-e16d-11ea-8f4c-c76073bde693.png)

### Why is it needed?
UI/UX fixes

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/14533
