### PR TITLE
Fix incorrect id format in modFileMediaSource

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -158,7 +158,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                 $dirnames[] = strtoupper($fileName);
                 $directories[$fileName] = array(
-                    'id' => rawurlencode($bases['urlRelative'].rtrim($fileName,'/').'/'),
+                    'id' => $bases['urlRelative'].rtrim($fileName,'/').'/',
                     'text' => $fileName,
                     'cls' => implode(' ',$cls),
                     'iconCls' => 'icon icon-folder',
@@ -199,7 +199,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                 $filenames[] = strtoupper($fileName);
                 $files[$fileName] = array(
-                    'id' => rawurlencode($bases['urlRelative'].$fileName),
+                    'id' => $bases['urlRelative'].$fileName,
                     'text' => $fileName,
                     'cls' => implode(' ',$cls),
                     'iconCls' => 'icon icon-file icon-'.$ext . ($file->isWritable() ? '' : ' icon-lock'),
@@ -266,7 +266,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                                     $imageHeight = $imageQueryHeight;
                                 }
                                 $imageQuery = http_build_query(array(
-                                    'src' => rawurlencode($bases['urlRelative'].$fileName),
+                                    'src' => $bases['urlRelative'].$fileName,
                                     'w' => $imageQueryWidth,
                                     'h' => $imageQueryHeight,
                                     'HTTP_MODAUTH' => $modAuth,


### PR DESCRIPTION
### What does it do?
Changes id attributes from 'folder%2F' back to 'folder/'.

### Why is it needed?
Any operations with elements in file tree are impossible, if their id's are incorrect.

### How to test
Drag and drop a file from one directory to another, or do any other similar operation.
This still has to be double checked for any potential display issues, which were fixed in the mentioned commit.

### Related issue(s)/PR(s)
Partially reverts https://github.com/modxcms/revolution/pull/15505
Resolves https://github.com/modxcms/revolution/issues/15694
Resolves https://github.com/modxcms/revolution/issues/15701