### PR TITLE
Fix MODX 3 installation for database passwords with backslashes and quotes

### DIFF
--- a/setup/includes/runner/modinstallrunner.class.php
+++ b/setup/includes/runner/modinstallrunner.class.php
@@ -167,15 +167,6 @@ abstract class modInstallRunner {
         $configTpl = MODX_CORE_PATH . 'docs/config.inc.tpl';
         $configFile = MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
 
-        /**
-         * Sanitize MySQL Password before writing to config, escaping '
-         * I'm sure there's a better way to do this, but this works for now.
-         * Otherwise, we risk fatal PHP errors if the entered Password
-         * contains any single quotes as they would escape the string.
-         * See GitHub issue 12502 for more information. https://github.com/modxcms/revolution/issues/12502
-         */
-        $this->install->settings->settings['database_password'] = addslashes($this->install->settings->settings['database_password']);
-
         $settings = $this->install->settings->fetch();
         $settings['last_install_time'] = time();
         $settings['site_id'] = uniqid('modx',true);
@@ -192,6 +183,11 @@ abstract class modInstallRunner {
                 if ($content) {
                     $replace = [];
                     foreach ($settings as $key => $value) {
+                        // Sanitize MySQL Password before writing to config, escaping single quotes and backslashes (https://github.com/modxcms/revolution/issues/12502)
+                        if ($key == 'database_password') {
+                            $value = str_replace("\\", "\\\\", $value);
+                            $value = str_replace("'", "\\'", $value);
+                        }
                         if (is_scalar($value)) {
                             $replace['{' . $key . '}'] = "{$value}";
                         } elseif (is_array($value)) {


### PR DESCRIPTION
### What does it do?
Only the value that is written to the config file is escaped, not the value in the code (that is later used to create the database connection).
`addslashes` is replaced by `str_replace` because double quotes (`"`) shouldn't be escaped.

### Why is it needed?
The MODX 3 installation fails at the `action=install` step, when the "Database password" contains a backslash, or a quote and shows a "Site temporarily unavailable." message.

### How to test
Install MODX 3 with a "Database password" that contains a backslash, single or double quote and make sure the installation runs successfully.

### Related issue(s)/PR(s)
Resolves #16261
