### PR TITLE
[Port to 3.x] Fix Various Issues with Form Panel Validation and Field Display - Part 6, Plugin Panel

### DIFF
--- a/core/lexicon/en/plugin.inc.php
+++ b/core/lexicon/en/plugin.inc.php
@@ -10,15 +10,13 @@ $_lang['event'] = 'Event';
 $_lang['events'] = 'Events';
 $_lang['plugin'] = 'Plugin';
 $_lang['plugin_add'] = 'Add Plugin';
-$_lang['plugin_code'] = 'Plugin code (php)';
+$_lang['plugin_category_desc'] = 'Use to group Plugins within the Elements tree.';
+$_lang['plugin_code'] = 'Plugin Code (PHP)';
 $_lang['plugin_config'] = 'Plugin configuration';
-$_lang['plugin_desc'] = 'Description';
-$_lang['plugin_desc_category'] = 'The Category this Plugin belongs in.';
-$_lang['plugin_desc_description'] = 'A short description of this Plugin.';
-$_lang['plugin_desc_name'] = 'The name of this Plugin.';
+$_lang['plugin_description_desc'] = 'Usage information for this Plugin shown in search results and as a tooltip in the Elements tree.';
 $_lang['plugin_delete_confirm'] = 'Are you sure you want to delete this plugin?';
-$_lang['plugin_disabled'] = 'Inactive plugin';
-$_lang['plugin_disabled_msg'] = 'Plugin is deactivated and will not respond to events.';
+$_lang['plugin_disabled'] = 'Deactivate Plugin';
+$_lang['plugin_disabled_msg'] = 'When deactivated, this Plugin will not respond to events.';
 $_lang['plugin_duplicate_confirm'] = 'Are you sure you want to duplicate this plugin?';
 $_lang['plugin_err_create'] = 'An error occurred while creating the plugin.';
 $_lang['plugin_err_ae'] = 'A plugin already exists with the name "[[+name]]".';
@@ -37,14 +35,24 @@ $_lang['plugin_event_err_save'] = 'An error occurred while saving the plugin eve
 $_lang['plugin_event_msg'] = 'Select the events that you would like this plugin to listen to.';
 $_lang['plugin_event_plugin_remove_confirm'] = 'Are you sure you want to delete this plugin from this event?';
 $_lang['plugin_lock'] = 'Plugin locked for editing';
-$_lang['plugin_lock_msg'] = 'Users must have the edit_locked attribute in order to edit this plugin.';
+$_lang['plugin_lock_desc'] = 'Only users with “edit_locked” permissions can edit this Plugin.';
 $_lang['plugin_locked_message'] = 'This plugin is locked.';
 $_lang['plugin_management_msg'] = 'Here you can choose which plugin you wish to edit.';
-$_lang['plugin_msg'] = 'Here you can create/edit plugins. Plugins are \'raw\' PHP codes that are invoked whenever the selected System Events are triggered.';
-$_lang['plugin_name'] = 'Plugin name';
+$_lang['plugin_name_desc'] = 'The name of this Plugin.';
 $_lang['plugin_new'] = 'Create Plugin';
 $_lang['plugin_priority'] = 'Edit Plugin Execution Order by Event';
 $_lang['plugin_properties'] = 'Plugin Properties';
+$_lang['plugin_tab_general_desc'] = 'Here you can enter the basic attributes for this <em>Plugin</em> as well as its content. The content must be PHP, either placed in the <a href="#x-form-el-modx-plugin-plugincode">Plugin Code</a> field below or in a static external file. The PHP code entered runs in response to one or more MODX System Events that you specify.';
 $_lang['plugin_title'] = 'Create/edit plugin';
 $_lang['plugin_untitled'] = 'Untitled plugin';
 $_lang['plugins'] = 'Plugins';
+
+// Temporarily match old keys to new ones to ensure compatibility
+// --fields
+$_lang['plugin_desc_category'] = $_lang['plugin_category_desc'];
+$_lang['plugin_desc_description'] = $_lang['plugin_description_desc'];
+$_lang['plugin_desc_name'] = $_lang['plugin_name_desc'];
+$_lang['plugin_lock_msg'] = $_lang['plugin_lock_desc'];
+
+// --tabs
+$_lang['plugin_msg'] = $_lang['plugin_tab_general_desc'];

--- a/core/lexicon/en/plugin.inc.php
+++ b/core/lexicon/en/plugin.inc.php
@@ -42,7 +42,7 @@ $_lang['plugin_name_desc'] = 'The name of this Plugin.';
 $_lang['plugin_new'] = 'Create Plugin';
 $_lang['plugin_priority'] = 'Edit Plugin Execution Order by Event';
 $_lang['plugin_properties'] = 'Plugin Properties';
-$_lang['plugin_tab_general_desc'] = 'Here you can enter the basic attributes for this <em>Plugin</em> as well as its content. The content must be PHP, either placed in the <a href="#x-form-el-modx-plugin-plugincode">Plugin Code</a> field below or in a static external file. The PHP code entered runs in response to one or more MODX System Events that you specify.';
+$_lang['plugin_tab_general_desc'] = 'Here you can enter the basic attributes for this <em>Plugin</em> as well as its content. The content must be PHP, either placed in the <em>Plugin Code</em> field below or in a static external file. The PHP code entered runs in response to one or more MODX System Events that you specify.';
 $_lang['plugin_title'] = 'Create/edit plugin';
 $_lang['plugin_untitled'] = 'Untitled plugin';
 $_lang['plugins'] = 'Plugins';

--- a/core/src/Revolution/mysql/modPlugin.php
+++ b/core/src/Revolution/mysql/modPlugin.php
@@ -11,11 +11,11 @@ class modPlugin extends \MODX\Revolution\modPlugin
         'version' => '3.0',
         'table' => 'site_plugins',
         'extends' => 'MODX\\Revolution\\modScript',
-        'tableMeta' => 
+        'tableMeta' =>
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' => 
+        'fields' =>
         array (
             'cache_type' => 0,
             'plugincode' => '',
@@ -26,9 +26,9 @@ class modPlugin extends \MODX\Revolution\modPlugin
             'static' => 0,
             'static_file' => '',
         ),
-        'fieldMeta' => 
+        'fieldMeta' =>
         array (
-            'cache_type' => 
+            'cache_type' =>
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -36,14 +36,14 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'null' => false,
                 'default' => 0,
             ),
-            'plugincode' => 
+            'plugincode' =>
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
             ),
-            'locked' => 
+            'locked' =>
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -53,13 +53,13 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'default' => 0,
                 'index' => 'index',
             ),
-            'properties' => 
+            'properties' =>
             array (
                 'dbtype' => 'text',
                 'phptype' => 'array',
                 'null' => true,
             ),
-            'disabled' => 
+            'disabled' =>
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -69,7 +69,7 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'default' => 0,
                 'index' => 'index',
             ),
-            'moduleguid' => 
+            'moduleguid' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '32',
@@ -78,7 +78,7 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'default' => '',
                 'index' => 'fk',
             ),
-            'static' => 
+            'static' =>
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -88,7 +88,7 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'default' => 0,
                 'index' => 'index',
             ),
-            'static_file' => 
+            'static_file' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -97,21 +97,21 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'default' => '',
             ),
         ),
-        'fieldAliases' => 
+        'fieldAliases' =>
         array (
             'content' => 'plugincode',
         ),
-        'indexes' => 
+        'indexes' =>
         array (
-            'locked' => 
+            'locked' =>
             array (
                 'alias' => 'locked',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'locked' => 
+                    'locked' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -119,15 +119,15 @@ class modPlugin extends \MODX\Revolution\modPlugin
                     ),
                 ),
             ),
-            'disabled' => 
+            'disabled' =>
             array (
                 'alias' => 'disabled',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'disabled' => 
+                    'disabled' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -135,15 +135,15 @@ class modPlugin extends \MODX\Revolution\modPlugin
                     ),
                 ),
             ),
-            'static' => 
+            'static' =>
             array (
                 'alias' => 'static',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' => 
+                'columns' =>
                 array (
-                    'static' => 
+                    'static' =>
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -152,24 +152,24 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 ),
             ),
         ),
-        'composites' => 
+        'composites' =>
         array (
-            'PropertySets' => 
+            'PropertySets' =>
             array (
                 'class' => 'MODX\\Revolution\\modElementPropertySet',
                 'local' => 'id',
                 'foreign' => 'element',
                 'owner' => 'local',
                 'cardinality' => 'many',
-                'criteria' => 
+                'criteria' =>
                 array (
-                    'foreign' => 
+                    'foreign' =>
                     array (
                         'element_class' => 'MODX\\Revolution\\modPlugin',
                     ),
                 ),
             ),
-            'PluginEvents' => 
+            'PluginEvents' =>
             array (
                 'class' => 'MODX\\Revolution\\modPluginEvent',
                 'local' => 'id',
@@ -178,16 +178,16 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'owner' => 'local',
             ),
         ),
-        'validation' => 
+        'validation' =>
         array (
-            'rules' => 
+            'rules' =>
             array (
-                'name' => 
+                'name' =>
                 array (
-                    'invalid' => 
+                    'invalid' =>
                     array (
                         'type' => 'preg_match',
-                        'rule' => '/^(?!\\s)[a-zA-Z0-9_-\\x7f-\\xff\\s]+(?!\\s)$/',
+                        'rule' => '/^(?!\\s)[a-zA-Z0-9\\x23-\\x2f\\x3a\\x5b-\\x5d\\x7f-\\xff-_\\s]+(?<!\\s)$/',
                         'message' => 'plugin_err_invalid_name',
                     ),
                 ),

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -23,219 +23,364 @@ MODx.panel.Plugin = function(config) {
         ,allowDrop: false
         ,previousFileSource: config.record.source != null ? config.record.source : MODx.config.default_media_source
         ,items: [{
-            html: _('plugin_new')
-            ,id: 'modx-plugin-header'
-            ,xtype: 'modx-header'
-        },MODx.getPageStructure([{
-            title: _('plugin_title')
+            id: 'modx-plugin-header',
+            xtype: 'modx-header'
+        }, MODx.getPageStructure([{
+            title: _('general_information')
             ,layout: 'form'
             ,id: 'modx-plugin-form'
             ,labelWidth: 150
-            ,defaults: { border: false ,msgTarget: 'side' }
+            ,defaults: {
+                border: false
+                ,layout: 'form'
+				,labelAlign: 'top'
+                ,labelSeparator: ''
+                ,msgTarget: 'side'
+            }
             ,items: [{
-                html: '<p>'+_('plugin_msg')+'</p>'
+                html: '<p>'+_('plugin_tab_general_desc')+'</p>'
                 ,id: 'modx-plugin-msg'
                 ,xtype: 'modx-description'
             },{
-                layout: 'column'
-                ,border: false
-                ,defaults: {
-                    layout: 'form'
-                    ,labelAlign: 'top'
-                    ,anchor: '100%'
-                    ,border: false
-                    ,cls:'main-wrapper'
-                    ,labelSeparator: ''
-                }
+                cls: 'main-wrapper'
                 ,items: [{
-                    columnWidth: .6
+                    // row 1
+                    cls:'form-row-wrapper'
+                    ,defaults: {
+                        layout: 'column'
+                    }
                     ,items: [{
-                        xtype: 'hidden'
-                        ,name: 'id'
-                        ,id: 'modx-plugin-id'
-                        ,value: config.record.id || 0
-                    },{
-                        xtype: 'hidden'
-                        ,name: 'props'
-                        ,id: 'modx-plugin-props'
-                        ,value: config.record.props || null
-                    },{
-                        xtype: 'textfield'
-                        ,fieldLabel: _('name')
-                        ,description: MODx.expandHelp ? '' : _('plugin_desc_name')
-                        ,name: 'name'
-                        ,id: 'modx-plugin-name'
-                        ,anchor: '100%'
-                        ,maxLength: 50
-                        ,enableKeyEvents: true
-                        ,allowBlank: false
-                        ,value: config.record.name
-                        ,listeners: {
-                            'keyup': {scope:this,fn:function(f,e) {
-                                var title = Ext.util.Format.stripTags(f.getValue());
-                                title = _('plugin')+': '+Ext.util.Format.htmlEncode(title);
-                                if (MODx.request.a !== 'element/plugin/create' && MODx.perm.tree_show_element_ids === true) {
-                                    title = title+ ' <small>('+this.config.record.id+')</small>';
-                                }
-
-                                Ext.getCmp('modx-plugin-header').getEl().update(title);
-
-                                MODx.setStaticElementPath('plugin');
-                            }}
+                        defaults: {
+                            layout: 'form'
+                            ,labelSeparator: ''
+                            ,labelAlign: 'top'
                         }
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-name'
-                        ,html: _('plugin_desc_name')
-                        ,cls: 'desc-under'
-                    },{
-                        xtype: 'textarea'
-                        ,fieldLabel: _('plugin_desc')
-                        ,description: MODx.expandHelp ? '' : _('plugin_desc_description')
-                        ,name: 'description'
-                        ,id: 'modx-plugin-description'
-                        ,anchor: '100%'
-                        ,maxLength: 255
-                        ,value: config.record.description
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-description'
-                        ,html: _('plugin_desc_description')
-                        ,cls: 'desc-under'
-                    },this.getStaticFileField('plugin', config.record),{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-static-file'
-                        ,id: 'modx-plugin-static-file-help'
-                        ,html: _('static_file_msg')
-                        ,cls: 'desc-under'
-                        ,hidden: !config.record['static']
-                        ,hideMode: 'offsets'
-                    },{
-                        html: MODx.onPluginFormRender
-                        ,border: false
-
+                        ,items: [{
+                            columnWidth: 0.5
+                            ,defaults: {
+                                anchor: '100%'
+                                ,msgTarget: 'under'
+                                ,validationEvent: 'change'
+                                ,validateOnBlur: false
+                            }
+                            ,items: [{
+                                xtype: 'hidden'
+                                ,name: 'id'
+                                ,id: 'modx-plugin-id'
+                                ,value: config.record.id || MODx.request.id
+                            },{
+                                xtype: 'hidden'
+                                ,name: 'props'
+                                ,id: 'modx-plugin-props'
+                                ,value: config.record.props || null
+                            },{
+                                xtype: 'textfield'
+                                ,fieldLabel: _('name')
+                                ,description: MODx.expandHelp ? '' : _('plugin_name_desc')
+                                ,name: 'name'
+                                ,id: 'modx-plugin-name'
+                                ,maxLength: 50
+                                ,enableKeyEvents: true
+                                ,allowBlank: false
+                                ,value: config.record.name
+                                ,tabIndex: 1
+                                ,listeners: {
+                                    keyup: {
+                                        fn: function(cmp, e) {
+                                            this.formatMainPanelTitle('plugin', this.config.record, cmp.getValue());
+                                            MODx.setStaticElementPath('plugin');
+                                        }
+                                        ,scope: this
+                                    }
+                                }
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-name'
+                                ,html: _('plugin_name_desc')
+                                ,cls: 'desc-under'
+                            }]
+                        },{
+                            columnWidth: 0.5
+                            ,defaults: {
+                                anchor: '100%'
+                                ,msgTarget: 'under'
+                            }
+                            ,items: [{
+                                xtype: 'modx-combo-category'
+                                ,fieldLabel: _('category')
+                                ,description: MODx.expandHelp ? '' : _('plugin_category_desc')
+                                ,name: 'category'
+                                ,id: 'modx-plugin-category'
+                                ,value: config.record.category || 0
+                                ,tabIndex: 2
+                                ,listeners: {
+                                    afterrender: {scope:this,fn:function(f,e) {
+                                        setTimeout(function(){
+                                            MODx.setStaticElementPath('plugin');
+                                        }, 200);
+                                    }}
+                                    ,change: {scope:this,fn:function(f,e) {
+                                        MODx.setStaticElementPath('plugin');
+                                    }}
+                                }
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-category'
+                                ,html: _('plugin_category_desc')
+                                ,cls: 'desc-under'
+                            }]
+                        }]
                     }]
                 },{
-                    columnWidth: .4
+                    // row 2
+                    cls:'form-row-wrapper'
+                    ,defaults: {
+                        layout: 'column'
+                    }
                     ,items: [{
-                        xtype: 'modx-combo-category'
-                        ,fieldLabel: _('category')
-                        ,description: MODx.expandHelp ? '' : _('plugin_desc_category')
-                        ,name: 'category'
-                        ,id: 'modx-plugin-category'
-                        ,anchor: '100%'
-                        ,value: config.record.category || 0
-                        ,listeners: {
-                            'afterrender': {scope:this,fn:function(f,e) {
-                                MODx.setStaticElementPath('plugin');
-                            }}
-                            ,'select': {scope:this,fn:function(f,e) {
-                                MODx.setStaticElementPath('plugin');
-                            }}
+                        defaults: {
+                            layout: 'form'
+                            ,labelSeparator: ''
+                            ,labelAlign: 'top'
                         }
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-category'
-                        ,html: _('plugin_desc_category')
-                        ,cls: 'desc-under'
-                    },{
-                        xtype: 'xcheckbox'
-                        ,description: MODx.expandHelp ? '' : _('plugin_disabled_msg')
-                        ,hideLabel: true
-                        ,boxLabel: _('plugin_disabled')
-                        ,name: 'disabled'
-                        ,id: 'modx-plugin-disabled'
-                        ,inputValue: 1
-                        ,checked: config.record.disabled || 0
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-disabled'
-                        ,html: _('plugin_disabled_msg')
-                        ,cls: 'desc-under'
-                    },{
-                        xtype: 'xcheckbox'
-                        ,boxLabel: _('plugin_lock')
-                        ,description: MODx.expandHelp ? '' : _('plugin_lock_msg')
-                        ,hideLabel: true
-                        ,name: 'locked'
-                        ,id: 'modx-plugin-locked'
-                        ,inputValue: 1
-                        ,checked: config.record.locked || 0
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-locked'
-                        ,html: _('plugin_lock_msg')
-                        ,cls: 'desc-under'
-                    },{
-                        xtype: 'xcheckbox'
-                        ,boxLabel: _('clear_cache_on_save')
-                        ,description: MODx.expandHelp ? '' : _('clear_cache_on_save_msg')
-                        ,hideLabel: true
-                        ,name: 'clearCache'
-                        ,id: 'modx-plugin-clear-cache'
-                        ,inputValue: 1
-                        ,checked: Ext.isDefined(config.record.clearCache) || true
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-clear-cache'
-                        ,html: _('clear_cache_on_save_msg')
-                        ,cls: 'desc-under'
-                    },{
-                        xtype: 'xcheckbox'
-                        ,hideLabel: true
-                        ,boxLabel: _('is_static')
-                        ,description: MODx.expandHelp ? '' : _('is_static_msg')
-                        ,name: 'static'
-                        ,id: 'modx-plugin-static'
-                        ,inputValue: 1
-                        ,checked: config.record['static'] || false
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-static'
-                        ,id: 'modx-plugin-static-help'
-                        ,html: _('is_static_msg')
-                        ,cls: 'desc-under'
-                    },{
-                        xtype: 'modx-combo-source'
-                        ,fieldLabel: _('static_source')
-                        ,description: MODx.expandHelp ? '' : _('static_source_msg')
-                        ,name: 'source'
-                        ,id: 'modx-plugin-static-source'
-                        ,anchor: '100%'
-                        ,maxLength: 255
-                        ,value: config.record.source != null ? config.record.source : MODx.config.default_media_source
-                        ,hidden: !config.record['static']
-                        ,hideMode: 'offsets'
-                        ,baseParams: {
-                            action: 'Source/GetList'
-                            ,showNone: true
-                            ,streamsOnly: true
+                        ,items: [{
+                            columnWidth: 0.5
+                            ,defaults: {
+                                anchor: '100%'
+                                ,msgTarget: 'under'
+                                ,validationEvent: 'change'
+                                ,validateOnBlur: false
+                            }
+                            ,items: [{
+                                xtype: 'textarea'
+                                ,fieldLabel: _('description')
+                                ,description: MODx.expandHelp ? '' : _('plugin_description_desc')
+                                ,name: 'description'
+                                ,id: 'modx-plugin-description'
+                                ,maxLength: 255
+                                ,tabIndex: 3
+                                ,value: config.record.description || ''
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-description'
+                                ,html: _('plugin_description_desc')
+                                ,cls: 'desc-under'
+                            }]
+                        },{
+                            columnWidth: 0.5
+                            ,cls: 'switch-container'
+                            ,defaults: {
+                                anchor: '100%'
+                                ,msgTarget: 'under'
+                                ,validationEvent: 'change'
+                                ,validateOnBlur: false
+                            }
+                            ,items: [{
+                                xtype: 'xcheckbox'
+                                ,hideLabel: true
+                                ,description: MODx.expandHelp ? '' : _('plugin_disabled_msg')
+                                ,boxLabel: _('plugin_disabled')
+                                ,name: 'disabled'
+                                ,id: 'modx-plugin-disabled'
+                                ,inputValue: 1
+                                ,tabIndex: 4
+                                ,checked: config.record.disabled || 0
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-disabled'
+                                ,html: _('plugin_disabled_msg')
+                                ,cls: 'desc-under toggle-slider-above'
+                            },{
+                                xtype: 'xcheckbox'
+                                ,hideLabel: true
+                                ,boxLabel: _('element_lock')
+                                ,description: MODx.expandHelp ? '' : _('plugin_lock_desc')
+                                ,name: 'locked'
+                                ,id: 'modx-plugin-locked'
+                                ,inputValue: 1
+                                ,tabIndex: 5
+                                ,checked: config.record.locked || false
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-locked'
+                                ,html: _('plugin_lock_desc')
+                                ,cls: 'desc-under toggle-slider-above'
+                            },{
+                                xtype: 'xcheckbox'
+                                ,hideLabel: true
+                                ,boxLabel: _('clear_cache_on_save')
+                                ,description: MODx.expandHelp ? '' : _('clear_cache_on_save_desc')
+                                ,name: 'clearCache'
+                                ,id: 'modx-plugin-clear-cache'
+                                ,inputValue: 1
+                                ,tabIndex: 6
+                                ,checked: Ext.isDefined(config.record.clearCache) || true
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-clear-cache'
+                                ,html: _('clear_cache_on_save_desc')
+                                ,cls: 'desc-under toggle-slider-above'
+                            }]
+                        }]
+                    }]
+                },{
+                    // row 3
+                    cls:'form-row-wrapper'
+                    ,defaults: {
+                        layout: 'column'
+                    }
+                    ,items: [{
+                        defaults: {
+                            layout: 'form'
+                            ,labelSeparator: ''
+                            ,labelAlign: 'top'
                         }
-                        ,listeners: {
-                            select: {
-                                fn: function(cmp, record, selectedIndex) {
-                                    this.onChangeStaticSource(cmp, 'plugin');
-                                },
-                                scope: this
+                        ,items: [{
+                            columnWidth: 1
+                            ,cls: 'fs-toggle'
+                            ,defaults: {
+                                anchor: '100%'
+                                ,msgTarget: 'under'
+                                ,validationEvent: 'change'
+                                ,validateOnBlur: false
+                            }
+                            ,items: [{
+                                xtype: 'xcheckbox'
+                                ,hideLabel: true
+                                ,boxLabel: _('is_static')
+                                ,description: MODx.expandHelp ? '' : _('is_static_desc')
+                                ,name: 'static'
+                                ,id: 'modx-plugin-static'
+                                ,inputValue: 1
+                                ,tabIndex: 7
+                                ,checked: config.record['static'] || false
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-static'
+                                ,id: 'modx-plugin-static-help'
+                                ,html: _('is_static_desc')
+                                ,cls: 'desc-under toggle-slider-above'
+                            }]
+                        }]
+                    }]
+                },{
+                    // row 4
+                    xtype: 'fieldset'
+                    ,layout: 'form'
+                    ,title: 'Static File Options'
+                    ,autoHeight: true
+                    ,cls: 'form-row-wrapper'
+                    ,id: 'element-static-options-fs'
+                    ,defaults: {
+                        layout: 'column'
+                    }
+                    ,items: [{
+                        defaults: {
+                            layout: 'form'
+                            ,labelSeparator: ''
+                            ,labelAlign: 'top'
+                        }
+                        ,items: [{
+                            columnWidth: 0.5
+                            ,defaults: {
+                                anchor: '100%'
+                                ,msgTarget: 'under'
+                                ,validationEvent: 'change'
+                                ,validateOnBlur: false
+                                ,hideMode: 'visibility'
+                            }
+                            ,items: [{
+                                xtype: 'modx-combo-source'
+                                ,fieldLabel: _('static_source')
+                                ,description: MODx.expandHelp ? '' : _('static_source_desc')
+                                ,name: 'source'
+                                ,id: 'modx-plugin-static-source'
+                                ,maxLength: 255
+                                ,value: config.record.source != null ? config.record.source : MODx.config.default_media_source
+                                ,tabIndex: 8
+                                ,baseParams: {
+                                    action: 'Source/GetList'
+                                    ,showNone: true
+                                    ,streamsOnly: true
+                                }
+                                ,listeners: {
+                                    select: {
+                                        fn: function() {
+                                            this.setMediaSources('plugin');
+                                        },
+                                        scope: this
+                                    }
+                                }
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-static-source'
+                                ,id: 'modx-plugin-static-source-help'
+                                ,html: _('static_source_desc')
+                                ,cls: 'desc-under'
+                            }]
+                        },{
+                            columnWidth: 0.5
+                            ,defaults: {
+                                anchor: '100%'
+                                ,msgTarget: 'under'
+                                ,validationEvent: 'change'
+                                ,validateOnBlur: false
+                                ,hideMode: 'visibility'
+                            }
+                            ,items: [{
+                                xtype: 'modx-combo-browser'
+                                ,browserEl: 'modx-browser'
+                                ,fieldLabel: _('static_file')
+                                ,description: MODx.expandHelp ? '' : _('static_file_desc')
+                                ,name: 'static_file'
+                                ,source: config.record.source != null ? config.record.source : MODx.config.default_media_source
+                                ,openTo: config.record.openTo || ''
+                                ,id: 'modx-plugin-static-file'
+                                ,triggerClass: 'x-form-code-trigger'
+                                ,maxLength: 255
+                                ,value: config.record.static_file || ''
+                                ,tabIndex: 9
+                                ,validator: function(value){
+                                    if (Ext.getCmp('modx-plugin-static').getValue() === true) {
+                                        if (Ext.util.Format.trim(value) != '') {
+                                            return true;
+                                        } else {
+                                            return _('static_file_ns');
+                                        }
+                                    }
+                                    return true;
+                                }
+                            },{
+                                xtype: MODx.expandHelp ? 'label' : 'hidden'
+                                ,forId: 'modx-plugin-static-file'
+                                ,id: 'modx-plugin-static-file-help'
+                                ,html: _('static_file_desc')
+                                ,cls: 'desc-under'
+                            }]
+                        }]
+                    }]
+                    ,listeners: {
+                        afterrender: function(cmp) {
+                            const isStaticCmp = Ext.getCmp('modx-plugin-static');
+                            if (isStaticCmp) {
+                                this.isStatic = isStaticCmp.checked;
+                                const   switchField = 'modx-plugin-static',
+                                        toggleFields = ['modx-plugin-static-file','modx-plugin-static-source']
+                                        ;
+                                isStaticCmp.on('check', function(){
+                                    this.toggleFieldVisibility(switchField, cmp.id, toggleFields);
+                                }, this);
+                                if(!this.isStatic) {
+                                    this.toggleFieldVisibility(switchField, cmp.id, toggleFields);
+                                }
                             }
                         }
-                    },{
-                        xtype: MODx.expandHelp ? 'label' : 'hidden'
-                        ,forId: 'modx-plugin-static-source'
-                        ,id: 'modx-plugin-static-source-help'
-                        ,html: _('static_source_msg')
-                        ,cls: 'desc-under'
-                        ,hidden: !config.record['static']
-                        ,hideMode: 'offsets'
-                    }]
-
+                        ,scope: this
+                    }
                 }]
             },{
 				xtype: 'panel'
-				,border: false
-				,layout: 'form'
 				,cls:'main-wrapper'
-				,labelAlign: 'top'
 				,items: [{
 					xtype: 'textarea'
 					,fieldLabel: _('plugin_code')
@@ -244,6 +389,7 @@ MODx.panel.Plugin = function(config) {
 					,anchor: '100%'
 					,height: 400
 					,value: config.record.plugincode || "<?php\n"
+                    ,tabIndex: 10
                 }]
             }]
         },{
@@ -259,8 +405,8 @@ MODx.panel.Plugin = function(config) {
                 ,preventRender: true
                 ,plugin: config.record.id || 0
                 ,listeners: {
-                    'updateEvent': {fn:this.markDirty,scope:this}
-                    ,'rowclick': {fn:this.markDirty,scope:this}
+                    updateEvent: {fn:this.markDirty,scope:this}
+                    ,rowclick: {fn:this.markDirty,scope:this}
                 }
             }]
         },{
@@ -274,43 +420,47 @@ MODx.panel.Plugin = function(config) {
         })]
         ,useLoadingMask: true
         ,listeners: {
-            'setup': {fn:this.setup,scope:this}
-            ,'success': {fn:this.success,scope:this}
-            ,'beforeSubmit': {fn:this.beforeSubmit,scope:this}
-            ,'failureSubmit': {
+            setup: {fn:this.setup,scope:this}
+            ,success: {fn:this.success,scope:this}
+            ,failure: {fn:this.failure,scope:this}
+            ,beforeSubmit: {fn:this.beforeSubmit,scope:this}
+            ,failureSubmit: {
                 fn: function () {
-                    this.showErroredTab(['modx-plugin-form'], 'modx-plugin-tabs')
+                    this.showErroredTab(this.errorHandlingTabs, 'modx-plugin-tabs')
                 },
                 scope: this
             }
         }
     });
     MODx.panel.Plugin.superclass.constructor.call(this,config);
-    var isStatic = Ext.getCmp('modx-plugin-static');
-    if (isStatic) { isStatic.on('check',this.toggleStaticFile); }
 };
 Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
+
     initialized: false
+
     ,setup: function() {
-        if (this.initialized) { this.clearDirty(); return true; }
-        this.getForm().setValues(this.config.record);
-        if (!Ext.isEmpty(this.config.record.name)) {
-            var title = _('plugin')+': '+this.config.record.name;
-            if (MODx.perm.tree_show_element_ids) {
-                title = title+ ' <small>('+this.config.record.id+')</small>';
-            }
-            Ext.getCmp('modx-plugin-header').getEl().update(title);
+
+        if (!this.initialized) {
+            /*
+                The itemId (not id) of each form tab to be included/excluded; these correspond to the
+                keys in each tab component's items property
+            */
+            this.errorHandlingTabs = ['modx-plugin-form'];
+            this.errorHandlingIgnoreTabs = ['modx-plugin-sysevents','modx-panel-element-properties'];
+            this.getForm().setValues(this.config.record);
+        } else {
+            this.clearDirty();
+            return true;
         }
-        if (!Ext.isEmpty(this.config.record.properties)) {
-            var d = this.config.record.properties;
-            var g = Ext.getCmp('modx-grid-element-properties');
-            if (g) {
-                g.defaultProperties = d;
-                g.getStore().loadData(d);
-            }
-        }
+
+        this.formatMainPanelTitle('plugin', this.config.record);
+        this.getElementProperties(this.config.record.properties);
         this.fireEvent('ready',this.config.record);
-        if (MODx.onLoadEditor) { MODx.onLoadEditor(this); }
+
+        if (MODx.onLoadEditor) {
+            MODx.onLoadEditor(this);
+        }
+
         this.clearDirty();
         MODx.fireEvent('ready');
         this.initialized = true;
@@ -328,6 +478,7 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
             ,stay: MODx.config.stay
         });
     }
+
     ,success: function(o) {
         if (MODx.request.id) Ext.getCmp('modx-grid-element-properties').save();
         Ext.getCmp('modx-grid-plugin-event').getStore().commitChanges();
@@ -342,6 +493,7 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
             t.refreshNode(u,true);
         }
     }
+
     ,changeEditor: function() {
         this.cleanupEditor();
         this.on('success',function(o) {
@@ -352,44 +504,13 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
         });
         this.submit();
     }
+
     ,cleanupEditor: function() {
         if (MODx.onSaveEditor) {
             var fld = Ext.getCmp('modx-plugin-plugincode');
             MODx.onSaveEditor(fld);
         }
     }
-    ,toggleStaticFile: function(cb) {
-        var flds = ['modx-plugin-static-file','modx-plugin-static-source'];
-        var fld;
-        var i;
-        var fldHelp;
-        if (cb.checked) {
-            for (i in flds) {
-                fld = Ext.getCmp(flds[i]);
-                if (fld) {
-                    fld.show();
-                    fld.updateBox(fld.getResizeEl().parent().getBox());
 
-                    fldHelp = Ext.getCmp(flds[i] + '-help');
-                    if (fldHelp) {
-                        fldHelp.show();
-                    }
-
-                }
-            }
-        } else {
-            for (i in flds) {
-                fld = Ext.getCmp(flds[i]);
-                if (fld) {
-                    fld.hide();
-
-                    fldHelp = Ext.getCmp(flds[i] + '-help');
-                    if (fldHelp) {
-                        fldHelp.hide();
-                    }
-                }
-            }
-        }
-    }
 });
 Ext.reg('modx-panel-plugin',MODx.panel.Plugin);

--- a/manager/assets/modext/widgets/element/modx.panel.plugin.js
+++ b/manager/assets/modext/widgets/element/modx.panel.plugin.js
@@ -305,8 +305,8 @@ MODx.panel.Plugin = function(config) {
                                 }
                                 ,listeners: {
                                     select: {
-                                        fn: function() {
-                                            this.setMediaSources('plugin');
+                                        fn: function(cmp, record, selectedIndex) {
+                                            this.onChangeStaticSource(cmp, 'plugin');
                                         },
                                         scope: this
                                     }
@@ -327,30 +327,8 @@ MODx.panel.Plugin = function(config) {
                                 ,validateOnBlur: false
                                 ,hideMode: 'visibility'
                             }
-                            ,items: [{
-                                xtype: 'modx-combo-browser'
-                                ,browserEl: 'modx-browser'
-                                ,fieldLabel: _('static_file')
-                                ,description: MODx.expandHelp ? '' : _('static_file_desc')
-                                ,name: 'static_file'
-                                ,source: config.record.source != null ? config.record.source : MODx.config.default_media_source
-                                ,openTo: config.record.openTo || ''
-                                ,id: 'modx-plugin-static-file'
-                                ,triggerClass: 'x-form-code-trigger'
-                                ,maxLength: 255
-                                ,value: config.record.static_file || ''
-                                ,tabIndex: 9
-                                ,validator: function(value){
-                                    if (Ext.getCmp('modx-plugin-static').getValue() === true) {
-                                        if (Ext.util.Format.trim(value) != '') {
-                                            return true;
-                                        } else {
-                                            return _('static_file_ns');
-                                        }
-                                    }
-                                    return true;
-                                }
-                            },{
+                            ,items: [
+                                this.getStaticFileField('plugin', config.record),{
                                 xtype: MODx.expandHelp ? 'label' : 'hidden'
                                 ,forId: 'modx-plugin-static-file'
                                 ,id: 'modx-plugin-static-file-help'
@@ -440,18 +418,17 @@ Ext.extend(MODx.panel.Plugin,MODx.FormPanel,{
 
     ,setup: function() {
 
-        if (!this.initialized) {
-            /*
-                The itemId (not id) of each form tab to be included/excluded; these correspond to the
-                keys in each tab component's items property
-            */
-            this.errorHandlingTabs = ['modx-plugin-form'];
-            this.errorHandlingIgnoreTabs = ['modx-plugin-sysevents','modx-panel-element-properties'];
-            this.getForm().setValues(this.config.record);
-        } else {
+        if (this.initialized) {
             this.clearDirty();
             return true;
         }
+        /*
+            The itemId (not id) of each form tab to be included/excluded; these correspond to the
+            keys in each tab component's items property
+        */
+        this.errorHandlingTabs = ['modx-plugin-form'];
+        this.errorHandlingIgnoreTabs = ['modx-plugin-sysevents','modx-panel-element-properties'];
+        this.getForm().setValues(this.config.record);
 
         this.formatMainPanelTitle('plugin', this.config.record);
         this.getElementProperties(this.config.record.properties);


### PR DESCRIPTION
_NOTE: This is part 6 of 6 of a revised submission of #15887. This should be reviewed after part 2 is merged (there are two small changes needed from that PR to make the locked switch appear correctly)._

### What does it do?

Ports enhancements to the Plugin form panel from PR #15146 to 3.x (including subsequent fixes by others). 
Changes include:
1. Updated panel JS to make form layout consistent with the layout introduced in the current TV panel, and utilize new shared methods introduced in the main FormPanel via part 1 of this PR set (already merged).
2. A handful of minor lexicon updates.

### Why is it needed?

Makes needed UI and consistency improvements to the Plugin panel.

### How to test

1. From your terminal app, run `grunt build` from within the `_build/templates/default` folder and clear your browser cache.
2. Create and update a few Plugins to verify behavior and appearance is as expected.

### Related issue(s)/PR(s)
Partial port of #15146 
