### PR TITLE
Fix rendering of user-entered values in editable listbox-multiple TVs

### DIFF
--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/listbox-multiple.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/listbox-multiple.class.php
@@ -61,10 +61,10 @@ class modTemplateVarInputRenderListboxMultiple extends modTemplateVarInputRender
 
         // Ensure custom values are displayed when the listbox is editable
         if (isset($params['forceSelection']) && empty($params['forceSelection'])) {
-            $customSelections = array_diff($savedValues, $optsValues);
-            if (!empty($customSelections)) {
+            $customValues = array_diff($savedValues, $optsValues);
+            if (!empty($customValues)) {
                 $customData = [];
-                foreach ($customSelections as $customValue) {
+                foreach ($customValues as $customValue) {
                     $customValue = htmlspecialchars($customValue, ENT_COMPAT, 'UTF-8');
                     $customData[] = [
                         'text' => $customValue,


### PR DESCRIPTION
### What does it do?
Refactored the listbox-multiple render class to ensure values that are not in a TV’s pre-defined options are rendered properly. The code has been restructured to make it more intuitive, as the previous code had a rather convoluted way of collecting and separating the selected (saved) and unselected values.

### Why is it needed?
User-entered values are saved to the database but are not subsequently rendered when reloading the Resource form.

### How to test
1. Create a listbox-multiple TV with _Enable Type-Ahead_ on and _Require Match_ set to “No.”
2. Enter a set of Input Options for the TV.
3. Make the TV available to a Resource and experiment with making selections from the dropdown, as well as entering ones directly in the field. Save the Resource and re-load it to verify all values show in the TV field as expected.

### Related issue(s)/PR(s)
Resolves #15136. 
