### PR TITLE
Avoid PHP warnings by only requiring deprecated.php once.

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -22,5 +22,5 @@ if (!file_exists(MODX_CORE_PATH . 'vendor/autoload.php')) {
     exit();
 }
 require MODX_CORE_PATH . 'vendor/autoload.php';
-require MODX_CORE_PATH . 'include/deprecated.php';
+require_once MODX_CORE_PATH . 'include/deprecated.php';
 


### PR DESCRIPTION
### What does it do?
Avoids PHP warnings in the MODX log when instantiating. 

### Why is it needed?
Sometimes when using tools such as Gitify and GitifyWatch, MODX may get re-instantiated causing errors/warnings in the log such as:
```
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 11) PHP warning: Cannot declare class xPDO, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 12) PHP warning: Cannot declare class xPDOCriteria, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 13) PHP warning: Cannot declare class xPDOSimpleObject, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 14) PHP warning: Cannot declare class xPDOQuery, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 15) PHP warning: Cannot declare class xPDOObject, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 16) PHP warning: Cannot declare class xPDOCacheManager, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 17) PHP warning: Cannot declare class xPDOFileCache, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 18) PHP warning: Cannot declare class xPDOTransport, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 19) PHP warning: Cannot declare class xPDOObjectVehicle, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 21) PHP warning: Cannot declare class modX, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 24) PHP warning: Cannot declare class modProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 25) PHP warning: Cannot declare class modObjectProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 26) PHP warning: Cannot declare class modDriverSpecificProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 27) PHP warning: Cannot declare class modProcessorResponse, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 28) PHP warning: Cannot declare class modProcessorResponseError, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 29) PHP warning: Cannot declare class modObjectCreateProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 30) PHP warning: Cannot declare class modObjectDuplicateProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 31) PHP warning: Cannot declare class modObjectExportProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 32) PHP warning: Cannot declare class modObjectGetListProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 33) PHP warning: Cannot declare class modObjectGetProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 34) PHP warning: Cannot declare class modObjectImportProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 35) PHP warning: Cannot declare class modObjectRemoveProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 36) PHP warning: Cannot declare class modObjectSoftRemoveProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 37) PHP warning: Cannot declare class modObjectUpdateProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 40) PHP warning: Cannot declare class modResourceCreateProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 41) PHP warning: Cannot declare class modResourceUpdateProcessor, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 44) PHP warning: Cannot declare class modManagerController, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 45) PHP warning: Cannot declare class modParsedManagerController, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 46) PHP warning: Cannot declare class modExtraManagerController, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 47) PHP warning: Cannot declare class modResource, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 50) PHP warning: Cannot declare class modParser, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 51) PHP warning: Cannot declare class modMail, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 52) PHP warning: Cannot declare class modPHPMailer, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 55) PHP warning: Cannot declare class modDashboardWidgetInterface, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 56) PHP warning: Cannot declare class modTemplateVarInputRender, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 57) PHP warning: Cannot declare class modTemplateVarOutputRender, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 58) PHP warning: Cannot declare class modSystemEvent, because the name is already in use
[2022-09-23 17:13:56] (ERROR @ /www/core/include/deprecated.php : 59) PHP warning: Cannot declare class modMediaSource, because the name is already in use
```

### How to test
Use MODX as normal to test that nothing breaks, or try using GitifyWatch (v2) with and without the change.

### Related issue(s)/PR(s)
n/a
