### PR TITLE
Revert passing script variables by reference

### DIFF
--- a/core/src/Revolution/modScript.php
+++ b/core/src/Revolution/modScript.php
@@ -84,7 +84,7 @@ class modScript extends modElement
                 $scriptProperties = $this->xpdo->event->params = $this->_properties; /* store params inside event object */
                 ob_start();
                 unset($properties, $content);
-                extract($scriptProperties, EXTR_SKIP|EXTR_REFS);
+                extract($scriptProperties, EXTR_SKIP);
                 $includeResult = include $this->_scriptFilename;
                 $includeResult = ($includeResult === null ? '' : $includeResult);
                 if (ob_get_length()) {


### PR DESCRIPTION
### What does it do?
https://github.com/modxcms/revolution/pull/15578 added the EXTR_REFS flag to the extract() function in modScript::process with the intention of allowing plugins to manipulated variables passed in to it. 

This PR reverts that back to how it was in 2.x.

### Why is it needed?

Unfortunately per https://community.modx.com/t/spform-how-to-change-language/4917/16 the pass by reference is causing issues when local variables in a snippet share the name of a script property or a copy of $scriptProperties is made. This is causing wildly unexpected results. 

### How to test

Two very simple snippets to reproduce the behavior are provided in the forum, both assuming the snippet is called with ```[[!mySnippet? &my_prop=`A`]]```:

```
<?php
$my_prop = 'B';
return $scriptProperties['my_prop']; // returns 'B'
```

```
<?php
$newArr = $scriptProperties;
$newArr['my_prop'] = 'B';

return $scriptProperties['my_prop']; // returns 'B'
```

The expected result, because there is no explicit change made to $scriptProperties, is `A`. However both return `B`. 

It also goes the other way, though this type of code would be less common:

```
<?php
$scriptProperties['my_prop'] = 'B';
return $my_prop;
```


### Related issue(s)/PR(s)

https://community.modx.com/t/spform-how-to-change-language/4917/15
https://github.com/modxcms/revolution/pull/15578/