### PR TITLE
Fix form customization on static resources

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
@@ -19,7 +19,7 @@ Ext.extend(MODx.panel.Static,MODx.panel.Resource,{
     defaultClassKey: 'MODX\\Revolution\\modStaticResource'
     ,classLexiconKey: 'static_resource'
     ,rteElements: false
-    ,contentField: 'modx-resource-content-static'
+    ,contentField: 'modx-resource-content'
 
     ,getContentField: function(config) {
         return {
@@ -30,22 +30,22 @@ Ext.extend(MODx.panel.Static,MODx.panel.Resource,{
             ,fieldLabel: _('static_resource')
             ,description: '<b>[[*content]]</b>'
             ,name: 'content'
-            ,id: 'modx-resource-content-static' // changed id to not have to usual box-shadow around the content field
+            ,id: 'modx-resource-content'
             ,maxLength: 255
             ,anchor: '100%'
             ,value: (config.record.content || config.record.ta) || ''
             ,openTo: config.record.openTo
             ,listeners: {
                 'select':{fn:function(data) {
-                        var str = data.fullRelativeUrl;
-                        if (MODx.config.base_url != '/') {
-                            var regex = new RegExp('^' + MODx.config.base_url + '(.*)');
-                            str = str.replace(regex, '/$1');
-                        }
-                        if (str.substring(0,1) == '/') { str = str.substring(1); }
-                        Ext.getCmp('modx-resource-content-static').setValue(str);
-                        this.markDirty();
-                    },scope:this}
+                    var str = data.fullRelativeUrl;
+                    if (MODx.config.base_url != '/') {
+                        var regex = new RegExp('^' + MODx.config.base_url + '(.*)');
+                        str = str.replace(regex, '/$1');
+                    }
+                    if (str.substring(0,1) === '/') { str = str.substring(1); }
+                    Ext.getCmp('modx-resource-content').setValue(str);
+                    this.markDirty();
+                },scope:this}
             }
         };
     }


### PR DESCRIPTION
### What does it do?
It renames back content field to proper `modx-resource-content` which also used in form customizations rules.

### Why is it needed?
It addresses the issue when impossible to hide the content field for static resources via form customization.

### How to test
- Create FC profile and set.
- Uncheck `modx-resource-content` and save set
- Create a static resource and check the content field. It should be hidden.

### Related issue(s)/PR(s)
It was introduced with this fix #11689 wherein comments said that is only one reason - shadow. In 3.x it looks fine without any shadows, so no reason to have a different name.

Fix #13042 
