### PR TITLE
Ignore E_DEPRECATED and E_STRICT errors in setup

### DIFF
--- a/setup/includes/request/modinstallrequest.class.php
+++ b/setup/includes/request/modinstallrequest.class.php
@@ -20,7 +20,7 @@
  * @package setup
  */
 
-error_reporting(E_ALL & ~E_NOTICE);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 @ ini_set('display_errors', 1);
 
 class modInstallRequest {

--- a/setup/processors/connector.php
+++ b/setup/processors/connector.php
@@ -22,7 +22,7 @@
 session_start();
 
 /* set error reporting */
-error_reporting(E_ALL & ~E_NOTICE);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 
 $setupPath= strtr(realpath(dirname(__DIR__)), '\\', '/') . '/';
 define('MODX_SETUP_PATH', $setupPath);


### PR DESCRIPTION
### What does it do?
Ignore E_DEPRECATED and E_STRICT errors in setup

### Why is it needed?
In PHP 8.1, functions are deprecated that will not be resolved in essential dependencies such as Smarty. If we do not ignore these errors during setup, whether a production server is properly set up to ignore these or not, MODX setup will be problematic, displaying concerning error messages on screen. This should have never been explicitly set, as these are meant to be informational errors.

### How to test
Test setup in PHP 8.1 and make sure deprecated errors are not displayed.

### Related issue(s)/PR(s)
N/A