### PR TITLE
Rename the lexicon key and text of mail_smtp_prefix

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -857,9 +857,9 @@ $settings['mail_smtp_port']->fromArray([
   'area' => 'mail',
   'editedon' => null,
 ], '', true, true);
-$settings['mail_smtp_prefix'] = $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_prefix']->fromArray([
-  'key' => 'mail_smtp_prefix',
+$settings['mail_smtp_secure'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_secure']->fromArray([
+  'key' => 'mail_smtp_secure',
   'value' => '',
   'xtype' => 'textfield',
   'namespace' => 'core',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -381,11 +381,11 @@ $_lang['setting_mail_smtp_pass_desc'] = 'The password to authenticate to SMTP ag
 $_lang['setting_mail_smtp_port'] = 'SMTP Port';
 $_lang['setting_mail_smtp_port_desc'] = 'Sets the default SMTP server port.';
 
-$_lang['setting_mail_smtp_prefix'] = 'SMTP Connection Prefix';
-$_lang['setting_mail_smtp_prefix_desc'] = 'Sets connection prefix. Options are "", "ssl" or "tls"';
+$_lang['setting_mail_smtp_secure'] = 'SMTP Secure';
+$_lang['setting_mail_smtp_secure_desc'] = 'Sets SMTP secure encyption type. Options are "", "ssl" or "tls"';
 
 $_lang['setting_mail_smtp_autotls'] = 'SMTP Auto TLS';
-$_lang['setting_mail_smtp_autotls_desc'] = 'Whether to enable TLS encryption automatically if a server supports it, even if "SMTP Encryption" is not set to "tls"';
+$_lang['setting_mail_smtp_autotls_desc'] = 'Whether to enable TLS encryption automatically if a server supports it, even if "SMTP Secure" is not set to "tls"';
 
 $_lang['setting_mail_smtp_single_to'] = 'SMTP Single To';
 $_lang['setting_mail_smtp_single_to_desc'] = 'Provides the ability to have the TO field process individual emails, instead of sending to entire TO addresses.';

--- a/core/src/Revolution/Mail/modMail.php
+++ b/core/src/Revolution/Mail/modMail.php
@@ -112,9 +112,9 @@ abstract class modMail
      */
     const MAIL_SMTP_PORT = 'mail_smtp_port';
     /**
-     * @const An option for setting the mail SMTP prefix
+     * @const An option for setting the mail SMTP secure encryption type
      */
-    const MAIL_SMTP_PREFIX = 'mail_smtp_prefix';
+    const MAIL_SMTP_SECURE = 'mail_smtp_secure';
     /**
      * @const An option for setting the mail SMTP AutoTLS option
      */
@@ -253,7 +253,7 @@ abstract class modMail
             $default[modMail::MAIL_SMTP_KEEPALIVE] = $this->modx->getOption('mail_smtp_keepalive', null, false);
             $default[modMail::MAIL_SMTP_PASS] = $this->modx->getOption('mail_smtp_pass', null, '');
             $default[modMail::MAIL_SMTP_PORT] = $this->modx->getOption('mail_smtp_port', null, 25);
-            $default[modMail::MAIL_SMTP_PREFIX] = $this->modx->getOption('mail_smtp_prefix', null, '');
+            $default[modMail::MAIL_SMTP_SECURE] = $this->modx->getOption('mail_smtp_secure', null, '');
             $default[modMail::MAIL_SMTP_AUTOTLS] = $this->modx->getOption('mail_smtp_autotls',null,true);
             $default[modMail::MAIL_SMTP_SINGLE_TO] = $this->modx->getOption('mail_smtp_single_to', null, false);
             $default[modMail::MAIL_SMTP_TIMEOUT] = $this->modx->getOption('mail_smtp_timeout', null, 10);

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -110,7 +110,7 @@ class modPHPMailer extends modMail
             case modMail::MAIL_SMTP_PORT :
                 $this->mailer->Port = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_PREFIX :
+            case modMail::MAIL_SMTP_SECURE :
                 $this->mailer->SMTPSecure = $this->attributes[$key];
                 break;
             case modMail::MAIL_SMTP_AUTOTLS :

--- a/setup/includes/upgrades/common/3.0.0-update-smtp-system-settings.php
+++ b/setup/includes/upgrades/common/3.0.0-update-smtp-system-settings.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Update the keys for smptp system settings
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$settingKeysMap = [
+    [
+        'old_key' => 'mail_smtp_prefix',
+        'new_key' => 'mail_smtp_secure',
+    ]
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+foreach ($settingKeysMap as $setting) {
+    /** @var modSystemSetting $systemSetting */
+    $systemSetting = $modx->getObject(modSystemSetting::class, [
+        'key' => $setting['old_key']
+    ]);
+    if ($systemSetting instanceof modSystemSetting) {
+        $systemSetting->set('key', $setting['new_key']);
+        if ($systemSetting->save()) {
+            $this->runner->addResult(
+                modInstallRunner::RESULT_SUCCESS,
+                sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_rename_key_success', $setting))
+            );
+        } else {
+            $this->runner->addResult(
+                modInstallRunner::RESULT_ERROR,
+                sprintf($messageTemplate, 'error', $this->install->lexicon('system_setting_rename_key_failure', $setting))
+            );
+        }
+    }
+}

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -53,3 +53,5 @@ $_lang['system_setting_update_xtype_success'] = 'Successfully changed the xtype 
 $_lang['system_setting_update_xtype_failure'] = 'Failed to change the xtype for System Setting `[[+key]]` from `[[+old_xtype]]` to `[[+new_xtype]]`.';
 $_lang['system_setting_update_success'] = 'System Setting `[[+key]]` updated.';
 $_lang['system_setting_update_failed'] = 'System Setting `[[+key]]` could not be updated.';
+$_lang['system_setting_rename_key_success'] = 'Successfully renamed the System Setting key from `[[+old_key]]` to `[[+new_key]]`.';
+$_lang['system_setting_rename_key_failure'] = 'Failed to rename the System Setting key from `[[+old_key]]` to `[[+new_key]]`.';


### PR DESCRIPTION
### What does it do?
Change the lexicon key and text for `mail_smtp_prefix`

### Why is it needed?
The current text is a bit misleading. This setting sets the value of `SMTPSecure` in PHPMailer 6. The description in PHPMailer is `What kind of encryption to use on the SMTP connection`.

### Related issue(s)/PR(s)
Improved version of #15527 (renaming the key too). Supercedes #15555 (see the discussion there).
