### PR TITLE
Add PHP 7.4 as test target for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 
 # Set php versions
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1
@@ -30,4 +31,4 @@ before_script: 'cd _build/test && ./generateConfigs.sh auto'
 
 before_install:
   -  if [[ ${TRAVIS_PHP_VERSION:0:3} == "5.5" ]]; then curl -sL -o ~/.phpenv/versions/5.5/bin/phpunit https://phar.phpunit.de/phpunit-4.8.phar; chmod +x ~/.phpenv/versions/5.5/bin/phpunit; fi
-  -  if [[ "(7.0 7.1 7.2 7.3 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  -  if [[ "(7.0 7.1 7.2 7.3 7.4 nightly)" =~ $(phpenv version-name) ]]; then curl -sL -o ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-5.7.phar; chmod +x ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi


### PR DESCRIPTION
### What does it do?
For now it only adds PHP 7.4 as test target for Travis

### Why is it needed?
[PHP 7.4.10 Released](https://www.php.net/archive/2020.php#2020-09-03-2)

### Related issue(s)/PR(s)
None