### PR TITLE
Fix typo on permission 'delete_static_resource'

### DIFF
--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -567,7 +567,7 @@ class Update extends UpdateProcessor
                 $map = [
                     modWebLink::class => 'delete_weblink',
                     modSymLink::class => 'delete_symlink',
-                    modStaticResource::class => 'delete_static_resource',
+                    modStaticResource::class => 'delete_resource',
                 ];
 
                 if (array_key_exists($this->object->get('class_key'), $map)) {
@@ -584,7 +584,7 @@ class Update extends UpdateProcessor
             }
         }
 
-        return $deleted;
+        return (bool)$deleted;
     }
 
     /**

--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -567,7 +567,7 @@ class Update extends UpdateProcessor
                 $map = [
                     modWebLink::class => 'delete_weblink',
                     modSymLink::class => 'delete_symlink',
-                    modStaticResource::class => 'delete_resource',
+                    modStaticResource::class => 'delete_static_resource',
                 ];
 
                 if (array_key_exists($this->object->get('class_key'), $map)) {


### PR DESCRIPTION
### What does it do?
Corrects the permission name in the resource update processor.

I also cast the return of this method as bool since it was creating an error when null was returned due to the return type being specified.

### Why is it needed?
The permission `delete_resource` doesn't exist.

### How to test
Check the permissions list


