### PR TITLE
Fix package manager only ever showing the last version changelog

### DIFF
--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -575,6 +575,7 @@ Ext.extend(MODx.window.PackageUpdate,MODx.Window,{
                 ,inputValue: pkg.info
                 ,labelSeparator: ''
                 ,checked: i === 0
+                ,_changelog: pkg.changelog
                 ,listeners: {
                     afterrender: {
                         fn: function (radio) {
@@ -592,7 +593,7 @@ Ext.extend(MODx.window.PackageUpdate,MODx.Window,{
                                     ,style: 'white-space: pre-wrap'
                                     ,fields: [{
                                         xtype: 'box'
-                                        ,html: pkg.changelog
+                                        ,html: radio._changelog
                                     }]
                                     ,buttons: [{
                                         text: _('close')


### PR DESCRIPTION
### What does it do?

Stores the changelog for a package as a transient property on the radio button, and use that instead of the mutable `pkg`, to make sure that it always shows the right changelog.

### Why is it needed?

When multiple versions are available as update target (for example, ), it would only ever allow you to see the changelog for the last version.

This happened because the value of pkg changes in the loop, so when the callback runs it is not the same as when it was created. 

### How to test

Download ContentBlocks 1.10 from modmore (it doesn't have to be installed, and free dev licenses work on localhost/*.local, dev.*, etc), which will then offer both 1.11 and 1.12 updates. (I don't know of examples on the MODX provider that offer multiple versions)

Try to view the changelog for each version. 

### Related issue(s)/PR(s)

None, was reported via Slack.
