### PR TITLE
Add remembering filter properties of template TVs grid in browser url

### DIFF
--- a/core/src/Revolution/Processors/Element/Template/TemplateVar/GetList.php
+++ b/core/src/Revolution/Processors/Element/Template/TemplateVar/GetList.php
@@ -47,14 +47,16 @@ class GetList extends GetListProcessor
 
         $category = (integer)$this->getProperty('category', 0);
         if ($category) {
-            $conditions['category'] = $category;
+            $conditions[] = ['category' => $category];
         }
 
-        $search = $this->getProperty('search', '');
-        if (!empty($search)) {
-            $conditions['name:LIKE'] = '%' . $search . '%';
-            $conditions['OR:description:LIKE'] = '%' . $search . '%';
-            $conditions['OR:caption:LIKE'] = '%' . $search . '%';
+        $query = $this->getProperty('query', '');
+        if (!empty($query)) {
+            $conditions[] = [
+                'name:LIKE' => '%' . $query . '%',
+                'OR:caption:LIKE' => '%' . $query . '%',
+                'OR:description:LIKE' => '%' . $query . '%',
+            ];
         }
 
         return $conditions;

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -284,6 +284,7 @@ MODx.panel.Template = function(config) {
             },{
                 xtype: 'modx-grid-template-tv'
                 ,cls:'main-wrapper'
+                ,urlFilters: ['category', 'query']
                 ,preventRender: true
                 ,anchor: '100%'
                 ,template: config.template


### PR DESCRIPTION
### What does it do?
- Added the selected filter properties in the browser url.

![tpl_tv_url](https://user-images.githubusercontent.com/12523676/154726652-9e9e3fbb-1b0e-4572-8598-9d2fbd0448a7.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/15946
https://github.com/modxcms/revolution/pull/15942
https://github.com/modxcms/revolution/pull/15935
https://github.com/modxcms/revolution/pull/15186
https://github.com/modxcms/revolution/pull/15185
https://github.com/modxcms/revolution/pull/15184
https://github.com/modxcms/revolution/pull/15183
https://github.com/modxcms/revolution/pull/15182
https://github.com/modxcms/revolution/pull/15181
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086