### PR TITLE
Add IDs to toolbar elements

### DIFF
--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -8,6 +8,7 @@
  */
 MODx.grid.SettingsGrid = function(config) {
     config = config || {};
+    this.ident = config.ident || 'modx-ssg-' + Ext.id();
     this.exp = new Ext.grid.RowExpander({
         tpl : new Ext.XTemplate(
             '<p class="desc">{[MODx.util.safeHtml(values.description_trans)]}</p>'
@@ -30,6 +31,7 @@ MODx.grid.SettingsGrid = function(config) {
     '->'
     ,{
         xtype: 'modx-combo-namespace'
+        ,id: this.ident + '-filter-ns'
         ,itemId: 'filter-ns'
         ,emptyText: _('namespace_filter')
         ,allowBlank: false
@@ -66,6 +68,7 @@ MODx.grid.SettingsGrid = function(config) {
         }
     },{
         xtype: 'modx-combo-area'
+        ,id: this.ident + '-filter-area'
         ,itemId: 'filter-area'
         ,emptyText: _('area_filter')
         ,value: MODx.request.area || null
@@ -98,6 +101,7 @@ MODx.grid.SettingsGrid = function(config) {
         }
     },{
         xtype: 'textfield'
+        ,id: this.ident + '-filter-query'
         ,itemId: 'filter-query'
         ,emptyText: _('search')
         ,value: MODx.request.query ? decodeURIComponent(MODx.request.query) : ''
@@ -129,6 +133,7 @@ MODx.grid.SettingsGrid = function(config) {
         }
     },{
         text: _('filter_clear')
+        ,id: this.ident + '-filter-query'
         ,itemId: 'filter-clear'
         ,listeners: {
             click: {


### PR DESCRIPTION
### What does it do?
Add IDs to toolbar elements in MODx.grid.SettingsGrid

### Why is it needed?
If toolbar elements i.e. have to be hidden in a class that extends MODx.grid.SettingsGrid, Ext.getCmp needs an ID to access the toolbar element.

In #16089 the ID was removed. This PR fixes that, but with an ID that is variably set with the Ext.id of the current MODx.grid.SettingsGrid. This way multiple MODx.grid.SettingsGrid will not interfere with each other by using the same ID multiple times.

### How to test
At the moment only in Agenda. There I extended the code to get the right toolbar elements.

before:
```
            afterrender: function () {
                var filterNamespace = Ext.getCmp('modx-filter-namespace');
                if (filterNamespace) {
                    filterNamespace.hide();
                }
            }
```

after:
```
            afterrender: function (cmp) {
                var filterNamespace = Ext.getCmp('modx-filter-namespace');
                filterNamespace = filterNamespace || Ext.getCmp(cmp.ident + '-filter-ns');
                if (filterNamespace) {
                    filterNamespace.hide();
                }
            }
```

### Related issue(s)/PR(s)
#16089
