### PR TITLE
Changed the minimum width of popup window

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.grid.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.trash.js
@@ -193,6 +193,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
 
     purgeResource: function () {
         MODx.msg.confirm({
+            minWidth: 500,
             title: _('trash.purge_confirm_title'),
             text: _('trash.purge_confirm_message', {
                 'list': this.listResources('')
@@ -226,6 +227,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
             withPublish = '_with_publish';
         }
         MODx.msg.confirm({
+            minWidth: 500,
             title: _('trash.restore_confirm_title'),
             text: _('trash.restore_confirm_message' + withPublish, {
                 'list': this.listResources('')
@@ -258,6 +260,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
         if (cs === false) return false;
 
         MODx.msg.confirm({
+            minWidth: 500,
             title: _('trash.purge_confirm_title'),
             text: _('trash.purge_confirm_message', {
                 'list': this.listResources('')
@@ -293,6 +296,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
         if (cs === false) return false;
 
         MODx.msg.confirm({
+            minWidth: 500,
             title: _('trash.restore_confirm_title'),
             text: _('trash.restore_confirm_message', {
                 'list': this.listResources('')
@@ -328,6 +332,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
         if (cs === false) return false;
 
         MODx.msg.confirm({
+            minWidth: 500,
             title: _('trash.purge_confirm_title'),
             text: _('trash.purge_all_confirm_message', {
                 'count': sm.selections.length,
@@ -375,6 +380,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
         if (cs === false) return false;
 
         MODx.msg.confirm({
+            minWidth: 500,
             title: _('trash.restore_confirm_title'),
             text: _('trash.restore_all_confirm_message', {
                 'count': sm.selections.length,


### PR DESCRIPTION
### What does it do?
For some reason the width of popups is sometimes reset to the minimum width.
~Previously, the value was equal to 200px, which is not enough, increased to 400px, so that even when resetting the content is not cut off.~

Set window width via parameter - https://github.com/modxcms/revolution/pull/15984#issuecomment-1020008136

Before (content can be cut off by window):
![trash](https://user-images.githubusercontent.com/12523676/52404292-1aac8480-2ae2-11e9-8f17-40af3a3fd420.gif)

After:
![minWidth](https://user-images.githubusercontent.com/12523676/150540999-7e884bee-5d07-4952-b613-4faa30d014a1.gif)

### Why is it needed?
Prevent cut off of window content.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14340
