### PR TITLE
Changed behavior of creating a file in media browser

### DIFF
--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -39,7 +39,7 @@ MODx.tree.Directory = function(config) {
         },{
             cls: 'x-btn-icon icon-page_white'
             ,tooltip: {text: _('file_create')}
-            ,handler: this.createFile
+            ,handler: this.quickCreateFile
             ,scope: this
             ,hidden: MODx.perm.file_create ? false : true
         },{
@@ -455,8 +455,9 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
 
     ,quickCreateFile: function(itm,e) {
         var node = this.cm.activeNode;
+        var directory = (node) ? decodeURIComponent(node.attributes.id) : '/';
         var r = {
-            directory: decodeURIComponent(node.attributes.id)
+            directory: directory
             ,source: this.getSource()
         };
         var w = MODx.load({
@@ -1043,6 +1044,10 @@ MODx.window.QuickCreateFile = function(config) {
             ,submitValue: true
             ,xtype: 'statictextfield'
             ,anchor: '100%'
+        },{
+            xtype: 'label'
+            ,html: _('file_folder_parent_desc')
+            ,cls: 'desc-under'
         },{
             fieldLabel: _('name')
             ,name: 'name'


### PR DESCRIPTION
### What does it do?
When creating a file in the media browser, the file creation page opens, closing the media browser itself, which is inconvenient.

Now the quick file creation window opens:

![browser_file_create](https://user-images.githubusercontent.com/12523676/114028921-ab797900-9881-11eb-8bc8-a1d20d92f7f3.gif)

### Why is it needed?
UX improvement

### Related issue(s)/PR(s)
p.s. I did not find the issue, but in my opinion there was such a proposal earlier in the repository.