### PR TITLE
Fix saving static elements

### DIFF
--- a/core/src/Revolution/Processors/Element/Create.php
+++ b/core/src/Revolution/Processors/Element/Create.php
@@ -77,20 +77,11 @@ abstract class Create extends CreateProcessor
         $this->setElementProperties();
         $this->validateElement();
 
-        if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
-            if ($this->object->get('content') !== '' && !$this->object->isStaticSourceMutable()) {
-                $source = $this->object->getSource();
-                if ($source && $source->hasErrors()) {
-                    $this->addFieldError('static_file', reset($source->getErrors()));
-                } else {
-                    $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-                }
-            } else {
-                if (!$this->object->isStaticSourceValidPath()) {
-                    $this->addFieldError('static_file',
-                        $this->modx->lexicon('element_static_source_protected_invalid'));
-                }
-            }
+        if (
+            ($this->object->staticSourceChanged() || $this->object->staticContentChanged())
+            && !$this->object->isStaticSourceValidPath()
+        ) {
+            $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
         }
 
         return !$this->hasErrors();

--- a/core/src/Revolution/Processors/Element/Update.php
+++ b/core/src/Revolution/Processors/Element/Update.php
@@ -70,20 +70,11 @@ abstract class Update extends UpdateProcessor
         }
 
         /* can't change content if static source is not writable */
-        if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
-            if (!$this->object->isStaticSourceMutable()) {
-                $source = $this->object->getSource();
-                if ($source && $source->hasErrors()) {
-                    $this->addFieldError('static_file', reset($source->getErrors()));
-                } else {
-                    $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-                }
-            } else {
-                if (!$this->object->isStaticSourceValidPath()) {
-                    $this->addFieldError('static_file',
-                        $this->modx->lexicon('element_static_source_protected_invalid'));
-                }
-            }
+        if (
+            ($this->object->staticSourceChanged() || $this->object->staticContentChanged())
+            && !$this->object->isStaticSourceValidPath()
+        ) {
+            $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
         }
 
         return !$this->hasErrors();

--- a/core/src/Revolution/Processors/Source/GetList.php
+++ b/core/src/Revolution/Processors/Source/GetList.php
@@ -12,6 +12,7 @@ namespace MODX\Revolution\Processors\Source;
 
 use MODX\Revolution\modAccessibleObject;
 use MODX\Revolution\Processors\Model\GetListProcessor;
+use MODX\Revolution\Sources\modFileMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -41,6 +42,7 @@ class GetList extends GetListProcessor
             'showNone' => false,
             'query' => '',
             'streamsOnly' => false,
+            'filesystemOnly' => false,
         ]);
         return $initialized;
     }
@@ -79,11 +81,16 @@ class GetList extends GetListProcessor
                 'modMediaSource.is_stream' => true,
             ]);
         }
+        if ($this->getProperty('filesystemOnly')) {
+            $c->where([
+                'modMediaSource.class_key' => modFileMediaSource::class
+            ]);
+        }
         return $c;
     }
 
     /**
-     * Filter the query by the valueField of MODx.combo.MediaSource to get the initially value displayed right
+     * Filter the query by the valueField of MODx.combo.MediaSource to get the initial value displayed right
      * @param xPDOQuery $c
      * @return xPDOQuery
      */

--- a/core/src/Revolution/Sources/modFileMediaSource.php
+++ b/core/src/Revolution/Sources/modFileMediaSource.php
@@ -17,7 +17,7 @@ class modFileMediaSource extends modMediaSource
 {
     protected $visibility_files = true;
     protected $visibility_dirs = true;
-
+    protected $static_element_mode = false;
 
     /**
      * @return bool
@@ -244,5 +244,29 @@ class modFileMediaSource extends modMediaSource
     public function getObjectUrl($object = '')
     {
         return $this->getBaseUrl() . $object;
+    }
+
+    /**
+     * Sets the media source to skip checking the file type.
+     *
+     * @return void
+     */
+    public function setStaticElementMode(): void
+    {
+        $this->static_element_mode = true;
+    }
+
+    /**
+     * Override to skip check for local static element filesystem saves.
+     *
+     * @inheritDoc
+     */
+    protected function checkFileType($filename): bool
+    {
+        if ($this->static_element_mode) {
+            return true;
+        }
+
+        return parent::checkFileType($filename);
     }
 }

--- a/core/src/Revolution/Sources/modFileMediaSource.php
+++ b/core/src/Revolution/Sources/modFileMediaSource.php
@@ -41,9 +41,9 @@ class modFileMediaSource extends modMediaSource
                         'public' => octdec($this->xpdo->getOption('new_folder_permissions', [], '0755')),
                         'private' => octdec($this->xpdo->getOption('private_folder_permissions', [], '0700')),
                     ],
-                ],Visibility::PUBLIC),
+                ],Visibility::PUBLIC), 
                 // Write flags
-                LOCK_EX,
+                LOCK_EX, 
                 // How to deal with links, either DISALLOW_LINKS or SKIP_LINKS
                 // Disallowing them causes exceptions when encountered
                 LocalFilesystemAdapter::DISALLOW_LINKS

--- a/core/src/Revolution/Sources/modFileMediaSource.php
+++ b/core/src/Revolution/Sources/modFileMediaSource.php
@@ -17,7 +17,7 @@ class modFileMediaSource extends modMediaSource
 {
     protected $visibility_files = true;
     protected $visibility_dirs = true;
-    protected $static_element_mode = false;
+    protected $ignore_file_type = false;
 
     /**
      * @return bool
@@ -41,9 +41,9 @@ class modFileMediaSource extends modMediaSource
                         'public' => octdec($this->xpdo->getOption('new_folder_permissions', [], '0755')),
                         'private' => octdec($this->xpdo->getOption('private_folder_permissions', [], '0700')),
                     ],
-                ],Visibility::PUBLIC), 
+                ],Visibility::PUBLIC),
                 // Write flags
-                LOCK_EX, 
+                LOCK_EX,
                 // How to deal with links, either DISALLOW_LINKS or SKIP_LINKS
                 // Disallowing them causes exceptions when encountered
                 LocalFilesystemAdapter::DISALLOW_LINKS
@@ -247,19 +247,19 @@ class modFileMediaSource extends modMediaSource
      *
      * @return void
      */
-    public function setStaticElementMode(): void
+    public function ignoreFileTypeMode(): void
     {
-        $this->static_element_mode = true;
+        $this->ignore_file_type = true;
     }
 
     /**
-     * Override to skip check for local static element filesystem saves.
+     * Override to skip file type checks.
      *
      * @inheritDoc
      */
     protected function checkFileType($filename): bool
     {
-        if ($this->static_element_mode) {
+        if ($this->ignore_file_type) {
             return true;
         }
 

--- a/core/src/Revolution/Sources/modFileMediaSource.php
+++ b/core/src/Revolution/Sources/modFileMediaSource.php
@@ -30,7 +30,6 @@ class modFileMediaSource extends modMediaSource
             $localAdapter = new LocalFilesystemAdapter(
                 // Determine the root directory
                 $this->getBasePath(),
-
                 // If users would like to modify the private values, they can create
                 // new system settings: private_file_permissions and private_folder_permissions.
                 PortableVisibilityConverter::fromArray([
@@ -43,15 +42,12 @@ class modFileMediaSource extends modMediaSource
                         'private' => octdec($this->xpdo->getOption('private_folder_permissions', [], '0700')),
                     ],
                 ],Visibility::PUBLIC),
-
                 // Write flags
                 LOCK_EX,
-
                 // How to deal with links, either DISALLOW_LINKS or SKIP_LINKS
                 // Disallowing them causes exceptions when encountered
                 LocalFilesystemAdapter::DISALLOW_LINKS
             );
-
         } catch (Exception $e) {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR,
                 $this->xpdo->lexicon('source_err_init', ['source' => $this->get('name')]) . ' ' . $e->getMessage());

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -375,16 +375,15 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 $this->addError('path', $this->xpdo->lexicon('file_folder_err_invalid'));
                 return [];
             }
-
         }
 
         try {
             $re = '#^(.*?/|)(' . implode('|', array_map('preg_quote', $skipFiles)) . ')/?$#';
             $contents = $this->filesystem->listContents($path)
-                ->filter(function(StorageAttributes $attributes) use ($re) {
+                ->filter(function (StorageAttributes $attributes) use ($re) {
                     return !preg_match($re, $attributes->path());
                 })
-                ->filter(function(StorageAttributes $attributes) use ($properties) {
+                ->filter(function (StorageAttributes $attributes) use ($properties) {
                     if ($attributes->isDir()) {
                         return $this->hasPermission('directory_list');
                     } elseif ($attributes->isFile()) {

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1782,7 +1782,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      *
      * @return bool
      */
-    protected function checkFileType($filename)
+    protected function checkFileType($filename): bool
     {
         if ($this->getOption('allowedFileTypes')) {
             $allowedFileTypes = $this->getOption('allowedFileTypes');

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -420,7 +420,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                         'items' => $this->getListDirContextMenu(),
                     ];
 
-                }
+                } 
                 elseif ($object instanceof FileAttributes) {
                     // @TODO review/refactor extension and mime_type would be better for filesystems that
                     // may not always have an extension on it. For example would be S3 and you have an HTML file
@@ -492,7 +492,6 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 $this->addError('path', $e->getMessage());
                 $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
                 return [];
-
             }
 
             // Ensure this is a directory.
@@ -993,11 +992,11 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             if (!$this->filesystem->fileExists($oldPath)) {
                 $this->addError('name', $this->xpdo->lexicon('file_err_invalid'));
                 return false;
-            }
+            } 
             elseif ($this->checkFileExists() && $this->filesystem->fileExists($newPath)) {
                 $this->addError('name', sprintf($this->xpdo->lexicon('file_err_ae'), $newName));
                 return false;
-            }
+            } 
             elseif (!$this->checkFileType($newName)) {
                 return false;
             }
@@ -1046,7 +1045,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         try {
             if (!$this->checkFileType($path)) {
                 return false;
-            }
+            } 
             elseif (!$this->filesystem->fileExists($path)) {
                 $this->addError('file', $this->xpdo->lexicon('file_err_nf') . ': ' . $path);
                 return false;
@@ -1222,7 +1221,6 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 $this->filesystem->setVisibility($path, $visibility);
                 return true;
             }
-
         } catch (FilesystemException | UnableToSetVisibility $e) {
             $this->addError('path', $this->xpdo->lexicon('file_err_nf') . ' ' . $e->getMessage());
         }
@@ -1560,7 +1558,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 return '';
             }
         } catch (FilesystemException | UnableToRetrieveMetadata $e) {
-            $this->xpdo->log(modX::LOG_LEVEL_ERROR,$e->getMessage());
+            $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
             return '';
         }
 
@@ -2315,7 +2313,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 try {
                     $file = $this->filesystem->read($path);
                 } catch (FilesystemException $e) {
-                    $this->addError('file',$e->getMessage());
+                    $this->addError('file', $e->getMessage());
                 }
                 $size = @getimagesize($this->getBasePath() . $path);
                 if (is_array($size)) {

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -588,7 +588,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         }
 
         $properties = $this->getPropertyList();
-        $imageExtensions = array_map('trim', explode(',', $this->getOption('imageExtensions', $properties, 'jpg,jpeg,png,gif,svg')));
+        $imageExtensions = array_map('trim', explode(',',
+            $this->getOption('imageExtensions', $properties, 'jpg,jpeg,png,gif,svg')));
         try {
             $fa = [
                 'name' => rtrim($path, DIRECTORY_SEPARATOR),
@@ -1194,7 +1195,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
         try {
             $mimeType = $this->filesystem->mimeType($path);
-            if (($mimeType === 'directory' && $this->visibility_dirs) || ($mimeType !== 'directory' && $this->visibility_files)) {
+            if (($mimeType === 'directory' && $this->visibility_dirs)
+                || ($mimeType !== 'directory' && $this->visibility_files)) {
                 return $this->filesystem->visibility($path);
             }
         } catch (FilesystemException | UnableToRetrieveMetadata $e) {
@@ -1216,7 +1218,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         $path = $this->sanitizePath($path);
         try {
             $mimeType = $this->filesystem->mimeType($path);
-            if (($mimeType === 'directory' && $this->visibility_dirs) || ($mimeType !== 'directory' && $this->visibility_files)) {
+            if (($mimeType === 'directory' && $this->visibility_dirs)
+                || ($mimeType !== 'directory' && $this->visibility_files)) {
                 $this->filesystem->setVisibility($path, $visibility);
                 return true;
             }

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -1178,7 +1178,8 @@ class modElement extends modAccessibleSimpleObject
      *
      * @return string
      */
-    public function getPreviewUrl() {
+    public function getPreviewUrl() 
+    {
         if (!empty($this->get('preview_file'))) {
             $previewfile = $this->get('preview_file');
 
@@ -1189,14 +1190,14 @@ class modElement extends modAccessibleSimpleObject
                 if ($source && $source->get('is_stream')) {
                     $source->initialize();
 
-                    if (file_exists($source->getBasePath().$previewfile)) {
-                        return $source->getBaseUrl().$previewfile;
+                    if (file_exists($source->getBasePath() . $previewfile)) {
+                        return $source->getBaseUrl() . $previewfile;
                     }
                 }
             } else {
                 // Return "as is" if not assigned to a media source
-                if (file_exists(MODX_BASE_PATH.$previewfile)) {
-                    return MODX_BASE_URL.$previewfile;
+                if (file_exists(MODX_BASE_PATH . $previewfile)) {
+                    return MODX_BASE_URL . $previewfile;
                 }
             }
 

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -207,10 +207,6 @@ class modElement extends modAccessibleSimpleObject
             }
 
             $staticContentChanged = $this->staticContentChanged();
-            if ($staticContentChanged) {
-                $this->setContent($this->getFileContent());
-                $staticContentChanged = false;
-            }
 
             /* If element is empty, set to true in order to create an empty static file. */
             $content = $this->get('content');
@@ -685,7 +681,7 @@ class modElement extends modAccessibleSimpleObject
                 // Allow filesystem static elements to be saved without checking file type.
                 if ($source->get('class_key') === modFileMediaSource::class) {
                     /** @var modFileMediaSource $source */
-                    $source->setStaticElementMode();
+                    $source->ignoreFileTypeMode();
                 }
 
                 if ($source->getMetaData($sourceFile)) {
@@ -1178,7 +1174,7 @@ class modElement extends modAccessibleSimpleObject
      *
      * @return string
      */
-    public function getPreviewUrl() 
+    public function getPreviewUrl()
     {
         if (!empty($this->get('preview_file'))) {
             $previewfile = $this->get('preview_file');

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -197,7 +197,7 @@ class modElement extends modAccessibleSimpleObject
             if ($this->staticSourceChanged()) {
                 $staticContent = $this->getFileContent();
                 if ($staticContent !== $this->get('content')) {
-                    if ($this->isStaticSourceMutable() && $staticContent === '') {
+                    if ($staticContent === '') {
                         $this->setDirty('content');
                     } else {
                         $this->setContent($staticContent);
@@ -207,7 +207,7 @@ class modElement extends modAccessibleSimpleObject
             }
 
             $staticContentChanged = $this->staticContentChanged();
-            if ($staticContentChanged && !$this->isStaticSourceMutable()) {
+            if ($staticContentChanged) {
                 $this->setContent($this->getFileContent());
                 $staticContentChanged = false;
             }
@@ -691,7 +691,7 @@ class modElement extends modAccessibleSimpleObject
                 }
             }
             else {
-                $set = file_put_contents($sourceFile, $content) > 0;
+                $set = $this->xpdo->getCacheManager()->writeFile($sourceFile, $content);
             }
         }
 
@@ -1139,20 +1139,11 @@ class modElement extends modAccessibleSimpleObject
      * Return if the static source is mutable.
      *
      * @return boolean True if the source file is mutable.
+     * @deprecated Unreliable; just try to write a file and act on errors.
      */
     public function isStaticSourceMutable()
     {
-        $isMutable = false;
-        $sourceFile = $this->getStaticFileName();
-        if ($sourceFile && $source = $this->getSource()) {
-            if (!$isMutable = (bool)$source->getMetaData($sourceFile)) {
-                $path = explode(DIRECTORY_SEPARATOR, trim($sourceFile, DIRECTORY_SEPARATOR));
-                $file = array_pop($path);
-                $isMutable = (bool)$source->createObject(implode(DIRECTORY_SEPARATOR, $path), $file, '');
-            }
-        }
-
-        return $isMutable;
+        return true;
     }
 
     /**

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -681,6 +681,13 @@ class modElement extends modAccessibleSimpleObject
             $sourceFile = $this->getStaticFileName();
             if (($this->get('source') > 0) && $source = $this->getSource()) {
                 $source->initialize();
+
+                // Allow filesystem static elements to be saved without checking file type.
+                if ($source->get('class_key') === modFileMediaSource::class) {
+                    /** @var modFileMediaSource $source */
+                    $source->setStaticElementMode();
+                }
+
                 if ($source->getMetaData($sourceFile)) {
                     $set = (bool)$source->updateObject($sourceFile, $content);
                 }

--- a/manager/assets/modext/widgets/element/modx.panel.chunk.js
+++ b/manager/assets/modext/widgets/element/modx.panel.chunk.js
@@ -183,6 +183,7 @@ MODx.panel.Chunk = function(config) {
                             action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
+                            ,filesystemOnly: true
                         }
                         ,listeners: {
                             select: {

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -210,6 +210,7 @@ MODx.panel.Plugin = function(config) {
                             action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
+                            ,filesystemOnly: true
                         }
                         ,listeners: {
                             select: {

--- a/manager/assets/modext/widgets/element/modx.panel.snippet.js
+++ b/manager/assets/modext/widgets/element/modx.panel.snippet.js
@@ -184,6 +184,7 @@ MODx.panel.Snippet = function(config) {
                             action: 'Source/GetList'
                             ,showNone: true
                             ,streamsOnly: true
+                            ,filesystemOnly: true
                         }
                         ,listeners: {
                             select: {

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -203,7 +203,8 @@ MODx.panel.Template = function(config) {
                         baseParams: {
                             action: 'source/getList',
                             showNone: true,
-                            streamsOnly: true
+                            streamsOnly: true,
+                            filesystemOnly: true
                         },
                         listeners: {
                             select: {

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -365,6 +365,7 @@ MODx.panel.TV = function(config) {
                                     action: 'Source/GetList'
                                     ,showNone: true
                                     ,streamsOnly: true
+                                    ,filesystemOnly: true
                                 }
                                 ,listeners: {
                                     select: {


### PR DESCRIPTION
### What does it do?
Allows static elements to save regardless of the file extension if on a filesystem media source.

Beyond the changes Mark made, this essentially adds an "ignore file type mode" to `modFileMediaSource` that allows skipping the file extension checks. When the mode is not active, any saving to a media source is still subject to those checks.

### Why is it needed?
See issue https://github.com/modxcms/revolution/issues/15927

This is a blocker for MODX 3.0 being released. This is meant to solve just this issue and be kept simple.

### How to test
Try saving static elements with and without a media source.

### Related issue(s)/PR(s)
This is an extension of the draft PR #16078 by @Mark-H . The first commit is his work, I just copied it. ;)
There's also a more in-depth approach by @smg6511 #16070 but that also involved solving other issues.