### PR TITLE
[3.x] Remove unused refreshTVs method

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.tv.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.tv.js
@@ -26,27 +26,5 @@ Ext.extend(MODx.panel.ResourceTV,MODx.Panel,{
     autoload: function() {
         return false;
     }
-    ,refreshTVs: function() {
-        return false;
-        var t = Ext.getCmp(this.config.templateField);
-        if (!t && !this.config.template) { return false; }
-        var template = this.config.template ? this.config.template : t.getValue();
-
-        this.getUpdater().update({
-            url: MODx.config.manager_url+'?a=resource/tvs'
-            ,method: 'GET'
-            ,params: {
-               'class_key': this.config.class_key
-               ,'template': template
-               ,'resource': this.config.resource
-            }
-            ,scripts: true
-            ,callback: function() {
-                this.fireEvent('load');
-                if (MODx.afterTVLoad) { MODx.afterTVLoad(); }
-            }
-            ,scope: this
-        });
-    }
 });
 Ext.reg('modx-panel-resource-tv',MODx.panel.ResourceTV);

--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -75,10 +75,6 @@ Ext.onReady(function() {
         id = id[3];
         MODx.resetTV(id);
     });
-    MODx.refreshTVs = function() {
-        if (MODx.unloadTVRTE) { MODx.unloadTVRTE(); }
-        Ext.getCmp('modx-panel-resource-tv').refreshTVs();
-    };
     {/literal}{if $tvcount GT 0}{literal}
     MODx.load({
         xtype: 'modx-vtabs'


### PR DESCRIPTION
### What does it do?
Removes old javascript method

### How to test
No real tests to do here. Just confirm resource editing page with TVs works as expected.

### Related issue(s)/PR(s)
No related issue.
