### PR TITLE
[3.x] Fix fatal error: "Uncaught Error: Call to undefined function get_magic_quotes_gpc()" on PHP8

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -344,7 +344,7 @@ class modX extends xPDO {
                         $iteration++;
                     }
                 }
-                if (get_magic_quotes_gpc()) {
+                if (version_compare(PHP_VERSION, '7.4.0', '<') && get_magic_quotes_gpc()) {
                     $target[$key]= stripslashes($value);
                 } else {
                     $target[$key]= $value;


### PR DESCRIPTION
### What does it do?
Fixes an issue on PHP8 related to calling a method that no longer exists, and was deprecated in PHP 7.4.

### Why is it needed?
Port of #15401 from 2.x

### How to test
See #15401 

### Related issue(s)/PR(s)
Port of #15401 from 2.x