### PR TITLE
Fix logging Could not load package metadata for package modx.transport

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Packages/Get.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Get.php
@@ -43,7 +43,7 @@ class Get extends GetProcessor
      */
     public function initialize()
     {
-        $this->modx->addPackage('modx.transport', $this->modx->getOption('core_path') . 'model/');
+        $this->modx->addPackage('Revolution\Transport', MODX_CORE_PATH . 'src/');
         $this->dateFormat = $this->getProperty('dateFormat',
             $this->modx->getOption('manager_date_format') . ', ' . $this->modx->getOption('manager_time_format'));
         return parent::initialize();

--- a/core/src/Revolution/Processors/Workspace/Packages/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetList.php
@@ -47,7 +47,7 @@ class GetList extends GetListProcessor
      */
     public function initialize()
     {
-        $this->modx->addPackage('modx.transport', $this->modx->getOption('core_path') . 'model/');
+        $this->modx->addPackage('Revolution\Transport', MODX_CORE_PATH . 'src/');
         $this->setDefaultProperties([
             'start' => 0,
             'limit' => 10,

--- a/core/src/Revolution/Processors/Workspace/Packages/Version/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Version/GetList.php
@@ -33,6 +33,7 @@ class GetList extends GetListProcessor
      */
     public function initialize()
     {
+        $this->modx->addPackage('Revolution\Transport', MODX_CORE_PATH . 'src/');
         $this->setDefaultProperties([
             'limit' => 10,
             'start' => 0,
@@ -40,7 +41,6 @@ class GetList extends GetListProcessor
             'dateFormat' => $this->modx->getOption('manager_date_format') . ', ' . $this->modx->getOption('manager_time_format'),
             'signature' => false,
         ]);
-        $this->modx->addPackage('modx.transport', $this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'model/');
         return parent::initialize();
     }
 


### PR DESCRIPTION
### What does it do?
Change the old addPackage to the new namespaced addPackage.

### Why is it needed?
Fixing logging of the error `(WARN @ /.../core/vendor/xpdo/xpdo/src/xPDO/xPDO.php : 526) Could not load package metadata for package modx.transport. Upgrade your model.`

But maybe those lines are not needed anymore.

### How to test
See #15450

### Related issue(s)/PR(s)
#15450

