### PR TITLE
Removed unused system settings

### DIFF
--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -22,13 +22,17 @@ $settings = [
     'manager_js_zlib_output_compression',
     'rb_base_dir',
     'rb_base_url',
+    'resource_static_allow_absolute',
+    'resource_static_path',
     'resolve_hostnames',
     'server_protocol',
     'strip_image_paths',
     'udperms_allowroot',
+    'upload_check_exist',
     'upload_flash',
     'use_browser',
     'webpwdreminder_message',
+    'websignupemail_message',
 ];
 
 $messageTemplate = '<p class="%s">%s</p>';

--- a/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-cleanup-system-settings.php
@@ -22,8 +22,6 @@ $settings = [
     'manager_js_zlib_output_compression',
     'rb_base_dir',
     'rb_base_url',
-    'resource_static_allow_absolute',
-    'resource_static_path',
     'resolve_hostnames',
     'server_protocol',
     'strip_image_paths',


### PR DESCRIPTION
### What does it do?
Removed unused system settings, which still appear after upgrading from 2.x to 3.x.

### Why is it needed?
These settings are outdated or found only in the "System Settings", do not participate in the remaining code:

- `upload_check_exist`
- `websignupemail_message`

### Related issue(s)/PR(s)
#15877
