### PR TITLE
Fix chunk/snippet blank page with <script><!--

### DIFF
--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -107,6 +107,9 @@ class ElementChunkUpdateManagerController extends modManagerController {
         $this->chunkArray['properties'] = $data;
         $this->chunkArray['snippet'] = $this->chunk->getContent();
 
+        /* Don't remove the following line or the edit chunk page blanks when saving <script><!-- GitHub issue: #15222 */
+        $this->chunkArray['__fix_for_15222'] = '-->';
+
         $this->prepareElement();
 
         /* invoke OnRichTextEditorInit event */

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -8,7 +8,9 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
+use MODX\Revolution\modSnippet;
 use MODX\Revolution\modSystemEvent;
 
 /**
@@ -103,6 +105,9 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         if (strpos(ltrim($this->snippetArray['snippet']),'<?php') !== 0) {
             $this->snippetArray['snippet'] = "<?php\n".$this->snippetArray['snippet'];
         }
+
+        /* Don't remove the following line or the edit snippet page blanks when saving <script><!-- GitHub issue: #15222 */
+        $this->snippetArray['__fix_for_15222'] = '-->';
 
         $this->prepareElement();
 


### PR DESCRIPTION
### What does it do?
It insert's `"-->"` at the end of the `snippetArray`/`chunkArray`.

The tricky question here is why it works. My humble opinion is that this is some kind of a browser issue. The edit snippet/chunk page's controller converts the object to JSON and passes it to `MODx.load` as `record` prop. The JSON itself is valid, but when it's placed in the source code of the page, it somehow breaks. Seems like the browser don't understand that the `<script><!--` is a part of a string and it stops processing any following JS/HTML code.

The issue also only happens when there is more than 1 occurrence of the `<script><!--` code. You can try this by a simple HTML page:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>Title</title>
    <script type="text/javascript">
        var test = {
            "a": "<script><!--",
            "b": "<script><!--",
        };
    </script>
</head>
<body>
HELLO
</body>
</html>
```

This page above won't render anything. If you remove the `b` property from the `test` object, it starts working.

Why it's twice in the snippet/chunk edit page, when we're putting it once in the content field? Snippet has alias for the `snippet` field which holds the value - `content` and they are both dumped to the JSON.

At first I tried removing the `content` from the JSON, as it's not used by the edit page anyways, but then I was able to break it 
with: 
```
<script><!--
<script><!--
````

For a strange reason, appending `-->` to the JSON, makes the browser think that everything is OK and it renders the page correctly. The JS is able to read the whole JSON without an issue.

### Why is it needed?
For unknown reason people tried to save a snippet or chunk with `<script><!--` which is obviously invalid for snippets and for html as well. So if you do this twisted thing, the edit snippet/chunk page will blank after reload.

### How to test
Described here: #15222 + try in chunk as well

### Final note
I'm not sure if we want to merge this, it seems like it fixes the related issue, but it's weird. I've spent so much time on this and I'm not willing to explore more. Feel free to submit other ideas. Resources and templates break as well, but the double script is needed:
```
<script><!--
<script><!--
````

### Related issue(s)/PR(s)
#15222
