### PR TITLE
Incorrect use of the getOption method

### DIFF
--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -180,7 +180,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     {
         /* setup the various options */
         $iconv = function_exists('iconv');
-        $mbext = function_exists('mb_strlen') && (boolean)$xpdo->getOption('use_multibyte', false);
+        $mbext = function_exists('mb_strlen') && (boolean)$xpdo->getOption('use_multibyte', $options, false);
         $charset = strtoupper((string)$xpdo->getOption('modx_charset', $options, 'UTF-8'));
         $delimiter = $xpdo->getOption('friendly_alias_word_delimiter', $options, '-');
         $delimiters = $xpdo->getOption('friendly_alias_word_delimiters', $options, '-_');


### PR DESCRIPTION
### What does it do?
Fixed the bug of calling the `modResource::filterPathSegment` method.

### Why is it needed?
Incorrect use of the getOption method.

### Related issue(s)/PR(s)
#14583.