### PR TITLE
Fixed PHP notices on the resource form

### DIFF
--- a/manager/templates/default/resource/create.tpl
+++ b/manager/templates/default/resource/create.tpl
@@ -5,7 +5,7 @@
     {$tv->get('formElement')}
 {/foreach}
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}

--- a/manager/templates/default/resource/staticresource/create.tpl
+++ b/manager/templates/default/resource/staticresource/create.tpl
@@ -1,7 +1,7 @@
 <div id="modx-panel-static-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}

--- a/manager/templates/default/resource/staticresource/update.tpl
+++ b/manager/templates/default/resource/staticresource/update.tpl
@@ -1,7 +1,7 @@
 <div id="modx-panel-static-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}

--- a/manager/templates/default/resource/symlink/create.tpl
+++ b/manager/templates/default/resource/symlink/create.tpl
@@ -1,7 +1,7 @@
 <div id="modx-panel-symlink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}

--- a/manager/templates/default/resource/symlink/update.tpl
+++ b/manager/templates/default/resource/symlink/update.tpl
@@ -1,7 +1,7 @@
 <div id="modx-panel-symlink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}

--- a/manager/templates/default/resource/update.tpl
+++ b/manager/templates/default/resource/update.tpl
@@ -5,7 +5,7 @@
     {$tv->get('formElement')}
 {/foreach}
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}

--- a/manager/templates/default/resource/weblink/create.tpl
+++ b/manager/templates/default/resource/weblink/create.tpl
@@ -1,7 +1,7 @@
 <div id="modx-panel-weblink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}

--- a/manager/templates/default/resource/weblink/update.tpl
+++ b/manager/templates/default/resource/weblink/update.tpl
@@ -1,7 +1,7 @@
 <div id="modx-panel-weblink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
 
-{$onDocFormPrerender}
+{$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}
-    {$onRichTextEditorInit}
+    {$onRichTextEditorInit|default}
 {/if}


### PR DESCRIPTION
### What does it do?
Fixed a notices about undefined variables on the resource form.

### Why is it needed?
Describe the issue you are solving.

### How to test
1. Set log level to 3.
2. Open any resource/symlink/weblink or create a new one.
3. Open MODX error log.
4. It should be clear.

### Related issue(s)/PR(s)
#15455
