### PR TITLE
Fix issues for plugins that pass around xPDOObjects

### DIFF
--- a/_build/test/Tests/Model/Element/modElementTest.php
+++ b/_build/test/Tests/Model/Element/modElementTest.php
@@ -150,4 +150,24 @@ class modElementTest extends MODxTestCase {
             ],
         ];
     }
+
+    /**
+     * Test the modElement->getTag() method with xPDOObjects as values.
+     * E.g the nodes when the event `OnResourceSort` is fired
+     *
+     */
+    public function testGetTagWithXPDOObjects()
+    {
+        /** @var modElement $element */
+        $element = $this->modx->newObject(modElement::class);
+        $element->getProperties([
+            'objects' => [
+                $this->modx->newObject(modElement::class),
+            ],
+            'object' => $this->modx->newObject(modElement::class),
+        ]);
+
+        $tag = $element->getTag();
+        $this->assertNotEmpty($tag);
+    }
 }

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -278,7 +278,7 @@ class modElement extends modAccessibleSimpleObject
                         $propTemp[$key] = $key . '=`' . $value . '`';
                     } else {
                         if (is_array($value)) {
-                            array_walk_recursive($value, function(&$item, $key) {
+                            array_walk_recursive($value, function (&$item, $key) {
                                 if ($item instanceof \xPDOObject) {
                                     $item = $item->toArray('', false, true);
                                 }
@@ -898,11 +898,15 @@ class modElement extends modAccessibleSimpleObject
                 $propertySet = $this->xpdo->getObject(modPropertySet::class, ['name' => $propertySet]);
             }
             if (is_object($propertySet) && $propertySet instanceof modPropertySet) {
-                if (!$this->isNew() && !$propertySet->isNew() && $this->xpdo->getCount(modElementPropertySet::class, [
+                if (
+                    !$this->isNew()
+                    && !$propertySet->isNew()
+                    && $this->xpdo->getCount(modElementPropertySet::class, [
                         'element' => $this->get('id'),
                         'element_class' => $this->_class,
                         'property_set' => $propertySet->get('id'),
-                    ])) {
+                    ])
+                ) {
                     $added = true;
                 } else {
                     if ($propertySet->isNew()) {

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -277,7 +277,21 @@ class modElement extends modAccessibleSimpleObject
                     if (is_scalar($value)) {
                         $propTemp[$key] = $key . '=`' . $value . '`';
                     } else {
-                        $propTemp[$key] = $key . '=`' . (is_array($value) ? md5(serialize($value)) : md5(uniqid(rand(), true))) . '`';
+                        if (is_array($value)) {
+                            array_walk_recursive($value, function(&$item, $key) {
+                                if ($item instanceof \xPDOObject) {
+                                    $item = $item->toArray('', false, true);
+                                }
+                            });
+                        } elseif ($value instanceof \xPDOObject) {
+                            $value = $value->toArray('', false, true);
+                        }
+                        try {
+                            $propTemp[$key] = $key . '=`' . (is_array($value) ? md5(serialize($value))
+                                    : md5(uniqid(rand(), true))) . '`';
+                        } catch (\Throwable $handlerException) {
+                            $propTemp[$key] = $key . '=`' . md5(uniqid(rand(), true)) . '`';
+                        }
                     }
                 }
                 if (!empty($propTemp)) {


### PR DESCRIPTION
### What does it do?
When serializing the element properties, check if it is an xPDOObject derivative and transform it into an array.

### Why is it needed?
To prevent an exception because we can't serialize xPDOObjects. This happens when objects are passed around.

### How to test
Run the newly added Unit Test or create a plugin that's listening to the `OnResourceSort` event and see it working properly.

### Related issue(s)/PR(s)
Closes issue #15657
Closes issue #15172
Supersedes PR #15467

