### PR TITLE
Fix fatal error: "Uncaught Error: Call to undefined function get_magic_quotes_gpc()" on PHP8

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -339,7 +339,7 @@ class modX extends xPDO {
                         $iteration++;
                     }
                 }
-                if (get_magic_quotes_gpc()) {
+                if (version_compare(PHP_VERSION, '7.4.0', '<') && get_magic_quotes_gpc()) {
                     $target[$key]= stripslashes($value);
                 } else {
                     $target[$key]= $value;
@@ -2463,7 +2463,7 @@ class modX extends xPDO {
         }
         if ($initialized) {
             $this->setLogLevel($this->getOption('log_level', $options, xPDO::LOG_LEVEL_ERROR));
-                
+
             $logTarget = $this->getOption('log_target', $options, 'FILE', true);
             if ($logTarget === 'FILE') {
                 $options = array();
@@ -2478,7 +2478,7 @@ class modX extends xPDO {
             } else {
                 $this->setLogTarget($logTarget);
             }
-            
+
             $debug = $this->getOption('debug');
             if (!is_null($debug) && $debug !== '') {
                 $this->setDebug($debug);


### PR DESCRIPTION
### What does it do?

Fixes an issue on PHP8 related to calling a method that no longer exists, and was deprecated in PHP 7.4.

### Why is it needed?

PHP 8 compatibility.

### How to test

Run on PHP 8, see it breaks without this patch.

### Related issue(s)/PR(s)

This change was originally included in #15335, but somehow didn't end up in the 2.x branch. Perhaps @opengeek wants to re-do that merge but at any rate without this fix PHP8 compatibility is impossible so I figured I'd dust off my ability to create PRs. 