### PR TITLE
Stay on the current page after language switch

### DIFF
--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -103,9 +103,7 @@ class modMenu extends modAccessibleObject
                     strtoupper($code)
                 ),
                 'parent' => 'language',
-                'action' => 'language',
-                'params' => '&switch=' . $code,
-                'namespace' => 'core',
+                'handler' => 'MODx.switchLanguage("' . $code . '"); return false;',
                 'permissions' => ''
             ];
         }

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -742,6 +742,16 @@ Ext.extend(MODx,Ext.Component,{
         MODx.createResourceWindow.setValues(record);
         MODx.createResourceWindow.show();
     }
+
+    ,switchLanguage: function(lang) {
+        var params = {
+            switch: lang
+        };
+        Ext.iterate(MODx.request, function (key, value) {
+            params['target_' + key] = value;
+        });
+        MODx.loadPage('language', params);
+    }
 });
 Ext.reg('modx',MODx);
 

--- a/manager/controllers/default/language.class.php
+++ b/manager/controllers/default/language.class.php
@@ -22,9 +22,16 @@ class LanguageManagerController extends modParsedManagerController
             return;
         }
 
+        $targetProperties = [];
+        foreach ($scriptProperties as $key => $value) {
+            if (strpos($key, 'target_') === 0) {
+                $key = substr($key, strlen('target_'));
+                $targetProperties[$key] = $value;
+            }
+        }
         $_SESSION['manager_language'] = $targetLanguage;
 
-        $this->modx->sendRedirect(MODX_MANAGER_URL);
+        $this->modx->sendRedirect(MODX_MANAGER_URL . (($targetProperties) ? '?' . http_build_query($targetProperties) : ''));
     }
 
     public function getPageTitle()


### PR DESCRIPTION
### What does it do?
It adds a new handler method for the language menu entries that collects the request parameter of the current page (in MODx.request) and includes them into the language redirect. Otherwise fallback to the manager base URL.

### Why is it needed?
Fix the issue that the user always returns to the manager base URL after switching the language.

### How to test
Since modx.js is changed you have to run `grunt build`. Afterwards change to any manager page i.e. manager/?a=system/settings and switch the language with the menu. The manager loads the system settings page with the switched language.

### Related issue(s)/PR(s)
Improve #15895 without the open redirect vulnerability, #15174, #14046