### PR TITLE
Add possibility to translate message about site unavailability

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1598,7 +1598,7 @@ $settings['site_status']->fromArray([
 $settings['site_unavailable_message']= $xpdo->newObject(modSystemSetting::class);
 $settings['site_unavailable_message']->fromArray([
   'key' => 'site_unavailable_message',
-  'value' => 'The site is currently unavailable',
+  'value' => '[[%site_unavailable_message]]',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'site',

--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -450,6 +450,7 @@ $_lang['show_preview'] = 'Show Preview Window';
 $_lang['show_tree'] = 'Show tree';
 $_lang['showing_pub'] = 'Showing Publish Dates';
 $_lang['showing_unpub'] = 'Showing Unpublish Dates';
+$_lang['site_unavailable_message'] = 'The site is currently unavailable';
 $_lang['snippet'] = 'Snippet';
 $_lang['snippets'] = 'Snippets';
 $_lang['sort_asc'] = 'Ascending';

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1061,7 +1061,7 @@
 
     <object class="modTemplate" table="site_templates" extends="MODX\Revolution\modElement">
         <field key="templatename" dbtype="varchar" precision="50" phptype="string" null="false" default="" index="unique" />
-        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="Template" />
+        <field key="description" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
         <field key="editor_type" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="category" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="fk" />
         <field key="icon" dbtype="varchar" precision="191" phptype="string" null="false" default="" />

--- a/core/model/schema/modx.sqlsrv.schema.xml
+++ b/core/model/schema/modx.sqlsrv.schema.xml
@@ -1007,7 +1007,7 @@
 
     <object class="modTemplate" table="site_templates" extends="MODX\Revolution\modElement">
         <field key="templatename" dbtype="nvarchar" precision="50" phptype="string" null="false" default="" index="unique" />
-        <field key="description" dbtype="nvarchar" precision="255" phptype="string" null="false" default="Template" />
+        <field key="description" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" />
         <field key="editor_type" dbtype="int" phptype="integer" null="false" default="0" />
         <field key="category" dbtype="int" phptype="integer" null="false" default="0" index="fk" />
         <field key="icon" dbtype="nvarchar" precision="255" phptype="string" null="false" default="" />

--- a/core/src/Revolution/mysql/modTemplate.php
+++ b/core/src/Revolution/mysql/modTemplate.php
@@ -16,7 +16,7 @@ class modTemplate extends \MODX\Revolution\modTemplate
         'fields' => 
         array (
             'templatename' => '',
-            'description' => 'Template',
+            'description' => '',
             'editor_type' => 0,
             'category' => 0,
             'icon' => '',
@@ -44,7 +44,7 @@ class modTemplate extends \MODX\Revolution\modTemplate
                 'precision' => '191',
                 'phptype' => 'string',
                 'null' => false,
-                'default' => 'Template',
+                'default' => '',
             ),
             'editor_type' => 
             array (

--- a/core/src/Revolution/sqlsrv/modTemplate.php
+++ b/core/src/Revolution/sqlsrv/modTemplate.php
@@ -12,7 +12,7 @@ class modTemplate extends \MODX\Revolution\modTemplate
         'fields' => 
         array (
             'templatename' => '',
-            'description' => 'Template',
+            'description' => '',
             'editor_type' => 0,
             'category' => 0,
             'icon' => '',
@@ -40,7 +40,7 @@ class modTemplate extends \MODX\Revolution\modTemplate
                 'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
-                'default' => 'Template',
+                'default' => '',
             ),
             'editor_type' => 
             array (


### PR DESCRIPTION
### What does it do?
Corrected untranslated lines:
- Removed untranslated description from Base Template
The Base Template description says "Template", but it is not useful.
- Added lexicon for `site_unavailable_message` setting
The lexicon will be replaced with the correct string depending on the `cultureKey` setting.

We can also display other settings through lexicons, for example, `phpthumb_nohotlink_text_message`, but these are technical messages and translation is not particularly needed.

### Why is it needed?
For unification in translation

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/6092