### PR TITLE
Fix readme logo to full logo, not just icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://modx.com/">
-    <img alt="MODX Revolution" src="https://raw.githubusercontent.com/modxcms/revolution/2.x/manager/templates/default/images/modx-icon-color.svg" width="180" />
+    <img alt="MODX Revolution" src="https://raw.githubusercontent.com/modxcms/revolution/2.x/manager/templates/default/images/modx-logo-color.svg" width="180" />
   </a>
 </p>
 <h1 align="center">


### PR DESCRIPTION
### What does it do?
Keeps the logo in the readme.md file consistent with previous releases, only updated.

### Why is it needed?
The logo was updated from the previous version to the icon-only.

### How to test
View: https://github.com/rthrash/revolution

### Related issue(s)/PR(s)
n/a