### PR TITLE
Fix Plugin and Template name validation

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -4,6 +4,7 @@ development release, and is only shown to give an idea of what's currently in th
 
 MODX Revolution 2.8.2-pl (TBD)
 ====================================
+- Fix Plugin and Template name validation [#15349]
 - Fix missing package signature when uninstalling [#15315]
 
 MODX Revolution 2.8.1-pl (October 22, 2020)

--- a/core/model/modx/mysql/modchunk.map.inc.php
+++ b/core/model/modx/mysql/modchunk.map.inc.php
@@ -8,11 +8,11 @@ $xpdo_meta_map['modChunk']= array (
   'version' => '1.1',
   'table' => 'site_htmlsnippets',
   'extends' => 'modElement',
-  'tableMeta' =>
+  'tableMeta' => 
   array (
     'engine' => 'InnoDB',
   ),
-  'fields' =>
+  'fields' => 
   array (
     'name' => '',
     'description' => 'Chunk',
@@ -25,9 +25,9 @@ $xpdo_meta_map['modChunk']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'name' =>
+    'name' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '50',
@@ -36,7 +36,7 @@ $xpdo_meta_map['modChunk']= array (
       'default' => '',
       'index' => 'unique',
     ),
-    'description' =>
+    'description' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -44,7 +44,7 @@ $xpdo_meta_map['modChunk']= array (
       'null' => false,
       'default' => 'Chunk',
     ),
-    'editor_type' =>
+    'editor_type' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -52,7 +52,7 @@ $xpdo_meta_map['modChunk']= array (
       'null' => false,
       'default' => 0,
     ),
-    'category' =>
+    'category' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -61,7 +61,7 @@ $xpdo_meta_map['modChunk']= array (
       'default' => 0,
       'index' => 'fk',
     ),
-    'cache_type' =>
+    'cache_type' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -69,12 +69,12 @@ $xpdo_meta_map['modChunk']= array (
       'null' => false,
       'default' => 0,
     ),
-    'snippet' =>
+    'snippet' => 
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'string',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -84,13 +84,13 @@ $xpdo_meta_map['modChunk']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'array',
       'null' => true,
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -100,7 +100,7 @@ $xpdo_meta_map['modChunk']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -109,21 +109,21 @@ $xpdo_meta_map['modChunk']= array (
       'default' => '',
     ),
   ),
-  'fieldAliases' =>
+  'fieldAliases' => 
   array (
     'content' => 'snippet',
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'name' =>
+    'name' => 
     array (
       'alias' => 'name',
       'primary' => false,
       'unique' => true,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'name' =>
+        'name' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -131,15 +131,15 @@ $xpdo_meta_map['modChunk']= array (
         ),
       ),
     ),
-    'category' =>
+    'category' => 
     array (
       'alias' => 'category',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'category' =>
+        'category' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -147,15 +147,15 @@ $xpdo_meta_map['modChunk']= array (
         ),
       ),
     ),
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -163,15 +163,15 @@ $xpdo_meta_map['modChunk']= array (
         ),
       ),
     ),
-    'static' =>
+    'static' => 
     array (
       'alias' => 'static',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'static' =>
+        'static' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -180,27 +180,27 @@ $xpdo_meta_map['modChunk']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modChunk',
         ),
       ),
     ),
   ),
-  'aggregates' =>
+  'aggregates' => 
   array (
-    'Category' =>
+    'Category' => 
     array (
       'class' => 'modCategory',
       'key' => 'id',
@@ -210,16 +210,16 @@ $xpdo_meta_map['modChunk']= array (
       'owner' => 'foreign',
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'name' =>
+      'name' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'chunk_err_invalid_name',
         ),
       ),

--- a/core/model/modx/mysql/modplugin.map.inc.php
+++ b/core/model/modx/mysql/modplugin.map.inc.php
@@ -184,7 +184,7 @@ $xpdo_meta_map['modPlugin']= array (
         'invalid' =>
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/',
           'message' => 'plugin_err_invalid_name',
         ),
       ),

--- a/core/model/modx/mysql/modplugin.map.inc.php
+++ b/core/model/modx/mysql/modplugin.map.inc.php
@@ -8,11 +8,11 @@ $xpdo_meta_map['modPlugin']= array (
   'version' => '1.1',
   'table' => 'site_plugins',
   'extends' => 'modScript',
-  'tableMeta' =>
+  'tableMeta' => 
   array (
     'engine' => 'InnoDB',
   ),
-  'fields' =>
+  'fields' => 
   array (
     'cache_type' => 0,
     'plugincode' => '',
@@ -23,9 +23,9 @@ $xpdo_meta_map['modPlugin']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'cache_type' =>
+    'cache_type' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -33,14 +33,14 @@ $xpdo_meta_map['modPlugin']= array (
       'null' => false,
       'default' => 0,
     ),
-    'plugincode' =>
+    'plugincode' => 
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'string',
       'null' => false,
       'default' => '',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -50,13 +50,13 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'array',
       'null' => true,
     ),
-    'disabled' =>
+    'disabled' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -66,7 +66,7 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'moduleguid' =>
+    'moduleguid' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '32',
@@ -75,7 +75,7 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => '',
       'index' => 'fk',
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -85,7 +85,7 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -94,21 +94,21 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => '',
     ),
   ),
-  'fieldAliases' =>
+  'fieldAliases' => 
   array (
     'content' => 'plugincode',
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -116,15 +116,15 @@ $xpdo_meta_map['modPlugin']= array (
         ),
       ),
     ),
-    'disabled' =>
+    'disabled' => 
     array (
       'alias' => 'disabled',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'disabled' =>
+        'disabled' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -132,15 +132,15 @@ $xpdo_meta_map['modPlugin']= array (
         ),
       ),
     ),
-    'static' =>
+    'static' => 
     array (
       'alias' => 'static',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'static' =>
+        'static' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -149,24 +149,24 @@ $xpdo_meta_map['modPlugin']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modPlugin',
         ),
       ),
     ),
-    'PluginEvents' =>
+    'PluginEvents' => 
     array (
       'class' => 'modPluginEvent',
       'local' => 'id',
@@ -175,16 +175,16 @@ $xpdo_meta_map['modPlugin']= array (
       'owner' => 'local',
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'name' =>
+      'name' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x23-\\x2f\\x3a\\x5b-\\x5d\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'plugin_err_invalid_name',
         ),
       ),

--- a/core/model/modx/mysql/modsnippet.map.inc.php
+++ b/core/model/modx/mysql/modsnippet.map.inc.php
@@ -8,11 +8,11 @@ $xpdo_meta_map['modSnippet']= array (
   'version' => '1.1',
   'table' => 'site_snippets',
   'extends' => 'modScript',
-  'tableMeta' =>
+  'tableMeta' => 
   array (
     'engine' => 'InnoDB',
   ),
-  'fields' =>
+  'fields' => 
   array (
     'cache_type' => 0,
     'snippet' => NULL,
@@ -22,9 +22,9 @@ $xpdo_meta_map['modSnippet']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'cache_type' =>
+    'cache_type' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -32,12 +32,12 @@ $xpdo_meta_map['modSnippet']= array (
       'null' => false,
       'default' => 0,
     ),
-    'snippet' =>
+    'snippet' => 
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'string',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -47,13 +47,13 @@ $xpdo_meta_map['modSnippet']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'array',
       'null' => true,
     ),
-    'moduleguid' =>
+    'moduleguid' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '32',
@@ -62,7 +62,7 @@ $xpdo_meta_map['modSnippet']= array (
       'default' => '',
       'index' => 'fk',
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -72,7 +72,7 @@ $xpdo_meta_map['modSnippet']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -81,21 +81,21 @@ $xpdo_meta_map['modSnippet']= array (
       'default' => '',
     ),
   ),
-  'fieldAliases' =>
+  'fieldAliases' => 
   array (
     'content' => 'snippet',
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -103,15 +103,15 @@ $xpdo_meta_map['modSnippet']= array (
         ),
       ),
     ),
-    'moduleguid' =>
+    'moduleguid' => 
     array (
       'alias' => 'moduleguid',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'moduleguid' =>
+        'moduleguid' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -119,15 +119,15 @@ $xpdo_meta_map['modSnippet']= array (
         ),
       ),
     ),
-    'static' =>
+    'static' => 
     array (
       'alias' => 'static',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'static' =>
+        'static' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -136,34 +136,34 @@ $xpdo_meta_map['modSnippet']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modSnippet',
         ),
       ),
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'name' =>
+      'name' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'snippet_err_invalid_name',
         ),
       ),

--- a/core/model/modx/mysql/modtemplate.map.inc.php
+++ b/core/model/modx/mysql/modtemplate.map.inc.php
@@ -241,7 +241,7 @@ $xpdo_meta_map['modTemplate']= array (
         'invalid' =>
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/',
           'message' => 'template_err_invalid_name',
         ),
       ),

--- a/core/model/modx/mysql/modtemplate.map.inc.php
+++ b/core/model/modx/mysql/modtemplate.map.inc.php
@@ -8,11 +8,11 @@ $xpdo_meta_map['modTemplate']= array (
   'version' => '1.1',
   'table' => 'site_templates',
   'extends' => 'modElement',
-  'tableMeta' =>
+  'tableMeta' => 
   array (
     'engine' => 'InnoDB',
   ),
-  'fields' =>
+  'fields' => 
   array (
     'templatename' => '',
     'description' => 'Template',
@@ -26,9 +26,9 @@ $xpdo_meta_map['modTemplate']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'templatename' =>
+    'templatename' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '50',
@@ -37,7 +37,7 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => '',
       'index' => 'unique',
     ),
-    'description' =>
+    'description' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -45,7 +45,7 @@ $xpdo_meta_map['modTemplate']= array (
       'null' => false,
       'default' => 'Template',
     ),
-    'editor_type' =>
+    'editor_type' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -53,7 +53,7 @@ $xpdo_meta_map['modTemplate']= array (
       'null' => false,
       'default' => 0,
     ),
-    'category' =>
+    'category' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -62,7 +62,7 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => 0,
       'index' => 'fk',
     ),
-    'icon' =>
+    'icon' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -70,7 +70,7 @@ $xpdo_meta_map['modTemplate']= array (
       'null' => false,
       'default' => '',
     ),
-    'template_type' =>
+    'template_type' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -78,14 +78,14 @@ $xpdo_meta_map['modTemplate']= array (
       'null' => false,
       'default' => 0,
     ),
-    'content' =>
+    'content' => 
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'string',
       'null' => false,
       'default' => '',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -95,13 +95,13 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'array',
       'null' => true,
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -111,7 +111,7 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -120,17 +120,17 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => '',
     ),
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'templatename' =>
+    'templatename' => 
     array (
       'alias' => 'templatename',
       'primary' => false,
       'unique' => true,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'templatename' =>
+        'templatename' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -138,15 +138,15 @@ $xpdo_meta_map['modTemplate']= array (
         ),
       ),
     ),
-    'category' =>
+    'category' => 
     array (
       'alias' => 'category',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'category' =>
+        'category' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -154,15 +154,15 @@ $xpdo_meta_map['modTemplate']= array (
         ),
       ),
     ),
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -170,15 +170,15 @@ $xpdo_meta_map['modTemplate']= array (
         ),
       ),
     ),
-    'static' =>
+    'static' => 
     array (
       'alias' => 'static',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'static' =>
+        'static' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -187,24 +187,24 @@ $xpdo_meta_map['modTemplate']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modTemplate',
         ),
       ),
     ),
-    'TemplateVarTemplates' =>
+    'TemplateVarTemplates' => 
     array (
       'class' => 'modTemplateVarTemplate',
       'local' => 'id',
@@ -213,9 +213,9 @@ $xpdo_meta_map['modTemplate']= array (
       'owner' => 'local',
     ),
   ),
-  'aggregates' =>
+  'aggregates' => 
   array (
-    'Category' =>
+    'Category' => 
     array (
       'class' => 'modCategory',
       'local' => 'category',
@@ -223,7 +223,7 @@ $xpdo_meta_map['modTemplate']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'Resources' =>
+    'Resources' => 
     array (
       'class' => 'modResource',
       'local' => 'id',
@@ -232,16 +232,16 @@ $xpdo_meta_map['modTemplate']= array (
       'owner' => 'local',
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'templatename' =>
+      'templatename' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x23-\\x2f\\x3a\\x5b-\\x5d\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'template_err_invalid_name',
         ),
       ),

--- a/core/model/modx/mysql/modtemplatevar.map.inc.php
+++ b/core/model/modx/mysql/modtemplatevar.map.inc.php
@@ -8,11 +8,11 @@ $xpdo_meta_map['modTemplateVar']= array (
   'version' => '1.1',
   'table' => 'site_tmplvars',
   'extends' => 'modElement',
-  'tableMeta' =>
+  'tableMeta' => 
   array (
     'engine' => 'InnoDB',
   ),
-  'fields' =>
+  'fields' => 
   array (
     'type' => '',
     'name' => '',
@@ -31,9 +31,9 @@ $xpdo_meta_map['modTemplateVar']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'type' =>
+    'type' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '20',
@@ -41,7 +41,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'null' => false,
       'default' => '',
     ),
-    'name' =>
+    'name' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '50',
@@ -50,7 +50,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'default' => '',
       'index' => 'unique',
     ),
-    'caption' =>
+    'caption' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '80',
@@ -58,7 +58,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'null' => false,
       'default' => '',
     ),
-    'description' =>
+    'description' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -66,7 +66,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'null' => false,
       'default' => '',
     ),
-    'editor_type' =>
+    'editor_type' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -74,7 +74,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'null' => false,
       'default' => 0,
     ),
-    'category' =>
+    'category' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -83,7 +83,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'default' => 0,
       'index' => 'fk',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -93,12 +93,12 @@ $xpdo_meta_map['modTemplateVar']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'elements' =>
+    'elements' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'string',
     ),
-    'rank' =>
+    'rank' => 
     array (
       'dbtype' => 'int',
       'precision' => '11',
@@ -107,7 +107,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'display' =>
+    'display' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '20',
@@ -115,30 +115,30 @@ $xpdo_meta_map['modTemplateVar']= array (
       'null' => false,
       'default' => '',
     ),
-    'default_text' =>
+    'default_text' => 
     array (
       'dbtype' => 'mediumtext',
       'phptype' => 'string',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'array',
       'null' => true,
     ),
-    'input_properties' =>
+    'input_properties' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'array',
       'null' => true,
     ),
-    'output_properties' =>
+    'output_properties' => 
     array (
       'dbtype' => 'text',
       'phptype' => 'array',
       'null' => true,
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -148,7 +148,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'varchar',
       'precision' => '191',
@@ -157,21 +157,21 @@ $xpdo_meta_map['modTemplateVar']= array (
       'default' => '',
     ),
   ),
-  'fieldAliases' =>
+  'fieldAliases' => 
   array (
     'content' => 'default_text',
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'name' =>
+    'name' => 
     array (
       'alias' => 'name',
       'primary' => false,
       'unique' => true,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'name' =>
+        'name' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -179,15 +179,15 @@ $xpdo_meta_map['modTemplateVar']= array (
         ),
       ),
     ),
-    'category' =>
+    'category' => 
     array (
       'alias' => 'category',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'category' =>
+        'category' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -195,15 +195,15 @@ $xpdo_meta_map['modTemplateVar']= array (
         ),
       ),
     ),
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -211,15 +211,15 @@ $xpdo_meta_map['modTemplateVar']= array (
         ),
       ),
     ),
-    'rank' =>
+    'rank' => 
     array (
       'alias' => 'rank',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'rank' =>
+        'rank' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -227,15 +227,15 @@ $xpdo_meta_map['modTemplateVar']= array (
         ),
       ),
     ),
-    'static' =>
+    'static' => 
     array (
       'alias' => 'static',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'static' =>
+        'static' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -244,24 +244,24 @@ $xpdo_meta_map['modTemplateVar']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modTemplateVar',
         ),
       ),
     ),
-    'TemplateVarTemplates' =>
+    'TemplateVarTemplates' => 
     array (
       'class' => 'modTemplateVarTemplate',
       'local' => 'id',
@@ -269,7 +269,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarResources' =>
+    'TemplateVarResources' => 
     array (
       'class' => 'modTemplateVarResource',
       'local' => 'id',
@@ -277,7 +277,7 @@ $xpdo_meta_map['modTemplateVar']= array (
       'cardinality' => 'many',
       'owner' => 'local',
     ),
-    'TemplateVarResourceGroups' =>
+    'TemplateVarResourceGroups' => 
     array (
       'class' => 'modTemplateVarResourceGroup',
       'local' => 'id',
@@ -286,9 +286,9 @@ $xpdo_meta_map['modTemplateVar']= array (
       'owner' => 'local',
     ),
   ),
-  'aggregates' =>
+  'aggregates' => 
   array (
-    'Category' =>
+    'Category' => 
     array (
       'class' => 'modCategory',
       'local' => 'category',
@@ -297,19 +297,19 @@ $xpdo_meta_map['modTemplateVar']= array (
       'owner' => 'foreign',
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'name' =>
+      'name' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'tv_err_invalid_name',
         ),
-        'reserved' =>
+        'reserved' => 
         array (
           'type' => 'preg_match',
           'rule' => '/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|alias_visible|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree|properties)$)/',

--- a/core/model/modx/sqlsrv/modchunk.map.inc.php
+++ b/core/model/modx/sqlsrv/modchunk.map.inc.php
@@ -8,7 +8,7 @@ $xpdo_meta_map['modChunk']= array (
   'version' => '1.1',
   'table' => 'site_htmlsnippets',
   'extends' => 'modElement',
-  'fields' =>
+  'fields' => 
   array (
     'name' => '',
     'description' => 'Chunk',
@@ -21,9 +21,9 @@ $xpdo_meta_map['modChunk']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'name' =>
+    'name' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '50',
@@ -32,7 +32,7 @@ $xpdo_meta_map['modChunk']= array (
       'default' => '',
       'index' => 'unique',
     ),
-    'description' =>
+    'description' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -40,14 +40,14 @@ $xpdo_meta_map['modChunk']= array (
       'null' => false,
       'default' => 'Chunk',
     ),
-    'editor_type' =>
+    'editor_type' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 0,
     ),
-    'category' =>
+    'category' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
@@ -55,7 +55,7 @@ $xpdo_meta_map['modChunk']= array (
       'default' => 0,
       'index' => 'fk',
     ),
-    'cache_type' =>
+    'cache_type' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -63,13 +63,13 @@ $xpdo_meta_map['modChunk']= array (
       'null' => false,
       'default' => 0,
     ),
-    'snippet' =>
+    'snippet' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
       'phptype' => 'string',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -77,14 +77,14 @@ $xpdo_meta_map['modChunk']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
       'phptype' => 'array',
       'null' => true,
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -92,7 +92,7 @@ $xpdo_meta_map['modChunk']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -101,21 +101,21 @@ $xpdo_meta_map['modChunk']= array (
       'default' => '',
     ),
   ),
-  'fieldAliases' =>
+  'fieldAliases' => 
   array (
     'content' => 'snippet',
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'name' =>
+    'name' => 
     array (
       'alias' => 'name',
       'primary' => false,
       'unique' => true,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'name' =>
+        'name' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -123,15 +123,15 @@ $xpdo_meta_map['modChunk']= array (
         ),
       ),
     ),
-    'category' =>
+    'category' => 
     array (
       'alias' => 'category',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'category' =>
+        'category' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -139,15 +139,15 @@ $xpdo_meta_map['modChunk']= array (
         ),
       ),
     ),
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -155,15 +155,15 @@ $xpdo_meta_map['modChunk']= array (
         ),
       ),
     ),
-    'static' =>
+    'static' => 
     array (
       'alias' => 'static',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'static' =>
+        'static' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -172,27 +172,27 @@ $xpdo_meta_map['modChunk']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modChunk',
         ),
       ),
     ),
   ),
-  'aggregates' =>
+  'aggregates' => 
   array (
-    'Category' =>
+    'Category' => 
     array (
       'class' => 'modCategory',
       'key' => 'id',
@@ -202,16 +202,16 @@ $xpdo_meta_map['modChunk']= array (
       'owner' => 'foreign',
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'name' =>
+      'name' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'chunk_err_invalid_name',
         ),
       ),

--- a/core/model/modx/sqlsrv/modplugin.map.inc.php
+++ b/core/model/modx/sqlsrv/modplugin.map.inc.php
@@ -8,7 +8,7 @@ $xpdo_meta_map['modPlugin']= array (
   'version' => '1.1',
   'table' => 'site_plugins',
   'extends' => 'modScript',
-  'fields' =>
+  'fields' => 
   array (
     'cache_type' => 0,
     'plugincode' => '',
@@ -19,9 +19,9 @@ $xpdo_meta_map['modPlugin']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'cache_type' =>
+    'cache_type' => 
     array (
       'dbtype' => 'tinyint',
       'precision' => '1',
@@ -29,7 +29,7 @@ $xpdo_meta_map['modPlugin']= array (
       'null' => false,
       'default' => 0,
     ),
-    'plugincode' =>
+    'plugincode' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
@@ -37,7 +37,7 @@ $xpdo_meta_map['modPlugin']= array (
       'null' => false,
       'default' => '',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -45,14 +45,14 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
       'phptype' => 'array',
       'null' => true,
     ),
-    'disabled' =>
+    'disabled' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -60,7 +60,7 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'moduleguid' =>
+    'moduleguid' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '32',
@@ -69,7 +69,7 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => '',
       'index' => 'fk',
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -77,7 +77,7 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -86,21 +86,21 @@ $xpdo_meta_map['modPlugin']= array (
       'default' => '',
     ),
   ),
-  'fieldAliases' =>
+  'fieldAliases' => 
   array (
     'content' => 'plugincode',
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -108,15 +108,15 @@ $xpdo_meta_map['modPlugin']= array (
         ),
       ),
     ),
-    'disabled' =>
+    'disabled' => 
     array (
       'alias' => 'disabled',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'disabled' =>
+        'disabled' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -125,24 +125,24 @@ $xpdo_meta_map['modPlugin']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modPlugin',
         ),
       ),
     ),
-    'PluginEvents' =>
+    'PluginEvents' => 
     array (
       'class' => 'modPluginEvent',
       'local' => 'id',
@@ -151,16 +151,16 @@ $xpdo_meta_map['modPlugin']= array (
       'owner' => 'local',
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'name' =>
+      'name' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x23-\\x2f\\x3a\\x5b-\\x5d\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'plugin_err_invalid_name',
         ),
       ),

--- a/core/model/modx/sqlsrv/modsnippet.map.inc.php
+++ b/core/model/modx/sqlsrv/modsnippet.map.inc.php
@@ -141,7 +141,7 @@ $xpdo_meta_map['modSnippet']= array (
         'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'snippet_err_invalid_name',
         ),
       ),

--- a/core/model/modx/sqlsrv/modtemplate.map.inc.php
+++ b/core/model/modx/sqlsrv/modtemplate.map.inc.php
@@ -8,7 +8,7 @@ $xpdo_meta_map['modTemplate']= array (
   'version' => '1.1',
   'table' => 'site_templates',
   'extends' => 'modElement',
-  'fields' =>
+  'fields' => 
   array (
     'templatename' => '',
     'description' => 'Template',
@@ -22,9 +22,9 @@ $xpdo_meta_map['modTemplate']= array (
     'static' => 0,
     'static_file' => '',
   ),
-  'fieldMeta' =>
+  'fieldMeta' => 
   array (
-    'templatename' =>
+    'templatename' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '50',
@@ -33,7 +33,7 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => '',
       'index' => 'unique',
     ),
-    'description' =>
+    'description' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -41,14 +41,14 @@ $xpdo_meta_map['modTemplate']= array (
       'null' => false,
       'default' => 'Template',
     ),
-    'editor_type' =>
+    'editor_type' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 0,
     ),
-    'category' =>
+    'category' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
@@ -56,7 +56,7 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => 0,
       'index' => 'fk',
     ),
-    'icon' =>
+    'icon' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -64,14 +64,14 @@ $xpdo_meta_map['modTemplate']= array (
       'null' => false,
       'default' => '',
     ),
-    'template_type' =>
+    'template_type' => 
     array (
       'dbtype' => 'int',
       'phptype' => 'integer',
       'null' => false,
       'default' => 0,
     ),
-    'content' =>
+    'content' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
@@ -79,7 +79,7 @@ $xpdo_meta_map['modTemplate']= array (
       'null' => false,
       'default' => '',
     ),
-    'locked' =>
+    'locked' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -87,14 +87,14 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'properties' =>
+    'properties' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => 'max',
       'phptype' => 'array',
       'null' => true,
     ),
-    'static' =>
+    'static' => 
     array (
       'dbtype' => 'bit',
       'phptype' => 'boolean',
@@ -102,7 +102,7 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => 0,
       'index' => 'index',
     ),
-    'static_file' =>
+    'static_file' => 
     array (
       'dbtype' => 'nvarchar',
       'precision' => '255',
@@ -111,17 +111,17 @@ $xpdo_meta_map['modTemplate']= array (
       'default' => '',
     ),
   ),
-  'indexes' =>
+  'indexes' => 
   array (
-    'templatename' =>
+    'templatename' => 
     array (
       'alias' => 'templatename',
       'primary' => false,
       'unique' => true,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'templatename' =>
+        'templatename' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -129,15 +129,15 @@ $xpdo_meta_map['modTemplate']= array (
         ),
       ),
     ),
-    'category' =>
+    'category' => 
     array (
       'alias' => 'category',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'category' =>
+        'category' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -145,15 +145,15 @@ $xpdo_meta_map['modTemplate']= array (
         ),
       ),
     ),
-    'locked' =>
+    'locked' => 
     array (
       'alias' => 'locked',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'locked' =>
+        'locked' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -161,15 +161,15 @@ $xpdo_meta_map['modTemplate']= array (
         ),
       ),
     ),
-    'static' =>
+    'static' => 
     array (
       'alias' => 'static',
       'primary' => false,
       'unique' => false,
       'type' => 'BTREE',
-      'columns' =>
+      'columns' => 
       array (
-        'static' =>
+        'static' => 
         array (
           'length' => '',
           'collation' => 'A',
@@ -178,24 +178,24 @@ $xpdo_meta_map['modTemplate']= array (
       ),
     ),
   ),
-  'composites' =>
+  'composites' => 
   array (
-    'PropertySets' =>
+    'PropertySets' => 
     array (
       'class' => 'modElementPropertySet',
       'local' => 'id',
       'foreign' => 'element',
       'owner' => 'local',
       'cardinality' => 'many',
-      'criteria' =>
+      'criteria' => 
       array (
-        'foreign' =>
+        'foreign' => 
         array (
           'element_class' => 'modTemplate',
         ),
       ),
     ),
-    'TemplateVarTemplates' =>
+    'TemplateVarTemplates' => 
     array (
       'class' => 'modTemplateVarTemplate',
       'local' => 'id',
@@ -204,9 +204,9 @@ $xpdo_meta_map['modTemplate']= array (
       'owner' => 'local',
     ),
   ),
-  'aggregates' =>
+  'aggregates' => 
   array (
-    'Category' =>
+    'Category' => 
     array (
       'class' => 'modCategory',
       'local' => 'category',
@@ -214,7 +214,7 @@ $xpdo_meta_map['modTemplate']= array (
       'cardinality' => 'one',
       'owner' => 'foreign',
     ),
-    'Resources' =>
+    'Resources' => 
     array (
       'class' => 'modResource',
       'local' => 'id',
@@ -223,17 +223,17 @@ $xpdo_meta_map['modTemplate']= array (
       'owner' => 'local',
     ),
   ),
-  'validation' =>
+  'validation' => 
   array (
-    'rules' =>
+    'rules' => 
     array (
-      'name' =>
+      'templatename' => 
       array (
-        'invalid' =>
+        'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
-          'message' => 'snippet_err_invalid_name',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x23-\\x2f\\x3a\\x5b-\\x5d\\x7f-\\xff-_\\s]+(?<!\\s)$/',
+          'message' => 'template_err_invalid_name',
         ),
       ),
     ),

--- a/core/model/modx/sqlsrv/modtemplatevar.map.inc.php
+++ b/core/model/modx/sqlsrv/modtemplatevar.map.inc.php
@@ -302,7 +302,7 @@ $xpdo_meta_map['modTemplateVar']= array (
         'invalid' => 
         array (
           'type' => 'preg_match',
-          'rule' => '/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/',
+          'rule' => '/^(?!\\s)[a-zA-Z0-9\\x2d-\\x2f\\x7f-\\xff-_\\s]+(?<!\\s)$/',
           'message' => 'tv_err_invalid_name',
         ),
         'reserved' => 

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -812,7 +812,7 @@
         </composite>
         <composite alias="PluginEvents" class="modPluginEvent" local="id" foreign="pluginid" cardinality="many" owner="local" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x7f-\xff-_\s]+(?<!\s)$/" message="plugin_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/" message="plugin_err_invalid_name" />
         </validation>
     </object>
 
@@ -1133,7 +1133,7 @@
         <composite alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="id" foreign="templateid" cardinality="many" owner="local" />
 
         <validation>
-            <rule field="templatename" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="template_err_invalid_name" />
+            <rule field="templatename" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/" message="template_err_invalid_name" />
         </validation>
     </object>
 

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -393,7 +393,7 @@
         </composite>
         <aggregate alias="Category" class="modCategory" key="id" local="category" foreign="id" cardinality="one" owner="foreign" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="chunk_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?&lt;!\s)$/" message="chunk_err_invalid_name" />
         </validation>
     </object>
 
@@ -812,7 +812,7 @@
         </composite>
         <composite alias="PluginEvents" class="modPluginEvent" local="id" foreign="pluginid" cardinality="many" owner="local" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/" message="plugin_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?&lt;!\s)$/" message="plugin_err_invalid_name" />
         </validation>
     </object>
 
@@ -1072,7 +1072,7 @@
         </composite>
 
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="snippet_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?&lt;!\s)$/" message="snippet_err_invalid_name" />
         </validation>
     </object>
 
@@ -1133,7 +1133,7 @@
         <composite alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="id" foreign="templateid" cardinality="many" owner="local" />
 
         <validation>
-            <rule field="templatename" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?<!\s)$/" message="template_err_invalid_name" />
+            <rule field="templatename" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?&lt;!\s)$/" message="template_err_invalid_name" />
         </validation>
     </object>
 
@@ -1183,7 +1183,7 @@
         <composite alias="TemplateVarResources" class="modTemplateVarResource" local="id" foreign="tmplvarid" cardinality="many" owner="local" />
         <composite alias="TemplateVarResourceGroups" class="modTemplateVarResourceGroup" local="id" foreign="tmplvarid" cardinality="many" owner="local" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="tv_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?&lt;!\s)$/" message="tv_err_invalid_name" />
             <rule field="name" name="reserved" type="preg_match" rule="/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|alias_visible|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree|properties)$)/" message="tv_err_reserved_name" />
         </validation>
     </object>

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -313,7 +313,7 @@
         </composite>
         <aggregate alias="Category" class="modCategory" key="id" local="category" foreign="id" cardinality="one" owner="foreign" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="chunk_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?&lt;!\s)$/" message="chunk_err_invalid_name" />
         </validation>
     </object>
 
@@ -765,7 +765,7 @@
         </composite>
         <composite alias="PluginEvents" class="modPluginEvent" local="id" foreign="pluginid" cardinality="many" owner="local" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x7f-\xff-_\s]+(?<!\s)$/" message="plugin_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?&lt;!\s)$/" message="plugin_err_invalid_name" />
         </validation>
     </object>
 
@@ -1016,7 +1016,7 @@
             ]]></criteria>
         </composite>
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="snippet_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?&lt;!\s)$/" message="snippet_err_invalid_name" />
         </validation>
     </object>
 
@@ -1074,6 +1074,10 @@
             ]]></criteria>
         </composite>
         <composite alias="TemplateVarTemplates" class="modTemplateVarTemplate" local="id" foreign="templateid" cardinality="many" owner="local" />
+
+        <validation>
+            <rule field="templatename" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x23-\x2f\x3a\x5b-\x5d\x7f-\xff-_\s]+(?&lt;!\s)$/" message="template_err_invalid_name" />
+        </validation>
     </object>
 
     <object class="modTemplateVar" table="site_tmplvars" extends="modElement">
@@ -1122,7 +1126,7 @@
         <composite alias="TemplateVarResources" class="modTemplateVarResource" local="id" foreign="tmplvarid" cardinality="many" owner="local" />
         <composite alias="TemplateVarResourceGroups" class="modTemplateVarResourceGroup" local="id" foreign="tmplvarid" cardinality="many" owner="local" />
         <validation>
-            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?<!\s)$/" message="tv_err_invalid_name" />
+            <rule field="name" name="invalid" type="preg_match" rule="/^(?!\s)[a-zA-Z0-9\x2d-\x2f\x7f-\xff-_\s]+(?&lt;!\s)$/" message="tv_err_invalid_name" />
             <rule field="name" name="reserved" type="preg_match" rule="/^(?!(id|type|contentType|pagetitle|longtitle|description|alias|alias_visible|link_attributes|published|pub_date|unpub_date|parent|isfolder|introtext|content|richtext|template|menuindex|searchable|cacheable|createdby|createdon|editedby|editedon|deleted|deletedby|deletedon|publishedon|publishedby|menutitle|donthit|privateweb|privatemgr|content_dispo|hidemenu|class_key|context_key|content_type|uri|uri_override|hide_children_in_tree|show_in_tree|properties)$)/" message="tv_err_reserved_name" />
         </validation>
     </object>


### PR DESCRIPTION
### What does it do?
Expands the qualifying character patterns for Template and Plugin names to prevent breaking sites during upgrade. 

### Why is it needed?
PR #15146 reduced the available characters in these non-callable element names. This breaks older sites that used common character patterns in their names.

### How to test
Attempt to add additional strings to a plugin or template names. It still blocks callable code, but allows commonly used special characters. 

### Related issue(s)/PR(s)
issue #15323
supercedes #15348