### PR TITLE
Improve field selection error for package provider

### DIFF
--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -177,6 +177,7 @@ $_lang['provider_err_no_client'] = '<p><b>You do not have a viable REST client f
 $_lang['provider_err_nfs'] = 'Provider not found with ID [[+id]]';
 $_lang['provider_err_no_response'] = 'Error in getting a response from the server: [[+provider]]';
 $_lang['provider_err_not_verified'] = 'This Provider could not be verified, and therefore cannot be used as a MODX Provider. Please check the service URL and try again.';
+$_lang['provider_err_not_selected'] = 'You must select a provider from the list above to continue.';
 $_lang['provider_err_ns'] = 'Provider not specified.';
 $_lang['provider_err_ns_name'] = 'Please specify a name for the Provider.';
 $_lang['provider_err_ns_url'] = 'Please provide a valid URL for the Provider.';

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -272,6 +272,8 @@ MODx.window.ChangeProvider = function(config) {
 				,id: 'modx-pdselprov-provider'
                 ,anchor: '100%'
 				,allowBlank: false
+                ,msgTarget: 'under'
+                ,blankText: _('provider_err_not_selected')
 				,baseParams: {
                     action: 'Workspace/Providers/GetList'
                     ,showNone: false

--- a/manager/assets/modext/workspace/package.windows.js
+++ b/manager/assets/modext/workspace/package.windows.js
@@ -256,6 +256,7 @@ MODx.window.ChangeProvider = function(config) {
         title: _('provider_select')
         ,width: 600 // prevents primary button text from being cut off if it is a long string
 		,layout: 'form'
+        ,closeAction: 'hide'
 		,items:[{
 			xtype: 'modx-template-panel'
 			,id: 'modx-cp-panel'
@@ -273,6 +274,7 @@ MODx.window.ChangeProvider = function(config) {
                 ,anchor: '100%'
 				,allowBlank: false
                 ,msgTarget: 'under'
+                ,labelSeparator: ''
                 ,blankText: _('provider_err_not_selected')
 				,baseParams: {
                     action: 'Workspace/Providers/GetList'
@@ -283,7 +285,9 @@ MODx.window.ChangeProvider = function(config) {
 		,buttons :[{
 			text: config.cancelBtnText || _('cancel')
             ,scope: this
-            ,handler: function() { this.hide(); }
+            ,handler: function() {
+                this.hide();
+            }
 		},{
 			text: _('save_and_go_to_browser')
             ,cls: 'primary-button'
@@ -292,7 +296,13 @@ MODx.window.ChangeProvider = function(config) {
 			,scope: this
 		}]
     });
+
     MODx.window.ChangeProvider.superclass.constructor.call(this,config);
+
+    this.on('beforehide', function(){
+        var form = Ext.getCmp('change-provider-form').getForm();
+        form.clearInvalid();
+    });
 };
 Ext.extend(MODx.window.ChangeProvider,Ext.Window,{ //Using MODx.Window would create an empty unused form (It's not a bug))
 	submit: function(o) {


### PR DESCRIPTION
### What does it do?
Made minor tweaks to Ext config for the MODx.window.ChangeProvider window and updated its related lexicon file.

### Why is it needed?
Shows expected error message if a provider is not chosen. It also fixes a problem not specified in the related issue where a JS error occurs when closing the provider window with the upper right "X" trigger (preventing further attempts to re-open the Select a Provider window).

### How to test
Navigate to Extras > Installer, then click on Download Extras > Select a Provider. Do not choose an option from the menu and attempt to Save. Also, close this window with the "X" trigger to confirm it no longer causes an error.

### Related issue(s)/PR(s)
Resolves #14675
