### PR TITLE
Remove duplicated curl option from request in modRest

### DIFF
--- a/core/model/modx/rest/modrest.class.php
+++ b/core/model/modx/rest/modrest.class.php
@@ -399,7 +399,6 @@ class RestClientRequest {
             CURLOPT_RETURNTRANSFER => $this->getOption('returnTransfer',true),
             CURLOPT_FOLLOWLOCATION => $this->getOption('followLocation',true),
             CURLOPT_TIMEOUT => $this->getOption('timeout',240),
-            CURLOPT_USERAGENT => $this->getOption('userAgent'),
             CURLOPT_CONNECTTIMEOUT => $this->getOption('connectTimeout',0),
             CURLOPT_DNS_CACHE_TIMEOUT => $this->getOption('dnsCacheTimeout',120),
             CURLOPT_VERBOSE => $this->getOption('verbose',false),


### PR DESCRIPTION
### What does it do?
Duplicate settings `CURLOPT_USER` removed

### Why is it needed?
This setting is also in this line [Describe the issue you are solving.](https://github.com/modxcms/revolution/blob/2.x/core/model/modx/rest/modrest.class.php#L412)

### Related issue(s)/PR(s)
NA
