### PR TITLE
Improve grid error handling when processor didn't return json

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -173,11 +173,16 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
     windows: {}
 
     ,onStoreException: function(dp,type,act,opt,resp){
-        var r = Ext.decode(resp.responseText);
-        if (r.message) {
-            this.getView().emptyText = r.message;
-            this.getView().refresh(false);
+        let r;
+        try {
+            r = Ext.decode(resp.responseText);
+        } catch (e) {
+            this.getView().emptyText = 'Invalid response from server: <pre><code>' + MODx.util.safeHtml(resp.responseText) + '</code></pre>';
         }
+        if (r && r.message) {
+            this.getView().emptyText = r.message;
+        }
+        this.getView().refresh(false);
     }
     ,saveRecord: function(e) {
         e.record.data.menu = null;


### PR DESCRIPTION
### What does it do?

Title.

### Why is it needed?

If a processor does not return valid JSON, but for example an uncaught PHP error, right now that causes a client-side error when attempting to parse the response. This is the infamous `Uncaught SyntaxError: expected expression, got '<'` error. 

This PR makes sure to not break the client-side if the response is not valid JSON, and actually shows the error in the grid contents. This makes getting to the actual root error a lot easier!

For example, I had some misconfigurations that caused a VersionX grid to fail to load. Rather than an empty grid and JS error, with this PR applied that now looks like this:

![Schermafbeelding 2022-11-04 om 20 28 06](https://user-images.githubusercontent.com/312944/200059991-a5aae60c-19fd-4cac-9413-e08e28a515c1.jpg)

Easy to debug, easy to report. 

### How to test

Break a getlist processor, for example call a non-existent function or break a class name, and test the grid.

Note that an assets rebuild is required if compress_js is enabled.   

### Related issue(s)/PR(s)

N/a