### PR TITLE
Improve the regular expression for stripping remaining MODX tags

### DIFF
--- a/core/model/modx/moddashboardwidget.class.php
+++ b/core/model/modx/moddashboardwidget.class.php
@@ -254,8 +254,7 @@ abstract class modDashboardWidgetInterface {
             $widgetArray['content'] = $output;
             $widgetArray['class'] = $this->cssBlockClass;
             $output = $this->getFileChunk('dashboard/block.tpl',$widgetArray);
-            $output = preg_replace('@\[\[(.[^\[\[]*?)\]\]@si','',$output);
-            $output = preg_replace('@\[\[(.[^\[\[]*?)\]\]@si','',$output);
+            $output = preg_replace('/\[\[([^\[\]]++|(?R))*?]]/s','',$output);
         }
         return $output;
     }


### PR DESCRIPTION
### What does it do?
Improve the regular expression for stripping remaining MODX tags by a recursing pattern.

### Why is it needed?
The current code does not remove nested tags (it is executed twice for this reason) and may remove closing square brackets too early. Due to the lack of recursion, nested tags with more than two levels are not removed, which leads to visual errors.

### How to test
See https://regex101.com/r/fNtARa/1

### Related issue(s)/PR(s)
#15963
