### PR TITLE
Fixed options for TV output with date type

### DIFF
--- a/manager/templates/default/element/tv/renders/properties/date.tpl
+++ b/manager/templates/default/element/tv/renders/properties/date.tpl
@@ -31,26 +31,14 @@ MODx.load({
         ,html: _('date_format_desc')
         ,cls: 'desc-under'
     },{
-        xtype: 'combo'
+        xtype: 'combo-boolean'
         ,fieldLabel: _('date_use_current')
         ,description: MODx.expandHelp ? '' : _('date_use_current_desc')
         ,name: 'prop_default'
-        ,hiddenName: 'prop_default'
         ,id: 'prop_default{/literal}{$tv|default}{literal}'
-        ,store: new Ext.data.SimpleStore({
-            fields: ['v','d']
-            ,data: [[1,_('yes')],[0,_('no')]]
-        })
-        ,displayField: 'd'
-        ,valueField: 'v'
-        ,mode: 'local'
-        ,editable: false
-        ,forceSelection: true
-        ,typeAhead: false
-        ,triggerAction: 'all'
-        ,value: params['default'] || 'no'
+        ,value: (params['default']) ? !(params['default'] === 0 || params['default'] === 'false') : true
         ,listeners: oc
-        ,width: 200
+        ,anchor: '100%'
     },{
         xtype: MODx.expandHelp ? 'label' : 'hidden'
         ,forId: 'prop_default{/literal}{$tv|default}{literal}'


### PR DESCRIPTION
### What does it do?
Fixed options for TV output with `date` type:
- Fixed xtype (the value was not displayed correctly)
- Fixed width (now 100%)

Before:
![tv-output-date_1](https://user-images.githubusercontent.com/12523676/91329242-99eecf80-e7d0-11ea-9149-9d927d4b0000.gif)

After:
![tv-output-date_2](https://user-images.githubusercontent.com/12523676/91329243-9a876600-e7d0-11ea-8c6a-d164be6774f6.png)

### Why is it needed?
UI/UX fixes

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15208