### PR TITLE
Avoid setting headers for modStaticResource when returning content

### DIFF
--- a/core/model/modx/modstaticresource.class.php
+++ b/core/model/modx/modstaticresource.class.php
@@ -141,10 +141,8 @@ class modStaticResource extends modResource implements modResourceInterface {
         }
 
         $content = false;
-        $streamable = false;
         if (file_exists($this->_sourceFile) && is_readable($this->_sourceFile)) {
             $content = $this->_sourceFile;
-            $streamable = true;
         }
 
         if (empty($content)) {
@@ -152,19 +150,15 @@ class modStaticResource extends modResource implements modResourceInterface {
             return false;
         }
 
-        // Set the appropriate content type and charset for non-binary content types
+        // Return the content if not binary
+        if (!$contentType->get('binary')) {
+            return file_get_contents($content);
+        }
+
+        // Set the appropriate content type header
         $mimeType = $contentType->get('mime_type') ?: 'text/html';
         $header = 'Content-Type: ' . $mimeType;
-        if (!$contentType->get('binary')) {
-            $charset = $this->xpdo->getOption('modx_charset',null,'UTF-8');
-            $header .= '; charset=' . $charset;
-        }
         header($header);
-
-        if ($contentType->get('binary')) {
-            // @todo This header dates back to pre-git revo circa 2008, but seems to be an email header and may need fixing
-            header('Content-Transfer-Encoding: binary');
-        }
 
         // Apply a content-length header if we know the size in bytes
         $filesize = $this->getSourceFileSize($options);
@@ -196,13 +190,7 @@ class modStaticResource extends modResource implements modResourceInterface {
         @session_write_close();
         while (ob_get_level() && @ob_end_clean()) {}
 
-        // Output the content, either streaming with readfile() or by echo'ing content that was retrieved earlier from media source
-        if ($streamable && $contentType->get('binary')) {
-            readfile($content);
-        }
-        else {
-            return file_get_contents($content);
-        }
+        readfile($content);
 
         exit();
     }


### PR DESCRIPTION
### What does it do?
Prevents setting headers if the static resource is not streamed directly to the browser.

### Why is it needed?
Incorrect filesize header is set on non-binary content types which are returned and then processed. This ultimately changes the actual content length and causes content to be truncated in most instances.

### How to test
Create a static resource of HTML or another non-binary content type that contains tags that are replaced with content larger than the tag string itself and notice the content is no longer truncated.

### Related issue(s)/PR(s)
Reverts issues inadvertently created by #15702 and #15656