### PR TITLE
Fix aliases for resource controllers

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -17,8 +17,6 @@ use xPDO\Om\xPDOQuery;
 
 require_once __DIR__ . '/resource.class.php';
 
-class_alias(ResourceCreateManagerController::class, 'DocumentCreateManagerController');
-
 /**
  * Loads the create resource page
  *
@@ -323,3 +321,5 @@ class ResourceCreateManagerController extends ResourceManagerController
         return 'resource/create.tpl';
     }
 }
+
+class_alias(ResourceCreateManagerController::class, 'DocumentCreateManagerController');

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -14,8 +14,6 @@ use MODX\Revolution\modUser;
 
 require_once __DIR__ . '/resource.class.php';
 
-class_alias(ResourceUpdateManagerController::class, 'DocumentUpdateManagerController');
-
 /**
  * Loads the update resource page
  *
@@ -281,3 +279,5 @@ class ResourceUpdateManagerController extends ResourceManagerController
         return 'resource/update.tpl';
     }
 }
+
+class_alias(ResourceUpdateManagerController::class, 'DocumentUpdateManagerController');


### PR DESCRIPTION
### What does it do?
Fixes class aliases for resource controllers introduced in #15888

### Why is it needed?
Create resource pages don't work, when you pass the class key, for example: `/manager/?a=resource/create&parent=1&context_key=web&class_key=MODX\Revolution\modDocument` will throw `Error: Class 'DocumentCreateManagerController' not found`

The class alias is defined before the class itself, which is probably invalid :)

### How to test
Open `/manager/?a=resource/create&parent=1&context_key=web&class_key=MODX\Revolution\modDocument` with and without this fix.

