### PR TITLE
Adjust PR template to encourage using right format to connect issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,4 @@ Describe the issue you are solving.
 Describe how to test the changes you made.
 
 ### Related issue(s)/PR(s)
-Let us know if this is related to any issue/pull request (see https://github.com/blog/1506-closing-issues-via-pull-requests)
+Provide any issue that's addressed by this change in the format "Resolves #<issue number>", and mention other issues/pull requests with relevant information. 


### PR DESCRIPTION
### What does it do?

Adjusts template for new PRs to suggest "Resolves #foo" format of issues.

### Why is it needed?

Allows issues to be correctly linked, which doesn't work if people only provide the number. https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

### How to test
N/a

### Related issue(s)/PR(s)
Resolves _absolutely nothing_ (but touches on conversation in governance/integrators about the project board)

(Yes I created a branch on the official repo again for a quick edit made via the GitHub UI because my fork was out of date so I couldn't easily do it a better way.)