### PR TITLE
Fix breadcrumbs on new resources

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -57,7 +57,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 var title = Ext.util.Format.stripTags(this.config.record.pagetitle);
                 title = Ext.util.Format.htmlEncode(title);
                 if (MODx.perm.tree_show_resource_ids) {
-                    title = title+ ' <small>('+this.config.record.id+')</small>';
+                    title = title + (this.config.record.id ? ' <small>('+this.config.record.id+')</small>' : '');
                 }
                 Ext.getCmp('modx-header-breadcrumbs').updateHeader(title);
             }
@@ -621,16 +621,22 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     ,allowBlank: false
                     ,enableKeyEvents: true
                     ,listeners: {
-                'keyup': {fn: function(f) {
+                        'keyup': {
+                            fn: function(f) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
 
-                    this.generateAliasRealTime(title);
+                                this.generateAliasRealTime(title);
 
                                 title = Ext.util.Format.htmlEncode(title);
                                 if (MODx.request.a !== 'resource/create' && MODx.perm.tree_show_resource_ids === true) {
                                     title = title+ ' <small>('+this.config.record.id+')</small>';
                                 }
-                                Ext.getCmp('modx-header-breadcrumbs').updateHeader(title);
+                                var breadCrumbsHeader = Ext.getCmp('modx-header-breadcrumbs');
+                                if (breadCrumbsHeader) {
+                                    breadCrumbsHeader.updateHeader(title);
+                                } else {
+                                    Ext.getCmp('modx-resource-header').el.dom.innerText = title;
+                                }
 
                                 // check some system settings before doing real time alias transliteration
                                 if (parseInt(MODx.config.friendly_alias_realtime, 10) && parseInt(MODx.config.automatic_alias, 10)) {
@@ -639,14 +645,19 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                                         this.translitAlias(title);
                                     }
                                 }
-                            }, scope: this}
+                            },
+                            scope: this
+                        }
                         // also do realtime transliteration of alias on blur of pagetitle field
                         // as sometimes (when typing very fast) the last letter(s) are not catched
-                        ,'blur': {fn: function(f,e) {
+                        ,'blur': {
+                            fn: function(f,e) {
                                 var title = Ext.util.Format.stripTags(f.getValue());
 
-                    this.generateAliasRealTime(title);
-                            }, scope: this}
+                                this.generateAliasRealTime(title);
+                            },
+                            scope: this
+                        }
                     }
                 }]
             },{

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -161,6 +161,7 @@ class ResourceCreateManagerController extends ResourceManagerController
         } else {
             $this->resourceArray = array_merge($this->resourceArray, $reloadData);
             $this->resourceArray['resourceGroups'] = [];
+            $this->resourceArray['parents'] = $this->getParents();
             $this->resourceArray['resource_groups'] = $this->modx->getOption('resource_groups',
                 $this->resourceArray, []);
             $this->resourceArray['resource_groups'] = is_array($this->resourceArray['resource_groups'])

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -586,11 +586,25 @@ abstract class ResourceManagerController extends modManagerController
         $ctx = null;
         $height = $this->modx->getOption('resource_panel_max_crumbs', null, 3);
         $columns = ['id', 'pagetitle', 'published', 'hidemenu', 'parent'];
-        if (!$id = $this->resource->get('id')) {
-            if ($this->parent && $id = $this->parent->get('id')) {
-                $ctx = $this->parent->get('context_key');
-                $parents[] = $this->parent->get($columns);
-                $height--;
+
+        if (empty($this->resource->id) && (empty($this->parent) || empty($this->parent->id))) {
+            $parentGet = (int)$this->modx->getOption('parent', $this->resourceArray, $this->modx->getOption('parent', $_GET));
+            if (!empty($parentGet)) {
+                $this->parent = $this->modx->getObject(modResource::class, ['id' => $parentGet]);
+            } else {
+                $ctx = $this->modx->getOption('context_key', $_GET);
+            }
+        }
+
+        $id = $this->resource->get('id');
+        if (!$id) {
+            if ($this->parent) {
+                $id = $this->parent->get('id');
+                if ($id) {
+                    $ctx = $this->parent->get('context_key');
+                    $parents[] = $this->parent->get($columns);
+                    $height--;
+                }
             }
         } else {
             $ctx = $this->resource->get('context_key');
@@ -604,7 +618,9 @@ abstract class ResourceManagerController extends modManagerController
                 }
             }
         }
-        if ($context = $this->modx->getObject(modContext::class, ['key' => $ctx])) {
+
+        $context = $this->modx->getObject(modContext::class, ['key' => $ctx]);
+        if ($context) {
             $parents[] = $context->get(['name','key']);
         }
 

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -49,7 +49,6 @@ class ResourceUpdateManagerController extends ResourceManagerController
             'xtype' => 'modx-page-resource-update',
             'resource' => $this->resource->get('id'),
             'record' => $this->resourceArray,
-            'parents' => $this->getParents(),
             'publish_document' => $this->canPublish,
             'preview_url' => $this->previewUrl,
             'locked' => (int)$this->locked,


### PR DESCRIPTION
### What does it do?
Adds full breadcrumbs in new resource page + fixes console error.

### Why is it needed?
Error in console when changing template on unsaved resource.

### How to test
Open new resource page, type something to the pagetitle, change template and check browser's console for errors.

### Related issue(s)/PR(s)
#15284
