### PR TITLE
Fix URL TV

### DIFF
--- a/manager/templates/default/element/tv/renders/input/url.tpl
+++ b/manager/templates/default/element/tv/renders/input/url.tpl
@@ -26,7 +26,12 @@ Ext.onReady(function() {
         ,typeAhead: false
         ,forceSelection: false
         ,msgTarget: 'under'
-        ,listeners: { 'select': { fn:MODx.fireResourceFormChange, scope:this}}
+        ,listeners: {
+            'select': {
+                fn:MODx.fireResourceFormChange,
+                scope:this
+            }
+        }
     });
 
     fld.wrap.applyStyles({
@@ -39,7 +44,12 @@ Ext.onReady(function() {
         ,enableKeyEvents: true
         ,msgTarget: 'under'
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
-        ,listeners: {'keydown': {fn:MODx.fireResourceFormChange, scope:this}}
+        ,listeners: {
+            'keydown': {
+                fn:MODx.fireResourceFormChange,
+                scope:this
+            }
+        }
     });
     MODx.makeDroppable(fld);
     Ext.getCmp('modx-panel-resource').getForm().add(fld);

--- a/manager/templates/default/element/tv/renders/input/url.tpl
+++ b/manager/templates/default/element/tv/renders/input/url.tpl
@@ -12,13 +12,18 @@
 />
 <script type="text/javascript">
 // <![CDATA[
+{literal}
 Ext.onReady(function() {
-    MODx.makeDroppable(Ext.get('tv{$tv->id}'));
+{/literal}
 
+    MODx.makeDroppable(Ext.get('tv{$tv->id}'));
+{literal}
     var fld = MODx.load({
         xtype: 'combo'
+{/literal}
         ,transform: 'tv{$tv->id}_prefix'
         ,id: 'tv{$tv->id}_prefix'
+{literal}
         ,triggerAction: 'all'
         ,width: 100
         ,allowBlank: true
@@ -40,10 +45,12 @@ Ext.onReady(function() {
 
     var fld = MODx.load({
         xtype: 'textfield'
+{/literal}
         ,applyTo: 'tv{$tv->id}'
+        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
+{literal}
         ,enableKeyEvents: true
         ,msgTarget: 'under'
-        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         ,listeners: {
             'keydown': {
                 fn:MODx.fireResourceFormChange,
@@ -54,5 +61,6 @@ Ext.onReady(function() {
     MODx.makeDroppable(fld);
     Ext.getCmp('modx-panel-resource').getForm().add(fld);
 });
+{/literal}
 // ]]>
 </script>


### PR DESCRIPTION
### What does it do?
Use `{literal}` wrapper around everything that doesn't need twig tags.

### Why is it needed?
When URL TV is assigned to resource, the edit resource panel breaks. It's caused by having `}}` in the input's tpl as twig is trying to parse that as twig tag.

### Related issue(s)/PR(s)
https://community.modx.com/t/bug-in-modx-2-8/3164
