### PR TITLE
Add a setting to set the order of System Settings Areas

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -920,6 +920,15 @@ $settings['manager_favicon_url']->fromArray([
   'area' => 'manager',
   'editedon' => null,
 ], '', true, true);
+$settings['manager_settings_areas_order'] = $xpdo->newObject(modSystemSetting::class);
+$settings['manager_settings_areas_order']->fromArray([
+  'key' => 'manager_settings_areas_order',
+  'value' => 'site, editor, furls, gateway, file, caching, mail, manager, language, static_resources, static_elements, authentication, proxy, session, phpthumb, system',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+], '', true, true);
 $settings['manager_time_format'] = $xpdo->newObject(modSystemSetting::class);
 $settings['manager_time_format']->fromArray([
   'key' => 'manager_time_format',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -432,6 +432,9 @@ $_lang['setting_manager_theme_desc'] = 'Select the Theme for the Content Manager
 $_lang['setting_manager_logo'] = 'Manager Logo';
 $_lang['setting_manager_logo_desc'] = 'The logo to show in the Content Manager header.';
 
+$_lang['setting_manager_settings_areas_order'] = 'Areas Order in System Settings';
+$_lang['setting_manager_settings_areas_order_desc'] = 'Here you can set the order of Areas via their aliases in System Settings section, separated by commas (by default: site, editor, furls, gateway, file, caching, mail, manager, language, static_resources, static_elements, authentication, proxy, session, phpthumb, system).';
+
 $_lang['setting_manager_time_format'] = 'Manager Time Format';
 $_lang['setting_manager_time_format_desc'] = 'The format string, in PHP date() format, for the time settings represented in the manager.';
 

--- a/core/src/Revolution/Processors/System/Settings/GetAreas.php
+++ b/core/src/Revolution/Processors/System/Settings/GetAreas.php
@@ -118,6 +118,11 @@ class GetAreas extends Processor
             'COUNT(settingsCount.' . $this->modx->escape('key') . ') AS num_settings',
         ]);
         $c->groupby('settingsArea.' . $this->modx->escape('area') . ', settingsArea.' . $this->modx->escape('namespace'));
+        $areasOrderSetting = $this->modx->getOption('manager_settings_areas_order', null, '');
+        if ($areasOrderSetting) {
+            $areasOrder = "'" . str_replace(",", "', '", (str_replace(' ', '', str_replace("'", "", $areasOrderSetting)))) . "'";
+            $c->sortby("FIELD(settingsArea.area, " . $areasOrder . "), 'ASC'");
+        }
         $c->sortby($this->modx->escape('area'), $this->getProperty('dir', 'ASC'));
         return $c;
     }

--- a/core/src/Revolution/mysql/modSystemSetting.php
+++ b/core/src/Revolution/mysql/modSystemSetting.php
@@ -138,6 +138,11 @@ class modSystemSetting extends \MODX\Revolution\modSystemSetting
         $c->where($criteria);
 
         $count = $xpdo->getCount(\MODX\Revolution\modSystemSetting::class, $c);
+        $areasOrderSetting = $xpdo->getOption('manager_settings_areas_order', null, '');
+        if ($areasOrderSetting) {
+            $areasOrder = "'" . str_replace(",", "', '", (str_replace(' ', '', str_replace("'", "", $areasOrderSetting)))) . "'";
+            $c->sortby("FIELD(modSystemSetting.area, " . $areasOrder . "), 'ASC'");
+        }
         $c->sortby($xpdo->getSelectColumns(\MODX\Revolution\modSystemSetting::class, 'modSystemSetting', '', ['area']), 'ASC');
         foreach ($sort as $field => $dir) {
             $c->sortby($xpdo->getSelectColumns(\MODX\Revolution\modSystemSetting::class, 'modSystemSetting', '', [$field]), $dir);

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -203,6 +203,7 @@ MODx.grid.SettingsGrid = function(config) {
         ,groupBy: 'area_text'
         ,singleText: _('setting')
         ,pluralText: _('settings')
+        ,remoteSort: true
         ,sortBy: 'key'
         ,plugins: this.exp
         ,primaryKey: 'key'


### PR DESCRIPTION
### What does it do?
Add a setting to set the order of System Settings Areas.

Areas in System Settings are arranged alphabetically by their aliases. At the same time, their text names (and in translation) are displayed in the list of filters or in the grid, i.e. it is difficult to understand by what logic they are sorted.

And, for example, areas that should be visible to the user immediately and are often used, for example, "Site" are located at the bottom, which again is not convenient.

Added a setting that allows you to set your order of areas.

![sys_setting_order](https://user-images.githubusercontent.com/12523676/155343741-493c3c8c-7449-4393-bdf6-9a0018a2a2c4.png)

It might be worth discussing/thinking more about the order of areas that are set by default.

### Why is it needed?
UI/UX improvement.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/14254
