### PR TITLE
Pass correct type to setlocale to prevent fatal error on PHP8 in rare edge cases

### DIFF
--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2506,8 +2506,10 @@ class modX extends xPDO {
         $this->setOption('cultureKey', $cultureKey);
 
         if ($this->getOption('setlocale', $options, true)) {
-            $locale = setlocale(LC_ALL, null);
-            $result = setlocale(LC_ALL, $this->getOption('locale', null, $locale));
+            $locale = setlocale(LC_ALL, '0');
+            $targetLocale = $this->getOption('locale', null, $locale, true);
+            $result = setlocale(LC_ALL, $targetLocale);
+
             if ($result === false) {
                 $this->log(modX::LOG_LEVEL_ERROR, 'Could not set the locale. Please check if the locale ' . $this->getOption('locale', null, $locale) . ' exists on your system');
             }


### PR DESCRIPTION
### What does it do?
Provide a `0`-integer instead of literal `null` for the current locale lookup.

### Why is it needed?
I cannot tell you why as I genuinely don't have the foggiest idea, but the `null` here is causing a local PHP 8.0.23 (and 8.1/8.2) environment to blow up. While other sites on the same environment work fine with the exact same server configuration (MAMP).  Downgrading to 7.4 makes it work again. 

This line just causes fastcgi to just shit itself, no errors get logged or shown in any log anywhere, I had to `echo __LINE__;exit()` my way through the code to even get here. 

(And yeah, it's line 2509 that crashes. Not 2510 that sets the locale.) 

This code has been unchanged since circa [2011](https://github.com/modxcms/revolution/commit/021fdb227ffe98da73ddc2e35c19a3bcc664175e), the [setlocale docs](https://www.php.net/manual/en/function.setlocale.php) don't mention any PHP8-related changes, the `locale` setting is irrelevant as it breaks on 2509 not 2510. 

The output (when called with 0) is `C`, indicating UTC. Nothing wrong with that. 

It's worth noting `null` as second argument is **not** listed as being valid in [the docs](https://www.php.net/manual/en/function.setlocale.php), but it does mention `0` being valid for "reading" the current method.  

My guess is this behavior used to rely on `null` being typecast to `0` and some internal type-checking was made stricter. Perhaps there is something in this test site (an extension package or plugin) that triggers a stricter parsing mode explaining why it only happens on the one site and not others on the same server configuration. Or maybe it's gremlins. 

### How to test
Come over for a strong drink (I'm way past coffee at this point) and I'll show you how null breaks my local environment, but 0 makes all problems ✨ disappear ✨. 

### Related issue(s)/PR(s)
~~N/a~~
Backport of #15961