### PR TITLE
Compatibility for custom templates between 2.8.1 and 2.8.2

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -19,7 +19,7 @@
 {/if}
 <script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
 <script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,trash,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$_authToken|default|htmlspecialchars}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}{if $_authToken}&HTTP_MODAUTH={$_authToken|default|htmlspecialchars}{/if}"></script>
 
 {$maincssjs}
 {foreach from=$cssjs item=scr}


### PR DESCRIPTION
### What does it do?
Make the smarty variable $_authToken optional.

### Why is it needed?
If the installation uses a custom manager template, the line of this patch has to be added to the custom template. After that the custom template is working in 2.8.1 and 2.8.2. Before it won't work in 2.8.1, since HTTP_MODAUTH will be used with an empty value. With the old custom manager template the manager won't work in 2.8.2.

### How to test
Create a custom template with the new header.tpl of 2.8.2 and add it to a 2.8.1 or lower installation. The modx.config.js.php is not loaded and a destroyed manager occurs.

### Related issue(s)/PR(s)
#15644
