### PR TITLE
Only post coverage comment when coverage changes.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+    require_changes: true


### PR DESCRIPTION
### What does it do?
Only post coverage comment when coverage changes.

### Why is it needed?
Don't clutter the PR comments when it's not necessary. 

### How to test
n/a

### Related issue(s)/PR(s)
n/a