### PR TITLE
fix name of permission 'delete_static_resource'

### DIFF
--- a/core/model/modx/processors/resource/delete.class.php
+++ b/core/model/modx/processors/resource/delete.class.php
@@ -58,7 +58,7 @@ class modResourceDeleteProcessor extends modProcessor {
         $map = [
             'modWebLink' => 'delete_weblink',
             'modSymLink' => 'delete_symlink',
-            'modStaticResource' => 'delete_resource',
+            'modStaticResource' => 'delete_static_resource',
         ];
         if (array_key_exists($classKey, $map)) {
             $permissions[] = $map[$classKey];


### PR DESCRIPTION
### What does it do?
Corrects the permission name in the resource delete processor. 

### Why is it needed?
The permission delete_resource doesn't exist. Users can't delete static resources.

### How to test
Check the permissions list. 

### Related issue(s)/PR(s)
Typo was fixed for 3.x in #16079 
