### PR TITLE
Fixed PHP notice "Undefined index" for resources without a template

### DIFF
--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -386,6 +386,9 @@ abstract class ResourceManagerController extends modManagerController {
         $this->setPlaceholder('tvCounts',$this->modx->toJSON($this->tvCounts));
         $this->setPlaceholder('tvMap',$this->modx->toJSON($tvMap));
         $this->setPlaceholder('hidden',$hidden);
+        if (is_null($this->getPlaceholder('tvcount'))) {
+            $this->setPlaceholder('tvcount', 0);
+        }
 
         if (!empty($this->scriptProperties['showCheckbox'])) {
             $this->setPlaceholder('showCheckbox',1);


### PR DESCRIPTION
### What does it do?
Fixed PHP notice "Undefined index" for resources without a template. The problem is in the smarty template [/manager/templates/default/resource/sections/tvs.tpl](https://github.com/modxcms/revolution/blob/85c6a6acafbfe9096a345c9ceaa6ad735e928183/manager/templates/default/resource/sections/tvs.tpl#L82).

### Why is it needed?
1. Set the `log_level` system setting to 2.
2. Open any resource page without a template for editing.
3. Open the error log.
```
[2020-08-27 07:00:00] (WARN @ path/to/site/core/cache/mgr/smarty/dc800d85e9f8b38c930da579fe8f8f5502b448c9_0.file.tvs.tpl.php : 155) PHP notice: Undefined index: tvcount
[2020-08-27 07:00:00] (WARN @ path/to/site/core/cache/mgr/smarty/dc800d85e9f8b38c930da579fe8f8f5502b448c9_0.file.tvs.tpl.php : 155) PHP notice: Trying to get property 'value' of non-object
```
That's because the number of TVs is not set for these resources.

