### PR TITLE
[3.x] Fix plugin's event property sets

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
+++ b/manager/assets/modext/widgets/element/modx.grid.plugin.event.js
@@ -64,7 +64,7 @@ MODx.grid.PluginEvent = function(config) {
                     action: 'Element/PropertySet/GetList'
                     ,showAssociated: true
                     ,elementId: config.plugin
-                    ,elementType: 'modPlugin'
+                    ,elementType: 'MODX\\Revolution\\modPlugin'
                 }
             }
             ,sortable: true
@@ -260,7 +260,7 @@ MODx.grid.PluginEventAssoc = function(config) {
                     action: 'Element/PropertySet/GetList'
                     ,showAssociated: true
                     ,elementId: config.plugin
-                    ,elementType: 'modPlugin'
+                    ,elementType: 'MODX\\Revolution\\modPlugin'
                 }
             }
         },{


### PR DESCRIPTION
### What does it do?
Fixes select box for property sets on plugin's event

### Why is it needed?
You can only select Default porperty set right now, because the select box pases `modPlugin` as elementType, instead of `MODX\\Revolution\\modPlugin`

### How to test
- Attach any property set to a plugin
- Go to the plugin -> events tab
- Dbl click the propertyset on attached event - you should see `Default` + the one property set you attached to plugin in first step

