### PR TITLE
Alternative fix for saving static elements in 3.0

### DIFF
--- a/core/src/Revolution/Processors/Element/Create.php
+++ b/core/src/Revolution/Processors/Element/Create.php
@@ -77,20 +77,11 @@ abstract class Create extends CreateProcessor
         $this->setElementProperties();
         $this->validateElement();
 
-        if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
-            if ($this->object->get('content') !== '' && !$this->object->isStaticSourceMutable()) {
-                $source = $this->object->getSource();
-                if ($source && $source->hasErrors()) {
-                    $this->addFieldError('static_file', reset($source->getErrors()));
-                } else {
-                    $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-                }
-            } else {
-                if (!$this->object->isStaticSourceValidPath()) {
-                    $this->addFieldError('static_file',
-                        $this->modx->lexicon('element_static_source_protected_invalid'));
-                }
-            }
+        if (
+            ($this->object->staticSourceChanged() || $this->object->staticContentChanged())
+            && !$this->object->isStaticSourceValidPath()
+        ) {
+            $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
         }
 
         return !$this->hasErrors();

--- a/core/src/Revolution/Processors/Element/Update.php
+++ b/core/src/Revolution/Processors/Element/Update.php
@@ -70,20 +70,11 @@ abstract class Update extends UpdateProcessor
         }
 
         /* can't change content if static source is not writable */
-        if ($this->object->staticSourceChanged() || $this->object->staticContentChanged()) {
-            if (!$this->object->isStaticSourceMutable()) {
-                $source = $this->object->getSource();
-                if ($source && $source->hasErrors()) {
-                    $this->addFieldError('static_file', reset($source->getErrors()));
-                } else {
-                    $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_immutable'));
-                }
-            } else {
-                if (!$this->object->isStaticSourceValidPath()) {
-                    $this->addFieldError('static_file',
-                        $this->modx->lexicon('element_static_source_protected_invalid'));
-                }
-            }
+        if (
+            ($this->object->staticSourceChanged() || $this->object->staticContentChanged())
+            && !$this->object->isStaticSourceValidPath()
+        ) {
+            $this->addFieldError('static_file', $this->modx->lexicon('element_static_source_protected_invalid'));
         }
 
         return !$this->hasErrors();


### PR DESCRIPTION
### What does it do?
This is an extension of #16078, and an alternative fix to #16091 and #16070 

### Why is it needed?
This fixes the issues described in #15927 

This is a different approach to the others in that it doesn't touch media sources except to get the base path.
Rather than attempt to write files through media source functions (and thus needing to check file extensions), it handles it the same way that 2.x does and writes static element files directly. 

### How to test
Create and save static elements, with and without a media source. Try doing it with files that are both writable and not. 

### Related issue(s)/PR(s)
See above.
