### PR TITLE
Added id / names of elements in context menu

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2061,7 +2061,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
         $menu = [];
         $menu[] = [
-            'text' => '<b>' . $dirName . '</b>',
+            'text' => '<b>' . htmlentities($dirName) . '</b>',
             'handler' => '',
             'header' => true,
         ];
@@ -2138,7 +2138,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
         $menu = [];
         $menu[] = [
-            'text' => '<b>' . $fileName . '</b>',
+            'text' => '<b>' . htmlentities($fileName) . '</b>',
             'handler' => '',
             'header' => true,
         ];

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -418,7 +418,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                         $directories[$file_name]['visibility'] = $visibility;
                     }
                     $directories[$file_name]['menu'] = [
-                        'items' => $this->getListDirContextMenu(),
+                        'items' => $this->getListDirContextMenu($file_name),
                     ];
 
                 }
@@ -2053,13 +2053,19 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      *
      * @return array
      */
-    protected function getListDirContextMenu()
+    protected function getListDirContextMenu($dirName)
     {
         $canSave = $this->checkPolicy('save');
         $canRemove = $this->checkPolicy('remove');
         $canCreate = $this->checkPolicy('create');
 
         $menu = [];
+        $menu[] = [
+            'text' => '<b>' . $dirName . '</b>',
+            'handler' => '',
+            'header' => true,
+        ];
+        $menu[] = '-';
         $menu[] = [
             'text' => $this->xpdo->lexicon('directory_refresh'),
             'handler' => 'this.refreshActiveNode',
@@ -2122,6 +2128,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     protected function getListFileContextMenu($path, $editable = true, $data = [])
     {
+        $fileName = basename($path);
+
         $canSave = $this->checkPolicy('save');
         $canRemove = $this->checkPolicy('remove');
         $canView = $this->checkPolicy('view');
@@ -2129,6 +2137,12 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             (empty($data['visibility']) || $data['visibility'] === Visibility::PUBLIC);
 
         $menu = [];
+        $menu[] = [
+            'text' => '<b>' . $fileName . '</b>',
+            'handler' => '',
+            'header' => true,
+        ];
+        $menu[] = '-';
         if ($this->hasPermission('file_update') && $canSave) {
             if ($editable) {
                 $menu[] = [

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -122,6 +122,12 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
      */
     ,getRootMenu: function(node) {
         var menu = [];
+        menu.push({
+            text: '<b>'+node.attributes.text+' ('+this.config.source+')</b>'
+            ,handler: function() {return false;}
+            ,header: true
+        });
+        menu.push('-');
         if (MODx.perm.directory_create) {
             menu.push({
                 text: _('file_folder_create')


### PR DESCRIPTION
### What does it do?
Added id / names of elements in tree. Now it takes less clicks to find out the key / id of an element in the tree + uniformity in the interface.

1) Added a source ID to context menu.

Before:
![src_tree_1](https://user-images.githubusercontent.com/12523676/144015402-c0270eeb-f1dd-4176-832e-be4b31cf98cf.png)

After:
![source_tree_id (1)](https://user-images.githubusercontent.com/12523676/144216131-ec3cef5b-77bd-4f8d-ac48-473a2407adb8.png)

2) Added names of elements (directory and file) to their context menu. Now it is clear for which directory / file the context menu is called.

Before:
![dir_tree_1](https://user-images.githubusercontent.com/12523676/144015986-c3d76ef3-c619-450a-a983-0382dadb8e17.png)
![file_tree_1](https://user-images.githubusercontent.com/12523676/144015994-6d274efd-4366-421d-b92a-d5922fc2124a.png)

After:
![dir_tree_2](https://user-images.githubusercontent.com/12523676/144015993-1957cb44-e613-4349-8aa9-60439ffb71f5.png)
![file_tree_2](https://user-images.githubusercontent.com/12523676/144015996-4d029348-abb5-4889-8ca5-03f58101ebf4.png)

### Why is it needed?
UX improvements

### Related issue(s)/PR(s)
N/A