### PR TITLE
Update htaccess delete rules for win xp and IE

### DIFF
--- a/ht.access
+++ b/ht.access
@@ -48,19 +48,10 @@ RewriteRule "/\.|^\.(?!well-known/)" - [F]
 #RewriteRule ^(.*)$ https://example.com/$1 [R=301,L]
 
 
-
 # The Friendly URLs part
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ index.php?q=$1 [L,QSA]
-
-
-
-# Make sure .htc files are served with the proper MIME type, which is critical
-# for XP SP2. Un-comment if your host allows htaccess MIME type overrides.
-
-#AddType text/x-component .htc
-
 
 
 # If your server is not already configured as such, the following directive
@@ -86,24 +77,8 @@ RewriteRule ^(.*)$ index.php?q=$1 [L,QSA]
 #php_flag register_globals Off
 
 
-
 # For servers that support output compression, you should pick up a bit of
 # speed by un-commenting the following lines.
 
 #php_flag zlib.output_compression On
 #php_value zlib.output_compression_level 5
-
-
-
-# The following directives stop screen flicker in IE on CSS rollovers. If
-# needed, un-comment the following rules. When they're in place, you may have
-# to do a force-refresh in order to see changes in your designs.
-
-#ExpiresActive On
-#ExpiresByType image/gif A2592000
-#ExpiresByType image/jpeg A2592000
-#ExpiresByType image/png A2592000
-#BrowserMatch "MSIE" brokenvary=1
-#BrowserMatch "Mozilla/4.[0-9]{2}" brokenvary=1
-#BrowserMatch "Opera" !brokenvary
-#SetEnvIf brokenvary 1 force-no-vary

--- a/ht.access
+++ b/ht.access
@@ -54,29 +54,6 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)$ index.php?q=$1 [L,QSA]
 
 
-# If your server is not already configured as such, the following directive
-# should be uncommented in order to set PHP's register_globals option to OFF.
-# This closes a major security hole that is abused by most XSS (cross-site
-# scripting) attacks. For more information: http://php.net/register_globals
-#
-# To verify that this option has been set to OFF, open the Manager and choose
-# Reports -> System Info and then click the phpinfo() link. Do a Find on Page
-# for "register_globals". The Local Value should be OFF. If the Master Value
-# is OFF then you do not need this directive here.
-#
-# IF REGISTER_GLOBALS DIRECTIVE CAUSES 500 INTERNAL SERVER ERRORS :
-#
-# Your server does not allow PHP directives to be set via .htaccess. In that
-# case you must make this change in your php.ini file instead. If you are
-# using a commercial web host, contact the administrators for assistance in
-# doing this. Not all servers allow local php.ini files, and they should
-# include all PHP configurations (not just this one), or you will effectively
-# reset everything to PHP defaults. Consult www.php.net for more detailed
-# information about setting PHP directives.
-
-#php_flag register_globals Off
-
-
 # For servers that support output compression, you should pick up a bit of
 # speed by un-commenting the following lines.
 


### PR DESCRIPTION
### What does it do?

Delete rules for win xp and IE

### Why is it needed?

These rules are no longer valid

### Related issue(s)/PR(s)

#14244 #15178 #15156