### PR TITLE
Return content from non-binary static resources

### DIFF
--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -145,6 +145,18 @@ class modStaticResource extends modResource implements modResourceInterface {
         if (file_exists($this->_sourceFile) && is_readable($this->_sourceFile)) {
             $content = $this->_sourceFile;
             $streamable = true;
+
+            // For non-binary types, return early to allow for template use.
+            if (!$contentType->get('binary')) {
+                // Set the appropriate content type and charset for non-binary content types
+                $mimeType = $contentType->get('mime_type') ?: 'text/html';
+                $charset = $this->xpdo->getOption('modx_charset',null,'UTF-8');
+
+                $header = 'Content-Type: ' . $mimeType . '; charset=' . $charset;
+                header($header);
+
+                return file_get_contents($content);
+            }
         }
 
         if (empty($content)) {
@@ -152,19 +164,8 @@ class modStaticResource extends modResource implements modResourceInterface {
             return false;
         }
 
-        // Set the appropriate content type and charset for non-binary content types
-        $mimeType = $contentType->get('mime_type') ?: 'text/html';
-        $header = 'Content-Type: ' . $mimeType;
-        if (!$contentType->get('binary')) {
-            $charset = $this->xpdo->getOption('modx_charset',null,'UTF-8');
-            $header .= '; charset=' . $charset;
-        }
-        header($header);
-
-        if ($contentType->get('binary')) {
-            // @todo This header dates back to pre-git revo circa 2008, but seems to be an email header and may need fixing
-            header('Content-Transfer-Encoding: binary');
-        }
+        // @todo This header dates back to pre-git revo circa 2008, but seems to be an email header and may need fixing
+        header('Content-Transfer-Encoding: binary');
 
         // Apply a content-length header if we know the size in bytes
         $filesize = $this->getSourceFileSize($options);


### PR DESCRIPTION
In my testing it seems like setting the headers for non-binary types here isn't actually required. I have however included that just in-case there's an edge case I missed.

### What does it do?
Returns the content of non-binary static resources so they can still be used with a template.

### Why is it needed?
In MODX 2.8.2 templates can no longer be rendered for static resources.

### How to test
Check the rendering of static resources with and without templates applied and check the headers.
Try changing the resource content type and test them all. e.g. html, json, pdf etc.

### Related issue(s)/PR(s)
See issue #15696
