### PR TITLE
Changed options for TV output with url type

### DIFF
--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/url.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/url.class.php
@@ -53,6 +53,7 @@ class modTemplateVarOutputRenderUrl extends modTemplateVarOutputRender {
                 $attr = [
                     'href' => $url,
                     'title' => !empty($params['title']) ? htmlspecialchars($params['title']) : $name,
+                    'id' => !empty($params['id']) ? $params['id'] : null,
                     'class' => !empty($params['class']) ? $params['class'] : null,
                     'style' => !empty($params['style']) ? $params['style'] : null,
                     'target' => !empty($params['target']) ? $params['target'] : null,

--- a/manager/templates/default/element/tv/renders/properties/url.tpl
+++ b/manager/templates/default/element/tv/renders/properties/url.tpl
@@ -59,9 +59,9 @@ MODx.load({
     },{
         xtype: 'textfield'
         ,fieldLabel: _('attributes')
-        ,name: 'prop_attrib'
-        ,id: 'prop_attrib{/literal}{$tv|default}{literal}'
-        ,value: params['attrib'] || ''
+        ,name: 'prop_attributes'
+        ,id: 'prop_attributes{/literal}{$tv|default}{literal}'
+        ,value: params['attributes'] || ''
         ,listeners: oc
         ,anchor: '100%'
     }]

--- a/manager/templates/default/element/tv/renders/properties/url.tpl
+++ b/manager/templates/default/element/tv/renders/properties/url.tpl
@@ -34,6 +34,14 @@ MODx.load({
         ,anchor: '100%'
     },{
         xtype: 'textfield'
+        ,fieldLabel: _('id')
+        ,name: 'prop_id'
+        ,id: 'prop_id{/literal}{$tv|default}{literal}'
+        ,value: params['id'] || ''
+        ,listeners: oc
+        ,anchor: '100%'
+    },{
+        xtype: 'textfield'
         ,fieldLabel: _('class')
         ,name: 'prop_class'
         ,id: 'prop_class{/literal}{$tv|default}{literal}'

--- a/manager/templates/default/element/tv/renders/properties/url.tpl
+++ b/manager/templates/default/element/tv/renders/properties/url.tpl
@@ -20,6 +20,7 @@ MODx.load({
         xtype: 'textfield'
         ,fieldLabel: _('url_display_text')
         ,name: 'prop_text'
+        ,id: 'prop_text{/literal}{$tv|default}{literal}'
         ,value: params['text'] || ''
         ,listeners: oc
         ,anchor: '100%'
@@ -27,6 +28,7 @@ MODx.load({
         xtype: 'textfield'
         ,fieldLabel: _('title')
         ,name: 'prop_title'
+        ,id: 'prop_title{/literal}{$tv|default}{literal}'
         ,value: params['title'] || ''
         ,listeners: oc
         ,anchor: '100%'
@@ -34,6 +36,7 @@ MODx.load({
         xtype: 'textfield'
         ,fieldLabel: _('class')
         ,name: 'prop_class'
+        ,id: 'prop_class{/literal}{$tv|default}{literal}'
         ,value: params['class'] || ''
         ,listeners: oc
         ,anchor: '100%'
@@ -41,6 +44,7 @@ MODx.load({
         xtype: 'textfield'
         ,fieldLabel: _('style')
         ,name: 'prop_style'
+        ,id: 'prop_style{/literal}{$tv|default}{literal}'
         ,value: params['style'] || ''
         ,listeners: oc
         ,anchor: '100%'
@@ -48,6 +52,7 @@ MODx.load({
         xtype: 'textfield'
         ,fieldLabel: _('target')
         ,name: 'prop_target'
+        ,id: 'prop_target{/literal}{$tv|default}{literal}'
         ,value: params['target'] || ''
         ,listeners: oc
         ,anchor: '100%'
@@ -55,6 +60,7 @@ MODx.load({
         xtype: 'textfield'
         ,fieldLabel: _('attributes')
         ,name: 'prop_attrib'
+        ,id: 'prop_attrib{/literal}{$tv|default}{literal}'
         ,value: params['attrib'] || ''
         ,listeners: oc
         ,anchor: '100%'


### PR DESCRIPTION
### Upd
Because here the option id also changes (`attrib` -> `atributes`), then **this PR needs to be merged after** https://github.com/modxcms/revolution/pull/15217 Because the update script is the same.

### What does it do?
- Changed id for options for TV output with **url type** `attributes` option.
- Added `ID` option: for all tags (img, html-tag) the output has an id, but for the link there is no, it will not be superfluous.

### Why is it needed?
Some option ids are the same and some are not.
Identical option ids are more convenient, because when you change the output type, the values are set in, you do not need to enter them again.

Example with  setting of option values:
![tv-tag-output](https://user-images.githubusercontent.com/12523676/91636920-238ae100-ea0d-11ea-821e-1ca03f2edc17.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15217
https://github.com/modxcms/revolution/pull/15212
https://github.com/modxcms/revolution/pull/15208