### PR TITLE
Fix accessing $modx->controller from plugins and services

### DIFF
--- a/core/src/Revolution/modManagerResponse.php
+++ b/core/src/Revolution/modManagerResponse.php
@@ -98,26 +98,24 @@ class modManagerResponse extends modResponse
             $className = $this->getControllerClassName($this->route);
 
             /** @var modManagerController $controller */
-            $controller = $className::getInstance($this->modx, $className, [
+            $this->modx->controller = $className::getInstance($this->modx, $className, [
                 'namespace' => $this->namespace,
                 'namespace_path' => $this->namespacePath,
                 'action' => $this->route,
                 'controller' => $this->route,
             ]);
-            $controller->setProperties(array_merge($_GET,$_POST));
-            $controller->initialize();
+            $this->modx->controller->setProperties(array_merge($_GET,$_POST));
+            $this->modx->controller->initialize();
 
-            if (!$controller->checkPermissions()) {
+            if (!$this->modx->controller->checkPermissions()) {
                 throw new AccessDeniedException('Not allowed to access this controller.');
             }
-
-            $this->modx->controller = $controller;
 
             $this->body = $this->modx->controller->render();
             return $this->send();
         }
         catch (NotFoundException $e) {
-            $controller = new Error($this->modx, [
+            $this->modx->controller = new Error($this->modx, [
                 'message' => $this->modx->lexicon('action_err_ns'),
                 'errors' => [
                     $e->getMessage()
@@ -130,7 +128,7 @@ class modManagerResponse extends modResponse
                 $message .= ' (' . $message . ')';
             }
 
-            $controller = new Error($this->modx, [
+            $this->modx->controller = new Error($this->modx, [
                 'message' => $message,
                 'errors' => [
                     $e->getMessage()
@@ -138,18 +136,18 @@ class modManagerResponse extends modResponse
             ]);
         }
         catch (\Exception $e) {
-            $controller = new Error($this->modx, [
+            $this->modx->controller = new Error($this->modx, [
                 'message' => get_class($e) . ': ' . $e->getMessage(),
                 'errors' => $this->_formatTrace($e->getTrace())
             ]);
         }
         catch (\Error $e) {
-            $controller = new Error($this->modx, [
+            $this->modx->controller = new Error($this->modx, [
                 'message' => get_class($e) . ': ' . $e->getMessage(),
                 'errors' => $this->_formatTrace($e->getTrace())
             ]);
         }
-        $this->body = $controller->render();
+        $this->body = $this->modx->controller->render();
         return $this->send();
     }
 


### PR DESCRIPTION
Please see #core-contributors on slack to discuss this as I'm _super confused_ why my extras are breaking in alpha3 without this. 

### What does it do?

Changes controller initialisation to immediately write to $modx->controller instead of a local variable that is then written to $modx->controller later. 

### Why is it needed?

While testing the alpha3 nightly from last night I kept running into inexplicable errors related to $modx->controller. 

Something as simple as this in a plugin:

    case 'OnManagerPageBeforeRender':
        $assetsUrl = $modx->getOption('commerce.assets_url', null, $modx->getOption('assets_url') . 'components/commerce/');
        $modx->controller->addCss($assetsUrl . 'tvs/products.css');

... would cause a fatal error `Call to undefined method addCss on null`, and a similar line of `$modx->controller->addLexiconTopic(..)` in an OnRichTextEditorInit event would also fail with a fatal error.

I wish I understood better _why_, but this change resolves those problems. 

There may be a relation to #14927 and modExtraManagerController. Previously those would be instantiated with a `getInstanceDeprecated()` method, but that was changed in #14927 to use the generic `getInstance()` method. Another reason to think it may be related to the modExtraManagerController somehow is that I did not see the Redactor error while editing a resource - only when it got loaded on another CMP it seemed to break. 

### How to test

It happened on an alpha3 nightly from yesterday using Redactor and Commerce with both triggering 

### Related issue(s)/PR(s)
N/a
