### PR TITLE
Prevent authorized access to hashed user password, cachepwd, salt, and sessionid [SEC-3837]

### DIFF
--- a/core/model/modx/processors/security/group/user/getlist.class.php
+++ b/core/model/modx/processors/security/group/user/getlist.class.php
@@ -55,7 +55,7 @@ class modUserGroupUserGetListProcessor extends modObjectGetListProcessor {
     }
 
     public function prepareQueryAfterCount(xPDOQuery $c) {
-        $c->select($this->modx->getSelectColumns($this->classKey,$this->classKey));
+        $c->select($this->modx->getSelectColumns($this->classKey, $this->classKey, '', ['id', 'username']));
         $c->select(array(
             'usergroup' => 'UserGroup.id',
             'usergroup_name' => 'UserGroup.name',
@@ -70,7 +70,7 @@ class modUserGroupUserGetListProcessor extends modObjectGetListProcessor {
     }
 
     public function prepareRow(xPDOObject $object) {
-        $objectArray = $object->toArray();
+        $objectArray = $object->toArray('', false, true);
         $objectArray['role_name'] .= ' - '.$objectArray['authority'];
         return $objectArray;
     }

--- a/core/model/modx/processors/security/user/duplicate.class.php
+++ b/core/model/modx/processors/security/user/duplicate.class.php
@@ -82,6 +82,10 @@ class modUserDuplicateProcessor extends modObjectDuplicateProcessor {
 
         return parent::beforeSave();
     }
+
+    public function cleanup() {
+        return $this->success('', $this->newObject->get(['id', 'username']));
+    }
 }
 
 return 'modUserDuplicateProcessor';

--- a/core/model/modx/processors/security/user/get.class.php
+++ b/core/model/modx/processors/security/user/get.class.php
@@ -94,7 +94,7 @@ class modUserGetProcessor extends modObjectGetProcessor {
             )
             : '';
 
-        unset($userArray['password'],$userArray['cachepwd']);
+        unset($userArray['password'], $userArray['cachepwd'], $userArray['sessionid'], $userArray['salt']);
         return $this->success('',$userArray);
     }
 }

--- a/core/model/modx/processors/security/user/update.class.php
+++ b/core/model/modx/processors/security/user/update.class.php
@@ -310,13 +310,20 @@ class modUserUpdateProcessor extends modObjectUpdateProcessor {
      * @return array|string
      */
     public function cleanup() {
+        $userArray = $this->object->toArray();
+        $profile = $this->object->getOne('Profile');
+        if ($profile) {
+            $userArray = array_merge($profile->toArray(),$userArray);
+        }
+        unset($userArray['password'], $userArray['cachepwd'], $userArray['sessionid'], $userArray['salt']);
+
         $passwordNotifyMethod = $this->getProperty('passwordnotifymethod');
         if (!empty($passwordNotifyMethod) && !empty($this->newPassword) && $passwordNotifyMethod  == 's') {
             return $this->success($this->modx->lexicon('user_updated_password_message',array(
                 'password' => $this->newPassword,
-            )),$this->object);
+            )), $userArray);
         } else {
-            return $this->success('',$this->object);
+            return $this->success('',$userArray);
         }
     }
 }


### PR DESCRIPTION
### What does it do?

This addresses a variety of different ways a manager user with permission to manage users might be able to access hashed passwords, the cachepwd, or a users' last sessionid. Follows from report by Solar Security who reported it was included in the security/group/user/getList response, after which I did some more searching and found a few more places that could return some of these.

### Why is it needed?

This is not super interesting from a security perspective, as passwords are hashed and any user that has permission to manage users could change their password and just take over an account that way. But as these fields are not supposed to be readable, good to lock 'm down anyway.

### How to test

Perform the actions and confirm there is no sensitive data in the raw response.

### Related issue(s)/PR(s)

https://community.modx.com/t/new-security-issues-reported-all-in-one-report/3837
