### PR TITLE
Switch non-index fields back to 255 char limit

### DIFF
--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -115,7 +115,7 @@
         <field key="template" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
         <field key="class" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index" />
         <field key="data" dbtype="text" phptype="json" default="{}" />
-        <field key="lexicon" dbtype="varchar" precision="191" phptype="string" null="false" default="permissions" />
+        <field key="lexicon" dbtype="varchar" precision="255" phptype="string" null="false" default="permissions" />
 
         <index alias="name" name="name" primary="false" unique="true" type="BTREE">
             <column key="name" length="" collation="A" null="false" />
@@ -139,7 +139,7 @@
         <field key="template_group" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
         <field key="name" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index" />
         <field key="description" dbtype="mediumtext" phptype="string" />
-        <field key="lexicon" dbtype="varchar" precision="191" phptype="string" null="false" default="permissions" />
+        <field key="lexicon" dbtype="varchar" precision="255" phptype="string" null="false" default="permissions" />
 
         <aggregate alias="TemplateGroup" class="MODX\Revolution\modAccessPolicyTemplateGroup" local="template_group" foreign="id" owner="foreign" cardinality="one" />
         <composite alias="Permissions" class="MODX\Revolution\modAccessPermission" local="id" foreign="template" owner="local" cardinality="many" />
@@ -208,10 +208,10 @@
         <field key="name" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index" />
         <field key="description" dbtype="text" phptype="string" />
         <field key="xtype" dbtype="varchar" precision="100" phptype="string" null="false" default="" /><!-- deprecated -->
-        <field key="container" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="container" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="rule" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="value" dbtype="text" phptype="string" null="false" default="" />
-        <field key="constraint" dbtype="varchar" precision="191" phptype="string" null="false" default="" /><!-- deprecated -->
+        <field key="constraint" dbtype="varchar" precision="255" phptype="string" null="false" default="" /><!-- deprecated -->
         <field key="constraint_field" dbtype="varchar" precision="100" phptype="string" null="false" default="" /><!-- deprecated -->
         <field key="constraint_class" dbtype="varchar" precision="100" phptype="string" null="false" default="" /><!-- deprecated -->
         <field key="active" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="1" index="index" /><!-- deprecated -->
@@ -247,11 +247,11 @@
     -->
     <object class="modActionField" table="actions_fields" extends="xPDO\Om\xPDOSimpleObject">
         <field key="action" dbtype="nvarchar" precision="191" phptype="string" null="false" default="" index="index" />
-        <field key="name" dbtype="varchar" precision="191" phptype="string" null="false" default="" /> <!-- name/id of field -->
+        <field key="name" dbtype="varchar" precision="255" phptype="string" null="false" default="" /> <!-- name/id of field -->
         <field key="type" dbtype="varchar" precision="100" phptype="string" null="false" default="field" index="index" /> <!-- either field/tab -->
         <field key="tab" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index" /> <!-- for fields, what tab they are on -->
-        <field key="form" dbtype="varchar" precision="191" phptype="string" null="false" default="" /> <!-- the form ID (for dom sel purposes) -->
-        <field key="other" dbtype="varchar" precision="191" phptype="string" null="false" default="" /> <!-- used on tabs to delineate TV tabs -->
+        <field key="form" dbtype="varchar" precision="255" phptype="string" null="false" default="" /> <!-- the form ID (for dom sel purposes) -->
+        <field key="other" dbtype="varchar" precision="255" phptype="string" null="false" default="" /> <!-- used on tabs to delineate TV tabs -->
         <field key="rank" dbtype="integer" precision="11" phptype="integer" null="false" default="0" />
 
         <index alias="action" name="action" primary="false" unique="false" type="BTREE">
@@ -272,7 +272,7 @@
         <field key="username" dbtype="varchar" precision="50" phptype="string" null="false" default="" />
         <field key="lasthit" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
         <field key="id" dbtype="int" precision="10" phptype="integer" null="true" />
-        <field key="action" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="action" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="ip" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
 
         <index alias="internalKey" name="internalKey" primary="true" unique="true" type="BTREE">
@@ -341,7 +341,7 @@
 
     <object class="modChunk" table="site_htmlsnippets" extends="MODX\Revolution\modElement">
         <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="Chunk" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="Chunk" />
         <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
         <field key="cache_type" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
@@ -349,7 +349,7 @@
         <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="properties" dbtype="text" phptype="array" null="true" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
-        <field key="static_file" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 
         <alias key="content" field="snippet" />
 
@@ -427,7 +427,7 @@
         <field key="value" dbtype="mediumtext" phptype="string" />
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
-        <field key="area" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
@@ -479,8 +479,8 @@
         <field key="properties" dbtype="text" phptype="json" null="true" />
         <field key="namespace" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index" />
         <field key="lexicon" dbtype="varchar" precision="191" phptype="string" null="false" default="core:dashboards" index="index" />
-        <field key="size" dbtype="varchar" precision="191" phptype="string" null="false" default="half" />
-        <field key="permission" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="size" dbtype="varchar" precision="255" phptype="string" null="false" default="half" />
+        <field key="permission" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 
         <index alias="name" name="name" primary="false" unique="false" type="BTREE">
             <column key="name" length="" collation="A" null="false" />
@@ -505,7 +505,7 @@
         <field key="dashboard" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
         <field key="widget" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
         <field key="rank" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
-        <field key="size" dbtype="varchar" precision="191" phptype="string" null="false" default="half" />
+        <field key="size" dbtype="varchar" precision="255" phptype="string" null="false" default="half" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true">
             <column key="user" collation="A" null="false" />
@@ -597,7 +597,7 @@
         <field key="description" dbtype="text" phptype="string" null="false" default="" />
         <field key="active" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" index="index" />
         <field key="template" dbtype="integer" precision="11" phptype="integer" null="false" default="0" index="index" />
-        <field key="constraint" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="constraint" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="constraint_field" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="constraint_class" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
 
@@ -649,7 +649,7 @@
         <field key="occurred" dbtype="datetime" phptype="datetime" null="true" default="NULL" />
         <field key="action" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="classKey" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
-        <field key="item" dbtype="varchar" precision="191" phptype="string" null="false" default="0" />
+        <field key="item" dbtype="varchar" precision="255" phptype="string" null="false" default="0" />
 
         <index alias="user_occurred" name="user_occurred" primary="false" unique="false" type="BTREE">
             <column key="user" length="" collation="A" null="false" />
@@ -663,8 +663,8 @@
         <field key="text" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="pk" />
         <field key="parent" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index" />
         <field key="action" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="index" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
-        <field key="icon" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="icon" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="menuindex" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" />
         <field key="params" dbtype="text" phptype="string" null="false" default="" />
         <field key="handler" dbtype="text" phptype="string" null="false" default="" />
@@ -726,11 +726,11 @@
         <!-- If empty, will assume the Namespace path -->
         <field key="path" dbtype="text" phptype="string" null="true" />
         <!-- If empty, will assume no table prefix and delegate to package schema -->
-        <field key="table_prefix" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="table_prefix" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <!-- If specified, will create an instance of the class with this name using modX.getService on the loading of this extension package -->
-        <field key="service_class" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="service_class" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <!-- The name to give the service on the modX object when instantiating. Only valid if service_class is not empty. -->
-        <field key="service_name" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="service_name" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <!-- When this extension package was made -->
         <field key="created_at" dbtype="datetime" phptype="datetime" null="true" />
         <!-- The last time this extension package was updated -->
@@ -754,7 +754,7 @@
         <field key="disabled" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
-        <field key="static_file" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 
         <alias key="content" field="plugincode" />
 
@@ -805,7 +805,7 @@
     <object class="modPropertySet" table="property_set" extends="xPDO\Om\xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
         <field key="category" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="fk" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="properties" dbtype="text" phptype="array" null="true" />
 
         <index alias="name" name="name" primary="false" unique="true" type="BTREE">
@@ -826,7 +826,7 @@
         <field key="longtitle" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="description" dbtype="text" phptype="string" null="false" default="" index="fulltext" indexgrp="content_ft_idx" />
         <field key="alias" dbtype="varchar" precision="191" phptype="string" null="true" default="" index="index" />
-        <field key="link_attributes" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="link_attributes" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="published" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="pub_date" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" index="index" />
         <field key="unpub_date" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" index="index" />
@@ -848,7 +848,7 @@
         <field key="deletedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         <field key="publishedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
         <field key="publishedby" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
-        <field key="menutitle" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="menutitle" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="donthit" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
         <field key="privateweb" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
         <field key="privatemgr" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" />
@@ -976,7 +976,7 @@
 
     <object class="modScript" table="site_script" extends="MODX\Revolution\modElement">
         <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
 
@@ -1014,7 +1014,7 @@
         <field key="properties" dbtype="text" phptype="array" null="true" />
         <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
-        <field key="static_file" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 
         <alias key="content" field="snippet" />
 
@@ -1048,7 +1048,7 @@
         <field key="value" dbtype="text" phptype="string" null="false" default="" />
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
-        <field key="area" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
@@ -1061,16 +1061,16 @@
 
     <object class="modTemplate" table="site_templates" extends="MODX\Revolution\modElement">
         <field key="templatename" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
-        <field key="icon" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="icon" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="template_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="content" dbtype="mediumtext" phptype="string" null="false" default="" />
         <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="properties" dbtype="text" phptype="array" null="true" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
-        <field key="static_file" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 
         <index alias="templatename" name="templatename" primary="false" unique="true" type="BTREE">
             <column key="templatename" length="" collation="A" null="false" />
@@ -1099,7 +1099,7 @@
         <field key="type" dbtype="varchar" precision="20" phptype="string" null="false" default="" />
         <field key="name" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
         <field key="caption" dbtype="varchar" precision="80" phptype="string" null="false" default="" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="description" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
         <field key="locked" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
@@ -1111,7 +1111,7 @@
         <field key="input_properties" dbtype="text" phptype="array" null="true" />
         <field key="output_properties" dbtype="text" phptype="array" null="true" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
-        <field key="static_file" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
 
         <alias key="content" field="default_text" />
 
@@ -1301,7 +1301,7 @@
         <field key="value" dbtype="text" phptype="string" />
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
-        <field key="area" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
@@ -1315,7 +1315,7 @@
 
     <object class="modUserMessage" table="user_messages" extends="xPDO\Om\xPDOSimpleObject">
         <field key="type" dbtype="varchar" precision="15" phptype="string" null="false" default="" />
-        <field key="subject" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="subject" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="message" dbtype="text" phptype="string" null="false" default="" />
         <field key="sender" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
         <field key="recipient" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
@@ -1344,14 +1344,14 @@
         <field key="dob" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         <field key="gender" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
         <field key="address" dbtype="text" phptype="string" null="false" default="" />
-        <field key="country" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
-        <field key="city" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="country" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="city" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="state" dbtype="varchar" precision="25" phptype="string" null="false" default="" />
         <field key="zip" dbtype="varchar" precision="25" phptype="string" null="false" default="" />
         <field key="fax" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
-        <field key="photo" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="photo" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="comment" dbtype="text" phptype="string" null="false" default="" />
-        <field key="website" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="website" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="extended" dbtype="text" phptype="json" null="true" index="fulltext" indexgrp="extended" />
 
         <index alias="internalKey" name="internalKey" primary="false" unique="true" type="BTREE">
@@ -1367,7 +1367,7 @@
         <field key="value" dbtype="text" phptype="string" />
         <field key="xtype" dbtype="varchar" precision="75" phptype="string" null="false" default="textfield" />
         <field key="namespace" dbtype="varchar" precision="40" phptype="string" null="false" default="core" />
-        <field key="area" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="area" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="editedon" dbtype="timestamp" phptype="timestamp" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">

--- a/core/src/Revolution/Registry/Db/sqlsrv/modDbRegisterMessage.php
+++ b/core/src/Revolution/Registry/Db/sqlsrv/modDbRegisterMessage.php
@@ -13,7 +13,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
         'version' => '3.0',
         'table' => 'register_messages',
         'extends' => 'MODX\\Revolution\\xPDOObject',
-        'fields' =>
+        'fields' => 
         array (
             'topic' => NULL,
             'id' => NULL,
@@ -25,16 +25,16 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
             'payload' => NULL,
             'kill' => 0,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'topic' =>
+            'topic' => 
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
                 'null' => false,
                 'index' => 'pk',
             ),
-            'id' =>
+            'id' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '255',
@@ -42,27 +42,27 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'null' => false,
                 'index' => 'pk',
             ),
-            'created' =>
+            'created' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'valid' =>
+            'valid' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'accessed' =>
+            'accessed' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'timestamp',
                 'index' => 'index',
             ),
-            'accesses' =>
+            'accesses' => 
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
@@ -70,7 +70,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
                 'index' => 'index',
             ),
-            'expires' =>
+            'expires' => 
             array (
                 'dbtype' => 'integer',
                 'phptype' => 'integer',
@@ -78,14 +78,14 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => '0',
                 'index' => 'index',
             ),
-            'payload' =>
+            'payload' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => 'max',
                 'phptype' => 'string',
                 'null' => false,
             ),
-            'kill' =>
+            'kill' => 
             array (
                 'dbtype' => 'bit',
                 'phptype' => 'boolean',
@@ -93,23 +93,23 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'topic' =>
+                    'topic' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'id' =>
+                    'id' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -117,15 +117,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'created' =>
+            'created' => 
             array (
                 'alias' => 'created',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'created' =>
+                    'created' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -133,15 +133,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'valid' =>
+            'valid' => 
             array (
                 'alias' => 'valid',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'valid' =>
+                    'valid' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -149,15 +149,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accessed' =>
+            'accessed' => 
             array (
                 'alias' => 'accessed',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'accessed' =>
+                    'accessed' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -165,15 +165,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accesses' =>
+            'accesses' => 
             array (
                 'alias' => 'accesses',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'accesses' =>
+                    'accesses' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -181,15 +181,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'expires' =>
+            'expires' => 
             array (
                 'alias' => 'expires',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'expires' =>
+                    'expires' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -198,9 +198,9 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Topic' =>
+            'Topic' => 
             array (
                 'class' => 'MODX\\Revolution\\Registry\\Db\\modDbRegisterTopic',
                 'local' => 'topic',

--- a/core/src/Revolution/Transport/mysql/modTransportPackage.php
+++ b/core/src/Revolution/Transport/mysql/modTransportPackage.php
@@ -11,11 +11,11 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
         'version' => '3.0',
         'table' => 'transport_packages',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'tableMeta' =>
+        'tableMeta' => 
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' =>
+        'fields' => 
         array (
             'signature' => NULL,
             'created' => NULL,
@@ -36,9 +36,9 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
             'release' => '',
             'release_index' => 0,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'signature' =>
+            'signature' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -46,24 +46,24 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'index' => 'pk',
             ),
-            'created' =>
+            'created' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
             ),
-            'updated' =>
+            'updated' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
-            'installed' =>
+            'installed' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
             ),
-            'state' =>
+            'state' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -72,7 +72,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'default' => 1,
             ),
-            'workspace' =>
+            'workspace' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -82,7 +82,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'fk',
             ),
-            'provider' =>
+            'provider' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -92,7 +92,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'fk',
             ),
-            'disabled' =>
+            'disabled' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -102,22 +102,22 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'source' =>
+            'source' => 
             array (
                 'dbtype' => 'tinytext',
                 'phptype' => 'string',
             ),
-            'manifest' =>
+            'manifest' => 
             array (
                 'dbtype' => 'text',
                 'phptype' => 'array',
             ),
-            'attributes' =>
+            'attributes' => 
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'array',
             ),
-            'package_name' =>
+            'package_name' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -125,12 +125,12 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'index' => 'index',
             ),
-            'metadata' =>
+            'metadata' => 
             array (
                 'dbtype' => 'text',
                 'phptype' => 'array',
             ),
-            'version_major' =>
+            'version_major' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -139,7 +139,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'version_minor' =>
+            'version_minor' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -148,7 +148,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'version_patch' =>
+            'version_patch' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -157,7 +157,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'release' =>
+            'release' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '100',
@@ -166,7 +166,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => '',
                 'index' => 'index',
             ),
-            'release_index' =>
+            'release_index' => 
             array (
                 'dbtype' => 'smallint',
                 'attributes' => 'unsigned',
@@ -176,17 +176,17 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'index' => 'index',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'signature' =>
+                    'signature' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -194,15 +194,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'workspace' =>
+            'workspace' => 
             array (
                 'alias' => 'workspace',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'workspace' =>
+                    'workspace' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -210,15 +210,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'provider' =>
+            'provider' => 
             array (
                 'alias' => 'provider',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'provider' =>
+                    'provider' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -226,15 +226,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'disabled' =>
+            'disabled' => 
             array (
                 'alias' => 'disabled',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'disabled' =>
+                    'disabled' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -242,15 +242,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'package_name' =>
+            'package_name' => 
             array (
                 'alias' => 'package_name',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'package_name' =>
+                    'package_name' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -258,15 +258,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_major' =>
+            'version_major' => 
             array (
                 'alias' => 'version_major',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_major' =>
+                    'version_major' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -274,15 +274,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_minor' =>
+            'version_minor' => 
             array (
                 'alias' => 'version_minor',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_minor' =>
+                    'version_minor' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -290,15 +290,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_patch' =>
+            'version_patch' => 
             array (
                 'alias' => 'version_patch',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_patch' =>
+                    'version_patch' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -306,15 +306,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'release' =>
+            'release' => 
             array (
                 'alias' => 'release',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'release' =>
+                    'release' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -322,15 +322,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'release_index' =>
+            'release_index' => 
             array (
                 'alias' => 'release_index',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'release_index' =>
+                    'release_index' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -339,9 +339,9 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Workspace' =>
+            'Workspace' => 
             array (
                 'class' => 'MODX\\Revolution\\modWorkspace',
                 'local' => 'workspace',
@@ -349,7 +349,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Provider' =>
+            'Provider' => 
             array (
                 'class' => 'MODX\\Revolution\\Transport\\modTransportProvider',
                 'local' => 'provider',

--- a/core/src/Revolution/Transport/sqlsrv/modTransportPackage.php
+++ b/core/src/Revolution/Transport/sqlsrv/modTransportPackage.php
@@ -11,7 +11,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
         'version' => '3.0',
         'table' => 'transport_packages',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'fields' =>
+        'fields' => 
         array (
             'signature' => NULL,
             'created' => NULL,
@@ -32,9 +32,9 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
             'release' => '',
             'release_index' => 0,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'signature' =>
+            'signature' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '255',
@@ -42,23 +42,23 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'index' => 'pk',
             ),
-            'created' =>
+            'created' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
             ),
-            'updated' =>
+            'updated' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'timestamp',
             ),
-            'installed' =>
+            'installed' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
             ),
-            'state' =>
+            'state' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -66,7 +66,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'default' => 1,
             ),
-            'workspace' =>
+            'workspace' => 
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
@@ -74,7 +74,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'fk',
             ),
-            'provider' =>
+            'provider' => 
             array (
                 'dbtype' => 'int',
                 'phptype' => 'integer',
@@ -82,7 +82,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'fk',
             ),
-            'disabled' =>
+            'disabled' => 
             array (
                 'dbtype' => 'bit',
                 'phptype' => 'boolean',
@@ -90,25 +90,25 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'source' =>
+            'source' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '512',
                 'phptype' => 'string',
             ),
-            'manifest' =>
+            'manifest' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => 'max',
                 'phptype' => 'array',
             ),
-            'attributes' =>
+            'attributes' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => 'max',
                 'phptype' => 'array',
             ),
-            'package_name' =>
+            'package_name' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '255',
@@ -116,13 +116,13 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'null' => false,
                 'index' => 'index',
             ),
-            'metadata' =>
+            'metadata' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => 'max',
                 'phptype' => 'array',
             ),
-            'version_major' =>
+            'version_major' => 
             array (
                 'dbtype' => 'smallint',
                 'phptype' => 'integer',
@@ -130,7 +130,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'version_minor' =>
+            'version_minor' => 
             array (
                 'dbtype' => 'smallint',
                 'phptype' => 'integer',
@@ -138,7 +138,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'version_patch' =>
+            'version_patch' => 
             array (
                 'dbtype' => 'smallint',
                 'phptype' => 'integer',
@@ -146,7 +146,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => 0,
                 'index' => 'index',
             ),
-            'release' =>
+            'release' => 
             array (
                 'dbtype' => 'nvarchar',
                 'precision' => '100',
@@ -155,7 +155,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'default' => '',
                 'index' => 'index',
             ),
-            'release_index' =>
+            'release_index' => 
             array (
                 'dbtype' => 'smallint',
                 'phptype' => 'integer',
@@ -164,17 +164,17 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'index' => 'index',
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'signature' =>
+                    'signature' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -182,15 +182,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'workspace' =>
+            'workspace' => 
             array (
                 'alias' => 'workspace',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'workspace' =>
+                    'workspace' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -198,15 +198,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'provider' =>
+            'provider' => 
             array (
                 'alias' => 'provider',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'provider' =>
+                    'provider' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -214,15 +214,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'disabled' =>
+            'disabled' => 
             array (
                 'alias' => 'disabled',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'disabled' =>
+                    'disabled' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -230,15 +230,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'package_name' =>
+            'package_name' => 
             array (
                 'alias' => 'package_name',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'package_name' =>
+                    'package_name' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -246,15 +246,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_major' =>
+            'version_major' => 
             array (
                 'alias' => 'version_major',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_major' =>
+                    'version_major' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -262,15 +262,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_minor' =>
+            'version_minor' => 
             array (
                 'alias' => 'version_minor',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_minor' =>
+                    'version_minor' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -278,15 +278,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'version_patch' =>
+            'version_patch' => 
             array (
                 'alias' => 'version_patch',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'version_patch' =>
+                    'version_patch' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -294,15 +294,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'release' =>
+            'release' => 
             array (
                 'alias' => 'release',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'release' =>
+                    'release' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -310,15 +310,15 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                     ),
                 ),
             ),
-            'release_index' =>
+            'release_index' => 
             array (
                 'alias' => 'release_index',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'release_index' =>
+                    'release_index' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -327,9 +327,9 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Workspace' =>
+            'Workspace' => 
             array (
                 'class' => 'MODX\\Revolution\\modWorkspace',
                 'local' => 'workspace',
@@ -337,7 +337,7 @@ class modTransportPackage extends \MODX\Revolution\Transport\modTransportPackage
                 'cardinality' => 'one',
                 'owner' => 'foreign',
             ),
-            'Provider' =>
+            'Provider' => 
             array (
                 'class' => 'MODX\\Revolution\\Transport\\modTransportProvider',
                 'local' => 'provider',

--- a/core/src/Revolution/mysql/modAccessPolicy.php
+++ b/core/src/Revolution/mysql/modAccessPolicy.php
@@ -78,7 +78,7 @@ class modAccessPolicy extends \MODX\Revolution\modAccessPolicy
             'lexicon' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => 'permissions',

--- a/core/src/Revolution/mysql/modAccessPolicyTemplate.php
+++ b/core/src/Revolution/mysql/modAccessPolicyTemplate.php
@@ -51,7 +51,7 @@ class modAccessPolicyTemplate extends \MODX\Revolution\modAccessPolicyTemplate
             'lexicon' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => 'permissions',

--- a/core/src/Revolution/mysql/modActionDom.php
+++ b/core/src/Revolution/mysql/modActionDom.php
@@ -77,7 +77,7 @@ class modActionDom extends \MODX\Revolution\modActionDom
             'container' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -100,7 +100,7 @@ class modActionDom extends \MODX\Revolution\modActionDom
             'constraint' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modActionField.php
+++ b/core/src/Revolution/mysql/modActionField.php
@@ -39,7 +39,7 @@ class modActionField extends \MODX\Revolution\modActionField
             'name' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -65,7 +65,7 @@ class modActionField extends \MODX\Revolution\modActionField
             'form' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -73,7 +73,7 @@ class modActionField extends \MODX\Revolution\modActionField
             'other' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modActiveUser.php
+++ b/core/src/Revolution/mysql/modActiveUser.php
@@ -62,7 +62,7 @@ class modActiveUser extends \MODX\Revolution\modActiveUser
             'action' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modChunk.php
+++ b/core/src/Revolution/mysql/modChunk.php
@@ -42,7 +42,7 @@ class modChunk extends \MODX\Revolution\modChunk
             'description' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => 'Chunk',
@@ -106,7 +106,7 @@ class modChunk extends \MODX\Revolution\modChunk
             'static_file' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modContextSetting.php
+++ b/core/src/Revolution/mysql/modContextSetting.php
@@ -67,7 +67,7 @@ class modContextSetting extends \MODX\Revolution\modContextSetting
             'area' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modDashboardWidget.php
+++ b/core/src/Revolution/mysql/modDashboardWidget.php
@@ -83,7 +83,7 @@ class modDashboardWidget extends \MODX\Revolution\modDashboardWidget
             'size' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => 'half',
@@ -91,7 +91,7 @@ class modDashboardWidget extends \MODX\Revolution\modDashboardWidget
             'permission' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modDashboardWidgetPlacement.php
+++ b/core/src/Revolution/mysql/modDashboardWidgetPlacement.php
@@ -68,7 +68,7 @@ class modDashboardWidgetPlacement extends \MODX\Revolution\modDashboardWidgetPla
             'size' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => 'half',

--- a/core/src/Revolution/mysql/modExtensionPackage.php
+++ b/core/src/Revolution/mysql/modExtensionPackage.php
@@ -55,7 +55,7 @@ class modExtensionPackage extends \MODX\Revolution\modExtensionPackage
             'table_prefix' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -63,7 +63,7 @@ class modExtensionPackage extends \MODX\Revolution\modExtensionPackage
             'service_class' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -71,7 +71,7 @@ class modExtensionPackage extends \MODX\Revolution\modExtensionPackage
             'service_name' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modFormCustomizationSet.php
+++ b/core/src/Revolution/mysql/modFormCustomizationSet.php
@@ -74,7 +74,7 @@ class modFormCustomizationSet extends \MODX\Revolution\modFormCustomizationSet
             'constraint' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modManagerLog.php
+++ b/core/src/Revolution/mysql/modManagerLog.php
@@ -60,7 +60,7 @@ class modManagerLog extends \MODX\Revolution\modManagerLog
             'item' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '0',

--- a/core/src/Revolution/mysql/modMenu.php
+++ b/core/src/Revolution/mysql/modMenu.php
@@ -60,7 +60,7 @@ class modMenu extends \MODX\Revolution\modMenu
             'description' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -68,7 +68,7 @@ class modMenu extends \MODX\Revolution\modMenu
             'icon' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modPlugin.php
+++ b/core/src/Revolution/mysql/modPlugin.php
@@ -91,7 +91,7 @@ class modPlugin extends \MODX\Revolution\modPlugin
             'static_file' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modPropertySet.php
+++ b/core/src/Revolution/mysql/modPropertySet.php
@@ -45,7 +45,7 @@ class modPropertySet extends \MODX\Revolution\modPropertySet
             'description' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modResource.php
+++ b/core/src/Revolution/mysql/modResource.php
@@ -121,7 +121,7 @@ class modResource extends \MODX\Revolution\modResource
             'link_attributes' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -311,7 +311,7 @@ class modResource extends \MODX\Revolution\modResource
             'menutitle' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modScript.php
+++ b/core/src/Revolution/mysql/modScript.php
@@ -36,7 +36,7 @@ class modScript extends \MODX\Revolution\modScript
             'description' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modSnippet.php
+++ b/core/src/Revolution/mysql/modSnippet.php
@@ -78,7 +78,7 @@ class modSnippet extends \MODX\Revolution\modSnippet
             'static_file' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modSystemSetting.php
+++ b/core/src/Revolution/mysql/modSystemSetting.php
@@ -61,7 +61,7 @@ class modSystemSetting extends \MODX\Revolution\modSystemSetting
             'area' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modTemplate.php
+++ b/core/src/Revolution/mysql/modTemplate.php
@@ -41,7 +41,7 @@ class modTemplate extends \MODX\Revolution\modTemplate
             'description' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -66,7 +66,7 @@ class modTemplate extends \MODX\Revolution\modTemplate
             'icon' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -115,7 +115,7 @@ class modTemplate extends \MODX\Revolution\modTemplate
             'static_file' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modTemplateVar.php
+++ b/core/src/Revolution/mysql/modTemplateVar.php
@@ -64,7 +64,7 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
             'description' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -154,7 +154,7 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
             'static_file' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modUserGroupSetting.php
+++ b/core/src/Revolution/mysql/modUserGroupSetting.php
@@ -68,7 +68,7 @@ class modUserGroupSetting extends \MODX\Revolution\modUserGroupSetting
             'area' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modUserMessage.php
+++ b/core/src/Revolution/mysql/modUserMessage.php
@@ -39,7 +39,7 @@ class modUserMessage extends \MODX\Revolution\modUserMessage
             'subject' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modUserProfile.php
+++ b/core/src/Revolution/mysql/modUserProfile.php
@@ -177,7 +177,7 @@ class modUserProfile extends \MODX\Revolution\modUserProfile
             'country' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -185,7 +185,7 @@ class modUserProfile extends \MODX\Revolution\modUserProfile
             'city' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -217,7 +217,7 @@ class modUserProfile extends \MODX\Revolution\modUserProfile
             'photo' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
@@ -232,7 +232,7 @@ class modUserProfile extends \MODX\Revolution\modUserProfile
             'website' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modUserSetting.php
+++ b/core/src/Revolution/mysql/modUserSetting.php
@@ -70,7 +70,7 @@ class modUserSetting extends \MODX\Revolution\modUserSetting
             'area' => 
             array (
                 'dbtype' => 'varchar',
-                'precision' => '191',
+                'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',

--- a/core/src/Revolution/mysql/modWorkspace.php
+++ b/core/src/Revolution/mysql/modWorkspace.php
@@ -11,11 +11,11 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
         'version' => '3.0',
         'table' => 'workspaces',
         'extends' => 'xPDO\\Om\\xPDOSimpleObject',
-        'tableMeta' => 
+        'tableMeta' =>
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' => 
+        'fields' =>
         array (
             'name' => '',
             'path' => '',
@@ -23,9 +23,9 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
             'active' => 0,
             'attributes' => NULL,
         ),
-        'fieldMeta' => 
+        'fieldMeta' =>
         array (
-            'name' => 
+            'name' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -34,7 +34,7 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
                 'default' => '',
                 'index' => 'index',
             ),
-            'path' => 
+            'path' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -43,13 +43,13 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
                 'default' => '',
                 'index' => 'unique',
             ),
-            'created' => 
+            'created' =>
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'timestamp',
                 'null' => false,
             ),
-            'active' => 
+            'active' =>
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -59,23 +59,23 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
                 'default' => 0,
                 'index' => 'index',
             ),
-            'attributes' => 
+            'attributes' =>
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'array',
             ),
         ),
-        'indexes' => 
+        'indexes' =>
         array (
-            'name' => 
+            'name' =>
             array (
                 'alias' => 'name',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'name' => 
+                    'name' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -83,15 +83,15 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
                     ),
                 ),
             ),
-            'path' => 
+            'path' =>
             array (
                 'alias' => 'path',
                 'primary' => false,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'path' => 
+                    'path' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -99,15 +99,15 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
                     ),
                 ),
             ),
-            'active' => 
+            'active' =>
             array (
                 'alias' => 'active',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'active' => 
+                    'active' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -116,9 +116,9 @@ class modWorkspace extends \MODX\Revolution\modWorkspace
                 ),
             ),
         ),
-        'composites' => 
+        'composites' =>
         array (
-            'Packages' => 
+            'Packages' =>
             array (
                 'class' => 'MODX\\Revolution\\Transport\\modTransportPackage',
                 'local' => 'id',

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -63,7 +63,7 @@ MODx.panel.Chunk = function(config) {
                         ,name: 'name'
                         ,id: 'modx-chunk-name'
                         ,anchor: '100%'
-                        ,maxLength: 255
+                        ,maxLength: 50
                         ,enableKeyEvents: true
                         ,allowBlank: false
                         ,value: config.record.name

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -65,7 +65,7 @@ MODx.panel.Plugin = function(config) {
                         ,name: 'name'
                         ,id: 'modx-plugin-name'
                         ,anchor: '100%'
-                        ,maxLength: 255
+                        ,maxLength: 50
                         ,enableKeyEvents: true
                         ,allowBlank: false
                         ,value: config.record.name

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -64,7 +64,7 @@ MODx.panel.Snippet = function(config) {
                         ,name: 'name'
                         ,id: 'modx-snippet-name'
                         ,anchor: '100%'
-                        ,maxLength: 255
+                        ,maxLength: 50
                         ,enableKeyEvents: true
                         ,allowBlank: false
                         ,value: config.record.name

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -66,7 +66,7 @@ MODx.panel.Template = function(config) {
                         ,name: 'templatename'
                         ,id: 'modx-template-templatename'
                         ,anchor: '100%'
-                        ,maxLength: 100
+                        ,maxLength: 50
                         ,enableKeyEvents: true
                         ,allowBlank: false
                         ,value: config.record.templatename

--- a/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcprofile.js
@@ -41,7 +41,7 @@ MODx.panel.FCProfile = function(config) {
                     ,name: 'name'
                     ,id: 'modx-fcp-name'
                     ,anchor: '100%'
-                    ,maxLength: 255
+                    ,maxLength: 191
                     ,enableKeyEvents: true
                     ,allowBlank: false
                     ,value: config.record.name

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -616,7 +616,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     ,description: '<b>[[*pagetitle]]</b><br />'+_('resource_pagetitle_help')
                     ,name: 'pagetitle'
                     ,id: 'modx-resource-pagetitle'
-                    ,maxLength: 255
+                    ,maxLength: 191
                     ,anchor: '100%'
                     ,allowBlank: false
                     ,enableKeyEvents: true
@@ -668,7 +668,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                     ,description: '<b>[[*alias]]</b><br />'+_('resource_alias_help')
                     ,name: 'alias'
                     ,id: 'modx-resource-alias'
-                    ,maxLength: (aliasLength > 255 || aliasLength === 0) ? 255 : aliasLength
+                    ,maxLength: (aliasLength > 191 || aliasLength === 0) ? 191 : aliasLength
                     ,anchor: '100%'
                     ,value: config.record.alias || ''
                     ,listeners: {
@@ -688,7 +688,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,description: '<b>[[*longtitle]]</b><br />'+_('resource_longtitle_help')
             ,name: 'longtitle'
             ,id: 'modx-resource-longtitle'
-            ,maxLength: 255
+            ,maxLength: 191
             ,anchor: '100%'
             ,value: config.record.longtitle || ''
         },{

--- a/manager/assets/modext/widgets/system/modx.panel.context.js
+++ b/manager/assets/modext/widgets/system/modx.panel.context.js
@@ -41,7 +41,7 @@ MODx.panel.Context = function(config) {
                     ,fieldLabel: _('name')
                     ,name: 'name'
                     ,width: 300
-                    ,maxLength: 255
+                    ,maxLength: 191
                 },{
                     xtype: 'textarea'
                     ,fieldLabel: _('description')

--- a/setup/includes/upgrades/common/3.0.0-non-index-field-length.php
+++ b/setup/includes/upgrades/common/3.0.0-non-index-field-length.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Adjust column sizes
+ *
+ * MySQL ONLY
+ *
+ * @var modX $modx
+ *
+ * @package setup
+ */
+
+
+$manager = $modx->getManager();
+
+$manager->alterField(\MODX\Revolution\modAccessPolicy::class, 'lexicon');
+
+$manager->alterField(\MODX\Revolution\modAccessPolicyTemplate::class, 'lexicon');
+
+$manager->alterField(\MODX\Revolution\modActionDom::class, 'container');
+$manager->alterField(\MODX\Revolution\modActionDom::class, 'constraint');
+
+$manager->alterField(\MODX\Revolution\modActionField::class, 'name');
+$manager->alterField(\MODX\Revolution\modActionField::class, 'form');
+$manager->alterField(\MODX\Revolution\modActionField::class, 'other');
+
+$manager->alterField(\MODX\Revolution\modActiveUser::class, 'action');
+
+$manager->alterField(\MODX\Revolution\modChunk::class, 'description');
+$manager->alterField(\MODX\Revolution\modChunk::class, 'static_file');
+
+$manager->alterField(\MODX\Revolution\modContextSetting::class, 'area');
+
+$manager->alterField(\MODX\Revolution\modDashboardWidget::class, 'size');
+$manager->alterField(\MODX\Revolution\modDashboardWidget::class, 'permission');
+
+$manager->alterField(\MODX\Revolution\modDashboardWidgetPlacement::class, 'size');
+
+$manager->alterField(\MODX\Revolution\modFormCustomizationSet::class, 'constraint');
+
+$manager->alterField(\MODX\Revolution\modManagerLog::class, 'item');
+
+$manager->alterField(\MODX\Revolution\modMenu::class, 'description');
+$manager->alterField(\MODX\Revolution\modMenu::class, 'icon');
+
+$manager->alterField(\MODX\Revolution\modExtensionPackage::class, 'table_prefix');
+$manager->alterField(\MODX\Revolution\modExtensionPackage::class, 'service_class');
+$manager->alterField(\MODX\Revolution\modExtensionPackage::class, 'service_name');
+
+$manager->alterField(\MODX\Revolution\modPlugin::class, 'static_file');
+$manager->alterField(\MODX\Revolution\modPlugin::class, 'description');
+
+$manager->alterField(\MODX\Revolution\modPropertySet::class, 'description');
+
+$manager->alterField(\MODX\Revolution\modResource::class, 'link_attributes');
+$manager->alterField(\MODX\Revolution\modResource::class, 'menutitle');
+
+$manager->alterField(\MODX\Revolution\modSnippet::class, 'static_file');
+$manager->alterField(\MODX\Revolution\modSnippet::class, 'description');
+
+$manager->alterField(\MODX\Revolution\modSystemSetting::class, 'area');
+
+$manager->alterField(\MODX\Revolution\modTemplate::class, 'description');
+$manager->alterField(\MODX\Revolution\modTemplate::class, 'icon');
+$manager->alterField(\MODX\Revolution\modTemplate::class, 'static_file');
+
+$manager->alterField(\MODX\Revolution\modTemplateVar::class, 'description');
+$manager->alterField(\MODX\Revolution\modTemplateVar::class, 'static_file');
+
+$manager->alterField(\MODX\Revolution\modUserGroupSetting::class, 'area');
+
+$manager->alterField(\MODX\Revolution\modUserMessage::class, 'subject');
+
+$manager->alterField(\MODX\Revolution\modUserProfile::class, 'country');
+$manager->alterField(\MODX\Revolution\modUserProfile::class, 'city');
+$manager->alterField(\MODX\Revolution\modUserProfile::class, 'photo');
+$manager->alterField(\MODX\Revolution\modUserProfile::class, 'website');
+
+$manager->alterField(\MODX\Revolution\modUserSetting::class, 'area');

--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -30,3 +30,4 @@ include dirname(__DIR__) . '/common/3.0.0-update-sys-setting_welcome_screen_url.
 include dirname(__DIR__) . '/common/3.0.0-policy-template-group-description.php';
 include dirname(__DIR__) . '/common/3.0.0-policy-template-description.php';
 include dirname(__DIR__) . '/common/3.0.0-policy-description.php';
+include dirname(__DIR__) . '/common/3.0.0-non-index-field-length.php';


### PR DESCRIPTION
### What does it do?
Switch non-index fields back to 255 char limit (from 191). Adjust JS validations to the same limit as in schema.

### Why is it needed?
JS validations stayed at 255 chars + there's no reason to limit non-index fields to 191 chars.

### Related issue(s)/PR(s)
#15339 #15319
