### PR TITLE
Use Codecov in informational mode.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,11 @@
 comment:
     require_changes: true
+
+coverage:
+    status:
+        project:
+            default:
+                informational: true
+        patch:
+            default:
+                informational: true


### PR DESCRIPTION
### What does it do?
Use Codecov in informational mode

### Why is it needed?
See status checks but prevent them from blocking / failing the build status.

> Use Codecov in informational mode. Default is false. If true is specified the resulting status will pass no matter what the coverage is or what other settings are specified. Informational mode is great to use if you want to expose codecov information to other developers in your pull request without necessarily gating PRs on that information.

### How to test
See builds pass the code coverage checks.

### Related issue(s)/PR(s)
n/a