### PR TITLE
PHP 8 Compatibility

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -819,7 +819,8 @@ class modTemplateVar extends modElement {
                     $dbtags['DBASE'] = $this->xpdo->getOption('dbname');
                     $dbtags['PREFIX'] = $this->xpdo->getOption('table_prefix');
                     foreach($dbtags as $key => $pValue) {
-                        $param = str_replace('[[+'.$key.']]', $pValue, $param);
+                        if (!is_scalar($pValue)) continue;
+                        $param = str_replace('[[+'.$key.']]', (string)$pValue, $param);
                     }
                     $stmt = $this->xpdo->query('SELECT '.$param);
                     if ($stmt && $stmt instanceof PDOStatement) {

--- a/core/model/modx/transport/modtransportpackage.class.php
+++ b/core/model/modx/transport/modtransportpackage.class.php
@@ -643,7 +643,7 @@ class modTransportPackage extends xPDOObject {
      */
     protected function _bytes($value) {
         $value = trim($value);
-        $modifier = strtolower($value{strlen($value)-1});
+        $modifier = strtolower($value[strlen($value) - 1]);
         switch($modifier) {
             case 'g':
                 $value *= 1024;

--- a/core/model/phpthumb/phpthumb.bmp.php
+++ b/core/model/phpthumb/phpthumb.bmp.php
@@ -725,7 +725,7 @@ class phpthumb_bmp {
 			}
 
 		}
-		if (!is_resource($gd)) {
+		if (!is_resource($gd) && !(is_object($gd) && $gd instanceOf \GdImage)) {
 			return false;
 		}
 

--- a/core/model/phpthumb/phpthumb.filters.php
+++ b/core/model/phpthumb/phpthumb.filters.php
@@ -1424,7 +1424,7 @@ class phpthumb_filters {
 
 	public function WatermarkOverlay(&$gdimg_dest, &$img_watermark, $alignment='*', $opacity=50, $margin_x=5, $margin_y=null) {
 
-		if (is_resource($gdimg_dest) && is_resource($img_watermark)) {
+		if ((is_resource($gdimg_dest) || (is_object($gdimg_dest) && $gdimg_dest instanceOf \GdImage)) && (is_resource($img_watermark) || (is_object($img_watermark) && $img_watermark instanceOf \GdImage))) {
 			$img_source_width          = imagesx($gdimg_dest);
 			$img_source_height         = imagesy($gdimg_dest);
 			$watermark_source_width    = imagesx($img_watermark);

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -11,6 +11,10 @@
 
 class phpthumb_functions {
 
+	public static function is_windows() {
+		return (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN');
+	}
+
 	public static function user_function_exists($functionname) {
 		if (function_exists('get_defined_functions')) {
 			static $get_defined_functions = array();
@@ -239,7 +243,7 @@ class phpthumb_functions {
 	}
 
 	public static function ImageHexColorAllocate(&$gdimg_hexcolorallocate, $HexColorString, $dieOnInvalid=false, $alpha=false) {
-		if (!is_resource($gdimg_hexcolorallocate)) {
+		if (!is_resource($gdimg_hexcolorallocate) && !(is_object($gdimg_hexcolorallocate) && $gdimg_hexcolorallocate instanceOf \GdImage)) {
 			die('$gdimg_hexcolorallocate is not a GD resource in ImageHexColorAllocate()');
 		}
 		if (self::IsHexColor($HexColorString)) {
@@ -261,7 +265,7 @@ class phpthumb_functions {
 
 
 	public static function GetPixelColor(&$img, $x, $y) {
-		if (!is_resource($img)) {
+		if (!is_resource($img) && !(is_object($img) && $img instanceOf \GdImage)) {
 			return false;
 		}
 		return @imagecolorsforindex($img, @imagecolorat($img, $x, $y));
@@ -841,17 +845,30 @@ class phpthumb_functions {
 		return false;
 	}
 
-	public static function EnsureDirectoryExists($dirname, $mask = 0755) {
-		$directory_elements = explode(DIRECTORY_SEPARATOR, $dirname);
-		$startoffset = (!$directory_elements[0] ? 2 : 1);  // unix with leading "/" then start with 2nd element; Windows with leading "c:\" then start with 1st element
-		$open_basedirs = preg_split('#[;:]#', ini_get('open_basedir'));
+	public static function EnsureDirectoryExists($dirname, $mask=0755) {
+		// https://www.php.net/manual/en/ini.core.php#ini.open-basedir says:
+		// "Under Windows, separate the directories with a semicolon. On all other systems, separate the directories with a colon."
+		$config_open_basedir = ini_get('open_basedir');
+		$startoffset = 2; // 1-based counting, first element to left of first directory separator will either be drive letter (Windows) or blank (unix). May be overridden below.
+		if (self::is_windows()) {
+			$delimiter = ';';
+			$case_insensitive_pathname = true;
+			// unix OSs will always use "/", some Windows configurations you may find "/" used interchangeably with the OS-correct "\", so standardize for ease of comparison
+			$dirname             = str_replace('/', DIRECTORY_SEPARATOR, $dirname);
+			$config_open_basedir = str_replace('/', DIRECTORY_SEPARATOR, $config_open_basedir);
+		} else {
+			$delimiter = ':';
+			$case_insensitive_pathname = false;
+		}
+		$open_basedirs = explode($delimiter, $config_open_basedir);
 		foreach ($open_basedirs as $key => $open_basedir) {
-			if (preg_match('#^'.preg_quote($open_basedir).'#', $dirname) && (strlen($dirname) > strlen($open_basedir))) {
+			if (preg_match('#^'.preg_quote($open_basedir).'#'.($case_insensitive_pathname ? 'i' : ''), $dirname) && (strlen($dirname) > strlen($open_basedir))) {
 				$startoffset = substr_count($open_basedir, DIRECTORY_SEPARATOR) + 1;
 				break;
 			}
 		}
-		$i = $startoffset;
+
+		$directory_elements = explode(DIRECTORY_SEPARATOR, $dirname);
 		$endoffset = count($directory_elements);
 		for ($i = $startoffset; $i <= $endoffset; $i++) {
 			$test_directory = implode(DIRECTORY_SEPARATOR, array_slice($directory_elements, 0, $i));
@@ -983,7 +1000,8 @@ if (!function_exists('gd_info')) {
 						if ($fp_tempfile = @fopen($tempfilename, 'wb')) {
 							fwrite($fp_tempfile, base64_decode('R0lGODlhAQABAIAAAH//AP///ywAAAAAAQABAAACAUQAOw==')); // very simple 1px GIF file base64-encoded as string
 							fclose($fp_tempfile);
-							@chmod($tempfilename, $this->getParameter('config_file_create_mask'));
+							$phpthumb_temp = new phpthumb();
+							@chmod($tempfilename, $phpthumb_temp->getParameter('config_file_create_mask'));
 
 							// if we can convert the GIF file to a GD image then GIF create support must be enabled, otherwise it's not
 							$gd_info['GIF Read Support'] = (bool) @imagecreatefromgif($tempfilename);

--- a/core/xpdo/changelog.txt
+++ b/core/xpdo/changelog.txt
@@ -1,5 +1,9 @@
 This file shows the changes in this release of xPDO.
 
+xPDO 2.8.2-pl (TBD)
+====================================
+- Fix error caused by merging PDO driver options
+
 xPDO 2.8.1-pl (July 13, 2020)
 ====================================
 - Add current_timestamp() to valid currentTimestamps list

--- a/core/xpdo/changelog.txt
+++ b/core/xpdo/changelog.txt
@@ -1,7 +1,8 @@
 This file shows the changes in this release of xPDO.
 
-xPDO 2.8.2-pl (TBD)
+xPDO 2.8.2-pl (February 19, 2021)
 ====================================
+- Update pclzip.lib.php to resolve PHP Notice
 - Fix error caused by merging PDO driver options
 
 xPDO 2.8.1-pl (July 13, 2020)

--- a/core/xpdo/compression/pclzip.lib.php
+++ b/core/xpdo/compression/pclzip.lib.php
@@ -1840,6 +1840,7 @@
     $v_memory_limit = ini_get('memory_limit');
     $v_memory_limit = trim($v_memory_limit);
     $last = strtolower(substr($v_memory_limit, -1));
+    $v_memory_limit = intval($v_memory_limit);
 
     if($last == 'g')
         //$v_memory_limit = $v_memory_limit*1024*1024*1024;

--- a/core/xpdo/xpdo.class.php
+++ b/core/xpdo/xpdo.class.php
@@ -3085,7 +3085,7 @@ class xPDOConnection {
         $this->config['password']= $password;
         $driverOptions = is_array($driverOptions) ? $driverOptions : array();
         if (array_key_exists('driverOptions', $this->config) && is_array($this->config['driverOptions'])) {
-            $driverOptions = array_merge($this->config['driverOptions'], $driverOptions);
+            $driverOptions = $driverOptions + $this->config['driverOptions'];
         }
         $this->config['driverOptions']= $driverOptions;
         if (array_key_exists(xPDO::OPT_CONN_MUTABLE, $this->config)) {
@@ -3111,7 +3111,7 @@ class xPDOConnection {
     public function connect($driverOptions = array()) {
         if ($this->pdo === null) {
             if (is_array($driverOptions) && !empty($driverOptions)) {
-                $this->config['driverOptions']= array_merge($this->config['driverOptions'], $driverOptions);
+                $this->config['driverOptions']= $driverOptions + $this->config['driverOptions'];
             }
             try {
                 $this->pdo= new PDO($this->config['dsn'], $this->config['username'], $this->config['password'], $this->config['driverOptions']);

--- a/setup/includes/new.install.php
+++ b/setup/includes/new.install.php
@@ -303,18 +303,9 @@ if ('sdk' === trim($currentVersion['distro'], '@')) {
     $setting->save();
 }
 
-$maxFileSize = ini_get('upload_max_filesize');
-$maxFileSize = trim($maxFileSize);
-$last = strtolower($maxFileSize[strlen($maxFileSize)-1]);
-switch ($last) {
-    // The 'G' modifier is available since PHP 5.1.0
-    case 'g':
-        $maxFileSize *= 1024;
-    case 'm':
-        $maxFileSize *= 1024;
-    case 'k':
-        $maxFileSize *= 1024;
-}
+$maxFileSize = trim(ini_get('upload_max_filesize'));
+$modifier = strtolower(substr($maxFileSize, -1));
+$maxFileSizeInBytes = (int) $maxFileSize * pow(1024, strpos('kmg', $modifier) + 1);
 
 $settings_maxFileSize = $modx->getObject('modSystemSetting', array('key' => 'upload_maxsize'));
 if (!$settings_maxFileSize) {
@@ -330,7 +321,7 @@ if (!$settings_maxFileSize) {
         true
     );
 }
-$settings_maxFileSize->set('value', $maxFileSize);
+$settings_maxFileSize->set('value', $maxFileSizeInBytes);
 $settings_maxFileSize->save();
 
 return true;


### PR DESCRIPTION
### What does it do?
* Resolves the change to PDO's default error mode, which is now ERRMODE_EXCEPTION in PHP 8
* Conditionally executes the get_magic_quotes_gpc() function on PHP < 7.4 since it was deprecated in that version and removed in PHP 8
* Fixes errors when merging PDO driver options in xPDOConnection objects as well as when loading modX configuration options

### Why is it needed?
To make 2.x compatible with PHP 8.

### How to test
Build, run, and test on PHP 8.

### Related issue(s)/PR(s)
n/a