### PR TITLE
Switched class condition to MODX\Revolution\modPlugin

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -17,7 +17,7 @@ MODx.panel.Plugin = function(config) {
         }
         ,id: 'modx-panel-plugin'
 		,cls: 'container form-with-labels'
-        ,class_key: 'modPlugin'
+        ,class_key: 'MODX\\Revolution\\modPlugin'
         ,plugin: ''
         ,bodyStyle: ''
         ,allowDrop: false

--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -395,7 +395,7 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
                     this.quickUpdate(itm,e,itm.type);
                 }
             });
-            if (a.classKey == 'modPlugin') {
+            if (a.classKey === 'MODX\\Revolution\\modPlugin') {
                 if (a.active) {
                     m.push({
                         text: _('plugin_deactivate')


### PR DESCRIPTION
### What does it do?
Fixes "Activate Plugin" and "Deactivate Plugin" not appearing in the element tree context menu

### Why is it needed?
Because this functionality is broken in 3.x

### How to test
Right click on a plugin in the tree

### Related issue(s)/PR(s)
issue #15446
