### PR TITLE
Fix permissions checking in modAccessibleObject objects

### DIFF
--- a/core/src/Revolution/modCategory.php
+++ b/core/src/Revolution/modCategory.php
@@ -202,7 +202,7 @@ class modCategory extends modAccessibleSimpleObject
                 $acls = $this->xpdo->getIterator(modAccessCategory::class, $c);
 
                 foreach ($acls as $acl) {
-                    $policy['modAccessCategory'][$acl->get('target')][] = [
+                    $policy[modAccessCategory::class][$acl->get('target')][] = [
                         'principal' => $acl->get('principal'),
                         'authority' => $acl->get('authority'),
                         'policy' => $acl->get('data') ? $this->xpdo->fromJSON($acl->get('data'), true) : [],

--- a/core/src/Revolution/modContext.php
+++ b/core/src/Revolution/modContext.php
@@ -219,7 +219,7 @@ class modContext extends modAccessibleObject
                 $acls = $this->xpdo->getCollection(modAccessContext::class, $c);
                 /** @var modAccessContext $acl */
                 foreach ($acls as $acl) {
-                    $policy['modAccessContext'][$acl->get('target')][] = [
+                    $policy[modAccessContext::class][$acl->get('target')][] = [
                         'principal' => $acl->get('principal'),
                         'authority' => $acl->get('authority'),
                         'policy' => $acl->get('data') ? json_decode($acl->get('data'), true) : [],

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -481,7 +481,7 @@ class modElement extends modAccessibleSimpleObject
                 $query = new xPDOCriteria($this->xpdo, $sql, $bindings);
                 if ($query->stmt && $query->stmt->execute()) {
                     while ($row = $query->stmt->fetch(PDO::FETCH_ASSOC)) {
-                        $policy['modAccessCategory'][$row['target']][] = [
+                        $policy[modAccessCategory::class][$row['target']][] = [
                             'principal' => $row['principal'],
                             'authority' => $row['authority'],
                             'policy' => $row['data'] ? $this->xpdo->fromJSON($row['data'], true) : [],

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -143,7 +143,7 @@ class modNamespace extends modAccessibleObject
             $query = new xPDOCriteria($this->xpdo, $sql, $bindings);
             if ($query->stmt && $query->stmt->execute()) {
                 while ($row = $query->stmt->fetch(PDO::FETCH_ASSOC)) {
-                    $policy['modAccessNamespace'][$row['target']][] = [
+                    $policy[modAccessNamespace::class][$row['target']][] = [
                         'principal' => $row['principal'],
                         'authority' => $row['authority'],
                         'policy' => $row['data'] ? $this->xpdo->fromJSON($row['data'], true) : [],

--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -906,7 +906,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                 $query = new xPDOCriteria($this->xpdo, $sql, $bindings);
                 if ($query->stmt && $query->stmt->execute()) {
                     while ($row = $query->stmt->fetch(PDO::FETCH_ASSOC)) {
-                        $policy['modAccessResourceGroup'][$row['target']][] = [
+                        $policy[modAccessResourceGroup::class][$row['target']][] = [
                             'principal' => $row['principal'],
                             'authority' => $row['authority'],
                             'policy' => $row['data'] ? $this->xpdo->fromJSON($row['data'], true) : [],

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -885,12 +885,12 @@ class modTemplateVar extends modElement
                     $output = $this->xpdo->getChunk($param, $properties);
                 }
                 break;
-                
+
             case 'SNIPPET':
                 if ($preProcess) {
                     $output = $this->xpdo->runSnippet($param, $properties);
                 }
-                break;                
+                break;
 
             case 'RESOURCE':
             case 'DOCUMENT': /* retrieve a document and process it's content */
@@ -996,12 +996,12 @@ class modTemplateVar extends modElement
         $match2 = [];
         $binding_string = trim($binding_string);
         $regexp = '/@(' . implode('|', $this->bindings) . ')\s*(.*)/is'; /* Split binding on whitespace */
-        
+
         if (preg_match($regexp, $binding_string, $match)) {
             /* We can't return the match array directly because the first element is the whole string */
-            
+
             $regexp2 = '/(\S+)\s+(.+)/is'; /* Split binding on second whitespace to get properties */
-            
+
             $properties = [];
             if (preg_match($regexp2, $match[2] , $match2)) {
                 if (isset($match2[2])) {
@@ -1015,7 +1015,7 @@ class modTemplateVar extends modElement
                     }
                 }
             }
-            
+
             $binding_array = [
                 strtoupper($match[1]),
                 trim($match[2]),
@@ -1140,7 +1140,7 @@ class modTemplateVar extends modElement
                     $query = new xPDOCriteria($this->xpdo, $sql, $bindings);
                     if ($query->stmt && $query->stmt->execute()) {
                         while ($row = $query->stmt->fetch(PDO::FETCH_ASSOC)) {
-                            $policy['modAccessResourceGroup'][$row['target']][] = [
+                            $policy[modAccessResourceGroup::class][$row['target']][] = [
                                 'principal' => $row['principal'],
                                 'authority' => $row['authority'],
                                 'policy' => $row['data'] ? $this->xpdo->fromJSON($row['data'], true) : [],


### PR DESCRIPTION
### What does it do?
Fixed permissions cheching in objects of the modAccessibleObject class.

### Why is it needed?
Permissions for Contexts, Namespaces, Resource Groups and Categories don't work at all.

### How to test
For "mgr" context 
1. Create a test user without the sudo permission.
2. Add him to the Administrator group with the "Super user" role.
3. Try to log in in the manager.

### Related issue(s)/PR(s)
#15586.
