### PR TITLE
Remove unnecessary type="text/javascript"

### DIFF
--- a/_build/docs/themes/modx/chrome.xsl
+++ b/_build/docs/themes/modx/chrome.xsl
@@ -30,11 +30,11 @@
         <link rel="stylesheet" href="{$root}css/black-tie/jquery-ui-1.8.2.custom.css" type="text/css" />
         <link rel="stylesheet" href="{$root}css/jquery.treeview.css" type="text/css" />
         <link rel="stylesheet" href="{$root}css/theme.css" type="text/css" />
-        <script type="text/javascript" src="{$root}js/jquery-1.4.2.min.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery.cookie.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery.treeview.js"></script>
-        <script type="text/javascript" src="{$root}js/tree.js"></script>
+        <script src="{$root}js/jquery-1.4.2.min.js"></script>
+        <script src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
+        <script src="{$root}js/jquery.cookie.js"></script>
+        <script src="{$root}js/jquery.treeview.js"></script>
+        <script src="{$root}js/tree.js"></script>
       </head>
       <body>
 

--- a/_build/docs/themes/modx/frames_table.xsl
+++ b/_build/docs/themes/modx/frames_table.xsl
@@ -13,8 +13,8 @@
         <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
         <link rel="stylesheet" href="{$root}css/black-tie/jquery-ui-1.8.2.custom.css" type="text/css" />
         <link rel="stylesheet" href="{$root}css/theme.css" type="text/css" />
-        <script type="text/javascript" src="{$root}js/jquery-1.4.2.min.js"></script>
-        <script type="text/javascript" src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
+        <script src="{$root}js/jquery-1.4.2.min.js"></script>
+        <script src="{$root}js/jquery-ui-1.8.2.custom.min.js"></script>
       </head>
       <body class="chrome">
         <table id="page">
@@ -37,7 +37,7 @@
           <tr>
             <td id="sidebar">
               <xsl:call-template name="search" />
-                <script type="text/javascript">
+                <script>
                     $(function() {
                         $("#sidebar-content").resizable({
                             helper: "ui-resizable-helper",

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -734,7 +734,7 @@ goes here'),
         $this->tag->set('name','utp:jsToBottom=`'.($plainText ? 1 : 0).'`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script type="text/javascript" src="'.$value.'"></script>';
+            $value = '<script src="'.$value.'"></script>';
         }
         $this->assertContains($value,$this->modx->jscripts);
         unset($this->modx->jscripts[$value]);
@@ -745,7 +745,7 @@ goes here'),
     public function providerJsToBottom() {
         return array(
             array('assets/js/script.js',true,false),
-            array('<script type="text/javascript" src="assets/js/script2.js"></script>',false,false),
+            array('<script src="assets/js/script2.js"></script>',false,false),
             array('assets/js/script3.js',false,true),
         );
     }
@@ -763,7 +763,7 @@ goes here'),
         $this->tag->set('name','utp:jsToHead=`'.($plainText ? 1 : 0).'`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script type="text/javascript" src="'.$value.'"></script>';
+            $value = '<script src="'.$value.'"></script>';
         }
         $this->assertContains($value,$this->modx->sjscripts);
         unset($this->modx->sjscripts[$value]);
@@ -774,7 +774,7 @@ goes here'),
     public function providerJsToHead() {
         return array(
             array('assets/js/hscript.js',true,false),
-            array('<script type="text/javascript" src="assets/js/hscript2.js"></script>',false,false),
+            array('<script src="assets/js/hscript2.js"></script>',false,false),
             array('assets/js/hscript3.js',false,true),
         );
     }

--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -148,7 +148,7 @@ abstract class modManagerController {
         $this->setCssURLPlaceholders();
         /* help url */
         $helpUrl = $this->getHelpUrl();
-        $this->addHtml('<script type="text/javascript">MODx.helpUrl = "'.($helpUrl).'"</script>');
+        $this->addHtml('<script>MODx.helpUrl = "'.($helpUrl).'"</script>');
 
         $this->modx->invokeEvent('OnManagerPageBeforeRender',array('controller' => &$this));
 
@@ -555,7 +555,7 @@ abstract class modManagerController {
             $o = '';
             // Add script tags for the required javascript
             foreach ($externals as $js) {
-                $o .= '<script type="text/javascript" src="'.$js.'"></script>'."\n";
+                $o .= '<script src="'.$js.'"></script>'."\n";
             }
 
             // Get the state and user token for adding to the init script
@@ -571,7 +571,7 @@ abstract class modManagerController {
                 $layout = 'MODx.load({xtype: "modx-layout",accordionPanels: MODx.accordionPanels || [],auth: "'.$siteId.'"});';
             }
             $o .= <<<HTML
-<script type="text/javascript">
+<script>
 Ext.onReady(function() {
     {$state}
     {$layout}
@@ -674,7 +674,7 @@ HTML;
         $cssjs = array();
         if (!empty($jsToCompress)) {
             foreach ($jsToCompress as $scr) {
-                $cssjs[] = '<script src="'.$scr.'" type="text/javascript"></script>';
+                $cssjs[] = '<script src="'.$scr.'"></script>';
             }
         }
 
@@ -704,7 +704,7 @@ HTML;
         }
         if (!empty($lastjs)) {
             foreach ($lastjs as $scr) {
-                $cssjs[] = '<script src="'.$scr.'" type="text/javascript"></script>';
+                $cssjs[] = '<script src="'.$scr.'"></script>';
             }
         }
 
@@ -858,7 +858,7 @@ HTML;
             if (!empty($r)) $rules[] = $r;
         }
         if (!empty($rules)) {
-            $this->ruleOutput[] = '<script type="text/javascript">Ext.onReady(function() {'.implode("\n",$rules).'});</script>';
+            $this->ruleOutput[] = '<script>Ext.onReady(function() {'.implode("\n",$rules).'});</script>';
         }
         return $overridden;
     }

--- a/core/model/modx/modmanagercontrollerdeprecated.class.php
+++ b/core/model/modx/modmanagercontrollerdeprecated.class.php
@@ -215,7 +215,7 @@ class modManagerControllerDeprecated extends modManagerController {
 
                 $path = str_replace(array(
                     $this->modx->getOption('manager_url').'assets/modext/',
-                    '<script type="text/javascript" src="',
+                    '<script src="',
                     '"></script>',
                 ),'',$newUrl);
 

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1544,7 +1544,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1567,7 +1567,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script type="text/javascript" src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
         }
     }
 

--- a/core/model/smarty/plugins/function.mailto.php
+++ b/core/model/smarty/plugins/function.mailto.php
@@ -101,7 +101,7 @@ function smarty_function_mailto($params)
         for ($x = 0, $_length = strlen($string); $x < $_length; $x++) {
             $js_encode .= '%' . bin2hex($string[ $x ]);
         }
-        return '<script type="text/javascript">eval(unescape(\'' . $js_encode . '\'))</script>';
+        return '<script>eval(unescape(\'' . $js_encode . '\'))</script>';
     } elseif ($encode === 'javascript_charcode') {
         $string = '<a href="mailto:' . $address . '" ' . $extra . '>' . $text . '</a>';
         for ($x = 0, $y = strlen($string); $x < $y; $x++) {

--- a/manager/controllers/default/browser/index.class.php
+++ b/manager/controllers/default/browser/index.class.php
@@ -34,7 +34,7 @@ class BrowserManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         /* invoke OnRichTextBrowserInit */
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 MODx.siteId = "'.$this->modx->user->getUserToken($this->modx->context->get('key')).'";
 MODx.ctx = "'.$this->ctx.'";
 </script>');

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -28,7 +28,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface {
 
     $this->controller->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/security/modx.grid.user.online.js');
     $this->controller->addHtml('
-    <script type="text/javascript">
+    <script>
       Ext.applyIf(MODx.lang, '. $this->modx->toJSON($this->modx->lexicon->loadCache('core', 'dashboard')) .');
       Ext.onReady(function() {
         MODx.load({

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -17,7 +17,7 @@
 class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterface {
     public function render() {
         $this->controller->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/security/modx.grid.user.recent.resource.js');
-        $this->controller->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->controller->addHtml('<script>Ext.onReady(function() {
     MODx.load({
         xtype: "modx-grid-user-recent-resource"
         ,user: "'.$this->modx->user->get('id').'"

--- a/manager/controllers/default/element/chunk/create.class.php
+++ b/manager/controllers/default/element/chunk/create.class.php
@@ -38,7 +38,7 @@ class ElementChunkCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/chunk/create.js');
 
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -42,7 +42,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.grid.element.properties.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.chunk.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/chunk/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/plugin/create.class.php
+++ b/manager/controllers/default/element/plugin/create.class.php
@@ -39,7 +39,7 @@ class ElementPluginCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.plugin.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/plugin/create.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -46,7 +46,7 @@ class ElementPluginUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.plugin.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/plugin/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/snippet/create.class.php
+++ b/manager/controllers/default/element/snippet/create.class.php
@@ -38,7 +38,7 @@ class ElementSnippetCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.snippet.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/snippet/create.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onSnipFormRender = "'.$this->onSnipFormRender.'";
         MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -45,7 +45,7 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.snippet.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/snippet/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onSnipFormRender = "'.$this->onSnipFormRender.'";
         MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';

--- a/manager/controllers/default/element/template/create.class.php
+++ b/manager/controllers/default/element/template/create.class.php
@@ -39,7 +39,7 @@ class ElementTemplateCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.template.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/template/create.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onTempFormRender = "'.$this->onTempFormRender.'";
         MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -46,7 +46,7 @@ class ElementTemplateUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.template.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/template/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/element/tv/create.class.php
+++ b/manager/controllers/default/element/tv/create.class.php
@@ -41,7 +41,7 @@ class ElementTVCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.tv.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/tv/create.js');
         $this->addHtml('
-<script type="text/javascript">
+<script>
 // <![CDATA[
 MODx.onTVFormRender = "'.$this->onTVFormRender.'";
 MODx.perm.unlock_element_properties = "'.($this->modx->hasPermission('unlock_element_properties') ? 1 : 0).'";

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -47,7 +47,7 @@ class ElementTVUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/element/modx.panel.tv.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/element/tv/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.onTVFormRender = "'.$this->onTVFormRender.'";
         MODx.perm.tree_show_element_ids = '.($this->modx->hasPermission('tree_show_element_ids') ? 1 : 0).';

--- a/manager/controllers/default/media/browser.class.php
+++ b/manager/controllers/default/media/browser.class.php
@@ -33,7 +33,7 @@ class MediaBrowserManagerController extends modManagerController
 
         $this->addHtml(
 <<<HTML
-<script type="text/javascript">
+<script>
 // <![CDATA[
     Ext.onReady(function() {
         Ext.getCmp('modx-layout').hideLeftbar(true, false);

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -37,7 +37,7 @@ class ResourceCreateManagerController extends ResourceManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/create.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.config.publish_document = "'.$this->canPublish.'";
         MODx.onDocFormRender = "'.$this->onDocFormRender.'";

--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -39,7 +39,7 @@ class ResourceDataManagerController extends ResourceManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.data.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/data.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.ctx = "'.$this->resource->get('context_key').'";

--- a/manager/controllers/default/resource/staticresource/create.class.php
+++ b/manager/controllers/default/resource/staticresource/create.class.php
@@ -21,7 +21,7 @@ class StaticResourceCreateManagerController extends ResourceCreateManagerControl
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.static.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/create.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/static/create.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 MODx.config.publish_document = "'.$this->canPublish.'";
 MODx.onDocFormRender = "'.$this->onDocFormRender.'";
@@ -41,7 +41,7 @@ Ext.onReady(function() {
         /* load RTE */
         $this->loadRichTextEditor();
     }
-    
+
     /**
      * Return the location of the template file
      * @return string

--- a/manager/controllers/default/resource/staticresource/update.class.php
+++ b/manager/controllers/default/resource/staticresource/update.class.php
@@ -21,7 +21,7 @@ class StaticResourceUpdateManagerController extends ResourceUpdateManagerControl
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.static.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/update.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/static/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 MODx.config.publish_document = "'.$this->canPublish.'";
 MODx.onDocFormRender = "'.$this->onDocFormRender.'";

--- a/manager/controllers/default/resource/symlink/create.class.php
+++ b/manager/controllers/default/resource/symlink/create.class.php
@@ -21,7 +21,7 @@ class SymLinkCreateManagerController extends ResourceCreateManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.symlink.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/create.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/symlink/create.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 MODx.config.publish_document = "'.$this->canPublish.'";
 MODx.onDocFormRender = "'.$this->onDocFormRender.'";

--- a/manager/controllers/default/resource/symlink/update.class.php
+++ b/manager/controllers/default/resource/symlink/update.class.php
@@ -22,7 +22,7 @@ class SymlinkUpdateManagerController extends ResourceUpdateManagerController {
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/update.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/symlink/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.config.publish_document = "'.$this->canPublish.'";
         MODx.onDocFormRender = "'.$this->onDocFormRender.'";

--- a/manager/controllers/default/resource/trash.class.php
+++ b/manager/controllers/default/resource/trash.class.php
@@ -23,7 +23,7 @@ class ResourceTrashManagerController extends modManagerController
         $this->addJavascript($mgrUrl . 'assets/modext/widgets/resource/modx.grid.trash.js');
         $this->addJavascript($mgrUrl . 'assets/modext/widgets/resource/modx.panel.trash.js');
         $this->addJavascript($mgrUrl . 'assets/modext/sections/resource/trash/index.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() { MODx.add("modx-page-trash"); });</script>');
+        $this->addHtml('<script>Ext.onReady(function() { MODx.add("modx-page-trash"); });</script>');
     }
 
     /**

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -37,7 +37,7 @@ class ResourceUpdateManagerController extends ResourceManagerController {
         $this->addJavascript($managerUrl.'assets/modext/widgets/resource/modx.panel.resource.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.config.publish_document = "'.$this->canPublish.'";
         MODx.onDocFormRender = "'.$this->onDocFormRender.'";

--- a/manager/controllers/default/resource/weblink/create.class.php
+++ b/manager/controllers/default/resource/weblink/create.class.php
@@ -21,7 +21,7 @@ class WebLinkCreateManagerController extends ResourceCreateManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/resource/modx.panel.resource.weblink.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/create.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/resource/weblink/create.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 MODx.config.publish_document = "'.$this->canPublish.'";
 MODx.onDocFormRender = "'.$this->onDocFormRender.'";

--- a/manager/controllers/default/resource/weblink/update.class.php
+++ b/manager/controllers/default/resource/weblink/update.class.php
@@ -22,7 +22,7 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController {
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/update.js');
         $this->addJavascript($managerUrl.'assets/modext/sections/resource/weblink/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         MODx.config.publish_document = "'.$this->canPublish.'";
         MODx.onDocFormRender = "'.$this->onDocFormRender.'";

--- a/manager/controllers/default/security/access/policy/template/update.class.php
+++ b/manager/controllers/default/security/access/policy/template/update.class.php
@@ -47,7 +47,7 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.access.policy.template.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/access/policy/template/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/access/policy/update.class.php
+++ b/manager/controllers/default/security/access/policy/update.class.php
@@ -34,7 +34,7 @@ class SecurityAccessPolicyUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.access.policy.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/access/policy/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/forms/profile/update.class.php
+++ b/manager/controllers/default/security/forms/profile/update.class.php
@@ -35,7 +35,7 @@ class SecurityFormsProfileUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.panel.fcprofile.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.grid.fcset.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/fc/profile/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/forms/set/update.class.php
+++ b/manager/controllers/default/security/forms/set/update.class.php
@@ -33,7 +33,7 @@ class SecurityFormsSetUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.fc.common.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/fc/modx.panel.fcset.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/fc/set/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/permission.class.php
+++ b/manager/controllers/default/security/permission.class.php
@@ -45,7 +45,7 @@ class SecurityPermissionManagerController extends modManagerController {
         $canAddUserGroup = $this->modx->hasPermission('usergroup_new') ? 1 : 0;
         $canEditUserGroup = $this->modx->hasPermission('usergroup_edit') ? 1 : 0;
         $canDeleteUserGroup = $this->modx->hasPermission('usergroup_delete') ? 1 : 0;
-        $this->addHtml('<script type="text/javascript">'
+        $this->addHtml('<script>'
                 .'MODx.perm.usergroup_view = '.$canListUserGroups.';'
                 .'MODx.perm.view_role = '.$canListRoles.';'
                 .'MODx.perm.policy_view = '.$canListPolicies.';'

--- a/manager/controllers/default/security/profile.class.php
+++ b/manager/controllers/default/security/profile.class.php
@@ -32,7 +32,7 @@ class SecurityProfileManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.recent.resource.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/profile/update.js');
         $this->addHtml('
-        <script type="text/javascript">
+        <script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/security/user/create.class.php
+++ b/manager/controllers/default/security/user/create.class.php
@@ -33,7 +33,7 @@ class SecurityUserCreateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/core/modx.orm.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.user.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <![CDATA[
         Ext.onReady(function() {
             MODx.load({ xtype: "modx-page-user-create" });

--- a/manager/controllers/default/security/user/update.class.php
+++ b/manager/controllers/default/security/user/update.class.php
@@ -38,7 +38,7 @@ class SecurityUserUpdateManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 MODx.onUserFormRender = "'.$this->onUserFormRender.'";
 MODx.perm.set_sudo = '.($this->modx->hasPermission('set_sudo') ? 1 : 0).';
@@ -52,7 +52,7 @@ MODx.perm.set_sudo = '.($this->modx->hasPermission('set_sudo') ? 1 : 0).';
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.grid.user.group.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/security/modx.panel.user.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/user/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 // <![CDATA[
 Ext.onReady(function() {
     MODx.load({

--- a/manager/controllers/default/security/usergroup/update.class.php
+++ b/manager/controllers/default/security/usergroup/update.class.php
@@ -42,7 +42,7 @@ class SecurityUserGroupUpdateManagerController extends modManagerController {
         $canEditUsers = $this->modx->hasPermission('usergroup_user_edit') ? 1 : 0;
         $canListUsers = $this->modx->hasPermission('usergroup_user_list') ? 1 : 0;
         $this->addJavascript($mgrUrl.'assets/modext/sections/security/usergroup/update.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         MODx.perm.usergroup_user_edit = '.$canEditUsers.';
         MODx.perm.usergroup_user_list = '.$canListUsers.';
         Ext.onReady(function() {

--- a/manager/controllers/default/source/index.class.php
+++ b/manager/controllers/default/source/index.class.php
@@ -31,7 +31,7 @@ class SourceManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/source/modx.panel.sources.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/source/index.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() { MODx.add("modx-page-sources"); });</script>');
+        $this->addHtml('<script>Ext.onReady(function() { MODx.add("modx-page-sources"); });</script>');
     }
 
     /**

--- a/manager/controllers/default/source/update.class.php
+++ b/manager/controllers/default/source/update.class.php
@@ -40,7 +40,7 @@ class SourceUpdateManagerController extends modManagerController {
         $this->addJavascript($mgrUrl.'assets/modext/widgets/source/modx.grid.source.access.js');
         $this->addJavascript($mgrUrl.'assets/modext/widgets/source/modx.panel.source.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/source/update.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {MODx.load({
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load({
     xtype: "modx-page-source-update"
     ,record: '.$this->modx->toJSON($this->sourceArray).'
     ,defaultProperties: '.$this->modx->toJSON($this->sourceDefaultProperties).'

--- a/manager/controllers/default/system/dashboards/create.class.php
+++ b/manager/controllers/default/system/dashboards/create.class.php
@@ -42,7 +42,7 @@ class SystemDashboardsCreateManagerController extends modManagerController {
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/modx.panel.dashboard.js");
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/dashboards/create.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
     MODx.add("modx-page-dashboard-create");
 });</script>');
     }

--- a/manager/controllers/default/system/dashboards/index.class.php
+++ b/manager/controllers/default/system/dashboards/index.class.php
@@ -43,7 +43,7 @@ class SystemDashboardsManagerController extends modManagerController {
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/modx.grid.dashboard.widgets.js");
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/modx.panel.dashboards.js");
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/dashboards/list.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         Ext.onReady(function() {
             MODx.add("modx-page-dashboards");
         });

--- a/manager/controllers/default/system/dashboards/update.class.php
+++ b/manager/controllers/default/system/dashboards/update.class.php
@@ -111,7 +111,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/modx.panel.dashboard.js");
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/dashboards/update.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
     MODx.load({
         xtype: "modx-page-dashboard-update"
         ,record: '.$this->modx->toJSON($this->dashboardArray).'

--- a/manager/controllers/default/system/dashboards/widget/create.class.php
+++ b/manager/controllers/default/system/dashboards/widget/create.class.php
@@ -44,7 +44,7 @@ class SystemDashboardsWidgetCreateManagerController extends modManagerController
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl."assets/modext/widgets/system/modx.panel.dashboard.widget.js");
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/dashboards/widget/create.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
     MODx.add("modx-page-dashboard-widget-create");
 });</script>');
     }

--- a/manager/controllers/default/system/dashboards/widget/update.class.php
+++ b/manager/controllers/default/system/dashboards/widget/update.class.php
@@ -91,7 +91,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl."assets/modext/widgets/system/modx.panel.dashboard.widget.js");
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/dashboards/widget/update.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
     MODx.load({
         xtype: "modx-page-dashboard-widget-update"
         ,record: '.$this->modx->toJSON($this->widgetArray).'

--- a/manager/controllers/default/system/event.class.php
+++ b/manager/controllers/default/system/event.class.php
@@ -26,7 +26,7 @@ class SystemEventManagerController extends modManagerController {
         $mgrUrl = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
         $this->addJavascript($mgrUrl.'assets/modext/widgets/system/modx.panel.error.log.js');
         $this->addJavascript($mgrUrl.'assets/modext/sections/system/error.log.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         MODx.hasEraseErrorLog = "'.($this->modx->hasPermission('error_log_erase') ? 1 : 0).'"
         Ext.onReady(function() {
             MODx.load({

--- a/manager/controllers/default/system/file/create.class.php
+++ b/manager/controllers/default/system/file/create.class.php
@@ -42,7 +42,7 @@ class SystemFileCreateManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/file/create.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-file-create"
                 ,record: {

--- a/manager/controllers/default/system/file/edit.class.php
+++ b/manager/controllers/default/system/file/edit.class.php
@@ -36,7 +36,7 @@ class SystemFileEditManagerController extends modManagerController {
      */
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/file/edit.js');
-        $this->addHtml('<script type="text/javascript">Ext.onReady(function() {
+        $this->addHtml('<script>Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-file-edit"
                 ,file: "'.$this->filename.'"

--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -63,7 +63,7 @@ class SystemInfoManagerController extends modManagerController {
         $this->addJavascript($this->modx->getOption('manager_url')."assets/modext/widgets/system/{$this->modx->getOption('dbtype')}/modx.grid.databasetables.js");
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/resource/modx.grid.resource.active.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/info.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         Ext.onReady(function() {
             MODx.load({
                 xtype: "modx-page-system-info"

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -29,7 +29,7 @@ class SystemSettingsManagerController extends modManagerController {
      * @return void
      */
     public function loadCustomCssJs() {
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
         // <[!CDATA[
         Ext.onReady(function() {
             MODx.add("modx-page-system-settings");

--- a/manager/controllers/default/welcome.class.php
+++ b/manager/controllers/default/welcome.class.php
@@ -42,7 +42,7 @@
     public function loadCustomCssJs() {
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/modx.panel.welcome.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/welcome.js');
-        $this->addHtml('<script type="text/javascript">
+        $this->addHtml('<script>
 Ext.onReady(function() {
     MODx.load({
         xtype: "modx-page-welcome"
@@ -52,7 +52,7 @@ Ext.onReady(function() {
 </script>');
         if ($this->showWelcomeScreen) {
             $url = $this->modx->getOption('welcome_screen_url',null,'http://misc.modx.com/revolution/welcome.20.html');
-            $this->addHtml('<script type="text/javascript">
+            $this->addHtml('<script>
 // <![CDATA[
 Ext.onReady(function() { MODx.loadWelcomePanel("'.$url.'"); });
 // ]]></script>');

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
+<!doctype html>
+<html {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
 <title>MODX :: {$_lang.modx_resource_browser}</title>
 <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
@@ -9,15 +9,15 @@
 <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/index{if $_config.compress_css}-min{/if}.css" />
 
 {if isset($_config.ext_debug) && $_config.ext_debug}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
 {else}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
 {/if}
-<script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}"></script>
 
 {$maincssjs}
 
@@ -30,7 +30,7 @@
 <body>
 
 {literal}
-<script type="text/javascript">
+<script>
 Ext.onReady(function() {
     Ext.QuickTips.init();
     Ext.BLANK_IMAGE_URL = MODx.config.manager_url+'assets/ext3/resources/images/default/s.gif';{/literal}

--- a/manager/templates/default/context/view.tpl
+++ b/manager/templates/default/context/view.tpl
@@ -31,4 +31,4 @@
 
 
 </div>
-<script type="text/javascript" src="assets/modext/sections/context/view.js"></script>
+<script src="assets/modext/sections/context/view.js"></script>

--- a/manager/templates/default/element/tv/renders/input/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/input/autotag.tpl
@@ -6,7 +6,7 @@
 />
 <div id="tv-tags-{$tv->id}"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -44,7 +44,7 @@ Ext.onReady(function() {
 {/foreach}
 </ul>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/checkbox.tpl
+++ b/manager/templates/default/element/tv/renders/input/checkbox.tpl
@@ -1,6 +1,6 @@
 <div id="tv{$tv->id}-cb"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/date.tpl
+++ b/manager/templates/default/element/tv/renders/input/date.tpl
@@ -2,7 +2,7 @@
     value="{$tv->value}" name="tv{$tv->id}"
     onblur="MODx.fireResourceFormChange();"/>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/email.tpl
+++ b/manager/templates/default/element/tv/renders/input/email.tpl
@@ -5,7 +5,7 @@
     tvtype="{$tv->type}"
 />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/file.tpl
+++ b/manager/templates/default/element/tv/renders/input/file.tpl
@@ -1,7 +1,7 @@
 <div id="tvpanel{$tv->id}"></div>
 
 {if $disabled}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -20,7 +20,7 @@ Ext.onReady(function() {
 // ]]>
 </script>
 {else}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/hidden.tpl
+++ b/manager/templates/default/element/tv/renders/input/hidden.tpl
@@ -1,6 +1,6 @@
 <input id="tv{$tv->id}" name="tv{$tv->id}" type="hidden" value="{$tv->get('value')|escape}" />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 MODx.on('ready',function() {

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -3,7 +3,7 @@
     {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}" alt="" />{/if}
 </div>
 {if $disabled}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -22,7 +22,7 @@ Ext.onReady(function() {
 // ]]>
 </script>
 {else}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/list-multiple-legacy.tpl
+++ b/manager/templates/default/element/tv/renders/input/list-multiple-legacy.tpl
@@ -4,7 +4,7 @@
 {/foreach}
 </select>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-multiple.tpl
@@ -11,7 +11,7 @@
 
 
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/listbox-single.tpl
+++ b/manager/templates/default/element/tv/renders/input/listbox-single.tpl
@@ -5,7 +5,7 @@
 </select>
 
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/number.tpl
+++ b/manager/templates/default/element/tv/renders/input/number.tpl
@@ -5,7 +5,7 @@
 	tvtype="{$tv->type}"
 />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -16,7 +16,7 @@ Ext.onReady(function() {
         ,width: 400
         ,enableKeyEvents: true
         ,autoStripChars: true
-        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if} 
+        ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
         ,allowDecimals: {if $params.allowDecimals|default && $params.allowDecimals|default != 'false' && $params.allowDecimals|default != 'No'}true{else}false{/if}
         ,allowNegative: {if $params.allowNegative|default && $params.allowNegative|default != 'false' && $params.allowNegative|default != 'No'}true{else}false{/if}
         ,decimalPrecision: {if $params.decimalPrecision|default >= 0}{$params.decimalPrecision|default|string_format:"%d"}{else}2{/if}

--- a/manager/templates/default/element/tv/renders/input/radio.tpl
+++ b/manager/templates/default/element/tv/renders/input/radio.tpl
@@ -1,6 +1,6 @@
 <div id="tv{$tv->id}-cb"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/input/resourcelist.tpl
@@ -5,7 +5,7 @@
 </select>
 
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/input/richtext.tpl
@@ -1,6 +1,6 @@
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" class="modx-richtext" {literal}onchange="MODx.fireResourceFormChange();"{/literal}>{$tv->get('value')|escape}</textarea>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/tag.tpl
+++ b/manager/templates/default/element/tv/renders/input/tag.tpl
@@ -6,7 +6,7 @@
 />
 <div id="tv-tags-{$tv->id}"></div>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {
@@ -43,7 +43,7 @@ Ext.onReady(function() {
 {/foreach}
 </ul>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/input/textarea.tpl
@@ -1,6 +1,6 @@
 <textarea id="tv{$tv->id}" name="tv{$tv->id}" rows="15">{$tv->get('value')|escape}</textarea>
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/textbox.tpl
+++ b/manager/templates/default/element/tv/renders/input/textbox.tpl
@@ -5,7 +5,7 @@
     tvtype="{$tv->type}"
 />
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/input/url.tpl
+++ b/manager/templates/default/element/tv/renders/input/url.tpl
@@ -10,7 +10,7 @@
     class="textfield x-form-text x-form-field"
     style="width: 283px;"
 />
-<script type="text/javascript">
+<script>
 // <![CDATA[
 {literal}
 Ext.onReady(function() {

--- a/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/autotag.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/checkbox.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/date.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/date.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/email.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/email.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/file.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/file.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/image.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/image.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/list-multiple-legacy.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox-multiple.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/listbox.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/number.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/number.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/radio.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/richtext.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/tag.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/text.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/text.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/textarea.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/inputproperties/url.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/url.tpl
@@ -1,7 +1,7 @@
 <div id="tv-input-properties-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/date.tpl
+++ b/manager/templates/default/element/tv/renders/properties/date.tpl
@@ -1,7 +1,7 @@
 <div id="modx-tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/delim.tpl
+++ b/manager/templates/default/element/tv/renders/properties/delim.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/htmltag.tpl
+++ b/manager/templates/default/element/tv/renders/properties/htmltag.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/image.tpl
+++ b/manager/templates/default/element/tv/renders/properties/image.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/richtext.tpl
+++ b/manager/templates/default/element/tv/renders/properties/richtext.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/string.tpl
+++ b/manager/templates/default/element/tv/renders/properties/string.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/element/tv/renders/properties/url.tpl
+++ b/manager/templates/default/element/tv/renders/properties/url.tpl
@@ -1,7 +1,7 @@
 <div id="tv-wprops-form{$tv|default}"></div>
 {literal}
 
-<script type="text/javascript">
+<script>
 // <![CDATA[
 var params = {
 {/literal}{foreach from=$params key=k item=v name='p'}

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -11,22 +11,22 @@
 <link rel="stylesheet" type="text/css" href="{$indexCss}?v={$versionToken}" />
 
 {if isset($_config.ext_debug) && $_config.ext_debug}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
 {else}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
 {/if}
-<script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,trash,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}" type="text/javascript"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}" type="text/javascript"></script>
+<script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,trash,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}"></script>
 
 {$maincssjs}
 {foreach from=$cssjs item=scr}
 {$scr}
 {/foreach}
 
-<script type="text/javascript">
+<script>
     Ext.onReady(function() {
         // Enable site name tooltip (on overflow only)
         if( Ext.get('site_name').dom.scrollWidth > Ext.get('site_name').dom.clientWidth ){

--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -25,7 +25,7 @@
             {$tv->get('formElement')}
         </div>
     </div>
-    <script type="text/javascript">{literal}Ext.onReady(function() { new Ext.ToolTip({{/literal}target: 'tv{$tv->id}-caption',html: '[[*{$tv->name}]]'{literal}});});{/literal}</script>
+    <script>{literal}Ext.onReady(function() { new Ext.ToolTip({{/literal}target: 'tv{$tv->id}-caption',html: '[[*{$tv->name}]]'{literal}});});{/literal}</script>
 {else}
     <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
     {$tv->get('formElement')}
@@ -39,7 +39,7 @@
 {/foreach}
 </div>
 {literal}
-<script type="text/javascript">
+<script>
 // <![CDATA[
 Ext.onReady(function() {
     MODx.resetTV = function(id) {

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
+<!doctype html>
+<html {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
     <title>{$_lang.login_title} | {$_config.site_name|strip_tags|escape}</title>
     <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
@@ -11,19 +11,19 @@
     <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/login{if $_config.compress_css}-min{/if}.css" />
 
 {if isset($_config.ext_debug) && $_config.ext_debug}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
 {else}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
 {/if}
-    <script src="assets/modext/core/modx.js" type="text/javascript"></script>
+    <script src="assets/modext/core/modx.js"></script>
 
-    <script src="assets/modext/core/modx.component.js" type="text/javascript"></script>
-    <script src="assets/modext/util/utilities.js" type="text/javascript"></script>
-    <script src="assets/modext/widgets/core/modx.panel.js" type="text/javascript"></script>
-    <script src="assets/modext/widgets/core/modx.window.js" type="text/javascript"></script>
-    <script src="assets/modext/sections/login.js" type="text/javascript"></script>
+    <script src="assets/modext/core/modx.component.js"></script>
+    <script src="assets/modext/util/utilities.js"></script>
+    <script src="assets/modext/widgets/core/modx.panel.js"></script>
+    <script src="assets/modext/widgets/core/modx.window.js"></script>
+    <script src="assets/modext/sections/login.js"></script>
 
     <meta name="robots" content="noindex, nofollow" />
 </head>

--- a/manager/templates/default/security/logout.tpl
+++ b/manager/templates/default/security/logout.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
+<!doctype html>
+<html {if $_config.manager_direction EQ 'rtl'}dir="rtl"{/if} lang="{$_config.manager_lang_attribute}" xml:lang="{$_config.manager_lang_attribute}">
 <head>
     <title>MODx :: {$_lang.permission_denied}</title>
     <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
@@ -10,26 +10,26 @@
 
 
     {if isset($_config.ext_debug) && $_config.ext_debug}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
     {else}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
     {/if}
-    <script src="{$_config.manager_url}assets/modext/core/modx.js" type="text/javascript"></script>
-    <script src="{$_config.connectors_url}lang.js.php?topic=login" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/core/modx.form.handler.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/core/modx.component.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/util/utilities.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/util/spotlight.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.panel.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.msg.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.window.js" type="text/javascript"></script>
-    <script src="{$_config.manager_url}assets/modext/sections/login.js" type="text/javascript"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
+    <script src="{$_config.connectors_url}lang.js.php?topic=login"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.form.handler.js"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.component.js"></script>
+    <script src="{$_config.manager_url}assets/modext/util/utilities.js"></script>
+    <script src="{$_config.manager_url}assets/modext/util/spotlight.js"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.panel.js"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.msg.js"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.window.js"></script>
+    <script src="{$_config.manager_url}assets/modext/sections/login.js"></script>
 
     <meta name="robots" content="noindex, nofollow" />
     {literal}<style>body, html { background: #fafafa !important; }</style>{/literal}
-	<script type="text/javascript">
+	<script>
 	var SITE_NAME = '{$_config.site_name|strip_tags|escape}';
 	var CONNECTORS_URL = '{$_config.connectors_url}';
 	</script>

--- a/setup/assets/js/inc/iepngfix.htc
+++ b/setup/assets/js/inc/iepngfix.htc
@@ -1,7 +1,7 @@
 <public:component>
 <public:attach event="onpropertychange" onevent="doFix()" />
 
-<script type="text/javascript">
+<script>
 
 // IE5.5+ PNG Alpha Fix v1.0RC4
 // (c) 2004-2005 Angus Turnbull http://www.twinhelix.com

--- a/setup/templates/contexts.tpl
+++ b/setup/templates/contexts.tpl
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="assets/js/sections/contexts.js"></script>
-<script type="text/javascript">
+<script src="assets/js/sections/contexts.js"></script>
+<script>
 Ext.onReady(function() {literal}{{/literal}
     MODx.context_web_path = "{$context_web_path}";
     MODx.context_web_url = "{$context_web_url}";
@@ -22,7 +22,7 @@ Ext.onReady(function() {literal}{{/literal}
 	<input type="checkbox" id="context_web_path_toggle" name="context_web_path_toggle" value="1" {$context_web_path_checked|default} style="width: 30px;" />
 </div>
 <div class="labelHolder">
-	<label for="context_web_url">{$_lang.context_web_url}:</label>	
+	<label for="context_web_url">{$_lang.context_web_url}:</label>
 	<input type="text" id="context_web_url" name="context_web_url" value="{$context_web_url}" style="width:350px" />
 	<input type="checkbox" id="context_web_url_toggle" name="context_web_url_toggle" value="1" {$context_web_url_checked|default} style="width:30px" onclick="if (!this.checked) Ext.get('context_web_url').set({literal}{{/literal} value: '{$context_web_url}' {literal}}{/literal});" />
 </div>
@@ -33,12 +33,12 @@ Ext.onReady(function() {literal}{{/literal}
 <p><small>{$_lang.context_override}</small></p>
 
 <div class="labelHolder">
-	<label for="context_connectors_path">{$_lang.context_connector_path}:</label>	
+	<label for="context_connectors_path">{$_lang.context_connector_path}:</label>
 	<input type="text" id="context_connectors_path" name="context_connectors_path" value="{$context_connectors_path}" style="width:350px" onchange="$('context_connectors_path_toggle').checked=true;" />
 	<input type="checkbox" id="context_connectors_path_toggle" name="context_connectors_path_toggle" value="1" {$context_connectors_path_checked|default} style="width:30px" onclick="if (!this.checked) $('context_connectors_path').value = '{$context_connectors_path}';" />
 </div>
 <div class="labelHolder">
-	<label for="context_connectors_url">{$_lang.context_connector_url}:</label>	
+	<label for="context_connectors_url">{$_lang.context_connector_url}:</label>
 	<input type="text" id="context_connectors_url" name="context_connectors_url" value="{$context_connectors_url}" style="width:350px" onchange="$('context_connectors_url_toggle').checked=true;" />
 	<input type="checkbox" id="context_connectors_url_toggle" name="context_connectors_url_toggle" value="1" {$context_connectors_url_checked|default} style="width:30px" onclick="if (!this.checked) $('context_connectors_url').value = '{$context_connectors_url}';" />
 </div>
@@ -49,12 +49,12 @@ Ext.onReady(function() {literal}{{/literal}
 <p><small>{$_lang.context_override}</small></p>
 
 <div class="labelHolder">
-	<label for="context_mgr_path">{$_lang.context_manager_path}:</label>	
+	<label for="context_mgr_path">{$_lang.context_manager_path}:</label>
 	<input type="text" id="context_mgr_path" name="context_mgr_path" value="{$context_mgr_path}" style="width:350px" onchange="$('context_mgr_path_toggle').checked=true;" />
 	<input type="checkbox" id="context_mgr_path_toggle" name="context_mgr_path_toggle" value="1" {$context_mgr_path_checked|default} style="width:30px;" onclick="if (!this.checked) $('context_mgr_path').value = '{$context_mgr_path}';" />
 </div>
 <div class="labelHolder">
-	<label for="context_mgr_url">{$_lang.context_manager_url}:</label>	
+	<label for="context_mgr_url">{$_lang.context_manager_url}:</label>
 	<input type="text" id="context_mgr_url" name="context_mgr_url" value="{$context_mgr_url}" style="width:350px" onchange="$('context_mgr_url_toggle').checked=true;" />
 	<input type="checkbox" id="context_mgr_url_toggle" name="context_mgr_url_toggle" value="1" {$context_mgr_url_checked|default} style="width:30px;" onclick="if (!this.checked) $('context_mgr_url').value = '{$context_mgr_url}';" />
 </div>

--- a/setup/templates/database.tpl
+++ b/setup/templates/database.tpl
@@ -1,7 +1,7 @@
 {if $showHidden|default}
-    <script type="text/javascript">MODx.showHidden = true;</script>
+    <script>MODx.showHidden = true;</script>
 {/if}
-<script type="text/javascript" src="assets/js/sections/database.js"></script>
+<script src="assets/js/sections/database.js"></script>
 <form id="install" action="?action=database" method="post">
     <h2>{$_lang.connection_title}</h2>
 
@@ -10,7 +10,7 @@
     <p>{$_lang.connection_connection_note}</p>
 
     <p class="error">{$error_message|default}</p>
-    
+
     <div class="labelHolder">
         <label for="database-type">{$_lang.connection_database_type}</label>
         <select id="database-type" name="database_type" autofocus="autofocus">

--- a/setup/templates/findcore.php
+++ b/setup/templates/findcore.php
@@ -44,10 +44,10 @@ if ($posted) {
     <link rel="stylesheet" href="assets/css/print.css" type="text/css" media="print" />
 
     <link href="assets/css/style.css" type="text/css" rel="stylesheet" />
-    <script type="text/javascript" src="assets/js/ext-core.js"></script>
-    <script type="text/javascript" src="assets/js/modx.setup.js"></script>
+    <script src="assets/js/ext-core.js"></script>
+    <script src="assets/js/modx.setup.js"></script>
     <!--[if lt IE 7]>
-        <script type="text/javascript" src="assets/js/inc/say.no.to.ie.6.js"></script>
+        <script src="assets/js/inc/say.no.to.ie.6.js"></script>
         <style type="text/css">
         body {
             behavior:url("assets/js/inc/csshover2.htc");

--- a/setup/templates/header.tpl
+++ b/setup/templates/header.tpl
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!doctype html>
+<html xml:lang="en" lang="en">
 <head>
     <title>{$app_name} {$app_version} &raquo; {$_lang.install}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -11,16 +11,16 @@
     <link rel="stylesheet" href="assets/modx.css" type="text/css" media="screen" />
 
     <link rel="stylesheet" href="assets/css/print.css" type="text/css" media="print" />
-    
+
     <link href="assets/css/style.css" type="text/css" rel="stylesheet" />
     {if $_lang.additional_css NEQ ''}
     <style type="text/css">{$_lang.additional_css}</style>
     {/if}
-    <script type="text/javascript" src="assets/js/ext-core.js"></script>
-    <script type="text/javascript" src="assets/js/modx.setup.js"></script>
+    <script src="assets/js/ext-core.js"></script>
+    <script src="assets/js/modx.setup.js"></script>
     <!--[if lt IE 7]>
     {literal}
-        <script type="text/javascript" src="assets/js/inc/say.no.to.ie.6.js"></script>
+        <script src="assets/js/inc/say.no.to.ie.6.js"></script>
         <style type="text/css">
         body {
             behavior:url("assets/js/inc/csshover2.htc");
@@ -31,7 +31,7 @@
         </style>
         {/literal}
     <![endif]-->
-    
+
 </head>
 
 <body>
@@ -58,4 +58,3 @@
        <!-- start content -->
         <div id="content" class="grid_12">
 
-        

--- a/setup/templates/index.tpl
+++ b/setup/templates/index.tpl
@@ -1,12 +1,12 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<!doctype html>
+<html xml:lang="en">
 <head>
 	<title><?php echo $moduleName; ?> &raquo; Install</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <style type="text/css">
-         @import url(./style/style.css);
+        @import url(./style/style.css);
     </style>
-</head>	
+</head>
 
 <body>
 

--- a/setup/templates/install.tpl
+++ b/setup/templates/install.tpl
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="assets/js/sections/install.js"></script>
+<script src="assets/js/sections/install.js"></script>
 <form id="install" action="?action=install" method="post">
 <h2>{$_lang.install_summary}</h2>
 {if $failed}
@@ -8,9 +8,8 @@
     {$_lang.install_success}
     <br />(<a style="font-size: .9em" href="#continuebtn">{$_lang.skip_to_bottom}</a>)
     <br /><br />
-    <a href="javascript:void(0);" class="modx-toggle-success">{$_lang.toggle_success}</a> | 
+    <a href="javascript:void(0);" class="modx-toggle-success">{$_lang.toggle_success}</a> |
     <a href="javascript:void(0);" class="modx-toggle-warning">{$_lang.toggle_warnings}</a>
-    
 </p>
 {/if}
 <ul class="checklist">

--- a/setup/templates/summary.tpl
+++ b/setup/templates/summary.tpl
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="assets/js/sections/summary.js"></script>
+<script src="assets/js/sections/summary.js"></script>
 <form id="install" action="?action=summary" method="post">
     <h2>{$_lang.install_summary}</h2>
     {if $failed}

--- a/setup/templates/welcome.tpl
+++ b/setup/templates/welcome.tpl
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="assets/js/sections/welcome.js"></script>
+<script src="assets/js/sections/welcome.js"></script>
 <form id="welcome" action="?action=welcome" method="post">
 <div>
     <h2>{$_lang.welcome}</h2>


### PR DESCRIPTION
### What does it do?
Remove an obsolete `type="text/javascript" `attribute from script tags.

### Why is it needed?

HTML5 no longer requires an explicit type statement.

``` html
<!-- HTML4 -->
<script type="text/javascript" src="javascript.js"></script>

<!-- HTML5 -->
<script src="javascript.js"></script>
```

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/13846 https://github.com/modxcms/revolution/pull/13850 https://github.com/modxcms/revolution/pull/13847
https://github.com/modxcms/revolution/pull/15553
