### PR TITLE
Changing the lexicon on the update widget

### DIFF
--- a/core/lexicon/en/dashboard.inc.php
+++ b/core/lexicon/en/dashboard.inc.php
@@ -24,7 +24,7 @@ $_lang['onlineusers_title'] = 'Online users';
 $_lang['onlineusers_user'] = 'User';
 $_lang['onlineusers_userid'] = 'User\'s ID';
 
-$_lang['updates_sort'] = 'Sort';
+$_lang['updates_type'] = 'Type';
 $_lang['updates_status'] = 'Status';
 $_lang['updates_action'] = 'Action';
 $_lang['updates_available'] = 'Updates available';

--- a/manager/templates/default/dashboard/updates.tpl
+++ b/manager/templates/default/dashboard/updates.tpl
@@ -3,7 +3,7 @@
         <table class="table">
             <thead>
             <tr>
-                <th>{$_lang.updates_sort}</th>
+                <th>{$_lang.updates_type}</th>
                 <th>{$_lang.updates_status}</th>
                 <th>{$_lang.updates_action}</th>
             </tr>


### PR DESCRIPTION
### What does it do?
Changing the lexicon on the update widget

### Why is it needed?

Changing the lexicon on the update widget

Before:
![изображение](https://user-images.githubusercontent.com/2138260/112426880-e7312080-8d62-11eb-9bb1-850d913e4c60.png)

After:
![изображение](https://user-images.githubusercontent.com/2138260/112426907-f6b06980-8d62-11eb-8df6-a00c2fd6122b.png)

### Related issue(s)/PR(s)
NA