### PR TITLE
Fix class key default value in the user creation form

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -417,7 +417,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             ,description: _('user_class_key_desc')
             ,xtype: 'textfield'
             ,anchor: '100%'
-            ,value: 'modUser'
+            ,value: 'MODX\\Revolution\\modUser'
         },{
             id: 'modx-user-comment'
             ,name: 'comment'


### PR DESCRIPTION
### What does it do?
Fixed incorrect default value for the class_key field in the "New user" form.

### Why is it needed?
Incorrect default value of the class key in the "New user" from. 

![user](https://user-images.githubusercontent.com/4679725/113248517-ccf8c480-92c5-11eb-9360-dace204c7076.jpg)

The default value should be `MODX\Revolution\modUser`.

### How to test
Try to create a new user.

### Related issue(s)/PR(s)
Resolves #15619.
