### PR TITLE
Add build assets to CI workflow

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,0 +1,31 @@
+name: "Compile Assets"
+
+on:
+    push:
+        paths:
+            - "_build/templates/**"
+    pull_request:
+        paths:
+            - "_build/templates/**"
+
+    workflow_dispatch:
+
+jobs:
+    compile-assets:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+
+            -   name: Install Node.js
+                uses: actions/setup-node@v2
+                with:
+                    node-version: '14'
+                    cache: 'npm'
+                    cache-dependency-path: _build/templates/default/package-lock.json
+
+            -   name: Install NPM dependencies
+                run: cd _build/templates/default && npm install
+
+            -   name: Run Grunt build
+                run: cd _build/templates/default && grunt build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,15 @@ on:
   push:
       branches-ignore:
           - 'l10n_**'
+      paths-ignore:
+          - "_build/templates/**"
   pull_request:
       branches-ignore:
           - 'l10n_**'
+      paths-ignore:
+          - "_build/templates/**"
 
-  # Allows you to run this workflow manually from the Actions tab
+          # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### What does it do?
Add a CI workflow to build assets.

### Why is it needed?
To test if changes don't break building the assets.

### How to test
Merge this PR and try to submit a new PR with a change that throws an error when running `grunt build`.

### Related issue(s)/PR(s)
n/a