### PR TITLE
Remove outdated lexicon about Google+

### DIFF
--- a/core/lexicon/en/about.inc.php
+++ b/core/lexicon/en/about.inc.php
@@ -36,6 +36,5 @@ $_lang['email_sub_button'] = 'Sign up';
 $_lang['social_follows'] = 'You can also <b>follow MODX</b> on these channels.';
 $_lang['follow'] = 'Follow MODX';
 $_lang['like'] = 'Like MODX';
-$_lang['circle'] = 'Circle MODX';
 $_lang['help_about'] = 'The MODX® software you are using is the result of collaboration with an amazing community of users, supporters and developers. Since 2004, the team behind MODX has sponsored and managed it, funding ongoing work through commercial support and commissioned features. You can <a href="https://modx.com/services/" class="supportTicket">buy support from the source</a> to get one hour of emergency support (also usable for two hours non-priority support). Or <a href="mailto:hello@modx.com?subject=MODX Manager Inquiry ">email us</a> if you have another question about MODX in general.';
 $_lang['help_credit'] = 'MODX is free open source software licensed under the <a href="http://www.gnu.org/licenses/gpl-2.0.html" target="_blank">GPL version 2.0</a> or later. Copyright 2005-[[+current_year]] by MODX, LLC. “MODX” is a registered trademark. Do the right thing—please keep this credit and the other information on this page intact.';


### PR DESCRIPTION
### What does it do?
Removes an entry from the lexicon file.

### Why is it needed?
This social network has gone, so no need to keep this entry. It is not used in the code as well.

### How to test
N/A

### Related issue(s)/PR(s)
N/A