### PR TITLE
Set controller property in controller's config

### DIFF
--- a/core/src/Revolution/modManagerResponse.php
+++ b/core/src/Revolution/modManagerResponse.php
@@ -102,6 +102,7 @@ class modManagerResponse extends modResponse
                 'namespace' => $this->namespace,
                 'namespace_path' => $this->namespacePath,
                 'action' => $this->route,
+                'controller' => $this->route,
             ]);
             $controller->setProperties(array_merge($_GET,$_POST));
             $controller->initialize();


### PR DESCRIPTION
### What does it do?
Sets `controller` property in a config passed to the controller's class constructor. This property is checked in FC rules and was empty (unset). There might be other places where this property is used.

### Why is it needed?
FC rules don't work

### How to test
#15544

### Related issue(s)/PR(s)
Resolves #15544
