### PR TITLE
Fix modManagerLog MySQL > 5.7.8

### DIFF
--- a/core/model/modx/mysql/modmanagerlog.map.inc.php
+++ b/core/model/modx/mysql/modmanagerlog.map.inc.php
@@ -36,7 +36,7 @@ $xpdo_meta_map['modManagerLog']= array (
       'dbtype' => 'datetime',
       'phptype' => 'datetime',
       'null' => false,
-      'default' => CURRENT_TIMESTAMP,
+      'default' => 'CURRENT_TIMESTAMP',
     ),
     'action' => 
     array (

--- a/core/model/modx/mysql/modmanagerlog.map.inc.php
+++ b/core/model/modx/mysql/modmanagerlog.map.inc.php
@@ -35,8 +35,8 @@ $xpdo_meta_map['modManagerLog']= array (
     array (
       'dbtype' => 'datetime',
       'phptype' => 'datetime',
-      'null' => true,
-      'default' => NULL,
+      'null' => false,
+      'default' => CURRENT_TIMESTAMP,
     ),
     'action' => 
     array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -679,7 +679,7 @@
 
     <object class="modManagerLog" table="manager_log" extends="xPDOSimpleObject">
         <field key="user" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
-        <field key="occurred" dbtype="datetime" phptype="datetime" null="true" default="NULL" />
+        <field key="occurred" dbtype="datetime" phptype="datetime" null="false" default="CURRENT_TIMESTAMP" />
         <field key="action" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="classKey" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="item" dbtype="varchar" precision="191" phptype="string" null="false" default="0" />


### PR DESCRIPTION
### What does it do?
Add right default value for datatime-type column in modx_manager_log table

### Why is it needed?
Beginning with MySQL > 5.7.8  added strict modes ERROR_FOR_DIVISION_BY_ZERO, NO_ZERO_DATE,  NO_ZERO_IN_DATE. In this strict modes datatime default value cannot be NULL and must be > '0000-00-00'.

### How to test
When setup modx In MySQL 5.7.8 not create index user_occurred at  modx_manager_log table.

Try to add index in console
`create index user_occurred ON modx_manager_log (user, occurred)`

Result
`ERROR 1067 (42000): Invalid default value for 'occurred'`
