### PR TITLE
Add support for WebP images in the Media Browser

### DIFF
--- a/core/src/Revolution/Sources/modFTPMediaSource.php
+++ b/core/src/Revolution/Sources/modFTPMediaSource.php
@@ -155,7 +155,7 @@ class modFTPMediaSource extends modMediaSource
                 'name' => 'imageExtensions',
                 'desc' => 'prop_file.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif',
+                'value' => 'jpg,jpeg,png,gif,webp',
                 'lexicon' => 'core:source',
             ],
             'skipFiles' => [

--- a/core/src/Revolution/Sources/modFileMediaSource.php
+++ b/core/src/Revolution/Sources/modFileMediaSource.php
@@ -143,7 +143,7 @@ class modFileMediaSource extends modMediaSource
                 'name' => 'imageExtensions',
                 'desc' => 'prop_file.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif,svg',
+                'value' => 'jpg,jpeg,png,gif,svg,webp',
                 'lexicon' => 'core:source',
             ],
             'thumbnailType' => [
@@ -154,6 +154,7 @@ class modFileMediaSource extends modMediaSource
                     ['name' => 'PNG', 'value' => 'png'],
                     ['name' => 'JPG', 'value' => 'jpg'],
                     ['name' => 'GIF', 'value' => 'gif'],
+                    ['name' => 'WebP', 'value' => 'webp'],
                 ],
                 'value' => 'png',
                 'lexicon' => 'core:source',

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -332,7 +332,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         $properties['modx_charset'] = $this->getOption('modx_charset', $properties, 'UTF-8');
         $properties['hideFiles'] = !empty($properties['hideFiles']) && $properties['hideFiles'] != 'false';
         $properties['hideTooltips'] = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false';
-        $properties['imageExtensions'] = $this->getOption('imageExtensions', $properties, 'jpg,jpeg,png,gif,svg');
+        $properties['imageExtensions'] = $this->getOption('imageExtensions', $properties, 'jpg,jpeg,png,gif,svg,webp');
 
         return $properties;
     }
@@ -588,7 +588,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         }
 
         $properties = $this->getPropertyList();
-        $imageExtensions = array_map('trim', explode(',', $this->getOption('imageExtensions', $properties, 'jpg,jpeg,png,gif,svg')));
+        $imageExtensions = array_map(
+            'trim',
+            explode(',', $this->getOption('imageExtensions', $properties, 'jpg,jpeg,png,gif,svg,webp'))
+        );
         try {
             $fa = [
                 'name' => rtrim($path, DIRECTORY_SEPARATOR),
@@ -1257,7 +1260,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      *
      * @return string
      */
-    public function getOpenTo($value,array $parameters = []) {
+    public function getOpenTo($value, array $parameters = [])
+    {
         $dirname = dirname($value);
         return $dirname == '.' ? '' : $dirname . '/';
     }

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -162,7 +162,7 @@ class modS3MediaSource extends modMediaSource
                 'name' => 'imageExtensions',
                 'desc' => 'prop_s3.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif,svg',
+                'value' => 'jpg,jpeg,png,gif,svg,webp',
                 'lexicon' => 'core:source',
             ],
             'visibility' => [


### PR DESCRIPTION
### What does it do?
- Include webp in the default `imageExtensions` value for Media Sources.
- Add WebP option for thumbnail generation.

### Why is it needed?
To add support for WebP images in the Media Browser.

### How to test
Use the Media Browser with a Media Source using the default properties.

### Related issue(s)/PR(s)
Issue #16234
