### PR TITLE
Update modTemplateVar.php

### DIFF
--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -830,9 +830,7 @@ class modTemplateVar extends modElement
      */
     public function getBindingDataFromValue($value)
     {
-        if (is_string($value)) {
-            $nvalue = trim($value);
-        }
+        $nvalue = is_string($value) ? trim($value) : '';
         $cmd = false;
         $param = '';
         $properties = [];


### PR DESCRIPTION
Make sure $nvalue is always set to prevent PHP warning:
```
/core/src/Revolution/modTemplateVar.php : 839) PHP warning: Undefined variable $nvalue
```

### What does it do?
Ensures $nvalue is always set to prevent undefined variable warning.

### Why is it needed?
To fix undefined variable warning.

### How to test
PHP 8.1
MODX 3
Set up template variable with an empty binding value.