### PR TITLE
Add remembering filter properties of Access Policy Templates grid in browser url

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -8,11 +8,11 @@ MODx.panel.GroupsRoles = function(config) {
     config = config || {};
     Ext.applyIf(config,{
         id: 'modx-panel-groups-roles'
-		,cls: 'container'
+        ,cls: 'container'
         ,defaults: { collapsible: false ,autoHeight: true }
         ,forceLayout: true
         ,items: [{
-             html: _('user_group_management')
+            html: _('user_group_management')
             ,id: 'modx-access-permissions-header'
             ,xtype: 'modx-header'
         },MODx.getPageStructure(this.getPageTabs(config),{

--- a/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
+++ b/manager/assets/modext/widgets/security/modx.panel.groups.roles.js
@@ -141,6 +141,7 @@ Ext.extend(MODx.panel.GroupsRoles,MODx.FormPanel,{
                 },{
                     xtype: 'modx-grid-access-policy-templates'
                     ,cls:'main-wrapper'
+                    ,urlFilters: ['query']
                 }]
             });
         }


### PR DESCRIPTION
### What does it do?
- Add remembering filter properties of Access Policy Templates grid in browser url

![apt_url](https://user-images.githubusercontent.com/12523676/156399986-2ef9c895-0af9-48b3-9720-527439e2c059.gif)

### Why is it needed?
Allow to copy/paste the state of the filter with the browser url.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/16081
https://github.com/modxcms/revolution/pull/16063
https://github.com/modxcms/revolution/pull/15946
https://github.com/modxcms/revolution/pull/15942
https://github.com/modxcms/revolution/pull/15935
https://github.com/modxcms/revolution/pull/15186
https://github.com/modxcms/revolution/pull/15185
https://github.com/modxcms/revolution/pull/15184
https://github.com/modxcms/revolution/pull/15183
https://github.com/modxcms/revolution/pull/15182
https://github.com/modxcms/revolution/pull/15181
https://github.com/modxcms/revolution/pull/15115
https://github.com/modxcms/revolution/issues/14086