### PR TITLE
Add OpenCollective sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: modx


### PR DESCRIPTION
### What does it do?
Add sponsor button for the MODX Open Collective per instructions at https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository

### Why is it needed?
Promote the OpenCollective on GitHub to show people how to support the project.

### How to test
N/a

### Related issue(s)/PR(s)
N/a
