### PR TITLE
Added remembering filter properties of plugin events grid in browser url

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -16,7 +16,7 @@ MODx.panel.Plugin = function(config) {
             action: 'Element/Plugin/Get'
         }
         ,id: 'modx-panel-plugin'
-		,cls: 'container form-with-labels'
+        ,cls: 'container form-with-labels'
         ,class_key: 'MODX\\Revolution\\modPlugin'
         ,plugin: ''
         ,bodyStyle: ''
@@ -357,17 +357,19 @@ MODx.panel.Plugin = function(config) {
                     }
                 }]
             },{
-				xtype: 'panel'
-				,cls:'main-wrapper'
-				,items: [{
-					xtype: 'textarea'
-					,fieldLabel: _('plugin_code')
-					,name: 'plugincode'
-					,id: 'modx-plugin-plugincode'
-					,anchor: '100%'
-					,height: 400
-					,value: config.record.plugincode || "<?php\n"
-                    ,tabIndex: 10
+                xtype: 'panel'
+                ,border: false
+                ,layout: 'form'
+                ,cls: 'main-wrapper'
+                ,labelAlign: 'top'
+                ,items: [{
+                    xtype: 'textarea'
+                    ,fieldLabel: _('plugin_code')
+                    ,name: 'plugincode'
+                    ,id: 'modx-plugin-plugincode'
+                    ,anchor: '100%'
+                    ,height: 400
+                    ,value: config.record.plugincode || "<?php\n"
                 }]
             }]
         },{
@@ -379,7 +381,8 @@ MODx.panel.Plugin = function(config) {
                 ,xtype: 'modx-description'
             },{
                 xtype: 'modx-grid-plugin-event'
-				,cls:'main-wrapper'
+                ,cls: 'main-wrapper'
+                ,urlFilters: ['group', 'query']
                 ,preventRender: true
                 ,plugin: config.record.id || 0
                 ,listeners: {


### PR DESCRIPTION
### What does it do?
- Added the selected filter properties in the browser url.

![plugin_events](https://user-images.githubusercontent.com/12523676/145247770-5dbeb412-6862-4a06-8e5d-9af517b44d61.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15186
https://github.com/modxcms/revolution/pull/15185
https://github.com/modxcms/revolution/pull/15184
https://github.com/modxcms/revolution/pull/15183
https://github.com/modxcms/revolution/pull/15182
https://github.com/modxcms/revolution/pull/15181
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086