### PR TITLE
Add a missing prefix to a setting lexicon entry

### DIFF
--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -817,5 +817,5 @@ $_lang['setting_passwordless_activated_desc'] = 'When enabled, users will enter 
 $_lang['setting_passwordless_expiration'] = 'Passwordless login expiration';
 $_lang['setting_passwordless_expiration_desc'] = 'How long a one-time login link is valid in seconds.';
 
-$_lang['static_elements_html_extension'] = 'Static elements html extension';
-$_lang['static_elements_html_extension_desc'] = 'The extension for files used by static elements with HTML content.';
+$_lang['setting_static_elements_html_extension'] = 'Static elements html extension';
+$_lang['setting_static_elements_html_extension_desc'] = 'The extension for files used by static elements with HTML content.';


### PR DESCRIPTION
### Why is it needed?
The prefix is missing and the setting is displayed without a translation in the settings grid.

### How to test
Add the prefix, clear the lexicon and search for static_elements_html_extension in the settings grid.

### Related issue(s)/PR(s)
Introduced in #15855
