### PR TITLE
Added icon classes for resources in resource group

### DIFF
--- a/core/src/Revolution/Processors/Security/ResourceGroup/GetNodes.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/GetNodes.php
@@ -13,6 +13,7 @@ namespace MODX\Revolution\Processors\Security\ResourceGroup;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use MODX\Revolution\modResourceGroup;
+use ReflectionClass;
 
 /**
  * Get the resource groups as nodes
@@ -85,13 +86,139 @@ class GetNodes extends Processor
                     $resources = $resourceGroup->getResources();
                     /** @var modResource $resource */
                     foreach ($resources as $resource) {
+                        $class = [];
+                        $hasChildren = $resource->get('childrenCount') > 0;
+                        if (!$resource->isfolder) {
+                            $class[] = 'x-tree-node-leaf';
+                        }
+                        if ($hasChildren) {
+                            $class[] = 'is_folder';
+                        }
+                        if (!$resource->get('published')) {
+                            $class[] = 'unpublished';
+                        }
+                        if ($resource->get('deleted')) {
+                            $class[] = 'deleted';
+                        }
+                        if ($resource->get('hidemenu')) {
+                            $class[] = 'hidemenu';
+                        }
+
+                        if (!empty($this->permissions['save_document'])) {
+                            $class[] = $this->permissions['save_document'];
+                        }
+                        if (!empty($this->permissions['view_document'])) {
+                            $class[] = $this->permissions['view_document'];
+                        }
+                        if (!empty($this->permissions['edit_document'])) {
+                            $class[] = $this->permissions['edit_document'];
+                        }
+                        if (!empty($this->permissions['resource_duplicate'])) {
+                            if ($resource->parent != $this->defaultRootId || $this->modx->hasPermission('new_document_in_root')) {
+                                $class[] = $this->permissions['resource_duplicate'];
+                            }
+                        }
+                        if ($resource->allowChildrenResources && !$resource->deleted) {
+                            if (!empty($this->permissions['new_document'])) {
+                                $class[] = $this->permissions['new_document'];
+                            }
+                            if (!empty($this->permissions['new_symlink'])) {
+                                $class[] = $this->permissions['new_symlink'];
+                            }
+                            if (!empty($this->permissions['new_weblink'])) {
+                                $class[] = $this->permissions['new_weblink'];
+                            }
+                            if (!empty($this->permissions['new_static_resource'])) {
+                                $class[] = $this->permissions['new_static_resource'];
+                            }
+                            if (!empty($this->permissions['resource_quick_create'])) {
+                                $class[] = $this->permissions['resource_quick_create'];
+                            }
+                        }
+                        if (!empty($this->permissions['resource_quick_update'])) {
+                            $class[] = $this->permissions['resource_quick_update'];
+                        }
+                        if (!empty($this->permissions['delete_document'])) {
+                            $class[] = $this->permissions['delete_document'];
+                        }
+                        if (!empty($this->permissions['undelete_document'])) {
+                            $class[] = $this->permissions['undelete_document'];
+                        }
+                        if (!empty($this->permissions['publish_document'])) {
+                            $class[] = $this->permissions['publish_document'];
+                        }
+                        if (!empty($this->permissions['unpublish_document'])) {
+                            $class[] = $this->permissions['unpublish_document'];
+                        }
+
+                        // Assign an icon class based on the class_key
+                        try {
+                            $reflectionClass = new ReflectionClass($resource->get('class_key'));
+                            $classKey = strtolower($reflectionClass->getShortName());
+                        } catch (ReflectionException $e) {
+                            $classKey = strtolower($resource->get('class_key'));
+                        }
+                        if (substr($classKey, 0, 3) === 'mod') {
+                            $classKey = substr($classKey, 3);
+                        }
+
+                        $iconCls = [];
+
+                        $contentType = $resource->getOne('ContentType');
+                        if ($contentType && $contentType->get('icon')) {
+                            $iconCls = [$contentType->get('icon')];
+                        }
+
+                        $template = $resource->getOne('Template');
+                        $tplIcon = '';
+                        if ($template && $template->get('icon')) {
+                            $tplIcon = $template->get('icon');
+                            $iconCls = [$template->get('icon')];
+                        }
+
+                        $classKeyIcon = $this->modx->getOption('mgr_tree_icon_' . $classKey, null, 'tree-resource', true);
+                        if (empty($iconCls)) {
+                            $iconCls[] = $classKeyIcon;
+                        }
+
+                        switch ($classKey) {
+                            case 'weblink':
+                                $iconCls[] = $this->modx->getOption('mgr_tree_icon_weblink', null, 'tree-weblink');
+                                break;
+
+                            case 'symlink':
+                                $iconCls[] = $this->modx->getOption('mgr_tree_icon_symlink', null, 'tree-symlink');
+                                break;
+
+                            case 'staticresource':
+                                $iconCls[] = $this->modx->getOption('mgr_tree_icon_staticresource', null, 'tree-static-resource');
+                                break;
+                        }
+
+                        // Icons specific with the context and resource ID for super specific tweaks
+                        $iconCls[] = 'icon-' . $resource->get('context_key') . '-' . $resource->get('id');
+                        $iconCls[] = 'icon-parent-' . $resource->get('context_key') . '-' . $resource->get('parent');
+
+                        // Modifiers to indicate resource _state_
+                        if ($hasChildren || $resource->isfolder) {
+                            if (empty($tplIcon) && $classKeyIcon === 'tree-resource') {
+                                $iconCls[] = $this->modx->getOption('mgr_tree_icon_folder', null, 'parent-resource');
+                            }
+                        }
+
+                        // Add icon class - and additional description to the tooltip - if the resource is locked.
+                        $locked = $resource->getLock();
+                        if ($locked && $locked != $this->modx->user->get('id')) {
+                            $iconCls[] = 'locked-resource';
+                        }
+
                         $list[] = [
                             'text' => $resource->get('pagetitle') . ' (' . $resource->get('id') . ')',
                             'id' => 'n_' . $resource->get('id') . '_' . $resourceGroup->get('id'),
                             'leaf' => true,
                             'type' => modResource::class,
-                            'cls' => 'icon-' . $resource->get('class_key'),
-                            'iconCls' => 'icon-file',
+                            'cls' => implode(' ', $class),
+                            'iconCls' => implode(' ', $iconCls),
                         ];
                     }
                 }


### PR DESCRIPTION
### What does it do?
Added icon classes for resources in resource group.
Now the status of the resource, its type and template are clear.

Took as a basis - https://github.com/modxcms/revolution/blob/3.x/core/src/Revolution/Processors/Resource/GetNodes.php#L406

Before:
![rg_before](https://user-images.githubusercontent.com/12523676/151547965-3e175462-30d1-48bd-8d10-5ff76b783c22.png)

After:
![rg_after](https://user-images.githubusercontent.com/12523676/151547958-00a61715-68c9-42bf-9a22-ec25c9cd69f4.png)

### Why is it needed?
UX Improvements

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14216 (icons)
