### PR TITLE
Pass correct type to setlocale

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2647,12 +2647,14 @@ class modX extends xPDO {
         $this->cultureKey = $cultureKey;
         $this->setOption('cultureKey', $cultureKey);
 
-        $locale = setlocale(LC_ALL, '0');
-        $targetLocale = $this->getOption('locale', null, $locale, true);
-        $result = setlocale(LC_ALL, $targetLocale);
+        if ($this->getOption('setlocale', $options, true)) {
+            $locale = setlocale(LC_ALL, '0');
+            $targetLocale = $this->getOption('locale', null, $locale, true);
+            $result = setlocale(LC_ALL, $targetLocale);
 
-        if ($result === false) {
-            $this->log(modX::LOG_LEVEL_ERROR, 'Could not set the locale. Please check if the locale ' . $this->getOption('locale', null, $locale) . ' exists on your system');
+            if ($result === false) {
+                $this->log(modX::LOG_LEVEL_ERROR, 'Could not set the locale. Please check if the locale ' . $this->getOption('locale', null, $locale) . ' exists on your system');
+            }
         }
 
         $this->services->add('lexicon', new modLexicon($this));

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2647,12 +2647,12 @@ class modX extends xPDO {
         $this->cultureKey = $cultureKey;
         $this->setOption('cultureKey', $cultureKey);
 
-        if ($this->getOption('setlocale', $options, true)) {
-            $locale = setlocale(LC_ALL, null);
-            $result = setlocale(LC_ALL, $this->getOption('locale', null, $locale));
-            if ($result === false) {
-                $this->log(modX::LOG_LEVEL_ERROR, 'Could not set the locale. Please check if the locale ' . $this->getOption('locale', null, $locale) . ' exists on your system');
-            }
+        $locale = setlocale(LC_ALL, '0');
+        $targetLocale = $this->getOption('locale', null, $locale, true);
+        $result = setlocale(LC_ALL, $targetLocale);
+
+        if ($result === false) {
+            $this->log(modX::LOG_LEVEL_ERROR, 'Could not set the locale. Please check if the locale ' . $this->getOption('locale', null, $locale) . ' exists on your system');
         }
 
         $this->services->add('lexicon', new modLexicon($this));


### PR DESCRIPTION
### What does it do?
Fixes calling setlocale. `setlocale` requires a string as a second argument (https://www.php.net/manual/en/function.setlocale.php). The current code passes `null` instead of `"0"` for reading the locale value - on my machine it was causing `502 Gateway Error`.

Also set `skipEmpty` to `true` when getting the locale from system settings - as this setting is present and empty by default, so it was using the empty string value instead of the value obtained by calling `setlocale(LC_ALL, '0')`.

Tested it on php 7.4, 8.0 and 8.1 (7.4 didn't have this issue, probably because it doesn't care about argument types).

### Why is it needed?
I'm not 100% sure about the setup needed for this, but for some instances NGINX was returning 502 gateway error. Also I'd say it's better to pass correct arguments to functions :)

### How to test
Not sure :)

### Related issue(s)/PR(s)
n/a
