### PR TITLE
Fix uninstalling package error message

### DIFF
--- a/core/model/modx/processors/workspace/packages/uninstall.class.php
+++ b/core/model/modx/processors/workspace/packages/uninstall.class.php
@@ -62,7 +62,7 @@ class modPackageUninstallProcessor extends modProcessor {
         );
 
         if ($this->package->uninstall($options) == false) {
-            return $this->failure(sprintf($this->modx->lexicon('package_err_uninstall'),$this->package->getPrimaryKey()));
+            return $this->failure(sprintf($this->modx->lexicon('package_err_uninstall',  array('signature' => $this->package->get('signature'))), $this->package->getPrimaryKey()));
         }
 
         $this->modx->log(modX::LOG_LEVEL_WARN,$this->modx->lexicon('package_uninstall_info_success',array('signature' => $this->package->get('signature'))));


### PR DESCRIPTION
### What does it do?
Fixes not passing property to a lexicon string & an error when uninstall fails.

### Why is it needed?
If package uninstall fails, user gets a message in the console:
```
Error uninstalling package with signature: [[+signature]]
```

![2020-11-02_21-28-53](https://user-images.githubusercontent.com/4679725/97949135-ba747080-1da3-11eb-861b-810a834dd65c.png)
