### PR TITLE
Fix PHP 8 compatibility with phpThumb

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -1907,8 +1907,8 @@ if (false) {
 
 							} else {
 
-								$this->w = (($this->aoe && $this->w) ? $this->w : ($this->w ? phpthumb_functions::nonempty_min($this->w, $getimagesize[0]) : ''));
-								$this->h = (($this->aoe && $this->h) ? $this->h : ($this->h ? phpthumb_functions::nonempty_min($this->h, $getimagesize[1]) : ''));
+								$this->w = (($this->aoe && $this->w) ? $this->w : ($this->w ? phpthumb_functions::nonempty_min($this->w, $getimagesize[0]) : null));
+								$this->h = (($this->aoe && $this->h) ? $this->h : ($this->h ? phpthumb_functions::nonempty_min($this->h, $getimagesize[1]) : null));
 								if ($this->w || $this->h) {
 									if ($IMuseExplicitImageOutputDimensions) {
 										if ($this->w && !$this->h) {


### PR DESCRIPTION
### What does it do?
In case next MODX release happens before phpThumb update, this will cover up the related issue.

### Why is it needed?
To make thumbnails in the Media Browser show up again.

### How to test
View folder with images in the Media Browser. Thumbnails will be there.

### Related issue(s)/PR(s)
Resolves https://github.com/modxcms/revolution/issues/15703
Duplicate of  https://github.com/JamesHeinrich/phpThumb/pull/177
