### PR TITLE
Updating url in system setting base_help_url

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -126,7 +126,7 @@ $settings['automatic_template_assignment']->fromArray(array (
 $settings['base_help_url']= $xpdo->newObject('modSystemSetting');
 $settings['base_help_url']->fromArray(array (
   'key' => 'base_help_url',
-  'value' => '//docs.modx.com/2.x/en/index',
+  'value' => '//docs.modx.com/help/',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',

--- a/setup/includes/upgrades/common/2.8.2-update-base_help_url.php
+++ b/setup/includes/upgrades/common/2.8.2-update-base_help_url.php
@@ -9,6 +9,6 @@ $base_help_url = $modx->getObject('modSystemSetting', array(
     'value' => '//docs.modx.com/display/revolution20/',
 ));
 if ($base_help_url) {
-    $base_help_url->set('value', '//docs.modx.com/2.x/en/index');
+    $base_help_url->set('value', '//docs.modx.com/help/');
     $base_help_url->save();
 }


### PR DESCRIPTION
### What does it do?
Updating url in system setting `base_help_url`

### Why is it needed?
Fixes invalid address error when navigating

### Related issue(s)/PR(s)
https://github.com/modxorg/Docs/commit/da56ad7151fa733f0e8330b93234b3bd6856c573

Resolves #15216