### PR TITLE
Strip base_url only from beginning of relative url

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
@@ -39,7 +39,8 @@ Ext.extend(MODx.panel.Static,MODx.panel.Resource,{
                 'select':{fn:function(data) {
                         var str = data.fullRelativeUrl;
                         if (MODx.config.base_url != '/') {
-                            str = str.replace(MODx.config.base_url,'');
+                            var regex = new RegExp('^' + MODx.config.base_url + '(.*)');
+                            str = str.replace(regex, '/$1');
                         }
                         if (str.substring(0,1) == '/') { str = str.substring(1); }
                         Ext.getCmp('modx-resource-content-static').setValue(str);


### PR DESCRIPTION
### What does it do?
Same as in https://github.com/modxcms/revolution/pull/15418, but for 3.x branch

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15418