### PR TITLE
Added a button "Update User Group" for "ACL" section

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -351,11 +351,16 @@ MODx.grid.UserGroupUsers = function(config) {
             ,sortable: true
         }]
         ,tbar: [{
+            text: _('user_group_update')
+            ,cls:'primary-button'
+            ,handler: this.updateUserGroup
+            ,hidden: MODx.perm.usergroup_edit == 0
+        },'->',{
             text: _('user_group_user_add')
             ,cls:'primary-button'
             ,handler: this.addMember
             ,hidden: MODx.perm.usergroup_user_edit == 0
-        },'->',{
+        },{
             xtype: 'textfield'
             ,id: 'modx-ugu-filter-username'
             ,cls: 'x-form-filter'
@@ -431,6 +436,12 @@ Ext.extend(MODx.grid.UserGroupUsers,MODx.grid.Grid,{
             }
         });
     }
+
+    ,updateUserGroup: function() {
+        var id = this.config.usergroup;
+        MODx.loadPage('security/usergroup/update', 'id=' + id);
+    }
+
     ,addMember: function(btn,e) {
         var r = {usergroup:this.config.usergroup};
 


### PR DESCRIPTION
### What does it do?
Same as https://github.com/modxcms/revolution/pull/15159 but for the 2.x branch
Added a button "Update User Group" for "ACL" section.
As suggested in https://github.com/modxcms/revolution/issues/15148#issuecomment-659629172 added a button, this option is easier.

The fixes aren't big, but the UX increases. I think even in this form it is worth merging for the 2.x branch.

Before:
![acl_1](https://user-images.githubusercontent.com/12523676/94901517-6d009d00-049f-11eb-818b-2f40d9bec3f6.png)

After:
![acl_2](https://user-images.githubusercontent.com/12523676/94901521-6e31ca00-049f-11eb-9dcd-3c0aeaef715e.gif)

### Why is it needed?
In the current version, it’s almost impossible to understand where to edit a specific “User Group”, because the editing link is hidden in the context menu.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15159
https://github.com/modxcms/revolution/issues/15148