### PR TITLE
Have the template picker respect new resource action permissions

### DIFF
--- a/core/src/Revolution/Processors/System/Derivatives/GetList.php
+++ b/core/src/Revolution/Processors/System/Derivatives/GetList.php
@@ -10,6 +10,10 @@
 
 namespace MODX\Revolution\Processors\System\Derivatives;
 
+use MODX\Revolution\modDocument;
+use MODX\Revolution\modStaticResource;
+use MODX\Revolution\modSymLink;
+use MODX\Revolution\modWebLink;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
 use xPDO\Om\xPDOObject;
@@ -52,9 +56,9 @@ class GetList extends Processor
         $actions = explode(',', $this->getProperty('restrict_actions'));
 
         $map = [
-            'MODX\Revolution\modWebLink' => 'weblink',
-            'MODX\Revolution\modSymLink' => 'symlink',
-            'MODX\Revolution\modStaticResource' => 'static_resource',
+            modWebLink::class => 'weblink',
+            modSymLink::class => 'symlink',
+            modStaticResource::class => 'static_resource',
         ];
 
         foreach ($actions as $action) {
@@ -63,7 +67,7 @@ class GetList extends Processor
             }
 
             foreach ($descendents as $descendent) {
-                if ($descendent === 'MODX\Revolution\modDocument') {
+                if ($descendent === modDocument::class) {
                     continue;
                 }
 

--- a/manager/assets/modext/widgets/resource/modx.window.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.window.resource.js
@@ -9,6 +9,11 @@ MODx.window.CreateResource = function(config = {}) {
                   items: [
                       {
                           xtype: 'modx-combo-class-derivatives',
+                          baseParams: {
+                              'action': 'System/Derivatives/GetList',
+                              'class': 'MODX\\Revolution\\modResource',
+                              'restrict_actions': 'new'
+                          },
                           fieldLabel: _('resource_type'),
                           description: MODx.expandHelp ? '' : _('resource_type_help'),
                           name: 'class_key',


### PR DESCRIPTION
### What does it do?
Adds an optional `restrict_actions` parameter to the `System/Derivatives/GetList` processor. Allowed values are `new`,`edit` or `delete`. This allows for checking newly introduced resource action permissions.

### Why is it needed?
The resource type dropdown in the template picker was not respecting these new permissions.

### How to test
Create a user that does not have one or more of these permissions: 
`new_weblink`, `new_symlink` or `new_static_resource`
Then open the template picker and check the resource type list.

### Related issue(s)/PR(s)
#15893 