### PR TITLE
Fix JavaScript error when create a new folder in the root

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -546,7 +546,7 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
                     fn:function() {
                         var parent = Ext.getCmp('folder-parent').getValue();
 
-                        if (this.cm.activeNode.constructor.name === 'constructor' || parent === '' || parent === '/') {
+                        if ((this.cm.activeNode && this.cm.activeNode.constructor.name === 'constructor') || parent === '' || parent === '/') {
                             this.refresh();
                         } else {
                             this.refreshActiveNode();


### PR DESCRIPTION
### What does it do?
Fix JavaScript error when create a new folder in the root

```
TypeError: Cannot read property 'constructor' of undefined
/manager/assets/modext/widgets/system/modx.tree.directory.js:593
```

### Why is it needed?
When we create a new folder at the root of the media source, we get a JavaScript error.

### Related issue(s)/PR(s)
#15263 