### PR TITLE
Don't show the Configuration Check dashboard widget if all checks pass

### DIFF
--- a/manager/templates/default/dashboard/configcheck.tpl
+++ b/manager/templates/default/dashboard/configcheck.tpl
@@ -8,6 +8,4 @@
             </li>
         {/foreach}
     </ul>
-{else}
-    <h4 class="green">{$_lang.configcheck_ok}</h4>
 {/if}


### PR DESCRIPTION
### What does it do?
Don't show the success message for the configuration check widget if all checks pass.

### Why is it needed?
This will hide the widget, otherwise it would stay visible indefinitely unless you manually remove the widget.

### How to test
Resolve all warnings shown in the configuration check widget.

### Related issue(s)/PR(s)
Resolves #16109
