### PR TITLE
Create a system setting mail_smtp_autotls

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -874,6 +874,15 @@ $settings['mail_smtp_single_to']->fromArray([
   'area' => 'mail',
   'editedon' => null,
 ], '', true, true);
+$settings['mail_smtp_autotls']= $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_autotls']->fromArray([
+    'key' => 'mail_smtp_autotls',
+    'value' => true,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'mail',
+    'editedon' => null,
+], '', true, true);
 $settings['mail_smtp_timeout']= $xpdo->newObject(modSystemSetting::class);
 $settings['mail_smtp_timeout']->fromArray([
   'key' => 'mail_smtp_timeout',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -384,6 +384,9 @@ $_lang['setting_mail_smtp_port_desc'] = 'Sets the default SMTP server port.';
 $_lang['setting_mail_smtp_prefix'] = 'SMTP Connection Prefix';
 $_lang['setting_mail_smtp_prefix_desc'] = 'Sets connection prefix. Options are "", "ssl" or "tls"';
 
+$_lang['setting_mail_smtp_autotls'] = 'SMTP Auto TLS';
+$_lang['setting_mail_smtp_autotls_desc'] = 'Whether to enable TLS encryption automatically if a server supports it, even if "SMTP Encryption" is not set to "tls"';
+
 $_lang['setting_mail_smtp_single_to'] = 'SMTP Single To';
 $_lang['setting_mail_smtp_single_to_desc'] = 'Provides the ability to have the TO field process individual emails, instead of sending to entire TO addresses.';
 

--- a/core/src/Revolution/Mail/modMail.php
+++ b/core/src/Revolution/Mail/modMail.php
@@ -116,6 +116,10 @@ abstract class modMail
      */
     const MAIL_SMTP_PREFIX = 'mail_smtp_prefix';
     /**
+     * @const An option for setting the mail SMTP AutoTLS option
+     */
+    const MAIL_SMTP_AUTOTLS = 'mail_smtp_autotls';
+    /**
      * @const An option for setting the mail SMTP Single-To option
      */
     const MAIL_SMTP_SINGLE_TO = 'mail_smtp_single_to';
@@ -250,6 +254,7 @@ abstract class modMail
             $default[modMail::MAIL_SMTP_PASS] = $this->modx->getOption('mail_smtp_pass', null, '');
             $default[modMail::MAIL_SMTP_PORT] = $this->modx->getOption('mail_smtp_port', null, 25);
             $default[modMail::MAIL_SMTP_PREFIX] = $this->modx->getOption('mail_smtp_prefix', null, '');
+            $default[modMail::MAIL_SMTP_AUTOTLS] = $this->modx->getOption('mail_smtp_autotls',null,true);
             $default[modMail::MAIL_SMTP_SINGLE_TO] = $this->modx->getOption('mail_smtp_single_to', null, false);
             $default[modMail::MAIL_SMTP_TIMEOUT] = $this->modx->getOption('mail_smtp_timeout', null, 10);
             $default[modMail::MAIL_SMTP_USER] = $this->modx->getOption('mail_smtp_user', null, '');

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -113,6 +113,9 @@ class modPHPMailer extends modMail
             case modMail::MAIL_SMTP_PREFIX :
                 $this->mailer->SMTPSecure = $this->attributes[$key];
                 break;
+            case modMail::MAIL_SMTP_AUTOTLS :
+                $this->mailer->SMTPAutoTLS= $this->attributes[$key];
+                break;
             case modMail::MAIL_SMTP_SINGLE_TO :
                 $this->mailer->SingleTo = $this->attributes[$key];
                 break;


### PR DESCRIPTION
### What does it do?

Create a system setting `mail_smtp_autotls`

### Why is it needed?

Allow the user to disable the use of TLS, even if the server communication seems to allow this. It changes the value of the PHPMailer 6 SMTPAutoTLS, which currently defaults to true.

### How to test

See https://github.com/modxcms/revolution/pull/15536

### Related issue(s)/PR(s)

https://github.com/modxcms/revolution/pull/15536