### PR TITLE
Adjust placeholder filtering and accessible options for @SELECT

### DIFF
--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -916,8 +916,8 @@ class modTemplateVar extends modElement
                     if ($modx->resource && $modx->resource instanceof modResource) {
                         $dbtags = $modx->resource->toArray();
                     }
-                    $dbtags['DBASE'] = $this->xpdo->getOption('dbname');
-                    $dbtags['PREFIX'] = $this->xpdo->getOption('table_prefix');
+                    $dbtags['DBASE'] = $dbtags['+dbname'] = $this->xpdo->getOption('dbname');
+                    $dbtags['PREFIX'] = $dbtags['+table_prefix'] = $this->xpdo->getOption('table_prefix');
                     foreach ($dbtags as $key => $pValue) {
                         if (!is_scalar($pValue)) continue;
                         $param = str_replace('[[+'.$key.']]', (string)$pValue, $param);

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -586,7 +586,7 @@ class modX extends xPDO {
             if (is_array ($this->config)) {
                 $c = $this->config;
                 if ((bool)$this->getOption('filter_config_placeholders', null, true)) {
-                    unset($c['password'], $c['username'], $c['mail_smtp_pass'], $c['mail_smtp_user'], $c['proxy_password'], $c['proxy_username'], $c['connections'], $c['connection_init'], $c['connection_mutable'], $c['dbname'], $c['database'], $c['table_prefix'], $c['driverOptions'], $c['dsn'], $c['session_name'], $c['assets_path'], $c['base_path'], $c['cache_path'], $c['connectors_path'], $c['core_path'], $c['friendly_alias_translit_class_path'], $c['manager_path'], $c['processors_path']);
+                    unset($c['password'], $c['username'], $c['mail_smtp_pass'], $c['mail_smtp_user'], $c['proxy_password'], $c['proxy_username'], $c['connections'], $c['connection_init'], $c['connection_mutable'], $c['dbname'], $c['database'], $c['table_prefix'], $c['driverOptions'], $c['dsn'], $c['session_name'], $c['cache_path'], $c['connectors_path'], $c['friendly_alias_translit_class_path'], $c['manager_path'], $c['processors_path']);
                 }
                 $this->setPlaceholders($c, '+');
             }


### PR DESCRIPTION
### What does it do?
Port adjustments to placeholder filtering and @SELECT options from 2.x

### Why is it needed?
This restores functionality that was originally lost and then restored in 2.x

### How to test
Test the usage of placeholders for assets_path, base_path, and core_path in parsed content, as well as legacy placeholders for @SELECT (table_prefix and dbname).

### Related issue(s)/PR(s)
Port of #15714 
Resolves #16148 