### PR TITLE
Prevent errors or incompatibilities in extras from breaking the setup

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -564,9 +564,11 @@ class modX extends xPDO {
 
             $this->getCacheManager();
             $this->getConfig();
-            $this->_initNamespaces();
-            $this->_initContext($contextKey, false, $options);
-            $this->_loadExtensionPackages($options);
+            if (!$this->getOption(xPDO::OPT_SETUP)) {
+                $this->_initNamespaces();
+                $this->_initContext($contextKey, false, $options);
+                $this->_loadExtensionPackages($options);
+            }
             $this->_initSession($options);
             $this->_initErrorHandler($options);
             $this->_initHttpClient();
@@ -575,13 +577,15 @@ class modX extends xPDO {
             $this->services->add('registry', new modRegistry($this));
             $this->registry = $this->services->get('registry');
 
-            $this->invokeEvent(
-                'OnMODXInit',
-                [
-                    'contextKey' => $contextKey,
-                    'options' => $options,
-                ]
-            );
+            if (!$this->getOption(xPDO::OPT_SETUP)) {
+                $this->invokeEvent(
+                    'OnMODXInit',
+                    [
+                        'contextKey' => $contextKey,
+                        'options' => $options,
+                    ]
+                );
+            }
 
             if (is_array ($this->config)) {
                 $c = $this->config;


### PR DESCRIPTION
### What does it do?

Avoid instantiating namespaces, extension packages, and the OnMODXInit event while in the setup.

### Why is it needed?

The upgrade from 2.x to 3.0 isn't always super smooth due to breaking changes. Some extras have different versions for different major releases, or other errors pop up. 

Especially extras with extension packages or those with the new `bootstrap.php` that runs from the namespace root can inadvertently be run in the setup, and cause the setup itself to throw an error. 

### How to test

I've not yet tested this extensively personally, though a quick test on my development install completed as expected. If a nightly would get built with this patch included, that would help test it for a client that's currently having this issue (S34224). 

The issue mostly seems to happen on a 2.x > 3.0 upgrade but could theoretically also occur on regular patch updates.

Basic testing requires [building a core package](https://docs.modx.com/current/en/contribute/code/tooling/core) and then running the setup. 

### Related issue(s)/PR(s)

It comes up every now and then, but I don't think this has a specific issue. 