### PR TITLE
Changed the default gravatar type

### DIFF
--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -1041,7 +1041,7 @@ class modUser extends modPrincipal
      *
      * @return string The Gravatar photo URL
      */
-    public function getGravatar($size = 128, $default = 'mm')
+    public function getGravatar($size = 128, $default = 'retro')
     {
         $gravemail = md5(
             strtolower(


### PR DESCRIPTION
### What does it do?
Changed the default gravatar type.

If you don't have a gravatar, then by default a picture with the `mm` type was displayed:
![gravatar_0](https://user-images.githubusercontent.com/12523676/108742617-ee3cf700-7548-11eb-8947-da43318e15fe.png)

But other types of gravatar (for example, `retro`) allow you to generate unique images by email hash:
email 1
![gravatar_1](https://user-images.githubusercontent.com/12523676/108742622-eed58d80-7548-11eb-9b9f-ef7dba980369.png)

email 2
![gravatar_2](https://user-images.githubusercontent.com/12523676/108742624-eed58d80-7548-11eb-8209-cf5f53e005c3.png)

And you can immediately understand under which account you are in the manager panel, **provided that the gravatar is enabled in the system settings** (disabled by default).

### Why is it needed?
UI / UX improvements