### PR TITLE
Update phpThumb 1.7.18 202208061319 

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1951,7 +1951,7 @@ $settings['upload_check_exists']->fromArray(array (
 $settings['upload_files']= $xpdo->newObject('modSystemSetting');
 $settings['upload_files']->fromArray(array (
   'key' => 'upload_files',
-  'value' => 'txt,html,htm,xml,js,js.map,css,scss,less,css.map,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,webp,odt,ods,odp,odb,odg,odf,md,ttf,woff,woff2,eot',
+  'value' => 'txt,html,htm,xml,js,js.map,css,scss,less,css.map,zip,gz,rar,z,tgz,tar,mp3,mp4,aac,wav,au,wmv,avi,mpg,mpeg,pdf,doc,docx,xls,xlsx,ppt,pptx,jpg,jpeg,png,tiff,svg,svgz,gif,psd,ico,bmp,webp,avif,odt,ods,odp,odb,odg,odf,md,ttf,woff,woff2,eot',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',
@@ -1969,7 +1969,7 @@ $settings['upload_flash']->fromArray(array (
 $settings['upload_images']= $xpdo->newObject('modSystemSetting');
 $settings['upload_images']->fromArray(array (
   'key' => 'upload_images',
-  'value' => 'jpg,jpeg,png,gif,psd,ico,bmp,tiff,svg,svgz,webp',
+  'value' => 'jpg,jpeg,png,gif,psd,ico,bmp,tiff,svg,svgz,webp,avif',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'file',

--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -40,6 +40,11 @@ class modPhpThumb extends phpThumb
             define('IMG_WEBP', 32);
         }
 
+        if (version_compare(PHP_VERSION, '8.1.0', '<=')) {
+            // The constant IMG_AVIF is available as of PHP 8.1.
+            define('IMG_AVIF', 256);
+        }
+
         parent::__construct();
     }
 

--- a/core/model/phpthumb/phpthumb.functions.php
+++ b/core/model/phpthumb/phpthumb.functions.php
@@ -173,7 +173,7 @@ class phpthumb_functions {
 
 
 	public static function ImageTypeToMIMEtype($imagetype) {
-		if (function_exists('image_type_to_mime_type') && ($imagetype >= 1) && ($imagetype <= 18)) {
+		if (function_exists('image_type_to_mime_type') && ($imagetype >= 1) && ($imagetype <= 19)) {
 			// PHP v4.3.0+
 			return image_type_to_mime_type($imagetype);
 		}
@@ -196,6 +196,7 @@ class phpthumb_functions {
 			16 => 'image/xbm',                     // IMAGETYPE_XBM
 			17 => 'image/x-icon',                  // IMAGETYPE_ICO
 			18 => 'image/webp',                    // IMAGETYPE_WEBP
+			19 => 'image/avif',                    // IMAGETYPE_AVIF
 
 			'gif'  => 'image/gif',                 // IMAGETYPE_GIF
 			'jpg'  => 'image/jpeg',                // IMAGETYPE_JPEG
@@ -204,6 +205,7 @@ class phpthumb_functions {
 			'bmp'  => 'image/bmp',                 // IMAGETYPE_BMP
 			'ico'  => 'image/x-icon',              // IMAGETYPE_ICO
 			'webp' => 'image/webp',                // IMAGETYPE_WEBP
+			'avif' => 'image/avif',                // IMAGETYPE_AVIF
 		);
 
 		return (isset($image_type_to_mime_type[$imagetype]) ? $image_type_to_mime_type[$imagetype] : false);
@@ -743,7 +745,7 @@ class phpthumb_functions {
 			'http'  => 80,
 			'https' => 443,
 		);
-		return (isset($schemePort[strtolower($scheme)]) ? $schemePort[strtolower($scheme)] : null);
+		return ((!empty($scheme) && isset($schemePort[strtolower($scheme)])) ? $schemePort[strtolower($scheme)] : null);
 	}
 
 	public static function ParseURLbetter($url) {

--- a/setup/includes/upgrades/common/2.8.5-update-upload_files-upload_images.php
+++ b/setup/includes/upgrades/common/2.8.5-update-upload_files-upload_images.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Common upgrade script for modify upload_files, upload_images System Setting
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+$keys = ['upload_files','upload_images'];
+
+foreach ($keys as $key) {
+    $success = false;
+
+    /** @var modSystemSetting $setting */
+    $setting = $modx->getObject('modSystemSetting', array('key' => $key));
+    if ($setting) {
+        $value = $setting->get('value');
+        $tmp = explode(',', $value);
+        if (in_array('avif', $tmp)) {
+            continue;
+        } else {
+            $setting->set('value', $value . ',avif');
+            if ($setting->save()) {
+                $success = true;
+            }
+        }
+    }
+
+    if ($success) {
+        $this->runner->addResult(modInstallRunner::RESULT_SUCCESS,
+            sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_update_success', ['key' => $key])));
+    } else {
+        $this->runner->addResult(modInstallRunner::RESULT_WARNING,
+            sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_update_failed', ['key' => $key])));
+    }
+}

--- a/setup/includes/upgrades/mysql/2.8.5-pl.php
+++ b/setup/includes/upgrades/mysql/2.8.5-pl.php
@@ -1,0 +1,3 @@
+<?php
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/2.8.5-update-upload_files-upload_images.php';


### PR DESCRIPTION
### What does it do?
Update phpThumb [v1.7.18-202208061319](https://github.com/JamesHeinrich/phpThumb/releases/tag/v1.7.18)

### Why is it needed?
Extra PHP8 compatibility fixes + add AVIF image format supported by phpThumb (requires PHP 8.1.0)
[See changes](https://github.com/JamesHeinrich/phpThumb/compare/v1.7.17...v1.7.18)
