### PR TITLE
Add consistent ?mv={version} cache busting suffix to prevent browser cache issues

### DIFF
--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -18,7 +18,7 @@
 <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
 <script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
 {/if}
-<script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
+<script src="{$_config.manager_url}assets/modext/core/modx.js?mv={$versionToken}"></script>
 <script src="{$_config.manager_url}assets/lib/popper.min.js"></script>
 <script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}"></script>
 <script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$_authToken|default|htmlspecialchars}"></script>


### PR DESCRIPTION
### What does it do?
Adds ?mv={version} to registered css and js scripts that are prone to change between releases.

Note I've opted for ?mv instead of ?v because there are extras that already use their own ?v so this reduces the odds of conflicts.

### Why is it needed?
Avoid sticky browser caches like https://community.modx.com/t/modx-3-0-0-package-management-processor-not-found/4908

### How to test
Confirm correct version string gets added and things still work. 

### Related issue(s)/PR(s)
N/a
