### PR TITLE
Fix duplicate array key

### DIFF
--- a/core/src/Revolution/Rest/RestClientRequest.php
+++ b/core/src/Revolution/Rest/RestClientRequest.php
@@ -308,7 +308,6 @@ class RestClientRequest
             CURLOPT_RETURNTRANSFER => $this->getOption('returnTransfer', true),
             CURLOPT_FOLLOWLOCATION => $this->getOption('followLocation', true),
             CURLOPT_TIMEOUT => $this->getOption('timeout', 240),
-            CURLOPT_USERAGENT => $this->getOption('userAgent'),
             CURLOPT_CONNECTTIMEOUT => $this->getOption('connectTimeout', 0),
             CURLOPT_DNS_CACHE_TIMEOUT => $this->getOption('dnsCacheTimeout', 120),
             CURLOPT_VERBOSE => $this->getOption('verbose', false),


### PR DESCRIPTION
### What does it do?

Fix duplicate array key. The user agent was being set twice, also on line 321/320.

### Why is it needed?

Confusing and invalid code.

### How to test
N/a

### Related issue(s)/PR(s)
N/a, found by PHPStorm's code analysis.
