### PR TITLE
Reworking the S3 System to return objects

### DIFF
--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -335,10 +335,13 @@ class modS3MediaSource extends modMediaSource
                 }
                 $file_name = basename($object['path']);
 
-                if ($object['type'] == 'dir' && $this->hasPermission('directory_list')) {
+                if (
+                    $object['type'] == 'dir' &&
+                    $this->hasPermission('directory_list')
+                ) {
                     $cls = $this->getExtJSDirClasses();
                     $dirNames[] = strtoupper($file_name);
-                    $visibility = $this->visibility_dirs ? $this->getVisibility($object['path']) : false;
+                    $visibility = $this->visibility_dirs && $this->getVisibility($object['path']);
                     $directories[$file_name] = [
                         'id' => $id,
                         'sid' => $this->get('id'),
@@ -358,7 +361,11 @@ class modS3MediaSource extends modMediaSource
                     $directories[$file_name]['menu'] = [
                         'items' => $this->getListDirContextMenu(),
                     ];
-                } elseif ($object['type'] == 'file' && !$properties['hideFiles'] && $this->hasPermission('file_list')) {
+                } elseif (
+                    $object['type'] == 'file' &&
+                    !$properties['hideFiles'] &&
+                    $this->hasPermission('file_list')
+                ) {
                     // @TODO review/refactor extension and mime_type would be better for filesystems that
                     // may not always have an extension on it. For example would be S3 and you have an HTML file
                     // but the name is just myPage - $this->filesystem->getMimetype($object['path']);
@@ -366,11 +373,20 @@ class modS3MediaSource extends modMediaSource
                     $ext = $properties['use_multibyte']
                         ? mb_strtolower($ext, $properties['modx_charset'])
                         : strtolower($ext);
-                    if (!empty($allowedExtensions) && !in_array($ext, $allowedExtensions)) {
+                    if (
+                        !empty($allowedExtensions) &&
+                        !in_array($ext, $allowedExtensions)
+                    ) {
                         continue;
                     }
                     $fileNames[] = strtoupper($file_name);
-                    $files[$file_name] = $this->buildFileList($object['path'], $ext, $imageExtensions, $bases, $properties);
+                    $files[$file_name] = $this->buildFileList(
+                        $object['path'],
+                        $ext,
+                        $imageExtensions,
+                        $bases,
+                        $properties
+                    );
                 }
             }
 
@@ -428,25 +444,46 @@ class modS3MediaSource extends modMediaSource
             return [];
         }
         foreach ($contents as $object) {
-            if (in_array($object['path'], $skipFiles) || in_array(trim($object['path'], DIRECTORY_SEPARATOR), $skipFiles) || (in_array($fullPath . $object['path'], $skipFiles))) {
+            if (
+                in_array($object['path'], $skipFiles) ||
+                in_array(trim($object['path'], DIRECTORY_SEPARATOR), $skipFiles) ||
+                (in_array($fullPath . $object['path'], $skipFiles))
+            ) {
                 continue;
             }
-            if ($object['type'] == 'dir' && !$this->hasPermission('directory_list')) {
+            if (
+                $object['type'] == 'dir' &&
+                !$this->hasPermission('directory_list')
+            ) {
                 continue;
-            } elseif ($object['type'] == 'file' && !$properties['hideFiles'] && $this->hasPermission('file_list')) {
-                // @TODO review/refactor ext and mime_type would be better for filesystems that may not always have an extension on it
+            } elseif (
+                $object['type'] == 'file' &&
+                !$properties['hideFiles'] &&
+                $this->hasPermission('file_list')
+            ) {
+                // @TODO review/refactor ext and mime_type would be better
+                // for filesystems that may not always have an extension on it
                 // example would be S3 and you have an HTML file but the name is just myPage
                 //$this->filesystem->getMimetype($object['path']);
                 $ext = pathinfo($object['path'], PATHINFO_EXTENSION);
                 $ext = $properties['use_multibyte']
                     ? mb_strtolower($ext, $properties['modx_charset'])
                     : strtolower($ext);
-                if (!empty($allowedExtensions) && !in_array($ext, $allowedExtensions)) {
+                if (
+                    !empty($allowedExtensions) &&
+                    !in_array($ext, $allowedExtensions)
+                ) {
                     continue;
                 }
                 $fileNames[] = strtoupper($object['path']);
 
-                $files[$object['path']] = $this->buildFileBrowserViewList($object['path'], $ext, $imageExtensions, $bases, $properties);
+                $files[$object['path']] = $this->buildFileBrowserViewList(
+                    $object['path'],
+                    $ext,
+                    $imageExtensions,
+                    $bases,
+                    $properties
+                );
             }
         }
 

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -4,7 +4,7 @@ namespace MODX\Revolution\Sources;
 
 use Aws\S3\S3Client;
 use Exception;
-use League\Flysystem\AwsS3v3\AwsS3V3Adapter;
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\Visibility;
@@ -19,7 +19,7 @@ use xPDO\xPDO;
  */
 class modS3MediaSource extends modMediaSource
 {
-    protected $visibility_files = true;
+    protected $visibility_files = false;
     protected $visibility_dirs = false;
 
 
@@ -292,16 +292,170 @@ class modS3MediaSource extends modMediaSource
      */
     protected function buildManagerImagePreview($path, $ext, $width, $height, $bases, $properties = [])
     {
-        if ($image = $this->getObjectUrl($path)) {
-            if ($this->getVisibility($path) !== Visibility::PUBLIC) {
-                $image = false;
-            }
-        }
-
         return [
-            'src' => $image,
+            'src' => $this->getObjectUrl($path),
             'width' => $width,
             'height' => $height,
         ];
+    }
+
+    /**
+     * Return an array of files and folders at this current level in the directory structure
+     *
+     * @param string $path
+     *
+     * @return array
+     */
+    public function getContainerList($path)
+    {
+        $properties = $this->getPropertyListWithDefaults();
+        $path = $this->postfixSlash($path);
+        if ($path == DIRECTORY_SEPARATOR || $path == '\\') {
+            $path = '';
+        }
+
+        $bases = $this->getBases($path);
+        $imageExtensions = explode(',', $properties['imageExtensions']);
+        $skipFiles = $this->getSkipFilesArray($properties);
+        $allowedExtensions = $this->getAllowedExtensionsArray($properties);
+
+        $directories = $dirNames = $files = $fileNames = [];
+
+        try {
+            $re = '#^(.*?/|)(' . implode('|', array_map('preg_quote', $skipFiles)) . ')/?$#';
+            /** @var array $contents */
+            $contents = $this->filesystem->listContents($path);
+            $pathid = rawurlencode(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+            foreach ($contents as $object) {
+                $id = rawurlencode(rtrim($object['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+                if (preg_match($re, $object['path']) || $id == $pathid) {
+                    continue;
+                }
+                $file_name = basename($object['path']);
+
+                if ($object['type'] == 'dir' && $this->hasPermission('directory_list')) {
+                    $cls = $this->getExtJSDirClasses();
+                    $dirNames[] = strtoupper($file_name);
+                    $visibility = $this->visibility_dirs ? $this->getVisibility($object['path']) : false;
+                    $directories[$file_name] = [
+                        'id' => $id,
+                        'sid' => $this->get('id'),
+                        'text' => $file_name,
+                        'cls' => implode(' ', $cls),
+                        'iconCls' => 'icon ' . ($visibility == Visibility::PRIVATE
+                                ? 'icon-eye-slash' : 'icon-folder'),
+                        'type' => 'dir',
+                        'leaf' => false,
+                        'path' => $object['path'],
+                        'pathRelative' => $object['path'],
+                        'menu' => [],
+                    ];
+                    if ($this->visibility_dirs && $visibility) {
+                        $directories[$file_name]['visibility'] = $visibility;
+                    }
+                    $directories[$file_name]['menu'] = [
+                        'items' => $this->getListDirContextMenu(),
+                    ];
+
+                } elseif ($object['type'] == 'file' && !$properties['hideFiles'] && $this->hasPermission('file_list')) {
+                    // @TODO review/refactor extension and mime_type would be better for filesystems that
+                    // may not always have an extension on it. For example would be S3 and you have an HTML file
+                    // but the name is just myPage - $this->filesystem->getMimetype($object['path']);
+                    $ext = pathinfo($object['path'], PATHINFO_EXTENSION);
+                    $ext = $properties['use_multibyte']
+                        ? mb_strtolower($ext, $properties['modx_charset'])
+                        : strtolower($ext);
+                    if (!empty($allowedExtensions) && !in_array($ext, $allowedExtensions)) {
+                        continue;
+                    }
+                    $fileNames[] = strtoupper($file_name);
+                    $files[$file_name] = $this->buildFileList($object['path'], $ext, $imageExtensions, $bases, $properties);
+                }
+            }
+
+            $ls = [];
+            // now sort files/directories
+            array_multisort($dirNames, SORT_ASC, SORT_STRING, $directories);
+            foreach ($directories as $dir) {
+                $ls[] = $dir;
+            }
+
+            array_multisort($fileNames, SORT_ASC, SORT_STRING, $files);
+            foreach ($files as $file) {
+                $ls[] = $file;
+            }
+
+            return $ls;
+        } catch (Exception $e) {
+            $this->addError('path', $e->getMessage());
+
+            return [];
+        }
+    }
+
+
+    /**
+     * Get a list of files in a specific directory.
+     *
+     * @param string $path
+     *
+     * @return array
+     */
+    public function getObjectsInContainer($path)
+    {
+        $properties = $this->getPropertyListWithDefaults();
+        $path = $this->postfixSlash($path);
+        $bases = $this->getBases($path);
+
+        $fullPath = $path;
+        if (!empty($bases['pathAbsolute'])) {
+            $fullPath = $bases['pathAbsolute'] . ltrim($path, DIRECTORY_SEPARATOR);
+        }
+
+        $imageExtensions = explode(',', $properties['imageExtensions']);
+        $skipFiles = $this->getSkipFilesArray($properties);
+
+        $allowedExtensions = $this->getAllowedExtensionsArray($properties);
+
+        $files = $fileNames = [];
+
+        try {
+            $contents = $this->filesystem->listContents($path);
+        } catch (FilesystemException $e) {
+            $this->addError('path', $e->getMessage());
+            $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
+            return [];
+        }
+        foreach ($contents as $object) {
+            if (in_array($object['path'], $skipFiles) || in_array(trim($object['path'], DIRECTORY_SEPARATOR), $skipFiles) || (in_array($fullPath . $object['path'], $skipFiles))) {
+                continue;
+            }
+            if ($object['type'] == 'dir' && !$this->hasPermission('directory_list')) {
+                continue;
+            } elseif ($object['type'] == 'file' && !$properties['hideFiles'] && $this->hasPermission('file_list')) {
+                // @TODO review/refactor ext and mime_type would be better for filesystems that may not always have an extension on it
+                // example would be S3 and you have an HTML file but the name is just myPage
+                //$this->filesystem->getMimetype($object['path']);
+                $ext = pathinfo($object['path'], PATHINFO_EXTENSION);
+                $ext = $properties['use_multibyte']
+                    ? mb_strtolower($ext, $properties['modx_charset'])
+                    : strtolower($ext);
+                if (!empty($allowedExtensions) && !in_array($ext, $allowedExtensions)) {
+                    continue;
+                }
+                $fileNames[] = strtoupper($object['path']);
+
+                $files[$object['path']] = $this->buildFileBrowserViewList($object['path'], $ext, $imageExtensions, $bases, $properties);
+            }
+        }
+
+        $ls = [];
+        // now sort files/directories
+        array_multisort($fileNames, SORT_ASC, SORT_STRING, $files);
+        foreach ($files as $file) {
+            $ls[] = $file;
+        }
+
+        return $ls;
     }
 }

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -51,8 +51,10 @@ class modS3MediaSource extends modMediaSource
         try {
             $client = new S3Client($config);
             if (!$client->doesBucketExist($bucket)) {
-                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,
-                    $this->xpdo->lexicon('source_err_init', ['source' => $this->get('name')]));
+                $this->xpdo->log(
+                    xPDO::LOG_LEVEL_ERROR,
+                    $this->xpdo->lexicon('source_err_init', ['source' => $this->get('name')])
+                );
 
                 return false;
             }
@@ -356,7 +358,6 @@ class modS3MediaSource extends modMediaSource
                     $directories[$file_name]['menu'] = [
                         'items' => $this->getListDirContextMenu(),
                     ];
-
                 } elseif ($object['type'] == 'file' && !$properties['hideFiles'] && $this->hasPermission('file_list')) {
                     // @TODO review/refactor extension and mime_type would be better for filesystems that
                     // may not always have an extension on it. For example would be S3 and you have an HTML file


### PR DESCRIPTION
### What does it do?
Rewrite on the s3 container to list files and folders with the limitations of an S3 endpoint in mind. 

### Why is it needed?
Previous version was depending on returning "visibility" and "mimeType" functions that were not working with the S3 endpoint, resulting in an empty container. 

### How to test
Connect this to an S3 bucket on MODX

### Related issue(s)/PR(s)
Resolves issues introduced in #15757
Extends fixes of issues originally detected in #15785

## Side note
This is a bit of hacking between what was changed in the #15757 update and some fixes I had been working on prior. I am open to suggestions for cleanup. 
