### PR TITLE
Displayed the username in user menu

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -347,7 +347,7 @@ $children = [];
 $children[0]= $xpdo->newObject(modMenu::class);
 $children[0]->fromArray([
   'menuindex' => 0,
-  'text' => 'profile',
+  'text' => '{$username}',
   'description' => 'profile_desc',
   'parent' => 'user',
   'permissions' => 'change_profile',

--- a/setup/includes/upgrades/common/3.0.0-update-menu-entries.php
+++ b/setup/includes/upgrades/common/3.0.0-update-menu-entries.php
@@ -30,3 +30,9 @@ if ($formCustomization) {
     }
 }
 
+/** @var modMenu $profileItem */
+$profileItem = $modx->getObject(modMenu::class, ['text' => 'profile']);
+if ($profileItem) {
+    $profileItem->set('text', '{$username}');
+    $profileItem->save();
+}


### PR DESCRIPTION
### What does it do?
Displayed the username in user menu.
The `{$username}` placeholder works in the menu, which allows to display the username.

Before:
![menuBefore](https://user-images.githubusercontent.com/12523676/149979538-e92783cf-7626-433b-a866-952c43e0447d.png)

After:
![menuAfter](https://user-images.githubusercontent.com/12523676/149979536-00fe13ba-bc8d-46a2-a6dd-fbdf4b9f9cbd.png)

### Why is it needed?
In the manager it is not clear what user is logged in.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/15595
