### PR TITLE
Typo in test

### DIFF
--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -321,7 +321,7 @@ class modRequestTest extends MODxTestCase {
                    &ids = `[[!getids 
                    &field=`id` 
                    &resource=`[[+resource]]`
-                   ]]
+                   ]]`
                    &parents=`2`
                    `]] Tags",'Nested MODX  Tags'),
             array('Javascript! <script>alert(\'test\');</script> Yay.','Javascript!  Yay.'),


### PR DESCRIPTION
### What does it do?
Fix a typo in the test MODX tag.

### Why is it needed?
It is not really needed, but it is somehow better to use valid tags in the tests.

### Related issue(s)/PR(s)
#15367
