### PR TITLE
Fix vtabs + grid horizontal overflow

### DIFF
--- a/manager/assets/modext/widgets/security/modx.panel.user.group.js
+++ b/manager/assets/modext/widgets/security/modx.panel.user.group.js
@@ -135,6 +135,7 @@ MODx.panel.UserGroup = function(config) {
                         ,itemId: 'user-group-context-access'
                         ,hideMode: 'offsets'
                         ,layout: 'form'
+                        ,autoWidth: false
                         ,items: [{
                             html: '<p>'+_('user_group_context_access_msg')+'</p>'
                             ,xtype: 'modx-description'


### PR DESCRIPTION
### What does it do?
Prevents `modx-vtabs` from causing part of the user group access permissions grid from being hidden.

### Why is it needed?
So users can see the right-hand column.

### How to test
Navigate to the grid and see the column is now visible.

### Related issue(s)/PR(s)
Resolves #16380 
