### PR TITLE
Fix nested ternary statement without explicit parentheses in modX class

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -675,7 +675,7 @@ class modX extends xPDO {
                 parent :: setDebug(false);
             }
             else {
-                $debug = ((is_int($debug) ? $debug : defined($debug)) ? intval(constant($debug)) : 0);
+                $debug = (is_int($debug) ? $debug : (defined($debug) ? intval(constant($debug)) : 0));
                 if ($debug) {
                     error_reporting($debug);
                     parent :: setLogLevel(xPDO::LOG_LEVEL_INFO);

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -675,7 +675,7 @@ class modX extends xPDO {
                 parent :: setDebug(false);
             }
             else {
-                $debug = (is_int($debug) ? $debug : defined($debug) ? intval(constant($debug)) : 0);
+                $debug = ((is_int($debug) ? $debug : defined($debug)) ? intval(constant($debug)) : 0);
                 if ($debug) {
                     error_reporting($debug);
                     parent :: setLogLevel(xPDO::LOG_LEVEL_INFO);


### PR DESCRIPTION
### What does it do?
Add parentheses for first check

### Why is it needed?
Get rid of deprecated error message for PHP 7.4.9

### Related issue(s)/PR(s)
- Not to my knowledge
