### PR TITLE
Restrict file management to allowed file types [SEC-3837]

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -709,6 +709,9 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $bases = $this->getBases($objectPath);
 
         $fullPath = $bases['pathAbsolute'].$objectPath;
+        if (!$this->checkFiletype($fullPath)) {
+            return false;
+        }
         if (!file_exists($fullPath)) {
             $this->addError('file',$this->xpdo->lexicon('file_folder_err_ns').': '.$fullPath);
             return false;
@@ -757,6 +760,9 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $bases = $this->getBases($objectPath);
 
         $fullPath = $bases['pathAbsolute'].ltrim($objectPath,'/');
+        if (!$this->checkFiletype($fullPath)) {
+            return false;
+        }
 
         /** @var modFile $file */
         $file = $this->fileHandler->make($fullPath);

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -720,7 +720,9 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
      * @return boolean|string
      */
     public function updateObject($objectPath,$content) {
-        /* create empty file that acts as folder */
+        if (!$this->checkFiletype($objectPath)) {
+            return false;
+        }
         $created = $this->driver->create_object($this->bucket,$objectPath,array(
                  'body' => $content,
                  'acl' => AmazonS3::ACL_PUBLIC,
@@ -744,6 +746,9 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
      * @return boolean
      */
     public function removeObject($objectPath) {
+        if (!$this->checkFiletype($objectPath)) {
+            return false;
+        }
         if (!$this->driver->if_object_exists($this->bucket,$objectPath)) {
             $this->addError('file',$this->xpdo->lexicon('file_folder_err_ns').': '.$objectPath);
             return false;


### PR DESCRIPTION
### What does it do?

Prevent editing of file types that are not allowed to be created or uploaded. 

### Why is it needed?

While creating/uploading files to a media source was properly limited to the allowed file types (either media source allowedFileTypes, or the upload_* settings), this was not the case for various other actions and most notably updating files. In security report 3837 (report by Solar Security) this was reported as a potential RCE by editing PHP files through manager XSS attacks. Personally I find labeling that a RCE debatable considering editing files is a core feature, but nevertheless it's definitely a bug that it allowed editing non-allowed file types.

### How to test

Before applying the patch, verify that creating or uploading PHP files is disallowed (unless you've whitelisted it in `upload_files`), then try to edit an existing php file and notice it lets you do so. Apply PR, confirm it no longer lets you edit it.

### Related issue(s)/PR(s)

Private security topic https://community.modx.com/t/new-security-issues-reported-all-in-one-report/3837/21
