### PR TITLE
[2.x] Fix isBinary check to correctly indicate certain textual formats as being not binary

### DIFF
--- a/core/model/modx/modfilehandler.class.php
+++ b/core/model/modx/modfilehandler.class.php
@@ -157,8 +157,24 @@ class modFileHandler {
 
         if (filesize($file) > 0 && class_exists('\finfo')) {
             $finfo = new \finfo(FILEINFO_MIME);
+            $mimeType = strtolower($finfo->file($file));
 
-            return substr($finfo->file($file), 0, 4) !== 'text';
+            // Some mimetypes include a character set, e.g. application/json; charset=utf-8
+            // so we filter out the last part to make comparison easier
+            if (strpos($mimeType, ';') > 0) {
+                $mimeType = substr($mimeType, 0, strpos($mimeType, ';'));
+            }
+
+            return substr($mimeType, 0, 4) !== 'text'
+                && !in_array($mimeType, array(
+                    'application/json',
+                    'application/ld+json',
+                    'application/x-httpd-php', // also restricted by default based on extension
+                    'application/x-sh',
+                    'image/svg+xml',
+                    'application/xhtml+xml',
+                    'application/xml',
+                ), true);
         }
 
         $fh = @fopen($file, 'r');


### PR DESCRIPTION
### What does it do?
Adjusts the isBinary check to make more file types accepted as being non-binary.

### Why is it needed?
This check is used to decide wether or not the files tree should offer the edit option. Some of these, especially json and xml, are not offered the edit option regardless of exension.

### How to test
Add a file with some JSON content, for example:

```
{
   "style_formats":[
      {
         "title":"Red text",
         "inline":"span",
         "styles":{
            "color":"#ff0000"
         }
      }
   ]
}
```

Note that in the files tree it is not editable (clicking it does nothing). 

Apply the patch, and note that now it can be edited.

### Related issue(s)/PR(s)

None, was reported in slack and I went straight from debugging to fixing.
