### PR TITLE
Fix inability to download files from the Media Browser

### DIFF
--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -189,25 +189,11 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         w.show(e.target);
     }
 
-    ,downloadFile: function(item,e) {
-        var node = this.cm.activeNode;
-        var data = this.lookup[node.id];
-        MODx.Ajax.request({
-            url: MODx.config.connector_url
-            ,params: {
-                action: 'Browser/File/Download'
-                ,file: data.pathRelative
-                ,wctx: MODx.ctx || ''
-                ,source: this.config.source
-            }
-            ,listeners: {
-                'success':{fn:function(r) {
-                    if (!Ext.isEmpty(r.object.url)) {
-                        location.href = MODx.config.connector_url+'?action=Browser/File/Download&download=1&file='+r.object.url+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.config.source+'&wctx='+MODx.ctx;
-                    }
-                },scope:this}
-            }
-        });
+    ,downloadFile: function(item, e) {
+        const node = this.cm.activeNode,
+              data = this.lookup[node.id]
+        ;
+        location.href = `${MODx.config.connector_url}?action=Browser/File/Download&download=1&file=${data.pathRelative}&HTTP_MODAUTH=${MODx.siteId}&source=${this.config.source}&wctx=${MODx.ctx}`;
     }
 
     ,copyRelativePath: function(item,e) {


### PR DESCRIPTION
### What does it do?
Removed unnecessary ajax call to the download class, making the Media Browser (MB) download method consistent with the currently-working directory tree one.

### Why is it needed?
To re-enable downloads from the MB.

### How to test
Navigate to the MB and verify that downloading files from various Media Sources (having both static and relative basePaths) operates as expected.

### Related issue(s)/PR(s)
Resolves #16134. Note that this PR picks up on what @halftrainedharry suggested as a solution in the referenced issue.
