### PR TITLE
[2.x] Fix trash manager to only show deleted resources if filtered

### DIFF
--- a/core/model/modx/processors/resource/trash/getlist.class.php
+++ b/core/model/modx/processors/resource/trash/getlist.class.php
@@ -52,17 +52,18 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
         // delete_document - thats perhaps not necessary, because all documents are already deleted
         // but we need the purge_deleted permission - for every single file
 
+        if ($deleted = $this->getDeleted()) {
+            $c->where(['modResource.id:IN' => $deleted]);
+        } else {
+            return;
+        }
+
         if (!empty($query)) {
             $c->where(array('modResource.pagetitle:LIKE' => '%' . $query . '%'));
             $c->orCondition(array('modResource.longtitle:LIKE' => '%' . $query . '%'));
         }
         if (!empty($context)) {
             $c->where(array('modResource.context_key' => $context));
-        }
-        if ($deleted = $this->getDeleted()) {
-            $c->where(array('modResource.id:IN' => $deleted));
-        } else {
-            $c->where(array('modResource.id' => 0));
         }
 
         return $c;


### PR DESCRIPTION
### What does it do?
Fix trash manager to only show deleted resources if filtered.

### Why is it needed?
Filtering the trash manager by a resource name, would show all resources and not only "deleted" resources.

### How to test
Delete a resource, open the trash manager and search for a resource that's not deleted and notice it not showing up in the results.

### Related issue(s)/PR(s)
Resolves #16224
