### PR TITLE
Fix inability to create/update user password

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.js
@@ -34,7 +34,11 @@
         }
     });
     MODx.panel.User.superclass.constructor.call(this,config);
-    Ext.getCmp('modx-user-panel-newpassword').getEl().dom.style.display = 'none';
+    const passwordPanel = Ext.getCmp('modx-user-panel-newpassword');
+    passwordPanel.items.each(item => {
+        item.getEl().set({autocomplete: 'new-password'});
+    });
+    passwordPanel.getEl().dom.style.display = 'none';
     Ext.getCmp('modx-user-password-genmethod-s').on('check',this.showNewPassword,this);
     Ext.getCmp('modx-extended-form').disable();
 };
@@ -109,12 +113,16 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
         }
     }
 
-    ,showNewPassword: function(cb,v) {
-        var el = Ext.getCmp('modx-user-panel-newpassword').getEl();
-        if (v) {
-            el.slideIn('t',{useDisplay:true});
+    ,showNewPassword: function(cmp, checked) {
+        const passwordPanel = Ext.getCmp('modx-user-panel-newpassword'),
+              panelElement = passwordPanel.getEl(),
+              fxOptions = { useDisplay: true }
+        ;
+        if (checked) {
+            panelElement.slideIn('t', fxOptions);
+            passwordPanel.doLayout();
         } else {
-            el.slideOut('t',{useDisplay:true});
+            panelElement.slideOut('t', fxOptions);
         }
     }
 
@@ -488,10 +496,6 @@ Ext.extend(MODx.panel.User,MODx.FormPanel,{
                     ,anchor: '100%'
                     ,inputType: 'password'
                     ,xtype: 'textfield'
-                    ,autoCreate: {
-                        tag: "input"
-                        ,autocomplete: "new-password"
-                    }
                 }
                 ,items: [{
                     id: 'modx-user-specifiedpassword'


### PR DESCRIPTION
### What does it do?
Implemented change made in PR #16105 in a different way so it doesn't break the ability to specify a user's password.

### Why is it needed?
User passwords cannot currently be specified. Saving silently fails.

### How to test
Create and update at least one user to verify the record saves as expected when choosing to specify their password. Also verify that the password fields do not autocomplete.

### Related issue(s)/PR(s)
Resolves #16124. 
