### PR TITLE
Add `upload_check_exists` system setting to allow overwriting files with same name

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1901,6 +1901,15 @@ $settings['unauthorized_page']->fromArray(array (
   'area' => 'site',
   'editedon' => null,
 ), '', true, true);
+$settings['upload_check_exists']= $xpdo->newObject('modSystemSetting');
+$settings['upload_check_exists']->fromArray(array (
+  'key' => 'upload_check_exists',
+  'value' => '1',
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'file',
+  'editedon' => null,
+), '', true, true);
 $settings['upload_files']= $xpdo->newObject('modSystemSetting');
 $settings['upload_files']->fromArray(array (
   'key' => 'upload_files',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -771,6 +771,9 @@ $_lang['setting_unauthorized_page'] = 'Unauthorized page';
 $_lang['setting_unauthorized_page_desc'] = 'Enter the ID of the Resource you want to send users to if they have requested a secured or unauthorized Resource. <strong>NOTE: Make sure the ID you enter belongs to an existing Resource, and that it has been published and is publicly accessible!</strong>';
 $_lang['setting_unauthorized_page_err'] = 'Please specify a Resource ID for the unauthorized page.';
 
+$_lang['setting_upload_check_exists'] = 'Check if uploaded file exists';
+$_lang['setting_upload_check_exists_desc'] = 'When enabled an error will be shown when uploading a file that already exists with the same name. When disabled, the existing file will be quietly replaced with the new file.';
+
 $_lang['setting_upload_files'] = 'Uploadable File Types';
 $_lang['setting_upload_files_desc'] = 'Here you can enter a list of files that can be uploaded into \'assets/files/\' using the Resource Manager. Please enter the extensions for the filetypes, seperated by commas.';
 

--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -605,7 +605,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 $this->addError('name', $this->xpdo->lexicon('file_folder_err_ae'));
                 return true;
             }
-            $this->addError('name', sprintf($this->xpdo->lexicon('file_err_ae'), $objectName));
+            $this->addError('name', sprintf($this->xpdo->lexicon('file_err_ae'), htmlentities($objectName, ENT_QUOTES, 'UTF-8')));
             return true;
         }
         return false;
@@ -888,7 +888,8 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
             $newPath = $this->fileHandler->sanitizePath($file['name']);
             $newPath = $directory->getPath().$newPath;
 
-            if ($this->checkObjectExist($newPath,$file['name'])) {
+            $checkAlreadyExists = (bool)$this->xpdo->getOption('upload_check_exists', null, true);
+            if ($checkAlreadyExists && $this->checkObjectExist($newPath,$file['name'])) {
                 return false;
             }
 


### PR DESCRIPTION
## What does it do?

Adds a new setting, upload_check_exists, to allow reverting to the pre-2.8.0 behavior of quietly overwriting files with the same name on upgrade. 

Also fixes a potential self-xss due to insufficient escaping of the filename.

### Why is it needed?

As discussed in https://community.modx.com/t/version-2-8-is-out-easy-replacement-of-files-pdf-images-is-axed/3166 and the discussion in #15232, some people are used to being able of replacing files simply by uploading them with the same name. That behaviour was removed in #15232 (v2.8.0-pl) to prefer a stricter check where users are presented with an error when a file already exists with the same name.

The new setting, enabled by default, gives users the choice to return to that old behaviour and bypassing the check on upload by disabling the setting. 

(The check is still in use, and valid, when renaming files. This is because the renameObject method on the media source will also fail if the target file already exists, so it makes sense to keep that there with the nice error.)

This specifically does **not** introduce new behaviour, like creating different file names if a file already exists, transliteration, etc. There's definitely room for improvement, and extras can also fill that gap by hooking into `OnFileManagerBeforeUpload` to rename the file/change the target directory/etc. It would be nice to incorporate some more standard behaviour in 3.0, tho given the amount of discussion and conflicting views surrounding the topic it may be desirable to leave that to extras for more flexibility. 

### How to test

- Re-run the build (`php _build/transport.core.php`) and run setup to create the new setting.
- Upload a file through the tree/browser so that it exists.
- Toggle the `upload_check_exists` setting between yes and no and identify that it properly refuses or allows the same file to be uploaded. 

### Related issue(s)/PR(s)

Discussion in #15232 and https://community.modx.com/t/version-2-8-is-out-easy-replacement-of-files-pdf-images-is-axed/3166/12

### Special thanks ❤️ 

Thanks for the [400 trees](https://ecologi.com/modmore) 🌴 