### PR TITLE
Avoid returning resource_groups on resource save

### DIFF
--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -799,7 +799,7 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
         $this->object->removeLock();
         $this->clearCache();
 
-        $returnArray = $this->object->get(array_diff(array_keys($this->object->_fields), array('content','ta','introtext','description','link_attributes','pagetitle','longtitle','menutitle','properties')));
+        $returnArray = $this->object->get(array_diff(array_keys($this->object->_fields), array('content','ta','introtext','description','link_attributes','pagetitle','longtitle','menutitle', 'properties', 'resource_groups')));
         foreach ($returnArray as $k => $v) {
             if (strpos($k,'tv') === 0) {
                 unset($returnArray[$k]);


### PR DESCRIPTION
### What does it do?

Filters resource_groups out of the returned array when saving a resource.

### Why is it needed?

ExtJS uses some stupid way of parsing JSON responses which causes it to break when html-ish structures are inside otherwise valid JSON. When a resource group contains html-ish structures, like a XSS payload, that breaks. 💩 

### How to test

- Create resource group with some html structure. For example, I've had one named `Foo <img src=xss onerror=alert("giraffee")>` because of testing some XSS reports. 
- Save a resource. Notice it fails to parse the response with a JS error, and sends a request to `/connectors/xss` indicating the html was processed.
- Apply fix. Save resource again. Notice it behaves better because the html is not there.

### Related issue(s)/PR(s)

N/a.