### PR TITLE
Remove create_function from moddashboardwidget

### DIFF
--- a/core/model/modx/moddashboardwidget.class.php
+++ b/core/model/modx/moddashboardwidget.class.php
@@ -317,10 +317,17 @@ abstract class modDashboardWidgetInterface {
     public function renderAsSnippet($content = '') {
         if (empty($content)) $content = $this->widget->get('content');
         $content = str_replace(array('<?php','?>'),'',$content);
-        $snippet = $this->modx->newObject('modSnippet');
-        $snippet->set('content', $content);
-        return $snippet->process(array(
+        $closure = function ($scriptProperties) use ($content) {
+            global $modx;
+            if (is_array($scriptProperties)) {
+                extract($scriptProperties, EXTR_SKIP);
+            }
+
+            return eval($content);
+        };
+
+        return $closure([
             'controller' => $this->controller,
-        ));
+        ]);
     }
 }

--- a/core/model/modx/moddashboardwidget.class.php
+++ b/core/model/modx/moddashboardwidget.class.php
@@ -326,8 +326,8 @@ abstract class modDashboardWidgetInterface {
             return eval($content);
         };
 
-        return $closure([
+        return $closure(array(
             'controller' => $this->controller,
-        ]);
+        ));
     }
 }

--- a/core/model/modx/moddashboardwidget.class.php
+++ b/core/model/modx/moddashboardwidget.class.php
@@ -317,8 +317,9 @@ abstract class modDashboardWidgetInterface {
     public function renderAsSnippet($content = '') {
         if (empty($content)) $content = $this->widget->get('content');
         $content = str_replace(array('<?php','?>'),'',$content);
-        $closure = create_function('$scriptProperties','global $modx;if (is_array($scriptProperties)) {extract($scriptProperties, EXTR_SKIP);}'.$content);
-        return $closure(array(
+        $snippet = $this->modx->newObject('modSnippet');
+        $snippet->set('content', $content);
+        return $snippet->process(array(
             'controller' => $this->controller,
         ));
     }


### PR DESCRIPTION
### What does it do?
Remove create_function from the PHP dashboard widget processor, and run the content as a snippet. 

### Why is it needed?
create_function is removed in PHP 8.0

### How to test
Create a PHP Dashboard widget in MODX running on PHP 8+
e.g. 
```
<?php 
echo "Hello world!"
```

### Related issue(s)/PR(s)
#15918 
