### PR TITLE
Fixed incorrect hour checks for the greeting message.

### DIFF
--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -66,13 +66,13 @@ class SecurityLoginManagerController extends modManagerController
         $this->setPlaceholder('onManagerLoginFormPrerender', $eventInfo);
 
         $hour = date('H') + (int)$this->modx->getOption('server_offset');
-        if ($hour > 18) {
+        if ($hour >= 18) {
             $greeting = $this->modx->lexicon('login_greeting_evening');
         }
-        elseif ($hour > 12) {
+        elseif ($hour >= 12) {
             $greeting = $this->modx->lexicon('login_greeting_afternoon');
         }
-        elseif ($hour > 6) {
+        elseif ($hour >= 6) {
             $greeting = $this->modx->lexicon('login_greeting_morning');
         }
         else {


### PR DESCRIPTION
### What does it do?
Fixed incorrect hour checks for the greeting message.

### Why is it needed?
For example, if time is 6:50am I got a greeting message "Good night". 

### How to test
Open the login page to the admin panel.
