### PR TITLE
Fix login screen php notice

### DIFF
--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -119,9 +119,9 @@
                             <form action="" method="post" id="modx-forgot-login-form" class="c-form can-toggle {if NOT $_post.username_reset|default}is-hidden{/if}">
                                 <p class="lead">{$_lang.login_forget_your_login_note}</p>
 
-                                {if $error_message}
+                                {if isset($error_message) && $error_message}
                                     <p class="is-error">{$error_message|default}</p>
-                                {elseif $success_message}
+                                {elseif isset($success_message) && $success_message}
                                     <p class="is-success">{$success_message|default}</p>
                                 {/if}
 


### PR DESCRIPTION
### What does it do?
Check if the error/success message variable is set.

### Why is it needed?
To prevent a PHP notice: Trying to get property 'value' of non-object in the cached file Smarty generates for this login template.

### Related issue(s)/PR(s)
#15140
