### PR TITLE
Fix TV sorting

### DIFF
--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -354,7 +354,7 @@ abstract class ResourceManagerController extends modManagerController
                     $c->select($this->modx->getSelectColumns(modTemplateVarResource::class, 'TemplateVarResource', '', ['value']));
                 }
                 $c->select($this->modx->getSelectColumns(modTemplateVarTemplate::class, 'TemplateVarTemplate', '', ['rank']));
-                $c->sortby('cat_category,TemplateVarTemplate.rank,modTemplateVar.rank', 'ASC');
+                $c->sortby('cat_category,modTemplateVar.rank', 'ASC');
                 $tvs = $this->modx->getCollection(modTemplateVar::class, $c);
 
                 $reloading = !empty($reloadData) && count($reloadData) > 0;


### PR DESCRIPTION
### What does it do?
Fix sorting of TVs in manager

### Why is it needed?
There is currently no user interface to manage ranks of `TemplateVarTemplate` (template!). Users can only manage the rank of the `modTemplateVar` itself. MODX should not sort by a value that a manager user can not manage.

### How to test
Specify the rank of TV in the TV edit view. Add more TVs to test. Verify sorting on the resource edit page in the TV tab.

### Related issue(s)/PR(s)
-
