### PR TITLE
Suppress PHP8 Smarty warnings

### DIFF
--- a/core/model/modx/smarty/modsmarty.class.php
+++ b/core/model/modx/smarty/modsmarty.class.php
@@ -74,6 +74,8 @@ class modSmarty extends SmartyBC {
 
         $this->_blocks = array();
         $this->_derived = null;
+        
+        $this->muteExpectedErrors();
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Suppresses warnings `Undefined array key "x"` and `Attempt to read property "value" on null` generated by Smarty on PHP8.

### Why is it needed?
Floods the modx error log with PHP warnings.

### How to test
Use PHP 8.1 and open a modx resource for editing.

### Related issue(s)/PR(s)
Resolves #16299 
