### PR TITLE
Fix for long dropdown submenus

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1894,6 +1894,15 @@ $settings['topmenu_show_descriptions']->fromArray(array (
   'area' => 'manager',
   'editedon' => null,
 ), '', true, true);
+$settings['topmenu_subitems_max']= $xpdo->newObject('modSystemSetting');
+$settings['topmenu_subitems_max']->fromArray(array (
+  'key' => 'topmenu_subitems_max',
+  'value' => '10',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 $settings['tree_default_sort']= $xpdo->newObject('modSystemSetting');
 $settings['tree_default_sort']->fromArray(array (
   'key' => 'tree_default_sort',

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -131,6 +131,23 @@
     top: 50%;
     transform: translateY(-50%);
   }
+
+  & .more {
+    top: unset !important;
+    bottom: -1px;
+  }
+}
+
+#modx-navbar #modx-user-menu .sub {
+  &:after {
+    border: 5px solid transparent;
+    border-right: 5px solid rgb(96,114,124);
+    position: absolute;
+    content: ' ';
+    left: 0px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
 }
 
 #modx-user-menu li.top > a,
@@ -159,11 +176,6 @@
   }
 }
 
-#modx-navbar #modx-user-menu ul.modx-subnav {
-  left: auto;
-  right: 0;
-}
-
 #modx-navbar ul.modx-subnav {
   border-radius: 0 $borderRadius $borderRadius $borderRadius;
   border: 1px solid $navbarBorder;
@@ -188,8 +200,22 @@
     display: none;
     list-style: none;
     padding-left: 0;
-    position: absolute; left: 270px; top: -1px;
+    position: absolute;
+    left: 270px;
+    top: -1px;
     z-index: 24;
+  }
+}
+
+#modx-navbar #modx-user-menu ul.modx-subnav {
+  border-radius: $borderRadius 0 $borderRadius $borderRadius;
+  left: auto;
+  right: 0;
+
+  ul.modx-subsubnav {
+    border-radius: $borderRadius 0 $borderRadius $borderRadius;
+    right: 270px;
+    left: auto;
   }
 }
 
@@ -211,9 +237,6 @@
   display: block;
   float: left;
 }
-/*#user-username {
-
-}*/
 
 #modx-navbar #modx-home-dashboard a {
   overflow: hidden;
@@ -302,36 +325,7 @@
   width: 100%;
 }
 
-#modx-navbar ul.modx-subnav li:first-child,
-#modx-navbar ul.modx-subnav li:first-child a {
-  border-radius: 0 $borderRadius 0 0;
-}
-
-#modx-navbar ul.modx-subnav ul li:first-child,
-#modx-navbar ul.modx-subnav ul li:first-child a {
-  border-radius: 0 $borderRadius 0 0;
-}
-
-#modx-navbar ul.modx-subnav ul li:last-child,
-#modx-navbar ul.modx-subnav ul li:last-child a {
-  border-radius: 0 0 $borderRadius 0;
-}
-
-#modx-navbar ul.modx-subnav ul ul li:last-child,
-#modx-navbar ul.modx-subnav ul ul li:last-child a {
-  border-radius: 0 0 $borderRadius $borderRadius;
-}
-
-#modx-navbar ul.modx-subnav li:hover ul ul,
-#modx-navbar ul.modx-subnav ul li:hover ul ul,
-#modx-navbar ul.modx-subnav ul ul li:hover ul ul {
-  display: none;
-}
-
-#modx-navbar ul.modx-subnav li:hover ul,
-#modx-navbar ul.modx-subnav ul li:hover ul,
-#modx-navbar ul.modx-subnav ul ul li:hover ul,
-#modx-navbar ul.modx-subnav ul ul ul li:hover ul {
+#modx-navbar ul.modx-subnav li:hover > ul {
   display: block;
 }
 

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -765,6 +765,9 @@ $_lang['setting_syncsite_default_err'] = 'Please state whether or not you want t
 $_lang['setting_topmenu_show_descriptions'] = 'Show Descriptions in Top Menu';
 $_lang['setting_topmenu_show_descriptions_desc'] = 'If set to \'No\', MODX will hide the descriptions from top menu items in the manager.';
 
+$_lang['setting_topmenu_subitems_max'] = 'Maximum items in the drop-down lists of the top menu bar';
+$_lang['setting_topmenu_subitems_max_desc'] = 'The maximum number of items displayed in the drop-down lists of the top menu bar. The remaining items will be hidden in the \'...\' item.';
+
 $_lang['setting_tree_default_sort'] = 'Resource Tree Default Sort Field';
 $_lang['setting_tree_default_sort_desc'] = 'The default sort field for the Resource tree when loading the manager.';
 

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -61,6 +61,7 @@ class TopMenu
         $this->controller =& $controller;
         $this->modx =& $controller->modx;
         $this->showDescriptions = (boolean) $this->modx->getOption('topmenu_show_descriptions', null, true);
+        $this->subItemsMax = abs((int) $this->modx->getOption('topmenu_subitems_max', null, 0, true));
     }
 
     /**
@@ -194,7 +195,7 @@ class TopMenu
 
             if (!empty($menu['children'])) {
                 $menuTpl .= '<ul class="modx-subnav">'."\n";
-                $this->processSubMenus($menuTpl, $menu['children']);
+                $this->processSubMenus($menuTpl, $menu['children'], $this->subItemsMax);
                 $menuTpl .= '</ul>'."\n";
             }
             $menuTpl .= '</li>'."\n";
@@ -303,9 +304,14 @@ class TopMenu
      *
      * @return void
      */
-    public function processSubMenus(&$output, array $menus = array())
+    public function processSubMenus(&$output, array $menus = array(), $maxItems = false)
     {
         //$output .= '<ul class="modx-subnav">'."\n";
+        $moreMenu = '';
+        if ($maxItems && count($menus) > $maxItems) {
+            $moreMenu = array_slice($menus, $maxItems);
+            $menus = array_slice($menus, 0, $maxItems);
+        }
 
         foreach ($menus as $menu) {
             if (!$this->hasPermission($menu['permissions'])) {
@@ -333,12 +339,19 @@ class TopMenu
 
             if (!empty($menu['children'])) {
                 $smTpl .= '<ul class="modx-subsubnav">'."\n";
-                $this->processSubMenus($smTpl, $menu['children']);
+                $this->processSubMenus($smTpl, $menu['children'], $this->subItemsMax);
                 $smTpl .= '</ul>'."\n";
             }
             $smTpl .= '</li>';
             $output .= $smTpl;
             $this->childrenCt++;
+        }
+
+        if (!empty($moreMenu)) {
+            $output .= '<li class="sub"><a href="#">...</a>'."\n";
+            $output .= '<ul class="modx-subsubnav more">'."\n";
+            $this->processSubMenus($output, $moreMenu, $this->subItemsMax);
+            $output .= '</ul>'."\n";
         }
 
         //$output .= '</ul>'."\n";


### PR DESCRIPTION
### What does it do?
Add new system setting `topmenu_subitems_max` to be able to restrict the dropdown menu.
Sometimes a large number of installed packages prevent the normal use of the menu.

How it looks (set to 3):
![menu_more_fix](https://user-images.githubusercontent.com/12523676/140332239-5d9e15ed-ce72-47db-a840-f4c13e202279.gif)

### Why is it needed?
Description from #11939

> When there's a long Extras dropdown menu, and not enough screen space, the bottom items get cut off. It's not possible to scroll down or access them.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/11939
https://github.com/modxcms/revolution/pull/14300
