### PR TITLE
Update xPDO to 3.1.0 and fix Container method signatures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require": {
         "php": ">=7.2.5",
-        "xpdo/xpdo": "~3.0.1",
+        "xpdo/xpdo": "~3.1.0",
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
         "phpmailer/phpmailer": "^6.0",

--- a/core/src/Revolution/Services/Container.php
+++ b/core/src/Revolution/Services/Container.php
@@ -8,7 +8,14 @@ use Psr\Container\ContainerInterface;
 
 class Container extends \Pimple\Container implements ContainerInterface
 {
-    public function add($id, $value)
+    /**
+     * Add an entry to the container.
+     *
+     * @param string $id
+     * @param mixed $value
+     * @return void
+     */
+    public function add(string $id, $value)
     {
         $this->offsetSet($id, $value);
     }
@@ -16,7 +23,7 @@ class Container extends \Pimple\Container implements ContainerInterface
     /**
      * @inheritDoc
      */
-    public function get($id)
+    public function get(string $id)
     {
         if ($this->has($id)) {
             try {
@@ -31,7 +38,7 @@ class Container extends \Pimple\Container implements ContainerInterface
     /**
      * @inheritDoc
      */
-    public function has($id)
+    public function has(string $id): bool
     {
         return $this->offsetExists($id);
     }

--- a/core/src/Revolution/Services/Container.php
+++ b/core/src/Revolution/Services/Container.php
@@ -1,9 +1,8 @@
 <?php
 
-
 namespace MODX\Revolution\Services;
 
-
+use Exception;
 use Psr\Container\ContainerInterface;
 
 class Container extends \Pimple\Container implements ContainerInterface
@@ -28,7 +27,7 @@ class Container extends \Pimple\Container implements ContainerInterface
         if ($this->has($id)) {
             try {
                 return $this->offsetGet($id);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 throw new ContainerException($e->getMessage(), $e->getCode(), $e);
             }
         }


### PR DESCRIPTION
### What does it do?
Updates xPDO to version 3.1 along with the psr/container dependency and the extended method signatures in the Container class.

### Why is it needed?
To resolve PHP 8.1 compatibility issues with Pimple. 

### How to test
Attempt to install and access the manager on PHP 8.1 with deprecation warnings enabled.

### Related issue(s)/PR(s)
n/a