### PR TITLE
Remove unused lexicon

### DIFF
--- a/core/lexicon/en/configcheck.inc.php
+++ b/core/lexicon/en/configcheck.inc.php
@@ -38,7 +38,6 @@ $_lang['configcheck_installer_msg'] = 'The setup/ directory contains the install
 $_lang['configcheck_lang_difference'] = 'Incorrect number of entries in language file';
 $_lang['configcheck_lang_difference_msg'] = 'The currently selected language has a different number of entries than the default language. While not necessarily a problem, this may mean the language file needs to be updated.';
 $_lang['configcheck_notok'] = 'One or more configuration details didn\'t check out OK: ';
-$_lang['configcheck_ok'] = 'Check passed OK - no warnings to report.';
 $_lang['configcheck_phpversion'] = 'PHP version is outdated';
 $_lang['configcheck_phpversion_msg'] = 'Your PHP version [[+phpversion]] is no longer maintained by the PHP developers, which means no security updates are available. It is also likely that MODX or an extra package now or in the near future will no longer support this version. Please update your environment at least to PHP [[+phprequired]] as soon as possible to secure your site.';
 $_lang['configcheck_register_globals'] = 'register_globals is set to ON in your php.ini configuration file';


### PR DESCRIPTION
### What does it do?
Remove the unused lexicon `configcheck_ok`

### Why is it needed?
It's no longer used

### Related issue(s)/PR(s)
PR #16151