### PR TITLE
[3.x] Package Manager UX - loading mask

### DIFF
--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -237,4 +237,4 @@ $_lang['modx'] = 'MODX';
 $_lang['modx_constraints'] = 'Please change the MODX version of your site to a version that suits the constraints.';
 $_lang['available'] = 'Available';
 $_lang['not_available'] = 'Not available';
-$_lang['checking_for_package_updates'] = 'Checking for package updates';
+$_lang['checking_for_package_updates'] = 'Checking for package updates...';

--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -237,3 +237,4 @@ $_lang['modx'] = 'MODX';
 $_lang['modx_constraints'] = 'Please change the MODX version of your site to a version that suits the constraints.';
 $_lang['available'] = 'Available';
 $_lang['not_available'] = 'Not available';
+$_lang['loading_packages'] = 'Loading packages';

--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -237,4 +237,4 @@ $_lang['modx'] = 'MODX';
 $_lang['modx_constraints'] = 'Please change the MODX version of your site to a version that suits the constraints.';
 $_lang['available'] = 'Available';
 $_lang['not_available'] = 'Not available';
-$_lang['loading_packages'] = 'Loading packages';
+$_lang['checking_for_package_updates'] = 'Checking for package updates';

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -149,7 +149,7 @@ MODx.grid.Package = function(config) {
     MODx.grid.Package.superclass.constructor.call(this,config);
     this.on('render',function() {
         this.mask = new Ext.LoadMask(this.body.dom, {
-            msg: _('checking_for_package_updates') + '...'
+            msg: _('checking_for_package_updates')
         });
         if (!this.loaded) {
             this.mask.show();

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -148,7 +148,9 @@ MODx.grid.Package = function(config) {
     });
     MODx.grid.Package.superclass.constructor.call(this,config);
     this.on('render',function() {
-        this.mask = new Ext.LoadMask(this.body.dom);
+        this.mask = new Ext.LoadMask(this.body.dom, {
+            msg: _('loading_packages') + '...'
+        });
         if (!this.loaded) {
             this.mask.show();
         }

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -148,8 +148,17 @@ MODx.grid.Package = function(config) {
     });
     MODx.grid.Package.superclass.constructor.call(this,config);
     this.on('render',function() {
-        this.getView().mainBody.update('<div class="x-grid-empty">' + _('loading') + '</div>');
-    },this);
+        this.mask = new Ext.LoadMask(this.body.dom);
+        if (!this.loaded) {
+            this.mask.show();
+        }
+    }, this);
+    this.getStore().on('load', function(s) {
+        if (this.mask) {
+            this.mask.hide();
+        }
+        this.loaded = true;
+    }, this);
     this.on('afterrender', function () {
         this.uploader = new MODx.util.MultiUploadDialog.Upload({
             url: MODx.config.connector_url,

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -149,7 +149,7 @@ MODx.grid.Package = function(config) {
     MODx.grid.Package.superclass.constructor.call(this,config);
     this.on('render',function() {
         this.mask = new Ext.LoadMask(this.body.dom, {
-            msg: _('loading_packages') + '...'
+            msg: _('checking_for_package_updates') + '...'
         });
         if (!this.loaded) {
             this.mask.show();


### PR DESCRIPTION
### What does it do?
Adds a mask with a loading animation to the packages grid on render. A small UX improvement.

Here is the current behaviour. Note that sometimes the wait time can be much longer than what is shown in the video.

https://user-images.githubusercontent.com/5160368/142601114-d6988a18-af79-48e2-aa28-c85f48f66967.mp4

Here is the behaviour with this change applied:

https://user-images.githubusercontent.com/5160368/142601420-9ec563c8-556c-423c-9ae1-4fb0909c3133.mp4




### Why is it needed?
When the cache has been cleared or doesn't exist yet, the main package management grid can take a while to load and currently it just sits there with no indication it's doing anything. 
It can be confusing considering this behaviour (before anything has loaded) is the same as if there are no packages installed.

### How to test
Delete your cache and then go to the package manager.

### Related issue(s)/PR(s)
n/a
