### PR TITLE
Changed brackets for category child elements

### DIFF
--- a/core/src/Revolution/Processors/Element/GetNodes.php
+++ b/core/src/Revolution/Processors/Element/GetNodes.php
@@ -399,7 +399,7 @@ class GetNodes extends Processor
                 }
             }
 
-            $cc = ($category->get('elementCount') > 0) ? ' (' . $category->get('elementCount') . ')' : '';
+            $cc = ($category->get('elementCount') > 0) ? ' [' . $category->get('elementCount') . ']' : '';
             $nodes[] = [
                 'text' => strip_tags($category->get('category')) . $cc,
                 'id' => 'n_' . $map[0] . '_category_' . ($category->get('id') != null ? $category->get('id') : 0),
@@ -623,7 +623,7 @@ class GetNodes extends Processor
                 }
             }
 
-            $cc = $elCount > 0 ? ' (' . $elCount . ')' : '';
+            $cc = $elCount > 0 ? ' [' . $elCount . ']' : '';
 
             $nodes[] = [
                 'text' => strip_tags($category->get('category')) . $cc,


### PR DESCRIPTION
### What does it do?
In the tree, elements in brackets have IDs, but for categories (except for the list of categories themselves), the number of child elements is indicated. And since the brackets are the same, it can be confusing.

I changed the brackets to others to visually make it clear that these are different entities.
**Because the question is not very important, then just changing the brackets, in my opinion, is enough.**

IDs are indicated in red, the number of child elements is indicated in blue:
![categoryElements](https://user-images.githubusercontent.com/12523676/152172631-8d235adf-b047-4fb2-a674-b95ed203e5a9.png)

### Why is it needed?
UI improvement: it is now visually clearer that not ID is specified

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14598
