### PR TITLE
Fix filesize() calculation for static resources

### DIFF
--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -90,7 +90,7 @@ class modStaticResource extends modResource implements modResourceInterface {
 
             $this->_sourceFile = $sourcePath . $filename;
             if (file_exists($this->_sourceFile)) {
-                $this->_sourceFileSize = filesize($filename);
+                $this->_sourceFileSize = filesize($this->_sourceFile);
             }
         }
 


### PR DESCRIPTION
### What does it do?
Includes the path along with the filename when checking the file size.
Currently only the filename is being sent, so it's not found.

### Why is it needed?
It prevents this error:
```
ERROR @ /var/www/html/core/model/modx/modstaticresource.class.php : 93) PHP warning: filesize(): stat failed for static.html
```

### How to test
Try to view a static resource and check the error log.


