### PR TITLE
Prevent line lengths over 120 from throwing errors

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,4 +20,10 @@
 
     <!-- Our base rule: set to PSR12-->
     <rule ref="PSR12"/>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120" />
+            <property name="absoluteLineLimit" value="0" />
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
### What does it do?
Overrides the hard line-length limit on the PHPCS check.

### Why is it needed?
Prevent PHPCS from failing code with lines longer than 120 characters.

### How to test
N/A

### Related issue(s)/PR(s)
N/A