### PR TITLE
Ignore l10n_** branches on ci workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
+      branches-ignore:
+          - 'l10n_**'
   pull_request:
+      branches-ignore:
+          - 'l10n_**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
### What does it do?
Prevents CI workflow on l10n_** branches pushed by CrowdIn

### Why is it needed?
When CrowdIn pushes a lot of individual commits for translations, a backlog of workflow is created.

### How to test
n/a

### Related issue(s)/PR(s)
none
