### PR TITLE
Enable to save changed attribute name or container name in the user's extended fields

### DIFF
--- a/manager/assets/modext/widgets/core/modx.orm.js
+++ b/manager/assets/modext/widgets/core/modx.orm.js
@@ -180,6 +180,7 @@ Ext.extend(MODx.orm.Tree,Ext.tree.TreePanel,{
                         var nd = this.getSelectedNode();
                         nd.setId(r.name);
                         nd.setText(r.name);
+                        nd.attributes.name = r.name;
                         this.markFormPanelDirty();
                     },scope:this}
                 }
@@ -322,6 +323,7 @@ Ext.extend(MODx.orm.Form,Ext.Panel,{
         var val = f.findField(this.config.prefix+'_value').getValue();
         n.attributes.id = f.findField(this.config.prefix+'_id').getValue();
         n.attributes.text = txt;
+        n.attributes.name = txt;
         n.attributes.value = val;
         n.setText(txt+' - <i>'+Ext.util.Format.ellipsis(val,33)+'</i>');
         fp.markDirty();


### PR DESCRIPTION
### What does it do?
Writes the changed name to the _name attribute_ of the tree node.

### Why is it needed?
In the "Extended Fields" tab of the user, you can change the name of an attribute or rename a container, but when you save the user, these changes are not saved.

### How to test
In the "Extended Fields" tab of the user, create an attribute and a container and click "Save". Rename the attribute and the container and click "Save" again. Reload the page to make sure, the changes are saved correctly.

### Related issue(s)/PR(s)
Resolves #16032
