### PR TITLE
Prevent potential XXE vulnerability in modRestService by disabling libxml entity loader

### DIFF
--- a/core/model/modx/rest/modrestservice.class.php
+++ b/core/model/modx/rest/modrestservice.class.php
@@ -59,6 +59,7 @@ class modRestService {
             'responseSuccessKey' => 'success',
             'trimParameters' => false,
             'xmlRootNode' => 'response',
+            'xmlDisableEntityLoader' => true,
 		),$config);
 		$this->modx->getService('lexicon','modLexicon');
         if ($this->modx->lexicon) {
@@ -397,7 +398,14 @@ class modRestServiceRequest {
             case 'text/xml':
                 $data = stream_get_contents($filehandle);
                 fclose($filehandle);
-                $xml = simplexml_load_string($data);
+                if (LIBXML_VERSION < 20900 && $this->service->getOption('xmlDisableEntityLoader')) {
+                    $disableEntities = libxml_disable_entity_loader(true);
+                    $xml = simplexml_load_string($data);
+                    libxml_disable_entity_loader($disableEntities);
+                }
+                else {
+                    $xml = simplexml_load_string($data);
+                }
                 $params = $this->_xml2array($xml);
                 break;
             case 'application/json':


### PR DESCRIPTION
### What does it do?

Disables the libxml entity loader when reading an XML string in a request to a modRestService API. This is enabled by default, but can be disabled with a service option if custom DTDs are necessary in an API.

### Why is it needed?

Makes modRestService implementations more secure by default, fixing the report in #15237. The MODX core does not use this particular service, so only third party implementations would be affected. 

### Related issue(s)/PR(s)
 
Fixes #15237