### PR TITLE
Make naming consistent when duplicating user in grid

### DIFF
--- a/core/src/Revolution/Processors/Security/User/Duplicate.php
+++ b/core/src/Revolution/Processors/Security/User/Duplicate.php
@@ -40,8 +40,10 @@ class Duplicate extends DuplicateProcessor
     public function getNewName()
     {
         $name = $this->getProperty('new_username', '');
-        $newName = !empty($name) ? $name : $this->modx->lexicon('duplicate_of',
-            ['name' => $this->object->get('username')]);
+        $newName = !empty($name) ? $name : $this->modx->lexicon(
+            'duplicate_of',
+            ['name' => $this->object->get('username')]
+        );
 
         return $newName;
     }

--- a/core/src/Revolution/Processors/Security/User/Duplicate.php
+++ b/core/src/Revolution/Processors/Security/User/Duplicate.php
@@ -33,12 +33,17 @@ class Duplicate extends DuplicateProcessor
     public $afterSaveEvent = 'OnUserDuplicate';
 
     /**
-     * @return mixed|string
+     * Get the new name for the duplicate
+     *
+     * @return string
      */
     public function getNewName()
     {
         $name = $this->getProperty('new_username', '');
-        return !empty($name) ? $name : $this->object->get('username') . '_copy';
+        $newName = !empty($name) ? $name : $this->modx->lexicon('duplicate_of',
+            ['name' => $this->object->get('username')]);
+
+        return $newName;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Fixed `getNewName()` when duplicating user in grid.
Because all other grids work according to the same pattern, in this PR I have brought `getNewName()` to the same pattern. It turned out that this function worked this way only for the users grid.

Before
![users](https://user-images.githubusercontent.com/12523676/123061698-ed47a380-d41c-11eb-9d93-b9774378118e.png)

After
![users_copy](https://user-images.githubusercontent.com/12523676/123264410-10e91780-d50b-11eb-9823-88476c040681.png)

Media Sources, for example
![sources](https://user-images.githubusercontent.com/12523676/123061691-ec167680-d41c-11eb-9a03-ad186e23b8f0.png)

### Why is it needed?
UI/UX

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/15745
