### PR TITLE
Modify delete and undelete processors to respect syncsite setting

### DIFF
--- a/core/model/modx/processors/resource/create.class.php
+++ b/core/model/modx/processors/resource/create.class.php
@@ -728,7 +728,7 @@ class modResourceCreateProcessor extends modObjectCreateProcessor {
      * @return boolean
      */
     public function clearCache() {
-        $clear = $this->getProperty('syncsite',false) || $this->getProperty('clearCache',false);
+        $clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
         if ($clear) {
             $this->modx->cacheManager->refresh(array(
                 'db' => array(),

--- a/core/model/modx/processors/resource/delete.class.php
+++ b/core/model/modx/processors/resource/delete.class.php
@@ -253,7 +253,7 @@ class modResourceDeleteProcessor extends modProcessor {
 
     /**
      * Clear the site cache
-     * @return boolean site cache cleared status
+     * @return void
      */
     public function clearCache() {
 	$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
@@ -265,7 +265,6 @@ class modResourceDeleteProcessor extends modProcessor {
                 'resource' => array('contexts' => array($this->workingContext->get('key'))),
             ));
         }
-        return $clear;
     }
 
     /**

--- a/core/model/modx/processors/resource/delete.class.php
+++ b/core/model/modx/processors/resource/delete.class.php
@@ -253,10 +253,10 @@ class modResourceDeleteProcessor extends modProcessor {
 
     /**
      * Clear the site cache
-     * @return void
+     * @return boolean site cache cleared status
      */
     public function clearCache() {
-		$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
+	$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
         if ($clear) {
             $this->modx->cacheManager->refresh(array(
                 'db' => array(),

--- a/core/model/modx/processors/resource/delete.class.php
+++ b/core/model/modx/processors/resource/delete.class.php
@@ -256,12 +256,16 @@ class modResourceDeleteProcessor extends modProcessor {
      * @return void
      */
     public function clearCache() {
-        $this->modx->cacheManager->refresh(array(
-            'db' => array(),
-            'auto_publish' => array('contexts' => array($this->resource->get('context_key'))),
-            'context_settings' => array('contexts' => array($this->resource->get('context_key'))),
-            'resource' => array('contexts' => array($this->resource->get('context_key'))),
-        ));
+		$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
+        if ($clear) {
+            $this->modx->cacheManager->refresh(array(
+                'db' => array(),
+                'auto_publish' => array('contexts' => array($this->workingContext->get('key'))),
+                'context_settings' => array('contexts' => array($this->workingContext->get('key'))),
+                'resource' => array('contexts' => array($this->workingContext->get('key'))),
+            ));
+        }
+        return $clear;
     }
 
     /**

--- a/core/model/modx/processors/resource/publish.class.php
+++ b/core/model/modx/processors/resource/publish.class.php
@@ -134,12 +134,15 @@ class modResourcePublishProcessor extends modProcessor {
      * @return void
      */
     public function clearCache() {
-        $this->modx->cacheManager->refresh(array(
-            'db' => array(),
-            'auto_publish' => array('contexts' => array($this->resource->get('context_key'))),
-            'context_settings' => array('contexts' => array($this->resource->get('context_key'))),
-            'resource' => array('contexts' => array($this->resource->get('context_key'))),
-        ));
+    	$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
+		if ($clear) {
+            $this->modx->cacheManager->refresh(array(
+                'db' => array(),
+                'auto_publish' => array('contexts' => array($this->resource->get('context_key'))),
+                'context_settings' => array('contexts' => array($this->resource->get('context_key'))),
+                'resource' => array('contexts' => array($this->resource->get('context_key'))),
+            ));
+        }
     }
 }
 return 'modResourcePublishProcessor';

--- a/core/model/modx/processors/resource/undelete.class.php
+++ b/core/model/modx/processors/resource/undelete.class.php
@@ -161,12 +161,15 @@ class modResourceUnDeleteProcessor extends modProcessor {
      * @return void
      */
     public function clearCache() {
-        $this->modx->cacheManager->refresh(array(
-            'db' => array(),
-            'auto_publish' => array('contexts' => array($this->resource->get('context_key'))),
-            'context_settings' => array('contexts' => array($this->resource->get('context_key'))),
-            'resource' => array('contexts' => array($this->resource->get('context_key'))),
-        ));
+			$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
+			if ($clear) {
+                $this->modx->cacheManager->refresh(array(
+                    'db' => array(),
+                    'auto_publish' => array('contexts' => array($this->resource->get('context_key'))),
+                    'context_settings' => array('contexts' => array($this->resource->get('context_key'))),
+                    'resource' => array('contexts' => array($this->resource->get('context_key'))),
+                ));
+			}
     }
 }
 return 'modResourceUnDeleteProcessor';

--- a/core/model/modx/processors/resource/unpublish.class.php
+++ b/core/model/modx/processors/resource/unpublish.class.php
@@ -118,12 +118,15 @@ class modResourceUnPublishProcessor extends modProcessor {
      * @return void
      */
     public function clearCache() {
-        $this->modx->cacheManager->refresh(array(
-            'db' => array(),
-            'auto_publish' => array('contexts' => array($this->resource->get('context_key'))),
-            'context_settings' => array('contexts' => array($this->resource->get('context_key'))),
-            'resource' => array('contexts' => array($this->resource->get('context_key'))),
-        ));
+		$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
+		if ($clear) {
+            $this->modx->cacheManager->refresh(array(
+                'db' => array(),
+                'auto_publish' => array('contexts' => array($this->resource->get('context_key'))),
+                'context_settings' => array('contexts' => array($this->resource->get('context_key'))),
+                'resource' => array('contexts' => array($this->resource->get('context_key'))),
+            ));
+        }
     }
 
 }

--- a/core/model/modx/processors/resource/update.class.php
+++ b/core/model/modx/processors/resource/update.class.php
@@ -890,9 +890,8 @@ class modResourceUpdateProcessor extends modObjectUpdateProcessor {
      * @return void
      */
     public function clearCache() {
-        $syncSite = $this->getProperty('syncsite',false);
-        $clearCache = $this->getProperty('clearCache',false);
-        if (!empty($syncSite) || !empty($clearCache)) {
+		$clear = $this->getProperty('syncsite',$this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache',false);
+        if ($clear) {
             $contexts = array($this->object->get('context_key'));
             if (!empty($this->oldContext)) {
                 $contexts[] = $this->oldContext->get('key');


### PR DESCRIPTION
### What does it do?
Makes resource delete, undelete, publish and unpublish processors to use syncsite property and the syncsite_default system setting.

### Why is it needed?
'syncsite' is a property that add the possibility to enable/disable the clearing of the cache in the resource create/update processors.
But it is not taken into account in the resource delete/undelete/publish/unpublish processors that would always clear the cache when called...
It would be now with this PR.

On the other hand, the system setting 'syncsite_default' seems to not be used to default syncsite property in the create/update  processors that is hard coded to false ...
This PR uses this system setting to default syncsite property in the processors.

### How to test
* change system setting "syncsite_default" to false and see how it now behaves when saving/changing resources with the cache...
* call the processors with "syncsite" property with true or false value 

### Related issue(s)/PR(s)
* #11980 about delete/undelete processors
* #12593 
