### PR TITLE
modElement: Fix getTag() side effects in MODX 3

### DIFF
--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -278,9 +278,9 @@ class modElement extends modAccessibleSimpleObject
                     } else {
                         if (is_array($value)) {
                             $func = function ($item) use (&$func) {
-                                if (is_array($item)){
+                                if (is_array($item)) {
                                     return array_map($func, $item);
-                                } else if ($item instanceof \xPDOObject) {
+                                } elseif ($item instanceof \xPDOObject) {
                                     return $item->toArray('', false, true);
                                 } else {
                                     return $item;

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -277,11 +277,16 @@ class modElement extends modAccessibleSimpleObject
                         $propTemp[$key] = $key . '=`' . $value . '`';
                     } else {
                         if (is_array($value)) {
-                            array_walk_recursive($value, function (&$item, $key) {
-                                if ($item instanceof \xPDOObject) {
-                                    $item = $item->toArray('', false, true);
+                            $func = function ($item) use (&$func) {
+                                if (is_array($item)){
+                                    return array_map($func, $item);
+                                } else if ($item instanceof \xPDOObject) {
+                                    return $item->toArray('', false, true);
+                                } else {
+                                    return $item;
                                 }
-                            });
+                            };
+                            $value = array_map($func, $value);
                         } elseif ($value instanceof \xPDOObject) {
                             $value = $value->toArray('', false, true);
                         }


### PR DESCRIPTION
### What does it do?
Creates the tag without accidentally changing the type of xPDOObjects in the properties.

### Why is it needed?
Currently in some cases an xPDOObject that is passed by reference as a property to a snippet, gets converted to an array.

### How to test

Run a snippet that has a property that is a _reference to an xPDOObject_ inside an array. Make sure the reference is of the same type after executing the snippet.

```php
<?php
$output = '';

$snippet = $modx->getObject('MODX\\Revolution\\modSnippet', ['name' => 'someSnippet']);
$user = $modx->getObject('MODX\\Revolution\\modUser', 1);
$properties = ['fields' => ['user' => &$user] ];

$output = "Type before: " . get_class($user);

$success = $snippet->process($properties);

$output .= " | Type after: " . (is_array($user) ? "ARRAY!" : get_class($user));
return $output;
```

### Related issue(s)/PR(s)
Resolves #16283
