### PR TITLE
Make sure file name and line number are included in error messages

### DIFF
--- a/core/src/Revolution/modManagerResponse.php
+++ b/core/src/Revolution/modManagerResponse.php
@@ -138,13 +138,13 @@ class modManagerResponse extends modResponse
         catch (\Exception $e) {
             $this->modx->controller = new Error($this->modx, [
                 'message' => get_class($e) . ': ' . $e->getMessage(),
-                'errors' => $this->_formatTrace($e->getTrace())
+                'errors' => [$e->getFile() . ':' . $e->getLine()] + $this->_formatTrace($e->getTrace())
             ]);
         }
         catch (\Error $e) {
             $this->modx->controller = new Error($this->modx, [
                 'message' => get_class($e) . ': ' . $e->getMessage(),
-                'errors' => $this->_formatTrace($e->getTrace())
+                'errors' => [$e->getFile() . ':' . $e->getLine()] + $this->_formatTrace($e->getTrace())
             ]);
         }
         $this->body = $this->modx->controller->render();
@@ -168,7 +168,7 @@ class modManagerResponse extends modResponse
                     $args[] = gettype($arg);
                 }
             }
-            $line .= implode(', ', $args) . ')';
+            $line .= implode(', ', $args) . ') in ' . $entry['file'] . ':' . $entry['line'];
             $return[] = htmlentities($line, ENT_QUOTES, 'UTF-8');
         }
         return $return;


### PR DESCRIPTION
### What does it do?

Adds file name and line number to manager errors.

### Why is it needed?
Easier debugging of issues.

### How to test
Cause an exception on a manager page. 

### Related issue(s)/PR(s)
N/a

Not a blocker to include in 3.0.0-pl but just realised I never pushed these changes.