### PR TITLE
Fixed PHP notices on the login page.

### DIFF
--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -44,9 +44,9 @@
 
                         <p class="lead">{$_lang.login_note_passwordless}</p>
 
-                        {if $error_message}
+                        {if $error_message|default}
                             <p class="is-error">{$error_message|default}</p>
-                        {elseif $success_message}
+                        {elseif $success_message|default}
                             <p class="is-success">{$success_message|default}</p>
                         {/if}
 
@@ -66,7 +66,7 @@
 
                 {else}
 
-                    {if !$_post.modhash}
+                    {if !$_post.modhash|default}
                         <form id="modx-login-form" class="c-form can-toggle {if $_post.username_reset|default}is-hidden{/if}" action="" method="post">
                             <input type="hidden" name="login_context" value="mgr">
                             <input type="hidden" name="modhash" value="{$modhash|default}">
@@ -74,9 +74,9 @@
 
                             <p class="lead">{$_lang.login_note}</p>
 
-                            {if $error_message}
+                            {if $error_message|default}
                                 <p class="is-error">{$error_message|default}</p>
-                            {elseif $success_message}
+                            {elseif $success_message|default}
                                 <p class="is-success">{$success_message|default}</p>
                             {/if}
 
@@ -146,9 +146,9 @@
                             <input type="hidden" name="modhash" value="{$_post.modhash|default}">
                             <p class="lead">{$_lang.login_new_password_note}</p>
 
-                            {if $error_message}
+                            {if $error_message|default}
                                 <p class="is-error">{$error_message|default}</p>
-                            {elseif $success_message}
+                            {elseif $success_message|default}
                                 <p class="is-success">{$success_message|default}</p>
                             {/if}
 
@@ -179,7 +179,7 @@
             <footer class="l-footer">
                 <div class="c-languageselect">
                     <select name="manager_language" id="modx-login-language-select" class="c-languageselect__select" aria-label="{$_config.cultureKey}">
-                        {foreach from=$languages key=language item=native}
+                        {foreach $languages as $language => $native}
                             <option lang="{$language}" value="{$language}"{if $language == $_config.cultureKey} selected{/if}>{$native|capitalize}</option>
                         {/foreach}
                     </select>


### PR DESCRIPTION
### What does it do?
Fixed PHP notices about undefined variables when open the manager login page.

### Why is it needed?
There are many warnings in the MODX error log.
```
[2021-03-05 13:00:42] (WARN @ D:\Projects\modx3.local\core\cache\mgr\smarty\default\c30b70275ddb4c76e2d98b034dff308016d73525_0.file.login.tpl.php : 112) PHP notice: Undefined index: _post
[2021-03-05 13:00:42] (WARN @ D:\Projects\modx3.local\core\cache\mgr\smarty\default\c30b70275ddb4c76e2d98b034dff308016d73525_0.file.login.tpl.php : 112) PHP notice: Trying to get property 'value' of non-object
[2021-03-05 13:00:42] (WARN @ D:\Projects\modx3.local\core\cache\mgr\smarty\default\c30b70275ddb4c76e2d98b034dff308016d73525_0.file.login.tpl.php : 112) PHP notice: Trying to access array offset on value of type null
[2021-03-05 13:00:42] (WARN @ D:\Projects\modx3.local\core\cache\mgr\smarty\default\c30b70275ddb4c76e2d98b034dff308016d73525_0.file.login.tpl.php : 123) PHP notice: Undefined index: error_message
[2021-03-05 13:00:42] (WARN @ D:\Projects\modx3.local\core\cache\mgr\smarty\default\c30b70275ddb4c76e2d98b034dff308016d73525_0.file.login.tpl.php : 123) PHP notice: Trying to get property 'value' of non-object
[2021-03-05 13:00:42] (WARN @ D:\Projects\modx3.local\core\cache\mgr\smarty\default\c30b70275ddb4c76e2d98b034dff308016d73525_0.file.login.tpl.php : 126) PHP notice: Undefined index: success_message
[2021-03-05 13:00:42] (WARN @ D:\Projects\modx3.local\core\cache\mgr\smarty\default\c30b70275ddb4c76e2d98b034dff308016d73525_0.file.login.tpl.php : 126) PHP notice: Trying to get property 'value' of non-object
```

### How to test
1. Set log level to 3.
2. Open the manager login page.
