### PR TITLE
Adjust getParents method to work with deleted resources

### DIFF
--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,7 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+- Fix resource breadcrumbs if the resource is deleted [#15243]
 - Only log session info if session is initialized [#15308]
 - Improve removal of nested MODX tag content in sanitizeRequest [#15370]
 - Improve Navigation for Access Control Lists > User Groups & Users [#15159]

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -597,24 +597,31 @@ abstract class ResourceManagerController extends modManagerController
         }
 
         $id = $this->resource->get('id');
+        $entryPoint = $this->resource;
         if (!$id) {
-            if ($this->parent) {
-                $id = $this->parent->get('id');
-                if ($id) {
-                    $ctx = $this->parent->get('context_key');
-                    $parents[] = $this->parent->get($columns);
-                    $height--;
-                }
+            $id = $this->parent->get('id');
+            $entryPoint = $this->parent;
+            if ($this->parent && $id) {
+                $ctx = $this->parent->get('context_key');
+                $parents[] = $this->parent->get($columns);
+                $height--;
             }
         } else {
             $ctx = $this->resource->get('context_key');
         }
 
-        if ($id) {
-            $pids = $this->modx->getParentIds($id, $height, ['context' => $ctx]);
-            foreach ($pids as $pid) {
-                if ($parent = $this->modx->getObject(modResource::class, $pid)) {
+        if ($entryPoint) {
+            $parent = $entryPoint->getOne('Parent');
+            if ($parent) {
+                $parents[] = $parent->get($columns);
+                $height--;
+            }
+
+            while($parent && ($height > 0)) {
+                $parent = $parent->getOne('Parent');
+                if ($parent) {
                     $parents[] = $parent->get($columns);
+                    $height--;
                 }
             }
         }


### PR DESCRIPTION
### What does it do?
I moved away from using resource map in the getParents method for getting the ID of all parents. The resource map doesn't contain deleted resources, so the parent ids were always empty for deleted resource. It also seemed unnecessary as for every ID the modResource object had to be fetched from DB. The new code is traversing the `Parent` relation until there's no parent or we hit the limit set by `resource_panel_max_crumbs` system setting.

### Why is it needed?
Breadcrumbs in edit resource panel don't show the parent path if the current resource is deleted.

### Related issue(s)/PR(s)
Resolves #15243
Supercedes #15258 