### PR TITLE
"Add" button in upper right of dashboard overlaps widgets

### DIFF
--- a/manager/templates/default/css/index.css
+++ b/manager/templates/default/css/index.css
@@ -21732,7 +21732,7 @@ ul.x-tab-strip-bottom {
   display: flex;
   -ms-flex-flow: row wrap;
       flex-flow: row wrap;
-  margin: -1rem 0 0 -1rem !important;
+  margin: -0.5rem 0 0 -1rem !important;
   padding: 0 15px; }
   .dashboard .dashboard-button {
     padding: 5px 20px;


### PR DESCRIPTION
## What does it do?
Reduces the negative margin at the top of the "modx-dashboard" div.

## Why is it needed?
The gray area around the "Add+" button slightly overlaps the widgets:

![overlap](https://user-images.githubusercontent.com/2528374/112219694-c00c0f00-8bfb-11eb-9610-7719cae53edb.png)

