### PR TITLE
Improved check to see if the key "url" exists in media source $properties array. This fixes the preview thumbnail issue.

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1496,7 +1496,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         }
 
         $properties = $this->getPropertyList();
-        if (array_key_exists('url',$properties)) {
+        if (isset($properties['url'])) {
             $src = $properties['url'] . DIRECTORY_SEPARATOR . ltrim($src, DIRECTORY_SEPARATOR);
         }
 

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1496,7 +1496,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         }
 
         $properties = $this->getPropertyList();
-        if ($properties['url']) {
+        if (array_key_exists('url',$properties)) {
             $src = $properties['url'] . DIRECTORY_SEPARATOR . ltrim($src, DIRECTORY_SEPARATOR);
         }
 


### PR DESCRIPTION

### What does it do?
Improves the check to see if the key `url` exists in the media source properties array when attempting to build a preview thumbnail.

### Why is it needed?
It fixes the problem in issue #15502 where .png and .jpg images had broken preview thumbnails in the tree and the media browser.

### How to test
Hover over an image file in the file tree or look at the thumbs in the media browser. You'll see they are no longer broken.

### Related issue(s)/PR(s)
issue #15502 
