### PR TITLE
Fixing an error when installing using composer

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1748,7 +1748,7 @@ $settings['upload_files']->fromArray([
   'area' => 'file',
   'editedon' => null,
 ], '', true, true);
-$settings['upload_file_exists']= $xpdo->newObject('modSystemSetting');
+$settings['upload_file_exists']= $xpdo->newObject(modSystemSetting::class);
 $settings['upload_file_exists']->fromArray([
   'key' => 'upload_file_exists',
   'value' => true,


### PR DESCRIPTION
### What does it do?
Fix PHP Fatal error: Uncaught Error: Call to a member function fromArray()

### Why is it needed?
Restores the operation of the installation using a composer

### How to test

Try to install modx 3 using:

``` bash
composer create-project modx/revolution . 3.x-dev
```

### Related issue(s)/PR(s)
#15432