### PR TITLE
Fix downloading files

### DIFF
--- a/core/src/Revolution/Processors/Browser/File/Download.php
+++ b/core/src/Revolution/Processors/Browser/File/Download.php
@@ -45,7 +45,6 @@ class Download extends Browser
 
         // Download file
         @session_write_close();
-        $file = $this->sanitize($this->getProperty('file'));
         try {
             if ($data = $this->source->getObjectContents($file)) {
                 $name = preg_replace('#[^\w-.]#ui', '_', $data['basename']);

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -683,22 +683,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
 
     ,downloadFile: function(item,e) {
         var node = this.cm.activeNode;
-        MODx.Ajax.request({
-            url: MODx.config.connector_url
-            ,params: {
-                action: 'Browser/File/Download'
-                ,file: node.attributes.pathRelative
-                ,wctx: MODx.ctx || ''
-                ,source: this.getSource()
-            }
-            ,listeners: {
-                'success':{fn:function(r) {
-                    if (!Ext.isEmpty(r.object.url)) {
-                        location.href = MODx.config.connector_url+'?action=Browser/File/Download&download=1&file='+r.object.url+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.getSource()+'&wctx='+MODx.ctx;
-                    }
-                },scope:this}
-            }
-        });
+        location.href = MODx.config.connector_url+'?action=Browser/File/Download&download=1&file='+node.attributes.pathRelative+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.getSource()+'&wctx='+MODx.ctx;
     }
 
     ,copyRelativePath: function(item,e) {


### PR DESCRIPTION
### What does it do?
Not sure why, but the download process was sending XHR request Download processor to get the url of the file and after success response the same processor was used to initiate the download... I skipped the the xhr request as we don't need the URL for download and passed directly the `relativePath` to the Download processor and it seems to be working :) (tested on assets media source and as well on s3 media source).

### Why is it needed?
Downloading files from any media source except Filesystem is broken.

### Related issue(s)/PR(s)
Resolves #15245
