### PR TITLE
[3.x] Include Flysystem FTP adapter in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "xpdo/xpdo": "~3.1.0",
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
+        "league/flysystem-ftp": "^2.0",
         "phpmailer/phpmailer": "^6.0",
         "smarty/smarty": "^4.0",
         "james-heinrich/phpthumb": "^1.7",


### PR DESCRIPTION
### What does it do?
Adds missing base FTP adapter package to require block.

### Why is it needed?
MODx 3 has a custom FTP adapter in the codebase and makes FTP an option as a type of media source. However, if you attempt to create an FTP source a fatal error will occur because the base package is missing.

### How to test

1. Run `composer update` in your base revolution directory.
2. Create an FTP media source, verifying it works as expected. (I created one using an open public FTP resource to keep it simple for testing.)
3. To verify the fatal error, remove the change I made to composer.json, re-run `composer update`, and attempt to access the manager.

### Related issue(s)/PR(s)
No related issues.
