### PR TITLE
Remove superfluous lexicon entries

### DIFF
--- a/core/lexicon/en/tv_widget.inc.php
+++ b/core/lexicon/en/tv_widget.inc.php
@@ -238,8 +238,6 @@ $_lang['tv_elements_listbox_desc'] = $_lang['tv_elements_desc'];
 $_lang['tv_elements_listbox-multiple_desc'] = $_lang['tv_elements_listbox_desc'];
 $_lang['tv_elements_radio_desc'] = $_lang['tv_elements_option_desc'] = $_lang['tv_elements_desc'];
 $_lang['tv_elements_tag_desc'] = $_lang['tv_elements_desc'];
-$_lang['tv_daterange_elements_desc'] = 'Test options desc for daterange with example ph: [[+ex1]]';
-$_lang['tv_daterange_default_text_desc'] = 'Test default text desc for daterange with example ph: [[+ex1]]';
 $_lang['tv_type'] = 'Input Type';
 $_lang['upper_case'] = 'Upper Case';
 $_lang['url'] = 'URL';


### PR DESCRIPTION
### What does it do?
Remove two superfluous lexicon entries.

### Why is it needed?
According to https://github.com/modxcms/revolution/pull/15773#pullrequestreview-786758229, they were not removed by mistake.

### Related issue(s)/PR(s)
#15773
