### PR TITLE
Fix parsing long template tags under some conditions [#16263]

### DIFF
--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -793,4 +793,19 @@ class modParserTest extends MODxTestCase {
         $this->assertEquals($output, "bar", "Did not parse non-existing TV with default modifier correctly");
 
     }
+
+    public function testBacktrackLimit()
+    {
+        // default values, but just making sure
+        ini_set('pcre.jit', 1);
+        ini_set('pcre.backtrack_limit', 1000000);
+        ini_set('pcre.recursion_limit', 100000);
+        $matches = [];
+
+        $longTag = '[[$anyChunk?
+	&content=`Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu. In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac, enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque sed ipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien. Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget, imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu, accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestibulum volutpat pretium libero. 1`
+]]';
+
+        $this->assertEquals(1, $this->modx->parser->collectElementTags($longTag, $matches));
+    }
 }

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -147,8 +147,11 @@ class modParser
             }
         }
 
-        $pattern = '/\Q'.$prefix.'\E((?:(?:[^'.$subSuffix.$subPrefix.'][\s\S]*?|(?R))*?))\Q'.$suffix.'\E/x';
+        $pattern = '/\Q'.$prefix.'\E((?:(?:[^'.$subSuffix.$subPrefix.']++[\s\S]*?|(?R))*?))\Q'.$suffix.'\E/x';
         preg_match_all($pattern, $origContent, $matches, PREG_SET_ORDER);
+        if (preg_last_error() !== PREG_NO_ERROR) {
+            $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'Encountered a parser error: [' . preg_last_error() . '] ' . preg_last_error_msg());
+        }
 
         $matchCount = count($matches);
 


### PR DESCRIPTION
### What does it do?

Improves the regex pattern used in modParser::collectElementTags() to avoid hitting a backtrack limit under some environments (PHP 7.2, 7.3). Also adds a log message in case an error is detected. 

Credit to @JoshuaLuckers for providing the patch.

### Why is it needed?

Make sure long tags can be parsed correctly and make debugging easier if something does fail. Please see #16263 for more details.

### How to test

Please see #16263 for more details. It's worth noting I've so far seen 3 people refer to the fix in the issue as fixing the issue they had. As with all parser tweaks, trying it out on different real sites would be preferred to ensure this doesn't introduce any new issues. 

[Here's a CI run of the unit test prior to applying the fix](https://github.com/Mark-H/revolution/actions/runs/3597851277/jobs/6060109440), to show the unit test and fix work. 

Locally I've also been able to reproduce it by running the test on 7.2 before:

``` 
➜  3.x git:(issue-16263) ✗ php core/vendor/bin/phpunit  _build/test/Tests/Model/modParserTest.php
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

..........................................................[1]    78526 segmentation fault  /Applications/MAMP/bin/php/php7.2.34/bin/php -c  core/vendor/bin/phpunit 
```

and after applying the fix:

```
➜  3.x git:(issue-16263) ✗ php core/vendor/bin/phpunit  _build/test/Tests/Model/modParserTest.php
PHPUnit 8.5.31 by Sebastian Bergmann and contributors.

...........................................................       59 / 59 (100%)

Time: 181 ms, Memory: 14.00 MB

OK (59 tests, 70 assertions)
```

(I'm doing `php core/vendor/bin/phpunit` because otherwise php can't get to mysql on my local machine.)

### Related issue(s)/PR(s)

Fixes #16263
