### PR TITLE
Fix display of optimize and truncate links in Database Tables panel

### DIFF
--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -30,21 +30,15 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
         $dt = [];
         while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
             /* calculations first */
-            if ($this->modx->hasPermission('settings') && $row['Name'] === $this->modx->getOption('table_prefix') . 'event_log' && $row['Data_length'] + $row['Data_free'] > 0) {
-                $row['Data_size'] = '<a href="javascript:;" onclick="truncate(\'' . $row['Name'] . '\')" title="' . $this->modx->lexicon('truncate_table') . '">' . $this->formatSize($row['Data_length'] + $row['Data_free']) . '</a>';
-            } else {
-                $row['Data_size'] = $this->formatSize($row['Data_length'] + $row['Data_free']);
-            }
+            $row['canTruncate'] = $this->modx->hasPermission('settings') && $row['Name'] === $this->modx->getOption('table_prefix') . 'manager_log' && $row['Data_length'] + $row['Data_free'] > 0 ? true : false ;
+            $row['Data_size'] = $this->formatSize($row['Data_length'] + $row['Data_free']);
             $row['Effective_size'] = $this->formatSize($row['Data_length'] - $row['Data_free']);
             $row['Total_size'] = $this->formatSize($row['Index_length'] + $row['Data_length'] + $row['Data_free']);
 
             /* now the non-calculated fields */
             $row['Data_length'] = $this->formatSize($row['Data_length']);
-            if ($this->modx->hasPermission('settings') && $row['Data_free'] > 0) {
-                $row['Data_free'] = '<a href="javascript:;" onclick="optimize(\'' . $row['Name'] . '\')" title="' . $this->modx->lexicon('optimize_table') . '">' . $this->formatSize($row['Data_free']) . '</a>';
-            } else {
-                $row['Data_free'] = $this->formatSize($row['Data_free']);
-            }
+            $row['Data_free'] = $this->formatSize($row['Data_free']);
+            $row['canOptimize'] = $this->modx->hasPermission('settings') && $row['Data_free'] > 0 ? true : false ;
             $row['Index_length'] = $this->formatSize($row['Index_length']);
             $dt[] = $row;
         }

--- a/manager/assets/modext/widgets/system/mysql/modx.grid.databasetables.js
+++ b/manager/assets/modext/widgets/system/mysql/modx.grid.databasetables.js
@@ -30,10 +30,22 @@ MODx.grid.DatabaseTables = function(config) {
             header: _('database_table_datasize')
             ,dataIndex: 'Data_size'
             ,width: 70
+            ,renderer: function(value, metaData, record, rowIndex, colIndex, store) {
+              if (record.json.canTruncate == true) {
+                  return `<a href="javascript:;" onclick="truncate('${record.data.Name}')" title="${_('truncate_table')}">${value}</a>`;
+              }
+              return value;
+           }
         },{
             header: _('database_table_overhead')
             ,dataIndex: 'Data_free'
             ,width: 70
+            ,renderer: function(value, metaData, record, rowIndex, colIndex, store) {
+              if (record.json.canOptimize == true) {
+                  return `<a href="javascript:;" onclick="optimize('${record.data.Name}')" title="${_('optimize_table')}">${value}</a>`;
+              }
+              return value;
+           }
         },{
             header: _('database_table_effectivesize')
             ,dataIndex: 'Effective_size'


### PR DESCRIPTION
### What does it do?
Changed the way these utility links are created, taking the anchor tags markup out of the `mysql/GetList` php file and placing them in the appropriate grid column's renderers. Also changed the table name for truncate from the non-existent `event_log` to `manager_log`.

### Why is it needed?
The link tag is currently incorporated in a way that it gets html encoded, killing its functionality. Also, whenever possible html markup of any kind should be kept out of the php files.

### How to test
#### Truncate
1. Go to _Manage/Reports/Manager Actions_ and ensure there are some entries shown in the grid
2. Go to _Manage/Reports/System Info_ and click on the _Database Tables_ tab
3. Scroll down to the `manager_log` table. The Data Size (second column) should show a link. Click on that link to truncate (empty) the table.
4. Go back to _Manage/Reports/System Info_ and click on the _Database Tables_ tab. Verify that the manager_log shows either **0 B** or a smaller size than before (some table types, such as InnoDB, rarely if ever will show a zero size).
#### Optimize
Two things to note: 
- Certain table types, such as InnoDB, have no optimize command (there's a different process to achieve its effect); thus clicking on optimize links for these types of tables will yield no result and no feedback indicating why is currently provided (this should be addressed in the future).
- You may need to force the condition to test the display of the optimize link if no tables currently actually need optimizing. 

Test:
1. Go to _Manage/Reports/System Info_ and click on the _Database Tables_ tab
2. If no optimize links are shown in the table listing's _Overhead_ column, edit the GetList file in this PR by temporarily commenting out line 41 `$row['canOptimize'] = [...]` and add `$row['canOptimize'] = true` (or your own logic if you'd like the link to be created randomly).
3. Reload the `System Info` page if you made changes. Verify that optimize links appear as expected and clicking on them produces a change in the Overhead value.

### Related issue(s)/PR(s)
Resolves #16131. 
