### PR TITLE
Flatten the lexicon parameters by dot notation

### DIFF
--- a/core/model/modx/modlexicon.class.php
+++ b/core/model/modx/modlexicon.class.php
@@ -457,10 +457,33 @@ class modLexicon {
         if (!$str) return '';
         if (empty($params)) return $str;
 
+        $params = $this->_flatten($params);
         foreach ($params as $k => $v) {
             $str = str_replace('[[+'.$k.']]',$v,$str);
         }
         return $str;
+    }
+
+    /**
+     * Flattens an array by dot notation
+     *
+     * @access private
+     * @param array $array The array to flatten
+     * @return array The processed array
+     */
+    private function _flatten($array) {
+        $result = array();
+        if (is_array($array)) {
+            $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($array));
+            foreach ($iterator as $value) {
+                $keys = array();
+                foreach (range(0, $iterator->getDepth()) as $depth) {
+                    $keys[] = $iterator->getSubIterator($depth)->key();
+                }
+                $result[ join('.', $keys) ] = $value;
+            }
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Flatten the lexicon parameters by dot notation

### Why is it needed?
modLexicon->parse() throws fatal error if $params contains a nested array

### How to test

Use the following code.

```
$this->modx->lexicon->load('core:default');
$test = $this->modx->lexicon('resource', ['key' => 'value', 'properties' => ['more' => 'values']]);
```

It will break on PHP 8 with: 

```
Exception: str_replace(): Argument #2 ($replace) must be of type string when argument #1 ($search) is a string
```

After the change the following array is sent to str_replace:

```
Array
(
    [key] => value
    [properties.more] => values
)
```

### Related issue(s)/PR(s)
#15415 