### PR TITLE
Improve default config xml files

### DIFF
--- a/setup/config.dist.new.xml
+++ b/setup/config.dist.new.xml
@@ -8,7 +8,7 @@
 -->
 <modx>
 	<database_type>mysql</database_type>
-    <database_server>localhost</database_server>
+    <database_server>127.0.0.1</database_server>
     <database>modx_modx</database>
     <database_user>db_username</database_user>
     <database_password>db_password</database_password>

--- a/setup/config.dist.upgrade-advanced.xml
+++ b/setup/config.dist.upgrade-advanced.xml
@@ -8,7 +8,7 @@
 -->
 <modx>
 	<database_type>mysql</database_type>
-    <database_server>localhost</database_server>
+    <database_server>127.0.0.1</database_server>
     <database>modx_modx</database>
     <database_user>db_username</database_user>
     <database_password>db_password</database_password>


### PR DESCRIPTION
### What does it do?
I've changed the default database server from "localhost" to "127.0.0.1".

### Why is it needed?
This circumvents the `Connection failed: SQLSTATE[HY000] [2002] No such file or directory` that I encountered on a fresh install of Modx Revolution. See [Connection failed: SQLSTATE[HY000] [2002] No such file or directory](https://forum.infinityfree.net/t/connection-failed-sqlstate-hy000-2002-no-such-file-or-directory/43590).

### How to test

**Prepare php and mysql for installation**:

- In mysql, run `create database modx_modx`
- Modify /etc/php/8.0/*/php.ini by setting `mysqli.default_socket` and `pdo_mysql.default_socket` correctly
- Modify /etc/php/8.0/*/php.ini by setting `date.timezone = America/New_York`

**Run CLI installation script with config**

```
wget https://gist.githubusercontent.com/tvquizphd/b4eaab96ac944328b9939deafc9940f5/raw/aa095175827519c8456d012e4543e54caf297c82/config.xml
wget https://raw.githubusercontent.com/craftsmancoding/modx_utils/master/installmodx.php
wget https://modx.com/download/direct/modx-3.0.1-pl-sdk.zip
```

Replace "user", "pass", and "domain.example.com" in config.xml, then run installation:

```
php installmodx.php --config=config.xml --zip=modx-3.0.1-pl-sdk.zip --target=jeannie.hoff.in --version=3.0.1 --installmode=new
```
### Related issue

This resolves [https://github.com/modxcms/revolution/issues/16229](issue 16229).