### PR TITLE
Fix PHPMailer version display

### DIFF
--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -45,7 +45,7 @@ class SystemInfoManagerController extends modManagerController {
         $mailerService = $this->modx->getService('mail', 'mail.modPHPMailer');
         $this->version = [
             'smarty'=> $this->modx->smarty->_version,
-            'PHPMailer'=> $mailerService->mailer->Version
+            'PHPMailer'=> $mailerService->mailer::VERSION
         ];
 
         $this->pi = array_merge($pi,$this->getPhpInfo(INFO_CONFIGURATION));


### PR DESCRIPTION
### What does it do?

Fixes PHPMailer version display in System Info.

### Why is it needed?

After the recent PHPMailer update, version was moved from property to constant. Which also produces this warning:
PHP warning: Undefined property: PHPMailer\PHPMailer\PHPMailer::$Version

### How to test

View System Info page /manager/?a=system/info
