### PR TITLE
properties for @CHUNK and @SNIPPET binding

### DIFF
--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -52,6 +52,7 @@ class modTemplateVar extends modElement
     public $bindings = [
         'FILE',
         'CHUNK',
+        'SNIPPET',
         'DOCUMENT',
         'RESOURCE',
         'SELECT',
@@ -833,11 +834,11 @@ class modTemplateVar extends modElement
         $cmd = false;
         $param = '';
         if (substr($nvalue, 0, 1) == '@') {
-            list($cmd, $param) = $this->parseBinding($nvalue);
+            list($cmd, $param, $properties) = $this->parseBinding($nvalue);
             $cmd = trim($cmd);
         }
 
-        return ['cmd' => $cmd, 'param' => $param];
+        return ['cmd' => $cmd, 'param' => $param, 'properties' => $properties];
     }
 
     /**
@@ -870,6 +871,7 @@ class modTemplateVar extends modElement
         }
         $cmd = $bdata['cmd'];
         $param = !empty($bdata['param']) ? $bdata['param'] : null;
+        $properties = !empty($bdata['properties']) ? $bdata['properties'] : [];
         switch ($cmd) {
             case 'FILE':
                 if ($preProcess) {
@@ -879,9 +881,15 @@ class modTemplateVar extends modElement
 
             case 'CHUNK': /* retrieve a chunk and process it's content */
                 if ($preProcess) {
-                    $output = $this->xpdo->getChunk($param);
+                    $output = $this->xpdo->getChunk($param, $properties);
                 }
                 break;
+                
+            case 'SNIPPET':
+                if ($preProcess) {
+                    $output = $this->xpdo->runSnippet($param, $properties);
+                }
+                break;                
 
             case 'RESOURCE':
             case 'DOCUMENT': /* retrieve a document and process it's content */
@@ -986,11 +994,27 @@ class modTemplateVar extends modElement
         $match = [];
         $binding_string = trim($binding_string);
         $regexp = '/@(' . implode('|', $this->bindings) . ')\s*(.*)/is'; /* Split binding on whitespace */
+        
         if (preg_match($regexp, $binding_string, $match)) {
             /* We can't return the match array directly because the first element is the whole string */
+            
+            $regexp2 = '/(\S+)\s+(.+)/is'; /* Split binding on second whitespace to get properties */
+            
+            $properties = [];
+            if (preg_match($regexp2, $match[2] , $match2)) {
+                if (isset($match2[2])) {
+                    $props = json_decode($match2[2],true);
+                    if (is_array($props)){
+                        $properties = $props;
+                        $match[2] = $match2[1];
+                    }
+                }
+            }
+            
             $binding_array = [
                 strtoupper($match[1]),
                 trim($match[2]),
+                $properties
             ]; /* Make command uppercase */
 
             return $binding_array;

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -993,6 +993,7 @@ class modTemplateVar extends modElement
     public function parseBinding($binding_string)
     {
         $match = [];
+        $match2 = [];
         $binding_string = trim($binding_string);
         $regexp = '/@(' . implode('|', $this->bindings) . ')\s*(.*)/is'; /* Split binding on whitespace */
         

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -833,6 +833,7 @@ class modTemplateVar extends modElement
         $nvalue = trim($value);
         $cmd = false;
         $param = '';
+        $properties = [];
         if (substr($nvalue, 0, 1) == '@') {
             list($cmd, $param, $properties) = $this->parseBinding($nvalue);
             $cmd = trim($cmd);

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -1006,9 +1006,12 @@ class modTemplateVar extends modElement
             if (preg_match($regexp2, $match[2] , $match2)) {
                 if (isset($match2[2])) {
                     $props = json_decode($match2[2],true);
-                    if (is_array($props)){
+                    $valid = json_last_error() === JSON_ERROR_NONE;
+                    if ($valid && is_array($props)){
                         $properties = $props;
                         $match[2] = $match2[1];
+                    } else {
+                        $this->xpdo->log(modX::LOG_LEVEL_ERROR, 'modTemplateVar::parseBinding - third parameter is invalid JSON :' . $binding_string);
                     }
                 }
             }


### PR DESCRIPTION
### What does it do?
Adds passing properties to snippets or chunks in @CHUNK and @SNIPPET bindings

### Why is it needed?
@CHUNK and @SNIPPET bindings doesn't support passing properties to snippets or chunks

### How to test
Could be tested with a binding like that: 
```@SNIPPET createOptions {"classname":"modResource","field":"pagetitle"}```

snippetcode:
```
$classname = $modx->getOption('classname',$scriptProperties,'');
$field = $modx->getOption('field',$scriptProperties,'');

$items = [];
if ($collection = $modx->getCollection($classname)){
    foreach ($collection as $object){
        $items[] = $object->get($field) . '==' . $object->get('id');
    }
}

return implode('||',$items);
```

### Related issue(s)/PR(s)
could close #14074
addition to #15454
