### PR TITLE
[3.x] Form Customization: Grid editing erases set data

### DIFF
--- a/core/src/Revolution/Processors/Security/Forms/Set/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/UpdateFromGrid.php
@@ -10,12 +10,22 @@
 
 namespace MODX\Revolution\Processors\Security\Forms\Set;
 
+use MODX\Revolution\modFormCustomizationSet;
+use MODX\Revolution\Processors\Model\UpdateProcessor;
+
 /**
  * Update a FC Profile from grid
  * @package MODX\Revolution\Processors\Security\Forms\Set
  */
-class UpdateFromGrid extends Update
+class UpdateFromGrid extends UpdateProcessor
 {
+    public $classKey = modFormCustomizationSet::class;
+    public $languageTopics = ['formcustomization'];
+    public $permission = 'customize_forms';
+    public $objectType = 'set';
+
+    protected $gridFields = ['id', 'action', 'description', 'template', 'constraint_field', 'constraint'];
+
     /**
      * @return bool|string|null
      * @throws \xPDO\xPDOException
@@ -27,9 +37,10 @@ class UpdateFromGrid extends Update
             return $this->modx->lexicon('invalid_data');
         }
         $properties = $this->modx->fromJSON($data);
+        $properties = array_intersect_key($properties, array_flip($this->gridFields));
         $this->setProperties($properties);
         $this->unsetProperty('data');
-        
+
         return parent::initialize();
     }
 }


### PR DESCRIPTION
### What does it do?
- Updates the UpdateFromGrid processor to extend directly core UpdateProcessor and not `MODX\Revolution\Processors\Security\Forms\Set\Update` Processor
- Make sure only fields editable from grid will store to db

### Why is it needed?
- Right now the update from grid processor extends the `MODX\Revolution\Processors\Security\Forms\Set\Update` which expects the whole data set to be present. The grid only passes a fraction of the data which causes the wipe of all rules, labels etc. (as described in #15929).

### How to test
Described in the related issue #15929

### Related issue(s)/PR(s)
Resolves #15929
