### PR TITLE
Flatten the lexicon parameters by dot notation

### DIFF
--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -597,7 +597,7 @@ class modLexicon
      * @return array The processed array
      */
     private function _flatten($array) {
-        $result = [];
+        $result = array();
 
         if (is_array($array)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($array));

--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -597,12 +597,12 @@ class modLexicon
      * @return array The processed array
      */
     private function _flatten($array) {
-        $result = array();
+        $result = [];
 
         if (is_array($array)) {
             $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($array));
             foreach ($iterator as $value) {
-                $keys = array();
+                $keys = [];
                 foreach (range(0, $iterator->getDepth()) as $depth) {
                     $keys[] = $iterator->getSubIterator($depth)->key();
                 }

--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -12,6 +12,8 @@ namespace MODX\Revolution;
 
 
 use DirectoryIterator;
+use RecursiveArrayIterator;
+use RecursiveIteratorIterator;
 use xPDO\Cache\xPDOCacheManager;
 use xPDO\xPDO;
 

--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -581,11 +581,35 @@ class modLexicon
             return $str;
         }
 
+        $params = $this->_flatten($params);
         foreach ($params as $k => $v) {
             $str = str_replace('[[+' . $k . ']]', $v, $str);
         }
 
         return $str;
+    }
+
+    /**
+     * Flattens an array by dot notation
+     *
+     * @access private
+     * @param array $array The array to flatten
+     * @return array The processed array
+     */
+    private function _flatten($array) {
+        $result = [];
+
+        if (is_array($array)) {
+            $iterator = new RecursiveIteratorIterator(new RecursiveArrayIterator($array));
+            foreach ($iterator as $value) {
+                $keys = array();
+                foreach (range(0, $iterator->getDepth()) as $depth) {
+                    $keys[] = $iterator->getSubIterator($depth)->key();
+                }
+                $result[ join('.', $keys) ] = $value;
+            }
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Flatten the lexicon parameters by dot notation

### Why is it needed?
`modLexicon->parse() throws fatal error if $params contains a nested array`

### How to test

Use the following code.

```php
$this->modx->lexicon->load('core:default');
$test = $this->modx->lexicon('resource', ['key' => 'value', 'properties' => ['more' => 'values']]);
```

It will break on PHP 8 with:

`Exception: str_replace(): Argument #2 ($replace) must be of type string when argument #1 ($search) is a string`

After the change the following array is sent to str_replace:

``` php
Array
(
    [key] => value
    [properties.more] => values
)
```

### Related issue(s)/PR(s)
#15415 https://github.com/modxcms/revolution/pull/15490