### PR TITLE
Fixed incorrect path setting when uploading files

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -254,6 +254,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
     }
 
     ,changeSource: function(sel) {
+        this.cm.activeNode = '';
         var s = sel.getValue();
         var rn = this.getRootNode();
         if (rn) { rn.setText(sel.getRawValue()); }

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -292,6 +292,9 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             // Node has been collapsed, grab its parent
             n = n.parentNode;
         }
+        if (n.id == this.config.openTo) {
+            n.select();
+        }
         var p = n.getPath('text');
         Ext.state.Manager.set(this.treestate_id, p);
     }

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -723,7 +723,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
     }
 
     ,beforeUpload: function() {
-        var path = this.config.rootId || '/';
+        var path = this.config.openTo || this.config.rootId || '/';
         if (this.cm.activeNode) {
             path = this.getPath(this.cm.activeNode);
             if(this.cm.activeNode.isLeaf()) {


### PR DESCRIPTION
### What does it do?
- Added reset of active node when changing source.

If you select directory in one media source, then select another source and immediately try to upload the file, the downloader will try to upload to the previous source (active node).

**How the bug looks:**
![sources_bug_1](https://user-images.githubusercontent.com/12523676/92327441-7e05ec00-f062-11ea-9411-7056e7a7ed5e.gif)

- Added saving previous path to upload file

If there are several directories in the source, then when editing the TV the file will be uploaded into the root of the source, although the viewer shows the files of the correct directory.

**How the bug looks:**
![sources_bug_2](https://user-images.githubusercontent.com/12523676/92327443-7f371900-f062-11ea-9308-85437f4c92c7.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14400
https://github.com/modxcms/revolution/issues/5320