### PR TITLE
redo 15787 without CS cleanup

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -158,7 +158,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                 $dirnames[] = strtoupper($fileName);
                 $directories[$fileName] = array(
-                    'id' => $bases['urlRelative'].rtrim($fileName,'/').'/',
+                    'id' => rawurlencode($bases['urlRelative'].rtrim($fileName, '/').'/'),
                     'text' => $fileName,
                     'cls' => implode(' ',$cls),
                     'iconCls' => 'icon icon-folder',
@@ -199,7 +199,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
 
                 $filenames[] = strtoupper($fileName);
                 $files[$fileName] = array(
-                    'id' => $bases['urlRelative'].$fileName,
+                    'id' => rawurlencode($bases['urlRelative'].$fileName),
                     'text' => $fileName,
                     'cls' => implode(' ',$cls),
                     'iconCls' => 'icon icon-file icon-'.$ext . ($file->isWritable() ? '' : ' icon-lock'),

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -212,7 +212,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
                 $filenames[] = strtoupper($fileName);
                 $files[$currentPath] = array(
-                    'id' => $currentPath,
+                    'id' => rawurlencode($currentPath),
                     'text' => $fileName,
                     'cls' => implode(' ', $cls),
                     'iconCls' => 'icon icon-file icon-'.$ext,
@@ -451,7 +451,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
 
                 $filenames[] = strtoupper($fileName);
                 $fileArray = array(
-                    'id' => $currentPath,
+                    'id' => rawurlencode($currentPath),
                     'name' => $fileName,
                     'url' => $url,
                     'relativeUrl' => $url,


### PR DESCRIPTION
What does it do?
Allows special characters in folder names.

Why is it needed?
ExtJs was having an issue when utilizing special characters, causing the user to be unable to edit a file or folder.

Additionally added some logic optimization suggestions from CodeSniffer

How to test
I created a folder named umlaute (äöü) and was unable to interact with it until applying the changes.

Related issue(s)/PR(s)
Issue https://github.com/modxcms/revolution/issues/15659
Pull Request: https://github.com/modxcms/revolution/pull/15787
