### PR TITLE
Fix Package Manager handling of API error

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Packages/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetList.php
@@ -215,7 +215,11 @@ class GetList extends GetListProcessor
                 }
                 if ($provider) {
                     $updates = $provider->latest($package->get('signature'));
-                    $updates = ['count' => count($updates)];
+                    if (is_string($updates)) {
+                        $updates = ['count' => 0];
+                    } else {
+                        $updates = ['count' => count($updates)];
+                    }
                     $this->modx->cacheManager->set($updateCacheKey, $updates, $this->updatesCacheExpire,
                         $updateCacheOptions);
                 }


### PR DESCRIPTION
### What does it do?
When checking for package updates, the updated code takes into account that the API may return an error.

### Why is it needed?
The function `latest()` of the class `MODX\Revolution\Transport\modTransportProvider` may return an error string if no package release can be found.

https://github.com/modxcms/revolution/blob/cb6f56a19af818ad4d1d62dc0d31b9819aaa876f/core/src/Revolution/Transport/modTransportProvider.php#L226-L234

This can 'crash' the Package Manager when using PHP 8.

### How to test

- In MODX 3.0.1-pl, in the Package Manager download the extra "getDate" (from the default provider `modx.com`).
- Make sure the Package Manager doesn't 'hang' (PHP 8) and there is not PHP warning (PHP 7.x | `count(): Parameter must be an array or an object that implements Countable`).

### Related issue(s)/PR(s)
https://community.modx.com/t/package-manager-crashed-by-loading-getdate-modx-3-0-1-pl/5501
