### PR TITLE
Fix issue with non-standard ssl ports being removed from site URL

### DIFF
--- a/core/docs/config.inc.tpl
+++ b/core/docs/config.inc.tpl
@@ -62,9 +62,9 @@ if (!defined('MODX_HTTP_HOST')) {
     } else {
         $http_host= array_key_exists('HTTP_HOST', $_SERVER) ? htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES) : '{http_host}';
         if ($_SERVER['SERVER_PORT'] != 80) {
-            $http_host= str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
+            $http_host = str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
         }
-        $http_host .= ($_SERVER['SERVER_PORT'] == 80 || $isSecureRequest) ? '' : ':' . $_SERVER['SERVER_PORT'];
+        $http_host .= in_array($_SERVER['SERVER_PORT'], [80, 443]) ? '' : ':' . $_SERVER['SERVER_PORT'];
         define('MODX_HTTP_HOST', $http_host);
     }
 }

--- a/setup/includes/config/modconfigreader.class.php
+++ b/setup/includes/config/modconfigreader.class.php
@@ -75,7 +75,7 @@ abstract class modConfigReader {
             if ($_SERVER['SERVER_PORT'] != 80) {
                 $this->config['http_host']= str_replace(':' . $_SERVER['SERVER_PORT'], '', $this->config['http_host']); /* remove port from HTTP_HOST */
             }
-            $this->config['http_host'] .= ($_SERVER['SERVER_PORT'] == 80 || $isSecureRequest) ? '' : ':' . $_SERVER['SERVER_PORT'];
+            $this->config['http_host'] .= in_array($_SERVER['SERVER_PORT'], [80, 443]) ? '' : ':' . $_SERVER['SERVER_PORT'];
         } else {
             $this->config['http_host'] = 'localhost';
             $this->config['https_port'] = 443;

--- a/setup/provisioner/bootstrap.php
+++ b/setup/provisioner/bootstrap.php
@@ -22,9 +22,7 @@ if (!MODX_SETUP_INTERFACE_IS_CLI) {
     if (isset($_SERVER['SERVER_PORT']) && (string)$_SERVER['SERVER_PORT'] !== '' && $_SERVER['SERVER_PORT'] !== 80) {
         $installBaseUrl = str_replace(':' . $_SERVER['SERVER_PORT'], '', $installBaseUrl);
     }
-    $installBaseUrl .= ($_SERVER['SERVER_PORT'] === 80 || ($https !== false || strtolower(
-                $https
-            ) === 'on')) ? '' : ':' . $_SERVER['SERVER_PORT'];
+    $installBaseUrl .= in_array($_SERVER['SERVER_PORT'], [80, 443]) ? '' : ':' . $_SERVER['SERVER_PORT'];
     $installBaseUrl .= $_SERVER['SCRIPT_NAME'];
     $installBaseUrl = htmlspecialchars($installBaseUrl, ENT_QUOTES, 'utf-8');
     define('MODX_SETUP_URL', $installBaseUrl);


### PR DESCRIPTION
### What does it do?

Ensures that non-standard ports persist in the `site_url`.

### Why is it needed?

Currently, when using a non-standard port for https (any one other than 443), the port gets stripped from the site's URL, making it impossible to properly navigate the site. Only the standard ports of 80 and 443 should be stripped.

### How to test

Configure the testing site on standard and non-standard ports, both with https on and off. Verify that setup, subsequent usage of the manager, and front end browsing all work as expected (with non-standard ports being maintained in the URL and 80/443 being stripped out).

### Related issue(s)/PR(s)
Resolves #16015
