### PR TITLE
Create a system setting mail_smtp_autotls

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -971,6 +971,15 @@ $settings['mail_smtp_prefix']->fromArray(array (
   'area' => 'mail',
   'editedon' => null,
 ), '', true, true);
+$settings['mail_smtp_autotls']= $xpdo->newObject('modSystemSetting');
+$settings['mail_smtp_autotls']->fromArray(array (
+  'key' => 'mail_smtp_autotls',
+  'value' => true,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'mail',
+  'editedon' => null,
+), '', true, true);
 $settings['mail_smtp_single_to']= $xpdo->newObject('modSystemSetting');
 $settings['mail_smtp_single_to']->fromArray(array (
   'key' => 'mail_smtp_single_to',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -417,6 +417,9 @@ $_lang['setting_mail_smtp_port_desc'] = 'Sets the default SMTP server port.';
 $_lang['setting_mail_smtp_prefix'] = 'SMTP Connection Prefix';
 $_lang['setting_mail_smtp_prefix_desc'] = 'Sets connection prefix. Options are "", "ssl" or "tls"';
 
+$_lang['setting_mail_smtp_autotls'] = 'SMTP Auto TLS';
+$_lang['setting_mail_smtp_autotls_desc'] = 'Whether to enable TLS encryption automatically if a server supports it, even if "SMTP Encryption" is not set to "tls"';
+
 $_lang['setting_mail_smtp_single_to'] = 'SMTP Single To';
 $_lang['setting_mail_smtp_single_to_desc'] = 'Provides the ability to have the TO field process individual emails, instead of sending to entire TO addresses.';
 

--- a/core/model/modx/mail/modmail.class.php
+++ b/core/model/modx/mail/modmail.class.php
@@ -109,6 +109,10 @@ abstract class modMail {
      */
     const MAIL_SMTP_PREFIX = 'mail_smtp_prefix';
     /**
+     * @const An option for setting the mail SMTP AutoTLS option
+     */
+    const MAIL_SMTP_AUTOTLS = 'mail_smtp_autotls';
+    /**
      * @const An option for setting the mail SMTP Single-To option
      */
     const MAIL_SMTP_SINGLE_TO = 'mail_smtp_single_to';
@@ -217,7 +221,7 @@ abstract class modMail {
      *
      * @param array $attributes An optional array of default attributes to override with
      * @return array An array of default attributes
-     */
+     */ 
     public function getDefaultAttributes(array $attributes = array()) {
         $default = array();
         if ($this->modx->getOption('mail_use_smtp',false)) {
@@ -230,6 +234,7 @@ abstract class modMail {
             $default[modMail::MAIL_SMTP_PASS] = $this->modx->getOption('mail_smtp_pass',null,'');
             $default[modMail::MAIL_SMTP_PORT] = $this->modx->getOption('mail_smtp_port',null,25);
             $default[modMail::MAIL_SMTP_PREFIX] = $this->modx->getOption('mail_smtp_prefix',null,'');
+            $default[modMail::MAIL_SMTP_AUTOTLS] = $this->modx->getOption('mail_smtp_autotls',null,true);
             $default[modMail::MAIL_SMTP_SINGLE_TO] = $this->modx->getOption('mail_smtp_single_to',null,false);
             $default[modMail::MAIL_SMTP_TIMEOUT] = $this->modx->getOption('mail_smtp_timeout',null,10);
             $default[modMail::MAIL_SMTP_USER] = $this->modx->getOption('mail_smtp_user',null,'');

--- a/core/model/modx/mail/modphpmailer.class.php
+++ b/core/model/modx/mail/modphpmailer.class.php
@@ -106,6 +106,9 @@ class modPHPMailer extends modMail {
             case modMail::MAIL_SMTP_PREFIX :
                 $this->mailer->SMTPSecure= $this->attributes[$key];
                 break;
+            case modMail::MAIL_SMTP_AUTOTLS :
+                $this->mailer->SMTPAutoTLS= $this->attributes[$key];
+                break;
             case modMail::MAIL_SMTP_SINGLE_TO :
                 $this->mailer->SingleTo= $this->attributes[$key];
                 break;


### PR DESCRIPTION
### What does it do?
Create a system setting mail_smtp_autotls

### Why is it needed?
Allow the user to disable the use of TLS, even if the server communication seems to allow this. It changes the value of the PHPMailer 6 SMTPAutoTLS, which currently defaults to true.

### How to test
Set it to false, mail_smtp_prefix to '', mail_smtp_port to 25 and use the QuickEmail debug output to see the CLIENT <-> SERVER communication.

### Related issue(s)/PR(s)
#12762
