### PR TITLE
Optionally determine context from config.context.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ web.config
 # ignore all config.core.php
 config.core.php
 
+# ignore all config.context.php
+config.context.php
+
 # ignore concatenated js
 modext.js
 

--- a/index.php
+++ b/index.php
@@ -47,8 +47,12 @@ if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
 /* Set the actual start time */
 $modx->startTime= $tstart;
 
-/* Initialize the default 'web' context */
-$modx->initialize('web');
+/* Initialize a context */
+$contextKey = 'web';
+if (is_readable(__DIR__ . '/config.context.php')) {
+    $contextKey = require __DIR__ . '/config.context.php';
+}
+$modx->initialize($contextKey);
 
 /* execute the request handler */
 if (!MODX_API_MODE) {

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
  * files found in the top-level directory of this distribution.
  */
 
-$tstart= microtime(true);
+$tstart = microtime(true);
 
 /* define this as true in another entry file, then include this file to simply access the API
  * without executing the MODX request handler */
@@ -18,13 +18,17 @@ if (!defined('MODX_API_MODE')) {
 
 /* include custom core config and define core path */
 @include(dirname(__FILE__) . '/config.core.php');
-if (!defined('MODX_CORE_PATH')) define('MODX_CORE_PATH', dirname(__FILE__) . '/core/');
-if (!defined('MODX_CONFIG_KEY')) define('MODX_CONFIG_KEY', 'config');
+if (!defined('MODX_CORE_PATH')) {
+    define('MODX_CORE_PATH', dirname(__FILE__) . '/core/');
+}
+if (!defined('MODX_CONFIG_KEY')) {
+    define('MODX_CONFIG_KEY', 'config');
+}
 
 /* include the autoloader */
-if (!@require_once (MODX_CORE_PATH . "vendor/autoload.php")) {
+if (!@require_once MODX_CORE_PATH . "vendor/autoload.php") {
     $errorMessage = 'Site temporarily unavailable';
-    @include(MODX_CORE_PATH . 'error/unavailable.include.php');
+    @include MODX_CORE_PATH . 'error/unavailable.include.php';
     header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
     echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
     exit();
@@ -34,18 +38,18 @@ if (!@require_once (MODX_CORE_PATH . "vendor/autoload.php")) {
 ob_start();
 
 /* Create an instance of the modX class */
-$modx= new \MODX\Revolution\modX();
+$modx = new \MODX\Revolution\modX();
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     ob_get_level() && @ob_end_flush();
     $errorMessage = '<a href="setup/">MODX not installed. Install now?</a>';
-    @include(MODX_CORE_PATH . 'error/unavailable.include.php');
+    @include MODX_CORE_PATH . 'error/unavailable.include.php';
     header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
     echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
     exit();
 }
 
 /* Set the actual start time */
-$modx->startTime= $tstart;
+$modx->startTime = $tstart;
 
 /* Initialize a context */
 $contextKey = 'web';


### PR DESCRIPTION
### What does it do?
Allows the `/index.php` file to look for an optional `/config.context.php` file in the same directory which returns the context key to use when initializing the modX class.

### Why is it needed?
This will allow a site to initialize a default context other than `web` based on simple logic determined in the optional `/config.context.php` file.

### How to test
Add a `/config.context.php` file in the base_path where the MODX /index.php file is which returns a string representing the context key to use when calling `modX::initialize()`. Ensure that this initializes the context you expect.

### Related issue(s)/PR(s)
Related to #14962
Alternative to #15944 
