### PR TITLE
Require auth token  to access MODx.config to prevent XSSI

### DIFF
--- a/connectors/modx.config.js.php
+++ b/connectors/modx.config.js.php
@@ -13,7 +13,5 @@
  * @var \MODX\Revolution\modX $modx
  */
 define('MODX_CONNECTOR_INCLUDED', 1);
-define('MODX_REQP',false);
-require_once dirname(__FILE__).'/index.php';
-$_SERVER['HTTP_MODAUTH'] = $modx->user->getUserToken($modx->context->get('key'));
+require_once __DIR__ .'/index.php';
 $modx->request->handleRequest(['location' => 'system','action' => 'System\ConfigJs']);

--- a/core/src/Revolution/Processors/System/ConfigJs.php
+++ b/core/src/Revolution/Processors/System/ConfigJs.php
@@ -18,6 +18,7 @@ use MODX\Revolution\modResource;
 
 /**
  * Outputs the $modx->config to JSON
+ *
  * @param string $action If set with context, will output the context info for a
  * custom context by the action
  * @param string $context If set with action, will output the context info for a
@@ -33,7 +34,7 @@ class ConfigJs extends Processor
     public function process()
     {
         if (!$this->modx->user->isAuthenticated('mgr')) {
-            return '';
+            return $this->failure($this->modx->lexicon('permission_denied'));
         }
         $this->modx->getVersionData();
 
@@ -41,7 +42,7 @@ class ConfigJs extends Processor
         if (!empty($wctx)) {
             $workingContext = $this->modx->getContext($wctx);
             if (!$workingContext) {
-                return $this->modx->error->failure($this->modx->error->failure($this->modx->lexicon('permission_denied')));
+                return $this->modx->error->failure($this->modx->lexicon('permission_denied'));
             }
         } else {
             $workingContext =& $this->modx->context;
@@ -66,20 +67,28 @@ class ConfigJs extends Processor
             }
         }
 
-        $template_url = $workingContext->getOption('manager_url', MODX_MANAGER_URL,
-                $this->modx->_userConfig) . 'templates/' . $workingContext->getOption('manager_theme', 'default',
-                $this->modx->_userConfig) . '/';
+        $template_url = $workingContext->getOption(
+            'manager_url', MODX_MANAGER_URL,
+            $this->modx->_userConfig
+        ) . 'templates/' . $workingContext->getOption(
+            'manager_theme', 'default',
+            $this->modx->_userConfig
+        ) . '/';
         $c = [
             'base_url' => $workingContext->getOption('base_url', MODX_BASE_URL, $this->modx->_userConfig),
-            'connectors_url' => $workingContext->getOption('connectors_url', MODX_CONNECTORS_URL,
-                $this->modx->_userConfig),
+            'connectors_url' => $workingContext->getOption(
+                'connectors_url', MODX_CONNECTORS_URL,
+                $this->modx->_userConfig
+            ),
             'icons_url' => $template_url . 'images/ext/modext/',
             'manager_url' => $workingContext->getOption('manager_url', MODX_MANAGER_URL, $this->modx->_userConfig),
             'template_url' => $template_url,
             'http_host' => $workingContext->getOption('http_host', MODX_HTTP_HOST, $this->modx->_userConfig),
             'site_url' => $workingContext->getOption('site_url', MODX_SITE_URL, $this->modx->_userConfig),
-            'http_host_remote' => MODX_URL_SCHEME . $workingContext->getOption('http_host', MODX_HTTP_HOST,
-                    $this->modx->_userConfig),
+            'http_host_remote' => MODX_URL_SCHEME . $workingContext->getOption(
+                'http_host', MODX_HTTP_HOST,
+                $this->modx->_userConfig
+            ),
             'user' => $this->modx->user->get('id'),
             'version' => $this->modx->version['full_version'],
             'resource_classes' => $resourceClasses,
@@ -92,7 +101,7 @@ class ConfigJs extends Processor
             $c['default_site_url'] = $ctx->makeUrl($ctx->getOption('site_start'));
         }
 
-        $namespace = (string)$this->getProperty('namespace','core');
+        $namespace = (string)$this->getProperty('namespace', 'core');
         /** @var modNamespace $namespace */
         $namespace = $this->modx->getObject(modNamespace::class, $namespace);
         if ($namespace) {

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -548,9 +548,11 @@ abstract class modManagerController
      */
     public function getHeader()
     {
+        $this->setPlaceholder('_authToken', $this->modx->user->getUserToken('mgr'));
         $this->loadController('header.php', true);
-
-        return $this->fetchTemplate('header.tpl');
+        $output = $this->fetchTemplate('header.tpl');
+        $this->setPlaceholder('_authToken', '');
+        return $output;
     }
 
     /**
@@ -960,8 +962,10 @@ abstract class modManagerController
             }
         }
         if (!empty($rules)) {
-            $this->ruleOutput[] = '<script>Ext.onReady(function() {' . implode("\n",
-                    $rules) . '});</script>';
+            $this->ruleOutput[] = '<script>Ext.onReady(function() {' . implode(
+                "\n",
+                $rules
+            ) . '});</script>';
         }
 
         return $overridden;

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -17,7 +17,7 @@
 {/if}
 <script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
 <script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$site_id|default|htmlspecialchars}"></script>
 
 {$maincssjs}
 
@@ -38,8 +38,8 @@ Ext.onReady(function() {
     MODx.onBrowserReturn = {/literal}{$rtecallback}{literal};{/literal}{/if}{literal}
     MODx.ctx = "{/literal}{if $_ctx}{$_ctx}{else}web{/if}{literal}";
     MODx.load({
-       xtype: 'modx-browser-rte'
-       ,auth: '{/literal}{$site_id}{literal}'
+        xtype: 'modx-browser-rte'
+        ,auth: '{/literal}{$site_id}{literal}'
     });
 });
 </script>

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -21,7 +21,7 @@
 <script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
 <script src="{$_config.manager_url}assets/lib/popper.min.js"></script>
 <script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$_authToken|default|htmlspecialchars}"></script>
 
 {$maincssjs}
 {foreach from=$cssjs item=scr}


### PR DESCRIPTION
### What does it do?
Request the `modx.config.js.php` connector/processor with the HTTP_MODAUTH url parameter, no longer bypassing the typical processor security checks and requiring first-party access to the auth token before the config can be loaded.

### Why is it needed?
See https://github.com/modxcms/revolution/pull/15644

### How to test
See https://github.com/modxcms/revolution/pull/15644

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15644
