### PR TITLE
Recursive display of the folder with MODX tags in the name

### DIFF
--- a/core/model/modx/processors/browser/directory/getlist.class.php
+++ b/core/model/modx/processors/browser/directory/getlist.class.php
@@ -37,7 +37,7 @@ class modBrowserFolderGetListProcessor extends modProcessor {
         $this->setDefaultProperties(array(
             'id' => '',
         ));
-        $dir = $this->getProperty('id');
+        $dir = $this->getProperty('node') ? rawurldecode($this->getProperty('node')) : $this->getProperty('id');
         $dir = preg_replace('/[\.]{2,}/', '', htmlspecialchars($dir));
         if (!strlen($dir) || $dir === 'root') {
             $this->setProperty('id','');


### PR DESCRIPTION
### What does it do?
Fixed a bug with recursive display of the directory with the MODX tag in the name.

### Why is it needed?
 If you create a folder named [[++holidaytheme]] in the file system the MODx folder tree will create an infinitely nested loop of those folders.
![97478165-f41e2500-1926-11eb-9b73-c505512e39f6](https://user-images.githubusercontent.com/4679725/110207435-806fc400-7e94-11eb-8818-bda2dcedbc46.png)

### How to test
1. Create a folder with name [[++holidaytheme]].
2. Try to open it in the MODX file manager.

The reason - MODX sanitized GET parameters and passes POST parameters if the system setting "allow_tags_in_post" is on.