### PR TITLE
Update base_help_url system settings with a new link to the documentation

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -130,7 +130,7 @@ $settings['automatic_template_assignment']->fromArray([
 $settings['base_help_url']= $xpdo->newObject(modSystemSetting::class);
 $settings['base_help_url']->fromArray([
   'key' => 'base_help_url',
-  'value' => '//docs.modx.com/3.x/en/index',
+  'value' => '//docs.modx.com/help/',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',

--- a/setup/includes/upgrades/common/3.0.0-update-sys-setting_base_help_url.php
+++ b/setup/includes/upgrades/common/3.0.0-update-sys-setting_base_help_url.php
@@ -10,6 +10,6 @@ $base_help_url = $modx->getObject(modSystemSetting::class, [
     'value' => '//docs.modx.com/display/revolution20/',
 ]);
 if ($base_help_url) {
-    $base_help_url->set('value', '//docs.modx.com/3.x/en/index');
+    $base_help_url->set('value', '//docs.modx.com/help/');
     $base_help_url->save();
 }


### PR DESCRIPTION
### What does it do?
Updating url in system setting `base_help_url`

### Why is it needed?
Fixes invalid address error when navigating

### Related issue(s)/PR(s)
https://github.com/modxorg/Docs/commit/da56ad7151fa733f0e8330b93234b3bd6856c573