### PR TITLE
Fix No such file or directory

### DIFF
--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -32,6 +32,5 @@ include dirname(__DIR__) . '/common/3.0.0-policy-template-group-description.php'
 include dirname(__DIR__) . '/common/3.0.0-policy-template-description.php';
 include dirname(__DIR__) . '/common/3.0.0-policy-description.php';
 include dirname(__DIR__) . '/common/3.0.0-non-index-field-length.php';
-include dirname(__DIR__) . '/common/3.0.0-update-base_help_url.php';
 include dirname(__DIR__) . '/common/3.0.0-template-preview.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-content-type-field.php';


### PR DESCRIPTION
### What does it do?
Fix No such file or directory

### Why is it needed?

We fix the error when updating/installing, since the file `3.0.0-update-base_help_url.php` was renamed to `3.0.0-update-sys-setting_base_help_url.php` and is listed in line 28

```shell
[2021-10-24 05:59:48] (ERROR @ /Users/bochkarev/Desktop/modx3/setup/includes/upgrades/mysql/3.0.0-pl.php : 35) PHP warning: include(/Users/bochkarev/Desktop/modx3/setup/includes/upgrades/common/3.0.0-update-base_help_url.php): failed to open stream: No such file or directory
[2021-10-24 05:59:48] (ERROR @ /Users/bochkarev/Desktop/modx3/setup/includes/upgrades/mysql/3.0.0-pl.php : 35) PHP warning: include(): Failed opening '/Users/bochkarev/Desktop/modx3/setup/includes/upgrades/common/3.0.0-update-base_help_url.php' for inclusion (include_path='.:/Applications/MAMP/bin/php/php7.4.12/lib/php')
```

### Related issue(s)/PR(s)
NA
