### PR TITLE
Remove unnecessary type="text/javascript"

### DIFF
--- a/_build/docs/themes/modx/chrome.xsl
+++ b/_build/docs/themes/modx/chrome.xsl
@@ -30,11 +30,11 @@
         <link rel="stylesheet" href="{$root}css/black-tie/jquery-ui-1.8.2.custom.css" type="text/css" />
         <link rel="stylesheet" href="{$root}css/jquery.treeview.css" type="text/css" />
         <link rel="stylesheet" href="{$root}css/theme.css" type="text/css" />
-        <script type="text/javascript" src="{$root}js/jquery-1.4.2.min.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery.cookie.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery.treeview.js"></script>
-        <script type="text/javascript" src="{$root}js/tree.js"></script>
+        <script src="{$root}js/jquery-1.4.2.min.js"></script>
+        <script src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
+        <script src="{$root}js/jquery.cookie.js"></script>
+        <script src="{$root}js/jquery.treeview.js"></script>
+        <script src="{$root}js/tree.js"></script>
       </head>
       <body>
 

--- a/_build/docs/themes/modx/frames_table.xsl
+++ b/_build/docs/themes/modx/frames_table.xsl
@@ -13,8 +13,8 @@
         <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
         <link rel="stylesheet" href="{$root}css/black-tie/jquery-ui-1.8.2.custom.css" type="text/css" />
         <link rel="stylesheet" href="{$root}css/theme.css" type="text/css" />
-        <script type="text/javascript" src="{$root}js/jquery-1.4.2.min.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
+        <script src="{$root}js/jquery-1.4.2.min.js"></script>
+        <script src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
       </head>
       <body class="chrome">
         <table id="page">
@@ -37,7 +37,7 @@
           <tr>
             <td id="sidebar">
               <xsl:call-template name="search" />
-                <script type="text/javascript">
+                <script>
                     $(function() {
                         $("#sidebar-content").resizable({
                             helper: "ui-resizable-helper",

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -754,7 +754,7 @@ goes here'
         $this->tag->set('name','utp:jsToBottom=`'.($plainText ? 1 : 0).'`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script type="text/javascript" src="'.$value.'"></script>';
+            $value = '<script src="'.$value.'"></script>';
         }
         $this->assertContains($value,$this->modx->jscripts);
         unset($this->modx->jscripts[$value]);
@@ -765,7 +765,7 @@ goes here'
     public function providerJsToBottom() {
         return [
             ['assets/js/script.js',true,false],
-            ['<script type="text/javascript" src="assets/js/script2.js"></script>',false,false],
+            ['<script src="assets/js/script2.js"></script>',false,false],
             ['assets/js/script3.js',false,true],
         ];
     }
@@ -783,7 +783,7 @@ goes here'
         $this->tag->set('name','utp:jsToHead=`'.($plainText ? 1 : 0).'`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script type="text/javascript" src="'.$value.'"></script>';
+            $value = '<script src="'.$value.'"></script>';
         }
         $this->assertContains($value,$this->modx->sjscripts);
         unset($this->modx->sjscripts[$value]);
@@ -794,7 +794,7 @@ goes here'
     public function providerJsToHead() {
         return [
             ['assets/js/hscript.js',true,false],
-            ['<script type="text/javascript" src="assets/js/hscript2.js"></script>',false,false],
+            ['<script src="assets/js/hscript2.js"></script>',false,false],
             ['assets/js/hscript3.js',false,true],
         ];
     }

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -168,7 +168,7 @@ abstract class modManagerController
         $this->setCssURLPlaceholders();
         /* help url */
         $helpUrl = $this->getHelpUrl();
-        $this->addHtml('<script type="text/javascript">MODx.helpUrl = "' . ($helpUrl) . '"</script>');
+        $this->addHtml('<script>MODx.helpUrl = "' . ($helpUrl) . '"</script>');
 
         $this->modx->invokeEvent('OnManagerPageBeforeRender', ['controller' => &$this]);
 
@@ -627,7 +627,7 @@ abstract class modManagerController
             $o = '';
             // Add script tags for the required javascript
             foreach ($externals as $js) {
-                $o .= '<script type="text/javascript" src="' . $js . '"></script>' . "\n";
+                $o .= '<script src="' . $js . '"></script>' . "\n";
             }
 
             // Get the state and user token for adding to the init script
@@ -645,7 +645,7 @@ abstract class modManagerController
                 ];
                 $layout = 'MODx.load(' . json_encode($data) . ');';
             }
-            $o .= '<script type="text/javascript">Ext.onReady(function() {' . $state . $layout . '});</script>';
+            $o .= '<script>Ext.onReady(function() {' . $state . $layout . '});</script>';
             $this->modx->smarty->assign('maincssjs', $o);
         }
     }
@@ -752,7 +752,7 @@ abstract class modManagerController
         $cssjs = [];
         if (!empty($jsToCompress)) {
             foreach ($jsToCompress as $scr) {
-                $cssjs[] = '<script src="' . $scr . '" type="text/javascript"></script>';
+                $cssjs[] = '<script src="' . $scr . '"></script>';
             }
         }
 
@@ -782,7 +782,7 @@ abstract class modManagerController
         }
         if (!empty($lastjs)) {
             foreach ($lastjs as $scr) {
-                $cssjs[] = '<script src="' . $scr . '" type="text/javascript"></script>';
+                $cssjs[] = '<script src="' . $scr . '"></script>';
             }
         }
 
@@ -960,7 +960,7 @@ abstract class modManagerController
             }
         }
         if (!empty($rules)) {
-            $this->ruleOutput[] = '<script type="text/javascript">Ext.onReady(function() {' . implode("\n",
+            $this->ruleOutput[] = '<script>Ext.onReady(function() {' . implode("\n",
                     $rules) . '});</script>';
         }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1573,7 +1573,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1596,7 +1596,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
         }
     }
 

--- a/manager/controllers/default/browser/index.class.php
+++ b/manager/controllers/default/browser/index.class.php
@@ -36,7 +36,7 @@ class BrowserManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         /* invoke OnRichTextBrowserInit */
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 MODx.siteId = "'.$this->modx->user->getUserToken($this->modx->context->get('key')).'";
 MODx.ctx = "'.$this->ctx.'";
 </script>');

--- a/manager/controllers/default/element/chunk/create.class.php
+++ b/manager/controllers/default/element/chunk/create.class.php
@@ -42,7 +42,7 @@ class ElementChunkCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/chunk/create.js');
 
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -46,7 +46,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.grid.element.properties.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.chunk.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/chunk/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/plugin/create.class.php
+++ b/manager/controllers/default/element/plugin/create.class.php
@@ -43,7 +43,7 @@ class ElementPluginCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.plugin.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/plugin/create.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -51,7 +51,7 @@ class ElementPluginUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.plugin.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/plugin/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/snippet/create.class.php
+++ b/manager/controllers/default/element/snippet/create.class.php
@@ -42,7 +42,7 @@ class ElementSnippetCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.snippet.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/snippet/create.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onSnipFormRender = "'.$this->onSnipFormRender.'";
         Ext.onReady(function() {

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -50,7 +50,7 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.snippet.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/snippet/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onSnipFormRender = "'.$this->onSnipFormRender.'";
         Ext.onReady(function() {

--- a/manager/controllers/default/element/template/create.class.php
+++ b/manager/controllers/default/element/template/create.class.php
@@ -43,7 +43,7 @@ class ElementTemplateCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.template.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/template/create.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onTempFormRender = "'.$this->onTempFormRender.'";
         Ext.onReady(function() {

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -51,7 +51,7 @@ class ElementTemplateUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.template.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/template/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/tv/create.class.php
+++ b/manager/controllers/default/element/tv/create.class.php
@@ -47,7 +47,7 @@ class ElementTVCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.tv.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/tv/create.js');
         $this->addHtml('
-<script type="text/javascript">
+<script>
 // <![CDATA[
 MODx.onTVFormRender = "'.$this->onTVFormRender.'";
 Ext.onReady(function() {

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -55,7 +55,7 @@ class ElementTVUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.tv.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/tv/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onTVFormRender = "'.$this->onTVFormRender.'";
         Ext.onReady(function() {

--- a/manager/controllers/default/media/browser.class.php
+++ b/manager/controllers/default/media/browser.class.php
@@ -32,7 +32,7 @@ class MediaBrowserManagerController extends modManagerController
     {
         $this->addHtml(
 <<<HTML
-<script type="text/javascript">
+<script>
 // <![CDATA[
     Ext.onReady(function() {
         Ext.getCmp('modx-layout').hideLeftbar(true, false);

--- a/manager/controllers/default/resource/trash.class.php
+++ b/manager/controllers/default/resource/trash.class.php
@@ -25,7 +25,7 @@ class ResourceTrashManagerController extends modManagerController
         $this->addJavascript($mgrUrl . 'assets/modext/widgets/resource/modx.grid.trash.js');
         $this->addJavascript($mgrUrl . 'assets/modext/widgets/resource/modx.panel.trash.js');
         $this->addJavascript($mgrUrl . 'assets/modext/sections/resource/trash/index.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() { MODx.add("modx-page-trash"); });</script>');
+        $this->addHtml('<script>Ext.onReady(function() { MODx.add("modx-page-trash"); });</script>');
     }
 
     /**

--- a/manager/controllers/default/security/access/policy/template/update.class.php
+++ b/manager/controllers/default/security/access/policy/template/update.class.php
@@ -51,7 +51,7 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.access.policy.template.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/access/policy/template/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/access/policy/update.class.php
+++ b/manager/controllers/default/security/access/policy/update.class.php
@@ -37,7 +37,7 @@ class SecurityAccessPolicyUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.access.policy.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/access/policy/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/forms/profile/update.class.php
+++ b/manager/controllers/default/security/forms/profile/update.class.php
@@ -40,7 +40,7 @@ class SecurityFormsProfileUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.panel.fcprofile.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.grid.fcset.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/fc/profile/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/forms/set/update.class.php
+++ b/manager/controllers/default/security/forms/set/update.class.php
@@ -37,7 +37,7 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.fc.common.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.panel.fcset.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/fc/set/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/profile.class.php
+++ b/manager/controllers/default/security/profile.class.php
@@ -34,7 +34,7 @@ class SecurityProfileManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.recent.resource.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/profile/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/user/create.class.php
+++ b/manager/controllers/default/security/user/create.class.php
@@ -38,7 +38,7 @@ class SecurityUserCreateManagerController extends modManagerController
         $this->addJavascript($mgrUrl.'assets/modext/widgets/core/modx.orm.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.user.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({ xtype: "modx-page-user-create" });

--- a/manager/controllers/default/security/user/update.class.php
+++ b/manager/controllers/default/security/user/update.class.php
@@ -42,7 +42,7 @@ class SecurityUserUpdateManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 MODx.onUserFormRender = "'.$this->onUserFormRender.'";
 MODx.perm.set_sudo = '.($this->modx->hasPermission('set_sudo') ? 1 : 0).';
@@ -56,7 +56,7 @@ MODx.perm.set_sudo = '.($this->modx->hasPermission('set_sudo') ? 1 : 0).';
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.user.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/user/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 Ext.onReady(function() {
     MODx.load({

--- a/manager/controllers/default/security/usergroup/update.class.php
+++ b/manager/controllers/default/security/usergroup/update.class.php
@@ -43,7 +43,7 @@ class SecurityUserGroupUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.group.namespace.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.user.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/usergroup/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-user-group-update"

--- a/manager/controllers/default/source/index.class.php
+++ b/manager/controllers/default/source/index.class.php
@@ -33,7 +33,7 @@ class SourceManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/source/modx.panel.sources.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/source/index.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() { MODx.add("modx-page-sources"); });</script>');
+        $this->addHtml('<script>Ext.onReady(function() { MODx.add("modx-page-sources"); });</script>');
     }
 
     /**

--- a/manager/controllers/default/source/update.class.php
+++ b/manager/controllers/default/source/update.class.php
@@ -47,7 +47,7 @@ class SourceUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/source/modx.grid.source.access.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/source/modx.panel.source.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/source/update.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {MODx.load({
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load({
     xtype: "modx-page-source-update"
     ,record: '.$this->modx->toJSON($this->sourceArray).'
     ,defaultProperties: '.$this->modx->toJSON($this->sourceDefaultProperties).'

--- a/manager/controllers/default/system/dashboards/create.class.php
+++ b/manager/controllers/default/system/dashboards/create.class.php
@@ -44,7 +44,7 @@ class SystemDashboardsCreateManagerController extends modManagerController {
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/modx.panel.dashboard.js");
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/dashboards/create.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
     MODx.add("modx-page-dashboard-create");
 });</script>');
     }

--- a/manager/controllers/default/system/dashboards/index.class.php
+++ b/manager/controllers/default/system/dashboards/index.class.php
@@ -45,7 +45,7 @@ class SystemDashboardsManagerController extends modManagerController {
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/modx.grid.dashboard.widgets.js");
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/modx.panel.dashboards.js");
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/dashboards/list.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         Ext.onReady(function() {
             MODx.add("modx-page-dashboards");
         });

--- a/manager/controllers/default/system/dashboards/update.class.php
+++ b/manager/controllers/default/system/dashboards/update.class.php
@@ -128,7 +128,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
             'xtype' => 'modx-page-dashboard-update',
             'record' => $this->dashboardArray,
         ]);
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function(){MODx.load(' . $data . ')});</script>');
+        $this->addHtml('<script>Ext.onReady(function(){MODx.load(' . $data . ')});</script>');
     }
 
     /**

--- a/manager/controllers/default/system/dashboards/widget/create.class.php
+++ b/manager/controllers/default/system/dashboards/widget/create.class.php
@@ -47,7 +47,7 @@ class SystemDashboardsWidgetCreateManagerController extends modManagerController
         $this->addJavascript($mgrUrl.'assets/modext/widgets/core/modx.orm.js');
         $this->addJavascript($mgrUrl."assets/modext/widgets/system/modx.panel.dashboard.widget.js");
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/dashboards/widget/create.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
     MODx.add("modx-page-dashboard-widget-create");
 });</script>');
     }

--- a/manager/controllers/default/system/dashboards/widget/update.class.php
+++ b/manager/controllers/default/system/dashboards/widget/update.class.php
@@ -111,7 +111,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
             'record' => $this->widgetArray,
         ];
 
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {MODx.load(' . json_encode($data) . ');});</script>');
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . json_encode($data) . ');});</script>');
     }
 
     /**

--- a/manager/controllers/default/system/event.class.php
+++ b/manager/controllers/default/system/event.class.php
@@ -29,7 +29,7 @@ class SystemEventManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.panel.error.log.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/error.log.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         MODx.hasEraseErrorLog = "'.($this->modx->hasPermission('error_log_erase') ? 1 : 0).'"
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/system/file/create.class.php
+++ b/manager/controllers/default/system/file/create.class.php
@@ -63,7 +63,7 @@ class SystemFileCreateManagerController extends modManagerController
             'xtype' => 'modx-page-file-create',
             'record' => $this->fileRecord,
         ]);
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {MODx.load(' . $data . ');});</script>');
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . $data . ');});</script>');
     }
 
 

--- a/manager/controllers/default/system/file/edit.class.php
+++ b/manager/controllers/default/system/file/edit.class.php
@@ -65,7 +65,7 @@ class SystemFileEditManagerController extends modManagerController
             'record' => $this->fileRecord,
             'canSave' => (int)$this->canSave,
         ]);
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {MODx.load(' . $data . ');});</script>');
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . $data . ');});</script>');
     }
 
 

--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -64,7 +64,7 @@ class SystemInfoManagerController extends modManagerController {
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/{$this->modx->getOption('dbtype')}/modx.grid.databasetables.js");
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/resource/modx.grid.resource.active.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/info.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-system-info"

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -31,7 +31,7 @@ class SystemSettingsManagerController extends modManagerController {
      * @return void
      */
     public function loadCustomCssJs() {
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <[!CDATA[
         Ext.onReady(function() {
             MODx.add("modx-page-system-settings");

--- a/manager/controllers/default/welcome.class.php
+++ b/manager/controllers/default/welcome.class.php
@@ -85,10 +85,10 @@ class WelcomeManagerController extends modManagerController
                 ['new_widgets' => $new_widgets]
             )
         ];
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {MODx.load(' . json_encode($obj) . ')});</script>');
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . json_encode($obj) . ')});</script>');
         if ($this->showWelcomeScreen) {
             $url = $this->modx->getOption('welcome_screen_url', null, 'http://misc.modx.com/revolution/welcome.20.html');
-            $this->addHtml('<script type="text/javascript">Ext.onReady(function() { MODx.loadWelcomePanel("' . htmlspecialchars($url) . '"); });</script>');
+            $this->addHtml('<script>Ext.onReady(function() { MODx.loadWelcomePanel("' . htmlspecialchars($url) . '"); });</script>');
         }
     }
 

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.cultureKey}" xml:lang="{$_config.cultureKey}">
+<!doctype html>
+<html {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.cultureKey}" xml:lang="{$_config.cultureKey}">
 <head>
 <title>MODX :: {$_lang.modx_resource_browser}</title>
 <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
@@ -9,15 +9,15 @@
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/index{if $_config.compress_css}-min{/if}.css" />
 
 {if isset($_config.ext_debug) && $_config.ext_debug}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
 {else}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
 {/if}
-<script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}"></script>
 
 {$maincssjs}
 
@@ -30,7 +30,7 @@
 <body>
 
 {literal}
-<script type="text/javascript">
+<script>
 Ext.onReady(function() {
     Ext.QuickTips.init();
     Ext.BLANK_IMAGE_URL = MODx.config.manager_url+'assets/ext3/resources/images/default/s.gif';{/literal}

--- a/manager/templates/default/context/view.tpl
+++ b/manager/templates/default/context/view.tpl
@@ -31,4 +31,4 @@
 
 
 </div>
-<script type="text/javascript" src="assets/modext/sections/context/view.js"></script>
+<script src="assets/modext/sections/context/view.js"></script>

--- a/manager/templates/default/element/tv/renders/input/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/input/autotag.tpl
@@ -6,7 +6,7 @@
 />
 <div id="tv-tags-{$tv->id}"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -44,7 +44,7 @@ Ext.onReady(function() {
 {/foreach}
 </ul>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/checkbox.tpl
+++ b/manager/templates/default/element/tv/renders/input/checkbox.tpl
@@ -1,6 +1,6 @@
 <div id="tv{$tv->id}-cb"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/date.tpl
+++ b/manager/templates/default/element/tv/renders/input/date.tpl
@@ -2,7 +2,7 @@
     value="{$tv->value}" name="tv{$tv->id}"
     onblur="MODx.fireResourceFormChange();"/>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/email.tpl
+++ b/manager/templates/default/element/tv/renders/input/email.tpl
@@ -5,7 +5,7 @@
     tvtype="{$tv->type}"
 />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/file.tpl
+++ b/manager/templates/default/element/tv/renders/input/file.tpl
@@ -1,7 +1,7 @@
 <div id="tvpanel{$tv->id}"></div>
 
 {if $disabled}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -20,7 +20,7 @@ Ext.onReady(function() {
 // ]]>
 </script>
 {else}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/hidden.tpl
+++ b/manager/templates/default/element/tv/renders/input/hidden.tpl
@@ -1,6 +1,6 @@
 <input id="tv{$tv->id}" name="tv{$tv->id}" type="hidden" value="{$tv->get('value')|escape}" />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 MODx.on('ready',function() {

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -5,7 +5,7 @@
 </div>
 
 {if $disabled}
-    <script type="text/javascript">
+    <script>
     // <![CDATA[
     {literal}
     Ext.onReady(function() {
@@ -24,7 +24,7 @@
     // ]]>
     </script>
 {else}
-    <script type="text/javascript">
+    <script>
     // <![CDATA[
     {literal}
     Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/list-multiple-legacy.tpl
+++ b/manager/templates/default/element/tv/renders/input/list-multiple-legacy.tpl
@@ -7,7 +7,7 @@ class="modx-tv-legacy-select">
     {/foreach}
 </select>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
@@ -9,7 +9,7 @@
     {/foreach}
 </select>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/listbox-single.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-single.tpl
@@ -4,7 +4,7 @@
     {/foreach}
 </select>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/number.tpl
+++ b/manager/templates/default/element/tv/renders/input/number.tpl
@@ -5,7 +5,7 @@
     tvtype="{$tv->type}"
 />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/radio.tpl
+++ b/manager/templates/default/element/tv/renders/input/radio.tpl
@@ -1,6 +1,6 @@
 <div id="tv{$tv->id}-cb"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/input/resourcelist.tpl
@@ -4,7 +4,7 @@
 {/foreach}
 </select>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/input/richtext.tpl
@@ -1,6 +1,6 @@
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" class="modx-richtext" {literal}onchange="MODx.fireResourceFormChange();"{/literal}>{$tv->get('value')|escape}</textarea>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/tag.tpl
+++ b/manager/templates/default/element/tv/renders/input/tag.tpl
@@ -6,7 +6,7 @@
 />
 <div id="tv-tags-{$tv->id}"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -43,7 +43,7 @@ Ext.onReady(function() {
 {/foreach}
 </ul>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/input/textarea.tpl
@@ -1,6 +1,6 @@
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" rows="15">{$tv->get('value')|escape}</textarea>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/textbox.tpl
+++ b/manager/templates/default/element/tv/renders/input/textbox.tpl
@@ -5,7 +5,7 @@
     tvtype="{$tv->type}"
 />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/url.tpl
+++ b/manager/templates/default/element/tv/renders/input/url.tpl
@@ -12,7 +12,7 @@
     style="width: 283px;"
 />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 Ext.onReady(function() {
     MODx.makeDroppable(Ext.get('tv{$tv->id}'));

--- a/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/date.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/date.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/email.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/email.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/file.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/file.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/image.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/image.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/number.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/number.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/text.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/text.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}

--- a/manager/templates/default/element/tv/renders/inputproperties/url.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/url.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/date.tpl
+++ b/manager/templates/default/element/tv/renders/properties/date.tpl
@@ -1,7 +1,7 @@
 <div id="modx-tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/delim.tpl
+++ b/manager/templates/default/element/tv/renders/properties/delim.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/htmltag.tpl
+++ b/manager/templates/default/element/tv/renders/properties/htmltag.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/image.tpl
+++ b/manager/templates/default/element/tv/renders/properties/image.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/properties/richtext.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/string.tpl
+++ b/manager/templates/default/element/tv/renders/properties/string.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/url.tpl
+++ b/manager/templates/default/element/tv/renders/properties/url.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" dir="{$_config.manager_direction}" lang="{$_config.cultureKey}" xml:lang="{$_config.cultureKey}">
+<!doctype html>
+<html dir="{$_config.manager_direction}" lang="{$_config.cultureKey}" xml:lang="{$_config.cultureKey}">
 <head>
 <title>{if $_pagetitle}{$_pagetitle|escape} | {/if}{$_config.site_name|strip_tags|escape}</title>
 <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
@@ -12,23 +12,23 @@
 <link rel="stylesheet" type="text/css" href="{$indexCss}?v={$versionToken}" />
 
 {if isset($_config.ext_debug) && $_config.ext_debug}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
 {else}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
 {/if}
-<script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/lib/popper.min.js" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
+<script src="{$_config.manager_url}assets/lib/popper.min.js"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}"></script>
 
 {$maincssjs}
 {foreach from=$cssjs item=scr}
 {$scr}
 {/foreach}
 
-<script type="text/javascript">
+<script>
     MODx.config.search_enabled = {$_search};
 </script>
 </head>

--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -25,7 +25,7 @@
             {$tv->get('formElement')}
         </div>
     </div>
-    <script type="text/javascript">{literal}Ext.onReady(function() { new Ext.ToolTip({{/literal}target: 'tv{$tv->id}-caption',html: '[[*{$tv->name}]]'{literal}});});{/literal}</script>
+    <script>{literal}Ext.onReady(function() { new Ext.ToolTip({{/literal}target: 'tv{$tv->id}-caption',html: '[[*{$tv->name}]]'{literal}});});{/literal}</script>
 {else}
     <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
     {$tv->get('formElement')}
@@ -39,7 +39,7 @@
 {/foreach}
 </div>
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 Ext.onReady(function() {
     MODx.resetTV = function(id) {

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -192,6 +192,6 @@
         </div>
         <div class="l-background" style="background-image:url({$background})"></div>
 
-        <script src="{$_config.manager_url}assets/modext/sections/login.js" type="text/javascript"></script>
+        <script src="{$_config.manager_url}assets/modext/sections/login.js"></script>
     </body>
 </html>

--- a/manager/templates/default/security/logout.tpl
+++ b/manager/templates/default/security/logout.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.cultureKey}" xml:lang="{$_config.cultureKey}">
+<!doctype html>
+<html {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.cultureKey}" xml:lang="{$_config.cultureKey}">
 <head>
     <title>MODx :: {$_lang.permission_denied}</title>
     <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
@@ -10,26 +10,26 @@
 
 
     {if isset($_config.ext_debug) && $_config.ext_debug}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
     {else}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
     {/if}
-    <script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
-    <script src="{$_config.connectors_url}lang.js.php?topic=login" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/core/modx.form.handler.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/core/modx.component.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/util/utilities.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/util/spotlight.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.panel.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.msg.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.window.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/sections/login.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
+    <script src="{$_config.connectors_url}lang.js.php?topic=login"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.form.handler.js"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.component.js"></script>
+    <script src="{$_config.manager_url}assets/modext/util/utilities.js"></script>
+    <script src="{$_config.manager_url}assets/modext/util/spotlight.js"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.panel.js"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.msg.js"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.window.js"></script>
+    <script src="{$_config.manager_url}assets/modext/sections/login.js"></script>
 
     <meta name="robots" content="noindex, nofollow" />
     {literal}<style>body, html { background: #fafafa !important; }</style>{/literal}
-	<script type="text/javascript">
+	<script>
 	var SITE_NAME = '{$_config.site_name|strip_tags|escape}';
 	var CONNECTORS_URL = '{$_config.connectors_url}';
 	</script>

--- a/setup/templates/contexts.tpl
+++ b/setup/templates/contexts.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="assets/js/sections/contexts.js"></script>
-<script type="text/javascript">
+<script src="assets/js/sections/contexts.js"></script>
+<script>
 Ext.onReady(function() {literal}{{/literal}
     MODx.context_web_path = "{$context_web_path}";
     MODx.context_web_url = "{$context_web_url}";

--- a/setup/templates/database.tpl
+++ b/setup/templates/database.tpl
@@ -1,9 +1,9 @@
 {if $showHidden|default}
-<script type="text/javascript">
+<script>
     MODx.showHidden = true;
 </script>
 {/if}
-<script type="text/javascript" src="assets/js/sections/database.js"></script>
+<script src="assets/js/sections/database.js"></script>
 <form id="install" action="?action=database" method="post">
 
     <h2 class="title">{$_lang.connection_connection_and_login_information}</h2>

--- a/setup/templates/findcore.php
+++ b/setup/templates/findcore.php
@@ -45,8 +45,8 @@ if ($posted) {
     <link rel="stylesheet" href="assets/css/print.css" type="text/css" media="print" />
 
     <link href="assets/css/style.css" type="text/css" rel="stylesheet" />
-    <script type="text/javascript" src="assets/js/ext-core.js"></script>
-    <script type="text/javascript" src="assets/js/modx.setup.js"></script>
+    <script src="assets/js/ext-core.js"></script>
+    <script src="assets/js/modx.setup.js"></script>
 </head>
 
 <body>

--- a/setup/templates/index.tpl
+++ b/setup/templates/index.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!doctype html>
+<html lang="en">
 
 <head>
   <title><?php echo $moduleName; ?> &raquo; Install</title>

--- a/setup/templates/summary.tpl
+++ b/setup/templates/summary.tpl
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="assets/js/sections/summary.js"></script>
+<script src="assets/js/sections/summary.js"></script>
 <form id="install" action="?action=summary" method="post">
     <h2>{$_lang.install_summary}</h2>
     {if $failed}


### PR DESCRIPTION
### What does it do?
Remove an obsolete `type="text/javascript" `attribute from script tags.

### Why is it needed?

HTML5 no longer requires an explicit type statement.

``` html
<!-- HTML4 -->
<script type="text/javascript" src="javascript.js"></script>

<!-- HTML5 -->
<script src="javascript.js"></script>
```

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13846 https://github.com/modxcms/revolution/pull/13850 https://github.com/modxcms/revolution/pull/13847
