### PR TITLE
Fix user block checks on login.

### DIFF
--- a/core/src/Revolution/Processors/Security/Login.php
+++ b/core/src/Revolution/Processors/Security/Login.php
@@ -187,7 +187,9 @@ class Login extends Processor
                 $profile->save();
             }
 
-            return $this->modx->lexicon('login_blocked_admin');
+            if ($profile->get('blocked')) {
+                return $this->modx->lexicon('login_blocked_admin');
+            }
         }
 
         if ($profile->get('blockedafter') > 0 && $profile->get('blockedafter') < time()) {

--- a/core/src/Revolution/Processors/Security/Login.php
+++ b/core/src/Revolution/Processors/Security/Login.php
@@ -178,16 +178,15 @@ class Login extends Processor
             return $this->modx->lexicon('login_blocked_too_many_attempts');
         }
 
-        if ($profile->get('blockeduntil') != 0 && $profile->get('blockeduntil') < time()) {
-            $profile->set('failedlogincount', 0);
-            $profile->set('blocked', 0);
-            $profile->save();
-        }
-
         if ($profile->get('blocked')) {
             if ($profile->get('blockeduntil') > time()) {
                 return $this->modx->lexicon('login_blocked_error');
+            } elseif ($profile->get('blockeduntil') != 0) {
+                $profile->set('failedlogincount', 0);
+                $profile->set('blocked', 0);
+                $profile->save();
             }
+
             return $this->modx->lexicon('login_blocked_admin');
         }
 

--- a/core/src/Revolution/Processors/Security/Login.php
+++ b/core/src/Revolution/Processors/Security/Login.php
@@ -170,29 +170,31 @@ class Login extends Processor
         /** @var modUserProfile $profile */
         $profile = $this->user->Profile;
 
-        if ($profile->get('failed_logins') >= $this->modx->getOption('failed_login_attempts') && $profile->get('blockeduntil') > time()) {
-            return $this->modx->lexicon('login_blocked_too_many_attempts');
-        }
-
         if ($profile->get('failedlogincount') >= $this->modx->getOption('failed_login_attempts')) {
             $profile->set('failedlogincount', 0);
             $profile->set('blocked', 1);
             $profile->set('blockeduntil', time() + (60 * $this->modx->getOption('blocked_minutes')));
             $profile->save();
+            return $this->modx->lexicon('login_blocked_too_many_attempts');
         }
+
         if ($profile->get('blockeduntil') != 0 && $profile->get('blockeduntil') < time()) {
             $profile->set('failedlogincount', 0);
             $profile->set('blocked', 0);
-            $profile->set('blockeduntil', 0);
             $profile->save();
         }
+
         if ($profile->get('blocked')) {
+            if ($profile->get('blockeduntil') > time()) {
+                return $this->modx->lexicon('login_blocked_error');
+            }
             return $this->modx->lexicon('login_blocked_admin');
         }
-        if ($profile->get('blockeduntil') > time()) {
-            return $this->modx->lexicon('login_blocked_error');
-        }
+
         if ($profile->get('blockedafter') > 0 && $profile->get('blockedafter') < time()) {
+            $profile->set('failedlogincount', 0);
+            $profile->set('blocked', 1);
+            $profile->save();
             return $this->modx->lexicon('login_blocked_error');
         }
 

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -277,6 +277,20 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             ,cls: 'danger'
             ,xtype: 'xcheckbox'
             ,inputValue: 1
+            ,listeners: {
+                'check': {
+                    fn: function (e, checked) {
+                        let blockeduntil = Ext.getCmp('modx-user-blockeduntil');
+                        if (checked) {
+                            blockeduntil.enable();
+                        } else {
+                            blockeduntil.disable();
+                            Ext.getCmp('modx-user-blockedafter').setValue(null);
+                        }
+                    }
+                    ,scope: this
+                }
+            }
         }];
         if (MODx.perm.set_sudo) {
             itemsRight.push({
@@ -305,6 +319,18 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             ,dateFormat: MODx.config.manager_date_format
             ,timeFormat: MODx.config.manager_time_format
             ,hiddenFormat: 'Y-m-d H:i:s'
+            ,listeners: {
+                'beforerender': {
+                    fn: function (e) {
+                        let blocked = Ext.getCmp('modx-user-blocked');
+                        if (blocked.checked) {
+                            e.enable();
+                        } else {
+                            e.disable();
+                        }
+                    }
+                }
+            }
         },{
             id: 'modx-user-blockedafter'
             ,name: 'blockedafter'


### PR DESCRIPTION
### What does it do?
Fixed logic errors and incorrect field name of the "user_attributes" table. 
The logic is next - the "blocked" checkbox is an indicator of the user's current state. It can be switched  manually or automatically if the user is blocked after time ("Blocked After") or the block time ("Blocked Unfil") is expired.
If the user is blocked because of the "Blocked After" time, then switching off the "blocked" checkbox will clear the "Blocked After" field.
The "Blocked Until" check will work if the "blocked" checkbox is On.

![blockuser](https://user-images.githubusercontent.com/4679725/110076403-7b781b00-7d95-11eb-91d1-5d669e3f3395.gif)


### Why is it needed?
Some user block state checks do not work correctly. Now you will see a message about too many attempts to login.

### How to test
1. Create a test user.
2. Play around with the block options. 
3. Open manager login page in the incognito browser mode. 
4. Then try to login.

### Related issue(s)/PR(s)
[External issue](https://github.com/Sterc/revolution/issues/27).
