### PR TITLE
Hide broken navigation in trees

### DIFF
--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -291,6 +291,10 @@
       color: $green !important;
     }
   }
+
+  #modx-gr-tree-resource &, #modx-ih-resource-tree & {
+    display: none;
+  }
 }
 
 /* Direct create buttons for a tree node */
@@ -314,6 +318,10 @@
         opacity: 1.0;
         color: $green;
       }
+    }
+
+    #modx-gr-tree-resource &, #modx-ih-resource-tree & {
+      display: none;
     }
   }
 

--- a/manager/assets/modext/widgets/security/modx.panel.resource.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.resource.group.js
@@ -8,7 +8,7 @@ MODx.panel.ResourceGroups = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-resource-groups'
-		,cls: 'container'
+        ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,items: [{
             html: _('resource_groups')
@@ -23,7 +23,7 @@ MODx.panel.ResourceGroups = function(config) {
                 ,xtype: 'modx-description'
             },{
                 layout: 'column'
-				,cls:'main-wrapper'
+                ,cls:'main-wrapper'
                 ,defaults: { border: false }
                 ,items: [{
                     columnWidth: .5
@@ -50,6 +50,9 @@ MODx.panel.ResourceGroups = function(config) {
                         ,allowDrop: false
                         ,enableDD: false
                         ,rootVisible: false
+                        ,listeners: {
+                            'click': {fn:function() {return false;}}
+                        }
                     }]
                 }]
             }]


### PR DESCRIPTION
### What does it do?
- Hide broken navigation in trees: Resource Groups, Import Static Resources, Import HTML.
- Disabled the ability to go inside editing a resource with an accidental click in Resource Groups section.

Before (on the gif, I click on the icons):
![rg_before](https://user-images.githubusercontent.com/12523676/123078271-dbb9c800-d42b-11eb-981e-00091412971e.gif)

After:
![rg_after](https://user-images.githubusercontent.com/12523676/123078264-d9f00480-d42b-11eb-8dbb-6bd30bfab275.png)

Navigation is not needed there, and links allow you to leave the section by accidental click, which is inconvenient.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14216