### PR TITLE
Change modSessionHandler->gc() to return number of removed sessions

### DIFF
--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -162,9 +162,8 @@ class modSessionHandler
     public function gc($max)
     {
         $maxtime = time() - $this->gcMaxLifetime;
-        $result = $this->modx->removeCollection(modSession::class, ["{$this->modx->escape('access')} < {$maxtime}"]);
 
-        return $result !== false;
+        return $this->modx->removeCollection(modSession::class, ["{$this->modx->escape('access')} < {$maxtime}"]);
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Changes modSessionHandler->gc() to return the output of xPDO->removeCollection()

### Why is it needed?
Port of #15393 from 2.x

### How to test
See #15393 

### Related issue(s)/PR(s)
Port of #15393 from 2.x
