### PR TITLE
S3 Incorrect Namespace

### DIFF
--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -4,7 +4,7 @@ namespace MODX\Revolution\Sources;
 
 use Aws\S3\S3Client;
 use Exception;
-use League\Flysystem\AwsS3v3\AwsS3V3Adapter;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\Visibility;


### PR DESCRIPTION
### What does it do?
Corrects the "League\Flysystem\AwsS3V3\AwsS3V3Adapter" namespace in the modS3MediaSource. 

### Why is it needed?
Previously declared as "League\Flysystem\AwsS3v3\AwsS3V3Adapter" which results in 500 error.

### How to test
Add an S3 bucket to the latest nightly, and try to it in the media browser. Correcting the namespace allows it to load. 

### Related issue(s)/PR(s)
Resolves issues introduced in #15757
