### PR TITLE
Prevent XSSI access to `MODx.config` by requiring the auth token to be present

### DIFF
--- a/connectors/modx.config.js.php
+++ b/connectors/modx.config.js.php
@@ -13,7 +13,5 @@
  * @var modX $modx
  */
 define('MODX_CONNECTOR_INCLUDED', 1);
-define('MODX_REQP',false);
-require_once dirname(__FILE__).'/index.php';
-$_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));
+require_once __DIR__ .'/index.php';
 $modx->request->handleRequest(array('location' => 'system','action' => 'config.js'));

--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -480,8 +480,11 @@ abstract class modManagerController {
      * @return string
      */
     public function getHeader() {
+        $this->setPlaceholder('_authToken', $this->modx->user->getUserToken('mgr'));
         $this->loadController('header.php',true);
-        return $this->fetchTemplate('header.tpl');
+        $output = $this->fetchTemplate('header.tpl');
+        $this->setPlaceholder('_authToken', '');
+        return $output;
     }
 
     /**

--- a/core/model/modx/processors/system/config.js.class.php
+++ b/core/model/modx/processors/system/config.js.class.php
@@ -23,7 +23,7 @@ class modConfigJsProcessor extends modProcessor
     public function process()
     {
         if (!$this->modx->user->isAuthenticated('mgr')) {
-            return '';
+            return $this->failure($this->modx->lexicon('permission_denied'));
         }
         $this->modx->getVersionData();
 
@@ -33,7 +33,7 @@ class modConfigJsProcessor extends modProcessor
             if ($workingContext instanceof modContext) {
                 $workingContext->prepare();
             } else {
-                return $this->modx->error->failure($this->modx->error->failure($this->modx->lexicon('permission_denied')));
+                return $this->modx->error->failure($this->modx->lexicon('permission_denied'));
             }
         } else {
             $workingContext =& $this->modx->context;

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -19,7 +19,7 @@
 {/if}
 <script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
 <script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,trash,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$_authToken|default|htmlspecialchars}"></script>
 
 {$maincssjs}
 {foreach from=$cssjs item=scr}


### PR DESCRIPTION
### What does it do?

Request the `modx.config.js.php` connector/processor with the HTTP_MODAUTH url parameter, no longer bypassing the typical processor security checks and requiring first-party access to the auth token before the config can be loaded.

### Why is it needed?

Reported by Solar Security in security report 3837, it's possible to bypass the Same Origin Policy when including the modx.config.js.php connector as a script tag, resulting in a [Cross-Site Script Inclusion vulnerability](https://www.scip.ch/en/?labs.20160414). If a logged-in user is tricked into visiting a malicious site, that would allow the attacker to access information meant for the manager typically available in MODx.config. This information is already filtered to exclude sensitive data like passwords, but may still leak the rest of the MODX configuration including extras.

To avoid this XSSI vulnerability, the connector is changed to require permissions the same way as other processors and the manager controller injects the HTTP_MODAUTH URL parameter. Attackers will now need first-party access to the auth token to abuse.

To avoid further leaking the auth token, it's only set temporarily while parsing the header.tpl. Should an attacker manage to inject arbitrary smarty tags, that does not provide them the token.

Also made sure an error message is returned when the user does not have permission.

Custom manager themes that override the header.tpl may require the same fix or break.

### How to test

Security report has a PoC. 

### Related issue(s)/PR(s)

Private report at https://community.modx.com/t/new-security-issues-reported-all-in-one-report/3837
