### PR TITLE
Update phpThumb v1.7.19-202210110924

### DIFF
--- a/core/model/phpthumb/phpthumb.filters.php
+++ b/core/model/phpthumb/phpthumb.filters.php
@@ -752,7 +752,7 @@ class phpthumb_filters {
 	}
 
 
-	public static function ImprovedImageRotate(&$gdimg_source, $rotate_angle=0, $config_background_hexcolor='FFFFFF', $bg=null, &$phpThumbObject) {
+	public static function ImprovedImageRotate(&$gdimg_source, $rotate_angle, $config_background_hexcolor, $bg, &$phpThumbObject) {
 		while ($rotate_angle < 0) {
 			$rotate_angle += 360;
 		}

--- a/core/model/phpthumb/phpthumb.gif.php
+++ b/core/model/phpthumb/phpthumb.gif.php
@@ -1093,9 +1093,9 @@ class CGIF
 		for ($i = 0; $i < $NumColorsInPal; $i++) {
 			$ThisImageColor[$i] = imagecolorallocate(
 									$PlottingIMG,
-									ord($pal{($i * 3) + 0}),
-									ord($pal{($i * 3) + 1}),
-									ord($pal{($i * 3) + 2}));
+									ord($pal[($i * 3) + 0]),
+									ord($pal[($i * 3) + 1]),
+									ord($pal[($i * 3) + 2]));
 		}
 
 		// PREPARE BITMAP BITS


### PR DESCRIPTION
### What does it do?
Update phpThumb v1.7.19-202210110924

### Why is it needed?
[Fixes IMAGETYPE_AVIF not defined #1](https://github.com/JamesHeinrich/phpThumb/issues/197) and [Fixes IMAGETYPE_AVIF not defined #2](https://github.com/JamesHeinrich/phpThumb/issues/191)

See changes https://github.com/JamesHeinrich/phpThumb/compare/v1.7.18...v1.7.19
