### PR TITLE
View values in TV listbox-multiple then it manually entered

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/listbox-multiple.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/listbox-multiple.class.php
@@ -35,6 +35,14 @@ class modTemplateVarInputRenderListboxMultiple extends modTemplateVarInputRender
         $orderedItems = array();
         // loop trough the selected values
         foreach ($value as $val) {
+            // add custom value (from TV) if it isset
+            if (isset($val)) {
+                $orderedItems[] = array(
+                    'text' => $val,
+                    'value' => $val,
+                    'selected' => 1,
+                );
+            }
             // find the corresponding option in the items array
             foreach ($items as $item => $values) {
                 // if found, add it in the right order to the $orderItems array


### PR DESCRIPTION
### What does it do?
- Displays values manually entered by the manager in the admin panel. For MODX 2.x

### Why is it needed?
- It is necessary to fix the display problem. #15136 (it for MODX 3.x, but for 2.x acutally too)

### How to test
- Created TV listbox-multiple add to template
- Open resource and type in this TV manually some words. -> press Enter -> Save Document.
- Reload page (F5), Open TV and see changes.
Describe how to test the changes you made.

### Related issue(s)/PR(s)
#15136