### PR TITLE
Change behavior of ENTER key in settings grid cell editor

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -237,7 +237,7 @@ MODx.grid.SettingsGrid = function(config) {
 
     // prevents navigation to next cell editor field when pressing the ENTER key
     this.selModel.onEditorKey = this.selModel.onEditorKey.createInterceptor(function(field, e) {
-        if (e.getKey() == Ext.EventObject.ENTER) {
+        if (e.getKey() == Ext.EventObject.ENTER && !e.ctrlKey) {
             e.stopEvent();
             return false;
         }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -234,6 +234,14 @@ MODx.grid.SettingsGrid = function(config) {
         ,scrollOffset: 0
     });
     MODx.grid.SettingsGrid.superclass.constructor.call(this,config);
+
+    // prevents navigation to next cell editor field when pressing the ENTER key
+    this.selModel.onEditorKey = this.selModel.onEditorKey.createInterceptor(function(field, e) {
+        if (e.getKey() == Ext.EventObject.ENTER) {
+            e.stopEvent();
+            return false;
+        }
+    });
 };
 Ext.extend(MODx.grid.SettingsGrid,MODx.grid.Grid,{
     _addEnterKeyHandler: function() {


### PR DESCRIPTION
### What does it do?
Overrides the grid selection model's `onEditorKey` method with an Interceptor so pressing the ENTER key (alone) does _not_ navigate to and open the next setting's value editor. Pressing the key combination of _control-ENTER_ will, however, behave as before (navigating down and opening that cell's editor).

### Why is it needed?
The current behavior is error-prone, and most users likely only edit one or a few setting(s) at a time (and not sequentially up and down the grid of settings).

### How to test
Simply change the value of a few settings using the grid editor using the ENTER key to commit your changes. Verify that changes are saved and that navigating the grid works as expected. Note that you can still TAB up and down once a cell editor is active.

### Related issue(s)/PR(s)
Resolves #5943.

### Special Note
There are a handful of grids where this solution could be applied as well (namespaces, content types, roles, etc.); or perhaps, if this is in fact the preferred behavior, we could consider applying it globally (via the base grid class).
