### PR TITLE
Fix Validation Error When Switching TV Types

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -1388,6 +1388,7 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
 
         if(inputOptValsItem){
             if(hideInputOptValsItemFor.indexOf(type) !== -1){
+                inputOptValsItem.allowBlank = true;
                 inputOptValsItem.hide().nextSibling().hide();
             } else {
                 this.updateSharedComponent(type, inputOptValsItem, inputOptValsItemVal);
@@ -1399,6 +1400,9 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
                 */
                 if (typeChanged) {
                     Ext.getCmp('modx-tv-elements').clearInvalid();
+                    if(this.isNativeType){
+                        inputOptValsItem.allowBlank = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### What does it do?
Explicitly sets allowBlank for `modx-tv-elements` (Input Options) when switching between TV types that hide that field and those that don’t (in which case it’s a required field).

### Why is it needed?
Even when hiding the referenced field, its other parameters (namely the allowBlank one) still take effect; this renders the TV unsavable if a user happens to switch from a type that requires Options to one that doesn't.

### How to test
1. Begin the process of creating a TV and choose a type that requires Options (_e.g._, listbox, radio, etc.) but do not fill in those options. ( Remember to fill in the Name under General Information ;-) )
2. Try to save; you should receive a validation error.
3. Switch the type to one without Options (_e.g._, text, email, hidden, etc.) and attempt to save; the TV should save without error.

### Related issue(s)/PR(s)
Resolves #16314
