### PR TITLE
Fix XSS in resource group name at TV > Access Permissions + XSS in resource list TV

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.tv.security.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.security.js
@@ -1,6 +1,6 @@
 /**
- * Loads a grid of resource groups assigned to a resource. 
- * 
+ * Loads a grid of resource groups assigned to a resource.
+ *
  * @class MODx.grid.TVSecurity
  * @extends MODx.grid.Grid
  * @param {Object} config An object of options.
@@ -34,8 +34,8 @@ MODx.grid.TVSecurity = function(config) {
             ,dataIndex: 'name'
             ,width: 200
             ,sortable: true
+            ,renderer: Ext.util.Format.htmlEncode
         },tt]
-        
     });
     MODx.grid.TVSecurity.superclass.constructor.call(this,config);
 };

--- a/manager/templates/default/element/tv/renders/input/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/input/resourcelist.tpl
@@ -1,6 +1,6 @@
 <select id="tv{$tv->id}" name="tv{$tv->id}">
 {foreach from=$opts item=item}
-	<option value="{$item.value}" {if $item.selected} selected="selected"{/if}>{$item.text}</option>
+	<option value="{$item.value|escape}" {if $item.selected} selected="selected"{/if}>{$item.text|escape}</option>
 {/foreach}
 </select>
 
@@ -17,7 +17,7 @@ Ext.onReady(function() {
         ,triggerAction: 'all'
         ,width: 400
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
-
+        ,tpl: {literal}'<tpl for="."><div class="x-combo-list-item">{text:htmlEncode}</div></tpl>'{/literal}
         {if $params.title|default},title: '{$params.title}'{/if}
         {if $params.listWidth|default},listWidth: {$params.listWidth}{/if}
         ,maxHeight: {if $params.maxHeight|default}{$params.maxHeight}{else}300{/if}


### PR DESCRIPTION
### What does it do?

Fixes a stored XSS similar to one fixed in 2.8.0. Exploitable only by admin users with permission to edit resource groups.

Also fixes XSS in the resourcelist TV, if a resource pagetitle contains markup.

### Why is it needed?

Because while admin users are trusted users and this requires permissions not typically given to editors, technically still counts as security issue.

### Related issue(s)/PR(s)

#15273 