### PR TITLE
Only log session info if session is initialized

### DIFF
--- a/core/model/modx/modsessionhandler.class.php
+++ b/core/model/modx/modsessionhandler.class.php
@@ -162,7 +162,9 @@ class modSessionHandler {
             $this->session->set('id', $id);
         }
         if (!($this->session instanceof modSession) || $id != $this->session->get('id') || !$this->session->validate()) {
-            $this->modx->log(modX::LOG_LEVEL_INFO, 'There was an error retrieving or creating session id: ' . $id);
+            if ($this->modx->getSessionState() == modX::SESSION_STATE_INITIALIZED) {
+                $this->modx->log(modX::LOG_LEVEL_INFO, 'There was an error retrieving or creating session id: ' . $id);
+            }
         }
         return $this->session;
     }


### PR DESCRIPTION
### What does it do?
Prevents unnecessary output of an info message (that states that an error occurred) when the triggering condition (session is not initialized) is expected.

### Why is it needed?
Reducing unnecessary output when log level is set to info or higher.

### How to test
Set the log level to info or higher and access the site as an anonymous user.  If the fix is not in place, a message will appear in the log file stating "There was an error retrieving or creating session id".  If the fix is in place, the message will not appear.

### Related issue(s)/PR(s)
#15188 