### PR TITLE
Cleanup legacy PHP version references

### DIFF
--- a/core/src/Revolution/Processors/System/ConfigCheck.php
+++ b/core/src/Revolution/Processors/System/ConfigCheck.php
@@ -140,10 +140,10 @@ class ConfigCheck extends Processor
 
     public function checkSystem()
     {
-        $require = $this->modx->getOption('configcheck_min_phpversion', null, '5.6');
+        $require = $this->modx->getOption('configcheck_min_phpversion', null, '7.2.5');
 
-        $compare = version_compare(PHP_VERSION, $require);
-        if ($compare === -1) {
+        $compare = version_compare(PHP_VERSION, $require, '>=');
+        if (!$compare) {
             $this->warnings[$this->modx->lexicon('configcheck_phpversion')] = $this->modx->lexicon('configcheck_phpversion_msg',
                 [
                     'phpversion' => PHP_VERSION,

--- a/core/src/Revolution/modPhpThumb.php
+++ b/core/src/Revolution/modPhpThumb.php
@@ -37,11 +37,6 @@ class modPhpThumb extends phpthumb
         $this->modx =& $modx;
         $this->config = $config;
 
-        if (version_compare(PHP_VERSION, '7.0.10', '<')) {
-            // The constant IMG_WEBP is available as of PHP 7.0.10, respectively.
-            define('IMG_WEBP', 32);
-        }
-
         parent::__construct();
     }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1681,11 +1681,7 @@ class modX extends xPDO {
             foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
                 /** @var modPlugin $plugin */
                 $plugin= null;
-                if (!version_compare(PHP_VERSION, '5.4', '>=')) {
-                    $this->Event = & $this->event;
-                } else {
-                    $this->Event = clone $this->event;
-                }
+                $this->Event = clone $this->event;
                 $this->event->resetEventObject();
                 $this->event->name= $eventName;
                 if (isset ($this->pluginCache[$pluginId])) {
@@ -2791,27 +2787,19 @@ class modX extends xPDO {
                 }
                 $site_sessionname = $this->getOption('session_name', $options, '');
                 if (!empty($site_sessionname)) session_name($site_sessionname);
-                if (PHP_VERSION_ID < 70300) {
-                    session_set_cookie_params(
-                        $cookieLifetime,
-                        $cookiePath,
-                        $cookieDomain,
-                        $cookieSecure,
-                        $cookieHttpOnly
-                    );
-                } else {
-                    $cookie_params = [
-                        'lifetime' => $cookieLifetime,
-                        'path' => $cookiePath,
-                        'domain' => $cookieDomain,
-                        'secure' => $cookieSecure,
-                        'httponly' => $cookieHttpOnly
-                    ];
-                    if ($cookieSamesite !== '') {
-                        $cookie_params['samesite'] = $cookieSamesite;
-                    }
-                    session_set_cookie_params($cookie_params);
+
+                $cookie_params = [
+                    'lifetime' => $cookieLifetime,
+                    'path' => $cookiePath,
+                    'domain' => $cookieDomain,
+                    'secure' => $cookieSecure,
+                    'httponly' => $cookieHttpOnly
+                ];
+                if ($cookieSamesite !== '') {
+                    $cookie_params['samesite'] = $cookieSamesite;
                 }
+                session_set_cookie_params($cookie_params);
+
                 if ($this->getOption('anonymous_sessions', $options, true) || isset($_COOKIE[session_name()])) {
                     if (!$this->startSession()) {
                         $this->log(modX::LOG_LEVEL_ERROR, 'Unable to initialize a session', '', __METHOD__, __FILE__, __LINE__);
@@ -2836,19 +2824,7 @@ class modX extends xPDO {
                             if ($cookieSamesite !== '') {
                                 $cookie_settings['samesite'] = $cookieSamesite;
                             }
-                            if (PHP_VERSION_ID < 70300) {
-                                setcookie(
-                                    session_name(),
-                                    session_id(),
-                                    $cookieExpiration,
-                                    $cookiePath,
-                                    $cookieDomain,
-                                    $cookieSecure,
-                                    $cookieHttpOnly
-                                );
-                            } else {
-                                setcookie(session_name(), session_id(), $cookie_settings);
-                            }
+                            setcookie(session_name(), session_id(), $cookie_settings);
                         }
                     }
                 } else {

--- a/manager/index.php
+++ b/manager/index.php
@@ -25,9 +25,9 @@ if (!defined('MODX_API_MODE')) {
 }
 
 /* check for correct version of php */
-$php_ver_comp = version_compare(phpversion(),'7.0');
-if ($php_ver_comp < 0) {
-    die('Wrong php version! You\'re using PHP version "'.phpversion().'", and MODX Revolution only works on 7.0 or higher.');
+$php_ver_comp = version_compare(PHP_VERSION,'7.2.5', '>=');
+if (!$php_ver_comp) {
+    die('Wrong php version! You\'re using PHP version "'.PHP_VERSION.'", and MODX Revolution only works on 7.2.5 or higher.');
 }
 
 /* set the document_root */


### PR DESCRIPTION
### What does it do?
Did some clean up of PHP version specific fixes that are no longer needed.
I also made sure we check for the correct current minimum PHP version we support.

### Why is it needed?
Clean up old code and make things more consistent. 

### How to test
n/a

### Related issue(s)/PR(s)
n/a