### PR TITLE
Fix JS TypeError if image/file TV fails validation, preventing error popup from showing [Rebuild]

### DIFF
--- a/manager/assets/modext/widgets/core/modx.panel.js
+++ b/manager/assets/modext/widgets/core/modx.panel.js
@@ -402,7 +402,7 @@ Ext.extend(MODx.FormPanel,Ext.FormPanel,{
                     ;
                 if (tvTabs && tvTabs.items && tvTabs.items.keys) {
                     var tvTabIndex = tvTabs.items.keys.indexOf(errFldPanelId);
-                    if (tvTabs.items.items[tvTabIndex].hidden)  {
+                    if (tvTabs.items.items[tvTabIndex] && tvTabs.items.items[tvTabIndex].hidden)  {
                         tvTabs.activate(errFldPanelId);
                     }
                 }


### PR DESCRIPTION
### What does it do?

Prevent JS error if an image/file tv fails validation.

### Why is it needed?

On 2.8.0 saving an image/file tv that is required (allow blank = no) results in:

```
modx.panel.js:405 Uncaught TypeError: Cannot read property 'hidden' of undefined
    at MODx.panel.Resource.showErroredTab (modx.panel.js:405)
    at MODx.panel.Resource.fn (modx.panel.resource.js:25)
    at h.Event.fire (ext-all.js:21)
    at MODx.panel.Resource.fireEvent (ext-all.js:21)
    at MODx.toolbar.ActionButtons.handleClick (modx.component.js:298)
    at S.onClick (ext-all.js:21)
    at HTMLSpanElement.I (ext-all.js:21)
 ```

This avoids the js error, allowing the popup to be shown. 

### Related issue(s)/PR(s)

#15146 