### PR TITLE
Fix PHP 8 compatibility issues in modPHPThumb

### DIFF
--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -266,7 +266,7 @@ class modPhpThumb extends phpThumb
             //$AbsoluteFilename = $filename;
             return $filename;
 
-        } elseif ($this->iswindows && isset($filename{1}) && ($filename{1} == ':')) {
+        } elseif ($this->iswindows && substr($filename, 1, 1) == ':') {
 
             // absolute pathname (Windows)
             $AbsoluteFilename = $filename;
@@ -276,14 +276,14 @@ class modPhpThumb extends phpThumb
             // absolute pathname (Windows)
             $AbsoluteFilename = $filename;
 
-        } elseif ($filename{0} == '/') {
+        } elseif (substr($filename, 0, 1) == '/') {
 
             if (@is_readable($filename) && !@is_readable($this->config_document_root.$filename)) {
 
                 // absolute filename (*nix)
                 $AbsoluteFilename = $filename;
 
-            } elseif (isset($filename{1}) && ($filename{1} == '~')) {
+            } elseif (substr($filename, 1, 1) == '~') {
 
                 // /~user/path
                 if ($ApacheLookupURIarray = phpthumb_functions::ApacheLookupURIarray($filename)) {


### PR DESCRIPTION
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported
