### PR TITLE
Fix setStaticElementPath method (port of #15912)

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -354,13 +354,30 @@ Ext.extend(MODx,Ext.Component,{
         }
 
         if (MODx.config["static_elements_automate_" + typePlural] == 1) {
-            if (Ext.getCmp("modx-" + type + "-category").getValue() > 0) {
-                category = Ext.getCmp("modx-" + type + "-category").lastSelectionText;
+            category = Ext.getCmp("modx-" + type + "-category").getValue();
+            if (category > 0) {
+                Ext.Ajax.request({
+                    url: MODx.config.connector_url,
+                    params: {
+                        action: 'Element/Category/GetList',
+                        id: category,
+                        limit: 0,
+                    },
+                    success: function (response) {
+                        var data = Ext.decode(response.responseText);
+                        categoryText = (data && data.success && data.results) ? data.results[0].name : '';
+                        if (categoryText) {
+                            name = Ext.getCmp("modx-" + type + "-" + nameField).getValue();
+                            path = MODx.getStaticElementsPath(name, categoryText, typePlural);
+                            Ext.getCmp("modx-" + type + "-static-file").setValue(path);
+                        }
+                    },
+                });
+            } else {
+                name = Ext.getCmp("modx-" + type + "-" + nameField).getValue();
+                path = MODx.getStaticElementsPath(name, '', typePlural);
+                Ext.getCmp("modx-" + type + "-static-file").setValue(path);
             }
-
-            name = Ext.getCmp("modx-" + type + "-" + nameField).getValue();
-            path = MODx.getStaticElementsPath(name, category, typePlural);
-            Ext.getCmp("modx-" + type + "-static-file").setValue(path);
         }
     }
 

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -149,11 +149,9 @@ MODx.panel.Chunk = function(config) {
                         ,value: config.record.category || 0
                         ,listeners: {
                             'afterrender': {scope:this,fn:function(f,e) {
-                                setTimeout(function(){
                                     MODx.setStaticElementPath('chunk');
-                                }, 200);
                             }}
-                            ,'change': {scope:this,fn:function(f,e) {
+                            ,'select': {scope:this,fn:function(f,e) {
                                 MODx.setStaticElementPath('chunk');
                             }}
                         }

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -152,11 +152,9 @@ MODx.panel.Plugin = function(config) {
                         ,value: config.record.category || 0
                         ,listeners: {
                             'afterrender': {scope:this,fn:function(f,e) {
-                                setTimeout(function(){
-                                    MODx.setStaticElementPath('plugin');
-                                }, 200);
+                                MODx.setStaticElementPath('plugin');
                             }}
-                            ,'change': {scope:this,fn:function(f,e) {
+                            ,'select': {scope:this,fn:function(f,e) {
                                 MODx.setStaticElementPath('plugin');
                             }}
                         }

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -150,11 +150,9 @@ MODx.panel.Snippet = function(config) {
                         ,value: config.record.category || 0
                         ,listeners: {
                             'afterrender': {scope:this,fn:function(f,e) {
-                                setTimeout(function(){
-                                    MODx.setStaticElementPath('snippet');
-                                }, 200);
+                                MODx.setStaticElementPath('snippet');
                             }}
-                            ,'change': {scope:this,fn:function(f,e) {
+                            ,'select': {scope:this,fn:function(f,e) {
                                 MODx.setStaticElementPath('snippet');
                             }}
                         }

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -187,11 +187,9 @@ MODx.panel.Template = function(config) {
                         ,value: config.record.category || 0
                         ,listeners: {
                             'afterrender': {scope:this,fn:function(f,e) {
-                                setTimeout(function(){
                                     MODx.setStaticElementPath('template');
-                                }, 200);
                             }}
-                            ,'change': {scope:this,fn:function(f,e) {
+                            ,'select': {scope:this,fn:function(f,e) {
                                 MODx.setStaticElementPath('template');
                             }}
                         }

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -137,11 +137,9 @@ MODx.panel.TV = function(config) {
                                 ,tabIndex: 2
                                 ,listeners: {
                                     afterrender: {scope:this,fn:function(f,e) {
-                                        setTimeout(function(){
                                             MODx.setStaticElementPath('tv');
-                                        }, 200);
                                     }}
-                                    ,change: {scope:this,fn:function(f,e) {
+                                    ,select: {scope:this,fn:function(f,e) {
                                         MODx.setStaticElementPath('tv');
                                     }}
                                 }


### PR DESCRIPTION
### What does it do?
Use an Ajax request to retrieve the category name instead of setTimeout to bypass a not set lastSelectionText. Use the select listener instead of a change listener.

### Why is it needed?
The previous implementation used a setTimeout to bypass a not set lastSelectionText. This timeout did not work on several installations with nested categories or a little more categories (~40 in my test) without increasing the timeout. Now the category name is retrieved with an Ajax request and the lastSelectionText and the timeout is no longer needed.

This solves the following issue: A static element is created with a path containing the category. If this static element is edited again, the category in the path is missing. If the static element is saved without temporary modifying the element name, the category path is removed without a notice.

### How to test
Setup an automatic static elements workflow. Create a nested category. Assign this category to a chunk and save that chunk. Reload the manager and look for the path of the static file. Before the category was missing in the path, after the patch it contains the category.

### Related issue(s)/PR(s)
#15912