### PR TITLE
Fix PHP error with absent array index

### DIFF
--- a/core/src/Revolution/Processors/Element/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/GetNodes.php
@@ -330,8 +330,10 @@ class GetNodes extends Processor
             ];
         }
 
-        foreach (array_keys($this->actionMap) as $type) {
-            $nodes = array_merge($nodes, $this->getInCategoryElements([$type, $map[1]]));
+        if (isset($map[1])) {
+            foreach (array_keys($this->actionMap) as $type) {
+                $nodes = array_merge($nodes, $this->getInCategoryElements([$type, $map[1]]));
+            }
         }
 
         return $nodes;


### PR DESCRIPTION
### What does it do?
Fix PHP error with absent array index in the category tree.

### Why is it needed?
If expand the category list (only the first level) in the element tree, `$map` contains only one element with index 0. And `$map[1] `is not set. To see this error the system setting "`log_level`"must be set to 2.

### Related issue(s)/PR(s)
#15199