### PR TITLE
Enable popper for the submenu too (opens on click)

### DIFF
--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -268,40 +268,43 @@
       }
     }
 
-    & li:hover ul ul,
-    & ul li:hover ul ul,
-    & ul ul li:hover ul ul {
-      display: none;
-    }
-
-    & li:hover ul,
-    & ul li:hover ul,
-    & ul ul li:hover ul,
-    & ul ul ul li:hover ul {
-      display: block;
-    }
-
     &.active {
       opacity: 1;
       visibility: visible;
     }
 
     .modx-subsubnav {
+      max-height: 99vh;
+      overflow-y: auto;
       border: 1px solid $navbarBorder;
       box-shadow: $boxShadowBig;
       border-radius: $borderRadius;
       background: $white;
-      display: none;
+      opacity: 0;
+      visibility: hidden;
       list-style: none;
       position: absolute;
-      left: 295px;
-      top: 0;
       z-index: 24;
-    }
-    &.modx-subnav-usernav {
-      .modx-subsubnav {
-        top: initial;
-        bottom: 0;
+      &.active {
+        opacity: 1;
+        visibility: visible;
+      }
+      &-arrow {
+        border: 8px solid transparent;
+        border-right-color: #FFF;
+        content: " ";
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translate(0, -50%);
+        z-index: 10010;
+        display: none;
+      }
+      &.active {
+        + .modx-subsubnav-arrow {
+          display: block;
+        }
       }
     }
 
@@ -314,12 +317,6 @@
       pointer-events: none;
       margin-top: -6px;
     }
-  }
-
-  // custom styles for language menu
-  #language .modx-subsubnav {
-    max-height: 86vh;
-    overflow-y: auto;
   }
 }
 
@@ -400,7 +397,6 @@
   #modx-footer {
     .modx-subnav {
       min-width: 300px;
-      top: 60px !important;
 
       .description {
         display: none;
@@ -437,8 +433,9 @@
       display: none;
     }
 
-    .modx-subnav-wrapper {
-      max-height: 400px;
+    // overflow for long subsubnav
+    .modx-subnav {
+      max-height: calc(99vh - 100px);
       overflow-y: auto;
     }
   }

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -323,6 +323,7 @@
   #language .modx-subsubnav {
     max-height: calc(100vh - 12px);
     overflow-y: auto;
+    overflow-x: hidden;
   }
 }
 
@@ -443,6 +444,7 @@
     .modx-subnav {
       max-height: calc(100vh - 109px);
       overflow-y: auto;
+      overflow-x: hidden;
     }
   }
 }

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -274,21 +274,15 @@
     }
 
     .modx-subsubnav {
-      max-height: 99vh;
+      max-height: calc(100vh - 12px);
       overflow-y: auto;
       border: 1px solid $navbarBorder;
       box-shadow: $boxShadowBig;
       border-radius: $borderRadius;
       background: $white;
-      opacity: 0;
-      visibility: hidden;
       list-style: none;
       position: absolute;
       z-index: 24;
-      &.active {
-        opacity: 1;
-        visibility: visible;
-      }
       &-arrow {
         border: 8px solid transparent;
         border-right-color: #FFF;
@@ -304,6 +298,14 @@
       &.active {
         + .modx-subsubnav-arrow {
           display: block;
+        }
+      }
+      @include grid-media($gtDesktop) {
+        opacity: 0;
+        visibility: hidden;
+        &.active {
+          opacity: 1;
+          visibility: visible;
         }
       }
     }
@@ -435,7 +437,7 @@
 
     // overflow for long subsubnav
     .modx-subnav {
-      max-height: calc(99vh - 100px);
+      max-height: calc(100vh - 109px);
       overflow-y: auto;
     }
   }

--- a/_build/templates/default/sass/_navbar.scss
+++ b/_build/templates/default/sass/_navbar.scss
@@ -274,8 +274,6 @@
     }
 
     .modx-subsubnav {
-      max-height: calc(100vh - 12px);
-      overflow-y: auto;
       border: 1px solid $navbarBorder;
       box-shadow: $boxShadowBig;
       border-radius: $borderRadius;
@@ -319,6 +317,12 @@
       pointer-events: none;
       margin-top: -6px;
     }
+  }
+
+  // custom styles for language menu
+  #language .modx-subsubnav {
+    max-height: calc(100vh - 12px);
+    overflow-y: auto;
   }
 }
 

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -508,6 +508,7 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                 for (var i = 0; i < buttons.length; i++) {
                     var submenu = buttons[i].getElementsByTagName('ul')[0];
                     submenu.classList.remove('active');
+                    submenu.removeAttribute('style');
                     buttons[i].classList.remove('active');
                 }
                 destroy();

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -388,7 +388,7 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
     ,initPopper: function() {
         var el = this;
         var buttons = document.getElementById('modx-navbar').getElementsByClassName('top');
-        var position = window.innerWidth <= 640 ? 'bottom' : 'right';
+        var position = window.innerWidth <= 960 ? 'bottom' : 'right';
         for (var i = 0; i < buttons.length; i++) {
             var submenu = document.getElementById(buttons[i].id + '-submenu');
             new Popper(buttons[i], submenu, {
@@ -404,7 +404,7 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                         enabled: true,
                         fn: function(data) {
                             for (var i in data.offsets.popper) {
-                                if (i != 'bottom' && i != 'right') {
+                                if (i !== 'bottom' && i !== 'right') {
                                     if (data.offsets.popper.hasOwnProperty(i)) {
                                         data.instance.popper.style[i] = !isNaN(parseFloat(data.offsets.popper[i]))
                                             ? data.offsets.popper[i] + 'px'
@@ -436,6 +436,9 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
         window.addEventListener('click', function() {
             el.hideMenu();
         });
+        if (window.innerWidth > 960) {
+            this.initSubPopper();
+        }
     }
 
     ,showMenu: function(el) {
@@ -446,11 +449,90 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
             this.hideMenu();
             submenu.classList.add('active');
         }
+        this.hideSubMenu();
     }
     ,hideMenu: function() {
         var submenus = document.getElementsByClassName('modx-subnav');
         for (var i = 0; i < submenus.length; i++) {
             submenus[i].classList.remove('active');
+        }
+    }
+
+    ,initSubPopper: function () {
+        var buttons = document.getElementById('modx-footer').querySelectorAll('.sub');
+        var position = window.innerWidth <= 960 ? 'bottom' : 'right';
+        for (var i = 0; i < buttons.length; i++) {
+            let popperInstance = null;
+            function create(button, submenu) {
+                popperInstance = new Popper(button, submenu, {
+                    placement: position,
+                    modifiers: {
+                        flip: {
+                            enabled: false
+                        },
+                        applyStyle: {
+                            enabled: true,
+                            fn: function(data) {
+                                for (var i in data.offsets.popper) {
+                                    if (i !== 'bottom' && i !== 'right') {
+                                        if (data.offsets.popper.hasOwnProperty(i)) {
+                                            data.instance.popper.style[i] = !isNaN(parseFloat(data.offsets.popper[i]))
+                                                ? data.offsets.popper[i] + 'px'
+                                                : data.offsets.popper[i];
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        preventOverflow: {
+                            boundariesElement: document.getElementById('modx-container'),
+                            priority: position === 'right'
+                                ? ['bottom','top']
+                                : ['left','right']
+                        }
+                    }
+                });
+            }
+            function destroy(){
+                if (popperInstance) {
+                    popperInstance.destroy();
+                    popperInstance = null;
+                }
+            }
+            function show(button, menu) {
+                menu.classList.add('active');
+                create(button, menu);
+            }
+            function hide(menu) {
+                var buttons = menu.querySelectorAll('.sub');
+                for (var i = 0; i < buttons.length; i++) {
+                    var submenu = buttons[i].getElementsByTagName('ul')[0];
+                    submenu.classList.remove('active');
+                    buttons[i].classList.remove('active');
+                }
+                destroy();
+            }
+            buttons[i].onclick = function(e) {
+                e.stopPropagation();
+                var submenu = this.getElementsByTagName('ul')[0];
+                var parentmenu = this.closest('ul');
+                hide(parentmenu);
+                if (this.classList.contains('active')) {
+                    this.classList.remove('active');
+                } else {
+                    this.classList.add('active');
+                    show(this, submenu);
+                }
+            };
+        }
+    }
+
+    ,hideSubMenu: function() {
+        var buttons = document.getElementById('modx-footer').querySelectorAll('.sub');
+        for (var i = 0; i < buttons.length; i++) {
+            var submenu = buttons[i].getElementsByTagName('ul')[0];
+            submenu.classList.remove('active');
+            buttons[i].classList.remove('active');
         }
     }
 

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -336,7 +336,7 @@ class TopMenu
             if (!empty($menu['children'])) {
                 $smTpl .= '<ul class="modx-subsubnav">'."\n";
                 $this->processSubMenus($smTpl, $menu['children']);
-                $smTpl .= '</ul>'."\n";
+                $smTpl .= '</ul><div class="modx-subsubnav-arrow"></div>'."\n";
             }
             $smTpl .= '</li>';
             $output .= $smTpl;

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -336,7 +336,7 @@ class TopMenu
             if (!empty($menu['children'])) {
                 $smTpl .= '<ul class="modx-subsubnav">'."\n";
                 $this->processSubMenus($smTpl, $menu['children']);
-                $smTpl .= '</ul><div class="modx-subsubnav-arrow"></div>'."\n";
+                $smTpl .= '</ul><div class="modx-subsubnav-arrow"></div>' . "\n";
             }
             $smTpl .= '</li>';
             $output .= $smTpl;


### PR DESCRIPTION
Same as #16041 but with click instead of hover.

The click menu has an issue, when the existing menu entry (which contains the submenu) has an action or a javascript handler attached. Then opening the submenu with a click will also run the action or the javascript.

If this change is accepted, the menu generating script has to be changed and existing menu entries with a submenu and an action/javascript have to be modified/moved with an update script.

Maybe this change is better moved to 3.1, but it is somehow breaking and for this reason it can be better added in 3.0.

Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/16029