### PR TITLE
Fix template picker component listeners to avoid errors in certain scenarios

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.window.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.window.resource.js
@@ -256,22 +256,21 @@ Ext.extend(MODx.combo.TemplatePicker, Ext.Panel, {
             columns: 1,
             items: items,
             listeners: {
-                'render': {
-                    fn: function(tf) {
-                        var value = tf.getValue();
-
-                        if (value.record) {
-                            this.fireEvent('select', value.record);
+                render: {
+                    fn: function(cmp) {
+                        const value = cmp.getValue(),
+                              record = value?.record
+                        ;
+                        if (record) {
+                            this.fireEvent('select', record);
                         }
                     },
                     scope: this
                 },
-                'change': {
-                    fn: function(tf) {
-                        var value = tf.getValue();
-
-                        if (value.record) {
-                            this.fireEvent('select', value.record);
+                change: {
+                    fn: function(cmp, checked) {
+                        if (checked.record) {
+                            this.fireEvent('select', checked.record);
                         }
                     },
                     scope: this


### PR DESCRIPTION
### Why is it needed?
When a template is unavailable (_e.g._, when it's access is hidden by an ACL) and it happens to be the default template for new documents, an error was occurring. The error's effects are not immediately obvious, as they only disrupt certain operations — one of them being the appending of the Resource Type (derivatives) combo with types added by Extras (such as Collections, Gallery, and the like).

### How to test
**Before checking out this PR.** To see the error in action:
1. Ensure `enable_template_picker_in_tree` system setting is enabled.
2. Create a Template and assign it to a new or existing Element Category.
3. Set the Template you created to be the system `default_template`.
4. Install an Extra that creates its own Resource Type(s) (suggest Collections).
5. Assign a secondary manager user to a user group that _does not_ have access to the Element Category you just assigned your new default template to.
6. Sign into a different browser as this secondary user and click in the tree to create a new Resource.
7. Note in the template picker window that only the native MODX Resource Types are available in the dropdown; assuming you have Collections installed, you should also see _Collection_ and _Selection_ but won't because the error prevents the appending of the combo (which happens later in the process via the Extra's plugin). You'll also see an error in your browser console. 

**After checkout:**
1. Clear caches and perform a grunt rebuild.
2. Force reload your testing user's browser window.
3. Create a new Resource from the tree and verify that no error occurs and the full Resource Types list is shown in the template picker window.

### Related issue(s)/PR(s)
I came across this issue when beginning review of #16067. At first I thought a change in that PR was causing the error, but this issue turned out to be unrelated.
