### PR TITLE
Add automatic detect context to initialize #modxbughunt

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -82,6 +82,15 @@ $settings['archive_with']->fromArray([
   'area' => 'system',
   'editedon' => null,
 ], '', true, true);
+$settings['auto_detect_context']= $xpdo->newObject(modSystemSetting::class);
+$settings['auto_detect_context']->fromArray([
+  'key' => 'auto_detect_context',
+  'value' => true,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'site',
+  'editedon' => null,
+], '', true, true);
 $settings['auto_menuindex']= $xpdo->newObject(modSystemSetting::class);
 $settings['auto_menuindex']->fromArray([
   'key' => 'auto_menuindex',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -85,7 +85,7 @@ $settings['archive_with']->fromArray([
 $settings['auto_detect_context']= $xpdo->newObject(modSystemSetting::class);
 $settings['auto_detect_context']->fromArray([
   'key' => 'auto_detect_context',
-  'value' => true,
+  'value' => false,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'site',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -106,6 +106,9 @@ $_lang['setting_anonymous_sessions_desc'] = 'If disabled, only authenticated use
 $_lang['setting_archive_with'] = 'Force PCLZip Archives';
 $_lang['setting_archive_with_desc'] = 'If true, will use PCLZip instead of ZipArchive as the zip extension. Turn this on if you are getting extractTo errors or are having problems with unzipping in Package Management.';
 
+$_lang['setting_auto_detect_context'] = 'Automatic switch context if possible';
+$_lang['setting_auto_detect_context_desc'] = 'Select \'Yes\' to turn on automatic detecting and initializing needed context.';
+
 $_lang['setting_auto_menuindex'] = 'Menu indexing default';
 $_lang['setting_auto_menuindex_desc'] = 'Select \'Yes\' to turn on automatic menu index incrementing by default.';
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2903,6 +2903,11 @@ class modX extends xPDO {
                         return $key;
                     }
                 }
+                if (!empty($settings['config']['base_url'])) {
+                    if (strpos($_SERVER['REQUEST_URI'], $settings['config']['base_url']) === 0) {
+                        return $key;
+                    }
+                }
             }
         }
         return $contextKey;

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
 $modx->startTime= $tstart;
 
 /* Initialize the default 'web' context */
-$modx->initialize('web');
+$modx->initialize();
 
 /* execute the request handler */
 if (!MODX_API_MODE) {


### PR DESCRIPTION
### What does it do?
Add context switch mechanism in core

### Why is it needed?
MODX have ability to create multiple contexts in the same CMS. But everyone needs to switch contexts by himself. Now MODX will switch context if you add context setting `site_url` or/and `base_url`

### How to test
Create new context, add context setting `site_url` or/and `base_url`, add domains to website. To handle context switching by `base_url` you can use this nginx rule `rewrite ^/(en|nl)/(.*)$ /?cultureKey=$1&q=$2 break;`

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14712, https://github.com/modxcms/revolution/issues/14364
