### PR TITLE
Fix Element/Template/GetList processor for >20 templates in manager

### DIFF
--- a/core/src/Revolution/Processors/Element/Template/GetList.php
+++ b/core/src/Revolution/Processors/Element/Template/GetList.php
@@ -33,7 +33,7 @@ class GetList extends \MODX\Revolution\Processors\Element\GetList
     public $languageTopics = ['template', 'category'];
     public $defaultSortField = 'templatename';
     public $permission = 'view_template';
-    
+
     public function initialize()
     {
         $this->setDefaultProperties([

--- a/core/src/Revolution/Processors/Element/Template/GetList.php
+++ b/core/src/Revolution/Processors/Element/Template/GetList.php
@@ -33,6 +33,15 @@ class GetList extends \MODX\Revolution\Processors\Element\GetList
     public $languageTopics = ['template', 'category'];
     public $defaultSortField = 'templatename';
     public $permission = 'view_template';
+    
+    public function initialize()
+    {
+        $this->setDefaultProperties([
+            'limit' => 0
+        ]);
+
+        return parent::initialize();
+    }
 
     public function prepareQueryBeforeCount(xPDOQuery $c)
     {
@@ -44,7 +53,7 @@ class GetList extends \MODX\Revolution\Processors\Element\GetList
             ]);
         }
 
-        $c->sortby('category_name');
+        $c->sortby('Category.category');
         $c->sortby('templatename');
 
         return $c;


### PR DESCRIPTION
### What does it do?
Currently the Element/Template/GetList processor always returns a 'total' value of `0`. This causes the pagination of the template-dropdown to not work properly.

Also in the "Create Document" window, there is no pagination and the filtering happens without further AJAX-requests. Therefore the processor should return all templates if no limit is specified.
(Maybe a better fix would be to send a limit = `0` request parameter from the form though.)

### Why is it needed?
If you have more than 20 templates, not all of them can be selected when creating/updating a resource in the manager.

### How to test
Create more than 20 templates.
Create/update a resource and test if all templates can be selected.

### Related issue(s)/PR(s)
Resolves #16135
