### PR TITLE
[3.x] Unit Test for modInputFilter

### DIFF
--- a/_build/test/Tests/Model/Filters/modInputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modInputFilterTest.php
@@ -12,6 +12,8 @@
 namespace MODX\Revolution\Tests\Model\Filters;
 
 
+use MODX\Revolution\Filters\modInputFilter;
+use MODX\Revolution\modFieldTag;
 use MODX\Revolution\MODxTestCase;
 
 /**
@@ -24,7 +26,46 @@ use MODX\Revolution\MODxTestCase;
  * @group modInputFilter
  */
 class modInputFilterTest extends MODxTestCase {
-    public function testExample() {
-        $this->assertTrue(true);
+
+    /**
+     * @dataProvider providerFilter
+     * @param $elementName
+     * @param $expectedElementName
+     * @param $expectedComands
+     * @param $expectedModifiers
+     * @return void
+     */
+    public function testFilter($elementName, $expectedElementName, $expectedComands, $expectedModifiers) {
+        $element = new modFieldTag($this->modx);
+        $element->set('name', $elementName);
+
+        $modInputFilter = new modInputFilter($this->modx);
+        $modInputFilter->filter($element);
+
+        $this->assertEquals($expectedElementName, $element->get('name'));
+        $this->assertEquals($expectedComands, $modInputFilter->getCommands());
+        $this->assertEquals($expectedModifiers, $modInputFilter->getModifiers());
+    }
+
+    /**
+     * dataProvider for testFilter
+     */
+    public function providerFilter() {
+        return [
+            [
+                'pagetitle:eq=`0`:then=`foo`:else=`bar`',
+                'pagetitle',
+                [
+                    'eq',
+                    'then',
+                    'else',
+                ],
+                [
+                    '0',
+                    'foo',
+                    'bar',
+                ]
+            ]
+        ];
     }
 }

--- a/_build/test/Tests/Model/Filters/modInputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modInputFilterTest.php
@@ -9,6 +9,7 @@
  *
  * @package modx-test
 */
+
 namespace MODX\Revolution\Tests\Model\Filters;
 
 
@@ -25,8 +26,8 @@ use MODX\Revolution\MODxTestCase;
  * @group Filters
  * @group modInputFilter
  */
-class modInputFilterTest extends MODxTestCase {
-
+class modInputFilterTest extends MODxTestCase
+{
     /**
      * @dataProvider providerFilter
      * @param $elementName
@@ -35,7 +36,8 @@ class modInputFilterTest extends MODxTestCase {
      * @param $expectedModifiers
      * @return void
      */
-    public function testFilter($elementName, $expectedElementName, $expectedComands, $expectedModifiers) {
+    public function testFilter($elementName, $expectedElementName, $expectedComands, $expectedModifiers)
+    {
         $element = new modFieldTag($this->modx);
         $element->set('name', $elementName);
 
@@ -50,7 +52,8 @@ class modInputFilterTest extends MODxTestCase {
     /**
      * dataProvider for testFilter
      */
-    public function providerFilter() {
+    public function providerFilter()
+    {
         return [
             [
                 'pagetitle:eq=`0`:then=`foo`:else=`bar`',


### PR DESCRIPTION
### What does it do?
Adds a Unit Test for modInputFilter.

### Why is it needed?
To make it easier to test if modInputFilter works as it should when we adjust things.

In another PR I will add data to the provider that will make the test fail, this is an issue we should solve. 
This will help with fixing issue #16044

### How to test
Run the Unit Tests suite (or the single test) and see it pass.

### Related issue(s)/PR(s)
Issue #16044
