### PR TITLE
Implement isDirty function in MODx.panel.ImageTV

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
@@ -56,7 +56,18 @@ MODx.panel.ImageTV = function(config) {
     MODx.panel.ImageTV.superclass.constructor.call(this,config);
     this.addEvents({select: true});
 };
-Ext.extend(MODx.panel.ImageTV,MODx.Panel);
+Ext.extend(MODx.panel.ImageTV,MODx.Panel, {
+    isDirty: function() {
+        if (this.disabled || !this.rendered) {
+            return false;
+        }
+
+        var inputField = this.find('name', 'tv' + this.config.tv);
+        if (!inputField || !inputField[0]) return false;
+
+        return inputField[0].isDirty();
+    }
+});
 Ext.reg('modx-panel-tv-image',MODx.panel.ImageTV);
 
 /**

--- a/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.renders.js
@@ -128,7 +128,18 @@ MODx.panel.FileTV = function(config) {
     MODx.panel.FileTV.superclass.constructor.call(this,config);
     this.addEvents({select: true});
 };
-Ext.extend(MODx.panel.FileTV,MODx.Panel);
+Ext.extend(MODx.panel.FileTV,MODx.Panel, {
+    isDirty: function() {
+        if (this.disabled || !this.rendered) {
+            return false;
+        }
+
+        var inputField = this.find('name', 'tv' + this.config.tv);
+        if (!inputField || !inputField[0]) return false;
+
+        return inputField[0].isDirty();
+    }
+});
 Ext.reg('modx-panel-tv-file',MODx.panel.FileTV);
 
 MODx.checkTV = function(id) {


### PR DESCRIPTION
### What does it do?
Implements isDirty function in MODx.panel.ImageTV and for MODx.panel.FileTV

### Why is it needed?
Close button doesn't work on Resource, if you have image tv assigned to it.

### How to test
Add image TV to a template, edit resource using this template, hit close button. It will show an error in console about missing `isDirty` function.

### Related issue(s)/PR(s)
#15299
