### PR TITLE
Fix issues with TV's Media Sources after upgrading to MODX 3

### DIFF
--- a/setup/includes/upgrades/common/3.0.3-update-legacy-class-references.php
+++ b/setup/includes/upgrades/common/3.0.3-update-legacy-class-references.php
@@ -20,6 +20,7 @@ use MODX\Revolution\modPlugin;
 use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVar;
+use MODX\Revolution\Sources\modMediaSourceElement;
 
 /* modify legacy core class references in modElementPropertySet element_class column */
 
@@ -34,3 +35,13 @@ $modx->updateCollection($class, ['element_class' => modTemplate::class], ['eleme
 $modx->updateCollection($class, ['element_class' => modTemplateVar::class], ['element_class' => 'modTemplateVar']);
 $modx->updateCollection($class, ['element_class' => modPlugin::class], ['element_class' => 'modPlugin']);
 $modx->updateCollection($class, ['element_class' => modSnippet::class], ['element_class' => 'modSnippet']);
+
+/* modify legacy core class references in modMediaSourceElement object_class column */
+
+$class = modMediaSourceElement::class;
+$table = $modx->getTableName($class);
+
+$elementClass = $this->install->lexicon('alter_column', ['column' => 'object_class', 'table' => $table]);
+$this->processResults($class, $elementClass, [$modx->manager, 'alterField'], [$class, 'object_class']);
+
+$modx->updateCollection($class, ['object_class' => modTemplateVar::class], ['object_class' => 'modTemplateVar']);

--- a/setup/includes/upgrades/common/3.0.3-update-legacy-class-references.php
+++ b/setup/includes/upgrades/common/3.0.3-update-legacy-class-references.php
@@ -11,7 +11,7 @@
 
 
 /**
- * @property modX $modx
+ * @var modX $modx
  */
 
 use MODX\Revolution\modChunk;


### PR DESCRIPTION
### What does it do?
Update legacy class references in `modMediaSourceElement::class` `object_class` column

### Why is it needed?
This will fix an "PHP Fatal error: Cannot declare class modTemplateVarInputRenderText, because the name is already in use".

### How to test
- Create a TV in 2.x and set a Custom Media Source for it.
- Upgrade to MODX 3.0.3-dev (build from this PR)

# IMPORTANT
Depends on PR #16337 to be merged first.

### Related issue(s)/PR(s)
Resolves #16329