### PR TITLE
Run manager style and scripts building via npm run.

### DIFF
--- a/_build/templates/default/package.json
+++ b/_build/templates/default/package.json
@@ -24,5 +24,8 @@
     "bourbon-neat": "^3.0.0",
     "@fortawesome/fontawesome-free": "^5.7.0",
     "normalize-scss": "^7.0.1"
+  },
+  "scripts": {
+    "build": "grunt build"
   }
 }


### PR DESCRIPTION
### What does it do?
It adds the possibility to run `npm run` to see, which actions available in the manager. And also run building by `npm run build`.

### Why is it needed?
Just to simplify for people who are not familiar with the building process to faster find the proper script.

### How to test
Go to `_build/templates/default/` and run `npm run`. Do not forget to install deps via `npm i` first.

### Related issue(s)/PR(s)
N/A
