### PR TITLE
Catch dashboard widget errors on a per-widget basis

### DIFF
--- a/core/src/Revolution/modDashboardWidgetInterface.php
+++ b/core/src/Revolution/modDashboardWidgetInterface.php
@@ -11,6 +11,7 @@
 namespace MODX\Revolution;
 
 
+use Throwable;
 use xPDO\xPDO;
 
 /**
@@ -78,7 +79,16 @@ abstract class modDashboardWidgetInterface
      * @return string
      */
     public function process() {
-        $output = $this->render();
+        try {
+            $output = $this->render();
+        } catch (Throwable $t) {
+            $this->controller->setPlaceholder('_e', [
+                'message' => $t->getMessage(),
+                'errors' => explode("\n", $t->getTraceAsString()),
+            ]);
+            $output = $this->controller->fetchTemplate('error.tpl');
+        }
+
         if (!empty($output)) {
             $widgetArray = $this->widget->toArray();
             $widgetArray['content'] = $output;


### PR DESCRIPTION
### What does it do?
Currently, if an error happens inside any dashboard widget, the entire page shows an error:
 
![Schermafbeelding 2022-10-31 om 21 31 42](https://user-images.githubusercontent.com/312944/199104672-df0532ed-08a5-499c-a1b9-bc6b07167f3d.jpg)

That's a step up from 2.x where an error on the dashboard makes the entire manager unusable, but still, not great. 

With this patch, errors are caught when rendering each of the widgets and the error is placed inside the widgets own frame and the rest of the manager remains unaffected:

![Schermafbeelding 2022-10-31 om 21 33 14](https://user-images.githubusercontent.com/312944/199105124-809ff185-533c-4f9e-822c-9ad6eabdf6a6.png)

### Why is it needed?

This change makes it clearer in what widget an error occurred, while still providing the same information to help with debugging. And any other widgets on the dashboard remain functional. 

### How to test

Add a broken dashboard widget. What I've done for testing is call an undefined function `bug()` inside `manager/controllers/default/dashboard/widget.grid-online.php` but there are many ways to cause an error, and `throw new Exception('Invalid condition');` for throwing an exception.

### Related issue(s)/PR(s)
N/a
