### PR TITLE
Update modUser.php

### DIFF
--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -166,7 +166,7 @@ class modUser extends modPrincipal
         }
         if ($this->_attributes === null || $reload) {
             $this->_attributes = [];
-            $_SESSION = isset($_SESSION)? $_SESSION : [];
+            $_SESSION = isset($_SESSION) ? $_SESSION : [];
             if (isset($_SESSION["modx.user.{$id}.attributes"])) {
                 if ($reload) {
                     unset($_SESSION["modx.user.{$id}.attributes"]);

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -166,6 +166,7 @@ class modUser extends modPrincipal
         }
         if ($this->_attributes === null || $reload) {
             $this->_attributes = [];
+            $_SESSION = isset($_SESSION)? $_SESSION : [];
             if (isset($_SESSION["modx.user.{$id}.attributes"])) {
                 if ($reload) {
                     unset($_SESSION["modx.user.{$id}.attributes"]);


### PR DESCRIPTION
Prevent PHP error when $_SESSION is not set (e.g., in a unit or acceptance test).

### What does it do?
Sanity check for $_SESSION

### Why is it needed?
Original code throws a PHP fatal error if $_SESSION is not set.

### How to test


### Related issue(s)/PR(s)
Issue: #15374