### PR TITLE
Upgrade Smarty to v4 for PHP 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
         "phpmailer/phpmailer": "^6.0",
-        "smarty/smarty": "^3.1",
+        "smarty/smarty": "^4.0",
         "james-heinrich/phpthumb": "^1.7",
         "erusev/parsedown": "^1.7",
         "inlinestyle/inlinestyle": "^1.2",

--- a/core/src/Revolution/Smarty/modSmarty.php
+++ b/core/src/Revolution/Smarty/modSmarty.php
@@ -14,7 +14,6 @@ namespace MODX\Revolution\Smarty;
 use Exception;
 use MODX\Revolution\modX;
 use Smarty;
-use SmartyBC;
 use xPDO\xPDO;
 
 /**
@@ -25,7 +24,7 @@ use xPDO\xPDO;
  *
  * @package MODX\Revolution\Smarty
  */
-class modSmarty extends SmartyBC
+class modSmarty extends Smarty
 {
     /**
      * A reference to the modX instance
@@ -56,7 +55,7 @@ class modSmarty extends SmartyBC
      * @param modX  $modx   A reference to the modX object
      * @param array $params An array of configuration parameters
      */
-    function __construct(modX &$modx, $params = [])
+    public function __construct(modX $modx, array $params = [])
     {
         parent:: __construct();
         $this->modx = &$modx;
@@ -79,6 +78,7 @@ class modSmarty extends SmartyBC
             $this->modx->cacheManager->writeTree($this->compile_dir);
         }
 
+        $this->muteUndefinedOrNullWarnings();
         $this->assign('app_name', 'MODX');
 
         $this->_blocks = [];

--- a/core/src/Revolution/modManagerResponse.php
+++ b/core/src/Revolution/modManagerResponse.php
@@ -352,7 +352,7 @@ class modManagerResponse extends modResponse
      */
     public function getLangTopics()
     {
-        $topics = $this->modx->smarty->get_template_vars('_lang_topics');
+        $topics = $this->modx->smarty->getTemplateVars('_lang_topics');
 
         return explode(',', $topics);
     }

--- a/manager/controllers/default/system/info.class.php
+++ b/manager/controllers/default/system/info.class.php
@@ -42,7 +42,7 @@ class SystemInfoManagerController extends modManagerController {
         if ($dbtype_mysql && !empty($m['pdo_mysql'])) $pi = array_merge($pi, ['pdo_mysql' => $m['pdo_mysql']]);
         if (!empty($m['zip'])) $pi = array_merge($pi, ['zip' => $m['zip']]);
         $this->version = [
-            'smarty'=> $this->modx->smarty->_version,
+            'smarty'=> Smarty::SMARTY_VERSION,
             'PHPMailer'=> PHPMailer\PHPMailer\PHPMailer::VERSION
         ];
 


### PR DESCRIPTION
### What does it do?

Swaps out v3 with [the new v4 pre-release](https://github.com/smarty-php/smarty/blob/master/CHANGELOG.md#400-rc0---2021-10-13), and makes the necessary adjustments. 

### Why is it needed?

Smarty v3 does not claim to support PHP 8. I've not personally seen any issues with it other than the odd notices, but this seems like a good time to upgrade MODX3. Hopefully while we stabilise MODX3, Smarty will also reach a stable v4. 

It may also be a good idea to backport this to 2.x, however the minimum PHP version in Smarty 4 is PHP 7.1. So I don't think we can. 

### How to test
`composer update` and use the manager. 

### Related issue(s)/PR(s)
This was brought up in the #core-contributors channel on Slack by Ivan.
