### PR TITLE
Avoid invalid UTF-8 characters breaking json_encode by applying JSON_INVALID_UTF8_SUBSTITUTE flag (#15796)

### DIFF
--- a/core/src/Revolution/Processors/Browser/Directory/GetList.php
+++ b/core/src/Revolution/Processors/Browser/Directory/GetList.php
@@ -45,6 +45,6 @@ class GetList extends Browser
 
         return $this->source->hasErrors()
             ? $this->failure($this->source->getErrors(), [])
-            : json_encode($list);
+            : json_encode($list, JSON_INVALID_UTF8_SUBSTITUTE);
     }
 }

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -263,13 +263,12 @@ abstract class Processor {
      */
     public function outputArray(array $array,$count = false) {
         if ($count === false) { $count = count($array); }
-        $output = json_encode(
-            [
+        $output = json_encode([
             'success' => true,
             'total' => $count,
             'results' => $array
-            ]
-        );
+        ], JSON_INVALID_UTF8_SUBSTITUTE);
+
         if ($output === false) {
             $this->modx->log(modX::LOG_LEVEL_ERROR, 'Processor failed creating output array due to JSON error '.json_last_error());
             return json_encode(['success' => false]);
@@ -291,7 +290,7 @@ abstract class Processor {
         if (is_array($data)) {
             array_walk_recursive($data, [&$this, '_encodeLiterals']);
         }
-        return $this->_decodeLiterals($this->modx->toJSON($data));
+        return $this->_decodeLiterals(json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE));
     }
 
     /**

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -62,7 +62,7 @@ class ResourceCreateManagerController extends ResourceManagerController
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->ctx . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -64,7 +64,7 @@ class ResourceDataManagerController extends ResourceManagerController
         ];
         $this->addHtml('<script>
         MODx.ctx = "' . $this->resource->get('context_key') . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
     }
 
 

--- a/manager/controllers/default/resource/staticresource/create.class.php
+++ b/manager/controllers/default/resource/staticresource/create.class.php
@@ -41,7 +41,7 @@ class StaticResourceCreateManagerController extends ResourceCreateManagerControl
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->ctx . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/resource/staticresource/update.class.php
+++ b/manager/controllers/default/resource/staticresource/update.class.php
@@ -49,7 +49,7 @@ class StaticResourceUpdateManagerController extends ResourceUpdateManagerControl
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->resource->get('context_key') . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/resource/symlink/create.class.php
+++ b/manager/controllers/default/resource/symlink/create.class.php
@@ -41,7 +41,7 @@ class SymLinkCreateManagerController extends ResourceCreateManagerController
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->ctx . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/resource/symlink/update.class.php
+++ b/manager/controllers/default/resource/symlink/update.class.php
@@ -49,7 +49,7 @@ class SymlinkUpdateManagerController extends ResourceUpdateManagerController
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->resource->get('context_key') . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/resource/update.class.php
+++ b/manager/controllers/default/resource/update.class.php
@@ -67,7 +67,7 @@ class ResourceUpdateManagerController extends ResourceManagerController
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->resource->get('context_key') . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/resource/weblink/create.class.php
+++ b/manager/controllers/default/resource/weblink/create.class.php
@@ -41,7 +41,7 @@ class WebLinkCreateManagerController extends ResourceCreateManagerController
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->ctx . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/resource/weblink/update.class.php
+++ b/manager/controllers/default/resource/weblink/update.class.php
@@ -49,7 +49,7 @@ class WebLinkUpdateManagerController extends ResourceUpdateManagerController
         MODx.config.publish_document = "' . $this->canPublish . '";
         MODx.onDocFormRender = "' . $this->onDocFormRender . '";
         MODx.ctx = "' . $this->resource->get('context_key') . '";
-        Ext.onReady(function() {MODx.load(' . json_encode($data) . ')});</script>');
+        Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
 
         $this->loadRichTextEditor();
     }

--- a/manager/controllers/default/search.class.php
+++ b/manager/controllers/default/search.class.php
@@ -38,7 +38,7 @@ class SearchManagerController extends modManagerController {
         $this->addHtml("<script type=\"text/javascript\">Ext.onReady(function() {
     MODx.load({
         xtype: 'modx-page-search'
-        ,record: " . json_encode(['q' => $this->searchQuery])  . "
+        ,record: " . json_encode(['q' => $this->searchQuery], JSON_INVALID_UTF8_SUBSTITUTE)  . "
     });
 });</script>");
     }

--- a/manager/controllers/default/system/dashboards/update.class.php
+++ b/manager/controllers/default/system/dashboards/update.class.php
@@ -127,7 +127,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
         $data = json_encode([
             'xtype' => 'modx-page-dashboard-update',
             'record' => $this->dashboardArray,
-        ]);
+        ], JSON_INVALID_UTF8_SUBSTITUTE);
         $this->addHtml('<script>Ext.onReady(function(){MODx.load(' . $data . ')});</script>');
     }
 

--- a/manager/controllers/default/system/dashboards/widget/update.class.php
+++ b/manager/controllers/default/system/dashboards/widget/update.class.php
@@ -111,7 +111,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
             'record' => $this->widgetArray,
         ];
 
-        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . json_encode($data) . ');});</script>');
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE) . ');});</script>');
     }
 
     /**

--- a/manager/controllers/default/system/file/create.class.php
+++ b/manager/controllers/default/system/file/create.class.php
@@ -62,7 +62,7 @@ class SystemFileCreateManagerController extends modManagerController
         $data = json_encode([
             'xtype' => 'modx-page-file-create',
             'record' => $this->fileRecord,
-        ]);
+        ], JSON_INVALID_UTF8_SUBSTITUTE);
         $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . $data . ');});</script>');
     }
 

--- a/manager/controllers/default/system/file/edit.class.php
+++ b/manager/controllers/default/system/file/edit.class.php
@@ -64,7 +64,7 @@ class SystemFileEditManagerController extends modManagerController
             'file' => $this->filename,
             'record' => $this->fileRecord,
             'canSave' => (int)$this->canSave,
-        ]);
+        ], JSON_INVALID_UTF8_SUBSTITUTE);
         $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . $data . ');});</script>');
     }
 

--- a/manager/controllers/default/welcome.class.php
+++ b/manager/controllers/default/welcome.class.php
@@ -85,7 +85,7 @@ class WelcomeManagerController extends modManagerController
                 ['new_widgets' => $new_widgets]
             )
         ];
-        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . json_encode($obj) . ')});</script>');
+        $this->addHtml('<script>Ext.onReady(function() {MODx.load(' . json_encode($obj, JSON_INVALID_UTF8_SUBSTITUTE) . ')});</script>');
         if ($this->showWelcomeScreen) {
             $url = $this->modx->getOption('welcome_screen_url', null, 'http://misc.modx.com/revolution/welcome.20.html');
             $this->addHtml('<script>Ext.onReady(function() { MODx.loadWelcomePanel("' . htmlspecialchars($url) . '"); });</script>');


### PR DESCRIPTION
### What does it do?

Add the JSON_INVALID_UTF8_SUBSTITUTE  flag to any json_encode usage in the core that may contain user-defined content that could through some issue contain invalid UTF-8 characters.

The most important change is in the Processor class, which basically applies the fix to any standard processor. 

### Why is it needed?

When encountering invalid characters, rather than breaking entirely, substitute the invalid characters with the boxed question mark. Avoids manager-breaking javascript errors. 

### How to test
Ensure changed processors/controllers continue to work as expected. Make sure I didn't accidentally put a comma in the wrong place. 

### Related issue(s)/PR(s)
Fixes #15796 
