### PR TITLE
Fix PHP5.6 compatibility issue on system info

### DIFF
--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -42,10 +42,12 @@ class SystemInfoManagerController extends modManagerController {
         if ($dbtype_mysql && !empty($m['pdo_mysql'])) $pi = array_merge($pi,array('pdo_mysql' => $m['pdo_mysql']));
         if ($dbtype_sqlsrv && !empty($m['pdo_sqlsrv'])) $pi = array_merge($pi,array('pdo_sqlsrv' => $m['pdo_sqlsrv']));
         if (!empty($m['zip'])) $pi = array_merge($pi,array('zip' => $m['zip']));
+        /** @var modPHPMailer $mailerService */
         $mailerService = $this->modx->getService('mail', 'mail.modPHPMailer');
+        $mailer = $mailerService->mailer;
         $this->version = [
             'smarty'=> $this->modx->smarty->_version,
-            'PHPMailer'=> $mailerService->mailer::VERSION
+            'PHPMailer'=> $mailer::VERSION,
         ];
 
         $this->pi = array_merge($pi,$this->getPhpInfo(INFO_CONFIGURATION));


### PR DESCRIPTION
### What does it do?

Changes the way the PHPMailer version is read to not throw a fatal error on PHP 5.6 or below. 

The problem is not the `::` itself (`VERSION` is a constant, so that's correct), but that it's being called on a member of an instance. Apparently the PHP parser can't handle that before PHP 7. [See explanation](https://stackoverflow.com/a/5447569/1277345) and [an 3v4l test](https://3v4l.org/4Vj1N)

### Why is it needed?

While nobody really should use PHP 5.6 these days, it is formally supported, and it breaking would be a technical breaking change not meant to be introduced in a patch release. 

The issue was introduced in #15704, which landed in 2.8.3. 

### How to test

Visit the system info page while using PHP 5.6. Before, it showed the fatal error `Parse error: syntax error, unexpected '::' (T_PAAMAYIM_NEKUDOTAYIM), expecting ']' in manager/controllers/default/system/info.class.php on line 48`, after it shows the version number correctly.

### Related issue(s)/PR(s)

Fixes #15727
