### PR TITLE
Fixed display of the pagination toolbar

### DIFF
--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -108,7 +108,7 @@ MODx.combo.ComboBox = function(config,getStore) {
         this.loaded = true;
         
         // Show the pagination panel if it didn't show up earlier
-        if (this.pageSize < this.store.getTotalCount() && this.pageTb.hidden === true) {
+        if (this.isExpanded() && this.pageSize < this.store.getTotalCount() && this.pageTb.hidden === true) {
             this.collapse();
             this.expand();
         }

--- a/manager/assets/modext/widgets/core/modx.combo.js
+++ b/manager/assets/modext/widgets/core/modx.combo.js
@@ -106,6 +106,12 @@ MODx.combo.ComboBox = function(config,getStore) {
         // Workaround to let the combobox know the store is loaded (to help hide/display the pagination if required)
         this.fireEvent('loaded', this);
         this.loaded = true;
+        
+        // Show the pagination panel if it didn't show up earlier
+        if (this.pageSize < this.store.getTotalCount() && this.pageTb.hidden === true) {
+            this.collapse();
+            this.expand();
+        }
     }, this, {
         single: true
     });
@@ -135,6 +141,7 @@ Ext.extend(MODx.combo.ComboBox,Ext.form.ComboBox, {
             }
             if(this.pageSize < this.store.getTotalCount()){
                 this.assetHeight += this.footer.getHeight();
+                this.pageTb.show();
             } else {
                 this.list.setHeight(this.list.getHeight() - this.footer.getHeight());
                 this.pageTb.hide();


### PR DESCRIPTION
Fixed bug with display of the pagination toolbar. If the request to the processor was delayed, the `expand` function had time to work because of this piece of code:
```
if (this.mode == 'remote' && !this.loaded && this.tries < 4) {
    // Store not yet loaded, let's wait a little bit
    this.tries += 1;
    Ext.defer(this.expand, 250, this);
    return false;
}
```
And when the answer came from the processor, the `expand' function was not started anymore. We had to make a small crutch that instantly collapse the list and expanded it again.

### What does it do?
Describe the technical changes you did.

### Why is it needed?
Describe the issue you are solving.

### Related issue(s)/PR(s)
Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)
