### PR TITLE
Form customization front end fixes/improvements

### DIFF
--- a/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
+++ b/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
@@ -55,10 +55,10 @@ class modActionDomTest extends MODxTestCase {
      */
     public function providerApply() {
         return array(
-            array('MODx.hideField("modx-panel-resource",["description"]);',
+            array('MODx.hideField("modx-panel-resource","description");',
                 'fieldVisible','description',0,'modx-panel-resource'),
 
-            array('MODx.renameLabel("modx-panel-resource",["published"],["Active"]);',
+            array('MODx.renameLabel("modx-panel-resource","published","Active");',
                 'fieldTitle','published','Active','modx-panel-resource'),
 
             array('MODx.renameTab("modx-resource-settings","Other Settings");',
@@ -70,7 +70,7 @@ class modActionDomTest extends MODxTestCase {
             array('MODx.addTab("modx-resource-tabs",{title:"Other Tab",id:"tab-other"});',
                 'tabNew','tab-other','Other Tab','modx-resource-tabs'),
 
-            array('MODx.moveTV(["tv15"],"modx-resource-settings");',
+            array('MODx.moveTV("tv15","modx-resource-settings");',
                 'tvMove','tv15','modx-resource-settings','modx-panel-resource'),
         );
     }

--- a/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
+++ b/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
@@ -55,22 +55,22 @@ class modActionDomTest extends MODxTestCase {
      */
     public function providerApply() {
         return array(
-            array('MODx.hideField("modx-panel-resource","description");',
+            array('MODx.hideField("modx-panel-resource", "description");',
                 'fieldVisible','description',0,'modx-panel-resource'),
 
-            array('MODx.renameLabel("modx-panel-resource","published","Active");',
+            array('MODx.renameLabel("modx-panel-resource", "published", "Active");',
                 'fieldTitle','published','Active','modx-panel-resource'),
 
-            array('MODx.renameTab("modx-resource-settings","Other Settings");',
+            array('MODx.renameTab("modx-resource-settings", "Other Settings");',
                 'tabTitle','modx-resource-settings','Other Settings','modx-resource-tabs'),
 
-            array('MODx.hideRegion("modx-resource-tabs","modx-resource-settings");',
+            array('MODx.hideRegion("modx-resource-tabs", "modx-resource-settings");',
                 'tabVisible','modx-resource-settings',0,'modx-resource-tabs'),
 
-            array('MODx.addTab("modx-resource-tabs",{title:"Other Tab",id:"tab-other"});',
+            array('MODx.addTab("modx-resource-tabs",{id:"tab-other", title:"Other Tab"});',
                 'tabNew','tab-other','Other Tab','modx-resource-tabs'),
 
-            array('MODx.moveTV("tv15","modx-resource-settings");',
+            array('MODx.moveTV("tv15", "modx-resource-settings");',
                 'tvMove','tv15','modx-resource-settings','modx-panel-resource'),
         );
     }

--- a/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
+++ b/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
@@ -67,7 +67,7 @@ class modActionDomTest extends MODxTestCase {
             array('MODx.hideRegion("modx-resource-tabs", "modx-resource-settings");',
                 'tabVisible','modx-resource-settings',0,'modx-resource-tabs'),
 
-            array('MODx.addTab("modx-resource-tabs",{id:"tab-other", title:"Other Tab"});',
+            array('MODx.addTab("modx-resource-tabs", {id: "tab-other", title: "Other Tab"});',
                 'tabNew','tab-other','Other Tab','modx-resource-tabs'),
 
             array('MODx.moveTV("tv15", "modx-resource-settings");',

--- a/core/model/modx/modactiondom.class.php
+++ b/core/model/modx/modactiondom.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -24,7 +25,9 @@
  * @see modFormCustomizationSet
  * @package modx
  */
-class modActionDom extends modAccessibleSimpleObject {
+
+class modActionDom extends modAccessibleSimpleObject
+{
 
     /**
      * Apply the rule to the current page.
@@ -33,51 +36,45 @@ class modActionDom extends modAccessibleSimpleObject {
      * @param int|string $objId The PK of the object that the rule is being applied to.
      * @return string The generated code that applies the rule.
      */
-    public function apply($objId = '') {
+    public function apply($objId = '')
+    {
         $rule = '';
-        $encoding = $this->xpdo->getOption('modx_charset',null,'UTF-8');
+        $encoding = $this->xpdo->getOption('modx_charset', null, 'UTF-8');
 
-        /* now switch by types of rules */
-        switch ($this->get('rule')) {
+        $boolRules = ['fieldVisible', 'tabVisible'];
+        $ruleType = $this->get('rule');
+
+        $container = json_encode($this->get('container'));
+        $itemId = json_encode($this->get('name'));
+        $value = in_array($ruleType, $boolRules)
+            ? (int)$this->get('value')
+            : json_encode(htmlspecialchars($this->get('value'), ENT_COMPAT, $encoding))
+            ;
+
+        switch ($ruleType) {
             case 'fieldVisible':
-                if (!$this->get('value')) {
-                    $fields = explode(',',$this->get('name'));
-                    $rule = 'MODx.hideField("'.$this->get('container').'",'.$this->xpdo->toJSON($fields).');';
-                }
+                $rule = $value === 0 ? "MODx.hideField({$container}, {$itemId});" : '' ;
                 break;
             case 'fieldLabel':
             case 'fieldTitle':
-                $fields = explode(',',$this->get('name'));
-                $values = explode(',',$this->get('value'));
-                foreach ($values as &$value) {
-                    $value = htmlspecialchars($value,ENT_COMPAT,$encoding);
-                }
-                $rule = 'MODx.renameLabel("'.$this->get('container').'",'.$this->xpdo->toJSON($fields).','.$this->xpdo->toJSON($values).');';
+                $rule = "MODx.renameLabel({$container}, {$itemId}, {$value});";
                 break;
             case 'panelTitle':
             case 'tabTitle':
             case 'tabLabel':
-                $rule = 'MODx.renameTab("'.$this->get('name').'","'.htmlspecialchars($this->get('value'),ENT_COMPAT,$encoding).'");';
+                $rule = "MODx.renameTab({$itemId}, {$value});";
                 break;
             case 'tabVisible':
-                if (!$this->get('value')) {
-                    $tabs = explode(',',$this->get('name'));
-                    $rule = '';
-                    foreach ($tabs as $tab) {
-                        $tab = trim($tab);
-                        $rule .= 'MODx.hideRegion("'.$this->get('container').'","'.$tab.'");';
-                    }
-                }
+                $rule = $value === 0 ? "MODx.hideRegion({$container}, {$itemId});" : '' ;
                 break;
             case 'tabNew':
-                $title = $this->get('value');
-                $rule = 'MODx.addTab("'.$this->get('container').'",{title:"'.htmlspecialchars($title,ENT_COMPAT,$encoding).'",id:"'.$this->get('name').'"});';
+                $rule = "MODx.addTab({$container}, {id: {$itemId}, title: {$value}});";
                 break;
             case 'tvMove':
-                $tvs = explode(',',$this->get('name'));
-                $rule = 'MODx.moveTV('.$this->xpdo->toJSON($tvs).',"'.$this->get('value').'");';
+                $rule = "MODx.moveTV({$itemId}, {$value});";
                 break;
-            default: break;
+            default:
+                break;
         }
 
         return $rule;

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -238,23 +238,23 @@ Ext.extend(MODx,Ext.Component,{
 			,listeners: {
 				'success': {
 					fn:function() {
-						var tree = Ext.getCmp("modx-resource-tree"); 
-						
+						var tree = Ext.getCmp("modx-resource-tree");
+
 						if (tree && tree.rendered) {
 							tree.refresh();
 						}
 
 						var cmp = Ext.getCmp("modx-panel-resource");
-						
+
 						if (cmp) {
 							Ext.getCmp('modx-abtn-locked').hide();
-							Ext.getCmp('modx-abtn-save').show();	
+							Ext.getCmp('modx-abtn-save').show();
 						}
 					},
 					scope:this
 				}
 			}
-		});  
+		});
     }
 
     ,sleep: function(ms) {
@@ -385,6 +385,7 @@ Ext.extend(MODx,Ext.Component,{
     }
 
     ,helpUrl: false
+
     ,loadHelpPane: function(b) {
         var url = MODx.helpUrl || MODx.config.help_url || '';
         if (!url || !url.length) { return false; }
@@ -403,34 +404,40 @@ Ext.extend(MODx,Ext.Component,{
             ,layout: 'fit'
 			,bodyStyle : 'padding: 0;'
             ,items: [{
-	        	xtype		: 'container',
-				layout		: {
-	            	type		: 'vbox',
-					align		: 'stretch'
+	        	xtype: 'container',
+				layout: {
+	            	type: 'vbox',
+					align: 'stretch'
 				},
-				width		: '100%',
-				height		: '100%',
-				items		:[{
-					autoEl 		: {
-		                tag 		: 'iframe',
-		                src			: url,
-		                width		: '100%',
-						height		: '100%',
+				width: '100%',
+				height: '100%',
+				items: [{
+					autoEl: {
+		                tag: 'iframe',
+		                src: url,
+		                width: '100%',
+						height: '100%',
 						frameBorder	: 0
 					}
 				}]
 			}]
-			//,html: '<iframe src="' + url + '" width="100%" height="100%" frameborder="0"></iframe>'
         });
         MODx.helpWindow.show(b);
         return true;
     }
 
-    ,addTab: function(tbp,opt) {
-        var tabs = Ext.getCmp(tbp);
-        if (tabs) {
-            Ext.applyIf(opt,{
-                id: 'modx-'+Ext.id()+'-tab'
+    /**
+     * Adds a new tab to the specified panel; method called from code inserted via modActionDom (modactiondom.class.php)
+     *
+     * @param {String} panelId - Text id of the tabPanel the new tab will be added to
+     * @param {Object} newTabConfig - The base configuration for the new tab
+     * @return {void}
+     */
+    ,addTab: function(panelId, newTabConfig) {
+        var tabPanel = Ext.getCmp(panelId);
+        if (tabPanel) {
+            Ext.applyIf(newTabConfig,{
+                id: 'modx-' + Ext.id() + '-tab'
                 ,layout: 'form'
                 ,labelAlign: 'top'
                 ,cls: 'modx-resource-tab'
@@ -442,30 +449,45 @@ Ext.extend(MODx,Ext.Component,{
                     ,width: 400
                 }
             });
-            tabs.add(opt);
-            tabs.doLayout();
-            tabs.setActiveTab(0);
+            tabPanel.add(newTabConfig);
+            tabPanel.doLayout();
+            tabPanel.setActiveTab(0);
         }
     }
+
     ,hiddenTabs: []
-    ,hideTab: function(ct,tab) {this.hideRegion(ct,tab);}
-    ,hideRegion: function(ct,tab) {
-        var tp = Ext.getCmp(ct);
-        if (tp) {
-            var tabObj = tp.getItem(tab);
+
+    ,hideTab: function(ct, tab) {
+        this.hideRegion(ct, tab);
+    }
+
+    /**
+     * Hides a region or tab; method called from code inserted via modActionDom (modactiondom.class.php)
+     * and from MODX.hideTab (above)
+     *
+     * @param {String} containerId - Text id of the region/tab's container
+     * @param {String} regionId - Text id of the region/tab to hide
+     * @return {void}
+     */
+    ,hideRegion: function(containerId, regionId) {
+        var tabPanel = Ext.getCmp(containerId);
+        if (tabPanel) {
+            var tabObj = tabPanel.getItem(regionId);
             if (tabObj) {
-                var z = tp.hideTabStripItem(tab);
-                MODx.hiddenTabs.push(tab);
-                var idx = this._getNextActiveTab(tp,tab);
-                tp.setActiveTab(idx);
+                var z = tabPanel.hideTabStripItem(regionId),
+                    idx = this._getNextActiveTab(tabPanel,regionId)
+                ;
+                MODx.hiddenTabs.push(regionId);
+                tabPanel.setActiveTab(idx);
             } else {
-                var region = Ext.getCmp(tab);
+                var region = Ext.getCmp(regionId);
                 if (region) {
                     region.hide();
                 }
             }
         }
     }
+
     ,_getNextActiveTab: function(tp,tab) {
         if (MODx.hiddenTabs.indexOf(tab) != -1) {
             var id;
@@ -477,33 +499,49 @@ Ext.extend(MODx,Ext.Component,{
         return id;
     }
 
-    ,moveTV: function(tvs,tab) {
-        if (!Ext.isArray(tvs)) { tvs = [tvs]; }
-        var tvp = Ext.getCmp('modx-panel-resource-tv');
-        if (!tvp) { return; }
+    /**
+     * Moves a TV to the specified a region or tab; method called from code inserted via modActionDom (modactiondom.class.php)
+     * and from MODX.hideTab (above)
+     *
+     * @param {String} tvId - Text id of the TV to move
+     * @param {String} targetId - Text id of the TV's destination (region/tab)
+     * @return {void}
+     */
+    ,moveTV: function(tvId, targetId) {
+        var sourcePanel = Ext.getCmp('modx-panel-resource-tv'),
+            sourceItem = Ext.get(tvId + '-tr'),
+            target = Ext.getCmp(targetId)
+        ;
+        if (!sourcePanel || !sourceItem || !target) {
+            return;
+        }
 
-        for (var i=0;i<tvs.length;i++) {
-            var tr = Ext.get(tvs[i]+'-tr');
+        target.add({
+            html: ''
+            ,width: '100%'
+            ,id: 'tv-tr-out-' + tvId
+            ,cls: 'modx-tv-out'
+        });
+        target.doLayout();
 
-            if (!tr) { return; }
-            var fp = Ext.getCmp(tab);
-            if (!fp) { return; }
-            fp.add({
-                html: ''
-                ,width: '100%'
-                ,id: 'tv-tr-out-'+tvs[i]
-                ,cls: 'modx-tv-out'
-            });
-            fp.doLayout();
-
-            var o = Ext.get('tv-tr-out-'+tvs[i]);
-            o.replaceWith(tr);
+        var targetItem = Ext.get('tv-tr-out-' + tvId);
+        if (targetItem) {
+            targetItem.replaceWith(sourceItem);
+        } else {
+            var id = tvId.replace('tv', '');
+            console.warn('Attempted to move the TV named "'
+                + sourceItem.dom.innerText + '" (id #' + id + ') to the panel with the id "'
+                + target.id + '" but the original TV field could not be found. '
+                + 'It is likely a conflicting customization rule has already tried to move this TV.'
+            );
         }
     }
+
     ,hideTV: function(tvs) {
         if (!Ext.isArray(tvs)) { tvs = [tvs]; }
         this.hideTVs(tvs);
     }
+
     ,hideTVs: function(tvs) {
         if (!Ext.isArray(tvs)) { tvs = [tvs]; }
         var el;
@@ -515,38 +553,64 @@ Ext.extend(MODx,Ext.Component,{
             }
         }
     }
-    ,renameLabel: function(ct,flds,vals) {
-        var cto;
-        if (ct == 'modx-panel-resource' && flds.indexOf('modx-resource-content') != -1) {
-            cto = Ext.getCmp('modx-resource-content');
-            if (cto) {
-                if (cto.setTitle) {
-                    cto.setTitle(vals[0]);
-                } else if (cto.setLabel) {
-                    cto.setLabel(flds,vals);
+
+    /**
+     * Changes the label of the specified field; method called from code inserted via modActionDom (modactiondom.class.php)
+     *
+     * @param {String} containerId - Text id of the field's/container's container
+     * @param {String} fieldId - Text id or name of field/container whose label/title being renamed
+     * @param {String} newLabel - The replacement label text
+     * @return {void}
+     */
+    ,renameLabel: function(containerId, fieldId, newLabel) {
+        var container;
+        if (containerId == 'modx-panel-resource' && fieldId.indexOf('modx-resource-content') != -1) {
+            container = Ext.getCmp('modx-resource-content');
+            if (container) {
+                if (container.setTitle) {
+                    container.setTitle(newLabel);
+                } else if (container.setLabel) {
+                    container.setLabel(fieldId, newLabel);
                 } else {
-                    cto.label.update(vals[0]);
+                    container.label.update(newLabel);
                 }
             }
         } else {
-            cto = Ext.getCmp(ct);
-            if (cto) {
-                cto.setLabel(flds,vals);
+            container = Ext.getCmp(containerId);
+            if (container) {
+                container.setLabel(fieldId, newLabel);
             }
         }
     }
-    ,renameTab: function(tb,title) {
-        var tab = Ext.getCmp(tb);
+
+    /**
+     * Renames a form tab; method called from code inserted via modActionDom (modactiondom.class.php)
+     *
+     * @param {String} tabId - Text id of tab being renamed
+     * @param {String} newTitle - The replacement title text
+     * @return {void}
+     */
+    ,renameTab: function(tabId, newTitle) {
+        var tab = Ext.getCmp(tabId);
         if (tab) {
-            tab.setTitle(title);
+            tab.setTitle(newTitle);
         }
     }
-    ,hideField: function(ct,flds) {
-        ct = Ext.getCmp(ct);
-        if (ct) {
-            ct.hideField(flds);
+
+    /**
+     * Hides a field in the specified container; method called from code inserted via modActionDom (modactiondom.class.php)
+     *
+     * @param {String} containerId - Text id of the field's container
+     * @param {String} fieldId - Text id or name of field being hidden
+     * @return {void}
+     */
+    ,hideField: function(containerId, fieldId) {
+        var container = Ext.getCmp(containerId);
+        if (container) {
+            container.hideField(fieldId);
         }
     }
+
     ,preview: function() {
         var url = MODx.config.site_url;
         if (MODx.config.default_site_url) {
@@ -554,6 +618,7 @@ Ext.extend(MODx,Ext.Component,{
         }
         window.open(url);
     }
+
     ,makeDroppable: function(fld,h,p) {
         if (!fld) return false;
         h = h || Ext.emptyFn;
@@ -573,6 +638,7 @@ Ext.extend(MODx,Ext.Component,{
         }
         return true;
     }
+
     ,debug: function(msg) {
         if (MODx.config.ui_debug_mode == 1) {
             console.log(msg);

--- a/manager/assets/modext/widgets/core/modx.panel.js
+++ b/manager/assets/modext/widgets/core/modx.panel.js
@@ -265,15 +265,22 @@ Ext.extend(MODx.FormPanel,Ext.FormPanel,{
         return fld;
     }
 
-    ,hideField: function(flds) {
-        if (!Ext.isArray(flds)) { flds = flds[flds]; }
-        var f;
-        for (var i=0;i<flds.length;i++) {
-            f = this.getField(flds[i]);
-            if (!f) return;
-            f.hide();
-            var d = f.getEl().up('.x-form-item');
-            if (d) { d.setDisplayed(false); }
+    /**
+     * Called exclusively from MODx.hideField (modx.js) for form customization
+     *
+     * @param {String} fieldId - Text id or name of field whose label is being hidden
+     * @return {void}
+     */
+    ,hideField: function(fieldId) {
+        var field = this.getField(fieldId),
+            label
+        ;
+        if (!field) {
+            return;
+        }
+        field.hide();
+        if (label = field.getEl().up('.x-form-item')) {
+            label.setDisplayed(false);
         }
     }
 
@@ -290,20 +297,28 @@ Ext.extend(MODx.FormPanel,Ext.FormPanel,{
         }
     }
 
-    ,setLabel: function(flds,vals,bp){
-        if (!Ext.isArray(flds)) { flds = flds[flds]; }
-        if (!Ext.isArray(vals)) { vals = valss[vals]; }
-        var f,v;
-        for (var i=0;i<flds.length;i++) {
-            f = this.getField(flds[i]);
-
-            if (!f) return;
-            v = String.format('{0}',vals[i]);
-            if (f.xtype == 'checkbox' || f.xtype == 'xcheckbox' || f.xtype == 'radio') {
-                f.setBoxLabel(v);
-            } else if (f.label) {
-                f.label.update(v);
-            }
+    /**
+     * Called exclusively from MODx.renameLabel (modx.js) for form customization
+     *
+     * @param {String} fieldId - Text id or name of field whose label is being renamed
+     * @param {String} newLabel - The replacement label text
+     * @return {void}
+     */
+    ,setLabel: function(fieldId, newLabel){
+        var field = this.getField(fieldId);
+        if (!field) {
+            return;
+        }
+        switch (field.xtype) {
+            case 'checkbox':
+            case 'xcheckbox':
+            case 'radio':
+                field.setBoxLabel(newLabel);
+                break;
+            default:
+                if (field.label) {
+                    field.label.update(newLabel);
+                }
         }
     }
 


### PR DESCRIPTION
### What does it do?
Reworks the methods responsible for moving and changing field/tab visibility and labelling. Code optimizations were made and method documentation was added.

### Why is it needed?
Most of these methods were written to receive/process serialized/array data, but there appears to be no reason (any longer at least) to keep them that way—especially given that problems have arisen such as the one referenced by this PR. The changes allow for the use of commas in labels and provides simplification and clarification of the relevant code.

### How to test
Clear your caches and remember to run `grunt build` within the __build/templates/default_ directory to compile the changes into the main js file. Create one or two test TVs, then create a Form Customization profile with at least one rule. Within your rule(s), experiment with re-labelling and hiding various resource fields along with your test TVs. Also create a new tab in Regions tab and verify that assigning your TVs to that tab (or the standard regions) works as expected.

### Related issue(s)/PR(s)
Resolves #15357. 
