### PR TITLE
Only log session info if session is initialized

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Only log session info if session is initialized [#15308]
 - Improve removal of nested MODX tag content in sanitizeRequest [#15370]
 - Improve Navigation for Access Control Lists > User Groups & Users [#15159]
 - Various quick search improvements [#15158]

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -187,7 +187,9 @@ class modSessionHandler
             $this->session->set('id', $id);
         }
         if (!($this->session instanceof modSession) || $id != $this->session->get('id') || !$this->session->validate()) {
-            $this->modx->log(modX::LOG_LEVEL_INFO, 'There was an error retrieving or creating session id: ' . $id);
+            if ($this->modx->getSessionState() == modX::SESSION_STATE_INITIALIZED) {
+                $this->modx->log(modX::LOG_LEVEL_INFO, 'There was an error retrieving or creating session id: ' . $id);
+            }
         }
 
         return $this->session;


### PR DESCRIPTION
### What does it do?
Prevents unnecessary output of an info message (that states that an error occurred) when the triggering condition (session is not initialized) is expected.

### Why is it needed?
Describe the issue you are solving.

### How to test
Set the log level to info or higher and access the site as an anonymous user. If the fix is not in place, a message will appear in the log file stating "There was an error retrieving or creating session id". If the fix is in place, the message will not appear.

### Related issue(s)/PR(s)
#15188 #15292 