### PR TITLE
Add modSessionHandlerInterface

### DIFF
--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -10,7 +10,6 @@
 
 namespace MODX\Revolution;
 
-
 /**
  * Default database session handler class for MODX.
  *
@@ -42,7 +41,7 @@ class modSessionHandler implements modSessionHandlerInterface
      *
      * @param modX &$modx A reference to a {@link modX} instance.
      */
-    function __construct(modX &$modx)
+    public function __construct(modX &$modx)
     {
         $this->modx = &$modx;
         $gcMaxlifetime = (integer)$this->modx->getOption('session_gc_maxlifetime');

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -16,7 +16,7 @@ namespace MODX\Revolution;
  *
  * @package MODX\Revolution
  */
-class modSessionHandler
+class modSessionHandler implements modSessionHandlerInterface
 {
     /**
      * @var modX A reference to the modX instance controlling this session
@@ -192,5 +192,25 @@ class modSessionHandler
         }
 
         return $this->session;
+    }
+
+    /**
+     * Removes all sessions.
+     *
+     * @param modX $modx
+     *
+     * @access public
+     *
+     * @return boolean
+     */
+    public static function flushSessions(modX &$modx)
+    {
+        $sessionTable = $modx->getTableName(modSession::class);
+        if ($modx->query("TRUNCATE TABLE {$sessionTable}") == false) {
+            return false;
+        }
+
+        $modx->user->endSession();
+        return true;
     }
 }

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *

--- a/core/src/Revolution/modSessionHandlerInterface.php
+++ b/core/src/Revolution/modSessionHandlerInterface.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MODX\Revolution;
+
+
+/**
+ * Default database session handler class for MODX.
+ *
+ * @package MODX\Revolution
+ */
+interface modSessionHandlerInterface
+{
+    function __construct(modX &$modx);
+
+    /**
+     * Opens the connection for the session handler.
+     *
+     * @access public
+     * @return boolean Always returns true; actual connection is managed by
+     * {@link modX}.
+     */
+    public function open();
+
+    /**
+     * Closes the connection for the session handler.
+     *
+     * @access public
+     * @return boolean Always returns true; actual connection is managed by
+     * {@link modX}
+     */
+    public function close();
+
+    /**
+     * Reads a specific {@link modSession} record's data.
+     *
+     * @access public
+     *
+     * @param integer $id The pk of the {@link modSession} object.
+     *
+     * @return string The data read from the {@link modSession} object.
+     */
+    public function read($id);
+
+    /**
+     * Writes data to a specific {@link modSession} object.
+     *
+     * @access public
+     *
+     * @param integer $id   The PK of the modSession object.
+     * @param mixed   $data The data to write to the session.
+     *
+     * @return boolean True if successfully written.
+     */
+    public function write($id, $data);
+
+    /**
+     * Destroy a specific {@link modSession} record.
+     *
+     * @access public
+     *
+     * @param integer $id
+     *
+     * @return boolean True if the session record was destroyed.
+     */
+    public function destroy($id);
+
+    /**
+     * Remove any expired sessions.
+     *
+     * @access public
+     *
+     * @param integer $max The amount of time since now to expire any session
+     *                     longer than.
+     *
+     * @return boolean True if session records were removed.
+     */
+    public function gc($max);
+
+    /**
+     * Removes all sessions.
+     *
+     * @param modX $modx
+     *
+     * @access public
+     *
+     * @return boolean
+     */
+    public static function flushSessions(modX &$modx);
+}

--- a/core/src/Revolution/modSessionHandlerInterface.php
+++ b/core/src/Revolution/modSessionHandlerInterface.php
@@ -10,7 +10,6 @@
 
 namespace MODX\Revolution;
 
-
 /**
  * Default database session handler class for MODX.
  *
@@ -18,7 +17,7 @@ namespace MODX\Revolution;
  */
 interface modSessionHandlerInterface
 {
-    function __construct(modX &$modx);
+    public function __construct(modX &$modx);
 
     /**
      * Opens the connection for the session handler.

--- a/core/src/Revolution/modSessionHandlerInterface.php
+++ b/core/src/Revolution/modSessionHandlerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *


### PR DESCRIPTION
### What does it do?
- Creates a modSessionHandlerInterface interface and uses it for modSessionHandler
- Moves flushSessions method from `Security\Flush` processor to the interface & handler
- In the `Security\Flush` processor - checks if `flushSessions` method exists in the handler class stored in `session_handler_class` system setting and executes it if so

### Why is it needed?
Custom session handlers can't flush all sessions.

### How to test
#15928

### Related issue(s)/PR(s)
Resolves #15928
