### PR TITLE
Fix import section lexicons

### DIFF
--- a/manager/assets/modext/sections/system/import/html.js
+++ b/manager/assets/modext/sections/system/import/html.js
@@ -4,7 +4,7 @@ MODx.page.ImportHTML = function(config) {
         formpanel: 'modx-panel-import-html'
         ,buttons: [{
             process: 'System/Import/Html'
-            ,text: _('import_site')
+            ,text: _('import_site_html')
             ,id: 'modx-abtn-import'
             ,cls:'primary-button'
             ,method: 'remote'

--- a/manager/assets/modext/sections/system/import/resource.js
+++ b/manager/assets/modext/sections/system/import/resource.js
@@ -4,7 +4,7 @@ MODx.page.ImportResource = function(config) {
         formpanel: 'modx-panel-import-resources'
         ,buttons: [{
             process: 'System/Import/Index'
-            ,text: _('import_resources')
+            ,text: _('import_site_resource')
             ,id: 'modx-abtn-import'
             ,cls: 'primary-button'
             ,method: 'remote'

--- a/manager/controllers/default/system/import/index.class.php
+++ b/manager/controllers/default/system/import/index.class.php
@@ -53,7 +53,7 @@ class SystemImportManagerController extends modManagerController {
      * @return string
      */
     public function getPageTitle() {
-        return $this->modx->lexicon('import_site');
+        return $this->modx->lexicon('import_site_resource');
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Fixed lexicons in the Import sections:
- On the page for importing from static files in the title there was a lexicon from the menu.
- On the import pages, the buttons had lexicons from the menu. Although there is more text now, the lexicons are from the correct section.

![import_btn](https://user-images.githubusercontent.com/12523676/123084081-ca73ba00-d431-11eb-8240-68f7a3dcbf07.png)

![static_import](https://user-images.githubusercontent.com/12523676/123084086-cc3d7d80-d431-11eb-8736-449466fa565b.gif)

### Why is it needed?
UI/UX

### Related issue(s)/PR(s)
N/A
