### PR TITLE
Add the EXTR_REFS flag to the extract function

### DIFF
--- a/core/src/Revolution/modScript.php
+++ b/core/src/Revolution/modScript.php
@@ -84,7 +84,7 @@ class modScript extends modElement
                 $scriptProperties = $this->xpdo->event->params = $this->_properties; /* store params inside event object */
                 ob_start();
                 unset($properties, $content);
-                extract($scriptProperties, EXTR_SKIP);
+                extract($scriptProperties, EXTR_SKIP|EXTR_REFS);
                 $includeResult = include $this->_scriptFilename;
                 $includeResult = ($includeResult === null ? '' : $includeResult);
                 if (ob_get_length()) {


### PR DESCRIPTION
### What does it do?
Adds the EXTR_REFS flag to the extract function.

### Why is it needed?
Allows you to pass to plugins not only objects but also variables by reference. Then the following code will work as expected
```
// modParser
$this->modx->invokeEvent('OnParseDocument', ['content' => &$content]);
```

### How to test
1. Create a plugin event with name "OnTestPassReference".
2. Create a snippet with content
```
$foo = 'bar';
$modx->invokeEvent('OnTestPassReference', ['foo' => &$foo]);
return $foo;
```
3. Create a plugin on the OnTestPassReference event with content
```
$foo = 'baz';
```
4. Put the created snippet in any resource `$foo = "[[!snippet]]"`.
5. Open this resource.
6. The page should display  `$foo = "baz"`.
