### PR TITLE
Disable actionsColumn for Dashboards grid in Widget section

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -335,6 +335,7 @@ MODx.grid.DashboardWidgetDashboards = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-grid-dashboard-widget-dashboards'
+        ,showActionsColumn: false
         ,url: MODx.config.connector_url
         ,action: 'System/Dashboard/GetList'
         ,fields: ['id','name','description']


### PR DESCRIPTION
### What does it do?
Disable actionsColumn for Dashboards grid in Widget section. 

![w_d](https://user-images.githubusercontent.com/12523676/110091670-c2700b80-7da9-11eb-8eb5-9f651e9b5c4b.png)

### Why is it needed?
In this section, this menu is unnecessary and does not work.

### Related issue(s)/PR(s)
Similarly with https://github.com/modxcms/revolution/pull/14938