### PR TITLE
Declare modX as final and so it cannot be extended

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -39,7 +39,7 @@ use xPDO\Om\xPDOObject;
  *
  * @package modx
  */
-class modX extends xPDO {
+final class modX extends xPDO {
     /**
      * The parameter for when a session state is not able to be accessed
      * @const SESSION_STATE_UNAVAILABLE


### PR DESCRIPTION
### What does it do?
Mark modX as final 

### Why is it needed?
It prevents extending the modX class. 

With this PR I want to re-open the discussion that started in PR #14574 and gather community input.

### Related issue(s)/PR(s)
PR #14574
