### PR TITLE
Mark modX::parseChunk as deprecated (#12433)

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1954,8 +1954,10 @@ class modX extends xPDO {
      * @param string $prefix The placeholder prefix, defaults to [[+.
      * @param string $suffix The placeholder suffix, defaults to ]].
      * @return string The processed chunk with the placeholders replaced.
+     * @deprecated Prefer using $modx->getChunk, to be removed in MODX 4.0.
      */
     public function parseChunk($chunkName, $chunkArr, $prefix='[[+', $suffix=']]') {
+        $this->deprecated('3.0.0', 'Use $modx->getChunk instead');
         $chunk= $this->getChunk($chunkName);
         if (!empty($chunk) || $chunk === '0') {
             if(is_array($chunkArr)) {


### PR DESCRIPTION
### What does it do?

Marks modX::parseChunk as deprecated to discourage its use, targeting removal with the next batch of breaking changes, in 4.0.

### Why is it needed?
As discussed in #12433, parseChunk doesn't behave how one would expect it to, and is a lesser alternative to getChunk. That means we're better off without it, however we can't just remove it out-right.

### How to test
Not applicable.

### Related issue(s)/PR(s)
Fixes #12433 
