### PR TITLE
Adjust filtering of placeholders and accessible options for `@SELECT`

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -816,8 +816,8 @@ class modTemplateVar extends modElement {
                     if ($modx->resource && $modx->resource instanceof modResource) {
                         $dbtags = $modx->resource->toArray();
                     }
-                    $dbtags['DBASE'] = $this->xpdo->getOption('dbname');
-                    $dbtags['PREFIX'] = $this->xpdo->getOption('table_prefix');
+                    $dbtags['DBASE'] = $dbtags['+dbname'] = $this->xpdo->getOption('dbname');
+                    $dbtags['PREFIX'] = $dbtags['+table_prefix'] = $this->xpdo->getOption('table_prefix');
                     foreach($dbtags as $key => $pValue) {
                         if (!is_scalar($pValue)) continue;
                         $param = str_replace('[[+'.$key.']]', (string)$pValue, $param);

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -574,7 +574,7 @@ class modX extends xPDO {
             if (is_array ($this->config)) {
                 $c = $this->config;
                 if ((bool)$this->getOption('filter_config_placeholders', null, true)) {
-                    unset($c['password'], $c['username'], $c['mail_smtp_pass'], $c['mail_smtp_user'], $c['proxy_password'], $c['proxy_username'], $c['connections'], $c['connection_init'], $c['connection_mutable'], $c['dbname'], $c['database'], $c['table_prefix'], $c['driverOptions'], $c['dsn'], $c['session_name'], $c['assets_path'], $c['base_path'], $c['cache_path'], $c['connectors_path'], $c['core_path'], $c['friendly_alias_translit_class_path'], $c['manager_path'], $c['processors_path']);
+                    unset($c['password'], $c['username'], $c['mail_smtp_pass'], $c['mail_smtp_user'], $c['proxy_password'], $c['proxy_username'], $c['connections'], $c['connection_init'], $c['connection_mutable'], $c['dbname'], $c['database'], $c['table_prefix'], $c['driverOptions'], $c['dsn'], $c['session_name'], $c['cache_path'], $c['connectors_path'], $c['friendly_alias_translit_class_path'], $c['manager_path'], $c['processors_path']);
                 }
                 $this->setPlaceholders($c, '+');
             }


### PR DESCRIPTION
### What does it do?

Once again makes `[[++core_path]]`, `[[++base_path]]` and `[[++assets_path]]` available as global placeholders after having been filtered in 2.8.2, and also provides `@SELECT` TV bindings access to `[[+table_prefix]]` and `[[+dbname]]` as aliases to the special `[[+DBASE]]` and `[[+PREFIX]]` to improve backwards compatibility while limiting exposure. 

### Why is it needed?

Following discussion in the private security forum, #15677 prevented anything that could reasonably be classified as sensitive information from being available as global `[[++placeholders]]`. 

That had the unintentional side effect of also affecting `@SELECT` TV input options (#15695), static elements using `[[++core_path]]` or `[[++base_path]]` (#15708), and probably a few as-of-yet undetermined edge cases where this information is used legitimately from the manager.

There can be different ways to deal with this but in the interest of time, my focus with this patch is on backwards compatibility. Without fully reverting the change (once again opening up information disclosure) or encouraging users to disable the filtering on their sites on upgrade (encouraging users to opt-in to information disclosure), the best I can come up with is to adjust what we're filtering to allow as many legitimate use cases as reasonably possible without the most sensitive data being leakable. [Sergant's (privately posted) proposal](https://community.modx.com/t/reasoning-about-issue-15708-static-element-with-core-path/4013) may be worth considering, but doesn't address existing sites so is not a short-term fix.

Going through the list of placeholders getting filtered, the core, base and assets path can be reasonably getting used for static elements or `@FILE` bindings on TVs. Some of the other paths (cache, connectors, manager, processor, etc) would not typically be used there as they're not places for custom code, so those are still filtered. Sensitive data related to the database, smtp email, proxies, connections are still filtered. 

One special case is added which is in the `@SELECT` binding. While the [documentation](https://docs.modx.com/current/en/building-sites/elements/template-variables/bindings/select-binding#syntax) mentions `[[+PREFIX]]` and the code also provides `[[+DBASE]]`, #15695 shows people have relied on the globally available `[[++table_prefix]]` in the past as well so this PR also brings that back, as well as `[[++dbame]]`, **only** for `@SELECT` binding preprocessing. 

As far as trade-offs go between security and restoring existing pre-2.8.2 functionality, this is as good as I can come up with. Better ideas/alternative solutions of course are welcome. 

### How to test

Attempt the steps to reproduce from #15695 and #15708 to confirm they work again.

### Related issue(s)/PR(s)

Fixes #15695 and fixes #15708
