### PR TITLE
Improve language selector accessibility on the login page

### DIFF
--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -180,7 +180,7 @@
                 <div class="c-languageselect">
                     <select name="manager_language" id="modx-login-language-select" class="c-languageselect__select" aria-label="{$_config.cultureKey}">
                         {foreach $languages as $language => $native}
-                            <option lang="{$language}" value="{$language}"{if $language == $_config.cultureKey} selected{/if}>{$native|capitalize}</option>
+                            <option lang="{$language}" aria-label="{$native|capitalize}" value="{$language}"{if $language == $_config.cultureKey} selected{/if}>{$native|capitalize}</option>
                         {/foreach}
                     </select>
                     <span class="c-languageselect__arrow"></span>


### PR DESCRIPTION
### What does it do?
Improve Accessibility of Language Select Boxes

### Why is it needed?

Adds date attributes to improve accessibility such as `data-iso-country-code` and `aria-label`

Before:

``` html
<option value="en" lang="en">English</option>
```

After

``` html
<option aria-label="English" value="en" lang="en">English</option>
```

### How to test
Describe how to test the changes you made.

### Related issue(s)/PR(s)
Resolves #12793
