### PR TITLE
[3.x] Prioritize exact matches in manager search result

### DIFF
--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -131,6 +131,7 @@ class Search extends Processor
         ];
         $c->where($querySearch, $queryContext);
 
+        $c->sortby('IF(`modResource`.`pagetitle` = ' . $this->modx->quote($this->query) . ', 0, 1)');
         $c->sortby('modResource.createdon', 'DESC');
 
         $c->limit($this->getMaxResults());
@@ -172,6 +173,8 @@ class Search extends Processor
         $querySearch['OR:id:='] = $this->query;
         $c->where($querySearch);
 
+        $c->sortby('IF(`' . $nameField . '` = ' . $this->modx->quote($this->query) . ', 0, 1)');
+
         $c->limit($this->getMaxResults());
 
         $collection = $this->modx->getIterator($class, $c);
@@ -204,6 +207,8 @@ class Search extends Processor
             'OR:Profile.email:LIKE' => '%' . $this->query .'%',
             'OR:id:=' => $this->query,
         ]);
+
+        $c->sortby('IF(`username` = ' . $this->modx->quote($this->query) . ', 0, 1)');
 
         $c->limit($this->getMaxResults());
 


### PR DESCRIPTION
### What does it do?
Adds a sort to the queries for the manager search, that puts an exact match of the "name" field at the top of the result.

### Why is it needed?
The search in the manager only shows a limited amount of results for each type of element. If there are a lot of elements with similar names, even one that exactly matches the search term may not be shown in the result.

### How to test
Create some snippets/chunks/etc. with similar names. Verify that the snippet/chunk that exactly matches the search term is shown first.

Can someone test if this solution slows down the search considerably, when there exist a lot of elements/resources?

### Related issue(s)/PR(s)
Port of #16244 to MODX 3
