### PR TITLE
Prevent line lengths over 120 from throwing errors

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,3 +25,4 @@ jobs:
                   files: "**.php"
                   phpcs_path: php phpcs.phar
                   standard: phpcs.xml
+                  fail_on_warnings: false

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,4 +20,10 @@
 
     <!-- Our base rule: set to PSR12-->
     <rule ref="PSR12" />
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120" />
+            <property name="absoluteLineLimit" value="0" />
+        </properties>
+    </rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,10 +20,4 @@
 
     <!-- Our base rule: set to PSR12-->
     <rule ref="PSR12" />
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="120" />
-            <property name="absoluteLineLimit" value="0" />
-        </properties>
-    </rule>
 </ruleset>


### PR DESCRIPTION
### What does it do?
- Overrides the hard line-length limit on the PHPCS check
- Disable fail on warnings for `thenabeel/action-phpcs`

### Why is it needed?
Prevent PHPCS from failing code with lines longer than 120 characters.

### How to test
No idea what's the best approach to test this. 

### Related issue(s)/PR(s)
Issue #15790
PR #15797