### PR TITLE
Fix preview resource link

### DIFF
--- a/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
+++ b/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
@@ -145,15 +145,14 @@ class GetRecentlyEditedResources extends GetListProcessor
                 ],
             ];
         }
+
         $row['menu'][] = '-';
         $row['menu'][] = [
-            'text' => $this->modx->lexicon('resource_preview'),
-            'params' => [
-                'url' => $this->modx->makeUrl($resource->get('id'), null, '', 'full'),
-                'type' => 'open',
-            ],
+            'text'    => $this->modx->lexicon('resource_preview'),
             'handler' => 'this.preview',
         ];
+
+        $row['link'] = $this->modx->makeUrl($resource->get('id'), $resource->get('context_key'));
 
         return $row;
     }

--- a/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.recent.resource.js
@@ -8,6 +8,7 @@
  */
 MODx.grid.RecentlyEditedResourcesByUser = function(config) {
     config = config || {};
+
     var dateFormat = MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format;
     Ext.applyIf(config,{
         title: _('recent_docs')


### PR DESCRIPTION
### What does it do?
This fixes the preview link in the Recent Resources tab in the profile page.

### Why is it needed?
Preview link was opening a blank page in a new window.

### How to test

1. Log in to the manager
2. Edit & save a resource
3. Go to your account page
4. Open Recent Resources
5. Right click any recently edited resource
6. Click "Preview Resource"

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/15448