### PR TITLE
Update PHP versions in setup tests

### DIFF
--- a/setup/includes/test/modinstalltest.class.php
+++ b/setup/includes/test/modinstalltest.class.php
@@ -66,8 +66,8 @@ abstract class modInstallTest
         $this->title('php_version', $this->install->lexicon('test_php_version_start') . ' ');
         $phpVersion = phpversion();
 
-        $recommended_version = "7.2";
-        $required_version = "7.0";
+        $recommended_version = "7.3";
+        $required_version = "7.2.5";
 
         $php_ver_comp = version_compare($phpVersion, $required_version, '>=');
 

--- a/setup/provisioner/requirements.php
+++ b/setup/provisioner/requirements.php
@@ -9,7 +9,7 @@
  * files found in the top-level directory of this distribution.
  */
 
-define('MODX_MINIMUM_REQUIRED_PHP_VERSION', '7.2.0');
+define('MODX_MINIMUM_REQUIRED_PHP_VERSION', '7.2.5');
 define('MODX_REQUIRED_EXTENSIONS', [
     "curl",
     "dom",


### PR DESCRIPTION
### What does it do?
Updates the required and recommended PHP versions in the setup version check.

### Why is it needed?
The version checks were outdated, allowing the installation of a downloaded distribution on versions that will not work.

### How to test
Try to install a distribution (not from git) on any PHP version prior to 7.2.5 and confirm it fails.

### Related issue(s)/PR(s)
n/a