### PR TITLE
Add support for WebP images in the Media Browser (backport 3.x commit)

### DIFF
--- a/core/model/modx/sources/modfilemediasource.class.php
+++ b/core/model/modx/sources/modfilemediasource.class.php
@@ -103,7 +103,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
         $editAction = $this->getEditActionId();
 
-        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg,webp');
         $imagesExts = explode(',',$imagesExts);
         $skipFiles = $this->getOption('skipFiles',$properties,'.svn,.git,_notes,nbproject,.idea,.DS_Store');
         $skipFiles = explode(',',$skipFiles);
@@ -679,7 +679,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         if (!$file->isReadable()) {
             $this->addError('file',$this->xpdo->lexicon('file_err_perms'));
         }
-        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
+        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg,webp');
         $imageExtensions = explode(',',$imageExtensions);
         $fileExtension = pathinfo($objectPath,PATHINFO_EXTENSION);
 
@@ -1030,7 +1030,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
         $modAuth = $this->xpdo->user->getUserToken($this->xpdo->context->get('key'));
 
         /* get default settings */
-        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
+        $imageExtensions = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg,webp');
         $imageExtensions = explode(',',$imageExtensions);
         $use_multibyte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
@@ -1292,7 +1292,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                 'name' => 'imageExtensions',
                 'desc' => 'prop_file.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif,svg',
+                'value' => 'jpg,jpeg,png,gif,svg,webp',
                 'lexicon' => 'core:source',
             ),
             'thumbnailType' => array(
@@ -1303,6 +1303,7 @@ class modFileMediaSource extends modMediaSource implements modMediaSourceInterfa
                     array('name' => 'PNG','value' => 'png'),
                     array('name' => 'JPG','value' => 'jpg'),
                     array('name' => 'GIF','value' => 'gif'),
+                    array('name' => 'WebP','value' => 'webp'),
                 ),
                 'value' => 'png',
                 'lexicon' => 'core:source',

--- a/core/model/modx/sources/mods3mediasource.class.php
+++ b/core/model/modx/sources/mods3mediasource.class.php
@@ -155,7 +155,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $useMultiByte = $this->ctx->getOption('use_multibyte', false);
         $encoding = $this->ctx->getOption('modx_charset', 'UTF-8');
 
-        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg');
+        $imagesExts = $this->getOption('imageExtensions',$properties,'jpg,jpeg,png,gif,svg,webp');
         $imagesExts = explode(',',$imagesExts);
 
         $hideTooltips = !empty($properties['hideTooltips']) && $properties['hideTooltips'] != 'false' ? true : false;
@@ -414,7 +414,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $bucketUrl = rtrim($properties['url'],'/').'/';
         $allowedFileTypes = $this->getOption('allowedFileTypes',$this->properties,'');
         $allowedFileTypes = !empty($allowedFileTypes) && is_string($allowedFileTypes) ? array_map("trim",explode(',',$allowedFileTypes)) : $allowedFileTypes;
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg,webp');
         $imageExtensions = explode(',',$imageExtensions);
         $thumbnailType = $this->getOption('thumbnailType',$this->properties,'png');
         $thumbnailQuality = $this->getOption('thumbnailQuality',$this->properties,90);
@@ -1040,6 +1040,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
             'wav' => 'audio/x-wav',
             'wcm' => 'application/vnd.ms-works',
             'wdb' => 'application/vnd.ms-works',
+            'webp' => 'image/webp',
             'wks' => 'application/vnd.ms-works',
             'wmf' => 'application/x-msmetafile',
             'wps' => 'application/vnd.ms-works',
@@ -1164,7 +1165,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 'name' => 'imageExtensions',
                 'desc' => 'prop_s3.imageExtensions_desc',
                 'type' => 'textfield',
-                'value' => 'jpg,jpeg,png,gif,svg',
+                'value' => 'jpg,jpeg,png,gif,svg,webp',
                 'lexicon' => 'core:source',
             ),
             'thumbnailType' => array(
@@ -1175,6 +1176,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
                     array('name' => 'PNG','value' => 'png'),
                     array('name' => 'JPG','value' => 'jpg'),
                     array('name' => 'GIF','value' => 'gif'),
+                    array('name' => 'WebP','value' => 'webp'),
                 ),
                 'value' => 'png',
                 'lexicon' => 'core:source',
@@ -1280,7 +1282,7 @@ class modS3MediaSource extends modMediaSource implements modMediaSourceInterface
         $objectUrl = $properties['url'].$objectPath;
         $contents = @file_get_contents($objectUrl);
 
-        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg');
+        $imageExtensions = $this->getOption('imageExtensions',$this->properties,'jpg,jpeg,png,gif,svg,webp');
         $imageExtensions = explode(',',$imageExtensions);
         $fileExtension = pathinfo($objectPath,PATHINFO_EXTENSION);
 


### PR DESCRIPTION
### What does it do?

- Include webp in the default imageExtensions value for Media Sources.
- Add WebP option for thumbnail generation.

This is a 3.x backport (original pull request https://github.com/modxcms/revolution/pull/16235 by https://github.com/JoshuaLuckers)

### Why is it needed?
To add support for WebP images in the Media Browser.

### How to test
Use the Media Browser with a Media Source using the default properties.

### Related issue(s)/PR(s)
Issue https://github.com/modxcms/revolution/issues/16234
