### PR TITLE
Fix uncaught TypeError when calling a deprecated method from file

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2468,7 +2468,7 @@ class modX extends xPDO {
         }
 
         $deprecation = $this->_getDeprecatedMethod($since, $deprecatedDef, $recommendation);
-        $deprecation->addCaller($caller['class'] ?? '', $caller['function'], $deprecatedMethod['file'], $deprecatedMethod['line']);
+        $deprecation->addCaller($caller['class'] ?? '', $caller['function'] ?? '', $deprecatedMethod['file'], $deprecatedMethod['line']);
     }
 
     /**


### PR DESCRIPTION
### What does it do?

Allow an empty caller to pass.


### Why is it needed?

When calling a deprecated method from a flat file (e.g. a bootstrap or build file that does `$modx->loadClass()`), the following error gets triggered:

```
Fatal error: Uncaught TypeError: Argument 2 passed to MODX\Revolution\modDeprecatedMethod::addCaller() must be of the type string, null given, called in core/src/Revolution/modX.php on line 2472 and defined in /core/src/Revolution/modDeprecatedMethod.php on line 20
```

This is because the `$caller` is empty. 

Another possible fix would be to change the index when determining the caller, however this seems like an edge case and sufficiently fixed this way.

### How to test

```
require_once __DIR__ . '/config.core.php';
require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
$modx= new modX();
$modx->initialize('mgr');
$modx->setLogLevel(modX::LOG_LEVEL_INFO);
$modx->setLogTarget('ECHO');

$modx->loadClass('transport.modPackageBuilder','',false, true);
```


### Related issue(s)/PR(s)
None.
