### PR TITLE
Improve stripmodxtags output filter

### DIFF
--- a/core/model/modx/filters/modoutputfilter.class.php
+++ b/core/model/modx/filters/modoutputfilter.class.php
@@ -255,7 +255,7 @@ class modOutputFilter {
                             }
                             break;
                         case 'stripmodxtags':
-                            $output = preg_replace("/\\[\\[([^\\[\\]]++|(?R))*?\\]\\]/s", '', $output);
+                            $output = preg_replace('/\[\[([^\[\]]++|(?R))*?]]/s', '', $output);
                             break;
                         case 'length':
                         case 'len':


### PR DESCRIPTION
### What does it do?
Improve the stripmodxtags regular expression

### Why is it needed?
The previous string was using double quotes. Because of this the backslashes inside have to be escaped and the regular expression was not directly readable. The closing square brackets don't have to be escaped with backslashes (redundant character escape according to PhpStorm).

### How to test
See this example: https://regex101.com/r/Tx8abk/1

### Related issue(s)/PR(s)
None