### PR TITLE
More powerful $modx->regClientStartupScript

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1536,9 +1536,11 @@ class modX extends xPDO {
      * tag of an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
+     * @param array $options Optional param to add script  attributes as
+     * defer, async, type="module" and etc
      * @return void
      */
-    public function regClientStartupScript($src, $plaintext= false) {
+    public function regClientStartupScript($src, $plaintext= false, $options = []) {
         if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
             if (isset ($this->loadedjscripts[$src]))
                 return;
@@ -1548,7 +1550,8 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $scriptOptions = implode(' ', $options);
+                $this->sjscripts[count($this->sjscripts)]= "<script $scriptOptions src=\"$src\"></script>";
             }
         }
     }


### PR DESCRIPTION


### What does it do?
Ability to add parameters to scripts.

### Why is it needed?
If i want add `<script type="module" src="/paht/to.js">` or `<script defer src="paht/to.js">` or `<script async defer src="paht/to.js"> `

### How to test
try to use `$modx->regClientStartupScript('/path/to.js', false, ['async', 'type="module"']);`
