### PR TITLE
Update minimum PHP version to 7.2 in setup requirements

### DIFF
--- a/setup/provisioner/requirements.php
+++ b/setup/provisioner/requirements.php
@@ -8,7 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
-define('MODX_MINIMUM_REQUIRED_PHP_VERSION', '7.0.0');
+define('MODX_MINIMUM_REQUIRED_PHP_VERSION', '7.2.0');
 define('MODX_REQUIRED_EXTENSIONS', [
     "curl",
     "dom",

--- a/setup/provisioner/requirements.php
+++ b/setup/provisioner/requirements.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *


### PR DESCRIPTION
### What does it do?
Update minimum PHP version to 7.2 in setup requirements

### Why is it needed?
The minimum PHP version was updated to PHP 7.2 in composer.json but not in the setup requirements.

### How to test
Try to install MODX on PHP < 7.2

### Related issue(s)/PR(s)
n/a
