### PR TITLE
Fix image rotation in media browser #modxbughunt

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2219,6 +2219,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             ]);
             $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL) . 'system/phpthumb.php?' . $imageQuery;
         }
+
         return [
             'src' => $image,
             'width' => $width,

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2184,13 +2184,15 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             } else {
                 $absolute_path = $path;
             }
-            $exif = @exif_read_data($absolute_path);
-            if (!empty($exif) && $exif['Orientation'] >= 5) {
-                // This image was rotated
-                $new_width = $size['height'];
-                $new_height = $size['width'];
-                $size['width'] = $new_width;
-                $size['height'] = $new_height;
+            if (function_exists('exif_read_data')) {
+                $exif = exif_read_data($absolute_path);
+                if (!empty($exif) && $exif['Orientation'] >= 5) {
+                    // This image was rotated
+                    $new_width = $size['height'];
+                    $new_height = $size['width'];
+                    $size['width'] = $new_width;
+                    $size['height'] = $new_height;
+                }
             }
             // get original image size for proportional scaling
             if ($size['width'] > $size['height']) {

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2178,6 +2178,18 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             } catch (Exception $E) {
                 $timestamp = 0;
             }
+
+            if ($bases['pathIsRelative']) {
+                $absolute_path = $bases['pathAbsolute'] . $path;
+            }
+            $exif = exif_read_data($absolute_path);
+            if (!empty($exif) && $exif['Orientation'] >= 5) {
+                // This image was rotated
+                $new_width = $size['height'];
+                $new_height = $size['width'];
+                $size['width'] = $new_width;
+                $size['height'] = $new_height;
+            }
             // get original image size for proportional scaling
             if ($size['width'] > $size['height']) {
                 // landscape
@@ -2203,10 +2215,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 'wctx' => $this->ctx->get('key'),
                 'source' => $this->get('id'),
                 't' => $timestamp,
+                'ar' => 'x'
             ]);
             $image = $this->ctx->getOption('connectors_url', MODX_CONNECTORS_URL) . 'system/phpthumb.php?' . $imageQuery;
         }
-
         return [
             'src' => $image,
             'width' => $width,

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2181,8 +2181,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
             if ($bases['pathIsRelative']) {
                 $absolute_path = $bases['pathAbsolute'] . $path;
+            } else {
+                $absolute_path = $path;
             }
-            $exif = exif_read_data($absolute_path);
+            $exif = @exif_read_data($absolute_path);
             if (!empty($exif) && $exif['Orientation'] >= 5) {
                 // This image was rotated
                 $new_width = $size['height'];

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2185,7 +2185,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 $absolute_path = $path;
             }
             if (function_exists('exif_read_data')) {
-                $exif = exif_read_data($absolute_path);
+                $exif = @exif_read_data($absolute_path);
                 if (!empty($exif) && $exif['Orientation'] >= 5) {
                     // This image was rotated
                     $new_width = $size['height'];


### PR DESCRIPTION
### What does it do?
Fixing images rotates in media browser

### Why is it needed?
If image have EXIF data and was made on rotated devise, it displays as rotated in mediabrowser. For example - [this image](https://user-images.githubusercontent.com/79689999/109482539-6b52f980-7a7e-11eb-876a-4eb0c59c3ae1.jpg). Now this images will be displayed as needed.

### How to test
Upload [this image](https://user-images.githubusercontent.com/79689999/109482539-6b52f980-7a7e-11eb-876a-4eb0c59c3ae1.jpg) in media browser.

### Related issue(s)/PR(s)
https://github.com/Sterc/revolution/issues/23
