### PR TITLE
Fix for Issue #15507

### DIFF
--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -115,7 +115,7 @@ class modTransportPackage extends xPDOObject
      */
     public function set($k, $v = null, $vType = '')
     {
-        $set = parent:: set($k, $v, $vType);
+        $set = parent::set($k, $v, $vType);
         if ($k == 'signature') {
             $this->parseSignature();
             if ($this->isNew() && !$this->get('source')) {
@@ -140,7 +140,8 @@ class modTransportPackage extends xPDOObject
             if (count($parsedSig) === 2 && !empty($parsedSig[0]) && !empty($parsedSig[1])) {
                 $this->identifier = $parsedSig[0];
                 $parsedVersion = explode('-', $parsedSig[1], 2);
-                if (count($parsedVersion) === 2) {
+                $parsedVersionEls = count($parsedVersion);
+                if ($parsedVersionEls === 2) {
                     $this->version = $parsedVersion[0];
                     $releaseChars = [];
                     parse_str($parsedVersion[1], $releaseChars);
@@ -155,15 +156,19 @@ class modTransportPackage extends xPDOObject
                         $releaseIndex .= $char;
                     }
                     $this->release = $release;
-                    $this->release_index = (integer)$releaseIndex;
+                    $this->release_index = (int)$releaseIndex;
                     $parsed = true;
-                } elseif (count($parsedVersion) === 1) {
+                } elseif ($parsedVersionEls === 1) {
                     $this->version = $parsedVersion[0];
                     $this->release = '';
                     $this->release_index = 0;
                     $parsed = true;
                 }
-                list($this->version_major, $this->version_minor, $this->version_patch) = explode('.', $this->version);
+                $version = explode('.', $this->version);
+                if (count($version) === 2) {
+                    $version[] = '0';
+                }
+                list($this->version_major, $this->version_minor, $this->version_patch) = $version;
             }
         }
 
@@ -240,8 +245,7 @@ class modTransportPackage extends xPDOObject
                             $state = is_dir($packageDir . $targetDir) ? $this->get('state') : xPDOTransport::STATE_PACKED;
                         }
                         /* retrieve the package */
-                        $this->package = xPDOTransport:: retrieve($this->xpdo, $packageDir . $sourceFile, $packageDir,
-                            $state);
+                        $this->package = xPDOTransport::retrieve($this->xpdo, $packageDir . $sourceFile, $packageDir, $state);
                         if ($this->package) {
                             /* set to unpacked state */
                             if ($state == xPDOTransport::STATE_PACKED) {
@@ -340,8 +344,7 @@ class modTransportPackage extends xPDOObject
         $installed = false;
         try {
             $installed = $this->package->install($attributes);
-        }
-        catch (Throwable $e) {
+        } catch (Throwable $e) {
             $this->xpdo->log(
                 xPDO::LOG_LEVEL_ERROR,
                 $this->xpdo->lexicon('package_err_caught', [
@@ -420,8 +423,8 @@ class modTransportPackage extends xPDOObject
             }
             $productVersion = $this->xpdo->version['code_name'] . '-' . $this->xpdo->version['full_version'];
 
-            $source = $this->get('service_url') . $sourceFile . (strpos($sourceFile,
-                    '?') !== false ? '&' : '?') . 'revolution_version=' . $productVersion;
+            $source = $this->get('service_url') . $sourceFile . (
+                strpos($sourceFile, '?') !== false ? '&' : '?') . 'revolution_version=' . $productVersion;
 
             /* see if user has allow_url_fopen on and is not behind a proxy */
             $proxyHost = $this->xpdo->getOption('proxy_host', null, '');
@@ -491,8 +494,10 @@ class modTransportPackage extends xPDOObject
                     $transferred = $cacheManager->writeFile($target, $content);
                 }
             } else {
-                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,
-                    'MODX could not download the file. You must enable allow_url_fopen, cURL or fsockopen to use remote transport packaging.');
+                $this->xpdo->log(
+                    xPDO::LOG_LEVEL_ERROR,
+                    'MODX could not download the file. You must enable allow_url_fopen, cURL or fsockopen to use remote transport packaging.'
+                );
             }
         } else {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $this->xpdo->lexicon('package_err_target_write', [
@@ -630,13 +635,17 @@ class modTransportPackage extends xPDOObject
             if ($transport) {
                 $installed = $transport->install();
                 if (!$installed) {
-                    $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,
-                        "Error installing dependency {$package} from {$transport->source}", '', __METHOD__, __FILE__,
-                        __LINE__);
+                    $this->xpdo->log(
+                        xPDO::LOG_LEVEL_ERROR,
+                        "Error installing dependency {$package} from {$transport->source}",
+                        '',
+                        __METHOD__,
+                        __FILE__,
+                        __LINE__
+                    );
                 }
             }
         }
-
         return $resolved;
     }
 
@@ -659,13 +668,27 @@ class modTransportPackage extends xPDOObject
         switch (strtolower($package)) {
             case 'php':
                 /* you must resolve php dependencies manually */
-                $this->xpdo->log(xPDO::LOG_LEVEL_WARN, "PHP version dependencies must be resolved manually", '', __METHOD__, __FILE__, __LINE__);
+                $this->xpdo->log(
+                    xPDO::LOG_LEVEL_WARN,
+                    "PHP version dependencies must be resolved manually",
+                    '',
+                    __METHOD__,
+                    __FILE__,
+                    __LINE__
+                );
                 break;
             case 'modx':
             case 'revo':
             case 'revolution':
                 /* resolve core dependencies manually for now */
-                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "MODX core version dependencies must be resolved manually", '', __METHOD__, __FILE__, __LINE__);
+                $this->xpdo->log(
+                    xPDO::LOG_LEVEL_ERROR,
+                    "MODX core version dependencies must be resolved manually",
+                    '',
+                    __METHOD__,
+                    __FILE__,
+                    __LINE__
+                );
                 break;
             default:
                 /* TODO: scan for local packages to satisfy dependency */
@@ -690,7 +713,14 @@ class modTransportPackage extends xPDOObject
                     }
                 }
                 if (empty($resolution)) {
-                    $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not find package to satisfy dependency {$package} @ {$constraint} from your currently active providers", '', __METHOD__, __FILE__, __LINE__);
+                    $this->xpdo->log(
+                        xPDO::LOG_LEVEL_ERROR,
+                        "Could not find package to satisfy dependency {$package} @ {$constraint} from your currently active providers",
+                        '',
+                        __METHOD__,
+                        __FILE__,
+                        __LINE__
+                    );
                 }
                 break;
         }
@@ -721,8 +751,10 @@ class modTransportPackage extends xPDOObject
         switch ($modifier) {
             case 'g':
                 $value *= 1024;
+                // no break
             case 'm':
                 $value *= 1024;
+                // no break
             case 'k':
                 $value *= 1024;
         }


### PR DESCRIPTION
### What does it do?
Added logic to ensure a default patch level of "0" when an extra does not declare one (specifically at line ~165 in the changed file where list() needs its subject array to have a matching number of elements.)

Note that a handful of other minor changes were made, mostly to align with the PSR-12 coding standard. On that note, this _will not pass_ due to two issues: the casing of the class name and the use of the underscore in three of the methods—the code owners should make the call if these things will be changed across the framework to adhere to the standard.

### How to test
Install an extra (usually the older ones) that does not have a patch level in its version, such as UltimateParent. Now it will not trigger an error message (shown in the package installation console). Note that this does not affect the version that is saved for the package in the db or displayed in the extras grid.

### Related issue(s)/PR(s)
Issue #15507
