### PR TITLE
[3.x] Fix dates on dashboard feeds in certain locales

### DIFF
--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -80,7 +80,7 @@ class Feed extends Processor
                 'title' => $item->get_title(),
                 'description' => $item->get_description(),
                 'link' => $item->get_permalink(),
-                'pubdate' => $item->get_local_date(),
+                'pubdate' => $item->get_date(),
             ]);
         }
 

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -93,7 +93,7 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
                             }
                             var datestamps = Ext.select(".date_stamp", container);
                             datestamps.each(function (el) {
-                                el.dom.innerText = new Date(el.dom.innerText).format(MODx.config.manager_date_format);
+                                el.dom.innerText = new Date(el.dom.innerText).toLocaleString();
                             });
                         }, scope: this
                     }

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -93,7 +93,7 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
                             }
                             var datestamps = Ext.select(".date_stamp", container);
                             datestamps.each(function (el) {
-                                el.dom.innerText = new Date(el.dom.innerText).toLocaleString();
+                                el.dom.innerText = new Date(el.dom.innerText).toLocaleString().format(MODx.config.manager_date_format);
                             });
                         }, scope: this
                     }

--- a/manager/assets/modext/widgets/modx.panel.welcome.js
+++ b/manager/assets/modext/widgets/modx.panel.welcome.js
@@ -93,7 +93,7 @@ Ext.extend(MODx.panel.Welcome, MODx.Panel, {
                             }
                             var datestamps = Ext.select(".date_stamp", container);
                             datestamps.each(function (el) {
-                                el.dom.innerText = new Date(el.dom.innerText).toLocaleString().format(MODx.config.manager_date_format);
+                                el.dom.innerText = new Date(el.dom.innerText).format(MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format);
                             });
                         }, scope: this
                     }


### PR DESCRIPTION
### What does it do?
The PR returns the date/time as is from the processor and applies locale formatting to it in the JS. 

### Why is it needed?
Previously dates on the dashboard feeds were showing as NaN in certain locales. This was due to locale formatting being applied in the processor and then the `Ext.select` function not recognising the format.
I'm in the Hong Kong locale and it is an issue for me.

### How to test
Look at the dates in the dashboard feeds and make sure they're displaying correctly. This workaround fixes it for me but it would be helpful if people in other locales could test to make sure the dates are still displaying correctly for them.

### Related issue(s)/PR(s)
Closes #15908 
