### PR TITLE
13970 ignore synlink

### DIFF
--- a/_build/test/README.md
+++ b/_build/test/README.md
@@ -7,4 +7,4 @@ Copy `_build/test/properties.sample.inc.php` to `_build/test/properties.inc.php`
 * `$properties['mysql_string_username']= '';` database username
 * `$properties['mysql_string_password']= '';` database password
 
-From the commandline at the root of the projeect, run `composer run-script phpunit`
+From the commandline at the root of the project, run `composer run-script phpunit`

--- a/_build/test/README.md
+++ b/_build/test/README.md
@@ -7,4 +7,4 @@ Copy `_build/test/properties.sample.inc.php` to `_build/test/properties.inc.php`
 * `$properties['mysql_string_username']= '';` database username
 * `$properties['mysql_string_password']= '';` database password
 
-from the commandline change to the test directory and run `phpunit`
+From the commandline at the root of the projeect, run `composer run-script phpunit`

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -37,8 +37,8 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
-        @rmdir(MODX_BASE_PATH.'assets/test5/');
-        @rmdir(MODX_BASE_PATH.'assets/test6/');
+        @rmdir(MODX_BASE_PATH . 'assets/test5/');
+        @rmdir(MODX_BASE_PATH . 'assets/test6/');
     }
     /**
      * Cleanup data after this test case.
@@ -49,8 +49,8 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
-        @rmdir(MODX_BASE_PATH.'assets/test5/');
-        @rmdir(MODX_BASE_PATH.'assets/test6/');
+        @rmdir(MODX_BASE_PATH . 'assets/test5/');
+        @rmdir(MODX_BASE_PATH . 'assets/test6/');
     }
     /**
      * Setup fixtures before each test.
@@ -232,7 +232,10 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
             $dirs = $result;
         }
         $success = !$response->isError() && is_array($dirs) && !empty($dirs);
-        $this->assertTrue($success,'Could not get list of files and dirs ignoring symlink in '.GetList::class.' test '.__METHOD__);
+        $this->assertTrue(
+            $success,
+            'Could not get list of files and dirs ignoring symlink in '.GetList::class.' test '.__METHOD__
+        );
     }
     /**
      * Test data provider for getList processor with symlink present

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -214,16 +214,17 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
      * @dataProvider providerGetDirectoryListWithSymlink
      * @param string $dir A string path to the directory to list.
      */
-    public function testGetDirectoryListWithSymlink($target, $link) {
-        $dirtarget = $this->modx->getOption('base_path').$target;
-        $dirlink = $this->modx->getOption('base_path').$link;
+    public function testGetDirectoryListWithSymlink($target, $link)
+    {
+        $dirtarget = $this->modx->getOption('base_path') . $target;
+        $dirlink = $this->modx->getOption('base_path') . $link;
         @symlink($dirtarget, $dirlink);
         /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(GetList::class, [
             'id' => 'assets',
         ]);
         if (empty($response)) {
-            $this->fail('Could not load '.GetList::class.' processor');
+            $this->fail('Could not load ' . GetList::class . ' processor');
         }
         $result = $response->getResponse();
         if (is_string($result)) {
@@ -234,14 +235,15 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
         $success = !$response->isError() && is_array($dirs) && !empty($dirs);
         $this->assertTrue(
             $success,
-            'Could not get list of files and dirs ignoring symlink in '.GetList::class.' test '.__METHOD__
+            'Could not get list of files and dirs ignoring symlink in ' . GetList::class . ' test ' . __METHOD__
         );
     }
     /**
      * Test data provider for getList processor with symlink present
      * @return array
      */
-    public function providerGetDirectoryListWithSymlink() {
+    public function providerGetDirectoryListWithSymlink()
+    {
         return [
             ['assets/test5', 'assets/test6'],
         ];

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -37,6 +37,8 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
+        @rmdir(MODX_BASE_PATH.'assets/test5/');
+        @rmdir(MODX_BASE_PATH.'assets/test6/');
     }
     /**
      * Cleanup data after this test case.
@@ -47,6 +49,8 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
+        @rmdir(MODX_BASE_PATH.'assets/test5/');
+        @rmdir(MODX_BASE_PATH.'assets/test6/');
     }
     /**
      * Setup fixtures before each test.
@@ -201,6 +205,42 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
             ['manager/',true],
             ['manager/assets',true],
             ['fakedirectory/',false],
+        ];
+    }
+
+    /**
+     * Tests the browser/directory/getList processor with symlink present
+     *
+     * @dataProvider providerGetDirectoryListWithSymlink
+     * @param string $dir A string path to the directory to list.
+     */
+    public function testGetDirectoryListWithSymlink($target, $link) {
+        $dirtarget = $this->modx->getOption('base_path').$target;
+        $dirlink = $this->modx->getOption('base_path').$link;
+        @symlink($dirtarget, $dirlink);
+        /** @var ProcessorResponse $response */
+        $response = $this->modx->runProcessor(GetList::class, [
+            'id' => 'assets',
+        ]);
+        if (empty($response)) {
+            $this->fail('Could not load '.GetList::class.' processor');
+        }
+        $result = $response->getResponse();
+        if (is_string($result)) {
+            $dirs = json_decode($result, true);
+        } else {
+            $dirs = $result;
+        }
+        $success = !$response->isError() && is_array($dirs) && !empty($dirs);
+        $this->assertTrue($success,'Could not get list of files and dirs ignoring symlink in '.GetList::class.' test '.__METHOD__);
+    }
+    /**
+     * Test data provider for getList processor with symlink present
+     * @return array
+     */
+    public function providerGetDirectoryListWithSymlink() {
+        return [
+            ['assets/test5', 'assets/test6'],
         ];
     }
 }

--- a/core/src/Revolution/Sources/modFileMediaSource.php
+++ b/core/src/Revolution/Sources/modFileMediaSource.php
@@ -49,7 +49,7 @@ class modFileMediaSource extends modMediaSource
 
                 // How to deal with links, either DISALLOW_LINKS or SKIP_LINKS
                 // Disallowing them causes exceptions when encountered
-                LocalFilesystemAdapter::DISALLOW_LINKS
+                LocalFilesystemAdapter::SKIP_LINKS
             );
 
         } catch (Exception $e) {


### PR DESCRIPTION
### What does it do?
Changed the `LocalFilesystemAdapter` config in `core/src/Revolution/Sources/modFileMediaSource.php` to skip (ignore) symlinks. Also updated unit tests and test readme to correctly instruct how to run phpunit.

### Why is it needed?
Prior to this, in the base branch, `modFileMediaSource`  would error when listing directory contents if that directory contained a symlink. Users could not inspect the contents of the directory at all in this case. With this PR it ignores symlinks and lists the other content.

### How to test
`composer run-script phpunit`
You can also test manually by logging into the manager, listing the contents of a directly like `assets` in the File Tree, then create a symlink there, and in the manager you will still be able to list the contents of the directory. It is expected that the symlink will simply be ignored and not displayed.

### Related issue(s)/PR(s)
Resolves #13970  and related issues that have the same cause
