### PR TITLE
Exclude @SELECT binding from properties check in MODX 3

### DIFF
--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -1003,7 +1003,7 @@ class modTemplateVar extends modElement
             $regexp2 = '/(\S+)\s+(.+)/is'; /* Split binding on second whitespace to get properties */
 
             $properties = [];
-            if (strtoupper($match[1]) != 'SELECT' && preg_match($regexp2, $match[2] , $match2)) {
+            if (strtoupper($match[1]) != 'SELECT' && preg_match($regexp2, $match[2], $match2)) {
                 if (isset($match2[2])) {
                     $props = json_decode($match2[2],true);
                     $valid = json_last_error() === JSON_ERROR_NONE;

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -1003,7 +1003,7 @@ class modTemplateVar extends modElement
             $regexp2 = '/(\S+)\s+(.+)/is'; /* Split binding on second whitespace to get properties */
 
             $properties = [];
-            if (preg_match($regexp2, $match[2] , $match2)) {
+            if (strtoupper($match[1]) != 'SELECT' && preg_match($regexp2, $match[2] , $match2)) {
                 if (isset($match2[2])) {
                     $props = json_decode($match2[2],true);
                     $valid = json_last_error() === JSON_ERROR_NONE;


### PR DESCRIPTION
### What does it do?
PR #15488 added a way to add properties to bindings in the form `@SNIPPET someSnippet {"someKey":"someValue"}` by looking for a value after **the second whitespace** and trying to parse this value as a JSON string.

Because every `@SELECT` binding contains a lot of whitespace an no JSON, it should be excluded from the check.

### Why is it needed?
To avoid constant (misleading) error log messages for every `@SELECT` binding.

### How to test
Create a TV with a `@SELECT` binding in the input option values and verify, that there are no more "third parameter is invalid JSON ..." error log messages.

### Related issue(s)/PR(s)
Resolves #16200
