### PR TITLE
Replace 'modPlugin' with modPlugin::class in elementClassKey checks

### DIFF
--- a/core/src/Revolution/Processors/Element/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/GetNodes.php
@@ -456,7 +456,7 @@ class GetNodes extends Processor
             if ($element->get('locked')) {
                 $class[] = 'element-node-locked';
             }
-            if ($elementClassKey === 'modPlugin' && $element->get('disabled')) {
+            if ($elementClassKey === modPlugin::class && $element->get('disabled')) {
                 $class[] = 'element-node-disabled';
             }
 
@@ -543,7 +543,7 @@ class GetNodes extends Processor
             if ($element->get('locked')) {
                 $class[] = 'element-node-locked';
             }
-            if ($elementClassKey == 'modPlugin' && $element->get('disabled')) {
+            if ($elementClassKey == modPlugin::class && $element->get('disabled')) {
                 $class[] = 'element-node-disabled';
             }
 


### PR DESCRIPTION
### What does it do?
Replace 'modPlugin' with modPlugin::class in elementClassKey checks

### Why is it needed?
'modPlugin' is not a thing anymore

### How to test
Create & disable plugin in a category. Disabled style won't apply.

### Related issue(s)/PR(s)
Resolves #15503
