### PR TITLE
[3.0.2] Fix parsing modifiers when encountering literal brackets

### DIFF
--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -646,6 +646,140 @@ class modParserTest extends MODxTestCase {
                     'depth' => 0
                 ]
             ],
+            [
+                // Various tests for literal brackets [] in the modifier
+                [
+                    'processed' => 1,
+                    'content' => "[]"
+                ],
+                "[[+tag1:notempty=`[]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                // Test for literal []'s not being broken things
+                [
+                    'processed' => 1,
+                    'content' => "[ ][ ]"
+                ],
+                "[[+tag1:notempty=`[ ][ ]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "["
+                ],
+                "[[+tag1:notempty=`[`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "["
+                ],
+                "[[!+tag1:notempty=`[`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "]"
+                ],
+                "[[+tag1:notempty=`]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                // various special characters in the modifier
+                [
+                    'processed' => 1,
+                    'content' => "]=:["
+                ],
+                "[[+tag1:notempty=`]=:[`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ],
+            [
+                // tags within brackets
+                [
+                    'processed' => 1,
+                    'content' => '<input type="text" name="item[ Tag2 ][name]" />'
+                ],
+                '[[+tag1:notempty=`<input type="text" name="item[ [[+tag2]] ][name]" />`]]',
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 1
+                ]
+            ],
+            // tags directly within brackets
+            // @todo this test fails
+//            [
+//                [
+//                    'processed' => 1,
+//                    'content' => '<input type="text" name="item[Tag2][name]" />'
+//                ],
+//                '[[+tag1:notempty=`<input type="text" name="item[[[+tag2]]][name]" />`]]',
+//                [
+//                    'parentTag' => '',
+//                    'processUncacheable' => true,
+//                    'removeUnprocessed' => false,
+//                    'prefix' => '[[',
+//                    'suffix' => ']]',
+//                    'tokens' => [],
+//                    'depth' => 1
+//                ]
+//            ],
         ];
     }
 

--- a/core/src/Revolution/Filters/modInputFilter.php
+++ b/core/src/Revolution/Filters/modInputFilter.php
@@ -72,11 +72,11 @@ class modInputFilter
                     case '[':
                         if ($chars[$i + 1] === '[') {
                             $depth++;
-                            $depth === 0 ? $command .= $char.$char : $commandModifiers .= $char.$char;
+                            $inModifier ? $commandModifiers .= $char.$char : $command .= $char.$char;
                             $skipNext = true;
                         }
                         else {
-                            $depth === 0 ? $command .= $char : $commandModifiers .= $char;
+                            $inModifier ? $commandModifiers .= $char : $command .= $char;
                         }
                         break;
 
@@ -84,12 +84,12 @@ class modInputFilter
                     // The character is added to either the command or the commandModifiers
                     case ']':
                         if ($chars[$i + 1] === ']') {
-                            $depth === 0 ? $command .= $char.$char : $commandModifiers .= $char.$char;
+                            $inModifier ? $commandModifiers .= $char.$char : $command .= $char.$char;
                             $depth--;
                             $skipNext = true;
                         }
                         else {
-                            $depth === 0 ? $command .= $char : $commandModifiers .= $char;
+                            $inModifier ? $commandModifiers .= $char : $command .= $char;
                         }
 
                         break;
@@ -110,7 +110,7 @@ class modInputFilter
                             $inModifier = !$inModifier;
                         }
                         else {
-                            $commandModifiers .= $char;
+                            $inModifier ? $commandModifiers .= $char : $command .= $char;
                         }
                         break;
                     // The `:` sign (colon) is a separator between multiple commands in a string.


### PR DESCRIPTION
### What does it do?
Fix where literal brackets (not intended as an opening/closing tag) go in the parsed command modifiers. 

### Why is it needed?

John MacDonald reported the parser breaking in the following scenario:

```
[[++google_analytics:notempty=`
<!-- Global site tag (gtag.js) - Google Analytics -->
<script async src="https://www.googletagmanager.com/gtag/js?id=[[++google_analytics]]"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', '[[++google_analytics]]');
</script>
`]]
```

Rather than outputting the script, it returned just the value of `[[++google_analytics]]`. 

That test case was simplified to ```[[+tag:notempty=`[]`]]``` as the literal brackets appeared to be the problem.

Internally, the command ended up as `notempty[]` with an empty modifier. The `notempty[]` command doesn't exist so the original value is returned in its place. 

By using the `$inModifier` flag (which gets set in the switch case for ``` ` ``` when depth is 0) the brackets are parsed into the modifiers as they should. 

### How to test

See tests for examples. Feel free to come up with more complex cases. 

### Related issue(s)/PR(s)

Reported via Slack. 

Introduced with #16288 in 3.0.2.
