### PR TITLE
[3.x] Remove unnecessary uses of deprecated strftime()

### DIFF
--- a/_build/test/properties.sample.inc.php
+++ b/_build/test/properties.sample.inc.php
@@ -19,7 +19,7 @@
 use xPDO\xPDO;
 
 /* define some properties */
-$properties['runtime'] = strftime("%Y%m%dT%H%M%S");
+$properties['runtime'] = date('Ymd\THis');
 $properties['config_key'] = 'test';
 
 /* driver-specific connection properties */

--- a/_build/test/properties.sample.inc.php
+++ b/_build/test/properties.sample.inc.php
@@ -24,27 +24,27 @@ $properties['config_key'] = 'test';
 
 /* driver-specific connection properties */
 /* mysql */
-$properties['mysql_string_dsn_test']= 'mysql:host=127.0.0.1;dbname=revo_test;charset=utf8';
-$properties['mysql_string_dsn_nodb']= 'mysql:host=127.0.0.1;charset=utf8';
-$properties['mysql_string_dsn_error']= 'mysql:host= nonesuchhost;dbname=nonesuchdb';
-$properties['mysql_string_username']= '';
-$properties['mysql_string_password']= '';
-$properties['mysql_array_options']= [
+$properties['mysql_string_dsn_test'] = 'mysql:host=127.0.0.1;dbname=revo_test;charset=utf8';
+$properties['mysql_string_dsn_nodb'] = 'mysql:host=127.0.0.1;charset=utf8';
+$properties['mysql_string_dsn_error'] = 'mysql:host= nonesuchhost;dbname=nonesuchdb';
+$properties['mysql_string_username'] = '';
+$properties['mysql_string_password'] = '';
+$properties['mysql_array_options'] = [
     xPDO::OPT_HYDRATE_FIELDS => true,
     xPDO::OPT_HYDRATE_RELATED_OBJECTS => true,
     xPDO::OPT_HYDRATE_ADHOC_FIELDS => true,
 ];
-$properties['mysql_array_driverOptions']= [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
+$properties['mysql_array_driverOptions'] = [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_SILENT];
 
 /* PHPUnit test config */
-$properties['xpdo_driver']= 'mysql';
-$properties['logTarget']= [
+$properties['xpdo_driver'] = 'mysql';
+$properties['logTarget'] = [
     'target' => 'file',
     'options' => [
         'filename' => "unit_test_{$properties['runtime']}.log",
         'filepath' => dirname(__FILE__) . '/'
     ]
 ];
-$properties['logLevel']= xPDO::LOG_LEVEL_INFO;
+$properties['logLevel'] = xPDO::LOG_LEVEL_INFO;
 $properties['context'] = 'web';
 $properties['debug'] = false;

--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -1,16 +1,19 @@
 <?php
+
 /**
  * Builds the MODX core transport package.
  *
  * @package modx
  * @subpackage build
  */
+
 $tstart = microtime(true);
 
 /* get rid of time limit */
 set_time_limit(0);
 
-error_reporting(E_ALL | E_STRICT); ini_set('display_errors',true);
+error_reporting(E_ALL | E_STRICT);
+ini_set('display_errors', true);
 
 /* buildImage can be defined for running against a specific build image
     wc default means it is run against working copy */
@@ -32,14 +35,14 @@ $included = false;
 if (file_exists($buildConfig)) {
     $included = @include $buildConfig;
 }
-if (!$included)
+if (!$included) {
     die($buildConfig . ' was not found. Please make sure you have created one using the template of build.config.sample.php.');
-
+}
 unset($included);
 
-if (!defined('MODX_CORE_PATH'))
+if (!defined('MODX_CORE_PATH')) {
     define('MODX_CORE_PATH', dirname(__DIR__) . '/core/');
-
+}
 require MODX_CORE_PATH . 'vendor/autoload.php';
 
 use MODX\Revolution\modContext;
@@ -51,28 +54,37 @@ use xPDO\xPDO;
 use xPDO\Transport\xPDOTransport;
 
 /* define the MODX path constants necessary for core installation */
-if (!defined('MODX_BASE_PATH'))
+if (!defined('MODX_BASE_PATH')) {
     define('MODX_BASE_PATH', dirname(MODX_CORE_PATH) . '/');
-if (!defined('MODX_MANAGER_PATH'))
+}
+if (!defined('MODX_MANAGER_PATH')) {
     define('MODX_MANAGER_PATH', MODX_BASE_PATH . 'manager/');
-if (!defined('MODX_CONNECTORS_PATH'))
+}
+if (!defined('MODX_CONNECTORS_PATH')) {
     define('MODX_CONNECTORS_PATH', MODX_BASE_PATH . 'connectors/');
-if (!defined('MODX_ASSETS_PATH'))
+}
+if (!defined('MODX_ASSETS_PATH')) {
     define('MODX_ASSETS_PATH', MODX_BASE_PATH . 'assets/');
+}
 
 /* define the connection variables */
-if (!defined('XPDO_DSN'))
+if (!defined('XPDO_DSN')) {
     define('XPDO_DSN', 'mysql:host=localhost;dbname=modx;charset=utf8');
-if (!defined('XPDO_DB_USER'))
+}
+if (!defined('XPDO_DB_USER')) {
     define('XPDO_DB_USER', 'root');
-if (!defined('XPDO_DB_PASS'))
+}
+if (!defined('XPDO_DB_PASS')) {
     define('XPDO_DB_PASS', '');
-if (!defined('XPDO_TABLE_PREFIX'))
+}
+if (!defined('XPDO_TABLE_PREFIX')) {
     define('XPDO_TABLE_PREFIX', 'modx_');
+}
 
 /* define the actual _build location for including build assets */
-if (!defined('MODX_BUILD_DIR'))
+if (!defined('MODX_BUILD_DIR')) {
     define('MODX_BUILD_DIR', MODX_BASE_PATH . '_build/');
+}
 
 /* get properties */
 $properties = [];
@@ -81,13 +93,17 @@ $included = false;
 if (file_exists($f)) {
     $included = @include $f;
 }
-if (!$included)
+if (!$included) {
     die('build.properties.php was not found. Please make sure you have created one using the template of build.properties.sample.php.');
+}
 
 unset($f, $included);
 
 /* instantiate xpdo instance */
-$xpdo = new xPDO(XPDO_DSN, XPDO_DB_USER, XPDO_DB_PASS,
+$xpdo = new xPDO(
+    XPDO_DSN,
+    XPDO_DB_USER,
+    XPDO_DB_PASS,
     [
         xPDO::OPT_TABLE_PREFIX => XPDO_TABLE_PREFIX,
         xPDO::OPT_CACHE_PATH => MODX_CORE_PATH . 'cache/',
@@ -96,13 +112,14 @@ $xpdo = new xPDO(XPDO_DSN, XPDO_DB_USER, XPDO_DB_PASS,
         PDO::ATTR_ERRMODE => PDO::ERRMODE_WARNING,
     ]
 );
-$cacheManager= $xpdo->getCacheManager();
+$cacheManager = $xpdo->getCacheManager();
 $xpdo->setLogLevel(xPDO::LOG_LEVEL_INFO);
 $xpdo->setLogTarget(XPDO_CLI_MODE ? 'ECHO' : 'HTML');
 
 $packageDirectory = MODX_CORE_PATH . 'packages/';
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Beginning build script processes...'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Beginning build script processes...');
+flush();
 
 /* remove pre-existing package files and directory */
 if (file_exists($packageDirectory . 'core.transport.zip')) {
@@ -116,28 +133,32 @@ if (file_exists($packageDirectory . 'core') && is_dir($packageDirectory . 'core'
     ]);
 }
 if (!file_exists($packageDirectory . 'core') && !file_exists($packageDirectory . 'core.transport.zip')) {
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Removed pre-existing core/ and core.transport.zip.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Removed pre-existing core/ and core.transport.zip.');
+    flush();
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_ERROR,'Could not remove core/ and core.transport.zip before starting build.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not remove core/ and core.transport.zip before starting build.');
+    flush();
 }
 
 /* create core transport package */
 $package = new xPDOTransport($xpdo, 'core', $packageDirectory);
 unset($packageDirectory);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Core transport package created.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Core transport package created.');
+flush();
 
 /* core namespace */
 $namespace = $xpdo->newObject(modNamespace::class);
-$namespace->set('name','core');
-$namespace->set('path','{core_path}');
-$namespace->set('assets_path','{assets_path}');
+$namespace->set('name', 'core');
+$namespace->set('path', '{core_path}');
+$namespace->set('assets_path', '{assets_path}');
 $package->put($namespace, [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => true,
 ]);
 unset($namespace);
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Core Namespace packaged.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Core Namespace packaged.');
+flush();
 
 /* modWorkspace */
 $collection = [];
@@ -155,9 +176,10 @@ $attributes = [
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
-unset ($collection, $c, $attributes);
+unset($collection, $c, $attributes);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Default workspace packaged.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Default workspace packaged.');
+flush();
 
 /* modx.com extras provisioner */
 $collection = [];
@@ -177,9 +199,10 @@ $attributes = [
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
-unset ($collection, $c, $attributes);
+unset($collection, $c, $attributes);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged modx.com transport provider.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged modx.com transport provider.');
+flush();
 
 /* modMenu */
 $collection = include MODX_BUILD_DIR . 'data/transport.core.menus.php';
@@ -201,10 +224,12 @@ if (!empty($collection)) {
         $package->put($c, $attributes);
     }
 
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' modMenus.'); flush();
-    unset ($collection, $c, $attributes);
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($collection) . ' modMenus.');
+    flush();
+    unset($collection, $c, $attributes);
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_ERROR,'Could not load modMenus.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not load modMenus.');
+    flush();
 }
 
 /* modContentTypes */
@@ -218,9 +243,10 @@ $attributes = [
 foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
-unset ($collection, $c, $attributes);
+unset($collection, $c, $attributes);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged all default modContentTypes.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged all default modContentTypes.');
+flush();
 
 /* modEvent collection */
 $events = include MODX_BUILD_DIR . 'data/transport.core.events.php';
@@ -232,16 +258,21 @@ if (is_array($events) && !empty($events)) {
     foreach ($events as $evt) {
         $package->put($evt, $attributes);
     }
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($events).' default events.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($events) . ' default events.');
+    flush();
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_FATAL,'Could not find default events!'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_FATAL, 'Could not find default events!');
+    flush();
 }
-unset ($events, $evt, $attributes);
+unset($events, $evt, $attributes);
 
 /* modSystemSetting collection */
 $settings = include MODX_BUILD_DIR . 'data/transport.core.system_settings.php';
-if (!is_array($settings) || empty($settings)) { $xpdo->log(xPDO::LOG_LEVEL_FATAL,'Could not package in settings!'); flush(); }
-$attributes= [
+if (!is_array($settings) || empty($settings)) {
+    $xpdo->log(xPDO::LOG_LEVEL_FATAL, 'Could not package in settings!');
+    flush();
+}
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
 ];
@@ -249,13 +280,14 @@ foreach ($settings as $setting) {
     $package->put($setting, $attributes);
 }
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($settings).' default system settings.'); flush();
-unset ($settings, $setting, $attributes);
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($settings) . ' default system settings.');
+flush();
+unset($settings, $setting, $attributes);
 
 /* modContextSetting collection */
 $collection = [];
 include MODX_BUILD_DIR . 'data/transport.core.context_settings.php';
-$attributes= [
+$attributes = [
     xPDOTransport::PRESERVE_KEYS => true,
     xPDOTransport::UPDATE_OBJECT => false,
     xPDOTransport::UNIQUE_KEY => ['context_key', 'key']
@@ -264,8 +296,9 @@ foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default context settings.'); flush();
-unset ($collection, $c, $attributes);
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($collection) . ' default context settings.');
+flush();
+unset($collection, $c, $attributes);
 
 /* modUserGroup */
 $collection = [];
@@ -278,8 +311,9 @@ foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default user groups.'); flush();
-unset ($collection, $c, $attributes);
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($collection) . ' default user groups.');
+flush();
+unset($collection, $c, $attributes);
 
 /* modDashboard */
 $collection = [];
@@ -293,8 +327,9 @@ foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default dashboards.'); flush();
-unset ($collection, $c, $attributes);
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($collection) . ' default dashboards.');
+flush();
+unset($collection, $c, $attributes);
 
 /* modMediaSource */
 $collection = [];
@@ -308,8 +343,9 @@ foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default media sources.'); flush();
-unset ($collection, $c, $attributes);
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($collection) . ' default media sources.');
+flush();
+unset($collection, $c, $attributes);
 
 /* modDashboardWidget */
 $widgets = include MODX_BUILD_DIR . 'data/transport.core.dashboard_widgets.php';
@@ -331,11 +367,13 @@ if (is_array($widgets)) {
         }
         $package->put($widget, $attributes);
     }
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($widgets).' default dashboard widgets.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($widgets) . ' default dashboard widgets.');
+    flush();
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_ERROR,'Could not load dashboard widgets!'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not load dashboard widgets!');
+    flush();
 }
-unset ($widgets,$widget,$attributes,$ct,$idx);
+unset($widgets, $widget, $attributes, $ct, $idx);
 
 /* modUserGroupRole */
 $collection = [];
@@ -348,8 +386,9 @@ foreach ($collection as $c) {
     $package->put($c, $attributes);
 }
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($collection).' default roles Member and SuperUser.'); flush();
-unset ($collection, $c, $attributes);
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($collection) . ' default roles Member and SuperUser.');
+flush();
+unset($collection, $c, $attributes);
 
 /* modAccessPolicyTemplateGroups */
 $templateGroups = include MODX_BUILD_DIR . 'data/transport.core.accesspolicytemplategroups.php';
@@ -362,11 +401,15 @@ if (is_array($templateGroups)) {
     foreach ($templateGroups as $templateGroup) {
         $package->put($templateGroup, $attributes);
     }
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($templateGroups).' default Access Policy Template Groups.'); flush();
+    $xpdo->log(
+        xPDO::LOG_LEVEL_INFO,
+        'Packaged in ' . count($templateGroups) . ' default Access Policy Template Groups.'
+    );
+    flush();
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_ERROR,'Could not package in Access Policy Template Groups.');
+    $xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not package in Access Policy Template Groups.');
 }
-unset ($templateGroups, $templateGroup, $attributes);
+unset($templateGroups, $templateGroup, $attributes);
 
 
 /* modAccessPolicyTemplate */
@@ -380,7 +423,7 @@ $attributes = [
         'Permissions' => [
             xPDOTransport::PRESERVE_KEYS => false,
             xPDOTransport::UPDATE_OBJECT => true,
-            xPDOTransport::UNIQUE_KEY => ['template','name'],
+            xPDOTransport::UNIQUE_KEY => ['template', 'name'],
         ],
     ]
 ];
@@ -397,11 +440,12 @@ if (is_array($templates)) {
         }
         $package->put($template, $attributes);
     }
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($templates).' default Access Policy Templates.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($templates) . ' default Access Policy Templates.');
+    flush();
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_ERROR,'Could not package in Access Policy Templates.');
+    $xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not package in Access Policy Templates.');
 }
-unset ($templates,$template,$idx,$ct,$attributes);
+unset($templates, $template, $idx, $ct, $attributes);
 
 /* modAccessPolicy */
 $policies = include MODX_BUILD_DIR . 'data/transport.core.accesspolicies.php';
@@ -423,12 +467,12 @@ if (is_array($policies)) {
         }
         $package->put($policy, $attributes);
     }
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in '.count($policies).' default Access Policies.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in ' . count($policies) . ' default Access Policies.');
+    flush();
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_ERROR,'Could not package in Access Policies.');
+    $xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not package in Access Policies.');
 }
-unset ($policies,$policy,$idx,$ct,$attributes);
-
+unset($policies, $policy, $idx, $ct, $attributes);
 
 
 /* modContext = web */
@@ -458,9 +502,10 @@ $attributes['resolve'][] = [
     'target' => "return MODX_BASE_PATH . 'config.core.php';",
 ];
 $package->put($c, $attributes);
-unset ($c, $attributes);
+unset($c, $attributes);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in web context.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in web context.');
+flush();
 
 /* modContext = mgr */
 $c = $xpdo->newObject(modContext::class);
@@ -504,9 +549,10 @@ $attributes['resolve'][] = [
     'target' => "return MODX_MANAGER_PATH . 'config.core.php';",
 ];
 $package->put($c, $attributes);
-unset ($c, $attributes);
+unset($c, $attributes);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in mgr context.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in mgr context.');
+flush();
 
 /* connector file transport */
 $attributes = [
@@ -527,7 +573,7 @@ $files[] = [
 foreach ($files as $fileset) {
     $package->put($fileset, $attributes);
 }
-unset ($files, $fileset);
+unset($files, $fileset);
 $fileset = [
     'source' => MODX_BASE_PATH . 'connectors/index.php',
     'target' => "return MODX_CONNECTORS_PATH;",
@@ -542,17 +588,21 @@ $attributes['resolve'][] = [
     'source' => MODX_BUILD_DIR . 'resolvers/resolve.actionfields.php',
 ];
 $package->put($fileset, $attributes);
-unset ($fileset, $attributes);
+unset($fileset, $attributes);
 
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Packaged in connectors.'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Packaged in connectors.');
+flush();
 
 
 /* zip up package */
-$xpdo->log(xPDO::LOG_LEVEL_INFO,'Beginning to zip up transport package...'); flush();
+$xpdo->log(xPDO::LOG_LEVEL_INFO, 'Beginning to zip up transport package...');
+flush();
 if ($package->pack()) {
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Transport zip created. Build script finished.'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Transport zip created. Build script finished.');
+    flush();
 } else {
-    $xpdo->log(xPDO::LOG_LEVEL_INFO,'Error creating transport zip!'); flush();
+    $xpdo->log(xPDO::LOG_LEVEL_INFO, 'Error creating transport zip!');
+    flush();
 }
 
 $mtime = microtime();
@@ -562,5 +612,6 @@ $tend = $mtime;
 $totalTime = ($tend - $tstart);
 $totalTime = sprintf("%2.4f s", $totalTime);
 
-echo "\nExecution time: {$totalTime}\n"; flush();
-exit ();
+echo "\nExecution time: {$totalTime}\n";
+flush();
+exit();

--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -167,7 +167,7 @@ $collection['1']->fromArray([
     'name' => 'modx.com',
     'description' => 'The official MODX transport provider for 3rd party components.',
     'service_url' => 'https://rest.modx.com/extras/',
-    'created' => strftime('%Y-%m-%d %H:%M:%S'),
+    'created' => date('Y-m-d H:i:s'),
 ], '', true, true);
 $attributes = [
     xPDOTransport::PRESERVE_KEYS => false,

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
@@ -18,7 +18,7 @@ class modTemplateVarInputRenderDate extends modTemplateVarInputRender {
     public function process($value,array $params = []) {
         $v = $value;
         if ($v != '' && $v != '0' && $v != '0000-00-00 00:00:00') {
-            $v = strftime('%Y-%m-%d %H:%M:%S',strtotime($v));
+            $v = date('Y-m-d H:i:s',strtotime($v));
         }
         $this->tv->set('value',$v);
 

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -14,31 +15,36 @@ use MODX\Revolution\modTemplateVarInputRender;
  * @package modx
  * @subpackage processors.element.tv.renders.mgr.input
  */
-class modTemplateVarInputRenderDate extends modTemplateVarInputRender {
-    public function process($value,array $params = []) {
+class modTemplateVarInputRenderDate extends modTemplateVarInputRender
+{
+    public function process($value, array $params = [])
+    {
         $v = $value;
         if ($v != '' && $v != '0' && $v != '0000-00-00 00:00:00') {
-            $v = date('Y-m-d H:i:s',strtotime($v));
+            $v = date('Y-m-d H:i:s', strtotime($v));
         }
-        $this->tv->set('value',$v);
+        $this->tv->set('value', $v);
 
         if (!empty($params['disabledDates'])) {
-            $params['disabledDates'] = $this->modx->toJSON(explode(',',$params['disabledDates']));
+            $params['disabledDates'] = $this->modx->toJSON(explode(',', $params['disabledDates']));
         }
         if (!empty($params['disabledDays'])) {
-            $params['disabledDays'] = $this->modx->toJSON(explode(',',$params['disabledDays']));
+            $params['disabledDays'] = $this->modx->toJSON(explode(',', $params['disabledDays']));
         }
         if (!empty($params['maxTimeValue'])) {
-            $params['maxTimeValue'] = date('g:i A',strtotime($params['maxTimeValue']));
+            $params['maxTimeValue'] = date('g:i A', strtotime($params['maxTimeValue']));
         }
         if (!empty($params['minTimeValue'])) {
-            $params['minTimeValue'] = date('g:i A',strtotime($params['minTimeValue']));
+            $params['minTimeValue'] = date('g:i A', strtotime($params['minTimeValue']));
         }
-        $this->setPlaceholder('params',$params);
-        $this->setPlaceholder('tv',$this->tv);
+        $this->setPlaceholder('params', $params);
+        $this->setPlaceholder('tv', $this->tv);
     }
-    public function getTemplate() {
+
+    public function getTemplate()
+    {
         return 'element/tv/renders/input/date.tpl';
     }
 }
+
 return 'modTemplateVarInputRenderDate';

--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -262,7 +262,7 @@ class Create extends CreateProcessor
         $scriptProperties['uri_override'] = empty($scriptProperties['uri_override']) ? 0 : 1;
 
         if (empty($scriptProperties['createdon'])) {
-            $scriptProperties['createdon'] = strftime('%Y-%m-%d %H:%M:%S');
+            $scriptProperties['createdon'] = date('Y-m-d H:i:s');
         }
 
         if (empty($scriptProperties['createdby'])) {
@@ -507,7 +507,7 @@ class Create extends CreateProcessor
                         $value = implode(',', $newTags);
                         break;
                     case 'date':
-                        $value = empty($value) ? '' : strftime('%Y-%m-%d %H:%M:%S', strtotime($value));
+                        $value = empty($value) ? '' : date('Y-m-d H:i:s', strtotime($value));
                         break;
                     case 'url':
                         if ($this->getProperty($tvKey . '_prefix', '--') != '--') {

--- a/core/src/Revolution/Processors/Resource/Event/UpdateFromGrid.php
+++ b/core/src/Revolution/Processors/Resource/Event/UpdateFromGrid.php
@@ -65,12 +65,12 @@ class UpdateFromGrid extends Processor
     {
         $publishDate = $this->getProperty('pub_date');
         if (!empty($publishDate)) {
-            $this->setProperty('pub_date', strftime('%Y-%m-%d %H:%M', strtotime($publishDate)));
+            $this->setProperty('pub_date', date('Y-m-d H:i', strtotime($publishDate)));
         }
 
         $unPublishDate = $this->getProperty('unpub_date');
         if (!empty($unPublishDate)) {
-            $this->setProperty('unpub_date', strftime('%Y-%m-%d %H:%M', strtotime($unPublishDate)));
+            $this->setProperty('unpub_date', date('Y-m-d H:i', strtotime($unPublishDate)));
         }
         return true;
     }

--- a/core/src/Revolution/Processors/Resource/Reload.php
+++ b/core/src/Revolution/Processors/Resource/Reload.php
@@ -71,7 +71,7 @@ class Reload extends Processor
                             }
                             break;
                         case 'date':
-                            $value = empty($value) ? '' : strftime('%Y-%m-%d %H:%M:%S', strtotime($value));
+                            $value = empty($value) ? '' : date('Y-m-d H:i:s', strtotime($value));
                             break;
                         /* ensure tag types trim whitespace from tags */
                         case 'tag':

--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -738,7 +738,7 @@ class Update extends UpdateProcessor
                         }
                         break;
                     case 'date':
-                        $value = empty($value) ? '' : strftime('%Y-%m-%d %H:%M:%S', strtotime($value));
+                        $value = empty($value) ? '' : date('Y-m-d H:i:s', strtotime($value));
                         break;
                     /* ensure tag types trim whitespace from tags */
                     case 'tag':

--- a/core/src/Revolution/Processors/Security/Profile/Get.php
+++ b/core/src/Revolution/Processors/Security/Profile/Get.php
@@ -71,12 +71,12 @@ class Get extends Processor
             $userArray = array_merge($profile->toArray(), $userArray);
         }
 
-        $userArray['dob'] = !empty($userArray['dob']) ? strftime('%m/%d/%Y', $userArray['dob']) : '';
-        $userArray['blockeduntil'] = !empty($userArray['blockeduntil']) ? strftime('%m/%d/%Y %I:%M %p',
+        $userArray['dob'] = !empty($userArray['dob']) ? date('m/d/Y', $userArray['dob']) : '';
+        $userArray['blockeduntil'] = !empty($userArray['blockeduntil']) ? date('m/d/Y h:i A',
             $userArray['blockeduntil']) : '';
-        $userArray['blockedafter'] = !empty($userArray['blockedafter']) ? strftime('%m/%d/%Y %I:%M %p',
+        $userArray['blockedafter'] = !empty($userArray['blockedafter']) ? date('m/d/Y h:i A',
             $userArray['blockedafter']) : '';
-        $userArray['lastlogin'] = !empty($userArray['lastlogin']) ? strftime('%m/%d/%Y', $userArray['lastlogin']) : '';
+        $userArray['lastlogin'] = !empty($userArray['lastlogin']) ? date('m/d/Y', $userArray['lastlogin']) : '';
 
         return $this->success('', $userArray);
     }

--- a/core/src/Revolution/Processors/Security/User/Get.php
+++ b/core/src/Revolution/Processors/Security/User/Get.php
@@ -91,10 +91,10 @@ class Get extends GetProcessor
             $userArray = array_merge($profile->toArray(), $userArray);
         }
 
-        $userArray['dob'] = !empty($userArray['dob']) ? strftime('%m/%d/%Y', $userArray['dob']) : '';
-        $userArray['blockeduntil'] = !empty($userArray['blockeduntil']) ? strftime('%Y-%m-%d %H:%M:%S',
+        $userArray['dob'] = !empty($userArray['dob']) ? date('m/d/Y', $userArray['dob']) : '';
+        $userArray['blockeduntil'] = !empty($userArray['blockeduntil']) ? date('Y-m-d H:i:s',
             $userArray['blockeduntil']) : '';
-        $userArray['blockedafter'] = !empty($userArray['blockedafter']) ? strftime('%Y-%m-%d %H:%M:%S',
+        $userArray['blockedafter'] = !empty($userArray['blockedafter']) ? date('Y-m-d H:i:s',
             $userArray['blockedafter']) : '';
         $userArray['lastlogin'] = !empty($userArray['lastlogin']) ? date($this->modx->getOption('manager_date_format') . ', ' . $this->modx->getOption('manager_time_format'),
             $userArray['lastlogin']) : '';

--- a/core/src/Revolution/Processors/System/Info.php
+++ b/core/src/Revolution/Processors/System/Info.php
@@ -40,8 +40,8 @@ class Info extends Processor
         /* general */
         $data['modx_version'] = $this->modx->version['full_appname'];
         $data['code_name'] = $this->modx->version['code_name'];
-        $data['servertime'] = strftime('%I:%M:%S %p', time());
-        $data['localtime'] = strftime('%I:%M:%S %p', time() + $serverOffset);
+        $data['servertime'] = date('h:i:s A', time());
+        $data['localtime'] = date('h:i:s A', time() + $serverOffset);
         $data['serveroffset'] = $serverOffset / (60 * 60);
 
         /* database info */
@@ -58,7 +58,7 @@ class Info extends Processor
         $data['database_name'] = trim($this->modx->getOption('dbname'),
             $this->modx->_escapeCharOpen . $this->modx->_escapeCharClose);
         $data['database_server'] = $this->modx->getOption('host');
-        $data['now'] = strftime('%b %d, %Y %I:%M %p', time());
+        $data['now'] = date('M d, Y h:i A', time());
         $data['table_prefix'] = $this->modx->getOption('table_prefix');
 
         return $this->success('', $data);

--- a/core/src/Revolution/Processors/System/Log/GetList.php
+++ b/core/src/Revolution/Processors/System/Log/GetList.php
@@ -121,11 +121,11 @@ class GetList extends Processor
             $wa['user'] = $user;
         }
         if (!empty($dateStart)) {
-            $dateStart = strftime('%Y-%m-%d', strtotime($dateStart . ' 00:00:00'));
+            $dateStart = date('Y-m-d', strtotime($dateStart . ' 00:00:00'));
             $wa['occurred:>='] = $dateStart;
         }
         if (!empty($dateEnd)) {
-            $dateEnd = strftime('%Y-%m-%d', strtotime($dateEnd . ' 23:59:59'));
+            $dateEnd = date('Y-m-d', strtotime($dateEnd . ' 23:59:59'));
             $wa['occurred:<='] = $dateEnd;
         }
 

--- a/core/src/Revolution/Processors/Workspace/Packages/ScanLocal.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/ScanLocal.php
@@ -123,7 +123,7 @@ class ScanLocal extends Processor
         $package = $this->modx->newObject(modTransportPackage::class);
         $package->set('signature', $signature);
         $package->set('state', 1);
-        $package->set('created', strftime('%Y-%m-%d %H:%M:%S'));
+        $package->set('created', date('Y-m-d H:i:s'));
         $package->set('workspace', $this->workspace->get('id'));
 
         /* set package version data */

--- a/core/src/Revolution/Registry/Db/mysql/modDbRegisterMessage.php
+++ b/core/src/Revolution/Registry/Db/mysql/modDbRegisterMessage.php
@@ -13,11 +13,11 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
         'version' => '3.0',
         'table' => 'register_messages',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'tableMeta' => 
+        'tableMeta' =>
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' => 
+        'fields' =>
         array (
             'topic' => NULL,
             'id' => NULL,
@@ -29,9 +29,9 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
             'payload' => NULL,
             'kill' => 0,
         ),
-        'fieldMeta' => 
+        'fieldMeta' =>
         array (
-            'topic' => 
+            'topic' =>
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -40,7 +40,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'null' => false,
                 'index' => 'pk',
             ),
-            'id' => 
+            'id' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -48,28 +48,28 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'null' => false,
                 'index' => 'pk',
             ),
-            'created' => 
+            'created' =>
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'valid' => 
+            'valid' =>
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'accessed' => 
+            'accessed' =>
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
                 'index' => 'index',
             ),
-            'accesses' => 
+            'accesses' =>
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -79,7 +79,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
                 'index' => 'index',
             ),
-            'expires' => 
+            'expires' =>
             array (
                 'dbtype' => 'integer',
                 'precision' => '20',
@@ -88,13 +88,13 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
                 'index' => 'index',
             ),
-            'payload' => 
+            'payload' =>
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'string',
                 'null' => false,
             ),
-            'kill' => 
+            'kill' =>
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -104,23 +104,23 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
             ),
         ),
-        'indexes' => 
+        'indexes' =>
         array (
-            'PRIMARY' => 
+            'PRIMARY' =>
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'topic' => 
+                    'topic' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'id' => 
+                    'id' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -128,15 +128,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'created' => 
+            'created' =>
             array (
                 'alias' => 'created',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'created' => 
+                    'created' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -144,15 +144,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'valid' => 
+            'valid' =>
             array (
                 'alias' => 'valid',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'valid' => 
+                    'valid' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -160,15 +160,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accessed' => 
+            'accessed' =>
             array (
                 'alias' => 'accessed',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'accessed' => 
+                    'accessed' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -176,15 +176,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accesses' => 
+            'accesses' =>
             array (
                 'alias' => 'accesses',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'accesses' => 
+                    'accesses' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -192,15 +192,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'expires' => 
+            'expires' =>
             array (
                 'alias' => 'expires',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'expires' => 
+                    'expires' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -209,9 +209,9 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 ),
             ),
         ),
-        'aggregates' => 
+        'aggregates' =>
         array (
-            'Topic' => 
+            'Topic' =>
             array (
                 'class' => 'MODX\\Revolution\\Registry\\Db\\modDbRegisterTopic',
                 'local' => 'topic',
@@ -239,7 +239,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
             $register->modx,
             "SELECT msg.* FROM {$msgTable} msg JOIN {$topicTable} topic ON msg.valid <= :now AND (topic.name = :topic OR (topic.name = :topicbase AND msg.id = :topicmsg)) AND topic.id = msg.topic ORDER BY msg.created ASC {$limitClause}",
             [
-                ':now' => strftime('%Y-%m-%d %H:%M:%S'),
+                ':now' => date('Y-m-d H:i:s'),
                 ':topic' => $topic,
                 ':topicbase' => $topicBase,
                 ':topicmsg' => $topicMsg,

--- a/core/src/Revolution/Registry/modDbRegister.php
+++ b/core/src/Revolution/Registry/modDbRegister.php
@@ -273,7 +273,7 @@ class modDbRegister extends modRegister
                 $topicObj = $this->modx->newObject(modDbRegisterTopic::class);
                 $topicObj->set('queue', $queueId);
                 $topicObj->set('name', $topic);
-                $topicObj->set('created', strftime('%Y-%m-%d %H:%M:%S'));
+                $topicObj->set('created', date('Y-m-d H:i:s'));
                 if (!$topicObj->save()) {
                     $error = true;
                 }
@@ -295,7 +295,7 @@ class modDbRegister extends modRegister
                                 if (!is_int($msgIdx)) {
                                     $msgKey = $msgIdx;
                                 } else {
-                                    $msgKey = strftime('%Y%m%dT%H%M%S', $timestamp) . '-' . sprintf("%03d", $msgIdx);
+                                    $msgKey = date('Ymd\THis', $timestamp) . '-' . sprintf("%03d", $msgIdx);
                                 }
                                 if ($expires > 0) {
                                     $payload .= "if (time() > {$expires}) return null;\n";
@@ -309,8 +309,8 @@ class modDbRegister extends modRegister
                                     $messageObj->set('id', $msgKey);
                                 }
                                 if ($messageObj) {
-                                    $messageObj->set('created', strftime('%Y-%m-%d %H:%M:%S'));
-                                    $messageObj->set('valid', strftime('%Y-%m-%d %H:%M:%S', $timestamp));
+                                    $messageObj->set('created', date('Y-m-d H:i:s'));
+                                    $messageObj->set('valid', date('Y-m-d H:i:s', $timestamp));
                                     $messageObj->set('expires', $expires);
                                     $messageObj->set('payload', $payload);
                                     $messageObj->set('kill', $kill);

--- a/core/src/Revolution/Registry/modFileRegister.php
+++ b/core/src/Revolution/Registry/modFileRegister.php
@@ -287,7 +287,7 @@ class modFileRegister extends modRegister
                                 }
                                 $msgKey = $msgIdx;
                             } else {
-                                $msgKey = strftime('%Y%m%dT%H%M%S', $timestamp) . '-' . sprintf("%03d", $msgIdx);
+                                $msgKey = date('Ymd\THis', $timestamp) . '-' . sprintf("%03d", $msgIdx);
                             }
                             $filename = $topicDirectory . $msgKey . '.msg.php';
                             $content = "<?php\n";

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -96,7 +96,7 @@ class modTransportPackage extends xPDOObject
     public function save($cacheFlag = null)
     {
         if ($this->_new && !$this->get('created')) {
-            $this->set('created', strftime('%Y-%m-%d %H:%M:%S'));
+            $this->set('created', date('Y-m-d H:i:s'));
         }
         $saved = parent:: save($cacheFlag);
 
@@ -355,7 +355,7 @@ class modTransportPackage extends xPDOObject
             );
         }
         if ($installed) {
-            $this->set('installed', strftime('%Y-%m-%d %H:%M:%S'));
+            $this->set('installed', date('Y-m-d H:i:s'));
             $this->set('attributes', $attributes);
             $this->save();
         }

--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -161,7 +161,7 @@ class modTransportProvider extends xPDOSimpleObject
                 'id' => (string)$package->id,
                 'name' => (string)$package->name,
                 'package_name' => (string)$package->package_name,
-                'releasedon' => strftime('%b %d, %Y', strtotime((string)$package->releasedon)),
+                'releasedon' => date('M d, Y', strtotime((string)$package->releasedon)),
             ];
         }
 
@@ -294,7 +294,7 @@ class modTransportProvider extends xPDOSimpleObject
             $package->set('signature', $signature);
             $package->set('state', 1);
             $package->set('workspace', 1);
-            $package->set('created', strftime('%Y-%m-%d %H:%M:%S'));
+            $package->set('created', date('Y-m-d H:i:s'));
             $package->set('provider', $this->get('id'));
             $package->set('metadata', $metadata);
             $package->set('package_name', $metadata['name']);
@@ -561,7 +561,7 @@ class modTransportProvider extends xPDOSimpleObject
     public function save($cacheFlag = null)
     {
         if ($this->isNew() && !$this->get('created')) {
-            $this->set('created', strftime('%Y-%m-%d %H:%M:%S'));
+            $this->set('created', date('Y-m-d H:i:s'));
         }
         $saved = parent:: save($cacheFlag);
 

--- a/core/src/Revolution/modExtensionPackage.php
+++ b/core/src/Revolution/modExtensionPackage.php
@@ -27,9 +27,9 @@ class modExtensionPackage extends xPDOSimpleObject
         if (!$this->getOption(xPDO::OPT_SETUP)) {
             $isNew = $this->isNew();
             if ($isNew) {
-                $this->set('created_at', strftime('%Y-%m-%d %H:%M:%S'));
+                $this->set('created_at', date('Y-m-d H:i:s'));
             } else {
-                $this->set('updated_at', strftime('%Y-%m-%d %H:%M:%S'));
+                $this->set('updated_at', date('Y-m-d H:i:s'));
             }
         }
         $saved = parent::save($cacheFlag);

--- a/core/src/Revolution/modLexiconEntry.php
+++ b/core/src/Revolution/modLexiconEntry.php
@@ -74,7 +74,7 @@ class modLexiconEntry extends xPDOSimpleObject
         }
         if ($this->_new) {
             if (!$this->get('createdon')) {
-                $this->set('createdon', strftime('%Y-%m-%d %H:%M:%S'));
+                $this->set('createdon', date('Y-m-d H:i:s'));
             }
         }
         $saved = parent::save($cacheFlag);

--- a/core/src/Revolution/modWorkspace.php
+++ b/core/src/Revolution/modWorkspace.php
@@ -27,7 +27,7 @@ class modWorkspace extends xPDOSimpleObject
     public function save($cacheFlag = null)
     {
         if ($this->_new && !$this->get('created')) {
-            $this->set('created', strftime('%Y-%m-%d %H:%M:%S'));
+            $this->set('created', date('Y-m-d H:i:s'));
         }
         $saved = parent:: save($cacheFlag);
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2025,7 +2025,7 @@ class modX extends xPDO {
         /** @var modManagerLog $ml */
         $ml = $this->newObject(modManagerLog::class);
         $ml->set('user', (integer) $userId);
-        $ml->set('occurred', strftime('%Y-%m-%d %H:%M:%S'));
+        $ml->set('occurred', date('Y-m-d H:i:s'));
         $ml->set('action', empty($action) ? 'unknown' : $action);
         $ml->set('classKey', empty($class_key) ? '' : $class_key);
         $ml->set('item', empty($item) ? 'unknown' : $item);
@@ -2921,7 +2921,7 @@ class modX extends xPDO {
                 if ($targetObj == 'FILE' && $cacheManager= $this->getCacheManager()) {
                     $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
                     $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
-                    $cacheManager->writeFile($filepath . $filename, '[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''), 'a');
+                    $cacheManager->writeFile($filepath . $filename, '[' . date('Y-m-d H:i:s') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''), 'a');
                 }
                 $this->sendError('fatal');
             }
@@ -2941,7 +2941,7 @@ class modX extends xPDO {
      * @param string $line The line number of the file that the message occurs for
      */
     protected function _logInRegister($register, $level, $msg, $def, $file, $line) {
-        $timestamp = strftime('%Y-%m-%d %H:%M:%S');
+        $timestamp = date('Y-m-d H:i:s');
         $messageKey = (string) time();
         $messageKey .= '-' . sprintf("%06d", $this->_logSequence);
         $message = [

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -200,7 +200,7 @@ class modInstall {
                 [
                 'target' => 'FILE',
                 'options' => [
-                    'filename' => 'install.' . MODX_CONFIG_KEY . '.' . strftime('%Y-%m-%dT%H.%M.%S').'.log'
+                    'filename' => 'install.' . MODX_CONFIG_KEY . '.' . date('Y-m-d\TH.i.s').'.log'
                 ]
                 ]
             );
@@ -476,7 +476,7 @@ class modInstall {
                 [
                 'target' => 'FILE',
                 'options' => [
-                    'filename' => 'install.' . MODX_CONFIG_KEY . '.' . strftime('%Y%m%dT%H%M%S') . '.log'
+                    'filename' => 'install.' . MODX_CONFIG_KEY . '.' . date('Ymd\THis') . '.log'
                 ]
                 ]
             );
@@ -509,7 +509,7 @@ class modInstall {
                     [
                     'target' => 'FILE',
                     'options' => [
-                        'filename' => 'install.' . MODX_CONFIG_KEY . '.' . strftime('%Y%m%dT%H%M%S') . '.log'
+                        'filename' => 'install.' . MODX_CONFIG_KEY . '.' . date('Ymd\THis') . '.log'
                     ]
                     ]
                 );


### PR DESCRIPTION
### What does it do?
Replace the function `strftime` with `date` where possible. 
If the `format` paramater comes from a variable the `strftime` function is not replaced since this means a breaking change.

### Why is it needed?
In PHP 8.1 the function `strftime` is deprecated.

### How to test
Use PHP 8.1 and see a lot less deprecation warnings.

### Related issue(s)/PR(s)
Resolves #15988
Related to #15864
