### PR TITLE
Improve Button Styling in Modals

### DIFF
--- a/_build/templates/default/sass/_windows.scss
+++ b/_build/templates/default/sass/_windows.scss
@@ -51,6 +51,10 @@
       padding: 8px;
       text-align: center;
     }
+
+    .x-window-header-text {
+        padding-left: 24px;
+    }
   }
 
   /* styles for a collapsed window */
@@ -110,6 +114,12 @@
       .x-window-body {
         padding-top: 15px;
       }
+    }
+
+    .x-window-tc {
+        .x-window-header-text {
+            padding-left: 64px;
+        }
     }
   }
 
@@ -234,6 +244,29 @@
     .error {
       color: $red;
     }
+  }
+
+  /* message dialog windows */
+  &.x-window-plain {
+      .x-toolbar-left-row {
+          .x-toolbar-cell {
+              /*
+                  Note that because the MessageBox class in Extjs 3 is a singleton,
+                  it can not be extended or overriden and is very limited in its
+                  configuration options. Thus the fragile method here of selecting
+                  the button by dom position. Ext always outputs all 4 buttons into
+                  the markup and just hides ones not in use for a particular window type.
+                  For the time-being, the primary button will always be the
+                  first ("ok") or second ("yes", typically our save button) index.
+              */
+              &:nth-child(1),
+              &:nth-child(2) {
+                  .x-btn {
+                      @extend %primary-button;
+                  }
+              }
+          }
+      }
   }
 }
 

--- a/_build/templates/default/sass/components/_primary-button.scss
+++ b/_build/templates/default/sass/components/_primary-button.scss
@@ -4,7 +4,11 @@
     box-shadow: none;
     color: $buttonColorPrimary;
 
-    &.x-btn-focus,
+    &.x-btn-focus:not(.x-btn-over) {
+        background: $green;
+        color: $buttonColorPrimary;
+    }
+
     &.x-btn-over,
     &:hover {
         background: $greener;

--- a/_build/templates/default/sass/components/_secondary-button.scss
+++ b/_build/templates/default/sass/components/_secondary-button.scss
@@ -61,17 +61,16 @@
     }
   }
 
+  &.x-btn-focus:not(.x-btn-over) {
+      background: $buttonBg;
+      color: $buttonColor;
+  }
+
   &.x-btn-over,
-  &:hover,
-  &.x-btn-focus,
-  &:focus {
+  &:hover {
     background-color: $lightGray;
     box-shadow: $softGray;
     color: $darkGray;
-
-    /*button {
-      color: inherit;
-    }*/
   }
 
   &.x-btn-click,
@@ -79,10 +78,6 @@
     background-color: $lightGray;
     box-shadow: $softGray;
     color: $darkGray;
-
-    /*button {
-      color: inherit;
-    }*/
   }
 
   &.x-btn-menu-active {


### PR DESCRIPTION
### What does it do?
Updates scss to show the correct primary button color in confirm, alert, and other message windows, making these modal windows consistent with the other modx-specific ones (usually involving a create/update action). 

### Why is it needed?
Some affirmative buttons were displaying a grey background instead of the primary button color (green in modx 3).

### How to test
From your terminal app, run `grunt build` from within the _build/templates/default folder. Then take various actions which trigger confirmation/alert dialogs—such as deleting a resource, purging deleted resources, deleting elements such as tvs (particularly one that's assigned to a template, as it will trigger an additional dialog), chunks, etc. Note how the affirmative buttons ("Save", "OK", etc.) should appear in the new primary button color (green).

### Related issue(s)/PR(s)
Addresses issue #15541.
