### PR TITLE
Fix invalid getOption call in modResource->filterPathSegment

### DIFF
--- a/core/model/modx/modresource.class.php
+++ b/core/model/modx/modresource.class.php
@@ -197,7 +197,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     public static function filterPathSegment(&$xpdo, $segment, array $options = array()) {
         /* setup the various options */
         $iconv = function_exists('iconv');
-        $mbext = function_exists('mb_strlen') && (boolean) $xpdo->getOption('use_multibyte', false);
+        $mbext = function_exists('mb_strlen') && (boolean) $xpdo->getOption('use_multibyte', $options, false);
         $charset = strtoupper((string) $xpdo->getOption('modx_charset', $options, 'UTF-8'));
         $delimiter = $xpdo->getOption('friendly_alias_word_delimiter', $options, '-');
         $delimiters = $xpdo->getOption('friendly_alias_word_delimiters', $options, '-_');


### PR DESCRIPTION
### What does it do?
Fixes a call to getOption in modResource->filterPathSegment that passes the wrong second parameter. Backport of #15638.

### Why is it needed?
See #14583 

### How to test
Unknown

### Related issue(s)/PR(s)
Resolves #14583