### PR TITLE
Added remembering filter properties of deleted resources grid in browser url

### DIFF
--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -597,8 +597,7 @@ a.x-grid-link:focus {
 .modx-page-header div {
   background-color: transparent !important;
 
-  #modx-panel-welcome &,
-  #modx-panel-trash & {
+  #modx-panel-welcome & {
     margin: 1rem !important;
   }
 }

--- a/core/src/Revolution/Processors/Resource/Trash/GetList.php
+++ b/core/src/Revolution/Processors/Resource/Trash/GetList.php
@@ -62,17 +62,20 @@ class GetList extends GetListProcessor
         // delete_document - thats perhaps not necessary, because all documents are already deleted
         // but we need the purge_deleted permission - for every single file
 
-        if (!empty($query)) {
-            $c->where(['modResource.pagetitle:LIKE' => '%' . $query . '%']);
-            $c->orCondition(['modResource.longtitle:LIKE' => '%' . $query . '%']);
-        }
-        if (!empty($context)) {
-            $c->where(['modResource.context_key' => $context]);
-        }
         if ($deleted = $this->getDeleted()) {
             $c->where(['modResource.id:IN' => $deleted]);
         } else {
-            $c->where(['modResource.id:IN' => 0]);
+            $c->where(['modResource.id' => 0]);
+        }
+
+        if (!empty($query)) {
+            $c->where([
+                'modResource.pagetitle:LIKE' => '%' . $query . '%',
+                'OR:modResource.longtitle:LIKE' => '%' . $query . '%'
+            ]);
+        }
+        if (!empty($context)) {
+            $c->where(['modResource.context_key' => $context]);
         }
 
         return $c;

--- a/manager/assets/modext/widgets/resource/modx.grid.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.trash.js
@@ -12,6 +12,7 @@ MODx.grid.Trash = function (config) {
         },
         fields: [
             'id',
+            'parent',
             'pagetitle',
             'longtitle',
             'published',
@@ -35,6 +36,11 @@ MODx.grid.Trash = function (config) {
             width: 20,
             sortable: true
         }, {
+            header: _('parent'),
+            dataIndex: 'parent',
+            width: 20,
+            sortable: true
+        }, {
             header: _('pagetitle'),
             dataIndex: 'pagetitle',
             width: 80,
@@ -54,12 +60,12 @@ MODx.grid.Trash = function (config) {
         }, {
             header: _('trash.deletedon_title'),
             dataIndex: 'deletedon',
-            width: 75,
+            width: 40,
             sortable: true
         }, {
             header: _('trash.deletedbyUser_title'),
             dataIndex: 'deletedby',
-            width: 75,
+            width: 40,
             sortable: true,
             renderer: function (value, metaData, record) {
                 return record.data.deletedby_name;

--- a/manager/assets/modext/widgets/resource/modx.panel.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.trash.js
@@ -11,6 +11,7 @@ MODx.panel.Trash = function (config) {
                 xtype: 'modx-grid-trash',
                 id: 'modx-trash-resources',
                 cls: 'main-wrapper',
+                urlFilters: ['context', 'query'],
                 preventRender: true
             }]
         }], {
@@ -41,4 +42,3 @@ MODx.panel.Trash = function (config) {
 };
 Ext.extend(MODx.panel.Trash, MODx.FormPanel);
 Ext.reg('modx-panel-trash', MODx.panel.Trash);
-


### PR DESCRIPTION
### What does it do?
- Added the selected filter properties in the browser url.
- Fixed processor displaying deleted resources in the trash.
In the trash, it was possible to find an **undeleted** resource (any resource from the tree) through a search :)
- Added a parent to the resource grid.
The relationship between the deleted parent and the undeleted child resources will be a little clearer. Because many resources are not deleted but appear in the grid and will be deleted due to the parent being deleted.
- Removed extra padding for heading in trash.

![trash](https://user-images.githubusercontent.com/12523676/147365292-68e59d85-79c7-425c-a1f8-5ca8066df625.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15942
https://github.com/modxcms/revolution/pull/15935
https://github.com/modxcms/revolution/pull/15186
https://github.com/modxcms/revolution/pull/15185
https://github.com/modxcms/revolution/pull/15184
https://github.com/modxcms/revolution/pull/15183
https://github.com/modxcms/revolution/pull/15182
https://github.com/modxcms/revolution/pull/15181
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086