### PR TITLE
Hide user settings tab based on permissions

### DIFF
--- a/core/model/modx/processors/system/settings/getareas.class.php
+++ b/core/model/modx/processors/system/settings/getareas.class.php
@@ -20,8 +20,10 @@
  * @subpackage processors.system.settings
  */
 class modSystemSettingsGetAreasProcessor extends modProcessor {
+    public $permission = 'settings';
+
     public function checkPermissions() {
-        return $this->modx->hasPermission('settings');
+        return $this->modx->hasPermission($this->permission);
     }
     public function getLanguageTopics() {
         return array('setting','namespace');

--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -126,7 +126,7 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
             ,labelAlign: 'top' // prevent default class of x-form-label-left
             ,items: this.getGeneralFields(config)
         }];
-        if (config.user != 0) {
+        if (config.user != 0 && MODx.perm.user_settings) {
             f.push({
                 title: _('settings')
                 ,autoHeight: true

--- a/manager/controllers/default/security/user/update.class.php
+++ b/manager/controllers/default/security/user/update.class.php
@@ -42,6 +42,7 @@ class SecurityUserUpdateManagerController extends modManagerController {
 // <![CDATA[
 MODx.onUserFormRender = "'.$this->onUserFormRender.'";
 MODx.perm.set_sudo = '.($this->modx->hasPermission('set_sudo') ? 1 : 0).';
+MODx.perm.user_settings = '.(($this->modx->hasPermission('settings') && $this->modx->hasPermission('namespace')) ? 1 : 0).';
 // ]]>
 </script>');
 


### PR DESCRIPTION
### What does it do?
Hide the user settings tab on base of `settings` and `namespace` permissions.

### Why is it needed?
There occur two combo permission messages otherwise:
`Permission 'namespaces' required for 'workspace/namespace/getlist'!`
`Permission '- unknown -' required for 'system/settings/getAreas'!`

The `'- unknown -'` string is solved with this PR too.

### How to test
Activate the `edit_user` permission for an access policy that does not contain the `settings` and `namespace` permissions, log into the manager using this ACL and edit a user. Before it shows the setting grid and the first combo permission message. Afterwards the user settings tab is not displayed.

### Related issue(s)/PR(s)
None known