### PR TITLE
RestController: when no specific classAlias is set, use automatic alias from xPDO

### DIFF
--- a/core/src/Revolution/Rest/modRestController.php
+++ b/core/src/Revolution/Rest/modRestController.php
@@ -511,7 +511,7 @@ abstract class modRestController
         $c = $this->addSearchQuery($c);
         $c = $this->prepareListQueryBeforeCount($c);
         $total = $this->modx->getCount($this->classKey, $c);
-        $alias = !empty($this->classAlias) ? $this->classAlias : $this->classKey;
+        $alias = !empty($this->classAlias) ? $this->classAlias : $this->modx->getAlias($this->classKey);
         $c->select($this->modx->getSelectColumns($this->classKey, $alias));
 
         $c = $this->prepareListQueryAfterCount($c);


### PR DESCRIPTION
### What does it do?

In the modRestController, change the classAlias fallback to the alias that gets autogenerated by xPDO.

### Why is it needed?

With namespaced model classes, the full classKey becomes invalid for aliases, and you'd really want that to use the clean short version. 

### How to test

In a rest controller without a specific classAlias, confirm you can get data. 

### Related issue(s)/PR(s)

This was recently reported via Slack and the fix confirmed by the reporter. 

I'm personally on the fence as to whether this is a 3.0.x bugfix or a 3.1 improved behavior but would suggest 3.1.