### PR TITLE
Fix static elements in 3.0

### DIFF
--- a/core/src/Revolution/Processors/Element/Create.php
+++ b/core/src/Revolution/Processors/Element/Create.php
@@ -79,17 +79,10 @@ abstract class Create extends CreateProcessor
 
         if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
             if ($this->object->get('content') !== '' && !$this->object->isStaticSourceMutable()) {
-                $source = $this->object->getSource();
-                if ($source && $source->hasErrors()) {
-                    $this->addFieldError('static_file', reset($source->getErrors()));
-                } else {
-                    $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-                }
-            } else {
-                if (!$this->object->isStaticSourceValidPath()) {
-                    $this->addFieldError('static_file',
-                        $this->modx->lexicon('element_static_source_protected_invalid'));
-                }
+                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
+            }
+            elseif (!$this->object->isStaticSourceValidPath()) {
+                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
             }
         }
 

--- a/core/src/Revolution/Processors/Element/Create.php
+++ b/core/src/Revolution/Processors/Element/Create.php
@@ -77,13 +77,11 @@ abstract class Create extends CreateProcessor
         $this->setElementProperties();
         $this->validateElement();
 
-        if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
-            if ($this->object->get('content') !== '' && !$this->object->isStaticSourceMutable()) {
-                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-            }
-            elseif (!$this->object->isStaticSourceValidPath()) {
-                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
-            }
+        if (
+            ($this->object->staticSourceChanged() || $this->object->staticContentChanged())
+            && !$this->object->isStaticSourceValidPath()
+        ) {
+            $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
         }
 
         return !$this->hasErrors();

--- a/core/src/Revolution/Processors/Element/Update.php
+++ b/core/src/Revolution/Processors/Element/Update.php
@@ -72,17 +72,10 @@ abstract class Update extends UpdateProcessor
         /* can't change content if static source is not writable */
         if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
             if (!$this->object->isStaticSourceMutable()) {
-                $source = $this->object->getSource();
-                if ($source && $source->hasErrors()) {
-                    $this->addFieldError('static_file', reset($source->getErrors()));
-                } else {
-                    $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-                }
-            } else {
-                if (!$this->object->isStaticSourceValidPath()) {
-                    $this->addFieldError('static_file',
-                        $this->modx->lexicon('element_static_source_protected_invalid'));
-                }
+                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
+            }
+            elseif (!$this->object->isStaticSourceValidPath()) {
+                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
             }
         }
 

--- a/core/src/Revolution/Processors/Element/Update.php
+++ b/core/src/Revolution/Processors/Element/Update.php
@@ -70,13 +70,11 @@ abstract class Update extends UpdateProcessor
         }
 
         /* can't change content if static source is not writable */
-        if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
-            if (!$this->object->isStaticSourceMutable()) {
-                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-            }
-            elseif (!$this->object->isStaticSourceValidPath()) {
-                $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
-            }
+        if (
+            ($this->object->staticSourceChanged() || $this->object->staticContentChanged())
+            && !$this->object->isStaticSourceValidPath()
+        ) {
+            $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
         }
 
         return !$this->hasErrors();

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -197,7 +197,7 @@ class modElement extends modAccessibleSimpleObject
             if ($this->staticSourceChanged()) {
                 $staticContent = $this->getFileContent();
                 if ($staticContent !== $this->get('content')) {
-                    if ($this->isStaticSourceMutable() && $staticContent === '') {
+                    if ($staticContent === '') {
                         $this->setDirty('content');
                     } else {
                         $this->setContent($staticContent);
@@ -207,7 +207,7 @@ class modElement extends modAccessibleSimpleObject
             }
 
             $staticContentChanged = $this->staticContentChanged();
-            if ($staticContentChanged && !$this->isStaticSourceMutable()) {
+            if ($staticContentChanged) {
                 $this->setContent($this->getFileContent());
                 $staticContentChanged = false;
             }
@@ -691,7 +691,7 @@ class modElement extends modAccessibleSimpleObject
                 }
             }
             else {
-                $set = file_put_contents($sourceFile, $content) > 0;
+                $set = $this->xpdo->getCacheManager()->writeFile($sourceFile, $content);
             }
         }
 
@@ -1139,27 +1139,10 @@ class modElement extends modAccessibleSimpleObject
      * Return if the static source is mutable.
      *
      * @return boolean True if the source file is mutable.
+     * @deprecated Unreliable; just try to write a file and act on errors.
      */
     public function isStaticSourceMutable()
     {
-        $file = $this->getSourceFile();
-        if (!$file) {
-            return false;
-        }
-
-        if (file_exists($file)) {
-            return is_writable($file) && !is_dir($file);
-        }
-
-        $path = dirname($file);
-        if (file_exists($path) && is_dir($path)) {
-            return is_writable($path);
-        }
-
-        // As we got a value from getSourceFile, but not a full path, it's safe to assume this
-        // is a source-relative path that cannot be converted directly to a local path (eg S3, FTP).
-        // While we don't know for sure if a write will be successful, we return true here to avoid
-        // not trying to write to a remote media source at all.
         return true;
     }
 


### PR DESCRIPTION
In progress - will add to this tomorrow. Alternative to #16070 that's focused on the current problems rather than refactoring.

Any local filesystem based static source should write to the absolute path returned in getSourceFile without checking extensions.. media sources internally still restrict extensions for non-local elements.

### What does it do?
Describe the technical changes you made.

### Why is it needed?
Describe the issue you are solving.

### How to test
Describe how to test the changes you made.

### Related issue(s)/PR(s)
Provide any issue that's addressed by this change in the format "Resolves #<issue number>", and mention other issues/pull requests with relevant information. 
