### PR TITLE
Adding system event OnBeforeInitSession

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -1210,5 +1210,10 @@ $events['OnPackageRemove']->fromArray([
   'service' => 2,
   'groupname' => 'Package Manager',
 ], '', true, true);
-
+$events['OnBeforeInitSession']= $xpdo->newObject(modEvent::class);
+$events['OnBeforeInitSession']->fromArray([
+    'name' => 'OnBeforeInitSession',
+    'service' => 5,
+    'groupname' => 'System',
+], '', true, true);
 return $events;

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -132,7 +132,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     {
         $this->setProperties($this->getProperties(true));
         $this->getPermissions();
-        $this->xpdo->lexicon->load('file');
+
+        if ($this->xpdo->lexicon) {
+            $this->xpdo->lexicon->load('file');
+        }
 
         if (!$this->ctx) {
             $this->ctx =& $this->xpdo->context;
@@ -1410,7 +1413,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     public function prepareProperties(array $properties = [])
     {
         foreach ($properties as &$property) {
-            if (!empty($property['lexicon'])) {
+            if (!empty($property['lexicon']) && $this->xpdo->lexicon) {
                 $this->xpdo->lexicon->load($property['lexicon']);
             }
             if (!empty($property['name'])) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2743,6 +2743,8 @@ class modX extends xPDO {
      * @param array|null $options Options to override Settings explicitly.
      */
     protected function _initSession($options = null) {
+        $this->invokeEvent('OnBeforeInitSession');
+
         $contextKey= $this->context instanceof modContext ? $this->context->get('key') : null;
         if ($this->getOption('session_enabled', $options, true) || isset($_GET['preview'])) {
             if (!in_array($this->getSessionState(), [modX::SESSION_STATE_INITIALIZED, modX::SESSION_STATE_EXTERNAL, modX::SESSION_STATE_UNAVAILABLE], true)) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2743,7 +2743,7 @@ class modX extends xPDO {
      * @param array|null $options Options to override Settings explicitly.
      */
     protected function _initSession($options = null) {
-        $this->invokeEvent('OnBeforeInitSession');
+        $this->invokeEvent('OnBeforeInitSession', $options);
 
         $contextKey= $this->context instanceof modContext ? $this->context->get('key') : null;
         if ($this->getOption('session_enabled', $options, true) || isset($_GET['preview'])) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2743,7 +2743,7 @@ class modX extends xPDO {
      * @param array|null $options Options to override Settings explicitly.
      */
     protected function _initSession($options = null) {
-        $this->invokeEvent('OnBeforeInitSession', $options);
+        $this->invokeEvent('OnBeforeInitSession', is_array($options) ? $options : []);
 
         $contextKey= $this->context instanceof modContext ? $this->context->get('key') : null;
         if ($this->getOption('session_enabled', $options, true) || isset($_GET['preview'])) {


### PR DESCRIPTION
### What does it do?
I've added a new system event called "OnBeforeInitSession" which is called prior to starting the session.

I also added some additional checks to verify if the lexicon service has been loaded yet in the modMediaSource class. This was causing conflicts when invoking an event before _initCulture was called (which loads the lexicon service) and when listening to the event using a static plugin file.

### Why is it needed?
We use a plugin to switch between contexts which listens to the OnMODXInit system event, but because this event is triggered after the _initSession method, the session is already set for context "web" and this causes conflicts with sessions. For example, not being able to login in the frontend for NON-web contexts.

Until this moment we switch the context in `index.php`, but it would be cleaner if we could do this by using plugins. 

To resolve this we added this new system event which is triggered before initialising the sessions, allowing the use of plugins to switch context before the session is initialised.

### How to test

- Create another context
- Create a login form on page (for example by using Login extra) on context which is not "web"
- Set up static plugin which switches the context which listens to system event "OnBeforeInitSession"

Now you should be able to login on the non-web context.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14962