### PR TITLE
Revert and break nested output filters

### DIFF
--- a/core/src/Revolution/Filters/modInputFilter.php
+++ b/core/src/Revolution/Filters/modInputFilter.php
@@ -53,7 +53,7 @@ class modInputFilter
             $matches = [];
             $name = trim(substr($output, 0, $splitPos));
             $modifiers = substr($output, $splitPos);
-            if (preg_match_all('~:([^:=]+)(?:=`((?:(?:[^:=][\s\S]*?|(?R))*?))`)?~s', $modifiers, $matches)) {
+            if (preg_match_all('~:([^:=]+)(?:=`(.*?)`[\r\n\s]*(?=:[^:=]+|$))?~s', $modifiers, $matches)) {
                 $this->_commands = $matches[1]; /* modifier commands */
                 $this->_modifiers = $matches[2]; /* modifier values */
             }


### PR DESCRIPTION
### What does it do?
Revert and break nested output filters to fix a lot of other issues with output filters introduced in PR #14458

### Why is it needed?
To fix a lot of issues with output filters being broken.

### Related issue(s)/PR(s)
Related issues: 
- #16044 
- #16186

Related PR: #14458
