### PR TITLE
[3.x] Make hidden TV's work for weblinks, symlinks and static resources

### DIFF
--- a/manager/templates/default/resource/staticresource/create.tpl
+++ b/manager/templates/default/resource/staticresource/create.tpl
@@ -1,5 +1,9 @@
 <div id="modx-panel-static-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
+{foreach from=$hidden item=tv name='tv'}
+    <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
+    {$tv->get('formElement')}
+{/foreach}
 
 {$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}

--- a/manager/templates/default/resource/staticresource/update.tpl
+++ b/manager/templates/default/resource/staticresource/update.tpl
@@ -1,5 +1,9 @@
 <div id="modx-panel-static-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
+{foreach from=$hidden item=tv name='tv'}
+    <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
+    {$tv->get('formElement')}
+{/foreach}
 
 {$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}

--- a/manager/templates/default/resource/symlink/create.tpl
+++ b/manager/templates/default/resource/symlink/create.tpl
@@ -1,5 +1,9 @@
 <div id="modx-panel-symlink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
+{foreach from=$hidden item=tv name='tv'}
+    <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
+    {$tv->get('formElement')}
+{/foreach}
 
 {$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}

--- a/manager/templates/default/resource/symlink/update.tpl
+++ b/manager/templates/default/resource/symlink/update.tpl
@@ -1,5 +1,9 @@
 <div id="modx-panel-symlink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
+{foreach from=$hidden item=tv name='tv'}
+    <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
+    {$tv->get('formElement')}
+{/foreach}
 
 {$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}

--- a/manager/templates/default/resource/weblink/create.tpl
+++ b/manager/templates/default/resource/weblink/create.tpl
@@ -1,5 +1,9 @@
 <div id="modx-panel-weblink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
+{foreach from=$hidden item=tv name='tv'}
+    <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
+    {$tv->get('formElement')}
+{/foreach}
 
 {$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}

--- a/manager/templates/default/resource/weblink/update.tpl
+++ b/manager/templates/default/resource/weblink/update.tpl
@@ -1,5 +1,9 @@
 <div id="modx-panel-weblink-div"></div>
 <div id="modx-resource-tvs-div" class="modx-resource-tab x-form-label-left x-panel">{$tvOutput|default}</div>
+{foreach from=$hidden item=tv name='tv'}
+    <input type="hidden" id="tvdef{$tv->id}" value="{$tv->default_text|escape}" />
+    {$tv->get('formElement')}
+{/foreach}
 
 {$onDocFormPrerender|default}
 {if $resource->richtext AND $_config.use_editor}


### PR DESCRIPTION
### What does it do?
Add the hidden TV inputs to the create/update manager templates for weblinks, symlinks and static resources

### Why is it needed?
To make hidden TV's work for weblinks, symlinks and static resources. Otherwise it would only work for resources with Resource Type "Document" .

### How to test
- Create a hidden TV
- Create/update a weblink, symlink and static resource.
- Set the value of the hidden TV (e.g install the DaterangeTV and set the `End Value Template Variable`)
- Save the resource.

### Related issue(s)/PR(s)
PR #16162