### PR TITLE
Changed id for options for TV output with html-tag type

### DIFF
--- a/core/lexicon/en/tv_widget.inc.php
+++ b/core/lexicon/en/tv_widget.inc.php
@@ -118,7 +118,6 @@ $_lang['start_day_desc'] = 'Day index at which the week should begin, 0-based (d
 $_lang['string'] = 'String';
 $_lang['string_format'] = 'String Format';
 $_lang['style'] = 'Style';
-$_lang['tag_id'] = 'Tag ID';
 $_lang['tag_name'] = 'Tag Name';
 $_lang['target'] = 'Target';
 $_lang['text'] = 'Text';

--- a/manager/templates/default/element/tv/renders/properties/htmltag.tpl
+++ b/manager/templates/default/element/tv/renders/properties/htmltag.tpl
@@ -26,10 +26,10 @@ MODx.load({
         ,anchor: '100%'
     },{
         xtype: 'textfield'
-        ,fieldLabel: _('tag_id')
-        ,name: 'prop_tagid'
-        ,id: 'prop_tagid{/literal}{$tv|default}{literal}'
-        ,value: params['tagid'] || ''
+        ,fieldLabel: _('id')
+        ,name: 'prop_id'
+        ,id: 'prop_id{/literal}{$tv|default}{literal}'
+        ,value: params['id'] || ''
         ,listeners: oc
         ,anchor: '100%'
     },{
@@ -51,9 +51,9 @@ MODx.load({
     },{
         xtype: 'textfield'
         ,fieldLabel: _('attributes')
-        ,name: 'prop_attrib'
-        ,id: 'prop_attrib{/literal}{$tv|default}{literal}'
-        ,value: params['attrib'] || ''
+        ,name: 'prop_attributes'
+        ,id: 'prop_attributes{/literal}{$tv|default}{literal}'
+        ,value: params['attributes'] || ''
         ,listeners: oc
         ,anchor: '100%'
     }]

--- a/setup/includes/upgrades/common/3.0.0-update-tvs-output-params.php
+++ b/setup/includes/upgrades/common/3.0.0-update-tvs-output-params.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Common upgrade script for modify modTemplateVar output params
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+use MODX\Revolution\modTemplateVar;
+
+/** @var modTemplateVar $tvs */
+$tvs = $modx->getCollection(modTemplateVar::class);
+
+if ($tvs) {
+
+    foreach ($tvs as $tv) {
+        $output_properties = $tv->get('output_properties');
+
+        if (!empty($output_properties['tagid'])) {
+            $output_properties['id'] = $output_properties['tagid'];
+        }
+        if (!empty($output_properties['attrib'])) {
+            $output_properties['attributes'] = $output_properties['attrib'];
+        }
+        unset($output_properties['tagid']);
+        unset($output_properties['attrib']);
+
+        $tv->set('output_properties', $output_properties);
+        $tv->save();
+    }
+
+}

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -26,3 +26,4 @@ include dirname(__DIR__) . '/common/3.0.0-update-menu-entries.php';
 include dirname(__DIR__) . '/common/3.0.0-update-default-media-source-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-woff2.php';
 include dirname(__DIR__) . '/common/3.0.0-update-tvs-params.php';
+include dirname(__DIR__) . '/common/3.0.0-update-tvs-output-params.php';

--- a/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
+++ b/setup/includes/upgrades/sqlsrv/3.0.0-pl.php
@@ -26,3 +26,4 @@ include dirname(__DIR__) . '/common/3.0.0-update-menu-entries.php';
 include dirname(__DIR__) . '/common/3.0.0-update-default-media-source-setting.php';
 include dirname(__DIR__) . '/common/3.0.0-update-upload_files-woff2.php';
 include dirname(__DIR__) . '/common/3.0.0-update-tvs-params.php';
+include dirname(__DIR__) . '/common/3.0.0-update-tvs-output-params.php';


### PR DESCRIPTION
### What does it do?
- Changed id for options for TV output with html-tag type: for `id` and `attributes` options.
- Removed unnecessary `tag_id` lexicon, replacing it with `id` lexicon.

### Why is it needed?
Some option ids are the same and some are not.
Identical option ids are more convenient, because when you change the output type, the values are set in, you do not need to enter them again.

![tv-tag-output](https://user-images.githubusercontent.com/12523676/91636920-238ae100-ea0d-11ea-821e-1ca03f2edc17.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15212
https://github.com/modxcms/revolution/pull/15208
