### PR TITLE
Update xPDO to 3.0.1 for PHP 8.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
         "vendor-dir": "core/vendor"
     },
     "require": {
-        "php": ">=7.2",
-        "xpdo/xpdo": "^3.0@dev",
+        "php": ">=7.2.5",
+        "xpdo/xpdo": "~3.0.1",
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
         "phpmailer/phpmailer": "^6.0",


### PR DESCRIPTION
### What does it do?
Updates xPDO to the 3.0.1 release.

### Why is it needed?
Various PHP 8.1 deprecation warnings were wreaking havoc and are addressed by the 3.0.1 release of xPDO.

### How to test
Run composer update and test on a PHP 8.1 environment.

### Related issue(s)/PR(s)
n/a