### PR TITLE
Fixes notification display time

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -830,9 +830,9 @@ Ext.extend(MODx.Msg,Ext.Component,{
         var fadeOpts = {remove:true,useDisplay:true};
         if (!opt.dontHide) {
             if(!Ext.isIE8) {
-                m.pause(opt.delay || 1.5).ghost("t",fadeOpts);
+                m.pause(opt.delay || 10).ghost("t",fadeOpts);
             } else {
-                fadeOpts.duration = (opt.delay || 1.5);
+                fadeOpts.duration = (opt.delay || 10);
                 m.ghost("t",fadeOpts);
             }
         } else {


### PR DESCRIPTION
### What does it do?
Fixes notification display time from 1.5 seconds to 10

### Why is it needed?
Fixes an issue with the inability to copy the generated password, but also affects other notifications in other parts of the control panel

### Related issue(s)/PR(s)
Resolves #15573
