### PR TITLE
Add typeahead to Resource List TV

### DIFF
--- a/manager/templates/default/element/tv/renders/input/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/input/resourcelist.tpl
@@ -15,22 +15,17 @@ Ext.onReady(function() {
         ,id: 'tv{$tv->id}'
         ,triggerAction: 'all'
         ,width: 400
+        ,maxHeight: 300
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}
-
-        {if $params.title|default},title: '{$params.title}'{/if}
-        {if $params.listWidth|default},listWidth: {$params.listWidth}{/if}
-        ,maxHeight: {if $params.maxHeight|default}{$params.maxHeight}{else}300{/if}
         {if $params.typeAhead == 1 || $params.typeAhead == 'true'}
             ,typeAhead: true
-            ,typeAheadDelay: {if $params.typeAheadDelay && $params.typeAheadDelay != ''}{$params.typeAheadDelay}{else}250{/if}
+            ,typeAheadDelay: {if $params.typeAheadDelay|default && $params.typeAheadDelay|default != ''}{$params.typeAheadDelay|default}{else}250{/if}
+            ,editable: true
         {else}
-            ,editable: false
             ,typeAhead: false
+            ,editable: false
         {/if}
-        {if $params.listEmptyText|default}
-            ,listEmptyText: '{$params.listEmptyText}'
-        {/if}
-        ,forceSelection: {if $params.forceSelection|default && $params.forceSelection != 'false'}true{else}false{/if}
+        ,forceSelection: false
         ,msgTarget: 'under'
 
         {if $params.allowBlank == 1 || $params.allowBlank == 'true'}

--- a/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
+++ b/manager/templates/default/element/tv/renders/inputproperties/resourcelist.tpl
@@ -47,6 +47,52 @@ MODx.load({
         ,items: [{
             columnWidth: .5
             ,items: [{
+                xtype: 'combo-boolean'
+                ,fieldLabel: _('combo_typeahead')
+                ,description: MODx.expandHelp ? '' : _('combo_typeahead_desc')
+                ,name: 'inopt_typeAhead'
+                ,hiddenName: 'inopt_typeAhead'
+                ,id: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
+                ,anchor: '100%'
+                ,value: (params['typeAhead']) ? !(params['typeAhead'] === 0 || params['typeAhead'] === 'false') : false
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_typeAhead{/literal}{$tv|default}{literal}'
+                ,html: _('combo_typeahead_desc')
+                ,cls: 'desc-under'
+            }]
+        },{
+            columnWidth: .5
+            ,items: [{
+                xtype: 'textfield'
+                ,fieldLabel: _('combo_typeahead_delay')
+                ,description: MODx.expandHelp ? '' : _('combo_typeahead_delay_desc')
+                ,name: 'inopt_typeAheadDelay'
+                ,id: 'inopt_typeAheadDelay{/literal}{$tv|default}{literal}'
+                ,value: params['typeAheadDelay'] || 250
+                ,anchor: '100%'
+                ,listeners: oc
+            },{
+                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                ,forId: 'inopt_typeAheadDelay{/literal}{$tv|default}{literal}'
+                ,html: _('typeahead_delay_desc')
+                ,cls: 'desc-under'
+            }]
+        }]
+    },{
+        layout: 'column'
+        ,border: false
+        ,defaults: {
+            layout: 'form'
+            ,labelAlign: 'top'
+            ,labelSeparator: ''
+            ,anchor: '100%'
+            ,border: false
+        }
+        ,items: [{
+            columnWidth: .5
+            ,items: [{
                 xtype: 'textfield'
                 ,fieldLabel: _('resourcelist_parents')
                 ,description: MODx.expandHelp ? '' : _('resourcelist_parents_desc')


### PR DESCRIPTION
### What does it do?
Added the ability to enter text for Resource List TV:
- Added "Type-Ahead" for Resource List TV input options;
- Fixed params in Resource List TV render (also removed unnecessary parameters that are not used).

![res_list](https://user-images.githubusercontent.com/12523676/120651702-1adda480-c490-11eb-8a55-abd78b3e5456.gif)

### Why is it needed?
It is not convenient to search for a resource in the drop-down list, especially if there are a lot of resources in TV.
Now there will be no such problem, since text input works.

### Related issue(s)/PR(s)
N/A
