### PR TITLE
Adding more character options to plugins and templates

### DIFF
--- a/core/model/modx/mysql/modplugin.map.inc.php
+++ b/core/model/modx/mysql/modplugin.map.inc.php
@@ -184,7 +184,7 @@ $xpdo_meta_map['modPlugin']= array (
         'invalid' =>
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/',
           'message' => 'plugin_err_invalid_name',
         ),
       ),

--- a/core/model/modx/mysql/modtemplate.map.inc.php
+++ b/core/model/modx/mysql/modtemplate.map.inc.php
@@ -241,7 +241,7 @@ $xpdo_meta_map['modTemplate']= array (
         'invalid' =>
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/',
           'message' => 'template_err_invalid_name',
         ),
       ),

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -812,7 +812,7 @@
         </composite>
         <composite alias="PluginEvents" class="modPluginEvent" local="id" foreign="pluginid" cardinality="many" owner="local" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x7f-\xff-_\s]+(?<!\s)$/" message="plugin_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/" message="plugin_err_invalid_name" />
         </validation>
     </object>
 
@@ -1133,7 +1133,7 @@
         <composite alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="id" foreign="templateid" cardinality="many" owner="local" />
 
         <validation>
-            <rule field="templatename" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="template_err_invalid_name" />
+            <rule field="templatename" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/" message="template_err_invalid_name" />
         </validation>
     </object>
 


### PR DESCRIPTION
### What does it do?
Expands the qualifying character patterns for Templates and Plugins names to prevent breaking sites during upgrade. 

### Why is it needed?
PR #15146 reduced the available characters in these non-callable element names. This breaks older sites that used common character patterns in their names. 

### How to test
Attempt to add additional strings to a plugin or template names. It still blocks callable code, but allows commonly used special characters. 

### Related issue(s)/PR(s)
issue #15323

_Edited: clarified these are referring to the names of the elements_
