### PR TITLE
Fallback to username when full name is missed in the Who is online widget

### DIFF
--- a/manager/templates/default/dashboard/onlineusers.tpl
+++ b/manager/templates/default/dashboard/onlineusers.tpl
@@ -23,7 +23,7 @@
                             {/if}
                         </div>
                         <div class="user-data">
-                            <div class="user-name">{$record.fullname}</div>
+                            <div class="user-name">{$record.fullname|default:$record.username}</div>
                             <div class="user-group">{$record.group}</div>
                         </div>
                     </td>


### PR DESCRIPTION
### What does it do?
Displaying username if fullname is not filled in the dashboard Who is online

### Why is it needed?

Before:
![2021-03-27_12-56-37](https://user-images.githubusercontent.com/2138260/112713586-2183f480-8f00-11eb-9c74-82eb119d37a6.jpg)

After:
![2021-03-27_13-22-20](https://user-images.githubusercontent.com/2138260/112713584-2052c780-8f00-11eb-943d-72d60618b91a.jpg)

### How to test
Create a user and do not fill in his Full name, go to the main page of the control panel

### Related issue(s)/PR(s)
NA
