### PR TITLE
Refactor input filter parsing to properly support nested tags

### DIFF
--- a/_build/test/Tests/Model/Filters/modInputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modInputFilterTest.php
@@ -91,6 +91,38 @@ class modInputFilterTest extends MODxTestCase
                     'title',
                 ]
             ],
+            [
+                'echoinput:input=`[[++mail_smtp_hosts]] [[echoinput:eq=`0`:then=`test1:[[++mail_smtp_hosts]];`:else=`test2:[[++mail_smtp_hosts]]`?input=`0`]]`',
+                'echoinput',
+                [
+                    'input',
+                ],
+                [
+                    '[[++mail_smtp_hosts]] [[echoinput:eq=`0`:then=`test1:[[++mail_smtp_hosts]];`:else=`test2:[[++mail_smtp_hosts]]`?input=`0`]]',
+                ]
+            ],
+            [
+                'content:notempty=`[[!Wayfinder? &startId=`0` &level=`1`]]`',
+                'content',
+                [
+                    'notempty',
+                ],
+                [
+                    '[[!Wayfinder? &startId=`0` &level=`1`]]',
+                ]
+            ],
+            [
+                'content:up:trim',
+                'content',
+                [
+                    'up',
+                    'trim',
+                ],
+                [
+                    '',
+                    '',
+                ]
+            ]
         ];
     }
 }

--- a/_build/test/Tests/Model/Filters/modInputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modInputFilterTest.php
@@ -68,7 +68,29 @@ class modInputFilterTest extends MODxTestCase
                     'foo',
                     'bar',
                 ]
-            ]
+            ],
+            [
+                'content:notempty=`[[!Wayfinder? &startId=`0` &level=`1`]]`',
+                'content',
+                [
+                    'notempty',
+                ],
+                [
+                    '[[!Wayfinder? &startId=`0` &level=`1`]]',
+                ]
+            ],
+            [
+                'pagetitle:default=`[[*longtitle]]`:toPlaceholder=`title`',
+                'pagetitle',
+                [
+                    'default',
+                    'toPlaceholder',
+                ],
+                [
+                    '[[*longtitle]]',
+                    'title',
+                ]
+            ],
         ];
     }
 }

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -33,7 +33,16 @@ class modParserTest extends MODxTestCase {
      */
     public static function setUpFixturesBeforeClass() {
         $modx = MODxTestHarness::getFixture(modX::class, 'modx', true);
-        $placeholders = ['tag' => 'Tag', 'tag1' => 'Tag1', 'tag2' => 'Tag2'];
+        $placeholders = [
+            'tag' => 'Tag',
+            'tag1' => 'Tag1',
+            'tag2' => 'Tag2',
+            'is1' => '1',
+            'is2' => '2',
+            'is3' => '3',
+            'not_empty_content' => 'This is some not empty content.',
+            'empty_content' => 'This is some not empty content.',
+        ];
         self::$scope = $modx->toPlaceholders($placeholders, '', '.', true);
     }
 
@@ -332,6 +341,136 @@ class modParserTest extends MODxTestCase {
                 [
                     'parentTag' => '',
                     'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "1"
+                ],
+                "[[+is1:is=`1`:then=`[[+is1]]`:else=`
+    [[+is1:is=`2`:then=`[[+is1]]`:else=`more`]]
+`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "[[+is2:is=`2`:then=`2`:else=`more`]]"
+                ],
+                "[[+is2:is=`1`:then=`[[+is2]]`:else=`[[+is2:is=`2`:then=`[[+is2]]`:else=`more`]]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 2,
+                    'content' => "2"
+                ],
+                "[[+is2:is=`1`:then=`[[+is2]]`:else=`[[+is2:is=`2`:then=`[[+is2]]`:else=`more`]]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 2
+                ]
+            ],
+            [
+                [
+                    'processed' => 2,
+                    'content' => "more"
+                ],
+                "[[+is3:is=`1`:then=`[[+is3]]`:else=`[[+is3:is=`2`:then=`[[+is3]]`:else=`more`]]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 2
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "[[!Wayfinder? &startId=`0` &level=`1`]]"
+                ],
+                "[[+not_empty_content:notempty=`[[!Wayfinder? &startId=`0` &level=`1`]]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "Tag1"
+                ],
+                "[[+tag[[+is1]]]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "Tag1"
+                ],
+                "[[[[+is1:gt=`1`:then=`+tag[[+is2]]`:default=`+tag[[+is1]]`]]]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "[[!+tag1]]"
+                ],
+                "[[![[+is1:lt=`2`:then=`+tag[[+is1]]`:default=`+tag[[+is2]]`]]]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => false,
                     'removeUnprocessed' => false,
                     'prefix' => '[[',
                     'suffix' => ']]',

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -58,7 +58,7 @@ class modOutputFilter
 
             for ($i = 0; $i < $count; $i++) {
 
-                $m_cmd = $modifier_cmd[$i];
+                $m_cmd = trim($modifier_cmd[$i]);
                 $m_val = $modifier_value[$i];
 
                 $this->log('Processing Modifier: ' . $m_cmd . ' (parameters: ' . $m_val . ')');


### PR DESCRIPTION
### What does it do?

Refactors the parsing in the modInputFilter, which gets passed the inside of a tag to break up into a filter command and it's modifiers (aka options). Adds more tests. 

Rather than relying on a very daunting regex that is clearly not handling nesting well, or reverting back to behavior that still has known issues with nested parsing, this refactor just changes the way that thing works entirely. 

It now parses the inside of a tag one character at a time to really understand what the implications of a certain nested tag are. It implements the parsing rules so that a `` ` `` inside a nested tag doesn't "close" the outer tag. It understands to not do anything with a nested tag within its own set of brackets. 

If there are other situations where this still doesn't address a nested tag yet, let me know.

### Why is it needed?

To fix the shitshow that has been recent parsing issues in 3.0.1 without reintroducing other limitations.  

### How to test

The expanded test suite should be looking green, at least it is for me locally 🤞 

I've also tried throwing some more complex ContentBlocks-powered 3-level-nested chunks against it, and it seems to be holding up where it would previously (even in 2.x) fail.

Getting even more tests in here would be preferred, as well as some real-world tests, would be ideal. 

### Related issue(s)/PR(s)

Related to / fixes:

- #13250: one of the earliest reports of issues with nested tags, with lots of discussions.
- #14095: report of nested conditionals causing broken tags
- #16254: proposed revert of #14458 which introduced issues with nested output filters (` characters)
- #16186: cut-off with nested snippet
- #16198: `:` inside an output filter breaking
- Passes Joshua's [test addition](https://github.com/JoshuaLuckers/revolution/commit/004b877ad0e597e77b19d4a6a09477495bdde4ad) and [tests added in #14458](https://github.com/modxcms/revolution/pull/14458/files) too

Does not yet seem to fix:

- #16044: the `;` seems to be tripping something up somewhere else. (`:` works fine.)