### PR TITLE
#modxbughunt Fix displaying big SVG images in media browser

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2264,8 +2264,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 }
                 $filemanager_thumb_height = $this->ctx->getOption('filemanager_thumb_height', 80);
                 if($height > $filemanager_thumb_height){
-                    $height = $filemanager_thumb_height;
                     $width = ($filemanager_thumb_height / $height) * $width;
+                    $height = $filemanager_thumb_height;
                 }
                 $file_size = [
                     'width' => $width,

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2263,7 +2263,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                     return false;
                 }
                 $filemanager_thumb_height = $this->ctx->getOption('filemanager_thumb_height', 80);
-                if($height > $filemanager_thumb_height){
+                if ($height > $filemanager_thumb_height) {
                     $width = ($filemanager_thumb_height / $height) * $width;
                     $height = $filemanager_thumb_height;
                 }

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2262,6 +2262,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 } else {
                     return false;
                 }
+                if($height > 80){
+                    $height = 80;
+                    $width = (80 / $height) * $width;
+                }
                 $file_size = [
                     'width' => $width,
                     'height' => $height,

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2262,9 +2262,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 } else {
                     return false;
                 }
-                if($height > 80){
-                    $height = 80;
-                    $width = (80 / $height) * $width;
+                $filemanager_thumb_height = $this->ctx->getOption('filemanager_thumb_height', 80);
+                if($height > $filemanager_thumb_height){
+                    $height = $filemanager_thumb_height;
+                    $width = ($filemanager_thumb_height / $height) * $width;
                 }
                 $file_size = [
                     'width' => $width,


### PR DESCRIPTION
### What does it do?
Fix displaying big SVG images (by big I mean width \ height that are set in svg)

### Why is it needed?
This allow to display svg correct
Before fix
![Screenshot_10](https://user-images.githubusercontent.com/4846064/110129306-dd0da900-7dd8-11eb-8363-215585350b30.jpg)
After Fix
![Screenshot_12](https://user-images.githubusercontent.com/4846064/110129335-e4cd4d80-7dd8-11eb-9f07-b84301ba990e.jpg)


### How to test
Upload svg with big viewBox (like 512*512)

 