### PR TITLE
Enable friendly url functionality by default for new installations

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -670,7 +670,7 @@ $settings['friendly_alias_word_delimiters']->fromArray([
 $settings['friendly_urls'] = $xpdo->newObject(modSystemSetting::class);
 $settings['friendly_urls']->fromArray([
   'key' => 'friendly_urls',
-  'value' => false,
+  'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',
@@ -1816,7 +1816,7 @@ $settings['upload_translit']->fromArray([
 $settings['use_alias_path'] = $xpdo->newObject(modSystemSetting::class);
 $settings['use_alias_path']->fromArray([
   'key' => 'use_alias_path',
-  'value' => false,
+  'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'furls',


### PR DESCRIPTION
### What does it do?
Enables `friendly_urls` and `use_alias_path` for new MODX installations.

### Why is it needed?
To make MODX more SEO friendly by default.

### How to test
Do a clean install and open a resource.

### Related issue(s)/PR(s)
Issue #13876
