### PR TITLE
Fix Custom Property Sets not working after upgrade to MODX 3

### DIFF
--- a/setup/includes/upgrades/common/3.0.3-update-legacy-class-references.php
+++ b/setup/includes/upgrades/common/3.0.3-update-legacy-class-references.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+/**
+ * @property modX $modx
+ */
+
+use MODX\Revolution\modChunk;
+use MODX\Revolution\modElementPropertySet;
+use MODX\Revolution\modPlugin;
+use MODX\Revolution\modSnippet;
+use MODX\Revolution\modTemplate;
+use MODX\Revolution\modTemplateVar;
+
+/* modify legacy core class references in modElementPropertySet element_class column */
+
+$class = modElementPropertySet::class;
+$table = $modx->getTableName($class);
+
+$elementClass = $this->install->lexicon('alter_column', ['column' => 'element_class', 'table' => $table]);
+$this->processResults($class, $elementClass, [$modx->manager, 'alterField'], [$class, 'element_class']);
+
+$modx->updateCollection($class, ['element_class' => modChunk::class], ['element_class' => 'modChunk']);
+$modx->updateCollection($class, ['element_class' => modTemplate::class], ['element_class' => 'modTemplate']);
+$modx->updateCollection($class, ['element_class' => modTemplateVar::class], ['element_class' => 'modTemplateVar']);
+$modx->updateCollection($class, ['element_class' => modPlugin::class], ['element_class' => 'modPlugin']);
+$modx->updateCollection($class, ['element_class' => modSnippet::class], ['element_class' => 'modSnippet']);

--- a/setup/includes/upgrades/mysql/3.0.3-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.3-pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.0.3-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.0.3-update-legacy-class-references.php';


### PR DESCRIPTION
### What does it do?
Update legacy class references in `modElementPropertySet::class` `element_class` column

### Why is it needed?
This will fix Custom Property Sets not working after upgrade to MODX 3.

### How to test
- Create a custom property set in 2.x and attach various elements to it (e.g a snippet).
- Upgrade to MODX 3.0.3-dev (build from this PR)

### Related issue(s)/PR(s)
Resolves #16332