### PR TITLE
Update minimum PHP version to 7.4 and recommended version to 8.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "vendor-dir": "core/vendor"
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.4.0",
         "xpdo/xpdo": "~3.1.0",
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",

--- a/core/src/Revolution/Processors/System/ConfigCheck.php
+++ b/core/src/Revolution/Processors/System/ConfigCheck.php
@@ -140,7 +140,7 @@ class ConfigCheck extends Processor
 
     public function checkSystem()
     {
-        $require = $this->modx->getOption('configcheck_min_phpversion', null, '7.2.5');
+        $require = $this->modx->getOption('configcheck_min_phpversion', null, '7.4.0');
 
         $compare = version_compare(PHP_VERSION, $require, '>=');
         if (!$compare) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -339,11 +339,7 @@ class modX extends xPDO {
                         $iteration++;
                     }
                 }
-                if (version_compare(PHP_VERSION, '7.4.0', '<') && get_magic_quotes_gpc()) {
-                    $target[$key]= stripslashes($value);
-                } else {
-                    $target[$key]= $value;
-                }
+                $target[$key]= $value;
             }
         }
         return $target;

--- a/manager/index.php
+++ b/manager/index.php
@@ -25,9 +25,9 @@ if (!defined('MODX_API_MODE')) {
 }
 
 /* check for correct version of php */
-$php_ver_comp = version_compare(PHP_VERSION,'7.2.5', '>=');
+$php_ver_comp = version_compare(PHP_VERSION,'7.4.0', '>=');
 if (!$php_ver_comp) {
-    die('Wrong php version! You\'re using PHP version "'.PHP_VERSION.'", and MODX Revolution only works on 7.2.5 or higher.');
+    die('Wrong php version! You\'re using PHP version "'.PHP_VERSION.'", and MODX Revolution only works on 7.4.0 or higher.');
 }
 
 /* set the document_root */

--- a/setup/includes/test/modinstalltest.class.php
+++ b/setup/includes/test/modinstalltest.class.php
@@ -66,8 +66,8 @@ abstract class modInstallTest
         $this->title('php_version', $this->install->lexicon('test_php_version_start') . ' ');
         $phpVersion = phpversion();
 
-        $recommended_version = "7.3";
-        $required_version = "7.2.5";
+        $recommended_version = "8.0.0";
+        $required_version = "7.4.0";
 
         $php_ver_comp = version_compare($phpVersion, $required_version, '>=');
 

--- a/setup/provisioner/requirements.php
+++ b/setup/provisioner/requirements.php
@@ -9,7 +9,7 @@
  * files found in the top-level directory of this distribution.
  */
 
-define('MODX_MINIMUM_REQUIRED_PHP_VERSION', '7.2.5');
+define('MODX_MINIMUM_REQUIRED_PHP_VERSION', '7.4.0');
 define('MODX_REQUIRED_EXTENSIONS', [
     "curl",
     "dom",


### PR DESCRIPTION
### What does it do?
Drop support for PHP 7.2 and 7.3 and update minimum PHP version to 7.4 and recommended version to 8.0.0

### Why is it needed?
Reduce the amount of PHP versions we have to support, especially if they are End of Life. 
We can't drop support for 7.4 just yet because it's still widely in use.

### How to test
-

### Related issue(s)/PR(s)
Provide any issue that's addressed by this change in the format "Resolves #<issue number>", and mention other issues/pull requests with relevant information. 
