### PR TITLE
Add remembering filter properties of Access Policies grid in browser url

### DIFF
--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -167,6 +167,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
         this.replaceState();
         this.getBottomToolbar().changePage(1);
     }
+
     ,clearFilter: function() {
         var s = this.getStore();
         s.baseParams.query = '';
@@ -197,6 +198,7 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
         this.windows.apc.reset();
         this.windows.apc.show(e.target);
     }
+
     ,exportPolicy: function(btn,e) {
         var id = this.menu.record.id;
         MODx.Ajax.request({

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -126,6 +126,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                 },{
                     xtype: 'modx-grid-access-policy'
                     ,cls:'main-wrapper'
+                    ,urlFilters: ['query']
                 }]
             });
         }

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -8,11 +8,11 @@ MODx.panel.GroupsRoles = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-groups-roles'
-		,cls: 'container'
+        ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,forceLayout: true
         ,items: [{
-             html: _('user_group_management')
+            html: _('user_group_management')
             ,id: 'modx-access-permissions-header'
             ,xtype: 'modx-header'
         },MODx.getPageStructure(this.getPageTabs(config),{
@@ -167,7 +167,6 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
             userGrid.store.baseParams.usergroup = usergroup;
             userGrid.clearFilter();
         }
-
     }
     ,fixPanelHeight: function() {
         // fixing border layout's height regarding to tree panel's


### PR DESCRIPTION
### What does it do?
- Add remembering filter properties of Access Policies grid in browser url

![ap_url](https://user-images.githubusercontent.com/12523676/155765702-eecc91ee-3e9e-4052-8b9c-43300731c232.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/16063
https://github.com/modxcms/revolution/pull/15946
https://github.com/modxcms/revolution/pull/15942
https://github.com/modxcms/revolution/pull/15935
https://github.com/modxcms/revolution/pull/15186
https://github.com/modxcms/revolution/pull/15185
https://github.com/modxcms/revolution/pull/15184
https://github.com/modxcms/revolution/pull/15183
https://github.com/modxcms/revolution/pull/15182
https://github.com/modxcms/revolution/pull/15181
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086