### PR TITLE
Fix of checking existence of <?php tag

### DIFF
--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -100,7 +100,7 @@ class ElementPluginUpdateManagerController extends modManagerController {
         $this->pluginArray = $this->plugin->toArray();
         $this->pluginArray['properties'] = $data;
         $this->pluginArray['plugincode'] = $this->plugin->getContent();
-        if (strpos($this->pluginArray['plugincode'],'<?php') === false) {
+        if (strpos(ltrim($this->pluginArray['plugincode']),'<?php') !== 0) {
             $this->pluginArray['plugincode'] = "<?php\n".$this->pluginArray['plugincode'];
         }
 

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -99,7 +99,7 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         $this->snippetArray = $this->snippet->toArray();
         $this->snippetArray['properties'] = $data;
         $this->snippetArray['snippet'] = $this->snippet->getContent();
-        if (strpos($this->snippetArray['snippet'],'<?php') === false) {
+        if (strpos(ltrim($this->snippetArray['snippet']),'<?php') !== 0) {
             $this->snippetArray['snippet'] = "<?php\n".$this->snippetArray['snippet'];
         }
 


### PR DESCRIPTION
### What does it do?
Fix the check of starting php tag existence.

### Why is it needed?
if snippet or plugin code contains the "<?php" tag somewhere, it will not be added to the beginning of the code. This causes some problems.

### Way to reproduce the problem
1. Create a snippet with code
```
<?php
$var1 = 'String';
$var2 = '<?php';
return $var2 . $var1;
```
2. Save it.
3. Wait for the page to reload.
4. Look at the code - 
```
$var1 = 'String';
$var2 = '<?php';
return $var2 . $var1;
```