### PR TITLE
Add consistent ?mv={version} cache busting suffix to prevent browser cache issues (part two)

### DIFF
--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -631,9 +631,10 @@ abstract class modManagerController
             }
 
             $o = '';
+            $suffix = '?mv=' . $this->_prepareVersionPostfix();
             // Add script tags for the required javascript
             foreach ($externals as $js) {
-                $o .= '<script src="' . $js . '"></script>' . "\n";
+                $o .= '<script src="' . $js . $suffix . '"></script>' . "\n";
             }
 
             // Get the state and user token for adding to the init script
@@ -758,6 +759,7 @@ abstract class modManagerController
         $cssjs = [];
         if (!empty($jsToCompress)) {
             foreach ($jsToCompress as $scr) {
+                $scr = strpos($scr, '?') === false ? $scr . '?mv=' . $versionPostFix : $scr . '&mv=' . $versionPostFix;
                 $cssjs[] = '<script src="' . $scr . '"></script>';
             }
         }
@@ -768,6 +770,7 @@ abstract class modManagerController
         }
         if (!empty($cssToCompress)) {
             foreach ($cssToCompress as $scr) {
+                $scr = strpos($scr, '?') === false ? $scr . '?mv=' . $versionPostFix : $scr . '&mv=' . $versionPostFix;
                 $cssjs[] = '<link href="' . $scr . '" rel="stylesheet" type="text/css" />';
             }
         }


### PR DESCRIPTION
I somehow missed committing these changes for #16016, so here's part two. 😬 

### What does it do?
Adds ?mv={version} to registered css and js scripts that are prone to change between releases.

Note I've opted for ?mv instead of ?v because there are extras that already use their own ?v so this reduces the odds of conflicts.

### Why is it needed?
Avoid sticky browser caches like https://community.modx.com/t/modx-3-0-0-package-management-processor-not-found/4908

### How to test
Confirm correct version string gets added and things still work.

### Related issue(s)/PR(s)
#16016 
