### PR TITLE
Increases the basic required version of php

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.1', '7.2', '7.3', '7.4', '8.0']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "vendor-dir": "core/vendor"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "xpdo/xpdo": "^3.0@dev",
         "league/flysystem": "^1.0",
         "league/flysystem-aws-s3-v3": "^1.0",
@@ -91,20 +91,20 @@
         ],
         "phpunit": "phpunit -c _build/test/phpunit.xml --coverage-text --colors",
         "parse-schema-mysql": [
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.mysql.schema.xml core/src/",
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.registry.db.mysql.schema.xml core/src/",
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.sources.mysql.schema.xml core/src/",
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.transport.mysql.schema.xml core/src/"
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.mysql.schema.xml core/src/",
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.registry.db.mysql.schema.xml core/src/",
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.sources.mysql.schema.xml core/src/",
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.transport.mysql.schema.xml core/src/"
         ],
         "parse-schema-sqlsrv": [
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.sqlsrv.schema.xml core/src/",
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.registry.db.sqlsrv.schema.xml core/src/",
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.sources.sqlsrv.schema.xml core/src/",
-          "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.transport.sqlsrv.schema.xml core/src/"
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.sqlsrv.schema.xml core/src/",
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.registry.db.sqlsrv.schema.xml core/src/",
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.sources.sqlsrv.schema.xml core/src/",
+            "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ sqlsrv core/model/schema/modx.transport.sqlsrv.schema.xml core/src/"
         ],
         "parse-schema": [
-          "composer run-script parse-schema-mysql",
-          "composer run-script parse-schema-sqlsrv"
+            "composer run-script parse-schema-mysql",
+            "composer run-script parse-schema-sqlsrv"
         ]
     },
     "scripts-descriptions": {


### PR DESCRIPTION
### What does it do?
Increases the basic required version of php

### Why is it needed?

https://docs.modx.com/3.x/en/getting-started/server-requirements

The documentation states that minimum version = 7.1. This fix upgrades the version to the required

https://github.com/modxcms/revolution/blob/3.x/.github/workflows/ci.yml#L28 - Do we need tests for 7.0?

### Related issue(s)/PR(s)
NA