### PR TITLE
Fix non-existent snippet tags being broken up by an @ tag 

### DIFF
--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -726,19 +726,14 @@ class modElement extends modAccessibleSimpleObject
     {
         $propertySet = null;
         $name = $this->get('name');
-        if (strpos($name, '@') !== false) {
-            $psName = '';
-            $split = xPDO:: escSplit('@', $name);
-            if ($split && isset($split[1])) {
-                $name = $split[0];
-                $psName = $split[1];
-                $filters = xPDO:: escSplit(':', $setName);
-                if ($filters && isset($filters[1]) && !empty($filters[1])) {
-                    $psName = $filters[0];
-                    $name .= ':' . $filters[1];
-                }
-                $this->set('name', $name);
-            }
+
+        $nameSplit = explode(':', $name);
+        $tagName = array_shift($nameSplit);
+        $remainingTag = implode(':', $nameSplit);
+        if (strpos($tagName, '@') !== false) {
+            $split = xPDO:: escSplit('@', $tagName);
+            $psName = $split[1];
+            $this->set('name', $split[0] . $remainingTag);
             if (!empty($psName)) {
                 $psObj = $this->xpdo->getObjectGraph(modPropertySet::class, '{"Elements":{}}', [
                     'Elements.element' => $this->id,

--- a/core/src/Revolution/modTag.php
+++ b/core/src/Revolution/modTag.php
@@ -511,19 +511,13 @@ abstract class modTag
     {
         $propertySet = null;
         $name = $this->get('name');
-        if (strpos($name, '@') !== false) {
-            $psName = '';
-            $split = xPDO:: escSplit('@', $name);
-            if ($split && isset($split[1])) {
-                $name = $split[0];
-                $psName = $split[1];
-                $filters = xPDO:: escSplit(':', $setName);
-                if ($filters && isset($filters[1]) && !empty($filters[1])) {
-                    $psName = $filters[0];
-                    $name .= ':' . $filters[1];
-                }
-                $this->set('name', $name);
-            }
+        $nameSplit = explode(':', $name);
+        $tagName = array_shift($nameSplit);
+        $remainingTag = implode(':', $nameSplit);
+        if (strpos($tagName, '@') !== false) {
+            $split = xPDO:: escSplit('@', $tagName);
+            $psName = $split[1];
+            $this->set('name', $split[0] . $remainingTag);
             if (!empty($psName)) {
                 $psObj = $this->modx->getObject(modPropertySet::class, ['name' => $psName]);
                 if ($psObj) {


### PR DESCRIPTION
### What does it do?
Described in #16318, if a non-existent snippet tag is found within an output filter, an @ tag inside the filter can cause the output to break.

The provided example where `xxx` doesn't exist:

```
[[+xyz:empty=`
aaa
[[xxx? &x=`bbb@ccc`]]
ddd
`]]
eee
```

is getting broken up by modTag/modElement::getPropertySet on the `@`, treating the part in front of it as the name of the tag/element, including half the snippet tag.

This fix makes sure that it only considers the bit up to the first `:`. 

To ensure property sets continue to work, I wanted to add some property set tests but I can't get this structure:

```
[[!Snippet@PropSet:default=`foo`]]
``` 

to return anything when the snippet returns an empty value. If someone can figure out why that's not working (in either the test or real world cases!) that would be great. 

### Why is it needed?
Make parser more resilient.

### How to test
Unit tests or create your own similar test cases with snippets on a resource.

### Related issue(s)/PR(s)
Fixes #16318
