### PR TITLE
Leave Element/GetClasses processor alone

### DIFF
--- a/setup/includes/upgrades/common/3.0.0-cleanup-files.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-files.php
@@ -159,7 +159,6 @@ $cleanup = [
         'src/Revolution/Processors/Element/TemplateVar/Renders/mgr/inputproperties/list-multiple-legacy.php',
 
         // remove modClassMap and dependencies
-        'src/Revolution/Processors/Element/GetClasses.php',
         'src/Revolution/Processors/System/ClassMap/GetList.php',
         'src/Revolution/modClassMap.php',
         'src/Revolution/mysql/modClassMap.php',


### PR DESCRIPTION
### What does it do?

Remove the Element/GetClasses processor from the list of files to be removed on upgrade.

### Why is it needed?

This was added to the list of files to delete in #15079, however is actually an unrelated processor to the modClassMap. It's part of the property sets UI which alloes selecting what type of element a property (set) can be used for.

### How to test

Make sure Element/GetClasses is not removed on upgrade. (Requires building first.)

### Related issue(s)/PR(s)
#15079
