### PR TITLE
Fixing error 500 when viewing system information

### DIFF
--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -42,7 +42,7 @@ class SystemInfoManagerController extends modManagerController {
         if ($dbtype_mysql && !empty($m['pdo_mysql'])) $pi = array_merge($pi,array('pdo_mysql' => $m['pdo_mysql']));
         if ($dbtype_sqlsrv && !empty($m['pdo_sqlsrv'])) $pi = array_merge($pi,array('pdo_sqlsrv' => $m['pdo_sqlsrv']));
         if (!empty($m['zip'])) $pi = array_merge($pi,array('zip' => $m['zip']));
-        $this->modx->getService('PHPMailer', 'mail.modPHPMailer');
+        $mailerService = $this->modx->getService('PHPMailer', 'mail.modPHPMailer');
         $this->version = [
             'smarty'=> $this->modx->smarty->_version,
             'PHPMailer'=> $this->modx->PHPMailer->mailer->Version

--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -42,9 +42,10 @@ class SystemInfoManagerController extends modManagerController {
         if ($dbtype_mysql && !empty($m['pdo_mysql'])) $pi = array_merge($pi,array('pdo_mysql' => $m['pdo_mysql']));
         if ($dbtype_sqlsrv && !empty($m['pdo_sqlsrv'])) $pi = array_merge($pi,array('pdo_sqlsrv' => $m['pdo_sqlsrv']));
         if (!empty($m['zip'])) $pi = array_merge($pi,array('zip' => $m['zip']));
+        $this->modx->getService('PHPMailer', 'mail.modPHPMailer');
         $this->version = [
             'smarty'=> $this->modx->smarty->_version,
-            'PHPMailer'=> PHPMailer\PHPMailer\PHPMailer::VERSION
+            'PHPMailer'=> $this->modx->PHPMailer->mailer->Version
         ];
 
         $this->pi = array_merge($pi,$this->getPhpInfo(INFO_CONFIGURATION));

--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -42,7 +42,7 @@ class SystemInfoManagerController extends modManagerController {
         if ($dbtype_mysql && !empty($m['pdo_mysql'])) $pi = array_merge($pi,array('pdo_mysql' => $m['pdo_mysql']));
         if ($dbtype_sqlsrv && !empty($m['pdo_sqlsrv'])) $pi = array_merge($pi,array('pdo_sqlsrv' => $m['pdo_sqlsrv']));
         if (!empty($m['zip'])) $pi = array_merge($pi,array('zip' => $m['zip']));
-        $mailerService = $this->modx->getService('PHPMailer', 'mail.modPHPMailer');
+        $mailerService = $this->modx->getService('mail', 'mail.modPHPMailer');
         $this->version = [
             'smarty'=> $this->modx->smarty->_version,
             'PHPMailer'=> $mailerService->mailer->Version

--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -45,7 +45,7 @@ class SystemInfoManagerController extends modManagerController {
         $mailerService = $this->modx->getService('PHPMailer', 'mail.modPHPMailer');
         $this->version = [
             'smarty'=> $this->modx->smarty->_version,
-            'PHPMailer'=> $this->modx->PHPMailer->mailer->Version
+            'PHPMailer'=> $mailerService->mailer->Version
         ];
 
         $this->pi = array_merge($pi,$this->getPhpInfo(INFO_CONFIGURATION));


### PR DESCRIPTION
Fixing error 500 when viewing system information after upgrading to 2.8.0

```php
2020/10/06 23:04:03 [error] 19542#19542: *440333 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Class 'PHPMailer\PHPMailer\PHPMailer' not found in /home/s*****/www/manager/controllers/default/system/info.class.php on line 48" while reading response header from upstream, client: ****, server: ****.modhost.pro, request: "GET /manager/?a=system/info HTTP/1.1", upstream: "fastcgi://127.0.0.1:33125", host: "****.modhost.pro", referrer: "http://****.modhost.pro/manager/?a=system/event"
```
After fix

![image](https://user-images.githubusercontent.com/2138260/95259416-f53cc480-0848-11eb-9e0d-b4690b04c3b8.png)


### Related issue(s)/PR(s)

#15248 