### PR TITLE
Use MODx.util.FileDownload for downloads

### DIFF
--- a/core/src/Revolution/File/modFile.php
+++ b/core/src/Revolution/File/modFile.php
@@ -243,6 +243,7 @@ class modFile extends modFileSystemResource
         header('Content-Disposition: attachment; filename=' . $options['filename']);
         header('Content-Length: ' . $this->getSize());
 
+        @session_write_close();
         echo $output;
         die();
     }

--- a/core/src/Revolution/Processors/Browser/File/Download.php
+++ b/core/src/Revolution/Processors/Browser/File/Download.php
@@ -51,6 +51,12 @@ class Download extends Browser
         @session_write_close();
         try {
             if ($data = $this->source->getObjectContents($file)) {
+                // Set cookie for sucessCallback in MODx.util.FileDownload
+                $cookieName = $this->getProperty('cookieName', '');
+                if ($cookieName) {
+                    setcookie($cookieName, 'true', time() + 10, '/');
+                }
+
                 $name = preg_replace('#[^\w\-.]#ui', '_', $data['basename']);
                 header('Content-type: ' . $data['mime']);
                 header('Content-Length: ' . $data['size']);

--- a/core/src/Revolution/Processors/Browser/File/Download.php
+++ b/core/src/Revolution/Processors/Browser/File/Download.php
@@ -48,7 +48,6 @@ class Download extends Browser
         }
 
         // Download file
-        @session_write_close();
         try {
             if ($data = $this->source->getObjectContents($file)) {
                 // Set cookie for sucessCallback in MODx.util.FileDownload
@@ -62,12 +61,13 @@ class Download extends Browser
                 header('Content-Length: ' . $data['size']);
                 header('Content-Disposition: attachment; filename=' . $name);
 
+                @session_write_close();
                 exit($data['content']);
             } else {
-                exit($this->modx->lexicon('file_err_open') . $this->getProperty('file'));
+                return $this->failure($this->modx->lexicon('file_err_open') . $this->getProperty('file'));
             }
         } catch (Exception $e) {
-            exit($e->getMessage());
+            return $this->failure($e->getMessage());
         }
     }
 }

--- a/core/src/Revolution/Processors/Element/ExportProperties.php
+++ b/core/src/Revolution/Processors/Element/ExportProperties.php
@@ -33,14 +33,12 @@ class ExportProperties extends Processor
 
     public function process()
     {
-        $response = false;
-        $download = $this->getProperty('download');
-
-        if (!empty($download)) {
-            $response = $this->download();
+        $cookieName = $this->getProperty('cookieName');
+        if ($cookieName) {
+            setcookie($cookieName, 'true', time() + 10, '/');
         }
 
-        return $response;
+        return $this->download();
     }
 
     /**
@@ -61,11 +59,12 @@ class ExportProperties extends Processor
 
         $fileName = strtolower(str_replace(' ', '-', $this->getProperty('id'))) . '.export.js';
 
-        $fileobj = $fileHandler->make($this->modx->getOption('core_path', null,
-                MODX_CORE_PATH) . 'export/properties/' . $fileName);
+        $fileobj = $fileHandler->make($this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'export/properties/' . $fileName);
 
         $fileobj->setContent($data);
-        $fileobj->download();
+        $fileobj->download([
+            'mimetype' => 'text/javascript'
+        ]);
 
         return true;
     }

--- a/core/src/Revolution/Processors/System/DownloadOutput.php
+++ b/core/src/Revolution/Processors/System/DownloadOutput.php
@@ -53,7 +53,7 @@ class DownloadOutput extends Processor
         /** @var modFileHandler $fileHandler */
         $fileHandler = $this->modx->getService('fileHandler', modFileHandler::class);
 
-        $fileName = 'output-' . date('Y-m-d Hi') . '.txt';
+        $fileName = 'output-' . date('Y-m-d_H-i') . '.txt';
 
         $fileobj = $fileHandler->make($this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'export/console/' . $fileName);
 

--- a/core/src/Revolution/Processors/System/ErrorLog/Download.php
+++ b/core/src/Revolution/Processors/System/ErrorLog/Download.php
@@ -32,6 +32,11 @@ class Download extends Processor
      */
     public function process()
     {
+        $cookieName = $this->getProperty('cookieName');
+        if ($cookieName) {
+            setcookie($cookieName, 'true', time() + 10, '/');
+        }
+
         $logTarget = $this->modx->getLogTarget();
         if (!is_array($logTarget)) {
             $logTarget = ['options' => []];
@@ -47,6 +52,7 @@ class Download extends Processor
         header('Content-Length: ' . filesize($file));
         header('Content-Disposition: attachment; filename="error.' . time() . '.log');
         ob_get_level() && @ob_end_flush();
+        @session_write_close();
         readfile($file);
         die();
     }

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -874,7 +874,7 @@ MODx.util.FileDownload = function (fields) {
         if (Ext.util.Cookies.get(cookieName) && Ext.util.Cookies.get(cookieName) === 'true') {
             me.clearCookie();
             if (successCallback) {
-                successCallback({success: true, message: _('$file_msg_download_success')});
+                successCallback({success: true, message: _('file_msg_download_success')});
             }
             return;
         }
@@ -941,14 +941,13 @@ MODx.util.FileDownload = function (fields) {
         params.cookieName = cookieName;
     }
     Ext.iterate(params, function (name, value) {
-        form.createChild({
-            tag: 'input',
-            type: 'text',
+        var textarea = form.createChild({
+            tag: 'textarea',
             cls: 'x-hidden',
             id: ident + '-' + name,
-            name: name,
-            value: value
+            name: name
         });
+        textarea.dom.innerText = value;
     });
     form.dom.submit();
     if (successCallback || failureCallback) {

--- a/manager/assets/modext/widgets/core/modx.console.js
+++ b/manager/assets/modext/widgets/core/modx.console.js
@@ -116,16 +116,21 @@ Ext.extend(MODx.Console,Ext.Window,{
 
     ,download: function() {
         var c = this.getComponent('body').getEl().dom.innerHTML || '&nbsp;';
-        MODx.Ajax.request({
-            url: MODx.config.connector_url
-            ,params: {
-                action: 'System/DownloadOutput'
-                ,data: c
-            }
-            ,listeners: {
-                'success':{fn:function(r) {
-                    location.href = MODx.config.connector_url+'?action=System/DownloadOutput&HTTP_MODAUTH='+MODx.siteId+'&download='+r.message;
-                },scope:this}
+        MODx.util.FileDownload({
+            url: MODx.config.connectorUrl,
+            params: {
+                action: 'System/DownloadOutput',
+                data: c
+            },
+            success: function (response) {
+                MODx.msg.status({
+                    title: _('success'),
+                    message: response.message || _('file_msg_download_success'),
+                    delay: 2
+                });
+            },
+            failure: function (response) {
+                MODx.msg.alert(_('error'), response.message);
             }
         });
     }

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -437,7 +437,27 @@ Ext.extend(MODx.grid.ElementProperties,MODx.grid.LocalProperty,{
 
     ,exportProperties: function (btn,e) {
         var id = Ext.getCmp('modx-combo-property-set').getValue();
-        location.href = MODx.config.connector_url+'?action=Element/ExportProperties&download=1&id='+id+'&data='+this.encode()+'&HTTP_MODAUTH='+MODx.siteId;
+        if (id) {
+            MODx.util.FileDownload({
+                url: MODx.config.connectorUrl,
+                params: {
+                    action: 'Element/ExportProperties',
+                    id: id,
+                    data: this.encode(),
+                    download: true,
+                },
+                success: function (response) {
+                    MODx.msg.status({
+                        title: _('success'),
+                        message: response.message || _('file_msg_download_success'),
+                        delay: 2
+                    });
+                },
+                failure: function (response) {
+                    MODx.msg.alert(_('error'), response.message);
+                }
+            });
+        }
     }
 
     ,importProperties: function (btn,e) {

--- a/manager/assets/modext/widgets/fc/modx.grid.fcset.js
+++ b/manager/assets/modext/widgets/fc/modx.grid.fcset.js
@@ -236,16 +236,22 @@ Ext.extend(MODx.grid.FCSet,MODx.grid.Grid,{
 
     ,exportSet: function(btn,e) {
         var id = this.menu.record.id;
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
-                action: 'Security/Forms/Set/Export'
-                ,id: id
-            }
-            ,listeners: {
-                'success': {fn:function(r) {
-                    location.href = this.config.url+'?action=Security/Forms/Set/Export&download='+r.message+'&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
-                },scope:this}
+        MODx.util.FileDownload({
+            url: MODx.config.connectorUrl,
+            params: {
+                action: 'Security/Forms/Set/Export',
+                id: id,
+                download: true,
+            },
+            success: function (response) {
+                MODx.msg.status({
+                    title: _('success'),
+                    message: response.message || _('file_msg_download_success'),
+                    delay: 2
+                });
+            },
+            failure: function (response) {
+                MODx.msg.alert(_('error'), response.message);
             }
         });
     }

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -189,26 +189,27 @@ Ext.extend(MODx.browser.View,MODx.DataView,{
         w.show(e.target);
     }
 
-    ,downloadFile: function(item,e) {
+    ,downloadFile: function(item, e) {
         var node = this.cm.activeNode;
         var data = this.lookup[node.id];
-        MODx.Ajax.request({
-            url: MODx.config.connector_url
-            ,params: {
-                action: 'Browser/File/Download'
-                ,file: data.pathRelative
-                ,wctx: MODx.ctx || ''
-                ,source: this.config.source
-            }
-            ,listeners: {
-                'failure': {fn: function(r) {
-                    MODx.msg.alert(_('alert'), r.message);
-                },scope:this},
-                'success':{fn:function(r) {
-                    if (!Ext.isEmpty(r.object.url)) {
-                        location.href = MODx.config.connector_url+'?action=Browser/File/Download&download=1&file='+r.object.url+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.config.source+'&wctx='+MODx.ctx;
-                    }
-                },scope:this}
+        MODx.util.FileDownload({
+            url: MODx.config.connectorUrl,
+            params: {
+                action: 'Browser/File/Download',
+                file: data.pathRelative,
+                wctx: MODx.ctx || '',
+                source: this.config.source,
+                download: true,
+            },
+            success: function (response) {
+                MODx.msg.status({
+                    title: _('success'),
+                    message: response.message || _('file_msg_download_success'),
+                    delay: 2
+                });
+            },
+            failure: function (response) {
+                MODx.msg.alert(_('error'), response.message);
             }
         });
     }

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.js
@@ -180,16 +180,22 @@ Ext.extend(MODx.grid.AccessPolicy,MODx.grid.Grid,{
     }
     ,exportPolicy: function(btn,e) {
         var id = this.menu.record.id;
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
-                action: 'Security/Access/Policy/Export'
-                ,id: id
-            }
-            ,listeners: {
-                'success': {fn:function(r) {
-                    location.href = this.config.url+'?action=Security/Access/Policy/Export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
-                },scope:this}
+        MODx.util.FileDownload({
+            url: MODx.config.connectorUrl,
+            params: {
+                action: 'Security/Access/Policy/Export',
+                id: id,
+                download: true,
+            },
+            success: function (response) {
+                MODx.msg.status({
+                    title: _('success'),
+                    message: response.message || _('file_msg_download_success'),
+                    delay: 2
+                });
+            },
+            failure: function (response) {
+                MODx.msg.alert(_('error'), response.message);
             }
         });
     }

--- a/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.grid.access.policy.template.js
@@ -226,16 +226,22 @@ Ext.extend(MODx.grid.AccessPolicyTemplate,MODx.grid.Grid,{
 
     ,exportPolicyTemplate: function(btn,e) {
         var id = this.menu.record.id;
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
-                action: 'Security/Access/Policy/Template/Export'
-                ,id: id
-            }
-            ,listeners: {
-                'success': {fn:function(r) {
-                    location.href = this.config.url+'?action=Security/Access/Policy/Template/Export&download=1&id='+id+'&HTTP_MODAUTH='+MODx.siteId;
-                },scope:this}
+        MODx.util.FileDownload({
+            url: MODx.config.connectorUrl,
+            params: {
+                action: 'Security/Access/Policy/Template/Export',
+                id: id,
+                download: true,
+            },
+            success: function (response) {
+                MODx.msg.status({
+                    title: _('success'),
+                    message: response.message || _('file_msg_download_success'),
+                    delay: 2
+                });
+            },
+            failure: function (response) {
+                MODx.msg.alert(_('error'), response.message);
             }
         });
     }

--- a/manager/assets/modext/widgets/system/modx.panel.error.log.js
+++ b/manager/assets/modext/widgets/system/modx.panel.error.log.js
@@ -91,7 +91,22 @@ Ext.extend(MODx.panel.ErrorLog,MODx.FormPanel,{
         return true;
     }
     ,download: function() {
-        location.href = this.config.url+'?action=System/ErrorLog/Download&HTTP_MODAUTH='+MODx.siteId;
+        MODx.util.FileDownload({
+            url: MODx.config.connectorUrl,
+            params: {
+                action: 'System/ErrorLog/Download'
+            },
+            success: function (response) {
+                MODx.msg.status({
+                    title: _('success'),
+                    message: response.message || _('file_msg_download_success'),
+                    delay: 2
+                });
+            },
+            failure: function (response) {
+                MODx.msg.alert(_('error'), response.message);
+            }
+        });
     }
     /**
      * Set the textarea height to make use of the maximum "space" the client viewport allows

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -689,9 +689,28 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
         });
     }
 
-    ,downloadFile: function(item,e) {
+    ,downloadFile: function(item, e) {
         var node = this.cm.activeNode;
-        location.href = MODx.config.connector_url+'?action=Browser/File/Download&download=1&file='+node.attributes.pathRelative+'&HTTP_MODAUTH='+MODx.siteId+'&source='+this.getSource()+'&wctx='+MODx.ctx;
+        MODx.util.FileDownload({
+            url: MODx.config.connectorUrl,
+            params: {
+                action: 'Browser/File/Download',
+                file: node.attributes.pathRelative,
+                wctx: MODx.ctx || '',
+                source: this.getSource(),
+                download: true,
+            },
+            success: function (response) {
+                MODx.msg.status({
+                    title: _('success'),
+                    message: response.message || _('file_msg_download_success'),
+                    delay: 2
+                });
+            },
+            failure: function (response) {
+                MODx.msg.alert(_('error'), response.message);
+            }
+        });
     }
 
     ,copyRelativePath: function(item,e) {


### PR DESCRIPTION
### What does it do?
Use MODx.util.FileDownload for downloads

### Why is it needed?
Allow success and failure messages during downloading files

### How to test
The new download method is used in the MODX file browser download, in the file tree download, in the Form Customisation export and in the Properties Set export.

### Related issue(s)/PR(s)
#16150, Discussion in #16140