### PR TITLE
[3.x Port] Configurable MessageBox minWidth

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -911,7 +911,7 @@ Ext.extend(MODx.Msg,Ext.Component,{
               this.addListener(i,l.fn,l.scope || this,l.options || {});
             }
         }
-        Ext.MessageBox.minWidth = (config.minWidth) ? config.minWidth : 200;
+        Ext.MessageBox.minWidth = config.minWidth || 200;
         Ext.Msg.confirm(config.title || _('warning'),config.text,function(e) {
             if (e == 'yes') {
                 MODx.Ajax.request({

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -911,6 +911,7 @@ Ext.extend(MODx.Msg,Ext.Component,{
               this.addListener(i,l.fn,l.scope || this,l.options || {});
             }
         }
+        Ext.MessageBox.minWidth = (config.minWidth) ? config.minWidth : 200;
         Ext.Msg.confirm(config.title || _('warning'),config.text,function(e) {
             if (e == 'yes') {
                 MODx.Ajax.request({


### PR DESCRIPTION
### What does it do?
Make the minWidth of MODx.Msg.confirm configurable

### Why is it needed?
The current confirm method of MODx.Msg uses the default Ext.MessageBox.minWidth set a few lines above.

### How to test
Set the minWidth property of MODx.confirm to a value and open+close and reopen the confirm box again. Without the minWidth property, the reopened box is too small, since the size is only calculated on the first display (which is a second issue – but thats inside of Ext JS).

### Related issue(s)/PR(s)
#15984, 3.x Port of #15995
