### PR TITLE
Added a check for the existence of a file when uploading it

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -593,6 +593,25 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
     }
 
     /**
+     * Check that an object (directory, file) exists
+     *
+     * @param string $objectPath The object path to check
+     * @param string $objectName The object name displayed in the error message
+     * @return bool
+     */
+    protected function checkObjectExist($objectPath, $objectName) {
+        if (file_exists($objectPath)) {
+            if (is_dir($objectPath)) {
+                $this->addError('name', $this->xpdo->lexicon('file_folder_err_ae'));
+                return true;
+            }
+            $this->addError('name', sprintf($this->xpdo->lexicon('file_err_ae'), $objectName));
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * @param string $oldPath
      * @param string $newName
      * @return bool
@@ -622,13 +641,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $newPath = $this->fileHandler->sanitizePath($newName);
         $newPath = dirname($oldPath).'/'.$newPath;
 
-        /* check to see if the new resource already exists */
-        if (file_exists($newPath)) {
-            if (is_dir($newPath)) {
-                $this->addError('name',$this->xpdo->lexicon('file_folder_err_ae'));
-                return false;
-            }
-            $this->addError('name',sprintf($this->xpdo->lexicon('file_err_ae'),$newName));
+        if ($this->checkObjectExist($newPath,$newName)) {
             return false;
         }
 
@@ -874,6 +887,10 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
             $newPath = $this->fileHandler->sanitizePath($file['name']);
             $newPath = $directory->getPath().$newPath;
+
+            if ($this->checkObjectExist($newPath,$file['name'])) {
+                return false;
+            }
 
             if (!move_uploaded_file($file['tmp_name'],$newPath)) {
                 $this->addError('path',$this->xpdo->lexicon('file_err_upload'));


### PR DESCRIPTION
### What does it do?
Added a check for the existence of a file when uploading it.
In the current version, **if the file names match, then the file will be overwritten.**

**This PR fixes that:**
![file_exist](https://user-images.githubusercontent.com/12523676/92950621-a9734700-f465-11ea-9a29-dcb9a5a83bb3.gif)

p.s. For Amazon source, we can probably add a file existence check too, in line
https://github.com/modxcms/revolution/blob/2.x/core/model/modx/sources/mods3mediasource.class.php#L823

add
```
if (file_exists($container.$file['name'])) {
    $this->addError('path',sprintf($this->xpdo->lexicon('file_err_ae'),$file['name']));
    continue;
}
```
but I cannot test it as I don't use sources from Amazon.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/8371
https://github.com/modxcms/revolution/issues/14641