### PR TITLE
Update modLexicon.php

### DIFF
--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -186,8 +186,7 @@ class modLexicon
         $topics = func_get_args(); /* allow for dynamic number of lexicons to load */
 
         if ($this->modx->context && $this->modx->context->get('key') == 'mgr') {
-            $defaultLanguage = $this->modx->getOption('manager_language', $_SESSION,
-                $this->modx->getOption('cultureKey', null, 'en'));
+            $defaultLanguage = $this->modx->getOption('manager_language', $_SESSION ?? [], $this->modx->getOption('cultureKey', null, 'en'));
         } else {
             $defaultLanguage = $this->modx->getOption('cultureKey', null, 'en');
         }


### PR DESCRIPTION
Sanity check to prevent PHP error if $_SESSION is not set

### What does it do?
Make sure $_SESSION variable exists before it's referenced

### Why is it needed?
Existing code breaks automated acceptance tests (and possibly unit tests) where $_SESSION isn't necessarily set.


### Related issue(s)/PR(s)
Issue: #15373
