### PR TITLE
Prevent sensitive config values being available as [[++placeholders]] [SEC-3866]

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -572,7 +572,11 @@ class modX extends xPDO {
             );
 
             if (is_array ($this->config)) {
-                $this->setPlaceholders($this->config, '+');
+                $c = $this->config;
+                if ((bool)$this->getOption('filter_config_placeholders', null, true)) {
+                    unset($c['password'], $c['username'], $c['mail_smtp_pass'], $c['mail_smtp_user'], $c['proxy_password'], $c['proxy_username'], $c['connections'], $c['connection_init'], $c['connection_mutable'], $c['dbname'], $c['database'], $c['table_prefix'], $c['driverOptions'], $c['dsn'], $c['session_name'], $c['assets_path'], $c['base_path'], $c['cache_path'], $c['connectors_path'], $c['core_path'], $c['friendly_alias_translit_class_path'], $c['manager_path'], $c['processors_path']);
+                }
+                $this->setPlaceholders($c, '+');
             }
 
             $this->_initialized= true;


### PR DESCRIPTION
### What does it do?

Prevents any manager user with permission to edit resources or elements from being able of reading sensitive configuration information, like database or email configuration.

### Why is it needed?

While manager users have a lot of control and power over the site by design, this prevents a moderately restricted user (ie only resource access, not snippets, files or settings) to get to sensitive information that we'd not want to see leaked. Brought up by sergant210 in the private security team forum.

This filtering, for the exact same keys, has also been in place for a very long time in the `modx.config.js.php` to make settings available in the manager.

### How to test

Place [[++mail_smtp_user]] somewhere on a resource or template. Before this patch, that renders the SMTP username (if set). After the patch, it doesn't.

### Related issue(s)/PR(s)

https://community.modx.com/t/system-settings-in-the-config-property/3866
