### PR TITLE
Fix image TV display via hash

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/image.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/image.class.php
@@ -31,20 +31,26 @@ class modTemplateVarInputRenderImage extends modTemplateVarInputRender {
         $this->modx->controller->setPlaceholder('source',$source->get('id'));
         $params = array_merge($source->getPropertyList(),$params);
 
+        $value = $this->tv->get('value');
+        $this->tv->set('relativeValue', $value);
         if (!$source->checkPolicy('view')) {
-            $this->setPlaceholder('disabled',true);
-            $this->tv->set('disabled',true);
-            $this->tv->set('relativeValue',$this->tv->get('value'));
+            $this->setPlaceholder('disabled', true);
+            $this->tv->set('disabled', true);
         } else {
-            $this->setPlaceholder('disabled',false);
-            $this->tv->set('disabled',false);
-            $value = $this->tv->get('value');
+            $this->setPlaceholder('disabled', false);
+            $this->tv->set('disabled', false);
             if (!empty($value)) {
-                $params['openTo'] = $source->getOpenTo($value,$params);
+                $params['openTo'] = $source->getOpenTo($value, $params);
             }
-            $this->tv->set('relativeValue',$value);
+        }
+        if (!empty($value) && file_exists($source->getBasePath() . $value)) {
+            $filename = $source->getBasePath() . $value;
+            $hash = hash('crc32', filemtime($filename) . filesize($filename));
+        } else {
+            $hash = hash('crc32', $value);
         }
 
+        $this->setPlaceholder('hash', $hash);
         $this->setPlaceholder('params',$params);
         $this->setPlaceholder('tv',$this->tv);
     }

--- a/core/model/modx/processors/system/phpthumb.class.php
+++ b/core/model/modx/processors/system/phpthumb.class.php
@@ -33,6 +33,7 @@ class modSystemPhpThumbProcessor extends modProcessor {
             'context' => $this->getProperty('wctx')
         ));
         $this->unsetProperty('wctx');
+        $this->unsetProperty('version');
         
         return true;
     }

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,6 +1,6 @@
 <div id="tv-image-{$tv->id}"></div>
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}" alt="" />{/if}
+    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}&version={rand(1,10000000)}" alt="" />{/if}
 </div>
 {if $disabled}
 <script>

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,6 +1,6 @@
 <div id="tv-image-{$tv->id}"></div>
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}&version={rand(1,10000000)}" alt="" />{/if}
+    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}&version={$hash}" alt="" />{/if}
 </div>
 {if $disabled}
 <script>


### PR DESCRIPTION
Если выбранные изображения имеют одинаковые названия, но при этом это разные изображения, то превью таких изображений не обновляются на разных страницах, т.к. браузер кеширует прошлое изображение. 
(If the selected images have the same name, but they are different images, then the previews of such images are not updated on different pages, because the browser caches the previous image.)
