### PR TITLE
Include the media source id in MODX media browser data [ReUp]

### DIFF
--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -864,13 +864,15 @@ Ext.extend(MODx.browser.Window,Ext.Window,{
     }
 
     ,onSelect: function(data) {
-        var selNode = this.view.getSelectedNodes()[0];
-        var callback = this.config.onSelect || this.onSelectHandler;
-        var lookup = this.view.lookup;
-        var scope = this.config.scope;
+        var selNode = this.view.getSelectedNodes()[0],
+            callback = this.config.onSelect || this.onSelectHandler,
+            lookup = this.view.lookup,
+            scope = this.config.scope,
+            source = data.source;
         this.hide(this.config.animEl || null,function(){
             if(selNode && callback){
                 var data = lookup[selNode.id];
+                data.source = source;
                 Ext.callback(callback,scope || this,[data]);
                 this.fireEvent('select',data);
             }
@@ -1596,12 +1598,14 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
     }
 
     ,onSelect: function(data) {
-        var selNode = this.view.getSelectedNodes()[0];
-        var callback = this.config.onSelect || this.onSelectHandler;
-        var lookup = this.view.lookup;
-        var scope = this.config.scope;
+        var selNode = this.view.getSelectedNodes()[0],
+            callback = this.config.onSelect || this.onSelectHandler,
+            lookup = this.view.lookup,
+            scope = this.config.scope,
+            source = data.source;
         if (callback) {
             data = (selNode) ? lookup[selNode.id] : null;
+            data.source = source;
             Ext.callback(callback, scope || this, [data]);
             this.fireEvent('select', data);
             if (window.top.opener) {

--- a/manager/assets/modext/widgets/media/modx.browser.js
+++ b/manager/assets/modext/widgets/media/modx.browser.js
@@ -868,7 +868,7 @@ Ext.extend(MODx.browser.Window,Ext.Window,{
             callback = this.config.onSelect || this.onSelectHandler,
             lookup = this.view.lookup,
             scope = this.config.scope,
-            source = data.source;
+            source = this.config.source;
         this.hide(this.config.animEl || null,function(){
             if(selNode && callback){
                 var data = lookup[selNode.id];
@@ -1602,7 +1602,7 @@ Ext.extend(MODx.browser.RTE,Ext.Viewport,{
             callback = this.config.onSelect || this.onSelectHandler,
             lookup = this.view.lookup,
             scope = this.config.scope,
-            source = data.source;
+            source = this.config.source;
         if (callback) {
             data = (selNode) ? lookup[selNode.id] : null;
             data.source = source;


### PR DESCRIPTION
### What does it do?
Includes the media source id in the "onSelect" callback data. 

### Why is it needed?
Currently the media source id is missing from that data. It would be useful for custom handling.

### How to test
Check that the correct "source" is now in the data array when listening for the select event.

e.g.
```
let browser = MODx.load({
    xtype: 'modx-browser',
    multiple: true,
    listeners: {
        select: {fn: function(data) {
            console.log(data.source);
    }, scope:this}
...
```


