### PR TITLE
Add transliteration of files when uploading to a media source #modxbughunt

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1784,6 +1784,15 @@ $settings['upload_media']->fromArray([
   'area' => 'file',
   'editedon' => null,
 ], '', true, true);
+$settings['upload_translit']= $xpdo->newObject(modSystemSetting::class);
+$settings['upload_translit']->fromArray([
+  'key' => 'upload_translit',
+  'value' => true,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'file',
+  'editedon' => null,
+], '', true, true);
 $settings['use_alias_path']= $xpdo->newObject(modSystemSetting::class);
 $settings['use_alias_path']->fromArray([
   'key' => 'use_alias_path',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -736,7 +736,7 @@ $_lang['setting_upload_media'] = 'Uploadable Media Types';
 $_lang['setting_upload_media_desc'] = 'Here you can enter a list of files that can be uploaded into \'assets/media/\' using the Resource Manager. Please enter the extensions for the media types, separated by commas.';
 
 $_lang['setting_upload_translit'] = 'Transliterate names of uploading files?';
-$_lang['setting_upload_translit_desc'] = 'If <b>yes</b> name of any uploading file will be transliterated by global translitiration rules.';
+$_lang['setting_upload_translit_desc'] = 'If \'Yes\' name of any uploading file will be transliterated by global translitiration rules.';
 
 $_lang['setting_use_alias_path'] = 'Use Friendly Alias Path';
 $_lang['setting_use_alias_path_desc'] = 'Setting this option to \'yes\' will display the full path to the Resource if the Resource has an alias. For example, if a Resource with an alias called \'child\' is located inside a container Resource with an alias called \'parent\', then the full alias path to the Resource will be displayed as \'/parent/child.html\'.<br /><strong>NOTE: When setting this option to \'Yes\' (turning on alias paths), reference items (such as images, CSS, JavaScripts, etc.) use the absolute path, e.g., \'/assets/images\' as opposed to \'assets/images\'. By doing so you will prevent the browser (or web server) from appending the relative path to the alias path.</strong>';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -735,6 +735,9 @@ $_lang['setting_upload_maxsize_desc'] = 'Enter the maximum file size that can be
 $_lang['setting_upload_media'] = 'Uploadable Media Types';
 $_lang['setting_upload_media_desc'] = 'Here you can enter a list of files that can be uploaded into \'assets/media/\' using the Resource Manager. Please enter the extensions for the media types, separated by commas.';
 
+$_lang['setting_upload_translit'] = 'Transliterate names of uploading files?';
+$_lang['setting_upload_translit_desc'] = 'If <b>yes</b> name of any uploading file will be transliterated by global translitiration rules.';
+
 $_lang['setting_use_alias_path'] = 'Use Friendly Alias Path';
 $_lang['setting_use_alias_path_desc'] = 'Setting this option to \'yes\' will display the full path to the Resource if the Resource has an alias. For example, if a Resource with an alias called \'child\' is located inside a container Resource with an alias called \'parent\', then the full alias path to the Resource will be displayed as \'/parent/child.html\'.<br /><strong>NOTE: When setting this option to \'Yes\' (turning on alias paths), reference items (such as images, CSS, JavaScripts, etc.) use the absolute path, e.g., \'/assets/images\' as opposed to \'assets/images\'. By doing so you will prevent the browser (or web server) from appending the relative path to the alias path.</strong>';
 

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -736,7 +736,7 @@ $_lang['setting_upload_media'] = 'Uploadable Media Types';
 $_lang['setting_upload_media_desc'] = 'Here you can enter a list of files that can be uploaded into \'assets/media/\' using the Resource Manager. Please enter the extensions for the media types, separated by commas.';
 
 $_lang['setting_upload_translit'] = 'Transliterate names of uploading files?';
-$_lang['setting_upload_translit_desc'] = 'If \'Yes\' name of any uploading file will be transliterated by global translitiration rules.';
+$_lang['setting_upload_translit_desc'] = 'If \'Yes\' name of any uploading file will be transliterated by global transliteration rules.';
 
 $_lang['setting_use_alias_path'] = 'Use Friendly Alias Path';
 $_lang['setting_use_alias_path_desc'] = 'Setting this option to \'yes\' will display the full path to the Resource if the Resource has an alias. For example, if a Resource with an alias called \'child\' is located inside a container Resource with an alias called \'parent\', then the full alias path to the Resource will be displayed as \'/parent/child.html\'.<br /><strong>NOTE: When setting this option to \'Yes\' (turning on alias paths), reference items (such as images, CSS, JavaScripts, etc.) use the absolute path, e.g., \'/assets/images\' as opposed to \'assets/images\'. By doing so you will prevent the browser (or web server) from appending the relative path to the alias path.</strong>';

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1085,6 +1085,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 continue;
             }
 
+            if ((boolean)$this->xpdo->getOption('upload_translit')) {
+                $file['name'] = $this->xpdo->filterPathSegment($file['name']);
+            }
+
             $newPath = $container . $this->sanitizePath($file['name']);
             try {
                 if ($this->checkFileExists() && $this->filesystem->has($newPath)) {


### PR DESCRIPTION
### What does it do?
Add system setting `upload_translit`. If this setting is `yes` (default), filename of any uploaded file will be transliterated according global translitirating rules (setting `friendly_alias_translit`)

### Why is it needed?
There are many problems a file can give on server, for example, with a russian name.

### How to test
You should to rebuild transport core - `php _build/transport.core.php`, remove `/setup/.locked/` and run setup. Then you can install `Translit` extra from MODX repo or any other, for example `yTranslit` from `modstore.pro`. Set setting `friendly_alias_translit` to `russian` or any other. Upload any files with non latin symbols. Name of uploaded file should be transliterated.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/15007
