### PR TITLE
Removed forced mgr context from findPolicy()

### DIFF
--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -641,7 +641,6 @@ class modMediaSource extends modAccessibleSimpleObject implements modMediaSource
     public function findPolicy($context = '') {
         $policy = array();
         $enabled = true;
-        $context = 'mgr';
         if ($context === $this->xpdo->context->get('key')) {
             $enabled = (boolean) $this->xpdo->getOption('access_media_source_enabled', null, true);
         } elseif ($this->xpdo->getContext($context)) {

--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -641,6 +641,7 @@ class modMediaSource extends modAccessibleSimpleObject implements modMediaSource
     public function findPolicy($context = '') {
         $policy = array();
         $enabled = true;
+        $context = !empty($context) ? $context : $this->xpdo->context->get('key');
         if ($context === $this->xpdo->context->get('key')) {
             $enabled = (boolean) $this->xpdo->getOption('access_media_source_enabled', null, true);
         } elseif ($this->xpdo->getContext($context)) {


### PR DESCRIPTION
### What does it do?
Removes the forced mgr context for the findPolicy() function.

### Why is it needed?
See bug #16212

### How to test
1. Turn on info level logging.
2. Turn off the access_resource_group_enabled setting.
3. Access a page in the web context as an anonymous user.
4. No log messages about the mgr context should show up.

### Related issue(s)/PR(s)
Resolves #16212
