### PR TITLE
Alternate Permissions Combo Fix

### DIFF
--- a/core/src/Revolution/Processors/Model/GetListProcessor.php
+++ b/core/src/Revolution/Processors/Model/GetListProcessor.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Model;
-
 
 use MODX\Revolution\modAccessibleObject;
 use MODX\Revolution\Processors\ModelProcessor;
@@ -25,8 +25,8 @@ use xPDO\Om\xPDOQuery;
  */
 abstract class GetListProcessor extends ModelProcessor
 {
-    const CLASS_ALLOW_EDIT = 'pedit';
-    const CLASS_ALLOW_REMOVE = 'premove';
+    public const CLASS_ALLOW_EDIT = 'pedit';
+    public const CLASS_ALLOW_REMOVE = 'premove';
 
     /** @var string $defaultSortField The default field to sort by */
     public $defaultSortField = 'name';
@@ -36,6 +36,8 @@ abstract class GetListProcessor extends ModelProcessor
     public $checkListPermission = true;
     /** @var int $currentIndex The current index of successful iteration */
     public $currentIndex = 0;
+    /** @var int $listTotal  An alternative and explicitly set count to be used in extending processors where the default getCount method will not work (e.g., when an accurate count depends upon an aggregated column) */
+    public $listTotal = 0;
 
     /**
      * {@inheritDoc}
@@ -147,17 +149,21 @@ abstract class GetListProcessor extends ModelProcessor
         /* query for chunks */
         $c = $this->modx->newQuery($this->classKey);
         $c = $this->prepareQueryBeforeCount($c);
-        $data['total'] = $this->modx->getCount($this->classKey, $c);
+        $data['total'] = $this->listTotal ?: $this->modx->getCount($this->classKey, $c);
         $c = $this->prepareQueryAfterCount($c);
 
         $sortClassKey = $this->getSortClassKey();
         $sortAlias = $this->getSortClassKey();
         if (strpos($sortAlias, '\\') !== false) {
             $explodedAlias = explode('\\', $sortAlias);
-            $sortAlias= array_pop($explodedAlias);
+            $sortAlias = array_pop($explodedAlias);
         }
-        $sortKey = $this->modx->getSelectColumns($sortClassKey, $this->getProperty('sortAlias', $sortAlias), '',
-            [$this->getProperty('sort')]);
+        $sortKey = $this->modx->getSelectColumns(
+            $sortClassKey,
+            $this->getProperty('sortAlias', $sortAlias),
+            '',
+            [$this->getProperty('sort')]
+        );
         if (empty($sortKey)) {
             $sortKey = $this->getProperty('sort');
         }

--- a/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/Permission/GetList.php
@@ -45,8 +45,8 @@ class GetList extends GetListProcessor
      */
     public function prepareQueryBeforeCount(xPDOQuery $c)
     {
-        $n = $this->modx->newQuery($this->classKey);
-        $n->select([
+        $totalQuery = $this->modx->newQuery($this->classKey);
+        $totalQuery->select([
             'total' => 'COUNT(DISTINCT `modAccessPermission`.`name`)'
         ]);
 
@@ -56,10 +56,10 @@ class GetList extends GetListProcessor
         if (!empty($query)) {
             $query = ['modAccessPermission.name:LIKE' => '%' . $query . '%'];
             $c->where($query);
-            $n->where($query);
+            $totalQuery->where($query);
         }
 
-        $this->listTotal = $this->modx->getObject($this->classKey, $n)->get('total');
+        $this->listTotal = $this->modx->getObject($this->classKey, $totalQuery)->get('total');
 
         return $c;
     }

--- a/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
+++ b/manager/assets/modext/widgets/security/modx.panel.access.policy.template.js
@@ -287,6 +287,16 @@ MODx.window.NewTemplatePermission = function(config) {
             ,hiddenName: 'name'
             ,id: 'modx-'+this.ident+'-name'
             ,anchor: '100%'
+            ,listeners: {
+                change: {
+                    fn: function(cmp, newValue, oldValue) {
+                        if (Ext.isEmpty(cmp.getValue())) {
+                            cmp.getStore().load();
+                        }
+                    },
+                    scope: this
+                }
+            }
         },{
             xtype: 'textarea'
             ,fieldLabel: _('description')

--- a/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
+++ b/manager/assets/modext/widgets/system/modx.panel.dashboard.widget.js
@@ -4,7 +4,7 @@
  * @param {Object} config An object of configuration properties
  * @xtype modx-dashboard-widget-form
  */
-MODx.panel.DashboardWidget = function(config) {
+ MODx.panel.DashboardWidget = function(config) {
     config = config || {};
 
     var itms = [];
@@ -126,6 +126,16 @@ MODx.panel.DashboardWidget = function(config) {
                     ,description: _('widget_permission_desc')
                     ,anchor: '100%'
                     ,value: config.record.permission || ''
+                    ,listeners: {
+                        change: {
+                            fn: function(cmp, newValue, oldValue) {
+                                if (Ext.isEmpty(cmp.getValue())) {
+                                    cmp.getStore().load();
+                                }
+                            },
+                            scope: this
+                        }
+                    }
                 },{
                     xtype: MODx.expandHelp ? 'label' : 'hidden'
                     ,forId: 'modx-dashboard-permission'


### PR DESCRIPTION
### What does it do?
This follows on work by @muzzwood (#16227) with additional fixes.

### Why is it needed?
The referenced PR works to fix the immediate issue, but I found an additional one when doing some final testing (playing with the paging of the combo): The total count was wrong, due to issues with how getCount works and the fact that aggregate functions need to be used to produce the combo's list correctly (without duplicates). Note that the original code (pre-@muzzwood's changes) attempted to use DISTINCT to do this, but that's not possible in this case, as there's only one column we desire to be distinct but we're selecting four.

The proposed solution queries for the total count in a different way, setting its value in a class property. In this way, the default getCount can be side-stepped for instances such as this without changing any method signatures or overriding the getData method in the child class (which would just produce 99% duplication of its parent class method).

Otherwise, a separate commit makes a minor change to the js, adding listeners to load the store when one happens to delete the current value in the combo's field. Previously to this addition, the paging would not get loaded correctly (or at all) after erasing the field's value.

### How to test
Rebuild, clear cache, and test the combo at:
`manager/?a=system/dashboards/widget/update&id=1` and
`manager/?a=security/access/policy/template/update&id=2` (Shown when you Create a new permission on the grid)

### Related issue(s)/PR(s)
Based on #16227
