### PR TITLE
Fix the appearance of PHP notices on the dashboard page

### DIFF
--- a/manager/templates/default/dashboard/recentlyeditedresources.tpl
+++ b/manager/templates/default/dashboard/recentlyeditedresources.tpl
@@ -49,18 +49,18 @@
                         </td>
                         <td class="widget-actions">
                             {foreach $record.menu as $menu}
-                                {if empty($menu.text) || $menu.text == '-'}
+                                {if empty($menu.text) || $menu.text == '-' || !isset($menu.params)}
                                     {continue}
                                 {/if}
 
                                 {if $menu.params.type == 'view'}
-                                    {assign var=icon value='icon icon-eye'}
+                                    {$icon='icon icon-eye'}
                                 {elseif $menu.params.type == 'edit'}
-                                    {assign var=icon value='icon icon-edit'}
+                                    {$icon='icon icon-edit'}
                                 {elseif $menu.params.type == 'open'}
-                                    {assign var=icon value='icon icon-external-link'}
+                                    {$icon='icon icon-external-link'}
                                 {else}
-                                    {assign var=icon value=null}
+                                    {$icon=null}
                                 {/if}
 
                                 {if !empty($menu.params.a) && !empty($menu.params.id)}


### PR DESCRIPTION
### What does it do?
Fixed Smarty tpl for the recently edited resources.

### Why is it needed?
Described in #15648 .

### How to test
1. Change the log_level system setting to 2.
2. Open the dashboard page in the manager.
3. Open the error log.

### Related issue(s)/PR(s)
#15648.
