### PR TITLE
Fixed incorrect behavior for resource form checkboxes "alias_visible" and "syncsite"

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -137,6 +137,7 @@ class ResourceCreateManagerController extends ResourceManagerController
                 'cacheable' => $this->context->getOption('cache_default', 1, $this->modx->_userConfig),
                 'syncsite' => $this->context->getOption('syncsite_default', 1, $this->modx->_userConfig),
                 'show_in_tree' => $this->context->getOption('show_in_tree_default', 1, $this->modx->_userConfig),
+                'alias_visible' => $this->context->getOption('alias_visible_default', 1, $this->modx->_userConfig),
             ]);
 
             // Allow certain fields to be prefilled from the OnDocFormRender plugin event
@@ -160,7 +161,6 @@ class ResourceCreateManagerController extends ResourceManagerController
         } else {
             $this->resourceArray = array_merge($this->resourceArray, $reloadData);
             $this->resourceArray['resourceGroups'] = [];
-            $this->resourceArray['syncsite'] = true;
             $this->resourceArray['resource_groups'] = $this->modx->getOption('resource_groups',
                 $this->resourceArray, []);
             $this->resourceArray['resource_groups'] = is_array($this->resourceArray['resource_groups'])
@@ -186,7 +186,7 @@ class ResourceCreateManagerController extends ResourceManagerController
         $this->resourceArray = array_merge($this->resourceArray, $overridden);
 
         // handle checkboxes and defaults
-        $fields = ['published', 'hidemenu', 'isfolder', 'richtext', 'searchable', 'cacheable', 'deleted', 'uri_override', 'syncsite', 'show_in_tree'];
+        $fields = ['published', 'hidemenu', 'isfolder', 'richtext', 'searchable', 'cacheable', 'deleted', 'uri_override', 'syncsite', 'show_in_tree', 'alias_visible'];
         foreach ($fields as $field) {
             $this->resourceArray[$field] = !empty($this->resourceArray[$field]);
         }

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -139,7 +139,7 @@ class ResourceUpdateManagerController extends ResourceManagerController
         $this->resourceArray = array_merge($this->resourceArray, $overridden);
         $this->resourceArray['parents'] = $this->getParents();
 
-        $fields = ['published', 'hidemenu', 'isfolder', 'richtext', 'searchable', 'cacheable', 'deleted', 'uri_override'];
+        $fields = ['published', 'hidemenu', 'isfolder', 'richtext', 'searchable', 'cacheable', 'deleted', 'uri_override', 'alias_visible'];
         foreach ($fields as $field) {
             $this->resourceArray[$field] = !empty($this->resourceArray[$field]);
         }


### PR DESCRIPTION
### What does it do?
Port of https://github.com/modxcms/revolution/pull/15289 to 3.x

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15289
