### PR TITLE
Strip base_url only from beginning of relative url

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
@@ -47,7 +47,8 @@ Ext.extend(MODx.panel.Static,MODx.panel.Resource,{
                 'select':{fn:function(data) {
                     var str = data.fullRelativeUrl;
                     if (MODx.config.base_url != '/') {
-                        str = str.replace(MODx.config.base_url,'');
+                        var regex = new RegExp('^' + MODx.config.base_url + '(.*)');
+                        str = str.replace(regex, '/$1');
                     }
                     if (str.substring(0,1) == '/') { str = str.substring(1); }
                     Ext.getCmp('modx-resource-content-static').setValue(str);


### PR DESCRIPTION
### What does it do?
Use a regular expression to replace MODx.config.base_url only at the beginning of the submitted relative url.

### Why is it needed?
MODx.config.base_url should only occur at the beginning of the beginning of the submitted relative url. Currently it is stripped everywhere in the string.

### How to test
Set the value of the base_url system setting to i.e. '/test/' and create/edit a static resource. Browse for the static resource file and edit the path at the bottom manually afterwards and insert the string '/test/' somewhere in that path. Before it will be replaced everywhere, afterwards it is only replaced at the start of the string.

### Related issue(s)/PR(s)
None known.
