### PR TITLE
Improve snippets logging in case error messages with arrays

### DIFF
--- a/core/model/modx/modsnippet.class.php
+++ b/core/model/modx/modsnippet.class.php
@@ -46,7 +46,7 @@ class modSnippet extends modScript {
             ));
         } else if (!$saved && !empty($this->xpdo->lexicon)) {
             $msg = $isNew ? $this->xpdo->lexicon('snippet_err_create') : $this->xpdo->lexicon('snippet_err_save');
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$msg.$this->toArray());
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$msg.print_r($this->toArray(),true));
         }
         return $saved;
     }
@@ -72,7 +72,7 @@ class modSnippet extends modScript {
                 'ancestors' => $ancestors,
             ));
         } else if (!$removed && !empty($this->xpdo->lexicon)) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$this->xpdo->lexicon('snippet_err_remove').$this->toArray());
+			$this->xpdo->log(xPDO::LOG_LEVEL_ERROR,$this->xpdo->lexicon('snippet_err_remove').print_r($this->toArray(),true));
         }
 
         return $removed;


### PR DESCRIPTION
### What does it do?
Fix bad log from modsnippet when there are errors when saving or removing snippet

### Why is it needed?
Better to have a correct log

### How to test
Remove the 'write' rights  of a snippet static file and try to save the snippet in the manager. It should try to log the error. The logged error shows the "snippet_err_save" message with "Array" written after... after fix, will show the content of the array of the snippet ($this->toArray() ) as it was designed...

### Related issue(s)/PR(s)
none