### PR TITLE
Update assets.yml

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -27,5 +27,5 @@ jobs:
             -   name: Install NPM dependencies
                 run: cd _build/templates/default && npm install
 
-            -   name: Run Grunt build
-                run: cd _build/templates/default && grunt build
+            -   name: Build assets
+                run: cd _build/templates/default && npm run build


### PR DESCRIPTION
Assets build command not depending on the tool (grunt at this moment) used

### What does it do?
Indirect build command call. The CI does not need to know about the build details.

### Why is it needed?
If the Grunt is ever replaced with an another tool (Gulp, Webpack, etc), then `assets.yml` will not need to be changed.

