### PR TITLE
Track unit test code coverage with PHPunit + Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,9 @@ jobs:
         run: cd _build/test && ./generateConfigs.sh auto
 
       - name: Run PHPUnit
-        run: core/vendor/bin/phpunit  --enforce-time-limit -c ./_build/test/phpunit.xml
+        run: XDEBUG_MODE=coverage core/vendor/bin/phpunit --enforce-time-limit -c ./_build/test/phpunit.xml --coverage-clover coverage.xml
+
+      - name: Upload CodeCov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 #### MODX Revolution is the world’s fastest, most secure, flexible and scalable Open Source CMS
 
-[![LICENSE](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](./LICENSE) [![Build Status](https://github.com/modxcms/revolution/workflows/CI/badge.svg?branch=3.x)](https://github.com/modxcms/revolution/actions?query=branch%3A3.x) [![Contributors](https://img.shields.io/github/contributors/modxcms/revolution.svg)](https://github.com/modxcms/revolution/graphs/contributors) [![Slack Chat](https://img.shields.io/badge/chat_in_slack-online-green.svg?longCache=true&style=flat&logo=slack)](https://modx.org) [![follow on Twitter](https://img.shields.io/twitter/follow/modx.svg?style=social&logo=twitter)](https://twitter.com/intent/follow?screen_name=modx)
+[![LICENSE](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](./LICENSE) [![Build Status](https://github.com/modxcms/revolution/workflows/CI/badge.svg?branch=3.x)](https://github.com/modxcms/revolution/actions?query=branch%3A3.x) [![codecov](https://codecov.io/github/modxcms/revolution/branch/3.x/graph/badge.svg?token=sJMrBYbkA6)](https://app.codecov.io/github/modxcms/revolution) [![Contributors](https://img.shields.io/github/contributors/modxcms/revolution.svg)](https://github.com/modxcms/revolution/graphs/contributors) [![Slack Chat](https://img.shields.io/badge/chat_in_slack-online-green.svg?longCache=true&style=flat&logo=slack)](https://modx.org) [![follow on Twitter](https://img.shields.io/twitter/follow/modx.svg?style=social&logo=twitter)](https://twitter.com/intent/follow?screen_name=modx)
 
 ## Content Management System and Application Framework
 


### PR DESCRIPTION
### What does it do?
Adds the necessary bits and pieces to the CI to start pushing data into Codecov. 

Once merged, any new PR made from that base will get an automatic comment after a few minutes showing the impact on unit test code coverage. In fact, you should see one appear on this PR, however that wont have any diff data yet as it'll be the first time it runs. 

### Why is it needed?
Increase awareness of the test suite and encourage work on expanding the test suite.  

### How to test
Sit back and relax and wait for the codecov bot to appear. [It already worked on my fork](https://github.com/Mark-H/revolution/pull/11), and I don't think any manual admin action is needed. 

### Related issue(s)/PR(s)
N/a.
