### PR TITLE
Quote a principal_class value

### DIFF
--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -894,7 +894,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                 $resourceGroupTable = $this->xpdo->getTableName(modResourceGroupResource::class);
                 $sql = "SELECT Acl.target, Acl.principal, Acl.authority, Acl.policy, Policy.data FROM {$accessTable} Acl " .
                     "LEFT JOIN {$policyTable} Policy ON Policy.id = Acl.policy " .
-                    "JOIN {$resourceGroupTable} ResourceGroup ON Acl.principal_class = 'MODX\\Revolution\\modUserGroup' " .
+                    "JOIN {$resourceGroupTable} ResourceGroup ON Acl.principal_class = {$this->xpdo->quote(modUserGroup::class)} " .
                     "AND (Acl.context_key = :context OR Acl.context_key IS NULL OR Acl.context_key = '') " .
                     "AND ResourceGroup.document = :resource " .
                     "AND ResourceGroup.document_group = Acl.target " .


### PR DESCRIPTION
### What does it do?
use `xpdo->quote` on `modUserGroup::class` to get a correct value for `principal_class`. Right now there's hardcoded value: `MODX\\Revolution\\modUserGroup` which is incorrect as it should be `MODX\\\Revolution\\\modUserGroup`.

### Why is it needed?
findPolicy method on modResource doesn't find any results

### How to test
Described in #15341

### Related issue(s)/PR(s)
#15341, #15375
