### PR TITLE
Fix setup option upgrade existing install

### DIFF
--- a/setup/includes/modinstallsettings.class.php
+++ b/setup/includes/modinstallsettings.class.php
@@ -97,6 +97,9 @@ class modInstallSettings {
      */
     public function load() {
         if (file_exists($this->fileName)) {
+            if (function_exists('opcache_invalidate')) {
+                opcache_invalidate($this->fileName);
+            }
             $this->settings = include $this->fileName;
             if (empty($this->settings)) {
                 $this->restart();


### PR DESCRIPTION
### What does it do?
Invalidate opcache for settings.cache.php when loading it.

### Why is it needed?
Right now the setup uses php file to store cached settings and `include` function to load it. The setup writes to the file several times during the setup flow and `include`s it several times as well. When opcache is used with php, the file got cached on first include and later updates are ignored (the include uses the opcached version with stale data).

Because of the stale data, the summary step is not able to read `installmode` from the cache, because it's not there and proceeds with the default value - new install. This results in not beeing able to connect to db and finish the upgrade.

### How to test
Try to upgrade existing install :P
