### PR TITLE
Move the existing value of mail_smtp_prefix to mail_smtp_secure

### DIFF
--- a/setup/includes/upgrades/mysql/3.0.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.0-pl.php
@@ -35,3 +35,4 @@ include dirname(__DIR__) . '/common/3.0.0-non-index-field-length.php';
 include dirname(__DIR__) . '/common/3.0.0-template-preview.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-content-type-field.php';
 include dirname(__DIR__) . '/common/3.0.0-remove-logs-permission.php';
+include dirname(__DIR__) . '/common/3.0.0-update-smtp-system-settings.php';


### PR DESCRIPTION
### What does it do?
Copy the existing value of mail_smtp_prefix to mail_smtp_secure if the new mail_smtp_secure key exist and remove the mail_smtp_prefix setting on success.

### Why is it needed?
The system setting mail_smtp_secure can be created during the update before the upgrade script is executed.

### Related issue(s)/PR(s)
#16062
