### PR TITLE
Hid the user group edit button inside the group itself

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -354,7 +354,7 @@ MODx.grid.UserGroupUsers = function(config) {
             text: _('user_group_update')
             ,cls:'primary-button'
             ,handler: this.updateUserGroup
-            ,hidden: MODx.perm.usergroup_edit == 0
+            ,hidden: (MODx.perm.usergroup_edit == 0 || config.ownerCt.id != 'modx-tree-panel-usergroup')
         },'->',{
             text: _('user_group_user_add')
             ,cls:'primary-button'


### PR DESCRIPTION
### What does it do?
It turns out that the user grid to the right of the group tree is also used within the user group. Those the group edit button also appeared inside the user group editing, but there it was not needed and confused users.

This PR adds a check for the id of the parent element.

![user_group_edit](https://user-images.githubusercontent.com/12523676/95434635-29ec7100-095a-11eb-8b3f-bdc5526038b2.gif)

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15270
