### PR TITLE
Fixed a notice about undefined index icon in the site manager (#15433).

### DIFF
--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -330,6 +330,7 @@ class TopMenu
             if (!empty($menu['handler'])) {
                 $attributes .= ' onclick="{literal} '.str_replace('"','\'',$menu['handler']).'{/literal} "';
             }
+            $menu['icon'] = $menu['icon'] ?? '';
             $smTpl .= '<a'.$attributes.'>'.$menu['text'].$menu['icon'].$description.'</a>'."\n";
 
             if (!empty($menu['children'])) {


### PR DESCRIPTION
### What does it do?
Fixes warnings about the undefined index icon.

### Why is it needed?
Fixes warnings about the undefined index icon.

### How to test
Set the system setting "log_level" to 3 and open the error log.

### Related issue(s)/PR(s)
#15433
