### PR TITLE
Configurable extension for static html files

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2259,4 +2259,13 @@ $settings['error_log_filepath']->fromArray(array (
     'area' => 'system',
     'editedon' => null,
 ), '', true, true);
+$settings['static_elements_html_extension']= $xpdo->newObject('modSystemSetting');
+$settings['static_elements_html_extension']->fromArray(array (
+    'key' => 'static_elements_html_extension',
+    'value' => '.tpl',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'static_elements',
+    'editedon' => null,
+), '', true, true);
 return $settings;

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -874,3 +874,6 @@ $_lang['setting_error_log_filename_desc'] = 'Customize the filename of the MODX 
 
 $_lang['setting_error_log_filepath'] = 'Error log path';
 $_lang['setting_error_log_filepath_desc'] = 'Optionally set a absolute path the a custom error log location. You might use placehodlers like {cache_path}.';
+
+$_lang['static_elements_html_extension'] = 'Static elements html extension';
+$_lang['static_elements_html_extension_desc'] = 'The extension for files used by static elements with HTML content.';

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -238,23 +238,23 @@ Ext.extend(MODx,Ext.Component,{
 			,listeners: {
 				'success': {
 					fn:function() {
-						var tree = Ext.getCmp("modx-resource-tree"); 
-						
+						var tree = Ext.getCmp("modx-resource-tree");
+
 						if (tree && tree.rendered) {
 							tree.refresh();
 						}
 
 						var cmp = Ext.getCmp("modx-panel-resource");
-						
+
 						if (cmp) {
 							Ext.getCmp('modx-abtn-locked').hide();
-							Ext.getCmp('modx-abtn-save').show();	
+							Ext.getCmp('modx-abtn-save').show();
 						}
 					},
 					scope:this
 				}
 			}
-		});  
+		});
     }
 
     ,sleep: function(ms) {
@@ -355,13 +355,13 @@ Ext.extend(MODx,Ext.Component,{
 
         switch(type) {
             case "templates":
-                ext = ".template.tpl";
+                ext = ".template" + (MODx.config.static_elements_html_extension || ".tpl");
                 break;
             case "tvs":
-                ext = ".tv.tpl";
+                ext = ".tv" + (MODx.config.static_elements_html_extension || ".tpl");
                 break;
             case "chunks":
-                ext = ".chunk.tpl";
+                ext = ".chunk" + (MODx.config.static_elements_html_extension || ".tpl");
                 break;
             case "snippets":
                 ext = ".snippet.php";


### PR DESCRIPTION
### What does it do?
Add a configurable extension for static html files

### Why is it needed?
PhpStorm does not really like the .tpl extension for html content and shows some code check issues. .tpl files are detected as Smarty template file by default. Changing this default means that real Smarty templates showing code checks issues afterwards.

### How to test
Rebuild the MODX assets, create the system setting static_elements_html_extension and set it i.e. to `.html`, enable the static_elements_automate_chunks system setting, edit a chunk and set it to static. The static file extension is set to `.chunk.html`.

### Additional work
The system setting static_elements_html_extension has to be added by a upgrade script.

### Related issue(s)/PR(s)
None known