### PR TITLE
Displayed caption instead of description in the template TV grid

### DIFF
--- a/core/model/modx/processors/element/template/tv/getlist.class.php
+++ b/core/model/modx/processors/element/template/tv/getlist.class.php
@@ -92,7 +92,7 @@ class modElementTemplateTvGetListProcessor extends modObjectGetListProcessor {
      * @return array|mixed
      */
     public function prepareRow(xPDOObject $object) {
-        $tvArray = $object->get(array('id','name','description','tv_rank','category_name'));
+        $tvArray = $object->get(array('id','name','caption','tv_rank','category_name'));
         $tvArray['access'] = (boolean)$object->get('access');
 
         $tvArray['perm'] = array();

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -18,7 +18,7 @@ MODx.grid.TemplateTV = function(config) {
         title: _('template_assignedtv_tab')
         ,id: 'modx-grid-template-tv'
         ,url: MODx.config.connector_url
-        ,fields: ['id','name','description','tv_rank','access','perm','category_name','category']
+        ,fields: ['id','name','caption','tv_rank','access','perm','category_name','category']
         ,baseParams: {
             action: 'element/template/tv/getlist'
             ,template: config.template
@@ -58,8 +58,8 @@ MODx.grid.TemplateTV = function(config) {
             ,width: 150
             ,sortable: true
         },{
-            header: _('description')
-            ,dataIndex: 'description'
+            header: _('caption')
+            ,dataIndex: 'caption'
             ,width: 350
             ,editor: { xtype: 'textfield' }
             ,sortable: false


### PR DESCRIPTION
### What does it do?
When creating a TV, the description is set less often than the caption field. Therefore, it is more logical to display caption.

Displayed `caption` instead of `description` in TV grid:

![tpl-tvs](https://user-images.githubusercontent.com/12523676/92742771-a0607800-f388-11ea-8262-be02a6f8fdcb.png)

This is useful if there are many TVs in the grid.

### Why is it needed?
UI/UX fix

### Related issue(s)/PR(s)
N/A
