### PR TITLE
Avoid returning resource_groups on resource save

### DIFF
--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -839,7 +839,7 @@ class Update extends UpdateProcessor
         $this->object->removeLock();
         $this->clearCache();
 
-        $returnArray = $this->object->get(array_diff(array_keys($this->object->_fields), ['content', 'ta', 'introtext', 'description', 'link_attributes', 'pagetitle', 'longtitle', 'menutitle', 'properties']));
+        $returnArray = $this->object->get(array_diff(array_keys($this->object->_fields), ['content', 'ta', 'introtext', 'description', 'link_attributes', 'pagetitle', 'longtitle', 'menutitle', 'properties', 'resource_groups']));
         foreach ($returnArray as $k => $v) {
             if (strpos($k, 'tv') === 0) {
                 unset($returnArray[$k]);


### PR DESCRIPTION
### What does it do?
Port of https://github.com/modxcms/revolution/pull/15293 to 3.x

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15293
