### PR TITLE
Fix visibility of Symlink, Weblink, and Static Resource in contextual menus (create) and combos

### DIFF
--- a/core/src/Revolution/modStaticResource.php
+++ b/core/src/Revolution/modStaticResource.php
@@ -27,7 +27,9 @@ class modStaticResource extends modResource
     {
         parent:: __construct($xpdo);
         $this->set('class_key', __CLASS__);
-        $this->showInContextMenu = true;
+        $canCreate = (bool)$this->xpdo->hasPermission('new_static_resource');
+        $this->allowListingInClassKeyDropdown = $canCreate;
+        $this->showInContextMenu = $canCreate;
     }
 
     /**

--- a/core/src/Revolution/modSymLink.php
+++ b/core/src/Revolution/modSymLink.php
@@ -20,7 +20,9 @@ class modSymLink extends modResource
         parent:: __construct($xpdo);
         $this->set('type', 'reference');
         $this->set('class_key', __CLASS__);
-        $this->showInContextMenu = true;
+        $canCreate = (bool)$this->xpdo->hasPermission('new_symlink');
+        $this->allowListingInClassKeyDropdown = $canCreate;
+        $this->showInContextMenu = $canCreate;
     }
 
     /**

--- a/core/src/Revolution/modWebLink.php
+++ b/core/src/Revolution/modWebLink.php
@@ -20,7 +20,9 @@ class modWebLink extends modResource
         parent:: __construct($xpdo);
         $this->set('type', 'reference');
         $this->set('class_key', __CLASS__);
-        $this->showInContextMenu = true;
+        $canCreate = (bool)$this->xpdo->hasPermission('new_weblink');
+        $this->allowListingInClassKeyDropdown = $canCreate;
+        $this->showInContextMenu = $canCreate;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Properly sets the `showInContextMenu` and `allowListingInClassKeyDropdown` class properties to ensure correct visibility of context menu items and combo options based on user permissions to create Symlinks, Weblinks, and/or Static Resources.

### Why is it needed?
This picks up on what #16067 is trying to solve, but uses functionality that is already present (just not taken advantage of) to achieve the end result. In this way, the visibility applies not only to the template picker but to other areas that utilize/extend the Derivatives classes, as well as the tree's context menu (applies to create visibility only).

### How to test

1. Create a secondary user and a new ACL policy for that user's usergroup.
2. Toggle the `new_weblink`, `new_symlink`, and `new_static_resource` permissions and verify that, when off, the related Resource Type combo option items do not show (in the template picker window, in the main Resource editing panel [under Settings], and if you have Collections installed in the Collections Settings are [_Default children's resource type_ combo]). Also note that when using the context menu in the tree, these items should only show under Create and Quick Create when the user has the appropriate permissions.

### Note ###
This only addresses visibility in the tree for create/new permission. More should be done on this subject to control the visibility of edit and delete on tree nodes where permission is not granted for the give Resource type. But that should be handled separately, as it may take a bit more "doing" to get that sorted.

### Related issue(s)/PR(s)
This is an alternate to PR #16067 to solve #15893 and more.
