### PR TITLE
Change generatePassword() logic

### DIFF
--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -904,19 +904,14 @@ class modUser extends modPrincipal
         if ($length < $passwordMinimumLength) {
             $length = $passwordMinimumLength;
         }
-        $options = array_merge([
-            'allowable_characters' => 'abcdefghjkmnpqrstuvxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789',
-            'srand_seed_multiplier' => 1000000,
-        ], $options);
 
-        $ps_len = strlen($options['allowable_characters']);
-        srand((double)microtime() * $options['srand_seed_multiplier']);
-        $pass = '';
-        for ($i = 0; $i < $length; $i++) {
-            $pass .= $options['allowable_characters'][mt_rand(0, $ps_len - 1)];
+        if ($options['alphabet']) {
+            $alphabet = array_merge(range('a', 'z'), range('A', 'Z'));
+            shuffle($alphabet);
+            return substr(implode($alphabet),0,$length);
         }
 
-        return $pass;
+        return bin2hex(random_bytes($length));
     }
 
 

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -898,7 +898,7 @@ class modUser extends modPrincipal
     public function generatePassword($length = null, array $options = [])
     {
         if ($length === null) {
-            $length = $this->xpdo->getOption('password_generated_length', null, 10, true);
+                $length = $this->xpdo->getOption('password_generated_length', null, 10, true);
         }
         $passwordMinimumLength = $this->xpdo->getOption('password_min_length', null, 8, true);
         if ($length < $passwordMinimumLength) {
@@ -911,7 +911,7 @@ class modUser extends modPrincipal
             return substr(implode($alphabet),0,$length);
         }
 
-        return bin2hex(random_bytes($length));
+        return substr(bin2hex(random_bytes($length)),$length);
     }
 
 


### PR DESCRIPTION
### What does it do?
Updated the password generation function using a truly random string

### Why is it needed?
I am deeply convinced that the more a password looks like a hash, the less it attracts the attention of hackers. Moreover, this implementation uses a truly random string in contrast to the stock implementation

The `options` parameter as part of password generation is a rather useless parameter. It is not safe to specify salt, any other parameters simply do not occur to me. As an option, I left the implementation of the classic `alphabet` password that can be invoked using options

### How to test
Standard tests work, no logic is affected.
You can also test password generation in the user control panel

### Related issue(s)/PR(s)
#15740
