### PR TITLE
Add snippet type binding for Template Variables

### DIFF
--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -52,6 +52,7 @@ class modTemplateVar extends modElement
     public $bindings = [
         'FILE',
         'CHUNK',
+        'SNIPPET',
         'DOCUMENT',
         'RESOURCE',
         'SELECT',
@@ -880,6 +881,12 @@ class modTemplateVar extends modElement
             case 'CHUNK': /* retrieve a chunk and process it's content */
                 if ($preProcess) {
                     $output = $this->xpdo->getChunk($param);
+                }
+                break;
+
+            case 'SNIPPET':
+                if ($preProcess) {
+                    $output = $this->xpdo->runSnippet($param);
                 }
                 break;
 


### PR DESCRIPTION
### What does it do?
Adds a new binding type (@SNIPPET) to Template Variables. 

### Why is it needed?
To make it possible to generate a dynamic list of input values. 
See #14074 for more info.

### How to test
Create a new snippet that returns a valid Input Options string for TV's:
``` 
<?php
$options = [
    'Option 1',
    'Option 2',
];

return implode('||', $options);
```

Create a new select TV with Input Type "Listbox" (single or multi).
In Input Option Values you can now use the `@SNIPPET` binding:
```
@SNIPPET snippetname
```

### Related issue(s)/PR(s)
Closes #14074 
