### PR TITLE
Add ability to return to the same page after language switching

### DIFF
--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -461,7 +461,7 @@ class modLexicon
      *
      * @return array An array of available languages
      */
-    public function getLanguageList($namespace = 'core')
+    public function getLanguageList(string $namespace = 'core'): array
     {
         $corePath = $this->getNamespacePath($namespace);
         $lexPath = str_replace('//', '/', $corePath . '/lexicon/');

--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -84,13 +84,13 @@ class modMenu extends modAccessibleObject
     }
 
     /**
-     * Returns list of available languages in the system with descriptions ans translated names
+     * Returns list of available languages in the system with descriptions and translated names
      *
-     * @return array|null
+     * @return array
      */
-    protected function getLanguageMenu()
+    protected function getLanguageMenu(): array
     {
-        $languages = array_flip($this->xpdo->lexicon->getLanguageList('core'));
+        $languages = array_flip($this->xpdo->lexicon->getLanguageList());
 
         $this->xpdo->lexicon->load('core:languages');
 

--- a/manager/controllers/default/language.class.php
+++ b/manager/controllers/default/language.class.php
@@ -4,41 +4,23 @@ use MODX\Revolution\modParsedManagerController;
 
 /**
  * Switches the current manger language to requested.
- *
- * Class LanguageManagerController
+ * @noinspection AutoloadingIssuesInspection
  */
 class LanguageManagerController extends modParsedManagerController
 {
-    public function checkPermissions()
+    public function checkPermissions(): bool
     {
         return $this->modx->hasPermission('language');
     }
 
-    public function process(array $scriptProperties = [])
+    public function process(array $scriptProperties = []): void
     {
         $targetLanguage = $this->modx->getOption('switch', $scriptProperties, 'en');
 
-        if (!in_array($targetLanguage, $this->modx->lexicon->getLanguageList())) {
-            return;
+        if (in_array($targetLanguage, $this->modx->lexicon->getLanguageList(), true)) {
+            $_SESSION['manager_language'] = $targetLanguage;
         }
 
-        $_SESSION['manager_language'] = $targetLanguage;
-
-        $this->modx->sendRedirect(MODX_MANAGER_URL);
-    }
-
-    public function getPageTitle()
-    {
-        return '';
-    }
-
-    public function loadCustomCssJs()
-    {
-        return;
-    }
-
-    public function getTemplateFile()
-    {
-        return '';
+        $this->modx->sendRedirect($_SERVER['HTTP_REFERER'] ?? MODX_MANAGER_URL);
     }
 }


### PR DESCRIPTION
### What does it do?
It fixes the issue when after switching the language user always returns to the main manager page. Now it respects the previous page (via referer header) and sends a redirect to that page if it exists. Otherwise fallback to the manager base URL. 

### Why is it needed?
Improve user experience during manager usage.

### How to test
Apply changes, go to any page inside the manager, and try to switch the language. You have to stay on the same page after language switching.

### Related issue(s)/PR(s)
#15174
#14046