### PR TITLE
Fixed work with menu items in the main menu

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.menu.js
+++ b/manager/assets/modext/widgets/system/modx.tree.menu.js
@@ -12,10 +12,11 @@ MODx.tree.Menu = function(config) {
         rootIconCls: 'icon-navicon'
         ,rootId: 'n_'
         ,rootName: _('menu_top')
-        ,rootVisible: true
+        ,rootVisible: false
         ,expandFirst: true
         ,enableDrag: true
         ,enableDrop: true
+        ,ddAppendOnly: true
         ,url: MODx.config.connector_url
         ,action: 'System/Menu/GetNodes'
         ,sortAction: 'System/Menu/Sort'
@@ -36,7 +37,7 @@ Ext.extend(MODx.tree.Menu, MODx.tree.Tree, {
 
     ,createMenu: function(n,e) {
         var r = {
-            parent: ''
+            parent: 'topnav'
         };
         if (this.cm && this.cm.activeNode && this.cm.activeNode.attributes && this.cm.activeNode.attributes.data) {
             r['parent'] = this.cm.activeNode.attributes.data.text;


### PR DESCRIPTION
### What does it do?
Fixed work with menu items in the main menu:

**- Disabled drag and drop for root menu.**

In the menu, you could move the menu item by dragging to the root, after which the menu item would not be displayed in the manager panel at all (since there are only 2 menu areas in manager).

Before:
![menu_dd_1](https://user-images.githubusercontent.com/12523676/92591988-89962480-f2a7-11ea-9eb1-1808600acc0d.gif)

After:
![menu_dd_2](https://user-images.githubusercontent.com/12523676/92591992-8a2ebb00-f2a7-11ea-9fe1-e1e5d88458e9.gif)

**- Set correct parent in menu item creation window.**

When creating a menu item, the parent was set empty, which is why, again, the menu item was not displayed in the manager panel.

Before:
![menu_create_1](https://user-images.githubusercontent.com/12523676/92591986-88fd8e00-f2a7-11ea-9ac9-2f8032e71f42.png)

After:
![menu_create_2](https://user-images.githubusercontent.com/12523676/92591987-89962480-f2a7-11ea-807f-125b3b310cf7.png)

p.s. Moreover, I left the opportunity to set an empty parent (perhaps this is need to somewhere), but it must be deliberately chosen :)

### Why is it needed?
UX fix

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14521