### PR TITLE
Added indication of selected file & expanding active source in tree

### DIFF
--- a/manager/assets/modext/widgets/core/tree/modx.tree.js
+++ b/manager/assets/modext/widgets/core/tree/modx.tree.js
@@ -257,8 +257,20 @@ Ext.extend(MODx.tree.Tree,Ext.tree.TreePanel,{
      * @param node
      */
     ,prepareNodes: function(node) {
+        var params = {};
+        if (location.search) {
+            var parts = location.search.substring(1).split('&');
+
+            for (var i = 0; i < parts.length; i++) {
+                var nv = parts[i].split('=');
+                if (!nv[0]) continue;
+                params[nv[0]] = nv[1] || true;
+            }
+        }
+        var activeFile = params.file;
+
         Ext.each(node.childNodes,function (node) {
-            if (node.attributes.selected) {
+            if (node.attributes.selected || node.id == activeFile) {
                 //node.select();
                 node.ui.addClass('x-tree-selected');
             }

--- a/manager/assets/modext/widgets/system/modx.panel.filetree.js
+++ b/manager/assets/modext/widgets/system/modx.panel.filetree.js
@@ -78,8 +78,26 @@ Ext.extend(MODx.panel.FileTree, Ext.Container, {
      * @returns {Object}
      */
     ,loadTree: function(source) {
+        var params = {};
+        if (location.search) {
+            var parts = location.search.substring(1).split('&');
+
+            for (var i = 0; i < parts.length; i++) {
+                var nv = parts[i].split('=');
+                if (!nv[0]) continue;
+                params[nv[0]] = nv[1] || true;
+            }
+        }
+        var activeSource = params.source,
+            expandSource = false;
+
+        if (source.id == activeSource) {
+            expandSource = true;
+        }
+
         return MODx.load({
             xtype: 'modx-tree-directory'
+            ,autoExpandRoot: expandSource
             ,itemId: this._treePrefix + source.id
             ,stateId: this._treePrefix + source.id
             ,id: this._treePrefix + source.id


### PR DESCRIPTION
### What does it do?
Added indication of selected file & expanding active source in tree.

In the current version, the sources in the tree are collapsed when you edit the file (until you expand any source folder).
And the file is not marked as active in the tree.

**This PR fixes that. How it looks now:**

![sources_files](https://user-images.githubusercontent.com/12523676/92372586-d641fa00-f105-11ea-80a9-ecaeb9932335.gif)

~p.s. `URLSearchParams` is not IE compatible, do I need to rewrite the code or can I leave it as it is?~

### Why is it needed?
UX fixes

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13234
