### PR TITLE
Upgrade legacy modSessionHandler class references in settings

### DIFF
--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -630,10 +630,10 @@ $_lang['setting_session_cookie_httponly'] = 'Session Cookie HttpOnly';
 $_lang['setting_session_cookie_httponly_desc'] = 'Use this setting to set the HttpOnly flag on session cookies.';
 
 $_lang['setting_session_gc_maxlifetime'] = 'Session Garbage Collector Max Lifetime';
-$_lang['setting_session_gc_maxlifetime_desc'] = 'Allows customization of the session.gc_maxlifetime PHP ini setting when using \'modSessionHandler\'.';
+$_lang['setting_session_gc_maxlifetime_desc'] = 'Allows customization of the session.gc_maxlifetime PHP ini setting when using \'MODX\\Revolution\\modSessionHandler\'.';
 
 $_lang['setting_session_handler_class'] = 'Session Handler Class Name';
-$_lang['setting_session_handler_class_desc'] = 'For database managed sessions, use \'modSessionHandler\'.  Leave this blank to use standard PHP session management.';
+$_lang['setting_session_handler_class_desc'] = 'For database managed sessions, use \'MODX\\Revolution\\modSessionHandler\'.  Leave this blank to use standard PHP session management.';
 
 $_lang['setting_session_name'] = 'Session Name';
 $_lang['setting_session_name_desc'] = 'Use this setting to customize the session name used for the sessions in MODX. Leave blank to use the default PHP session name.';

--- a/setup/includes/upgrades/common/3.0.4-update-session-handler-class.php
+++ b/setup/includes/upgrades/common/3.0.4-update-session-handler-class.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+/**
+ * @var modX $modx
+ */
+
+/* modify legacy modSessionHandler references in system settings */
+$class = \MODX\Revolution\modSystemSetting::class;
+$table = $modx->getTableName($class);
+
+$modx->updateCollection($class, ['value' => \MODX\Revolution\modSessionHandler::class], [
+    'key' => 'session_handler_class',
+    'value' => 'modSessionHandler'
+]);
+
+/* modify legacy modSessionHandler references in context settings */
+$class = \MODX\Revolution\modContextSetting::class;
+$table = $modx->getTableName($class);
+
+$modx->updateCollection($class, ['value' => \MODX\Revolution\modSessionHandler::class], [
+    'key' => 'session_handler_class',
+    'value' => 'modSessionHandler'
+]);

--- a/setup/includes/upgrades/mysql/3.0.4-pl.php
+++ b/setup/includes/upgrades/mysql/3.0.4-pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.0.4-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.0.4-update-session-handler-class.php';


### PR DESCRIPTION
### What does it do?
Upgrades legacy references to `modSessionHandler` in system and context settings to `MODX\Revolution\modSessionHandler`

### Why is it needed?
Sites upgraded from 2.x still had the legacy `modSessionHandler` class referenced in the `session_handler_class` setting.

### How to test
Find a 2.x site with `session_handler_class` set to `modSessionHandler`, upgrade it to 3.0.4-dev, and confirm that the value is updated to `MODX\Revolution\modSessionHandler`

### Related issue(s)/PR(s)
n/a