### PR TITLE
Fixed 'undefined' error if TV is located under content

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -268,7 +268,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
         }
 
         // We are already on a tab that has an invalid state. No need to switch
-        if (!tabs.items.items[tabs_index].hidden)  {
+        if (tabs.items.items[tabs_index] && !tabs.items.items[tabs_index].hidden) {
             return;
         }
 


### PR DESCRIPTION
### What does it do?
Fixed 'undefined' error if TV is located under content, and not in the tab.
When saving the resource, an error occurred in the console and the validation message did not appear.

### How to test
1) Create a required TV.
2) Position the TV below the content (setting `tvs_below_content`).
3) Without setting a value in TV, save the resource and watch the console.

### Related issue(s)/PR(s)
NA
