### PR TITLE
Fix "Undefined array key" warnings in modPhpThumb

### DIFF
--- a/core/src/Revolution/modPhpThumb.php
+++ b/core/src/Revolution/modPhpThumb.php
@@ -302,11 +302,10 @@ class modPhpThumb extends phpthumb
             $this->SendSaveAsFileHeaderIfNeeded();
 
             header('Last-Modified: ' . gmdate('D, d M Y H:i:s', $nModified) . ' GMT');
-            # Fix PHP warning: Undefined array key "HTTP_IF_MODIFIED_SINCE"
-               if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && ($nModified == strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE'])) && isset($_SERVER['SERVER_PROTOCOL'])) {
-                  header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
-               exit;
-               }
+            if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE'], $_SERVER['SERVER_PROTOCOL']) && $nModified === strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE'])) {
+                header($_SERVER['SERVER_PROTOCOL'] . ' 304 Not Modified');
+            exit;
+            }
 
             $getimagesize = @getimagesize($this->cache_filename);
             if ($getimagesize) {
@@ -333,24 +332,18 @@ class modPhpThumb extends phpthumb
         if (headers_sent()) {
             return false;
         }
-    # Fix PHP warning: "Undefined array key sia"
-    if (isset($_GET['sia'])) {
-        $downloadfilename = phpthumb_functions::SanitizeFilename($_GET['sia']);
-    } elseif (isset($_GET['down'])) {
-        $downloadfilename = phpthumb_functions::SanitizeFilename($_GET['down']);
-    } else {
-        $downloadfilename = 'phpThumb_generated_thumbnail' . (isset($_GET['f']) ? $_GET['f'] : 'jpg');
-    } 
-   
-    # Fix PHP warning: "Undefined array key down"
-    if (isset($downloadfilename)) {
-        if (isset($_GET['down'])) {
-            $this->DebugMessage('SendSaveAsFileHeaderIfNeeded() sending header: Content-Disposition: attachment; filename="' . $downloadfilename . '"', __FILE__, __LINE__);
-            header('Content-Disposition: attachment; filename="' . $downloadfilename . '"');
+        $inlineFilename = $_GET['sia'] ?? false;
+        $attachmentFilename = $_GET['down'] ?? false;
+        if ($inlineFilename || $attachmentFilename) {
+            $filename = $inlineFilename ? $inlineFilename : $attachmentFilename ;
+            $filename = phpthumb_functions::SanitizeFilename($filename);
         } else {
-            $this->DebugMessage('SendSaveAsFileHeaderIfNeeded() sending header: Content-Disposition: inline; filename="' . $downloadfilename . '"', __FILE__, __LINE__);
-            header('Content-Disposition: inline; filename="' . $downloadfilename . '"');
+            $filename = 'phpThumb_generated_thumbnail' . ($_GET['f'] ?? 'jpg');
         }
+        if ($filename) {
+            $disposition = $attachmentFilename ? 'attachment' : 'inline' ;
+            $this->DebugMessage('SendSaveAsFileHeaderIfNeeded() sending header: Content-Disposition: ' . $disposition . '; filename="' . $filename . '"', __FILE__, __LINE__);
+            header('Content-Disposition: ' . $disposition . '; filename="' . $filename . '"');
     }
         return true;
     }


### PR DESCRIPTION
Fix PHP warning: "undefined array key ..."  HTTP_IF_MODIFIED_SINCE, sia and down

### What does it do?
Prevents 3 modPhpThumb.php warnings when uploading files via the media browser

### Why is it needed?
no PHP warnings in MODX error log

### How to test
Describe how to test the changes you made.

### Related issue(s)/PR(s)
Please also refer to [16340](https://github.com/modxcms/revolution/issues/16340)
