### PR TITLE
Fixing the names of processor actions

### DIFF
--- a/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/GetList.php
@@ -145,7 +145,7 @@ class GetList extends GetListProcessor
             '-',
             [
                 'text' => $this->modx->lexicon('access_rgroup_remove'),
-                'handler' => 'this.confirm.createDelegate(this,["security/access/usergroup/resourcegroup/remove"])',
+                'handler' => 'this.confirm.createDelegate(this,["Security/Access/UserGroup/ResourceGroup/Remove"])',
             ],
         ];
 

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Source/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Source/GetList.php
@@ -152,7 +152,7 @@ class GetList extends GetListProcessor
             '-',
             [
                 'text' => $this->modx->lexicon('access_source_remove'),
-                'handler' => 'this.confirm.createDelegate(this,["security/access/usergroup/source/remove"])',
+                'handler' => 'this.confirm.createDelegate(this,["Security/Access/UserGroup/Source/Remove"])',
             ],
         ];
 

--- a/core/src/Revolution/Processors/Workspace/Providers/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Providers/GetList.php
@@ -94,7 +94,7 @@ class GetList extends GetListProcessor
                 '-',
                 [
                     'text' => $this->modx->lexicon('delete'),
-                    'handler' => 'this.remove.createDelegate(this,["provider_confirm_remove", "workspace/providers/remove"])',
+                    'handler' => 'this.remove.createDelegate(this,["provider_confirm_remove", "Workspace/Providers/Remove"])',
                 ]
             ];
         }


### PR DESCRIPTION
### What does it do?
Fixing the names of processor actions

### Why is it needed?
To restore the operation of the processor call actions

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/16238