### PR TITLE
Fix empty files considered non-existant (#15976)

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -577,10 +577,11 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     public function getObjectContents($path)
     {
         try {
-            if (!$file = $this->filesystem->read($path)) {
+            if (!$this->filesystem->fileExists($path)) {
                 $this->addError('file', $this->xpdo->lexicon('file_err_nf'));
                 return [];
             }
+            $content = $this->filesystem->read($path);
         } catch (FilesystemException | UnableToReadFile $e) {
             $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
             return [];
@@ -596,7 +597,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 'size' => $this->filesystem->fileSize($path),
                 'last_accessed' => $this->filesystem->lastModified($path), // We only have lastModified() here.
                 'last_modified' => $this->filesystem->lastModified($path),
-                'content' => $file,
+                'content' => $content,
                 'mime' => $this->filesystem->mimeType($path),
                 'image' => $this->isFileImage($path, $imageExtensions),
             ];


### PR DESCRIPTION
### What does it do?
Fixes a logic issue in the media source implementation.

### Why is it needed?
Relying on `read()` limits the functionality to files that can be read. But readable files may still exist and should be editable.

### How to test
Create an empty file and try to edit it. Note MODX shows the "File doesn't exist!" error. Apply patch, try again.

### Related issue(s)/PR(s)
#15976
