### PR TITLE
Fix: anonymous_sessions

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -341,7 +341,8 @@ class modUser extends modPrincipal {
                 foreach ($legacyContextTokens as $token)
                     $this->addSessionContext($token);
             }
-            $_SESSION['modx.user.contextTokens']= $this->sessionContexts;
+            if ($this->xpdo->getSessionState())
+                $_SESSION['modx.user.contextTokens']= $this->sessionContexts;
         }
         return $this->sessionContexts;
     }


### PR DESCRIPTION
Writing to $_SESSION before session_start() when anonymous_sessions set to FALSE leads to modX::SESSION_STATE_EXTERNAL and prevents startSession() calls from properly starting it on demand.
