### PR TITLE
Add PHP Code Sniffer configuration file

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruleset name="MODX Coding Standards">
+    <description>MODX dev PHP_CodeSniffer ruleset</description>
+    <file>_build</file>
+    <file>connectors</file>
+    <file>core</file>
+    <file>manager</file>
+    <file>setup</file>
+
+    <!-- Exclude paths -->
+    <exclude-pattern>manager/assets/ext3</exclude-pattern>
+    <exclude-pattern>core/lexicon</exclude-pattern>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps" />
+
+    <!-- Ignore vendor files -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Our base rule: set to PSR12-->
+    <rule ref="PSR12"/>
+</ruleset>


### PR DESCRIPTION
### What does it do?
Fixes an error when checking the sent PR

### Why is it needed?
Fixes an error when checking the sent PR

### How to test
This config will be used to check the sent PRs. Now, when checking, the action works but gives an error on all PRs:

``` shell
ERROR: the "phpcs.xml" coding standard is not installed. The installed coding standards are MySource, PEAR, PSR1, PSR12, PSR2, Squiz and Zend
```

https://github.com/squizlabs/PHP_CodeSniffer/blob/master/phpcs.xml.dist

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15603
