### PR TITLE
Update editorconfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,29 +7,11 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-tab_width = 4
+indent_size = 4
 max_line_length = off
 
 [**.scss]
-tab_width = 2
-
-[**.js]
-tab_width = 4
-
-[**.coffee]
-tab_width = 4
-
-[**.cson]
-tab_width = 4
-
-[**.json]
-tab_width = 4
-
-[**rc]
-tab_width = 4
-
-[**php]
-tab_width = 4
+indent_size = 2
 
 [*.md]
 max_line_length = off


### PR DESCRIPTION
### What does it do?
Update editorconfig

### Why is it needed?

`tab_width = 4` - it is specified in the general rules, and you do not need to specify it for each format.
`tab_width` - changed to `indent_size` since no tabs are used in `indent_style`

### Related issue(s)/PR(s)
NA
