### PR TITLE
Incorrect regular expression for the downloaded file.

### DIFF
--- a/core/src/Revolution/Processors/Browser/File/Download.php
+++ b/core/src/Revolution/Processors/Browser/File/Download.php
@@ -47,7 +47,7 @@ class Download extends Browser
         @session_write_close();
         try {
             if ($data = $this->source->getObjectContents($file)) {
-                $name = preg_replace('#[^\w-.]#ui', '_', $data['basename']);
+                $name = preg_replace('#[^\w\-.]#ui', '_', $data['basename']);
                 header('Content-type: ' . $data['mime']);
                 header('Content-Length: ' . $data['size']);
                 header('Content-Disposition: attachment; filename=' . $name);


### PR DESCRIPTION
### What does it do?
Fixed incorrect regular expression for a downloaded file.

### Why is it needed?
When trying to download a file an error occurs 
```
[2021-03-07 13:38:00] (ERROR @ ...\core\src\Revolution\Processors\Browser\File\Download.php : 50) PHP warning: preg_replace(): Compilation failed: invalid range in character class at offset 4
```

### How to test
Open the media manager and try to download any file. Then open the log error.

