### PR TITLE
Add PHP 8.1 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### What does it do?
Adds PHP 8.1 to CI matrix.

### Why is it needed?
To test with PHP 8.1.

### How to test
N/A

### Related issue(s)/PR(s)
N/A