### PR TITLE
Allow calls to the session handler gc() to return number of removed sessions

### DIFF
--- a/core/model/modx/modsessionhandler.class.php
+++ b/core/model/modx/modsessionhandler.class.php
@@ -141,8 +141,7 @@ class modSessionHandler {
      */
     public function gc($max) {
         $maxtime= time() - $this->gcMaxLifetime;
-        $result = $this->modx->removeCollection('modSession', array("{$this->modx->escape('access')} < {$maxtime}"));
-        return $result !== false;
+        return $this->modx->removeCollection('modSession', array("{$this->modx->escape('access')} < {$maxtime}"));
     }
 
     /**


### PR DESCRIPTION
### What does it do?

Changes modSessionHandler->gc() to return the output of xPDO->removeCollection()

### Why is it needed?

The `gc()` method of a custom session handler is supposed to return either a boolean `false` or an integer representing the number of stale sessions that were removed: https://www.php.net/manual/en/sessionhandlerinterface.gc.php

Typical users don't see the return of this method, but I've just added an option for SiteDash to remotely run the garbage collector for servers that have it disabled, which tries to use the number of removed stale sessions to plan future calls. For example if it wiped 1000 stale sessions, it will schedule the next call a little earlier, but if there were only 5 sessions it'll slow itself down. 

Took me longer than I care to admit to figure out my code was fine, but MODX just always returned 1 (technically, a boolean `true` that gets cast to 1). 

As the xPDO->removeCollection() call has the same signature as expected by the gc() method (false if an error occurred, otherwise the number of removed rows), we can just return it as-is. 

This should also make it into 3.x. Should be cherry-pickable but if not I'll happily create an extra PR. 

### How to test

Little tricky - you'll need a way to see the return value of a function rarely called directly.

What I've done is apply this patch, install the sitedash client v1.4 on a site that I know has the GC issue, go to manage > session garbage collector in the SiteDash dashboard, switch it to enabled, refresh after 10 seconds and see that the number of removed sessions it tells is larger than 1. Obviously a lot of steps for a small fix. :P 

Simpler approach might be to setup a snippet with `var_dump(session_gc());` on a site that has stale sessions and inspect the output. Tip: export your sessions table and reimport that into the database after calling session_gc so you can run it on the same site again.  

### Related issue(s)/PR(s)

None that I know off. 
