### PR TITLE
Fix classes used by property sets

### DIFF
--- a/core/src/Revolution/Processors/Element/GetClasses.php
+++ b/core/src/Revolution/Processors/Element/GetClasses.php
@@ -12,6 +12,7 @@ namespace MODX\Revolution\Processors\Element;
 
 
 use MODX\Revolution\modClassMap;
+use MODX\Revolution\modElement;
 use MODX\Revolution\Processors\Processor;
 
 /**
@@ -31,7 +32,7 @@ class GetClasses extends Processor
     public function initialize()
     {
         $this->setDefaultProperties([
-            'limit' => 10,
+            'limit' => 0,
             'start' => 0,
             'sort' => 'class',
             'dir' => 'ASC',
@@ -42,36 +43,14 @@ class GetClasses extends Processor
 
     public function process()
     {
-        $this->modx->deprecated('2.1.4', 'Please use $modx->getDescendants($className) now.',
-            'modElementGetClassesProcessor support');
+        $classes = $this->modx->getDescendants(modElement::class);
 
-        $limit = $this->getProperty('limit', 10);
-        $isLimit = !empty($limit);
-
-        /* build query */
-        $c = $this->modx->newQuery(modClassMap::class);
-        $c->where([
-            'parent_class' => 'modElement',
-            'class:!=' => 'modTemplate',
-        ]);
-        $c->sortby($this->getProperty('sort'), $this->getProperty('dir'));
-        $name = $this->getProperty('name', '');
-        if (!empty($name)) {
-            $c->where([
-                'modClassMap.name:IN' => is_string($name) ? explode(',', $name) : $name,
-            ]);
-        }
-        if ($isLimit) {
-            $c->limit($limit, $this->getProperty('start'));
-        }
-        $classes = $this->modx->getCollection(modClassMap::class, $c);
-
-        /* iterate */
         $list = [];
-        /** @var modClassMap $class */
+
         foreach ($classes as $class) {
-            $el = ['name' => $class->get('class')];
-            $list[] = $el;
+            if ($class === 'MODX\\Revolution\\modScript') continue;
+
+            $list[] = ['name' => $class];
         }
 
         return $this->outputArray($list);

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -292,7 +292,7 @@ MODx.panel.Plugin = function(config) {
             xtype: 'modx-panel-element-properties'
             ,elementPanel: 'modx-panel-plugin'
             ,elementId: config.plugin
-            ,elementType: 'modPlugin'
+            ,elementType: 'MODX\\Revolution\\modPlugin'
             ,record: config.record
         }],{
             id: 'modx-plugin-tabs'

--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -354,8 +354,8 @@ Ext.extend(MODx.window.AddElementToPropertySet,MODx.Window,{
     }
     ,onElementSelect: function(cb) {
         var ec = Ext.getCmp('modx-combo-element-class');
-        if (ec.getValue() == '') {
-            ec.setValue('modSnippet');
+        if (ec.getValue() === '') {
+            ec.setValue('MODX\\Revolution\\modSnippet');
         }
     }
 });
@@ -406,7 +406,7 @@ MODx.combo.Elements = function(config) {
         ,url: MODx.config.connector_url
         ,baseParams: {
             action: 'Element/GetListByClass'
-            ,element_class: 'modSnippet'
+            ,element_class: 'MODX\\Revolution\\modSnippet'
         }
     });
     MODx.combo.Elements.superclass.constructor.call(this,config);

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -248,7 +248,7 @@ MODx.panel.Snippet = function(config) {
             xtype: 'modx-panel-element-properties'
             ,elementPanel: 'modx-panel-snippet'
             ,elementId: config.snippet
-            ,elementType: 'modSnippet'
+            ,elementType: 'MODX\\Revolution\\modSnippet'
             ,record: config.record
         }],{
             id: 'modx-snippet-tabs'

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -287,7 +287,7 @@ MODx.panel.Template = function(config) {
             ,collapsible: true
             ,elementPanel: 'modx-panel-template'
             ,elementId: config.template
-            ,elementType: 'modTemplate'
+            ,elementType: 'MODX\\Revolution\\modTemplate'
             ,record: config.record
         }],{
             id: 'modx-template-tabs'

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -323,7 +323,7 @@ MODx.panel.TV = function(config) {
             ,itemId: 'panel-properties'
             ,elementPanel: 'modx-panel-tv'
             ,elementId: config.tv
-            ,elementType: 'modTemplateVar'
+            ,elementType: 'MODX\\Revolution\\modTemplateVar'
             ,record: config.record
         }],{
             id: 'modx-tv-tabs'


### PR DESCRIPTION
### What does it do?
Right now property sets uses old element class `modSnippet` vs `MODX\Revolution\modSnippet` which breaks relations. This fixes it :)

### Why is it needed?
Describe the issue you are solving.

### How to test
Try to link property set to an element, from property sets page. Without this you won't see list of element classes.

### Related issue(s)/PR(s)
Not sure if any, but didn't look tbh.
