### PR TITLE
Modify (un)delete and (un)publish processors to respect syncsite setting

### DIFF
--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -750,7 +750,7 @@ class Create extends CreateProcessor
      */
     public function clearCache()
     {
-        $clear = $this->getProperty('syncsite', false) || $this->getProperty('clearCache', false);
+        $clear = $this->getProperty('syncsite', $this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache', false);
         if ($clear) {
             $this->modx->cacheManager->refresh([
                 'db' => [],

--- a/core/src/Revolution/Processors/Resource/Delete.php
+++ b/core/src/Revolution/Processors/Resource/Delete.php
@@ -266,12 +266,15 @@ class Delete extends Processor
      */
     public function clearCache()
     {
-        $this->modx->cacheManager->refresh([
-            'db' => [],
-            'auto_publish' => ['contexts' => [$this->resource->get('context_key')]],
-            'context_settings' => ['contexts' => [$this->resource->get('context_key')]],
-            'resource' => ['contexts' => [$this->resource->get('context_key')]],
-        ]);
+        $clear = $this->getProperty('syncsite', $this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache', false);
+        if ($clear) {
+            $this->modx->cacheManager->refresh([
+                'db' => [],
+                'auto_publish' => ['contexts' => [$this->resource->get('context_key')]],
+                'context_settings' => ['contexts' => [$this->resource->get('context_key')]],
+                'resource' => ['contexts' => [$this->resource->get('context_key')]],
+            ]);
+        }
     }
 
     /**

--- a/core/src/Revolution/Processors/Resource/Publish.php
+++ b/core/src/Revolution/Processors/Resource/Publish.php
@@ -149,11 +149,14 @@ class Publish extends Processor
      */
     public function clearCache()
     {
-        $this->modx->cacheManager->refresh([
-            'db' => [],
-            'auto_publish' => ['contexts' => [$this->resource->get('context_key')]],
-            'context_settings' => ['contexts' => [$this->resource->get('context_key')]],
-            'resource' => ['contexts' => [$this->resource->get('context_key')]],
-        ]);
+        $clear = $this->getProperty('syncsite', $this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache', false);
+        if ($clear) {
+            $this->modx->cacheManager->refresh([
+                'db' => [],
+                'auto_publish' => ['contexts' => [$this->resource->get('context_key')]],
+                'context_settings' => ['contexts' => [$this->resource->get('context_key')]],
+                'resource' => ['contexts' => [$this->resource->get('context_key')]],
+            ]);
+        }
     }
 }

--- a/core/src/Revolution/Processors/Resource/Undelete.php
+++ b/core/src/Revolution/Processors/Resource/Undelete.php
@@ -176,11 +176,14 @@ class Undelete extends Processor
      */
     public function clearCache()
     {
-        $this->modx->cacheManager->refresh([
-            'db' => [],
-            'auto_publish' => ['contexts' => [$this->resource->get('context_key')]],
-            'context_settings' => ['contexts' => [$this->resource->get('context_key')]],
-            'resource' => ['contexts' => [$this->resource->get('context_key')]],
-        ]);
+        $clear = $this->getProperty('syncsite', $this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache', false);
+        if ($clear) {
+            $this->modx->cacheManager->refresh([
+                'db' => [],
+                'auto_publish' => ['contexts' => [$this->resource->get('context_key')]],
+                'context_settings' => ['contexts' => [$this->resource->get('context_key')]],
+                'resource' => ['contexts' => [$this->resource->get('context_key')]],
+            ]);
+        }
     }
 }

--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -942,9 +942,8 @@ class Update extends UpdateProcessor
      */
     public function clearCache()
     {
-        $syncSite = $this->getProperty('syncsite', false);
-        $clearCache = $this->getProperty('clearCache', false);
-        if (!empty($syncSite) || !empty($clearCache)) {
+        $clear = $this->getProperty('syncsite', $this->modx->getOption('syncsite_default')) || $this->getProperty('clearCache', false);
+        if ($clear) {
             $contexts = [$this->object->get('context_key')];
             if (!empty($this->oldContext)) {
                 $contexts[] = $this->oldContext->get('key');


### PR DESCRIPTION
### What does it do?
Makes the (un)delete and (un)publish processors respect the syncsite setting.

### Why is it needed?
Allows these processors to be used without refreshing the cache.

### How to test
Test the affected processors.

### Related issue(s)/PR(s)
Port of #16060 to 3.x
