### PR TITLE
Fix and Enhance Usergroup ACL Permissions Grids and Filtering

### DIFF
--- a/core/src/Revolution/Processors/Context/GetList.php
+++ b/core/src/Revolution/Processors/Context/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -10,8 +11,9 @@
 
 namespace MODX\Revolution\Processors\Context;
 
-
 use MODX\Revolution\modContext;
+use MODX\Revolution\modAccessContext;
+use MODX\Revolution\modUserGroup;
 use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
 use xPDO\Om\xPDOQuery;
@@ -40,6 +42,9 @@ class GetList extends GetListProcessor
     /** @var boolean $canCreate Determines whether or not the user can create a context (/duplicate one) */
     public $canCreate = false;
 
+    /** @param boolean $isGridFilter Indicates the target of this list data is a filter field */
+    protected $isGridFilter = false;
+
     /**
      * {@inheritDoc}
      * @return boolean
@@ -54,7 +59,7 @@ class GetList extends GetListProcessor
         $this->canCreate = $this->modx->hasPermission('new_context');
         $this->canEdit = $this->modx->hasPermission('edit_context');
         $this->canRemove = $this->modx->hasPermission('delete_context');
-
+        $this->isGridFilter = $this->getProperty('isGridFilter', false);
         return $initialized;
     }
 
@@ -79,7 +84,28 @@ class GetList extends GetListProcessor
                 'key:NOT IN' => is_string($exclude) ? explode(',', $exclude) : $exclude,
             ]);
         }
-
+        /*
+            When this class is used to fetch data for a grid filter's store (combo),
+            limit results to only those contexts present in the current grid.
+        */
+        if ($this->isGridFilter) {
+            if ($userGroup = $this->getProperty('usergroup', false)) {
+                $c->innerJoin(
+                    modAccessContext::class,
+                    'modAccessContext',
+                    [
+                        '`modAccessContext`.`target` = `modContext`.`key`',
+                        '`modAccessContext`.`principal` = ' . (int)$userGroup,
+                        '`modAccessContext`.`principal_class` = ' . $this->modx->quote(modUserGroup::class)
+                    ]
+                );
+                if ($policy = $this->getProperty('policy', false)) {
+                    $c->where([
+                        '`modAccessContext`.`policy`' => (int)$policy
+                    ]);
+                }
+            }
+        }
         return $c;
     }
 

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/AccessNamespace/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -113,7 +114,10 @@ class GetList extends GetListProcessor
         if (empty($objectArray['name'])) {
             $objectArray['name'] = '(' . $this->modx->lexicon('none') . ')';
         }
-        $objectArray['authority_name'] = !empty($objectArray['role_name']) ? $objectArray['role_name'] . ' - ' . $objectArray['authority'] : $objectArray['authority'];
+        $objectArray['authority_name'] = !empty($objectArray['role_name'])
+            ? $objectArray['role_name'] . ' - ' . $objectArray['authority']
+            : $objectArray['authority']
+            ;
 
         /* get permissions list */
         $data = $objectArray['policy_data'];
@@ -130,21 +134,8 @@ class GetList extends GetListProcessor
             $objectArray['permissions'] = implode(', ', $permissions);
         }
 
-
         $cls = 'pedit premove';
-
         $objectArray['cls'] = $cls;
-        $objectArray['menu'] = [
-            [
-                'text' => $this->modx->lexicon('access_namespace_update'),
-                'handler' => 'this.updateAcl',
-            ],
-            '-',
-            [
-                'text' => $this->modx->lexicon('access_namespace_remove'),
-                'handler' => 'this.confirm.createDelegate(this,["Security/Access/UserGroup/AccessNamespace/Remove"])',
-            ],
-        ];
 
         return $objectArray;
     }

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Category/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Category/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -138,17 +139,6 @@ class GetList extends GetListProcessor
             $cls .= 'pedit premove';
         }
         $objectArray['cls'] = $cls;
-        $objectArray['menu'] = [
-            [
-                'text' => $this->modx->lexicon('access_category_update'),
-                'handler' => 'this.updateAcl',
-            ],
-            '-',
-            [
-                'text' => $this->modx->lexicon('access_category_remove'),
-                'handler' => 'this.confirm.createDelegate(this,["Security/Access/UserGroup/Category/Remove"])',
-            ]
-        ];
 
         return $objectArray;
     }

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Context/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Context/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -67,7 +68,7 @@ class GetList extends GetListProcessor
         $userGroup = $this->getProperty('usergroup');
         $c->where([
             'principal_class' => modUserGroup::class,
-            'principal' => $userGroup,
+            'principal' => $userGroup
         ]);
         $context = $this->getProperty('context', false);
         if (!empty($context)) {
@@ -94,7 +95,6 @@ class GetList extends GetListProcessor
             'policy_name' => 'Policy.name',
             'policy_data' => 'Policy.data',
         ]);
-
         return $c;
     }
 
@@ -109,7 +109,10 @@ class GetList extends GetListProcessor
         if (empty($objectArray['name'])) {
             $objectArray['name'] = '(' . $this->modx->lexicon('none') . ')';
         }
-        $objectArray['authority_name'] = !empty($objectArray['role_name']) ? $objectArray['role_name'] . ' - ' . $objectArray['authority'] : $objectArray['authority'];
+        $objectArray['authority_name'] = !empty($objectArray['role_name'])
+            ? $objectArray['role_name'] . ' - ' . $objectArray['authority']
+            : $objectArray['authority']
+            ;
 
         /* get permissions list */
         $data = $objectArray['policy_data'];
@@ -127,7 +130,11 @@ class GetList extends GetListProcessor
         }
 
         $cls = '';
-        if (($objectArray['target'] === 'web' || $objectArray['target'] === 'mgr') && $objectArray['policy_name'] === 'Administrator' && ($this->userGroup && $this->userGroup->get('name') === 'Administrator')) {
+        if (
+            ($objectArray['target'] === 'web' || $objectArray['target'] === 'mgr')
+            && $objectArray['policy_name'] === 'Administrator'
+            && ($this->userGroup && $this->userGroup->get('name') === 'Administrator')
+        ) {
         } else {
             $cls .= 'pedit premove';
         }

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/ResourceGroup/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -115,7 +116,10 @@ class GetList extends GetListProcessor
         if (empty($objectArray['name'])) {
             $objectArray['name'] = '(' . $this->modx->lexicon('none') . ')';
         }
-        $objectArray['authority_name'] = !empty($objectArray['role_name']) ? $objectArray['role_name'] . ' - ' . $objectArray['authority'] : $objectArray['authority'];
+        $objectArray['authority_name'] = !empty($objectArray['role_name'])
+            ? $objectArray['role_name'] . ' - ' . $objectArray['authority']
+            : $objectArray['authority']
+            ;
 
         /* get permissions list */
         $data = $objectArray['policy_data'];
@@ -132,22 +136,15 @@ class GetList extends GetListProcessor
         }
 
         $cls = '';
-        if (($objectArray['target'] === 'web' || $objectArray['target'] == 'mgr') && $objectArray['policy_name'] === 'Administrator' && ($this->userGroup && $this->userGroup->get('name') === 'Administrator')) {
+        if (
+            ($objectArray['target'] === 'web' || $objectArray['target'] == 'mgr')
+            && $objectArray['policy_name'] === 'Administrator'
+            && ($this->userGroup && $this->userGroup->get('name') === 'Administrator')
+        ) {
         } else {
             $cls .= 'pedit premove';
         }
         $objectArray['cls'] = $cls;
-        $objectArray['menu'] = [
-            [
-                'text' => $this->modx->lexicon('access_rgroup_update'),
-                'handler' => 'this.updateAcl',
-            ],
-            '-',
-            [
-                'text' => $this->modx->lexicon('access_rgroup_remove'),
-                'handler' => 'this.confirm.createDelegate(this,["Security/Access/UserGroup/ResourceGroup/Remove"])',
-            ],
-        ];
 
         return $objectArray;
     }

--- a/core/src/Revolution/Processors/Security/Access/UserGroup/Source/GetList.php
+++ b/core/src/Revolution/Processors/Security/Access/UserGroup/Source/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -121,7 +122,10 @@ class GetList extends GetListProcessor
         if (empty($objectArray['name'])) {
             $objectArray['name'] = '(' . $this->modx->lexicon('none') . ')';
         }
-        $objectArray['authority_name'] = !empty($objectArray['role_name']) ? $objectArray['role_name'] . ' - ' . $objectArray['authority'] : $objectArray['authority'];
+        $objectArray['authority_name'] = !empty($objectArray['role_name'])
+            ? $objectArray['role_name'] . ' - ' . $objectArray['authority']
+            : $objectArray['authority']
+            ;
 
         /* get permissions list */
         $data = $objectArray['policy_data'];
@@ -139,22 +143,15 @@ class GetList extends GetListProcessor
         }
 
         $cls = '';
-        if (($objectArray['target'] === 'web' || $objectArray['target'] === 'mgr') && $objectArray['policy_name'] === 'Administrator' && ($this->userGroup && $this->userGroup->get('name') === 'Administrator')) {
+        if (
+            ($objectArray['target'] === 'web' || $objectArray['target'] === 'mgr')
+            && $objectArray['policy_name'] === 'Administrator'
+            && ($this->userGroup && $this->userGroup->get('name') === 'Administrator')
+        ) {
         } else {
             $cls .= 'pedit premove';
         }
         $objectArray['cls'] = $cls;
-        $objectArray['menu'] = [
-            [
-                'text' => $this->modx->lexicon('access_source_update'),
-                'handler' => 'this.updateAcl',
-            ],
-            '-',
-            [
-                'text' => $this->modx->lexicon('access_source_remove'),
-                'handler' => 'this.confirm.createDelegate(this,["Security/Access/UserGroup/Source/Remove"])',
-            ],
-        ];
 
         return $objectArray;
     }

--- a/core/src/Revolution/Processors/Security/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -11,7 +12,9 @@
 namespace MODX\Revolution\Processors\Security\ResourceGroup;
 
 use MODX\Revolution\Processors\Model\GetListProcessor;
+use MODX\Revolution\modAccessResourceGroup;
 use MODX\Revolution\modResourceGroup;
+use MODX\Revolution\modUserGroup;
 use xPDO\Om\xPDOQuery;
 
 /**
@@ -28,6 +31,48 @@ class GetList extends GetListProcessor
     public $languageTopics = ['access'];
     public $permission = 'resourcegroup_view';
 
+    /** @param boolean $isGridFilter Indicates the target of this list data is a filter field */
+    protected $isGridFilter = false;
+
+    public function initialize()
+    {
+        $initialized = parent::initialize();
+        $this->isGridFilter = $this->getProperty('isGridFilter', false);
+        return $initialized;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param xPDOQuery $c
+     * @return xPDOQuery
+     */
+    public function prepareQueryBeforeCount(xPDOQuery $c)
+    {
+        /*
+            When this class is used to fetch data for a grid filter's store (combo),
+            limit results to only those resource groups present in the current grid.
+        */
+        if ($this->isGridFilter) {
+            if ($userGroup = $this->getProperty('usergroup', false)) {
+                $c->innerJoin(
+                    modAccessResourceGroup::class,
+                    'modAccessResourceGroup',
+                    [
+                        '`modAccessResourceGroup`.`target` = `modResourceGroup`.`id`',
+                        '`modAccessResourceGroup`.`principal` = ' . (int)$userGroup,
+                        '`modAccessResourceGroup`.`principal_class` = ' . $this->modx->quote(modUserGroup::class)
+                    ]
+                );
+            }
+            if ($policy = $this->getProperty('policy', false)) {
+                $c->where([
+                    '`modAccessResourceGroup`.`policy`' => (int)$policy
+                ]);
+            }
+        }
+        return $c;
+    }
+
     /**
      * Filter the query by the valueField of MODx.combo.ResourceGroup to get the initially value displayed right
      * @param xPDOQuery $c
@@ -42,7 +87,6 @@ class GetList extends GetListProcessor
                 $c->getAlias() . '.id:IN' => is_string($key) ? explode(',', $key) : $key,
             ]);
         }
-
         return $c;
     }
 }

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -79,7 +79,6 @@ MODx.grid.Grid = function(config) {
         };
 
         Ext.applyIf(config.groupingConfig, groupingConfig);
-
         Ext.applyIf(config,{
             view: new Ext.grid.GroupingView(config.groupingConfig)
         });
@@ -392,6 +391,7 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
                     ,direction: this.config.sortDir || 'ASC'
                 }
                 ,remoteSort: this.config.remoteSort || false
+                ,remoteGroup: this.config.remoteGroup || false
                 ,groupField: this.config.groupBy || 'name'
                 ,storeId: this.config.storeId || Ext.id()
                 ,autoDestroy: true
@@ -729,6 +729,42 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         return el.dom.outerHTML;
     }
 
+    /**
+     * @property {Function} getLinkTemplate - Adds a link on a grid column's value based on the passed params.
+     * Usage of this method is necessary for grouping grids, where usage of renderers on its column model
+     * interfere with the grouping functionality.
+     *
+     * @param {String} controllerPath - The initial part of the URL query indicating the controller action
+     * @param {String} displayValueIndex - The data index used as the link's text
+     * @param {Object} options - Additional URL query parameters (linkParams) and attributes for the link's anchor tag
+     * @return {Ext.Template}
+     */
+    ,getLinkTemplate: function(controllerPath, displayValueIndex, options = {}) {
+        /*
+            linkParams, if given, should be an array of objects in the following format:
+            [{ key: 'paramKey', valueIndex: 'paramValue' }, ...{}]
+        */
+        Ext.applyIf(options, {
+            linkParams: [],
+            linkClass: 'x-grid-link',
+            linkTitle: _('edit'),
+            linkTarget: '_blank'
+        });
+        let params = '';
+        controllerPath = controllerPath.indexOf('?a=') === 0 ? controllerPath : `?a=${controllerPath}` ;
+        if (options.linkParams.length > 0) {
+            params = [];
+            options.linkParams.forEach(param => {
+                params.push(`${param.key}={${param.valueIndex}}`);
+            });
+            params = `&${params.join('&')}`;
+        }
+        return new Ext.Template(
+            `<tpl><a href="${controllerPath}${params}" class="${options.linkClass}" title="${options.linkTitle}" target="${options.linkTarget}">{${displayValueIndex}:htmlEncode}</a></tpl>`,
+            { compiled: true }
+        );
+    }
+
     ,getActions: function(record, rowIndex, colIndex, store) {
         return [];
     }
@@ -883,8 +919,10 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
             itemId: 'filter-category', where 'category' is the record index to filter on
         */
         itemIds.forEach(itemId => {
-            const cmp = this.getTopToolbar().getComponent(itemId.trim());
-            let param = cmp.itemId.replace('filter-', '');
+            const id = itemId.trim(),
+                  cmp = this.getFilterComponent(id)
+            ;
+            let param = id.split('-')[1];
             param = param == 'ns' ? 'namespace' : param ;
             if (cmp.xtype.includes('combo')) {
                 cmp.setValue(null);
@@ -897,6 +935,82 @@ Ext.extend(MODx.grid.Grid,Ext.grid.EditorGridPanel,{
         MODx.util.url.clearParams();
         if (bottomToolbar) {
             bottomToolbar.changePage(1);
+        }
+    }
+    
+    /**
+     * @property {Boolean} hasNestedFilters - Indicates whether the top toolbar filter(s) are nested
+     * within a secondary container; they will be nested when they have labels and those labels are
+     * positioned above the filter's input.
+     */
+    ,hasNestedFilters: false
+
+    /**
+     * @property {Function} getFilterComponent - Gets a filter component from the top toolbar by its itemId
+     *
+     * @param {String} filterId - The Ext itemId of the filter component to fetch
+     * @return {Ext.Component}
+     */
+    ,getFilterComponent: function(filterId) {
+        const topToolbar = this.getTopToolbar(),
+              cmp = this.hasNestedFilters && filterId !== 'filter-query'
+                ? topToolbar.find('itemId', `${filterId}-container`)[0].getComponent(filterId)
+                : topToolbar.getComponent(filterId)
+        ;
+        if (typeof cmp !== 'undefined') {
+            return cmp;
+        }
+        console.error(`getFilterComponent: The filter component with itemId '${filterId}' could not be retrieved.`);
+    }
+
+    /**
+     * @property {Function} refreshFilterOptions - Used to syncronize a filter's store options to those available in its target grid
+     *
+     * @param {Array} filterData - An array of objects containing info needed to refresh each filter
+     * @param {Boolean} clearDependentParams - If true, will clear values of dependentParams specified in the filterData
+     */
+    ,refreshFilterOptions: function(filterData = [], clearDependentParams = true) {
+        if (filterData.length > 0) {
+            filterData.forEach(data => {
+                const filter = this.getFilterComponent(data.filterId);
+                if (filter) {
+                    const store = filter.getStore();
+                    filter.setValue('');
+                    if (store) {
+                        if (data.hasOwnProperty('dependentParams')) {
+                            const dependentParams = Array.isArray(data.dependentParams) ? data.dependentParams : data.dependentParams.split(',');
+                            dependentParams.forEach(param => {
+                                if (clearDependentParams && store.baseParams.hasOwnProperty(param)) {
+                                    store.baseParams[param] = '';
+                                }
+                            });
+                        }
+                        store.load();
+                    }
+                }
+            });
+        this.refresh();
+        }
+    }
+
+    /**
+     * @property {Function} updateDependentFilter - Reloads a related filter's store based on the current filter's selected item
+     *
+     * @param {String} filterId - The Ext id of the filter to update
+     * @param {String} paramKey - Filter baseParams property
+     * @param {Mixed} paramValue - Filter baseParams value for the paramKey
+     * @param {Boolean} clearValue - Set true to clear filter's selected value
+     */
+    ,updateDependentFilter: function(filterId, paramKey, paramValue, clearValue = false) {
+        const filter = this.getFilterComponent(filterId),
+              filterStore = filter ? filter.getStore() : null
+        ;
+        if (filterStore && typeof paramKey == 'string') {
+            if (clearValue) {
+                filter.setValue('');
+            }
+            filterStore.baseParams[paramKey] = paramValue;
+            filterStore.load();
         }
     }
 });
@@ -967,8 +1081,8 @@ MODx.grid.LocalGrid = function(config) {
 
     MODx.grid.LocalGrid.superclass.constructor.call(this,config);
     this.addEvents({
-        beforeRemoveRow: true
-        ,afterRemoveRow: true
+        beforeRemoveRow: true,
+        afterRemoveRow: true
     });
     this.on('rowcontextmenu',this._showMenu,this);
 };

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.category.js
@@ -20,21 +20,21 @@ MODx.grid.UserGroupCategory = function(config) {
             ,category: MODx.request.category || null
             ,policy: MODx.request.policy || null
         }
-        ,paging: true
-        ,hideMode: 'offsets'
         ,fields: [
             'id',
-            'target',
-            'name',
-            'principal',
-            'authority',
-            'authority_name',
-            'policy',
-            'policy_name',
-            'context_key',
-            'permissions',
-            'menu'
+			'target',
+			'name',
+			'principal',
+			'authority',
+			'authority_name',
+			'policy',
+			'policy_name',
+			'context_key',
+			'permissions',
+			'cls'
         ]
+        ,paging: true
+        ,hideMode: 'offsets'
         ,grouping: true
         ,groupBy: 'authority_name'
         ,singleText: _('policy')
@@ -43,105 +43,170 @@ MODx.grid.UserGroupCategory = function(config) {
         ,sortDir: 'ASC'
         ,remoteSort: true
         ,plugins: [this.exp]
-        ,columns: [this.exp,{
-            header: _('category')
-            ,dataIndex: 'name'
-            ,width: 120
-            ,sortable: true
-        },{
-            header: _('minimum_role')
-            ,dataIndex: 'authority_name'
-            ,width: 100
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=security/permission'
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        },{
-            header: _('policy')
-            ,dataIndex: 'policy_name'
-            ,width: 200
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=security/access/policy/update&id=' + record.data.policy
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        },{
-            header: _('context')
-            ,dataIndex: 'context_key'
-            ,width: 150
-            ,sortable: true
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=context/update&key=' + record.data.context_key
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        }]
-        ,tbar: [{
-            text: _('category_add')
-            ,cls: 'primary-button'
-            ,scope: this
-            ,handler: this.createAcl
-        },'->',{
-            xtype: 'modx-combo-category'
-            ,itemId: 'filter-category'
-            ,emptyText: _('filter_by_category')
-            ,width: 200
-            ,allowBlank: true
-            ,value: MODx.request.category || null
-            ,listeners: {
-                select: {
-                    fn: function (cmp, record, selectedIndex) {
-                        this.applyGridFilter(cmp, 'category');
-                    },
-                    scope: this
+        ,columns: [
+            this.exp,
+            {
+                header: _('category')
+                ,dataIndex: 'name'
+                ,width: 120
+                ,sortable: true
+            },{
+                header: _('minimum_role')
+                ,dataIndex: 'authority_name'
+                ,width: 100
+                ,xtype: 'templatecolumn'
+                ,tpl: this.getLinkTemplate('security/permission', 'authority_name')
+            },{
+                header: _('policy')
+                ,dataIndex: 'policy_name'
+                ,width: 200
+                ,xtype: 'templatecolumn'
+                ,tpl: this.getLinkTemplate('security/access/policy/update', 'policy_name', {
+                    linkParams: [{ key: 'id', valueIndex: 'policy'}]
+                })
+            },{
+                header: _('context')
+                ,dataIndex: 'context_key'
+                ,width: 150
+                ,sortable: true
+                ,xtype: 'templatecolumn'
+                ,tpl: this.getLinkTemplate('context/update', 'context_key', {
+                    linkParams: [{ key: 'key', valueIndex: 'context_key'}]
+                })
+            }
+        ]
+        ,tbar: [
+            {
+                text: _('category_add')
+                ,cls: 'primary-button'
+                ,scope: this
+                ,handler: this.createAcl
+            },
+            '->',
+            {
+                xtype: 'modx-combo-category'
+                ,itemId: 'filter-category'
+                ,emptyText: _('filter_by_category')
+                ,width: 200
+                ,allowBlank: true
+                ,value: MODx.request.category || null
+                ,baseParams: {
+                    action: 'Element/Category/GetList',
+                    isGridFilter: true,
+                    usergroup: config.usergroup
                 }
-            }
-        },{
-            xtype: 'modx-combo-policy'
-            ,itemId: 'filter-policy'
-            ,emptyText: _('filter_by_policy')
-            ,allowBlank: true
-            ,value: MODx.request.policy || null
-            ,baseParams: {
-                action: 'Security/Access/Policy/GetList'
-                ,group: 'Object'
-            }
-            ,listeners: {
-                select: {
-                    fn: function (cmp, record, selectedIndex) {
-                        this.applyGridFilter(cmp, 'policy');
-                    },
-                    scope: this
-                }
-            }
-        },{
-            text: _('filter_clear')
-            ,itemId: 'filter-clear'
-            ,listeners: {
-                click: {
-                    fn: function() {
-                        this.clearGridFilters('filter-category, filter-policy');
-                    },
-                    scope: this
-                },
-                mouseout: {
-                    fn: function(evt) {
-                        this.removeClass('x-btn-focus');
+                ,listeners: {
+                    select: {
+                        fn: function(cmp, record, selectedIndex) {
+                            this.updateDependentFilter('filter-policy-category', 'category', record.data.id);
+                            this.applyGridFilter(cmp, 'category');
+                        },
+                        scope: this
                     }
                 }
+            },{
+                xtype: 'modx-combo-policy'
+                ,itemId: 'filter-policy-category'
+                ,emptyText: _('filter_by_policy')
+                ,width: 180
+                ,allowBlank: true
+                ,value: MODx.request.policy || null
+                ,baseParams: {
+                    action: 'Security/Access/Policy/GetList',
+                    group: 'Element,Object',
+                    isGridFilter: true,
+                    targetGrid: 'MODx.grid.UserGroupCategory',
+                    usergroup: config.usergroup
+                }
+                ,listeners: {
+                    select: {
+                        fn: function(cmp, record, selectedIndex) {
+                            this.updateDependentFilter('filter-category', 'policy', record.data.id);
+                            this.applyGridFilter(cmp, 'policy');
+                        },
+                        scope: this
+                    }
+                }
+            },{
+                text: _('filter_clear')
+                ,itemId: 'filter-clear'
+                ,listeners: {
+                    click: {
+                        fn: function() {
+                            this.updateDependentFilter('filter-policy-category', 'category', '', true);
+                            this.updateDependentFilter('filter-category', 'policy', '', true);
+                            this.clearGridFilters('filter-category, filter-policy-category');
+                        },
+                        scope: this
+                    },
+                    mouseout: {
+                        fn: function(evt) {
+                            this.removeClass('x-btn-focus');
+                        }
+                    }
+                }
+                ,scope: this
             }
-        }]
+        ]
     });
     MODx.grid.UserGroupCategory.superclass.constructor.call(this,config);
     this.addEvents('createAcl','updateAcl');
+
+    const gridFilterData = [
+        { filterId: 'filter-policy-category', dependentParams: ['category'] },
+        { filterId: 'filter-category', dependentParams: ['policy'] }
+    ];
+
+    this.on({
+        createAcl: function() {
+            if (arguments[0].a.response.status == 200) {
+                this.refreshFilterOptions(gridFilterData);
+            }
+        },
+        updateAcl: function() {
+            if (arguments[0].a.response.status == 200) {
+                this.refreshFilterOptions(gridFilterData);
+            }
+        },
+        afterRemoveRow: function() {
+            this.refreshFilterOptions(gridFilterData);
+        }
+    });
 };
 Ext.extend(MODx.grid.UserGroupCategory,MODx.grid.Grid,{
     combos: {}
     ,windows: {}
+
+    ,getMenu: function() {
+        const record = this.getSelectionModel().getSelected(),
+              permissions = record.data.cls,
+              menu = []
+        ;
+
+        if (this.getSelectionModel().getCount() > 1) {
+            // Currently not allowing bulk actions for this grid
+        } else {
+            if (permissions.indexOf('pedit') != -1) {
+                menu.push({
+                    text: _('access_category_update'),
+                    handler: this.updateAcl
+                });
+            }
+            if (permissions.indexOf('premove') != -1) {
+                if (menu.length > 0) {
+                    menu.push('-');
+                }
+                menu.push({
+                    text: _('access_category_remove'),
+                    handler: this.remove.createDelegate(this,['confirm_remove','Security/Access/UserGroup/Category/Remove'])
+                });
+            }
+        }
+
+        if (menu.length > 0) {
+            this.addContextMenuItem(menu);
+        }
+    }
 
     ,createAcl: function(itm,e) {
         var r = {

--- a/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
+++ b/manager/assets/modext/widgets/security/modx.grid.user.group.namespace.js
@@ -17,24 +17,24 @@ MODx.grid.UserGroupNamespace = function(config) {
         ,baseParams: {
             action: 'Security/Access/UserGroup/AccessNamespace/GetList'
             ,usergroup: config.usergroup
-            ,namespace: MODx.request.namespace || null
+            ,namespace: MODx.request.ns || null
             ,policy: MODx.request.policy || null
         }
-        ,paging: true
-        ,hideMode: 'offsets'
         ,fields: [
             'id',
-            'target',
-            'name',
-            'principal',
-            'authority',
-            'authority_name',
+			'target',
+			'name',
+			'principal',
+			'authority',
+			'authority_name',
             'policy',
-            'context_key',
             'policy_name',
-            'permissions',
-            'menu'
+            'context_key',
+			'permissions',
+			'cls'
         ]
+        ,paging: true
+        ,hideMode: 'offsets'
         ,grouping: true
         ,groupBy: 'authority_name'
         ,singleText: _('policy')
@@ -43,100 +43,169 @@ MODx.grid.UserGroupNamespace = function(config) {
         ,sortDir: 'ASC'
         ,remoteSort: true
         ,plugins: [this.exp]
-        ,columns: [this.exp,{
-            header: _('namespace')
-            ,dataIndex: 'name'
-            ,width: 120
-            ,sortable: true
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=workspaces/namespace'
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        },{
-            header: _('minimum_role')
-            ,dataIndex: 'authority_name'
-            ,width: 100
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=security/permission'
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        },{
-            header: _('policy')
-            ,dataIndex: 'policy_name'
-            ,width: 200
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=security/access/policy/update&id=' + record.data.policy
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        }]
-        ,tbar: [{
-            text: _('namespace_add')
-            ,cls:'primary-button'
-            ,scope: this
-            ,handler: this.createAcl
-        },'->',{
-            xtype: 'modx-combo-namespace'
-            ,itemId: 'filter-namespace'
-            ,emptyText: _('filter_by_namespace')
-            ,width: 200
-            ,allowBlank: true
-            ,value: MODx.request.namespace || null
-            ,listeners: {
-                select: {
-                    fn: function (cmp, record, selectedIndex) {
-                        this.applyGridFilter(cmp, 'namespace');
-                    },
-                    scope: this
+        ,columns: [
+            this.exp,
+            {
+                header: _('namespace')
+                ,dataIndex: 'name'
+                ,width: 120
+                ,sortable: true
+                ,xtype: 'templatecolumn'
+                ,tpl: this.getLinkTemplate('workspaces/namespace', 'name')
+            },{
+                header: _('minimum_role')
+                ,dataIndex: 'authority_name'
+                ,width: 100
+                ,xtype: 'templatecolumn'
+                ,tpl: this.getLinkTemplate('security/permission', 'authority_name')
+            },{
+                header: _('policy')
+                ,dataIndex: 'policy_name'
+                ,width: 200
+                ,xtype: 'templatecolumn'
+                ,tpl: this.getLinkTemplate('security/access/policy/update', 'policy_name', {
+                    linkParams: [{ key: 'id', valueIndex: 'policy'}]
+                })
+            }
+        ]
+        ,tbar: [
+            {
+                text: _('namespace_add')
+                ,cls: 'primary-button'
+                ,scope: this
+                ,handler: this.createAcl
+            },
+            '->',
+            {
+                xtype: 'modx-combo-namespace'
+                ,itemId: 'filter-namespace'
+                ,emptyText: _('filter_by_namespace')
+                ,editable: false
+                ,width: 200
+                ,allowBlank: true
+                ,value: MODx.request.ns || null
+                ,baseParams: {
+                    action: 'Workspace/PackageNamespace/GetList',
+                    isGridFilter: true,
+                    usergroup: config.usergroup
                 }
-            }
-        },{
-            xtype: 'modx-combo-policy'
-            ,itemId: 'filter-policy'
-            ,emptyText: _('filter_by_policy')
-            ,allowBlank: true
-            ,value: MODx.request.policy || null
-            ,baseParams: {
-                action: 'Security/Access/Policy/GetList'
-                ,group: 'Namespace'
-            }
-            ,listeners: {
-                select: {
-                    fn: function (cmp, record, selectedIndex) {
-                        this.applyGridFilter(cmp, 'policy');
-                    },
-                    scope: this
-                }
-            }
-        },{
-            text: _('filter_clear')
-            ,itemId: 'filter-clear'
-            ,listeners: {
-                click: {
-                    fn: function() {
-                        this.clearGridFilters('filter-namespace, filter-policy');
-                    },
-                    scope: this
-                },
-                mouseout: {
-                    fn: function(evt) {
-                        this.removeClass('x-btn-focus');
+                ,listeners: {
+                    select: {
+                        fn: function(cmp, record, selectedIndex) {
+                            this.updateDependentFilter('filter-policy-namespace', 'namespace', record.data.name);
+                            /*
+                                There's an odd conflict in the processor when using 'namespace' as the
+                                query param, therefor the alternate param 'ns' is used this listener, its component value, and in the value of
+                                this grid's main baseParams config
+                            */
+                            this.applyGridFilter(cmp, 'ns');
+                        },
+                        scope: this
                     }
                 }
+            },{
+                xtype: 'modx-combo-policy'
+                ,itemId: 'filter-policy-namespace'
+                ,emptyText: _('filter_by_policy')
+                ,width: 180
+                ,allowBlank: true
+                ,value: MODx.request.policy || null
+                ,baseParams: {
+                    action: 'Security/Access/Policy/GetList',
+                    group: 'Namespace',
+                    isGridFilter: true,
+                    targetGrid: 'MODx.grid.UserGroupNamespace',
+                    usergroup: config.usergroup
+                }
+                ,listeners: {
+                    select: {
+                        fn: function(cmp, record, selectedIndex) {
+                            this.updateDependentFilter('filter-namespace', 'policy', record.data.id);
+                            this.applyGridFilter(cmp, 'policy');
+                        },
+                        scope: this
+                    }
+                }
+            },{
+                text: _('filter_clear')
+                ,itemId: 'filter-clear'
+                ,listeners: {
+                    click: {
+                        fn: function() {
+                            this.updateDependentFilter('filter-policy-namespace', 'namespace', '', true);
+                            this.updateDependentFilter('filter-namespace', 'policy', '', true);
+                            this.clearGridFilters('filter-namespace, filter-policy-namespace');
+                        },
+                        scope: this
+                    },
+                    mouseout: {
+                        fn: function(evt) {
+                            this.removeClass('x-btn-focus');
+                        }
+                    }
+                }
+                ,scope: this
             }
-        }]
+        ]
     });
     MODx.grid.UserGroupNamespace.superclass.constructor.call(this,config);
     this.addEvents('createAcl','updateAcl');
+
+    const gridFilterData = [
+        { filterId: 'filter-policy-namespace', dependentParams: ['namespace'] },
+        { filterId: 'filter-namespace', dependentParams: ['policy'] }
+    ];
+
+    this.on({
+        createAcl: function() {
+            if (arguments[0].a.response.status == 200) {
+                this.refreshFilterOptions(gridFilterData);
+            }
+        },
+        updateAcl: function() {
+            if (arguments[0].a.response.status == 200) {
+                this.refreshFilterOptions(gridFilterData);
+            }
+        },
+        afterRemoveRow: function() {
+            this.refreshFilterOptions(gridFilterData);
+        }
+    });
 };
 Ext.extend(MODx.grid.UserGroupNamespace,MODx.grid.Grid,{
     combos: {}
     ,windows: {}
+
+    ,getMenu: function() {
+        const record = this.getSelectionModel().getSelected(),
+              permissions = record.data.cls,
+              menu = []
+        ;
+
+        if (this.getSelectionModel().getCount() > 1) {
+            // Currently not allowing bulk actions for this grid
+        } else {
+            if (permissions.indexOf('pedit') != -1) {
+                menu.push({
+                    text: _('access_namespace_update'),
+                    handler: this.updateAcl
+                });
+            }
+            if (permissions.indexOf('premove') != -1) {
+                if (menu.length > 0) {
+                    menu.push('-');
+                }
+                menu.push({
+                    text: _('access_namespace_remove'),
+                    handler: this.remove.createDelegate(this,['confirm_remove','Security/Access/UserGroup/AccessNamespace/Remove'])
+                });
+            }
+        }
+
+        if (menu.length > 0) {
+            this.addContextMenuItem(menu);
+        }
+    }
 
     ,createAcl: function(itm,e) {
         var r = {


### PR DESCRIPTION
After difficulties rebasing and resolving conflicts of the original PR (#16251) in preparation for final merge, elected to create this clean re-submission that resolves all issues.

### What does it do?
Made a number of changes and additions in the processors and grid JS files to correct issues with the grids’ grouping functionality and more accurately build the grid filters depending on the data shown. More specifically:

1. Replaced the column model renderers (used to render links on column data) with a `templatecolumn` specification (generated by a new method in the grids base class), as using renderers on grouping grids interferes with the grouping functionality (because a renderer is an interceptor method in Ext).
2. Moved menu specifications (grid context menus) out of processors and into the grid js for all sections (context was already this way). The primary reason being that some events (such as `afterRemoveRow`) were not firing when set up this way; monitoring these events is necessary for maintaining accurate filter options when making changes to a grid's data. Also, there's no reason to specify js in php unless the item in question will change on the fly and needs setup data from the processor.
3. Grid view, including the bottom toolbar, now correctly updates when a row is deleted.
4. Created new methods to update dependent filters (when two or more filters are present) based upon the selected value of any given filter.
5. Fixed some filters that were missing options due to an incorrect specification of their `baseParams.group` property.

### Why is it needed?
Grouping in these grids was not working correctly. Also, providing filter options where no relevant data is available in a given grid is a UX problem that needs to be fixed not only here, but across all grids with filters. 

### How to test
1. Ensure modx and browser caches are fully cleared.
2. Create a number of policies in each area (if you don't already have some set up) and play with the grouping and filtering of items in each grid. (These are the five Access Permissions grids — Context, Resource Groups, Element Categories, Media Sources, and Namespaces.) Verify that filters only show relevant options depending on the grid data and other filters you've made selections on.
3. Verify that other operations (editing and deleting) affect filter options as expected.

### Related issue(s)/PR(s)
Resolves #16239.

### Special Note
Because these updates involve a lot of changes, I didn't want to execute them for _all_ relevant grids at once. This PR completes a logical section and, depending on any requested changes, other PRs will follow what I've done here for other grids.

### Before and After Examples
Currently, in MODx 3.0.3-dev, note each of the following problems (in order of appearance in the video):

1. Each ACL area grid does not group properly; where an area's rows should be grouped under a common heading, they are not. To see this clearly, pause each time I click on each area and note where grouping should be occurring (for example, in Contexts, the three assigned the _Editors - 1000_ Role should be grouped under one row heading for that Role).
2. [0:19] Next, notice how the grid filters show irrelevant options where they should only show those present in the grid data. The _Filter by Context_ combo shows all Contexts instead of those present (dupctx1, dupctx2, dev2, and www2). The same goes for the _Filter by Policy_ combo. [0:42] Additionally, the Filter by Policy combo is mis-configured in places; here the problem in the Contexts area is illustrated. When adding a new Context, you are given the full Policies list in the Create window, but the filter combo shows an incomplete subset. [1:02] Lastly, when attempting to create additional policies for the same Context, an error occurs due to an incorrect validation for a unique context key. 
3. [1:32] When deleting a row, see how the count is not updated in the lower right grid status area.
4. [1:50] Next, when filtering, a choice in one combo should update the others to show only entries relevant to the current state of the query. They do not currently react to changes as one would expect.

https://user-images.githubusercontent.com/689075/209720912-944ca7bb-2d91-4aae-9bdd-f0b5b7d71b18.mov

Now, note how each problem is fixed (action taken in same order as above):

https://user-images.githubusercontent.com/689075/209720965-f3b53940-7554-4db1-a695-86bc2b25c8b7.mov

