### PR TITLE
Add PHP 8.2 as CI target + minor associated fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -47,10 +47,10 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -11,18 +11,27 @@ jobs:
     phpcs:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
 
-            - name: Install PHP_CodeSniffer
-              run: |
-                  curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
-                  php phpcs.phar --version --config-set ignore_warnings_on_exit 1
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache composer dependencies
+              uses: actions/cache@v3
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: Install dependencies
+              run: composer install --no-progress --prefer-dist --optimize-autoloader
 
             - uses: thenabeel/action-phpcs@v8
               with:
-                  files: "**.php"
-                  phpcs_path: php phpcs.phar
-                  standard: phpcs.xml
-                  fail_on_warnings: false
+                files: "**.php"
+                phpcs_path: core/vendor/bin/phpcs
+                standard: phpcs.xml
+                fail_on_warnings: false

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,9 @@
         ],
         "parse-schema": [
           "composer run-script parse-schema-mysql"
-        ]
+        ],
+        "phpcs": "core/vendor/bin/phpcs --standard=phpcs.xml",
+        "phpcbf": "core/vendor/bin/phpcbf --standard=phpcs.xml"
     },
     "scripts-descriptions": {
         "phpunit": "Run PHPUnit test"
@@ -117,6 +119,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "yoast/phpunit-polyfills": "^0.2.0"
+        "yoast/phpunit-polyfills": "^0.2.0",
+        "squizlabs/php_codesniffer": "3.*",
+        "phpcompatibility/php-compatibility": "^9.3"
     }
 }

--- a/core/src/Revolution/Filters/modInputFilter.php
+++ b/core/src/Revolution/Filters/modInputFilter.php
@@ -54,7 +54,7 @@ class modInputFilter
             $modifiers = substr($output, $splitPos);
 
 
-            $chars = mb_str_split($modifiers);
+            $chars = function_exists('mb_str_split') ? mb_str_split($modifiers) : str_split($modifiers);
             $depth = 0;
             $command = '';
             $commandModifiers = '';

--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -238,7 +238,7 @@ class modLexicon
                         $entries = [];
                     }
                 }
-                if (is_array($englishEntries) && !empty($englishEntries)) {
+                if (is_array($englishEntries) && !empty($englishEntries) && is_array($entries)) {
                     $entries = array_merge($englishEntries, $entries);
                 }
                 if (is_array($entries)) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -294,12 +294,6 @@ class modX extends xPDO {
      * @static
      */
     public static function protect() {
-        if (@ ini_get('register_globals') && isset ($_REQUEST)) {
-            foreach ($_REQUEST as $key => $value) {
-                $GLOBALS[$key] = null;
-                unset ($GLOBALS[$key]);
-            }
-        }
         $targets= ['PHP_SELF', 'HTTP_USER_AGENT', 'HTTP_REFERER', 'QUERY_STRING'];
         foreach ($targets as $target) {
             $_SERVER[$target] = isset ($_SERVER[$target]) ? htmlspecialchars($_SERVER[$target], ENT_QUOTES) : null;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0"?>
 <ruleset name="MODX Coding Standards">
     <description>MODX dev PHP_CodeSniffer ruleset</description>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps" />
+    <arg name="extensions" value="php" />
+    <arg name="colors" />
+
+    <config name="installed_paths" value="core/vendor/phpcompatibility/php-compatibility" />
+    <config name="testVersion" value="7.2-"/>
+
     <file>_build</file>
     <file>connectors</file>
     <file>core</file>
@@ -10,19 +19,19 @@
     <!-- Exclude paths -->
     <exclude-pattern>manager/assets/ext3/</exclude-pattern>
     <exclude-pattern>core/lexicon/</exclude-pattern>
+    <exclude-pattern>core/components/</exclude-pattern>
+    <exclude-pattern>core/packages/</exclude-pattern>
+    <exclude-pattern>assets/components/</exclude-pattern>
     <exclude-pattern>setup/lang/</exclude-pattern>
-
-    <!-- Show progress, show the error codes for each message (source). -->
-    <arg value="ps" />
 
     <!-- Ignore vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
     <!-- Ignore generated model files -->
     <exclude-pattern>*/mysql/*.php</exclude-pattern>
 
-    <!-- Our base rule: set to PSR12-->
-    <rule ref="PSR12" />
+    <!-- Our base rule: set to PSR12 -->
     <rule ref="PSR12">
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
     </rule>
+    <rule ref="PHPCompatibility"/>
 </ruleset>

--- a/setup/processors/connector.php
+++ b/setup/processors/connector.php
@@ -14,8 +14,6 @@
  * @package setup
  */
 /* do a little bit of environment cleanup if possible */
-@ini_set('magic_quotes_runtime',0);
-@ini_set('magic_quotes_sybase',0);
 @ini_set('opcache.revalidate_freq', 0);
 
 /* start session */


### PR DESCRIPTION
### What does it do?

- Add PHP 8.2 as CI target
- Include php compat checker in phpcs, and fix some minor compatibility issues
- update actions/checkout@v2 to @v3 as @v2 is deprecated
- fix potential mb_str_split error on PHP 7.2
- fix potential typeerror on PHP 8 in modLexicon with invalid lexicon configurations
- remove a few legacy (php <5.4) checks that are obsolete

### Why is it needed?
PHP 8.2 is out! 🎉 

Tried running php compat to see if there's any issues to be expected. Found a few things, tho mostly legacy stuff. Figured these things are so small it's okay to review as one. 

### How to test
N/a

### Related issue(s)/PR(s)
N/a
