### PR TITLE
Update default welcome screen url when upgrading from 2.8 to 3.x

### DIFF
--- a/manager/controllers/default/welcome.class.php
+++ b/manager/controllers/default/welcome.class.php
@@ -87,7 +87,7 @@ class WelcomeManagerController extends modManagerController
         ];
         $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . json_encode($obj) . ')});</script>');
         if ($this->showWelcomeScreen) {
-            $url = $this->modx->getOption('welcome_screen_url', null, 'http://misc.modx.com/revolution/welcome.20.html');
+            $url = $this->modx->getOption('welcome_screen_url', null, '//misc.modx.com/revolution/welcome.30.html');
             $this->addHtml('<script>Ext.onReady(function() { MODx.loadWelcomePanel("' . htmlspecialchars($url) . '"); });</script>');
         }
     }

--- a/setup/includes/upgrades/common/3.0.0-update-sys-setting_welcome_screen_url.php
+++ b/setup/includes/upgrades/common/3.0.0-update-sys-setting_welcome_screen_url.php
@@ -7,7 +7,10 @@ use MODX\Revolution\modSystemSetting;
 /** @var modSystemSetting $welcome_screen_url */
 $welcome_screen_url = $modx->getObject(modSystemSetting::class, [
     'key' => 'welcome_screen_url',
-    'value' => '//misc.modx.com/revolution/welcome.27.html',
+    'value:IN' => [
+        '//misc.modx.com/revolution/welcome.27.html',
+        '//misc.modx.com/revolution/welcome.28.html',
+    ],
 ]);
 if ($welcome_screen_url) {
     $welcome_screen_url->set('value', '//misc.modx.com/revolution/welcome.30.html');


### PR DESCRIPTION
### What does it do?
Make sure we update the welcome screen url if you upgrade from 2.8 to 3.x

### Why is it needed?
Currently it checks for the 2.7 welcome screen url in 3.x and only then it changes the value to the new one for 3.x

### How to test
Upgrade from 2.8 to 3.x and check the welcome screen url.

### Related issue(s)/PR(s)
Closes #15879 