### PR TITLE
Prevent autofilling passwords where appropriate

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -488,6 +488,10 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,anchor: '100%'
                     ,inputType: 'password'
                     ,xtype: 'textfield'
+                    ,autoCreate: {
+                        tag: "input"
+                        ,autocomplete: "new-password"
+                    }
                 }
                 ,items: [{
                     id: 'modx-user-specifiedpassword'

--- a/setup/templates/database.tpl
+++ b/setup/templates/database.tpl
@@ -46,7 +46,7 @@
             <label for="database-user">{$_lang.connection_database_login}</label>
         </div>
         <div class="col">
-            <input type="text" id="database-user" name="database_user" value="" />
+            <input type="text" id="database-user" name="database_user" value="" autocomplete="new-password" />
             <span class="field_error" id="database-user-error"></span>
         </div>
     </div>
@@ -55,7 +55,7 @@
             <label for="database-password">{$_lang.connection_database_pass}</label>
         </div>
         <div class="col">
-            <input id="database-password" type="password" name="database_password" value="" />
+            <input id="database-password" type="password" name="database_password" value="" autocomplete="new-password" />
             <span class="field_error" id="database-password-error"></span>
         </div>
     </div>


### PR DESCRIPTION
### What does it do?
Add `autocomplete="new-password"` for the database user password in setup and the new password fields when editing a user in the manager.

### Why is it needed?
Prevent autofilling of password fields (or suggesting a new strong password). 

More info: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#preventing_autofilling_with_autocompletenew-password

### How to test
- Go through the setup and don't see the database password being autofilled

- Edit a user and change his password.  

### Related issue(s)/PR(s)
n/a
