### PR TITLE
Import missing classes

### DIFF
--- a/_build/test/Tests/Controllers/Resources/SymLink/SymLinkCreateControllerTest.php
+++ b/_build/test/Tests/Controllers/Resources/SymLink/SymLinkCreateControllerTest.php
@@ -2,6 +2,7 @@
 namespace MODX\Revolution\Tests\Controllers\Resources\SymLink;
 
 
+use MODX\Revolution\modSymLink;
 use MODX\Revolution\Tests\Controllers\Resources\ResourceCreateControllerTest;
 
 class SymLinkCreateControllerTest extends ResourceCreateControllerTest

--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -13,7 +13,6 @@ namespace MODX\Revolution\Tests\Model\Request;
 
 
 use MODX\Revolution\Error\modError;
-use MODX\Revolution\modAction;
 use MODX\Revolution\modNamespace;
 use MODX\Revolution\modRequest;
 use MODX\Revolution\MODxTestCase;

--- a/core/src/Revolution/Processors/Security/Role/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Security/Role/UpdateFromGrid.php
@@ -11,14 +11,13 @@
 namespace MODX\Revolution\Processors\Security\Role;
 
 
-use modUserGroupRoleUpdateProcessor;
 
 /**
  * Updates a role from a grid. Passed as JSON data
  * @param integer $id The ID of the role
  * @package MODX\Revolution\Processors\Security\Role
  */
-class UpdateFromGrid extends modUserGroupRoleUpdateProcessor
+class UpdateFromGrid extends Update
 {
     /**
      * @return bool|string|null

--- a/core/src/Revolution/Processors/System/Log/GetList.php
+++ b/core/src/Revolution/Processors/System/Log/GetList.php
@@ -10,7 +10,6 @@
 
 namespace MODX\Revolution\Processors\System\Log;
 
-use MODX\Revolution\modAction;
 use MODX\Revolution\modCategory;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modContextSetting;

--- a/core/src/Revolution/Processors/System/Menu/Remove.php
+++ b/core/src/Revolution/Processors/System/Menu/Remove.php
@@ -60,5 +60,3 @@ class Remove extends RemoveProcessor
         parent::cleanup();
     }
 }
-
-return modMenuRemoveProcessor::class;

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -22,7 +22,6 @@ use xPDO\xPDO;
  * @property modUserSetting[]      $UserSettings
  * @property modExtensionPackage[] $ExtensionPackages
  * @property modAccessNamespace[]  $Acls
- * @property modAction[]           $Actions
  *
  * @package MODX\Revolution
  */

--- a/manager/controllers/default/element/chunk/create.class.php
+++ b/manager/controllers/default/element/chunk/create.class.php
@@ -8,6 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
 

--- a/manager/controllers/default/element/plugin/create.class.php
+++ b/manager/controllers/default/element/plugin/create.class.php
@@ -8,6 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
 

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -8,7 +8,9 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
+use MODX\Revolution\modPlugin;
 use MODX\Revolution\modSystemEvent;
 
 /**

--- a/manager/controllers/default/element/snippet/create.class.php
+++ b/manager/controllers/default/element/snippet/create.class.php
@@ -8,6 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
 

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -8,7 +8,9 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
+use MODX\Revolution\modSnippet;
 use MODX\Revolution\modSystemEvent;
 
 /**

--- a/manager/controllers/default/element/template/create.class.php
+++ b/manager/controllers/default/element/template/create.class.php
@@ -8,6 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
 

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -8,8 +8,10 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
+use MODX\Revolution\modTemplate;
 
 /**
  * Load update template page

--- a/manager/controllers/default/element/tv/create.class.php
+++ b/manager/controllers/default/element/tv/create.class.php
@@ -8,6 +8,8 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
+use MODX\Revolution\modContext;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
 use MODX\Revolution\Sources\modMediaSource;

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -8,8 +8,11 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCategory;
+use MODX\Revolution\modContext;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\modSystemEvent;
+use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\Sources\modMediaSource;
 use MODX\Revolution\Sources\modMediaSourceElement;
 

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -10,6 +10,7 @@
 
 use MODX\Revolution\modContextSetting;
 use MODX\Revolution\modResource;
+use MODX\Revolution\modUser;
 
 require_once dirname(__FILE__) . '/resource.class.php';
 

--- a/manager/controllers/default/security/access/policy/template/update.class.php
+++ b/manager/controllers/default/security/access/policy/template/update.class.php
@@ -8,6 +8,8 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modAccessPermission;
+use MODX\Revolution\modAccessPolicyTemplate;
 use MODX\Revolution\modManagerController;
 
 /**

--- a/manager/controllers/default/security/access/policy/update.class.php
+++ b/manager/controllers/default/security/access/policy/update.class.php
@@ -8,6 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modManagerController;
 
 /**

--- a/manager/controllers/default/workspaces/index.class.php
+++ b/manager/controllers/default/workspaces/index.class.php
@@ -8,6 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
+use MODX\Revolution\modCacheManager;
 use MODX\Revolution\modManagerController;
 use MODX\Revolution\Transport\modTransportProvider;
 

--- a/setup/includes/modinstallversion.class.php
+++ b/setup/includes/modinstallversion.class.php
@@ -14,6 +14,8 @@
  * @package setup
 */
 
+use MODX\Revolution\modSystemSetting;
+
 /**
  * Handles version-specific upgrades for Revolution
  *

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -26,7 +26,6 @@ use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPermission;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modAccessPolicyTemplate;
-use MODX\Revolution\modAction;
 use MODX\Revolution\modActionDom;
 use MODX\Revolution\modFormCustomizationProfile;
 use MODX\Revolution\modFormCustomizationProfileUserGroup;

--- a/setup/includes/upgrades/common/3.0.0-update-upload_files-woff2.php
+++ b/setup/includes/upgrades/common/3.0.0-update-upload_files-woff2.php
@@ -6,6 +6,8 @@
  * @package setup
  */
 
+use MODX\Revolution\modSystemSetting;
+
 $messageTemplate = '<p class="%s">%s</p>';
 
 $keys = ['upload_files'];
@@ -14,7 +16,7 @@ foreach ($keys as $key) {
     $success = false;
 
     /** @var modSystemSetting $setting */
-    $setting = $modx->getObject('modSystemSetting', array('key' => $key));
+    $setting = $modx->getObject(modSystemSetting::class, array('key' => $key));
     if ($setting) {
         $value = $setting->get('value');
         $tmp = explode(',', $value);


### PR DESCRIPTION
### What does it do?
Add missing use statements in various files.

### Why is it needed?
To prevent deprecation messages.

### How to test
Set log_level to 4 and notice less deprecation messages

### Related issue(s)/PR(s)
Closes #15471
Probably others as well
