### PR TITLE
Fix only_full_group_by issue in permission processor query

### DIFF
--- a/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
@@ -68,7 +68,7 @@ class GetList extends GetListProcessor
             'modAccessPermission.description',
             'Template.lexicon',
         ]);
-        $c->groupby('modAccessPermission.name');
+        $c->groupby('modAccessPermission.id');
         $name = $this->getProperty('name', '');
         if (!empty($name)) {
             $c->where([

--- a/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
@@ -63,12 +63,12 @@ class GetList extends GetListProcessor
     public function prepareQueryAfterCount(xPDOQuery $c)
     {
         $c->select([
-            'modAccessPermission.id',
+            'id' => 'MIN(modAccessPermission.id)',
             'modAccessPermission.name',
             'modAccessPermission.description',
             'Template.lexicon',
         ]);
-        $c->groupby('modAccessPermission.id');
+        $c->groupby('modAccessPermission.name, modAccessPermission.description, Template.lexicon');
         $name = $this->getProperty('name', '');
         if (!empty($name)) {
             $c->where([


### PR DESCRIPTION
### What does it do?
Fixes an `only_full_group_by` issue in `MODX\Revolution\Processors\Security\Access\Permission\GetList`

### Why is it needed?
So the permission combobox works when `only_full_group_by` is enabled.

### How to test
Have `only_full_group_by` enabled in MySQL and try to select a permission on either the widget edit panel on the Dashboards page, or create a new permission in a policy template.

### Related issue(s)/PR(s)
Resolves #16226 
