### PR TITLE
MagpieRSS::feed_start_element() error with PHP 8.0 and 8.1

### DIFF
--- a/core/model/modx/xmlrss/magpierss.class.php
+++ b/core/model/modx/xmlrss/magpierss.class.php
@@ -149,7 +149,7 @@ class MagpieRSS {
         $this->normalize();
     }
 
-    function feed_start_element($p, $element, &$attrs) {
+    function feed_start_element($p, $element, $attrs) {
         $el = $element = strtolower($element);
         $attrs = array_change_key_case($attrs, CASE_LOWER);
 


### PR DESCRIPTION
### What does it do?
Adjust the type declaration for argument $attrs from a reference to a value on function feed_start_element

### Why is it needed?
PHP 8+ is much more strict about variable types. This resulted in an excess of warnings in the error log. 

### How to test
Open the dashboard in MODX 2.x and PHP 8.1, and then check for errors generated in the error.log. 

### Related issue(s)/PR(s)
Issue #16208
