### PR TITLE
Fix modElement getTag error (#15172)

### DIFF
--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -275,14 +275,13 @@ class modElement extends modAccessibleSimpleObject
                     if (is_scalar($value)) {
                         $propTemp[$key] = $key . '=`' . $value . '`';
                     } else {
-                        if(is_array($value)){
-                            foreach($value as $v){
-                                if(is_object($v)){
-                                    $value = '';
-                                }
-                            }
+                        try {
+                            $propTemp[$key] = $key . '=`' . (is_array($value) ? md5(serialize($value))
+                                    : md5(uniqid(rand(), true))) . '`';
                         }
-                        $propTemp[$key] = $key . '=`' . (is_array($value) ? md5(serialize($value)) : md5(uniqid(rand(), true))) . '`';
+                        catch (\Throwable $handlerException) {
+                            $propTemp[$key] = $key . '=`' . md5(uniqid(rand(), true)) . '`';
+                        }
                     }
                 }
                 if (!empty($propTemp)) {

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -275,6 +275,13 @@ class modElement extends modAccessibleSimpleObject
                     if (is_scalar($value)) {
                         $propTemp[$key] = $key . '=`' . $value . '`';
                     } else {
+                        if(is_array($value)){
+                            foreach($value as $v){
+                                if(is_object($v)){
+                                    $value = '';
+                                }
+                            }
+                        }
                         $propTemp[$key] = $key . '=`' . (is_array($value) ? md5(serialize($value)) : md5(uniqid(rand(), true))) . '`';
                     }
                 }


### PR DESCRIPTION
### What does it do?
Fix issue #15172 . Check if value is_object and set is to empty string

### Why is it needed?
Because earlier this cause fatal error 

### How to test
 
Step to reproduce
create plugin which is invoked on "OnBeforeEmptyTrash" and "OnEmptyTrash" and returns empty string. now delete one or more resources and purge them in the trash manager.

Observed behavior
The trash purge processor invokes events "OnBeforeEmptyTrash" and "OnEmptyTrash". if a plugin is triggered by the event, the parameters will pass through as properties to the getTag-function of modElement. My example plugin only returns empty string. "invokeEvent" function of modx calls the process function of modScript which calls parent process function and thats modElement. modElement process function calls the getTag function, which raises the error:
PHP Fatal error: Uncaught PDOException: You cannot serialize or unserialize PDO instances

### Related issue(s)/PR(s)
#15172
