### PR TITLE
Fix Blank page when trying to create a Dashboard Widget

### DIFF
--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -268,7 +268,10 @@ MODx.panel.DashboardWidget = function(config) {
         }
     });
     MODx.panel.DashboardWidget.superclass.constructor.call(this,config);
-    Ext.getCmp('modx-extended-form').disable();
+    var ef = Ext.getCmp('modx-extended-form');
+    if (ef) {
+        ef.disable();
+    }
 };
 Ext.extend(MODx.panel.DashboardWidget,MODx.FormPanel,{
     initialized: false


### PR DESCRIPTION
### What does it do?
Tests if the component exists, before calling a function on it.

### Why is it needed?
Form is not shown when trying to create a dashboard widget in the manager.

### How to test
Open `manager/?a=system/dashboards/widget/create`.

### Related issue(s)/PR(s)
Resolves #15982
