### PR TITLE
Fix POST requests through modTransportProvider::request

### DIFF
--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -506,7 +506,7 @@ class modTransportProvider extends xPDOSimpleObject
 
         // Add params to the body if this is a POST request
         if ($method === 'POST') {
-            $request->withHeader('Content-Type','application/x-www-form-urlencoded');
+            $request = $request->withHeader('Content-Type','application/x-www-form-urlencoded');
             $request->getBody()->write(http_build_query($params));
         }
 


### PR DESCRIPTION
### What does it do?

When sending a POST request through modTransportProvider::request, make sure that the Content-Type header is set accordingly. As requests are largely immutable, this line of code failed to get the desired effect. 

### Why is it needed?

Core does not use this, however premium extras from both modmore and modstore typically use an encryptedvehicle to protect the source code until it gets decrypted following a license check. I can't speak for modstore extras, but for modmore we've been using POSTs to get the decryption key. Those failed to send the parameters on the alpha3 nightly.

Technically alpha3 is already a breaking change for these vehicles because the return type for request() changed, however that doesn't mean we should keep this broken until beta1. 

### How to test
Try to install the new builds for premium modmore extras (most coming available tomorrow, Commerce 1.2.4 is available right now). Without this patch, the decode key can't be retrieved with an error `Invalid request. Required parameters may be missing, or you're using an unsupported version of MODX. Or, you're human trying to access a system meant for computers.` which indicates parameters were not found.

With the patch, the installation works as expected. 

### Related issue(s)/PR(s)

Introduced in #15781 by yours truly
