### PR TITLE
Call OnFileManagerFileRename if upload_translit changes the name of a new file

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1130,7 +1130,19 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             }
 
             if ((boolean)$this->xpdo->getOption('upload_translit')) {
-                $file['name'] = $this->xpdo->filterPathSegment($file['name']);
+                $newName = $this->xpdo->filterPathSegment($file['name']);
+
+                // If the file name is different after filtering, call OnFileManagerFileRename
+                // so the change can be tracked by plugins
+                if ($newName !== $file['name']) {
+                    $path = $container . $this->sanitizePath($newName);
+                    $file['name'] = $newName;
+
+                    $this->xpdo->invokeEvent('OnFileManagerFileRename', [
+                        'path' => $path,
+                        'source' => &$this,
+                    ]);
+                }
             }
 
             $newPath = $container . $this->sanitizePath($file['name']);


### PR DESCRIPTION
### What does it do?
Calls the [OnFileManagerFileRename](https://docs.modx.com/current/en/extending-modx/plugins/system-events/onfilemanagerfilerename) event if the uploaded filename is changed by the automatic file name sanitisation (enabled with the upload_translit setting, new in 3.0 iirc). 

### Why is it needed?

With upload_translit enabled, the name of a file may change when uploaded. That can break extras/integrations that perform an upload through the uploadObjectsToContainer method, and expect to be able to refer to the file after. 

That's not a new problem; even in 2.x this situation can happen when using plugins that hook into OnFileManagerUpload to sanitise/localise the file name, such as filesluggy. However those use $source->renameObject which triggers OnFileManagerFileRename which the original integration can then listen to for identifying the new name. Because upload_translit happens pre-upload, there's no trace of it, and file references break.

Calling OnFileManagerFileRename for the upload_translit gives a consistent way to deal with this challenge.

### How to test

Enable upload_translit, confirm OnFileManagerFileRename gets executed with the correct (source-relative) path.

### Related issue(s)/PR(s)

No issue that I know off; noticed this myself when working on 3.0 compatibility for MoreGallery. 
