### PR TITLE
Fix access policy template group name

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.context.js
@@ -83,7 +83,7 @@ MODx.grid.UserGroupContext = function(config) {
             ,allowBlank: true
             ,baseParams: {
                 action: 'Security/Access/Policy/GetList'
-                ,group: 'Admin'
+                ,group: 'Administrator'
             }
             ,listeners: {
                 'select': {fn:this.filterPolicy,scope:this}
@@ -242,7 +242,7 @@ MODx.window.CreateUGAccessContext = function(config) {
             ,hiddenName: 'policy'
             ,baseParams: {
                 action: 'Security/Access/Policy/GetList'
-                ,group: 'Admin,Object'
+                ,group: 'Administrator,Object'
                 ,combo: '1'
             }
             ,allowBlank: false

--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -62,7 +62,7 @@ MODx.panel.UserGroup = function(config) {
                             },{
                                 name: 'name'
                                 ,id: 'modx-usergroup-name'
-                                ,xtype: config.record && (config.record.name == 'Administrator' || config.record.id == 0) ? 'statictextfield' : 'textfield'
+                                ,xtype: config.record && (config.record.name === 'Administrator' || config.record.id === 0) ? 'statictextfield' : 'textfield'
                                 ,fieldLabel: _('name')
                                 ,allowBlank: false
                                 ,enableKeyEvents: true

--- a/manager/assets/modext/widgets/security/modx.tree.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.tree.user.group.js
@@ -322,7 +322,7 @@ MODx.window.CreateUserGroup = function(config) {
                         xtype: 'modx-combo-policy'
                         ,baseParams: {
                             action: 'Security/Access/Policy/GetList'
-                            ,group: 'Admin'
+                            ,group: 'Administrator'
                             ,combo: '1'
                         }
                         ,name: 'aw_manager_policy'


### PR DESCRIPTION
### What does it do?
It renames access policy template group to proper Administrator instead of short and ugly Admin.

### Why is it needed?
When creating new ACL rules, like adding access to contexts, in popup access policy templates filtered by groups, so that group name goes as a parameter and it tries to filter templates by this group. In case the wrong name, not the full list will be shown.

#### How it looks before (not the length of the list)
![User Group_ test _ MODX Revolution (1)](https://user-images.githubusercontent.com/303498/113413006-60172480-93c2-11eb-8577-30f589e29562.png)

#### How it looks after
![User Group_ test _ MODX Revolution](https://user-images.githubusercontent.com/303498/113413023-65746f00-93c2-11eb-9e64-1151f3f9766a.png)

### How to test
Open ACL manager page, edit any user group and on the tab `Access Permissions` try to add a new rule for Context (vertical tab). In the popup in the field  `Access Policy` try to select any item and check how many there are items.

### Related issue(s)/PR(s)
#14009