### PR TITLE
[3.x] Fixes active tab state for form customization when disabling regions

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -586,8 +586,8 @@ Ext.extend(MODx,Ext.Component,{
     }
 
     ,_getNextActiveTab: function(tp,tab) {
+        let id;
         if (MODx.hiddenTabs.indexOf(tab) != -1) {
-            let id;
             for (var i=0;i<tp.items.items.length;i++) {
                  id = tp.items.items[i].id;
                 if (MODx.hiddenTabs.indexOf(id) == -1) { break; }


### PR DESCRIPTION
### What does it do?
Fixes the scope of the variable `id` in the function.

### Why is it needed?
When disabling regions in a Form customization set, for example `modx-resource-access-permissions`, the default Document tab does not have the active state/styling.

### How to test
Create a new Form customization set for 'Create and Edit resource', and disable one of the regions, for example `modx-resource-access-permissions`. Then go to a Resource create/update page, and verify that the Document tab has the active tab styling.

### Related issue(s)/PR(s)
Resolves #16399
