### PR TITLE
PHP8 compatibility for 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
 
     steps:
       - name: Checkout
@@ -55,4 +55,4 @@ jobs:
         run: cd _build/test && ./generateConfigs.sh auto
 
       - name: Run PHPUnit
-        run: core/vendor/bin/phpunit -c ./_build/test/phpunit.xml
+        run: core/vendor/bin/phpunit  --enforce-time-limit -c ./_build/test/phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ composer.lock
 
 # ignore composer vendor dir
 /vendor
+
+# ignore phpunit cache files
+.phpunit.result.cache

--- a/_build/build.properties.sample.php
+++ b/_build/build.properties.sample.php
@@ -16,7 +16,7 @@ $properties['mysql_array_options']= [
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
 ];
-$properties['mysql_array_driverOptions']= [];
+$properties['mysql_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 
 /* sqlsrv */
 $properties['sqlsrv_string_dsn_test']= 'sqlsrv:server=(local);database=revo_test';
@@ -30,7 +30,7 @@ $properties['sqlsrv_array_options']= [
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
 ];
-$properties['sqlsrv_array_driverOptions']= [/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/];
+$properties['sqlsrv_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 
 /* PHPUnit test config */
 $properties['xpdo_driver']= 'mysql';

--- a/_build/test/MODxControllerTestCase.php
+++ b/_build/test/MODxControllerTestCase.php
@@ -33,8 +33,13 @@ abstract class MODxControllerTestCase extends MODxTestCase {
      */
     public $controllerName;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
 
         /* load smarty template engine */
         $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
@@ -60,8 +65,13 @@ abstract class MODxControllerTestCase extends MODxTestCase {
         $this->modx->controller = $this->controller;
     }
 
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->controller = null;
     }
 }

--- a/_build/test/MODxTestCase.php
+++ b/_build/test/MODxTestCase.php
@@ -12,15 +12,15 @@
 namespace MODX\Revolution;
 
 use MODX\Revolution\Processors\ProcessorResponse;
-use PHPUnit\Framework\TestCase;
 use xPDO\xPDOException;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
  * Extends the basic PHPUnit TestCase class to provide MODX specific methods
  *
  * @package modx-test
  */
-abstract class MODxTestCase extends TestCase {
+abstract class MODxTestCase extends XTestCase {
     /**
      * @var modX $modx
      */
@@ -33,9 +33,10 @@ abstract class MODxTestCase extends TestCase {
     /**
      * Ensure all tests have a reference to the MODX object
      *
+     * @before
      * @throws xPDOException
      */
-    public function setUp() {
+    public function setUpFixtures() {
         $this->modx = MODxTestHarness::getFixture(modX::class, 'modx');
         if ($this->modx->request) {
             $this->modx->request->loadErrorHandler();
@@ -49,8 +50,10 @@ abstract class MODxTestCase extends TestCase {
 
     /**
      * Remove reference at end of test case
+     *
+     * @after
      */
-    public function tearDown() {}
+    public function tearDownFixtures() {}
 
     /**
      * Check a MODX return result for a success flag

--- a/_build/test/Tests/Cases/Modx/ReplaceReservedTest.php
+++ b/_build/test/Tests/Cases/Modx/ReplaceReservedTest.php
@@ -2,10 +2,10 @@
 namespace MODX\Revolution\Tests\Cases\Modx;
 
 use MODX\Revolution\modX;
-use PHPUnit\Framework\TestCase;
 use stdClass;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
-class ReplaceReservedTest extends TestCase
+class ReplaceReservedTest extends XTestCase
 {
     public function testEmptyString()
     {

--- a/_build/test/Tests/Cases/Request/MakeUrlTest.php
+++ b/_build/test/Tests/Cases/Request/MakeUrlTest.php
@@ -24,8 +24,13 @@ use MODX\Revolution\MODxTestCase;
  * @group MakeUrl
  */
 class MakeUrlTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
 
         /** @var modResource $resource */
         $resource = $this->modx->newObject(modResource::class);
@@ -87,8 +92,13 @@ class MakeUrlTest extends MODxTestCase {
         //$this->modx->context->prepare(true);
         $this->modx->context->aliasMap = null;
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         /** @var modResource $resource */
         $resource = $this->modx->getObject(modResource::class, ['pagetitle' => 'Unit Test Resource']);
         if ($resource) $resource->remove();

--- a/_build/test/Tests/Controllers/Context/ContextUpdateControllerTest.php
+++ b/_build/test/Tests/Controllers/Context/ContextUpdateControllerTest.php
@@ -30,8 +30,13 @@ class ContextUpdateControllerTest extends MODxControllerTestCase {
     public $controllerName = 'ContextUpdateManagerController';
     public $controllerPath = 'context/update';
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->controller->setProperty('key','web');
     }
 

--- a/_build/test/Tests/Controllers/LoadControllerTest.php
+++ b/_build/test/Tests/Controllers/LoadControllerTest.php
@@ -17,9 +17,13 @@ class LoadControllerTest extends MODxTestCase
     /** @var modManagerResponse */
     protected $response;
 
-    public function setUp()
+    /**
+     * @before
+     * @throws \xPDO\xPDOException
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
 
         /* load smarty template engine */
         $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';

--- a/_build/test/Tests/Controllers/Resources/ResourceCreateControllerTest.php
+++ b/_build/test/Tests/Controllers/Resources/ResourceCreateControllerTest.php
@@ -13,10 +13,12 @@ class ResourceCreateControllerTest extends MODxControllerTestCase
     public $controllerName = 'ResourceCreateManagerController';
     public $controllerPath = 'resource/create';
 
-
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         $this->controller->setProperties([
             'id' => 0,
             'class_key' => modDocument::class,

--- a/_build/test/Tests/Controllers/Resources/StaticResource/StaticResourceCreateControllerTest.php
+++ b/_build/test/Tests/Controllers/Resources/StaticResource/StaticResourceCreateControllerTest.php
@@ -13,10 +13,12 @@ class StaticResourceCreateControllerTest extends ResourceCreateControllerTest
     public $controllerName = 'StaticResourceCreateManagerController';
     public $controllerPath = 'resource/staticresource/create';
 
-
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         $this->controller->setProperties([
             'id' => 0,
             'class_key' => modStaticResource::class,

--- a/_build/test/Tests/Controllers/Resources/SymLink/SymLinkCreateControllerTest.php
+++ b/_build/test/Tests/Controllers/Resources/SymLink/SymLinkCreateControllerTest.php
@@ -12,10 +12,12 @@ class SymLinkCreateControllerTest extends ResourceCreateControllerTest
     public $controllerName = 'SymLinkCreateManagerController';
     public $controllerPath = 'resource/symlink/create';
 
-
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         $this->controller->setProperties([
             'id' => 0,
             'class_key' => modSymlink::class,

--- a/_build/test/Tests/Controllers/Resources/WebLink/WebLinkCreateControllerTest.php
+++ b/_build/test/Tests/Controllers/Resources/WebLink/WebLinkCreateControllerTest.php
@@ -13,10 +13,12 @@ class WebLinkCreateControllerTest extends ResourceCreateControllerTest
     public $controllerName = 'WebLinkCreateManagerController';
     public $controllerPath = 'resource/weblink/create';
 
-
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
         $this->controller->setProperties([
             'id' => 0,
             'class_key' => modWeblink::class,

--- a/_build/test/Tests/Controllers/WelcomeControllerTest.php
+++ b/_build/test/Tests/Controllers/WelcomeControllerTest.php
@@ -33,8 +33,13 @@ class WelcomeControllerTest extends MODxControllerTestCase {
     public $controllerName = 'WelcomeManagerController';
     public $controllerPath = 'welcome';
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
 
         /** @var modDashboard $dashboard */
         $this->controller->dashboard = $this->modx->newObject(modDashboard::class);
@@ -79,8 +84,13 @@ class WelcomeControllerTest extends MODxControllerTestCase {
 
     }
 
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $userGroups = $this->modx->getCollection(modUserGroup::class, ['name:LIKE' => '%Unit Test%']);
         /** @var modUserGroup $userGroup */
         foreach ($userGroups as $userGroup) {
@@ -129,7 +139,7 @@ class WelcomeControllerTest extends MODxControllerTestCase {
         $this->modx->user->set('primary_group',10000);
         $dashboard = $this->controller->dashboard;
         $content = $dashboard->render($this->controller);
-        $this->assertContains('<h2>Unit Test Widget Output</h2>',$content);
+        $this->assertStringContainsString('<h2>Unit Test Widget Output</h2>',$content);
     }
 
     /**

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -30,11 +30,12 @@ class modDashboardTest extends MODxTestCase {
     /**
      * Load some utility classes this case uses
      *
+     * @before
      * @return void
      * @throws xPDOException
      */
-    public function setUp() {
-        parent::setUp();
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         require_once MODX_MANAGER_PATH.'controllers/default/welcome.class.php';
     }
 

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -50,6 +50,8 @@ class modDashboardTest extends MODxTestCase {
 
     /**
      * Ensure the rendering of the dashboard works properly
+     *
+     * @medium 
      */
     public function testRender() {
         /** @var modManagerController $controller Fake running the welcome controller */

--- a/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
@@ -34,11 +34,12 @@ class modDashboardWidgetTest extends MODxTestCase {
     /**
      * Load some utility classes this case uses
      *
+     * @before
      * @return void
      * @throws xPDOException
      */
-    public function setUp() {
-        parent::setUp();
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         require_once MODX_MANAGER_PATH.'controllers/default/welcome.class.php';
 
         $this->widget = $this->modx->newObject(modDashboardWidget::class);

--- a/_build/test/Tests/Model/Element/modChunkTest.php
+++ b/_build/test/Tests/Model/Element/modChunkTest.php
@@ -30,8 +30,13 @@ class modChunkTest extends MODxTestCase {
     /** @var modChunk $chunk */
     public $chunk;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->chunk = $this->modx->newObject(modChunk::class);
         $this->chunk->fromArray([
             'id' => 12345,
@@ -44,8 +49,13 @@ class modChunkTest extends MODxTestCase {
         $this->chunk->setProperties(['name' => 'John']);
         $this->chunk->setCacheable(false);
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->chunk = null;
     }
 

--- a/_build/test/Tests/Model/Element/modPluginTest.php
+++ b/_build/test/Tests/Model/Element/modPluginTest.php
@@ -30,8 +30,13 @@ class modPluginTest extends MODxTestCase {
     /** @var modPlugin $plugin */
     public $plugin;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->plugin = $this->modx->newObject(modPlugin::class);
         $this->plugin->fromArray([
             'id' => 12345,
@@ -45,8 +50,13 @@ class modPluginTest extends MODxTestCase {
         $this->plugin->setProperties(['name' => 'John']);
         $this->plugin->setCacheable(false);
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->plugin = null;
     }
 

--- a/_build/test/Tests/Model/Element/modSnippetTest.php
+++ b/_build/test/Tests/Model/Element/modSnippetTest.php
@@ -31,8 +31,13 @@ class modSnippetTest extends MODxTestCase {
     /** @var modSnippet $snippet */
     public $snippet;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->snippet = $this->modx->newObject(modSnippet::class);
         $this->snippet->fromArray([
             'name' => 'Unit Test Snippet',
@@ -46,8 +51,13 @@ class modSnippetTest extends MODxTestCase {
         $this->snippet->save();
         $this->modx->event= new modSystemEvent();
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->snippet->remove();
         $this->snippet = null;
     }

--- a/_build/test/Tests/Model/Element/modStaticElementTest.php
+++ b/_build/test/Tests/Model/Element/modStaticElementTest.php
@@ -28,7 +28,11 @@ use MODX\Revolution\Sources\modMediaSource;
  * @group modTag
  */
 class modStaticElementTest extends MODxTestCase {
-    public function setUp()
+    /**
+     * @before
+     * @throws \xPDO\xPDOException
+     */
+    public function setUpFixtures()
     {
         $this->modx = MODxTestHarness::getFixture(modX::class, 'modx');
     }

--- a/_build/test/Tests/Model/Element/modTagTest.php
+++ b/_build/test/Tests/Model/Element/modTagTest.php
@@ -25,7 +25,7 @@ use MODX\Revolution\MODxTestHarness;
  * @group modTag
  */
 class modTagTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    public static function setUpFixturesBeforeClass() {
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
     }
 

--- a/_build/test/Tests/Model/Element/modTemplateTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateTest.php
@@ -29,8 +29,13 @@ class modTemplateTest extends MODxTestCase {
     /** @var modTemplate $template */
     public $template;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->template = $this->modx->newObject(modTemplate::class);
         $this->template->fromArray([
             'id' => 12345,
@@ -43,8 +48,13 @@ class modTemplateTest extends MODxTestCase {
         $this->template->setProperties(['name' => 'John']);
         $this->template->setCacheable(false);
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->template = null;
     }
 

--- a/_build/test/Tests/Model/Element/modTemplateVarTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateVarTest.php
@@ -29,8 +29,13 @@ class modTemplateVarTest extends MODxTestCase {
     /** @var modTemplateVar $tv */
     public $tv;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->tv = $this->modx->newObject(modTemplateVar::class);
         $this->tv->fromArray([
             'id' => 12345,
@@ -44,8 +49,13 @@ class modTemplateVarTest extends MODxTestCase {
         $this->tv->setProperties(['name' => 'John']);
         $this->tv->setCacheable(false);
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->tv = null;
     }
 

--- a/_build/test/Tests/Model/Error/modErrorTest.php
+++ b/_build/test/Tests/Model/Error/modErrorTest.php
@@ -28,16 +28,23 @@ class modErrorTest extends MODxTestCase {
     /** @var modError $error */
     public $error;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->error = $this->modx->getService('error','error.modError');
     }
 
     /**
      * Ensure that the error class is reset on each load
+     *
+     * @after
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->modx->services['error'] = null;
         $this->modx->error = null;
     }

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -28,8 +28,13 @@ class modOutputFilterTest extends MODxTestCase {
     /** @var modPlaceholderTag $tag */
     public $tag;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->modx->getParser();
         $this->tag = new modPlaceholderTag($this->modx);
         $this->tag->setCacheable(false);

--- a/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
+++ b/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
@@ -25,8 +25,13 @@ use MODX\Revolution\MODxTestCase;
  * @group modActionDom
  */
 class modActionDomTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
     }
 
     /**

--- a/_build/test/Tests/Model/Lexicon/modLexiconTest.php
+++ b/_build/test/Tests/Model/Lexicon/modLexiconTest.php
@@ -28,12 +28,22 @@ class modLexiconTest extends MODxTestCase {
     /** @var modLexicon $lexicon */
     public $lexicon;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->lexicon = new modLexicon($this->modx);
     }
 
-    public function tearDown() {
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
         $this->lexicon->clear();
     }
 

--- a/_build/test/Tests/Model/Mail/modMailTest.php
+++ b/_build/test/Tests/Model/Mail/modMailTest.php
@@ -31,8 +31,13 @@ class modMailTest extends MODxTestCase {
      */
     public $mail;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->mail = $this->getMockForAbstractClass(modMail::class, [&$this->modx]);
         $this->mail->expects($this->any())
                    ->method('_getMailer')

--- a/_build/test/Tests/Model/Registry/modFileRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modFileRegisterTest.php
@@ -27,14 +27,22 @@ use MODX\Revolution\MODxTestHarness;
  * @group modFileRegister
  */
 class modFileRegisterTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    /**
+     * @beforeClass
+     * @throws \xPDO\xPDOException
+     */
+    public static function setUpFixturesBeforeClass() {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');
         $modx->registry->addRegister('register', 'registry.modFileRegister', ['directory' => 'register']);
     }
 
-    public static function tearDownAfterClass() {
+    /**
+     * @afterClass
+     * @throws \xPDO\xPDOException
+     */
+    public static function tearDownFixturesAfterClass() {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');

--- a/_build/test/Tests/Model/Registry/modRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modRegisterTest.php
@@ -26,14 +26,22 @@ use MODX\Revolution\MODxTestHarness;
  * @group modRegister
  */
 class modRegisterTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    /**
+     * @beforeClass
+     * @throws \xPDO\xPDOException
+     */
+    public static function setUpFixturesBeforeClass() {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');
         $modx->registry->addRegister('register', modMemoryRegister::class, ['directory' => 'register']);
     }
 
-    public static function tearDownAfterClass() {
+    /**
+     * @afterClass
+     * @throws \xPDO\xPDOException
+     */
+    public static function tearDownFixturesAfterClass() {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');

--- a/_build/test/Tests/Model/Registry/modRegistryTest.php
+++ b/_build/test/Tests/Model/Registry/modRegistryTest.php
@@ -29,8 +29,8 @@ use MODX\Revolution\Registry\modRegister;
  * @group modRegistry
  */
 class modRegistryTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
+    public static function setUpFixturesBeforeClass() {
+        parent::setUpFixturesBeforeClass();
         $modx =& MODxTestHarness::getFixture(modX::class, 'modx');
         $modx->getService('registry', 'registry.modRegistry');
     }

--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -31,8 +31,13 @@ class modRequestTest extends MODxTestCase {
     /** @var modRequest $request */
     public $request;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modNamespace $namespace */
         $namespace = $this->modx->newObject(modNamespace::class);
         $namespace->set('name','unit-test');
@@ -47,10 +52,11 @@ class modRequestTest extends MODxTestCase {
     }
 
     /**
+     * @after
      * @return void
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
 
         /** @var modNamespace $namespace */
         $namespace = $this->modx->getObject(modNamespace::class, ['name' => 'unit-test']);

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -27,9 +27,13 @@ use MODX\Revolution\MODxTestCase;
 class modUserTest extends MODxTestCase {
     /** @var modUser $user */
     public $user;
-
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup dummy data for each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->user = $this->modx->newObject(modUser::class);
         $this->user->fromArray([
             'id' => 123456,

--- a/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
@@ -30,8 +30,13 @@ class modFileMediaSourceTest extends MODxTestCase {
     /** @var modFileMediaSource $source */
     public $source;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
 
         $this->source = $this->modx->newObject(modFileMediaSource::class);
         $this->source->fromArray([
@@ -41,8 +46,13 @@ class modFileMediaSourceTest extends MODxTestCase {
             'properties' => [],
         ],'',true);
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->source = null;
     }
 

--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -29,8 +29,13 @@ class modMediaSourceTest extends MODxTestCase {
     /** @var modMediaSource $source */
     public $source;
 
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
 
         $this->source = $this->modx->newObject(modMediaSource::class);
         $this->source->fromArray([
@@ -40,8 +45,13 @@ class modMediaSourceTest extends MODxTestCase {
             'properties' => [],
         ],'',true);
     }
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->source = null;
     }
 

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -27,13 +27,21 @@ use MODX\Revolution\MODxTestHarness;
 class modParserTest extends MODxTestCase {
     public static $scope = [];
 
-    public static function setUpBeforeClass() {
+    /**
+     * @beforeClass
+     * @throws \xPDO\xPDOException
+     */
+    public static function setUpFixturesBeforeClass() {
         $modx = MODxTestHarness::getFixture(modX::class, 'modx', true);
         $placeholders = ['tag' => 'Tag', 'tag1' => 'Tag1', 'tag2' => 'Tag2'];
         self::$scope = $modx->toPlaceholders($placeholders, '', '.', true);
     }
 
-    public static function tearDownAfterClass() {
+    /**
+     * @afterClass
+     * @throws \xPDO\xPDOException
+     */
+    public static function tearDownFixturesAfterClass() {
         if (!empty(self::$scope)) {
             $modx = MODxTestHarness::getFixture(modX::class, 'modx');
             if (array_key_exists('keys', self::$scope)) {

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -27,9 +27,13 @@ use stdClass;
  */
 class modXTest extends MODxTestCase
 {
-    public function setUp()
+    /**
+     * @before
+     * @throws \xPDO\xPDOException
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
 
         /*
          * This map following the next pattern:
@@ -85,8 +89,13 @@ class modXTest extends MODxTestCase
 
 
 
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $this->modx->placeholders = [];
         $this->modx->resourceMap = [[1]];
         unset($this->modx->contexts['custom']);

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -30,21 +30,31 @@ use MODX\Revolution\Processors\Browser\Directory\Update;
  * @group BrowserProcessors
  */
 class BrowserDirectoryProcessorsTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    /**
+     * @beforeClass
+     */
+    public static function setUpFixturesBeforeClass() {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
     }
     /**
      * Cleanup data after this test case.
+     *
+     * @afterClass
      */
-    public static function tearDownAfterClass() {
+    public static function tearDownFixturesAfterClass() {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
     }
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
     }
 
     /**
@@ -172,13 +182,13 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
         if (empty($response)) {
             $this->fail('Could not load '.GetList::class.' processor');
         }
-        $dirs = json_decode($response->getResponse(), true);
 
         /* ensure correct test result */
         if ($shouldWork) {
+            $dirs = json_decode($response->getResponse(), true);
             $success = !empty($dirs);
         } else {
-            $success = empty($dirs);
+            $success = $response->isError();
         }
         $this->assertTrue($success,'Could not get list of files and dirs for '.$dir.' in '.GetList::class.' test');
     }

--- a/_build/test/Tests/Processors/Context/ContextSettingTest.php
+++ b/_build/test/Tests/Processors/Context/ContextSettingTest.php
@@ -31,8 +31,13 @@ use MODX\Revolution\Processors\Context\Setting\Create;
  * @group modContextSetting
  */
 class ContextSettingProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modContext $ctx */
         $ctx = $this->modx->newObject(modContext::class);
         $ctx->set('key','unittest');
@@ -40,8 +45,13 @@ class ContextSettingProcessorsTest extends MODxTestCase {
         $ctx->save();
     }
 
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         /** @var modContext $ctx */
         $ctx = $this->modx->getObject(modContext::class,'unittest');
         if ($ctx) $ctx->remove();

--- a/_build/test/Tests/Processors/Context/ContextTest.php
+++ b/_build/test/Tests/Processors/Context/ContextTest.php
@@ -33,8 +33,13 @@ use MODX\Revolution\Processors\Context\Update;
  * @group modContext
  */
 class ContextProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modContext $ctx */
         $ctx = $this->modx->newObject(modContext::class);
         $ctx->fromArray([
@@ -48,8 +53,13 @@ class ContextProcessorsTest extends MODxTestCase {
         $ctx->save();
     }
 
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $contexts = $this->modx->getCollection(modContext::class, [
             'key:LIKE' => '%unittest%'
         ]);

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -31,8 +31,13 @@ use MODX\Revolution\Processors\Element\Category\Remove;
  * @group CategoryProcessors
  */
 class CategoryProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modCategory $category */
         $category = $this->modx->newObject(modCategory::class);
         $category->fromArray(['category' => 'UnitTestCategory']);
@@ -45,9 +50,11 @@ class CategoryProcessorsTest extends MODxTestCase {
 
     /**
      * Cleanup data after this test.
+     *
+     * @after
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         /** @var modCategory $category */
         $categories = $this->modx->getCollection(modCategory::class, [
             'category:LIKE' => 'UnitTest%',

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -34,8 +34,13 @@ use MODX\Revolution\Processors\Element\Chunk\Update;
  * @group ChunkProcessors
  */
 class ChunkProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->modx->lexicon->load('chunk');
         /** @var modChunk $chunk */
         $chunk = $this->modx->newObject(modChunk::class);
@@ -51,9 +56,11 @@ class ChunkProcessorsTest extends MODxTestCase {
 
     /**
      * Cleanup data after each test.
+     *
+     * @after
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $chunks = $this->modx->getCollection(modChunk::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modChunk $chunk */
         foreach ($chunks as $chunk) {

--- a/_build/test/Tests/Processors/Element/PluginTest.php
+++ b/_build/test/Tests/Processors/Element/PluginTest.php
@@ -31,8 +31,13 @@ use MODX\Revolution\Processors\Element\Plugin\Remove;
  * @group PluginProcessors
  */
 class PluginProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modPlugin $plugin */
         $plugin = $this->modx->newObject(modPlugin::class);
         $plugin->fromArray([
@@ -41,8 +46,13 @@ class PluginProcessorsTest extends MODxTestCase {
         $plugin->save();
     }
 
-    public function tearDown() {
-        parent::tearDown();
+    /**
+     * Tear down fixtures after each test.
+     *
+     * @after
+     */
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $plugins = $this->modx->getCollection(modPlugin::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modPlugin $plugin */
         foreach ($plugins as $plugin) {

--- a/_build/test/Tests/Processors/Element/PropertySetTest.php
+++ b/_build/test/Tests/Processors/Element/PropertySetTest.php
@@ -32,8 +32,13 @@ use MODX\Revolution\Processors\Element\PropertySet\Remove;
  * @group PropertySetProcessors
  */
 class PropertySetProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modPropertySet $propertySet */
         $propertySet = $this->modx->newObject(modPropertySet::class);
         $propertySet->fromArray(['name' => 'UnitTestPropertySet']);
@@ -42,9 +47,11 @@ class PropertySetProcessorsTest extends MODxTestCase {
 
     /**
      * Cleanup data after this test.
+     *
+     * @after
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $propertySets = $this->modx->getCollection(modPropertySet::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modPropertySet $propertySet */
         foreach ($propertySets as $propertySet) {

--- a/_build/test/Tests/Processors/Element/SnippetTest.php
+++ b/_build/test/Tests/Processors/Element/SnippetTest.php
@@ -30,8 +30,13 @@ use MODX\Revolution\Processors\Element\Snippet\Remove;
  * @group SnippetProcessors
  */
 class SnippetProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modSnippet $snippet */
         $snippet = $this->modx->newObject(modSnippet::class);
         $snippet->fromArray(['name' => 'UnitTestSnippet']);
@@ -40,8 +45,10 @@ class SnippetProcessorsTest extends MODxTestCase {
 
     /**
      * Cleanup data after this test.
+     *
+     * @after
      */
-    public function tearDown() {
+    public function tearDownFixtures() {
         $snippets = $this->modx->getCollection(modSnippet::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modSnippet $snippet */
         foreach ($snippets as $snippet) {

--- a/_build/test/Tests/Processors/Element/TemplateTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateTest.php
@@ -31,8 +31,13 @@ use MODX\Revolution\Processors\Element\Template\Remove;
  * @group TemplateProcessors
  */
 class TemplateProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->modx->error->reset();
         /** @var modTemplate $template */
         $template = $this->modx->newObject(modTemplate::class);
@@ -43,9 +48,11 @@ class TemplateProcessorsTest extends MODxTestCase {
 
     /**
      * Cleanup data after this test.
+     *
+     * @after
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         $templates = $this->modx->getCollection(modTemplate::class, ['templatename:LIKE' => '%UnitTest%']);
         /** @var modTemplate $template */
         foreach ($templates as $template) {

--- a/_build/test/Tests/Processors/Element/TemplateVarTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateVarTest.php
@@ -30,8 +30,13 @@ use MODX\Revolution\Processors\Element\TemplateVar\Remove;
  * @group TemplateVarProcessors
  */
 class TemplateVarProcessorsTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         /** @var modTemplateVar $tv */
         $tv = $this->modx->newObject(modTemplateVar::class);
         $tv->fromArray(['name' => 'UnitTestTv']);
@@ -40,8 +45,10 @@ class TemplateVarProcessorsTest extends MODxTestCase {
 
     /**
      * Cleanup data after this test.
+     *
+     * @after
      */
-    public function tearDown() {
+    public function tearDownFixtures() {
         $tvs = $this->modx->getCollection(modTemplateVar::class, ['name:LIKE' => '%UnitTest%']);
         /** @var modTemplateVar $tv */
         foreach ($tvs as $tv) {

--- a/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
+++ b/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
@@ -29,8 +29,13 @@ use MODX\Revolution\Processors\Resource\Create;
  * @group modResource
  */
 class ResourceCreateProcessorTest extends MODxTestCase {
-    public function setUp() {
-        parent::setUp();
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures() {
+        parent::setUpFixtures();
         $this->modx->eventMap = [];
         if ($this->modx instanceof modX) {
             $resources = $this->modx->getCollection(modResource::class, [
@@ -45,9 +50,11 @@ class ResourceCreateProcessorTest extends MODxTestCase {
 
     /**
      * Cleanup data after this test.
+     *
+     * @after
      */
-    public function tearDown() {
-        parent::tearDown();
+    public function tearDownFixtures() {
+        parent::tearDownFixtures();
         if ($this->modx instanceof modX) {
             $resources = $this->modx->getCollection(modResource::class, [
                 'pagetitle:LIKE' => '%Unit Test Resource%'

--- a/_build/test/Tests/Transport/TransportCoreTest.php
+++ b/_build/test/Tests/Transport/TransportCoreTest.php
@@ -23,10 +23,13 @@ use MODX\Revolution\MODxTestCase;
  */
 class TransportCoreTest extends MODxTestCase
 {
-
-    public function setUp()
+    /**
+     * @before
+     * @throws \xPDO\xPDOException
+     */
+    public function setUpFixtures()
     {
-        parent::setUp();
+        parent::setUpFixtures();
 
         if (!defined('MODX_SOURCE_PATH')) {
             define('MODX_SOURCE_PATH', dirname(__DIR__) . '/../../../');
@@ -41,18 +44,24 @@ class TransportCoreTest extends MODxTestCase
         }
     }
 
-    public function tearDown()
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
     {
         @unlink(MODX_PACKAGES_PATH. "core.transport.zip");
     }
 
+    /**
+     * @large
+     */
     public function testBuildCoreTransportPackage()
     {
         $transportCoreFile = MODX_BUILD_DIR. 'transport.core.php';
         $transportCorePackFile = MODX_PACKAGES_PATH. 'core.transport.zip';
 
         $result = shell_exec("php $transportCoreFile");
-        $this->assertContains('Transport zip created. Build script finished.', $result);
+        $this->assertStringContainsString('Transport zip created. Build script finished.', $result);
 
         $this->assertFileExists($transportCorePackFile);
     }

--- a/_build/test/Tests/modXSetupTest.php
+++ b/_build/test/Tests/modXSetupTest.php
@@ -10,7 +10,7 @@
  */
 namespace MODX\Revolution\Tests;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
  * Tests related to verifying and setting up the test environment.
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
  * @package modx-test
  * @subpackage modx
  */
-class modXSetupTest extends TestCase {
+class modXSetupTest extends XTestCase {
     /**
      * Test that the PDO extension is available and loaded.
      */

--- a/_build/test/Tests/modXTeardownTest.php
+++ b/_build/test/Tests/modXTeardownTest.php
@@ -10,7 +10,7 @@
  */
 namespace MODX\Revolution\Tests;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
  * Tests related to cleaning up the test environment.
@@ -18,8 +18,8 @@ use PHPUnit\Framework\TestCase;
  * @package modx-test
  * @subpackage modx
  */
-class MODxTeardownTest extends TestCase {
-    public function testTearDown() {
+class modXTeardownTest extends XTestCase {
+    public function testtearDownFixtures() {
         $this->assertTrue(true);
     }
 }

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -4,16 +4,11 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
          bootstrap="MODxTestHarness.php"
          timeoutForSmallTests="5"
          timeoutForMediumTests="5"
-         timeoutForLargeTests="10"
-         reportUselessTests="true"
-         strictCoverage="true"
-         disallowTestOutput="true"
-         enforceTimeLimit="true">
+         timeoutForLargeTests="10">
     <php>
         <server name="REQUEST_URI" value="/"/>
     </php>

--- a/_build/test/properties.sample.inc.php
+++ b/_build/test/properties.sample.inc.php
@@ -34,7 +34,7 @@ $properties['mysql_array_options']= [
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
 ];
-$properties['mysql_array_driverOptions']= [];
+$properties['mysql_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 
 /* sqlsrv */
 $properties['sqlsrv_string_dsn_test']= 'sqlsrv:server=(local);database=revo_test';
@@ -47,7 +47,7 @@ $properties['sqlsrv_array_options']= [
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
 ];
-$properties['sqlsrv_array_driverOptions']= [/*PDO::SQLSRV_ATTR_DIRECT_QUERY => false*/];
+$properties['sqlsrv_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 
 /* PHPUnit test config */
 $properties['xpdo_driver']= 'mysql';

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,6 @@
             "@php _build/transport.core.php"
         ],
         "phpunit": "phpunit -c _build/test/phpunit.xml --coverage-text --colors",
-        "coverage": "phpunit -c _build/test/phpunit.xml --colors --coverage-html ./.coverage",
         "parse-schema-mysql": [
           "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.mysql.schema.xml core/src/",
           "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.registry.db.mysql.schema.xml core/src/",
@@ -109,13 +108,11 @@
         ]
     },
     "scripts-descriptions": {
-        "phpunit": "Run PHPUnit test",
-        "coverage": "Generating the code coverage report in HTML format"
+        "phpunit": "Run PHPUnit test"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^6",
-        "php-coveralls/php-coveralls": "~2.1"
+        "yoast/phpunit-polyfills": "^0.2.0"
     }
 }

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -908,7 +908,8 @@ class modTemplateVar extends modElement
                     $dbtags['DBASE'] = $this->xpdo->getOption('dbname');
                     $dbtags['PREFIX'] = $this->xpdo->getOption('table_prefix');
                     foreach ($dbtags as $key => $pValue) {
-                        $param = str_replace('[[+' . $key . ']]', $pValue, $param);
+                        if (!is_scalar($pValue)) continue;
+                        $param = str_replace('[[+'.$key.']]', (string)$pValue, $param);
                     }
                     $stmt = $this->xpdo->query('SELECT ' . $param);
                     if ($stmt && $stmt instanceof PDOStatement) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -451,7 +451,7 @@ class modX extends xPDO {
                 null,
                 null,
                 $options,
-                null
+                array(PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT)
             );
             $this->setLogLevel($this->getOption('log_level', null, xPDO::LOG_LEVEL_ERROR));
             $this->setLogTarget($this->getOption('log_target', null, 'FILE'));
@@ -475,12 +475,12 @@ class modX extends xPDO {
      *
      * @param string $configPath    An absolute path location to search for the modX config file.
      * @param array  $data          Data provided to initialize the instance with, overriding config file entries.
-     * @param null   $driverOptions Driver options for the primary connection.
+     * @param array   $driverOptions Driver options for the primary connection.
      *
      * @return Container A DI container containing the config data ready for use by the modX::__construct() method.
      * @throws xPDOException
      */
-    protected function loadConfig($configPath = '', $data = [], $driverOptions = null) {
+    protected function loadConfig($configPath = '', $data = [], $driverOptions = array()) {
         if (!is_array($data)) $data = [];
         modX :: protect();
         if (!defined('MODX_CONFIG_KEY')) {
@@ -495,6 +495,8 @@ class modX extends xPDO {
             if (MODX_CONFIG_KEY !== 'config') $cachePath .= MODX_CONFIG_KEY . '/';
             if (!is_array($config_options)) $config_options = [];
             if (!is_array($driver_options)) $driver_options = [];
+            if (!is_array($driverOptions)) $driverOptions = [];
+            $driver_options = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT) + $driverOptions + $driver_options;
             $data = array_merge(
                 [
                     xPDO::OPT_CACHE_KEY => 'default',

--- a/setup/includes/new.install.php
+++ b/setup/includes/new.install.php
@@ -283,18 +283,9 @@ if ('sdk' === trim($currentVersion['distro'], '@')) {
     $setting->save();
 }
 
-$maxFileSize = ini_get('upload_max_filesize');
-$maxFileSize = trim($maxFileSize);
-$last = strtolower($maxFileSize[strlen($maxFileSize)-1]);
-switch ($last) {
-    // The 'G' modifier is available since PHP 5.1.0
-    case 'g':
-        $maxFileSize *= 1024;
-    case 'm':
-        $maxFileSize *= 1024;
-    case 'k':
-        $maxFileSize *= 1024;
-}
+$maxFileSize = trim(ini_get('upload_max_filesize'));
+$modifier = strtolower(substr($maxFileSize, -1));
+$maxFileSizeInBytes = (int) $maxFileSize * pow(1024, strpos('kmg', $modifier) + 1);
 
 $settings_maxFileSize = $modx->getObject(modSystemSetting::class, ['key' => 'upload_maxsize']);
 if (!$settings_maxFileSize) {
@@ -310,7 +301,7 @@ if (!$settings_maxFileSize) {
         true
     );
 }
-$settings_maxFileSize->set('value', $maxFileSize);
+$settings_maxFileSize->set('value', $maxFileSizeInBytes);
 $settings_maxFileSize->save();
 
 return true;


### PR DESCRIPTION
### What does it do?

Assorted PHP8 compatibility fixes, ported from #15335 and c032c2652fbbc9ea75ed947187b5434c2238a98c

### Why is it needed?

To support the <3 PHP8

### How to test

Run on a PHP8 server. 

### Related issue(s)/PR(s)

#15335 
