### PR TITLE
[3.x Port] Use compare instead of assign

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.grid.trash.js
+++ b/manager/assets/modext/widgets/resource/modx.grid.trash.js
@@ -433,7 +433,7 @@ Ext.extend(MODx.grid.Trash, MODx.grid.Grid, {
         if (total !== undefined) {
             // if no resource is deleted, we disable the icon.
             // otherwise we have to update the tooltip
-            if (total = 0) {
+            if (total == 0) {
                 trashButton.disable();
                 trashButton.tooltip = new Ext.ToolTip({
                     target: trashButton.tabEl,


### PR DESCRIPTION
### What does it do?
Change assign to compare

### Why is it needed?
It's a bug

### How to test
The trash button is disabled here all the time. It is maybe fixed elsewhere but then the assign is still wrong.

### Related issue(s)/PR(s)
3.x port of #15993 