### PR TITLE
Suggest installing the PHP Internationalization extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,8 @@
         "ext-imagick": "To process images in a more advanced way",
         "ext-iconv": "Needed if you want to use the built-in transliteration service",
         "ext-mbstring": "Needed when use_multibyte is enabled or when using some extras like Gallery",
-        "ext-xmlwriter": "To use the export functionalities"
+        "ext-xmlwriter": "To use the export functionalities",
+        "ext-intl": ""
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### What does it do?
Suggest installing the PHP Internationalization extension if you install MODX with composer.

### Why is it needed?
It's merely a suggestion in preparation to use `IntlDateFormatter` as replacement for the deprecated function `strftime()`.

### How to test
n/a

### Related issue(s)/PR(s)
For more info see the discussion in issue #15864