### PR TITLE
Fix Zend OPcache API warning when upgrading MODX

### DIFF
--- a/setup/includes/modinstallsettings.class.php
+++ b/setup/includes/modinstallsettings.class.php
@@ -94,7 +94,9 @@ class modInstallSettings {
     public function load() {
         if (file_exists($this->fileName)) {
             if (function_exists('opcache_invalidate')) {
-                opcache_invalidate($this->fileName);
+                if (stripos(__FILE__, ini_get('opcache.restrict_api')) !== false) {
+                    opcache_invalidate($this->fileName);
+                }
             }
             $this->settings = include $this->fileName;
             if (empty($this->settings)) {

--- a/setup/includes/modinstallsettings.class.php
+++ b/setup/includes/modinstallsettings.class.php
@@ -41,11 +41,6 @@ class modInstallSettings
     public function load()
     {
         if (file_exists($this->fileName)) {
-            if (function_exists('opcache_invalidate')) {
-                if (stripos(__FILE__, ini_get('opcache.restrict_api')) !== false) {
-                    opcache_invalidate($this->fileName);
-                }
-            }
             $this->settings = include $this->fileName;
             if (empty($this->settings)) {
                 $this->restart();

--- a/setup/includes/modinstallsettings.class.php
+++ b/setup/includes/modinstallsettings.class.php
@@ -11,31 +11,88 @@
 /**
  * @package setup
  */
-class modInstallSettings {
+class modInstallSettings
+{
     public $install = null;
     public $config = [];
     public $fileName = '';
     public $settings = [];
 
-    function __construct(modInstall &$install,array $config = []) {
+    public function __construct(modInstall &$install, array $config = [])
+    {
         $this->install =& $install;
-        $this->config = array_merge([],$config);
+        $this->config = array_merge([], $config);
 
-        $this->fileName = $this->getCachePath().'settings.cache.php';
+        $this->fileName = $this->getCachePath() . 'settings.cache.php';
         $this->load();
     }
 
     /**
      * @return string
      */
-    protected function getCachePath() {
+    protected function getCachePath()
+    {
         return MODX_CORE_PATH . 'cache/' . (MODX_CONFIG_KEY == 'config' ? '' : MODX_CONFIG_KEY . '/') . 'setup/';
     }
 
     /**
      * @return void
      */
-    protected function rebuildDSN() {
+    public function load()
+    {
+        if (file_exists($this->fileName)) {
+            if (function_exists('opcache_invalidate')) {
+                if (stripos(__FILE__, ini_get('opcache.restrict_api')) !== false) {
+                    opcache_invalidate($this->fileName);
+                }
+            }
+            $this->settings = include $this->fileName;
+            if (empty($this->settings)) {
+                $this->restart();
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function restart()
+    {
+        $this->erase();
+        if (empty($this->install->request) && !($this->install->request instanceof modInstallCLIRequest)) {
+            header('Location: ' . MODX_SETUP_URL . '?restarted=1');
+            exit();
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function erase()
+    {
+        if (file_exists($this->fileName)) {
+            @unlink($this->fileName);
+        }
+    }
+
+    /**
+     * @param string $k
+     * @param mixed $v
+     * @return void
+     */
+    public function set($k, $v)
+    {
+        $this->settings[$k] = $v;
+        if (in_array($k, ['database_type', 'database_server', 'dbase', 'database_connection_charset'])) {
+            $this->rebuildDSN();
+        }
+    }
+
+    /**
+     * @return void
+     */
+    protected function rebuildDSN()
+    {
         if (array_key_exists('database_type', $this->settings)) {
             switch ($this->settings['database_type']) {
                 case 'mysql':
@@ -56,22 +113,11 @@ class modInstallSettings {
 
     /**
      * @param string $k
-     * @param mixed $v
-     * @return void
-     */
-    public function set($k,$v) {
-        $this->settings[$k] = $v;
-        if (in_array($k, ['database_type', 'database_server', 'dbase', 'database_connection_charset'])) {
-            $this->rebuildDSN();
-        }
-    }
-
-    /**
-     * @param string $k
      * @param mixed $default
      * @return mixed
      */
-    public function get($k,$default = null) {
+    public function get($k, $default = null)
+    {
         if (in_array($k, ['database_dsn', 'server_dsn'])) {
             $this->rebuildDSN();
         }
@@ -82,7 +128,8 @@ class modInstallSettings {
      * @param array $array
      * @return void
      */
-    public function fromArray($array) {
+    public function fromArray($array)
+    {
         foreach ($array as $k => $v) {
             $this->settings[$k] = $v;
         }
@@ -91,24 +138,8 @@ class modInstallSettings {
     /**
      * @return void
      */
-    public function load() {
-        if (file_exists($this->fileName)) {
-            if (function_exists('opcache_invalidate')) {
-                if (stripos(__FILE__, ini_get('opcache.restrict_api')) !== false) {
-                    opcache_invalidate($this->fileName);
-                }
-            }
-            $this->settings = include $this->fileName;
-            if (empty($this->settings)) {
-                $this->restart();
-            }
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function check() {
+    public function check()
+    {
         $this->load();
         if (empty($this->settings)) {
             $this->restart();
@@ -116,21 +147,11 @@ class modInstallSettings {
     }
 
     /**
-     * @return void
-     */
-    public function restart() {
-        $this->erase();
-        if (empty($this->install->request) && !($this->install->request instanceof modInstallCLIRequest)) {
-            header('Location: ' . MODX_SETUP_URL.'?restarted=1');
-            exit();
-        }
-    }
-
-    /**
      * @param string $k
      * @return void
      */
-    public function delete($k) {
+    public function delete($k)
+    {
         unset($this->settings[$k]);
     }
 
@@ -139,35 +160,28 @@ class modInstallSettings {
      * @param int $expire
      * @return bool|int
      */
-    public function store(array $settings = [],$expire = 900) {
-        $this->settings = array_merge($this->settings,$settings);
+    public function store(array $settings = [], $expire = 900)
+    {
+        $this->settings = array_merge($this->settings, $settings);
         $this->rebuildDSN();
         $written = false;
 
-        if ($file= @ fopen($this->fileName,'wb')) {
-            $expirationTS= $expire ? time() + $expire : time();
-            $expireContent= 'if(time() > ' . $expirationTS . '){return array();}';
+        if ($file = @ fopen($this->fileName, 'wb')) {
+            $expirationTS = $expire ? time() + $expire : time();
+            $expireContent = 'if(time() > ' . $expirationTS . '){return array();}';
             $content = '<?php ' . $expireContent . ' return ' . var_export($this->settings, true) . ';';
 
-            $written= @ fwrite($file, $content);
+            $written = @ fwrite($file, $content);
             @ fclose($file);
         }
         return $written;
     }
 
     /**
-     * @return void
-     */
-    public function erase() {
-        if (file_exists($this->fileName)) {
-            @unlink($this->fileName);
-        }
-    }
-
-    /**
      * @return array
      */
-    public function fetch() {
+    public function fetch()
+    {
         ksort($this->settings);
         return $this->settings;
     }

--- a/setup/index.php
+++ b/setup/index.php
@@ -14,6 +14,9 @@
  * @package modx
  * @subpackage setup
  */
+if (ini_get('opcache.enable')) {
+    ini_set('opcache.enable', false);
+}
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'provisioner' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 $modInstall = new modInstall();


### PR DESCRIPTION
### What does it do?
Check if we are allowed to call OPcache API functions.

### Why is it needed?
To fix an OPcache API functions warning during upgrades.

### How to test?
See issue #15897 

### Related issue(s)/PR(s)
Closes #15897