### PR TITLE
Ensure modHashing::getHash is limited to modHash instances

### DIFF
--- a/_build/test/Tests/Model/Hashing/modHashingTest.php
+++ b/_build/test/Tests/Model/Hashing/modHashingTest.php
@@ -12,6 +12,11 @@
 namespace MODX\Revolution\Tests\Model\Hashing;
 
 
+use MODX\Revolution\Hashing\modHashing;
+use MODX\Revolution\Hashing\modMD5;
+use MODX\Revolution\Hashing\modNative;
+use MODX\Revolution\Hashing\modPBKDF2;
+use MODX\Revolution\modParser;
 use MODX\Revolution\MODxTestCase;
 
 /**
@@ -54,6 +59,37 @@ class modHashingTest extends MODxTestCase {
             ['option8', null, null, [], null],
             ['option8', [], null, [], null],
             ['option8', null, [], [], null],
+        ];
+    }
+
+    /**
+     * @dataProvider providerGetHashInstance
+     * @param $key
+     * @param $class
+     * @param $expected
+     * @return void
+     */
+    public function testGetHashInstance($key, $class, $expected)
+    {
+        /** @var modHashing $modHashing */
+        $modHashing = $this->modx->getService('hashing', 'hashing.modHashing');
+
+        $hasher = $modHashing->getHash($key, $class);
+        if ($expected === null) {
+            $this->assertNull($hasher);
+        }
+        else {
+            $this->assertInstanceOf($expected, $hasher);
+        }
+    }
+
+    public function providerGetHashInstance()
+    {
+        return [
+            ['hasher-md5', modMD5::class, modMD5::class],
+            ['hasher-native', modNative::class, modNative::class],
+            ['hasher-pbkdf2', modPBKDF2::class, modPBKDF2::class],
+            ['hasher-null', modParser::class, null], // Not a hasher class should return null
         ];
     }
 }

--- a/core/src/Revolution/Hashing/modHashing.php
+++ b/core/src/Revolution/Hashing/modHashing.php
@@ -95,7 +95,7 @@ class modHashing
     public function getHash($key, $class, $options = [])
     {
         $className = $this->modx->loadClass($class, '', false, true);
-        if ($className) {
+        if (class_exists($className) && is_subclass_of($className, modHash::class, true)) {
             if (empty($key)) {
                 $exploded = explode('\\', $className);
                 $key = strtolower(str_replace('mod', '', array_pop($exploded)));


### PR DESCRIPTION
### What does it do?
Makes sure the requested modHash implementation is actually a modHash implementation, right now it can instantiate any class. 

Also brings tests for this file to 100% as a test for codecov. :D

### Why is it needed?
Wanted to make sure codecov works properly. Found issue writing test. Win. 

### How to test
Covered by tests.

### Related issue(s)/PR(s)
#16317 
