### PR TITLE
Changed the order of the fields in Form Customization

### DIFF
--- a/core/model/schema/modx.action.fields.schema.xml
+++ b/core/model/schema/modx.action.fields.schema.xml
@@ -22,10 +22,14 @@
             <field name="description" />
             <field name="introtext" />
         </tab>
+        <tab name="modx-resource-content">
+            <field name="modx-resource-content" />
+        </tab>
         <tab name="modx-resource-main-right">
         </tab>
         <tab name="modx-resource-main-right-top">
             <field name="published" />
+            <field name="deleted" />
             <field name="publishedon" />
             <field name="pub_date" />
             <field name="unpub_date" />
@@ -34,9 +38,9 @@
             <field name="template" />
         </tab>
         <tab name="modx-resource-main-right-bottom">
+            <field name="hidemenu" />
             <field name="menutitle" />
             <field name="link_attributes" />
-            <field name="hidemenu" />
             <field name="menuindex" />
         </tab>
         <tab name="modx-page-settings">
@@ -51,25 +55,20 @@
         </tab>
         <tab name="modx-page-settings-box-left">
             <field name="isfolder" />
-            <field name="alias_visible" />
+            <field name="show_in_tree" />
             <field name="hide_children_in_tree" />
             <field name="alias_visible" />
-            <field name="richtext" />
             <field name="uri_override" />
             <field name="uri" />
         </tab>
         <tab name="modx-page-settings-box-right">
+            <field name="richtext" />
             <field name="cacheable" />
             <field name="searchable" />
-            <field name="show_in_tree" />
             <field name="syncsite" />
-            <field name="deleted" />
         </tab>
         <tab name="modx-panel-resource-tv" other="tv" />
         <tab name="modx-resource-access-permissions" />
-        <tab name="modx-resource-content">
-            <field name="modx-resource-content" />
-        </tab>
     </action>
 
     <action controller="resource/create" form="modx-panel-resource">
@@ -83,10 +82,14 @@
             <field name="description" />
             <field name="introtext" />
         </tab>
+        <tab name="modx-resource-content">
+            <field name="modx-resource-content" />
+        </tab>
         <tab name="modx-resource-main-right">
         </tab>
         <tab name="modx-resource-main-right-top">
             <field name="published" />
+            <field name="deleted" />
             <field name="publishedon" />
             <field name="pub_date" />
             <field name="unpub_date" />
@@ -95,9 +98,9 @@
             <field name="template" />
         </tab>
         <tab name="modx-resource-main-right-bottom">
+            <field name="hidemenu" />
             <field name="menutitle" />
             <field name="link_attributes" />
-            <field name="hidemenu" />
             <field name="menuindex" />
         </tab>
         <tab name="modx-page-settings">
@@ -112,24 +115,19 @@
         </tab>
         <tab name="modx-page-settings-box-left">
             <field name="isfolder" />
+            <field name="show_in_tree" />
             <field name="hide_children_in_tree" />
             <field name="alias_visible" />
-            <field name="alias_visible" />
-            <field name="richtext" />
             <field name="uri_override" />
             <field name="uri" />
         </tab>
         <tab name="modx-page-settings-box-right">
+            <field name="richtext" />
             <field name="cacheable" />
             <field name="searchable" />
-            <field name="show_in_tree" />
             <field name="syncsite" />
-            <field name="deleted" />
         </tab>
         <tab name="modx-panel-resource-tv" other="tv" />
         <tab name="modx-resource-access-permissions" />
-        <tab name="modx-resource-content">
-            <field name="modx-resource-content" />
-        </tab>
     </action>
 </actions>

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -240,14 +240,14 @@ MODx.grid.FCSetFields = function(config) {
         ,fields: ['id','action','name','tab','tab_rank','other','rank','visible','label','default_value']
         ,autoHeight: true
         ,grouping: true
-        ,groupBy: 'tab'
+        ,groupBy: 'tab_rank'
         ,plugins: [this.vcb]
         ,stateful: false
         ,remoteSort: false
         ,sortBy: 'rank'
         ,sortDir: 'ASC'
         ,hideGroupedColumn: true
-        ,groupTextTpl: '{group} ({[values.rs.length]} {[values.rs.length > 1 ? "'+_('fields')+'" : "'+_('field')+'"]})'
+        ,groupTextTpl: '{[values.rs[0].data.tab]} ({[values.rs.length]} {[values.rs.length > 1 ? "'+_('fields')+'" : "'+_('field')+'"]})'
         ,columns: [{
             header: _('name')
             ,dataIndex: 'name'
@@ -255,6 +255,10 @@ MODx.grid.FCSetFields = function(config) {
         },{
             header: _('region')+' ('+_('tab_id')+')'
             ,dataIndex: 'tab'
+            ,width: 100
+        },{
+            header: _('tab_rank')
+            ,dataIndex: 'tab_rank'
             ,width: 100
         },this.vcb,{
             header: _('label')

--- a/manager/assets/modext/widgets/fc/modx.panel.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.panel.fcset.js
@@ -253,7 +253,7 @@ MODx.grid.FCSetFields = function(config) {
             ,dataIndex: 'name'
             ,width: 200
         },{
-            header: _('region')
+            header: _('region')+' ('+_('tab_id')+')'
             ,dataIndex: 'tab'
             ,width: 100
         },this.vcb,{
@@ -310,7 +310,7 @@ MODx.grid.FCSetTabs = function(config) {
         ,plugins: [this.vcb]
         ,stateful: false
         ,columns: [{
-            header: _('tab_id')
+            header: _('region')+' ('+_('tab_id')+')'
             ,dataIndex: 'name'
             ,width: 100
         },this.vcb,{
@@ -433,7 +433,7 @@ MODx.grid.FCSetTVs = function(config) {
             ,dataIndex: 'default_text'
             ,editable: false
         },{
-            header: _('region')
+            header: _('region')+' ('+_('tab_id')+')'
             ,dataIndex: 'tab'
             ,width: 100
             ,editor: { xtype: 'textfield' }
@@ -486,7 +486,7 @@ MODx.window.AddTabToSet = function(config) {
         },{
             xtype: 'textfield'
             ,name: 'name'
-            ,fieldLabel: _('tab_id')
+            ,fieldLabel: _('region')+' ('+_('tab_id')+')'
             ,id: 'modx-fcatab-id'
             ,allowBlank: false
             ,anchor: '100%'


### PR DESCRIPTION
### What does it do?
1) Changed the order of the fields in Form Customization as in the resource form.

Before:
![fcf_b](https://user-images.githubusercontent.com/12523676/153648533-bcf8e9a5-50a7-4fc2-b1fc-eb8b0fd18200.png)

After:
![fc_group](https://user-images.githubusercontent.com/12523676/154854035-77d0810c-3953-4fdf-87ad-07284c8341f4.png)

2) Set the headings of the regions in the same style.
The headings were called somewhere just "ID", somewhere "Region", which was confusing.
Now the "Region (ID)" is specified - now it is clear that this is a region, and its ID is involved in the rendering of forms.

### Why is it needed?
Now clearer when working with regions in FC

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14226
