### PR TITLE
Update uploadObjectsToContainer method

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1108,7 +1108,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         $this->xpdo->context->prepare();
         $maxFileSize = $this->xpdo->getOption('upload_maxsize', null, 1048576);
 
-        foreach ($objects as $file) {
+        foreach ($objects as $key => $file) {
             $this->xpdo->invokeEvent('OnFileManagerBeforeUpload', [
                 'files' => &$objects,
                 'file' => &$file,
@@ -1170,6 +1170,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                     $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
                 }
             }
+            
+            $objects[$key] = $file;
         }
 
         $this->xpdo->invokeEvent('OnFileManagerUpload', [


### PR DESCRIPTION
Update uploadObjectsToContainer so the files array passed to the OnFileManagerUpload event includes an up-to-date version of $objects. So if a file name has been renamed, $objects passed to the OnFileManagerUpload also reflects these changes.

### What does it do?
This ensures that $objects is kept up-to-date after looping through the array.

### Why is it needed?
Having an old file name triggered an unforced error in FileSluggy because the old file name was passed instead of the renamed filename.

### How to test
Install FileSluggy and try to upload a file with a name such as "Modx - Test.jpg". Now you'll see the unforced error:
```
 Error
- Modx - Test.jpg: The file is not a regular file and cannot be removed.
```
Even though the file has been uploaded successfully and can also be removed.

