### PR TITLE
Treat email contents as UTF-8, fixing mangled characters [#16116]

### DIFF
--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -222,13 +222,14 @@ class modPHPMailer extends modMail
 
         $sent = false;
         try {
-            if (strpos($this->mailer->ContentType, 'html') !== false) {
-                if (!empty($this->mailer->Body)) {
-                    $html = new InlineStyle($this->mailer->Body);
-                    /** @noinspection PhpParamsInspection */
-                    $html->applyStylesheet($html->extractStylesheets());
-                    $this->mailer->Body = $html->getHTML();
-                }
+            if (!empty($this->mailer->Body) && (strpos($this->mailer->ContentType, 'html') !== false)) {
+                $body = $this->mailer->Body;
+                // Turn UTF-8 characters into entities
+                $body = mb_convert_encoding($body, 'HTML-ENTITIES', 'UTF-8');
+                $html = new InlineStyle($body);
+                /** @noinspection PhpParamsInspection */
+                $html->applyStylesheet($html->extractStylesheets());
+                $this->mailer->Body = $html->getHTML();
             }
             $sent = $this->mailer->send();
         } catch (Exception $e) {


### PR DESCRIPTION
### What does it do?
Uses `mb_convert_encoding` to turn UTF-8 characters in email contents into entities before passing it to the InlineStyle class. 

### Why is it needed?
The style inlining added in 3.0 is mangling characters: #16116 

With this tweak, that should be resolved.

### How to test
Try sending an email that contains any sort of unicode characters through the mailer. #16116 has an example to quickly put in a snippet, but even better might be testing actual emails (login, contact forms) with this tweak.   

### Related issue(s)/PR(s)
Fixes #16116 

https://community.modx.com/t/characters-in-email-body-messed-up/5145/17?u=markh