### PR TITLE
Patch MagpieRSS for basic use in PHP 8

### DIFF
--- a/core/model/modx/processors/system/dashboard/widget/feed.class.php
+++ b/core/model/modx/processors/system/dashboard/widget/feed.class.php
@@ -40,7 +40,16 @@ class modDashboardWidgetFeedProcessor extends modProcessor
             return $this->failure();
         }
 
-        return $this->loadFeed($url);
+        $cacheKey = 'dashboard_feed/' . $feed;
+        $fromCache = $this->modx->getCacheManager()->get($cacheKey);
+        if ($fromCache) {
+            return $fromCache;
+        }
+
+        $result = $this->loadFeed($url);
+        $this->modx->getCacheManager()->set($cacheKey, $result, 3600);
+
+        return $result;
     }
 
     public function loadFeed($url)

--- a/core/model/modx/xmlrss/magpierss.class.php
+++ b/core/model/modx/xmlrss/magpierss.class.php
@@ -33,7 +33,7 @@ require_once MAGPIE_DIR . 'rss_utils.inc';
 */
 class MagpieRSS {
     public  $parser;
-    
+
     public $current_item   = array();  // item currently being parsed
     public $items          = array();  // collection of parsed items
     public $channel        = array();  // hash of channel fields
@@ -42,14 +42,14 @@ class MagpieRSS {
     public $feed_type;
     public $feed_version;
     public $encoding       = '';       // output encoding of parsed rss
-    
+
     public $_source_encoding = '';     // only set if we have to parse xml prolog
-    
+
     public $ERROR = "";
     public $WARNING = "";
-    
+
     // define some constants
-    
+
     public $_CONTENT_CONSTRUCTS = array('content', 'summary', 'info', 'title', 'tagline', 'copyright');
     public $_KNOWN_ENCODINGS    = array('UTF-8', 'US-ASCII', 'ISO-8859-1');
 
@@ -61,32 +61,32 @@ class MagpieRSS {
     public $intextinput        = false;
     public $inimage            = false;
     public $current_namespace  = false;
-    
+
 
     /**
      *  Set up XML parser, parse source, and return populated RSS object..
-     *   
+     *
      *  @param string $source           string containing the RSS to be parsed
      *
      *  NOTE:  Probably a good idea to leave the encoding options alone unless
      *         you know what you're doing as PHP's character set support is
      *         a little weird.
      *
-     *  NOTE:  A lot of this is unnecessary but harmless with PHP5 
+     *  NOTE:  A lot of this is unnecessary but harmless with PHP5
      *
      *
-     *  @param string $output_encoding  output the parsed RSS in this character 
+     *  @param string $output_encoding  output the parsed RSS in this character
      *                                  set defaults to ISO-8859-1 as this is PHP's
      *                                  default.
      *
      *                                  NOTE: might be changed to UTF-8 in future
      *                                  versions.
-     *                               
-     *  @param string $input_encoding   the character set of the incoming RSS source. 
+     *
+     *  @param string $input_encoding   the character set of the incoming RSS source.
      *                                  Leave blank and Magpie will try to figure it
      *                                  out.
-     *                                  
-     *                                   
+     *
+     *
      *  @param bool   $detect_encoding  if false Magpie won't attempt to detect
      *                                  source encoding. (caveat emptor)
      *
@@ -95,35 +95,43 @@ class MagpieRSS {
         # if PHP xml isn't compiled in, die
         #
         if (!function_exists('xml_parser_create')) {
-            $this->error( "Failed to load PHP's XML Extension. " . 
+            $this->error( "Failed to load PHP's XML Extension. " .
                           "http://www.php.net/manual/en/ref.xml.php",
                            E_USER_ERROR );
         }
-        
-        list($parser, $source) = $this->create_parser($source, 
+
+        list($parser, $source) = $this->create_parser($source,
                 $output_encoding, $input_encoding, $detect_encoding);
-        
-        
-        if (!is_resource($parser)) {
-            $this->error( "Failed to create an instance of PHP's XML parser. " .
-                          "http://www.php.net/manual/en/ref.xml.php",
-                          E_USER_ERROR );
+
+        if (substr(phpversion(),0,1) > 7) {
+            if (!$parser instanceof XMLParser) {
+                $this->error( "Failed to create an instance of PHP's XML parser. " .
+                    "http://www.php.net/manual/en/ref.xml.php",
+                    E_USER_ERROR );
+            }
+        } else {
+            if (!is_resource($parser)) {
+                $this->error(
+                    "Failed to create an instance of PHP's XML parser. " .
+                    "http://www.php.net/manual/en/ref.xml.php",
+                    E_USER_ERROR
+                );
+            }
         }
 
-        
         $this->parser = $parser;
-        
+
         # pass in parser, and a reference to this object
         # setup handlers
         #
         xml_set_object( $this->parser, $this );
-        xml_set_element_handler($this->parser, 
+        xml_set_element_handler($this->parser,
                 'feed_start_element', 'feed_end_element' );
-                        
-        xml_set_character_data_handler( $this->parser, 'feed_cdata' ); 
-    
+
+        xml_set_character_data_handler( $this->parser, 'feed_cdata' );
+
         $status = xml_parse( $this->parser, $source );
-        
+
         if (! $status ) {
             $errorcode = xml_get_error_code( $this->parser );
             if ( $errorcode != XML_ERROR_NONE ) {
@@ -135,16 +143,16 @@ class MagpieRSS {
                 $this->error( $errormsg );
             }
         }
-        
+
         xml_parser_free( $this->parser );
 
         $this->normalize();
     }
-    
+
     function feed_start_element($p, $element, &$attrs) {
         $el = $element = strtolower($element);
         $attrs = array_change_key_case($attrs, CASE_LOWER);
-        
+
         // check for a namespace, and split if found
         $ns = false;
         if ( strpos( $element, ':' ) ) {
@@ -153,7 +161,7 @@ class MagpieRSS {
         if ( $ns and $ns != 'rdf' ) {
             $this->current_namespace = $ns;
         }
-            
+
         # if feed type isn't set, then this is first element of feed
         # identify feed from root element
         #
@@ -173,37 +181,37 @@ class MagpieRSS {
             }
             return;
         }
-    
-        if ( $el == 'channel' ) 
+
+        if ( $el == 'channel' )
         {
             $this->inchannel = true;
         }
-        elseif ($el == 'item' or $el == 'entry' ) 
+        elseif ($el == 'item' or $el == 'entry' )
         {
             $this->initem = true;
             if ( isset($attrs['rdf:about']) ) {
-                $this->current_item['about'] = $attrs['rdf:about']; 
+                $this->current_item['about'] = $attrs['rdf:about'];
             }
         }
-        
+
         // if we're in the default namespace of an RSS feed,
         //  record textinput or image fields
-        elseif ( 
-            $this->feed_type == RSS and 
-            $this->current_namespace == '' and 
-            $el == 'textinput' ) 
+        elseif (
+            $this->feed_type == RSS and
+            $this->current_namespace == '' and
+            $el == 'textinput' )
         {
             $this->intextinput = true;
         }
-        
+
         elseif (
-            $this->feed_type == RSS and 
-            $this->current_namespace == '' and 
-            $el == 'image' ) 
+            $this->feed_type == RSS and
+            $this->current_namespace == '' and
+            $el == 'image' )
         {
             $this->inimage = true;
         }
-        
+
         # handle atom content constructs
         elseif ( $this->feed_type == ATOM and in_array($el, $this->_CONTENT_CONSTRUCTS) )
         {
@@ -211,40 +219,40 @@ class MagpieRSS {
             if ($el == 'content' ) {
                 $el = 'atom_content';
             }
-            
+
             $this->incontent = $el;
-            
-            
+
+
         }
-        
+
         // if inside an Atom content construct (e.g. content or summary) field treat tags as text
-        elseif ($this->feed_type == ATOM and $this->incontent ) 
+        elseif ($this->feed_type == ATOM and $this->incontent )
         {
             // if tags are inlined, then flatten
-            $attrs_str = join(' ', 
-                    array_map('map_attrs', 
-                    array_keys($attrs), 
+            $attrs_str = join(' ',
+                    array_map('map_attrs',
+                    array_keys($attrs),
                     array_values($attrs) ) );
-            
+
             $this->append_content( "<$element $attrs_str>"  );
-                    
+
             array_unshift( $this->stack, $el );
         }
-        
+
         // Atom support many links per containging element.
         // Magpie treats link elements of type rel='alternate'
         // as being equivalent to RSS's simple link element.
         //
-        elseif ($this->feed_type == ATOM and $el == 'link' ) 
+        elseif ($this->feed_type == ATOM and $el == 'link' )
         {
-            if ( isset($attrs['rel']) and $attrs['rel'] == 'alternate' ) 
+            if ( isset($attrs['rel']) and $attrs['rel'] == 'alternate' )
             {
                 $link_el = 'link';
             }
             else {
                 $link_el = 'link_' . $attrs['rel'];
             }
-            
+
             $this->append($link_el, $attrs['href']);
         }
         // set stack[0] to current element
@@ -252,11 +260,11 @@ class MagpieRSS {
             array_unshift($this->stack, $el);
         }
     }
-    
 
-    
+
+
     function feed_cdata ($p, $text) {
-        if ($this->feed_type == ATOM and $this->incontent) 
+        if ($this->feed_type == ATOM and $this->incontent)
         {
             $this->append_content( $text );
         }
@@ -265,36 +273,36 @@ class MagpieRSS {
             $this->append($current_el, $text);
         }
     }
-    
+
     function feed_end_element ($p, $el) {
         $el = strtolower($el);
-        
-        if ( $el == 'item' or $el == 'entry' ) 
+
+        if ( $el == 'item' or $el == 'entry' )
         {
             $this->items[] = $this->current_item;
             $this->current_item = array();
             $this->initem = false;
         }
-        elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'textinput' ) 
+        elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'textinput' )
         {
             $this->intextinput = false;
         }
-        elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'image' ) 
+        elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'image' )
         {
             $this->inimage = false;
         }
         elseif ($this->feed_type == ATOM and in_array($el, $this->_CONTENT_CONSTRUCTS) )
-        {   
+        {
             $this->incontent = false;
         }
-        elseif ($el == 'channel' or $el == 'feed' ) 
+        elseif ($el == 'channel' or $el == 'feed' )
         {
             $this->inchannel = false;
         }
         elseif ($this->feed_type == ATOM and $this->incontent  ) {
             // balance tags properly
             // note:  i don't think this is actually neccessary
-            if ( $this->stack[0] == $el ) 
+            if ( $this->stack[0] == $el )
             {
                 $this->append_content("</$el>");
             }
@@ -307,19 +315,19 @@ class MagpieRSS {
         else {
             array_shift( $this->stack );
         }
-        
+
         $this->current_namespace = false;
     }
-    
+
     function concat (&$str1, $str2="") {
         if (!isset($str1) ) {
             $str1="";
         }
         $str1 .= $str2;
     }
-    
-    
-    
+
+
+
     function append_content($text) {
         if ( $this->initem ) {
             $this->concat( $this->current_item[ $this->incontent ], $text );
@@ -328,13 +336,13 @@ class MagpieRSS {
             $this->concat( $this->channel[ $this->incontent ], $text );
         }
     }
-    
+
     // smart append - field and namespace aware
     function append($el, $text) {
         if (!$el) {
             return;
         }
-        if ( $this->current_namespace ) 
+        if ( $this->current_namespace )
         {
             if ( $this->initem ) {
                 $this->concat(
@@ -370,10 +378,10 @@ class MagpieRSS {
                 $this->concat(
                     $this->channel[ $el ], $text );
             }
-            
+
         }
     }
-    
+
     function normalize () {
         // if atom populate rss fields
         if ( $this->is_atom() ) {
@@ -384,7 +392,7 @@ class MagpieRSS {
                     $item['description'] = $item['summary'];
                 if ( isset($item['atom_content']))
                     $item['content']['encoded'] = $item['atom_content'];
-                
+
                 $atom_date = (isset($item['issued']) ) ? $item['issued'] : $item['modified'];
                 if ( $atom_date ) {
                     $epoch = @parse_w3cdtf($atom_date);
@@ -392,9 +400,9 @@ class MagpieRSS {
                         $item['date_timestamp'] = $epoch;
                     }
                 }
-                
+
                 $this->items[$i] = $item;
-            }       
+            }
         }
         elseif ( $this->is_rss() ) {
             $this->channel['tagline'] = $this->channel['description'];
@@ -404,7 +412,7 @@ class MagpieRSS {
                     $item['summary'] = $item['description'];
                 if ( isset($item['content']['encoded'] ) )
                     $item['atom_content'] = $item['content']['encoded'];
-                
+
                 if ( $this->is_rss() == '1.0' and isset($item['dc']['date']) ) {
                     $epoch = @parse_w3cdtf($item['dc']['date']);
                     if ($epoch and $epoch > 0) {
@@ -417,22 +425,22 @@ class MagpieRSS {
                         $item['date_timestamp'] = $epoch;
                     }
                 }
-                
+
                 $this->items[$i] = $item;
             }
         }
     }
-    
-    
+
+
     function is_rss () {
         if ( $this->feed_type == RSS ) {
-            return $this->feed_version; 
+            return $this->feed_version;
         }
         else {
             return false;
         }
     }
-    
+
     function is_atom() {
         if ( $this->feed_type == ATOM ) {
             return $this->feed_version;
@@ -457,15 +465,15 @@ class MagpieRSS {
             $this->encoding = $out_enc;
             xml_parser_set_option($parser, XML_OPTION_TARGET_ENCODING, $out_enc);
         }
-        
+
         return array($parser, $source);
     }
-    
+
     /**
     * Instantiate an XML parser under PHP5
     *
     * PHP5 will do a fine job of detecting input encoding
-    * if passed an empty string as the encoding. 
+    * if passed an empty string as the encoding.
     *
     * All hail libxml2!
     *
@@ -479,7 +487,7 @@ class MagpieRSS {
             return xml_parser_create('');
         }
     }
-    
+
     /**
     * Instaniate an XML parser under PHP4
     *
@@ -499,7 +507,7 @@ class MagpieRSS {
         if ( !$detect ) {
             return array(xml_parser_create($in_enc), $source);
         }
-        
+
         if (!$in_enc) {
             if (preg_match('/<?xml.*encoding=[\'"](.*?)[\'"].*?>/m', $source, $m)) {
                 $in_enc = strtoupper($m[1]);
@@ -509,24 +517,24 @@ class MagpieRSS {
                 $in_enc = 'UTF-8';
             }
         }
-        
+
         if ($this->known_encoding($in_enc)) {
             return array(xml_parser_create($in_enc), $source);
         }
-        
+
         // the dectected encoding is not one of the simple encodings PHP knows
-        
+
         // attempt to use the iconv extension to
         // cast the XML to a known encoding
         // @see http://php.net/iconv
-       
+
         if (function_exists('iconv'))  {
             $encoded_source = iconv($in_enc,'UTF-8', $source);
             if ($encoded_source) {
                 return array(xml_parser_create('UTF-8'), $encoded_source);
             }
         }
-        
+
         // iconv didn't work, try mb_convert_encoding
         // @see http://php.net/mbstring
         if(function_exists('mb_convert_encoding')) {
@@ -535,15 +543,15 @@ class MagpieRSS {
                 return array(xml_parser_create('UTF-8'), $encoded_source);
             }
         }
-        
-        // else 
+
+        // else
         $this->error("Feed is in an unsupported character encoding. ($in_enc) " .
                      "You may see strange artifacts, and mangled characters.",
                      E_USER_NOTICE);
-            
+
         return array(xml_parser_create(), $source);
     }
-    
+
     function known_encoding($enc) {
         $enc = strtoupper($enc);
         if ( in_array($enc, $this->_KNOWN_ENCODINGS) ) {
@@ -556,16 +564,16 @@ class MagpieRSS {
 
     function error ($errormsg, $lvl=E_USER_WARNING) {
         // append PHP's error message if track_errors enabled
-        if ( isset($php_errormsg) ) { 
+        if ( isset($php_errormsg) ) {
             $errormsg .= " ($php_errormsg)";
         }
         if ( MAGPIE_DEBUG ) {
-            trigger_error( $errormsg, $lvl);        
+            trigger_error( $errormsg, $lvl);
         }
         else {
             error_log( $errormsg, 0);
         }
-        
+
         $notices = E_USER_NOTICE|E_NOTICE;
         if ( $lvl&$notices ) {
             $this->WARNING = $errormsg;
@@ -573,15 +581,15 @@ class MagpieRSS {
             $this->ERROR = $errormsg;
         }
     }
-    
-    
+
+
 } // end class RSS
 
 function map_attrs($k, $v) {
     return "$k=\"$v\"";
 }
 
-// patch to support medieval versions of PHP4.1.x, 
+// patch to support medieval versions of PHP4.1.x,
 // courtesy, Ryan Currie, ryan@digibliss.com
 
 if (!function_exists('array_change_key_case')) {

--- a/core/model/modx/xmlrss/rssfetch.class.php
+++ b/core/model/modx/xmlrss/rssfetch.class.php
@@ -15,7 +15,7 @@
  * magpierss-general@lists.sourceforge.net
  *
  */
- 
+
 // Setup MAGPIE_DIR for use on hosts that don't include
 // the current path in include_path.
 // with thanks to rajiv and smarty
@@ -35,18 +35,18 @@ define('MAGPIE_EXTLIB', MAGPIE_DIR . 'extlib' . DIR_SEP);
 require_once MAGPIE_EXTLIB . 'snoopy.class.php';
 
 
-/* 
+/*
  * CONSTANTS - redefine these in your script to change the
  * behaviour of fetch_rss() currently, most options effect the cache
  *
- * MAGPIE_CACHE_ON - Should Magpie cache parsed RSS objects? 
- * For me a built in cache was essential to creating a "PHP-like" 
+ * MAGPIE_CACHE_ON - Should Magpie cache parsed RSS objects?
+ * For me a built in cache was essential to creating a "PHP-like"
  * feel to Magpie, see rss_cache.inc for rationale
  *
  *
  * MAGPIE_CACHE_DIR - Where should Magpie cache parsed RSS objects?
- * This should be a location that the webserver can write to.   If this 
- * directory does not already exist Mapie will try to be smart and create 
+ * This should be a location that the webserver can write to.   If this
+ * directory does not already exist Mapie will try to be smart and create
  * it.  This will often fail for permissions reasons.
  *
  *
@@ -62,20 +62,20 @@ require_once MAGPIE_EXTLIB . 'snoopy.class.php';
 
 
 /*=======================================================================*\
-    Function: fetch_rss: 
+    Function: fetch_rss:
     Purpose:  return RSS object for the give url
               maintain the cache
     Input:    url of RSS file
     Output:   parsed RSS object (see rss_parse.inc)
 
-    NOTES ON CACHEING:  
+    NOTES ON CACHEING:
     If caching is on (MAGPIE_CACHE_ON) fetch_rss will first check the cache.
-    
+
     NOTES ON RETRIEVING REMOTE FILES:
     If conditional gets are on (MAGPIE_CONDITIONAL_GET_ON) fetch_rss will
     return a cached object, and touch the cache object upon recieving a
     304.
-    
+
     NOTES ON FAILED REQUESTS:
     If there is an HTTP error while fetching an RSS object, the cached
     version will be return, if it exists (and if MAGPIE_CACHE_FRESH_ONLY is off)
@@ -88,14 +88,14 @@ $MAGPIE_ERROR = "";
 function fetch_rss ($url) {
     // initialize constants
     init();
-    
+
     if ( !isset($url) ) {
         error("fetch_rss called without a url");
         return false;
     }
-    
+
     // if cache is disabled
-    if ( !MAGPIE_CACHE_ON ) {
+    if ( PHP_MAJOR_VERSION >= 8 || !MAGPIE_CACHE_ON ) {
         // fetch file, and parse it
         $resp = _fetch_remote_file( $url );
         if ( is_success( $resp->status ) ) {
@@ -105,7 +105,7 @@ function fetch_rss ($url) {
             error("Failed to fetch $url and cache is off");
             return false;
         }
-    } 
+    }
     // else cache is ON
     else {
         // Flow
@@ -113,28 +113,28 @@ function fetch_rss ($url) {
         // 2. if there is a hit, make sure its fresh
         // 3. if cached obj fails freshness check, fetch remote
         // 4. if remote fails, return stale object, or error
-        
+
         $cache = new RSSCache( MAGPIE_CACHE_DIR, MAGPIE_CACHE_AGE );
-        
+
         if (MAGPIE_DEBUG and $cache->ERROR) {
             debug($cache->ERROR, E_USER_WARNING);
         }
-        
-        
+
+
         $cache_status    = 0;       // response of check_cache
         $request_headers = array(); // HTTP headers to send with fetch
         $rss             = 0;       // parsed RSS object
         $errormsg        = 0;       // errors, if any
-        
+
         // store parsed XML by desired output encoding
         // as character munging happens at parse time
         $cache_key       = $url . MAGPIE_OUTPUT_ENCODING;
-        
+
         if (!$cache->ERROR) {
             // return cache HIT, MISS, or STALE
             $cache_status = $cache->check_cache( $cache_key);
         }
-                
+
         // if object cached, and cache is fresh, return cached obj
         if ( $cache_status == 'HIT' ) {
             $rss = $cache->get( $cache_key );
@@ -147,9 +147,9 @@ function fetch_rss ($url) {
                 return $rss;
             }
         }
-        
+
         // else attempt a conditional get
-        
+
         // setup headers
         if ( $cache_status == 'STALE' ) {
             $rss = $cache->get( $cache_key );
@@ -158,7 +158,7 @@ function fetch_rss ($url) {
                 $request_headers['If-Last-Modified'] = $rss->last_modified;
             }
         }
-        
+
         $resp = _fetch_remote_file( $url, $request_headers );
 
         if ($resp) {
@@ -194,7 +194,7 @@ function fetch_rss ($url) {
                 elseif ( $resp->error ) {
                     # compensate for Snoopy's annoying habbit to tacking
                     # on '\n'
-                    $http_error = substr($resp->error, 0, -2); 
+                    $http_error = substr($resp->error, 0, -2);
                     $errormsg .= "(HTTP Error: $http_error)";
                 }
                 else {
@@ -205,7 +205,7 @@ function fetch_rss ($url) {
         else {
             $errormsg = "Unable to retrieve RSS file for unknown reasons.";
         }
-        
+
         // else fetch failed
         // attempt to return cached object
         if ($rss) {
@@ -214,12 +214,12 @@ function fetch_rss ($url) {
             }
             return $rss;
         }
-        
+
         // else we totally failed
-        error( $errormsg ); 
-        
+        error( $errormsg );
+
         return false;
-        
+
     } // end if ( !MAGPIE_CACHE_ON ) {
 } // end fetch_rss()
 
@@ -230,34 +230,34 @@ function fetch_rss ($url) {
 
 function error ($errormsg, $lvl=E_USER_WARNING) {
         global $MAGPIE_ERROR;
-        
+
         // append PHP's error message if track_errors enabled
-        if ( isset($php_errormsg) ) { 
+        if ( isset($php_errormsg) ) {
             $errormsg .= " ($php_errormsg)";
         }
         if ( $errormsg ) {
             $errormsg = "MagpieRSS: $errormsg";
             $MAGPIE_ERROR = $errormsg;
-            trigger_error( $errormsg, $lvl);                
+            trigger_error( $errormsg, $lvl);
         }
 }
 
 function debug ($debugmsg, $lvl=E_USER_NOTICE) {
     trigger_error("MagpieRSS [debug] $debugmsg", $lvl);
 }
-            
+
 /*=======================================================================*\
     Function:   magpie_error
     Purpose:    accessor for the magpie error variable
 \*=======================================================================*/
 function magpie_error ($errormsg="") {
     global $MAGPIE_ERROR;
-    
-    if ( isset($errormsg) and $errormsg ) { 
+
+    if ( isset($errormsg) and $errormsg ) {
         $MAGPIE_ERROR = $errormsg;
     }
-    
-    return $MAGPIE_ERROR;   
+
+    return $MAGPIE_ERROR;
 }
 
 /*=======================================================================*\
@@ -265,7 +265,7 @@ function magpie_error ($errormsg="") {
     Purpose:    retrieve an arbitrary remote file
     Input:      url of the remote file
                 headers to send along with the request (optional)
-    Output:     an HTTP response object (see Snoopy.class.inc)  
+    Output:     an HTTP response object (see Snoopy.class.inc)
 \*=======================================================================*/
 function _fetch_remote_file ($url, $headers = "" ) {
     // Snoopy is an HTTP client in PHP
@@ -276,7 +276,7 @@ function _fetch_remote_file ($url, $headers = "" ) {
     if (is_array($headers) ) {
         $client->rawheaders = $headers;
     }
-    
+
     @$client->fetch($url);
     return $client;
 
@@ -290,10 +290,10 @@ function _fetch_remote_file ($url, $headers = "" ) {
 \*=======================================================================*/
 function _response_to_rss ($resp) {
     $rss = new MagpieRSS( $resp->results, MAGPIE_OUTPUT_ENCODING, MAGPIE_INPUT_ENCODING, MAGPIE_DETECT_ENCODING );
-    
-    // if RSS parsed successfully       
+
+    // if RSS parsed successfully
     if ( $rss and !$rss->ERROR) {
-        
+
         // find Etag, and Last-Modified
         foreach($resp->headers as $h) {
             // 2003-03-02 - Nicola Asuni (www.tecnick.com) - fixed bug "Undefined offset: 1"
@@ -304,26 +304,26 @@ function _response_to_rss ($resp) {
                 $field = $h;
                 $val = "";
             }
-            
+
             if ( $field == 'ETag' ) {
                 $rss->etag = $val;
             }
-            
+
             if ( $field == 'Last-Modified' ) {
                 $rss->last_modified = $val;
             }
         }
-        
-        return $rss;    
+
+        return $rss;
     } // else construct error message
     else {
         $errormsg = "Failed to parse RSS file.";
-        
+
         if ($rss) {
             $errormsg .= " (" . $rss->ERROR . ")";
         }
         error($errormsg);
-        
+
         return false;
     } // end if ($rss and !$rss->error)
 }
@@ -340,7 +340,7 @@ function init () {
     else {
         define('MAGPIE_INITALIZED', true);
     }
-    
+
     if ( !defined('MAGPIE_CACHE_ON') ) {
         define('MAGPIE_CACHE_ON', true);
     }
@@ -360,39 +360,39 @@ function init () {
     if ( !defined('MAGPIE_OUTPUT_ENCODING') ) {
         define('MAGPIE_OUTPUT_ENCODING', 'UTF-8');
     }
-    
+
     if ( !defined('MAGPIE_INPUT_ENCODING') ) {
         define('MAGPIE_INPUT_ENCODING', null);
     }
-    
+
     if ( !defined('MAGPIE_DETECT_ENCODING') ) {
         define('MAGPIE_DETECT_ENCODING', true);
     }
-    
+
     if ( !defined('MAGPIE_DEBUG') ) {
         define('MAGPIE_DEBUG', 0);
     }
-    
+
     if ( !defined('MAGPIE_USER_AGENT') ) {
         $ua = 'MagpieRSS/'. MAGPIE_VERSION . ' (+http://magpierss.sf.net';
-        
+
         if ( MAGPIE_CACHE_ON ) {
             $ua = $ua . ')';
         }
         else {
             $ua = $ua . '; No cache)';
         }
-        
+
         define('MAGPIE_USER_AGENT', $ua);
     }
-    
+
     if ( !defined('MAGPIE_FETCH_TIME_OUT') ) {
         define('MAGPIE_FETCH_TIME_OUT', 5); // 5 second timeout
     }
-    
+
     // use gzip encoding to fetch rss files if supported?
     if ( !defined('MAGPIE_USE_GZIP') ) {
-        define('MAGPIE_USE_GZIP', true);    
+        define('MAGPIE_USE_GZIP', true);
     }
 }
 
@@ -403,7 +403,7 @@ function init () {
     HTTP STATUS CODE PREDICATES
     These functions attempt to classify an HTTP status code
     based on RFC 2616 and RFC 2518.
-    
+
     All of them take an HTTP status code as input, and return true or false
 
     All this code is adapted from LWP's HTTP::Status.
@@ -414,46 +414,46 @@ function init () {
     Function:   is_info
     Purpose:    return true if Informational status code
 \*=======================================================================*/
-function is_info ($sc) { 
-    return $sc >= 100 && $sc < 200; 
+function is_info ($sc) {
+    return $sc >= 100 && $sc < 200;
 }
 
 /*=======================================================================*\
     Function:   is_success
     Purpose:    return true if Successful status code
 \*=======================================================================*/
-function is_success ($sc) { 
-    return $sc >= 200 && $sc < 300; 
+function is_success ($sc) {
+    return $sc >= 200 && $sc < 300;
 }
 
 /*=======================================================================*\
     Function:   is_redirect
     Purpose:    return true if Redirection status code
 \*=======================================================================*/
-function is_redirect ($sc) { 
-    return $sc >= 300 && $sc < 400; 
+function is_redirect ($sc) {
+    return $sc >= 300 && $sc < 400;
 }
 
 /*=======================================================================*\
     Function:   is_error
     Purpose:    return true if Error status code
 \*=======================================================================*/
-function is_error ($sc) { 
-    return $sc >= 400 && $sc < 600; 
+function is_error ($sc) {
+    return $sc >= 400 && $sc < 600;
 }
 
 /*=======================================================================*\
     Function:   is_client_error
     Purpose:    return true if Error status code, and its a client error
 \*=======================================================================*/
-function is_client_error ($sc) { 
-    return $sc >= 400 && $sc < 500; 
+function is_client_error ($sc) {
+    return $sc >= 400 && $sc < 500;
 }
 
 /*=======================================================================*\
     Function:   is_client_error
     Purpose:    return true if Error status code, and its a server error
 \*=======================================================================*/
-function is_server_error ($sc) { 
-    return $sc >= 500 && $sc < 600; 
+function is_server_error ($sc) {
+    return $sc >= 500 && $sc < 600;
 }


### PR DESCRIPTION
### What does it do?
Patch MagpieRSS to work in PHP 8

### Why is it needed?
News and Security feeds are currently blank in PHP 8.

### How to test
Load the Manager Dashboard in a PHP 8 environment and confirm the News and Security feeds are not blank.

### Related issue(s)/PR(s)
Resolves #15712 

### Note
Though this makes it work for now in PHP 8, it is not an ideal solution because it bypasses MagpieRSS cache features to get around the fact that in PHP 8 you cannot serialize an XMLParser instance.