### PR TITLE
Increased the width of the text (input) TV

### DIFF
--- a/manager/templates/default/element/tv/renders/input/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/input/autotag.tpl
@@ -14,7 +14,7 @@ Ext.onReady(function() {
     {/literal}
         xtype: 'textfield'
         ,applyTo: 'tv{$tv->id}'
-        ,width: 400
+        ,width: '99%'
         ,id: 'tv{$tv->id}'
         ,enableKeyEvents: true
         ,msgTarget: 'under'

--- a/manager/templates/default/element/tv/renders/input/email.tpl
+++ b/manager/templates/default/element/tv/renders/input/email.tpl
@@ -13,7 +13,7 @@ Ext.onReady(function() {
     {/literal}
         xtype: 'textfield'
         ,applyTo: 'tv{$tv->id}'
-        ,width: 400
+        ,width: '99%'
         ,vtype: 'email'
         ,enableKeyEvents: true
         ,msgTarget: 'under'

--- a/manager/templates/default/element/tv/renders/input/number.tpl
+++ b/manager/templates/default/element/tv/renders/input/number.tpl
@@ -13,7 +13,7 @@ Ext.onReady(function() {
     {/literal}
         xtype: 'numberfield'
         ,applyTo: 'tv{$tv->id}'
-        ,width: 400
+        ,width: '99%'
         ,enableKeyEvents: true
         ,autoStripChars: true
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}


### PR DESCRIPTION
### What does it do?
Increased the width of the text (input) TV.
For other TV types (date, file), the question is not obvious, see https://github.com/modxcms/revolution/issues/11856#issuecomment-453766597.

Before:
![tv_input_1](https://user-images.githubusercontent.com/12523676/110139799-7b533c00-7de4-11eb-8290-70828bb8fc77.png)

After:
![tv_input_2](https://user-images.githubusercontent.com/12523676/110139801-7c846900-7de4-11eb-8380-b35c053f0748.png)

### Why is it needed?
UI/UX improvement

### Related issue(s)/PR(s)
Partially fixes https://github.com/modxcms/revolution/issues/11856