### PR TITLE
Added class with padding for package update window

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -376,6 +376,7 @@ Ext.extend(MODx.grid.Package,MODx.grid.Grid,{
                 'success': {fn:function(r) {
                     this.loadWindow(btn,e,{
                         xtype: 'modx-window-package-update'
+                        ,cls: 'modx-alert'
                         ,packages: r.object
                         ,record: this.menu.record
                         ,force: true


### PR DESCRIPTION
### What does it do?
Same as in https://github.com/modxcms/revolution/pull/14764 but for 3.x branch

Before:
![update_1](https://user-images.githubusercontent.com/12523676/93463969-27fe3780-f8f1-11ea-9710-6904439e9973.png)

After:
![update_2](https://user-images.githubusercontent.com/12523676/93463977-292f6480-f8f1-11ea-978d-b7f78338bf75.png)

p.s. I wonder how many more fixes didn't go into the 3.x branch, but remained in the 2.x branch?

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/14764
