### PR TITLE
Pass auth token to the config in the Browser controller

### DIFF
--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -17,7 +17,7 @@
 {/if}
 <script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
 <script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$site_id|default|htmlspecialchars}"></script>
 
 {$maincssjs}
 


### PR DESCRIPTION
### What does it do?

After #15644, the modx config is only available when an authentication token is provided in the parameters. The ?a=browser controller is a special one used by extras (in particular tinymce rte, probably tinymce as well) that provices the regular media browser (?a=media/browser) without the manager frame. It's meant to be opened in an iframe.

This PR adds the necessary token (which is already being set in the BrowserIndexController) to the request to restore the functionality of third party editors.

### Why is it needed?

Without it, ?a=browser is broken and editors like TinyMCE RTE fail to access the media browser. 

### How to test

You could install TinyMCE RTE and try adding an image to the page. That will show you a few warnings in the console and an empty panel.

Alternatively, simply browse to ?a=browser and verify that before this fix nothing was shown, and after this fix it shows the functional media browser as expected. 

### Related issue(s)/PR(s)

Regression from #15644.

Reported on Slack. 
