### PR TITLE
Remove legacy class log message in modX::loadClass

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2544,8 +2544,6 @@ class modX extends xPDO {
 
                 return $class;
             }
-
-            $this->log(self::LOG_LEVEL_WARN, "Could not find legacy class {$fqn} after converting to {$class}");
         }
 
         return parent::loadClass($fqn, $path, $ignorePkg, $transient);


### PR DESCRIPTION

### What does it do?

Removes a log message from modX::loadClass.

### Why is it needed?

Referencing 2.x-style models, wether core or third-party, in a call to loadClass (or newObject, getObject, etc) would cause an unnecessary error message. For a longer description, please see #15515.

This warning can be easily removed for the simple reason that the next line (`parent::loadClass`, which calls `xPDO::loadClass`) still contains the class resolving for plain 2.x models. That will load the class just fine out of the box, and if even that fails due to passing a wrong class it will log an error on its own already. 

### How to test

One way to test is installing ClientConfig or any other extra that comes with its own models to see if any warnings are shown in the installation console. 

### Related issue(s)/PR(s)
Fixes #15515
