### PR TITLE
[3.x] Fix problems in lexicon creation form

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
@@ -43,14 +43,16 @@ class Create extends Processor
      */
     public function process()
     {
-        if ($this->alreadyExists()) {
+        $data = array_map('trim', $this->getProperties());
+
+        if ($this->alreadyExists($data)) {
             return $this->failure($this->modx->lexicon('entry_err_ae'));
         }
 
         $this->entry = $this->modx->newObject(modLexiconEntry::class);
-        $this->entry->fromArray($this->getProperties());
+        $this->entry->fromArray($data);
         $this->entry->set('editedon', date('Y-m-d h:i:s'));
-
+        
         if ($this->entry->save() === false) {
             return $this->failure($this->modx->lexicon('entry_err_save'));
         }
@@ -61,13 +63,13 @@ class Create extends Processor
     /**
      * @return bool
      */
-    public function alreadyExists()
+    public function alreadyExists($data)
     {
         return $this->modx->getCount(modLexiconEntry::class, [
-                'name' => $this->getProperty('name'),
-                'namespace' => $this->getProperty('namespace'),
-                'language' => $this->getProperty('language'),
-                'topic' => $this->getProperty('topic'),
+                'name' => $data['name'],
+                'namespace' => $data['namespace'],
+                'language' => $data['language'],
+                'topic' => $data['topic']
             ]) > 0;
     }
 

--- a/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -52,7 +53,7 @@ class Create extends Processor
         $this->entry = $this->modx->newObject(modLexiconEntry::class);
         $this->entry->fromArray($data);
         $this->entry->set('editedon', date('Y-m-d h:i:s'));
-        
+
         if ($this->entry->save() === false) {
             return $this->failure($this->modx->lexicon('entry_err_save'));
         }

--- a/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/Create.php
@@ -44,7 +44,10 @@ class Create extends Processor
      */
     public function process()
     {
-        $data = array_map('trim', $this->getProperties());
+        $data = [];
+        foreach ($this->getProperties() as $k => $v) {
+            $data[$k] = $k === 'value' ? $v : trim($v);
+        }
 
         if ($this->alreadyExists($data)) {
             return $this->failure($this->modx->lexicon('entry_err_ae'));

--- a/core/src/Revolution/Processors/Workspace/Lexicon/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/UpdateFromGrid.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -52,6 +53,7 @@ class UpdateFromGrid extends Processor
         if (empty($data)) {
             return $this->modx->lexicon('invalid_data');
         }
+        $data = array_map('trim', $data);
         $this->setProperties($data);
         $this->unsetProperty('data');
 

--- a/core/src/Revolution/Processors/Workspace/Lexicon/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/UpdateFromGrid.php
@@ -53,7 +53,9 @@ class UpdateFromGrid extends Processor
         if (empty($data)) {
             return $this->modx->lexicon('invalid_data');
         }
-        $data = array_map('trim', $data);
+        foreach ($data as $k => $v) {
+            $data[$k] = $k === 'value' ? $v : trim($v);
+        }
         $this->setProperties($data);
         $this->unsetProperty('data');
 

--- a/core/src/Revolution/modLexiconEntry.php
+++ b/core/src/Revolution/modLexiconEntry.php
@@ -39,18 +39,45 @@ class modLexiconEntry extends xPDOSimpleObject
     }
 
     /**
+     * Ensures required values are present or set to their defaults, when applicable
+     *
+     * @return boolean True when valid
+     */
+    private function validateEntry()
+    {
+        if (empty($this->get('name'))) {
+            return false;
+        }
+        if (empty($this->get('namespace'))) {
+            $this->set('namespace', 'core');
+        }
+        if (empty($this->get('topic'))) {
+            $this->set('topic', 'default');
+        }
+        if (empty($this->get('language'))) {
+            $defaultLanguage = $this->xpdo->getOption('cultureKey');
+            $language = !empty($defaultLanguage) ? $defaultLanguage : 'en' ;
+            $this->set('language', $language);
+        }
+        return true;
+    }
+
+    /**
      * Overrides xPDOObject::save to clear lexicon cache on saving.
      *
      * {@inheritdoc}
      */
     public function save($cacheFlag = null)
     {
+        if (!$this->validateEntry()) {
+            return false;
+        }
         if ($this->_new) {
             if (!$this->get('createdon')) {
                 $this->set('createdon', strftime('%Y-%m-%d %H:%M:%S'));
             }
         }
-        $saved = parent:: save($cacheFlag);
+        $saved = parent::save($cacheFlag);
         if ($saved && empty($this->xpdo->config[xPDO::OPT_SETUP])) {
             $this->clearCache();
         }

--- a/manager/assets/modext/workspace/lexicon/lexicon.grid.js
+++ b/manager/assets/modext/workspace/lexicon/lexicon.grid.js
@@ -405,6 +405,8 @@ MODx.window.LexiconEntryCreate = function(config) {
             ,itemId: 'name'
             ,name: 'name'
             ,anchor: '100%'
+            ,msgTarget: 'under'
+            ,allowBlank: false
         },{
             xtype: 'modx-combo-namespace'
             ,fieldLabel: _('namespace')
@@ -412,6 +414,8 @@ MODx.window.LexiconEntryCreate = function(config) {
             ,id: 'modx-'+this.ident+'-namespace'
             ,itemId: 'namespace'
             ,anchor: '100%'
+            ,msgTarget: 'under'
+            ,allowBlank: false
             ,listeners: {
                 'select': {fn: function(cb,r,i) {
                     cle = this.fp.getComponent('topic');
@@ -429,6 +433,8 @@ MODx.window.LexiconEntryCreate = function(config) {
             ,id: 'modx-'+this.ident+'-topic'
             ,itemId: 'topic'
             ,anchor: '100%'
+            ,msgTarget: 'under'
+            ,allowBlank: false
         },{
             xtype: 'modx-combo-language'
             ,fieldLabel: _('language')
@@ -436,6 +442,8 @@ MODx.window.LexiconEntryCreate = function(config) {
             ,id: 'modx-'+this.ident+'-language'
             ,itemId: 'language'
             ,anchor: '100%'
+            ,msgTarget: 'under'
+            ,allowBlank: false
         },{
             xtype: 'textarea'
             ,fieldLabel: _('value')
@@ -443,6 +451,7 @@ MODx.window.LexiconEntryCreate = function(config) {
             ,itemId: 'value'
             ,name: 'value'
             ,anchor: '100%'
+            ,msgTarget: 'under'
         }]
     });
     MODx.window.LexiconEntryCreate.superclass.constructor.call(this,config);


### PR DESCRIPTION
### What does it do?
Made changes to lexicon processors to add simple validation logic and changed js form to make certain fields required.

### Why is it needed?
As there is currently no validation of lexicon form values, records without all the required data save to the database but cannot display because of missing information.

### How to test
Test this under two conditions: 
1. Disable the allowBlank properties I added to the js form; in this way you can verify that the basic php validation works when trying to create a lexicon entry with one or more blank values.
2. Re-enable the allowBlank properties and to verify that the front end validation stops the form from submitting when required values are missing.

Note: Now only valid entries will be saved, so they will always be found in the grid when using the filtering toolbar.

### Related issue(s)/PR(s)
Addresses issue #15223.
