### PR TITLE
[Security] [Requires rebuild] Fix XSS in file upload and file tree

### DIFF
--- a/core/model/modx/processors/browser/directory/getlist.class.php
+++ b/core/model/modx/processors/browser/directory/getlist.class.php
@@ -59,6 +59,10 @@ class modBrowserFolderGetListProcessor extends modProcessor {
         $this->source->initialize();
 
         $list = $this->source->getContainerList($this->getProperty('dir'));
+        foreach ($list as &$item) {
+            // Make sure the id is HTML-safe as it will be inserted into an attribute
+            $item['id'] = htmlentities($item['id'], ENT_QUOTES, 'UTF-8');
+        }
         return $this->modx->toJSON($list);
     }
 

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -190,7 +190,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 if ($this->hasPermission('file_update') && $canSave) $cls[] = 'pupdate';
 
                 $encFile = rawurlencode($fullPath.$fileName);
-                $page = !empty($editAction) ? '?a='.$editAction.'&file='.$bases['urlRelative'].$fileName.'&wctx='.$this->ctx->get('key').'&source='.$this->get('id') : null;
+                $page = !empty($editAction) ? '?a='.$editAction.'&file='.rawurlencode($bases['urlRelative'].$fileName).'&wctx='.$this->ctx->get('key').'&source='.$this->get('id') : null;
                 $url = $bases['urlRelative'] . $fileName;
 
                 /* get relative url from manager/ */

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -198,7 +198,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
             } else {
                 $url = rtrim($properties['url'],'/').'/'.$currentPath;
                 $url = str_replace(' ','%20',$url);
-                $page = '?a='.$editAction.'&file='.$currentPath.'&wctx='.$this->ctx->get('key').'&source='.$this->get('id');
+                $page = '?a='.$editAction.'&file='.rawurlencode($currentPath).'&wctx='.$this->ctx->get('key').'&source='.$this->get('id');
                 // $isBinary = $this->isBinary(rtrim($properties['url'],'/').'/'.$currentPath);
 
                 // $cls = array();

--- a/manager/assets/modext/util/multiuploaddialog.js
+++ b/manager/assets/modext/util/multiuploaddialog.js
@@ -248,7 +248,7 @@
                             }
                         });
 
-                    return '<div id="' + id + '"><p>' + value + '</p></div>';
+                    return '<div id="' + id + '"><p>' + Ext.util.Format.htmlEncode(value) + '</p></div>';
                 }
             }
             ,{


### PR DESCRIPTION
### What does it do?

Prevent XSS vulnerabilities in the manager by users with file upload permission.

### Why is it needed?

Specially crafted filenames can result in a self-xss in the file upload dialog and a stored XSS by the file tree. This sanitises that.

This also, inadvertently, fixes crlf line endings in the s3 media source file which were incorrect. [Diff without line ending change](https://github.com/modxcms/revolution/pull/15262/files?diff=unified&w=1)

### Related issue(s)/PR(s)

Responsibly disclosed by Nguyen Dang Toan from VSEC RED TEAM, thanks.