### PR TITLE
Fix fatal TypeError when using modRestService

### DIFF
--- a/core/src/Revolution/Rest/modRestServiceRequest.php
+++ b/core/src/Revolution/Rest/modRestServiceRequest.php
@@ -115,7 +115,7 @@ class modRestServiceRequest
                 }
             }
         }
-        array_walk_recursive($headers, ['modRestServiceRequest', '_trimString']);
+        array_walk_recursive($headers, [$this, '_trimString']);
         $this->headers = $headers;
     }
 
@@ -204,7 +204,7 @@ class modRestServiceRequest
                 break;
         }
         if ($this->service->getOption('trimParameters', false)) {
-            array_walk_recursive($this->parameters, ['modRestServiceRequest', '_trimString']);
+            array_walk_recursive($this->parameters, [$this, '_trimString']);
         }
 
         return $params;


### PR DESCRIPTION
### What does it do?
Update the callbacks to make them valid.

### Why is it needed?
To fix a fatal TypeError caused by a class not found.

### How to test
Use the modRestService 

### Related issue(s)/PR(s)
Resolves #16189