### PR TITLE
Fix PHP Fatal error: Cannot declare class modTemplateVarInputRenderText

### DIFF
--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -486,6 +486,7 @@ class modTemplateVar extends modElement
                 $className = $method == 'output' ? 'modTemplateVarOutputRenderText' : 'modTemplateVarInputRenderText';
                 if (!class_exists($className, false) && file_exists($p . 'text.class.php')) {
                     $className = include $p . 'text.class.php';
+                    $this->registerRenderMethod('text', $method, $className);
                 }
                 if (class_exists($className, false)) {
                     $render = new $className($this);


### PR DESCRIPTION
### What does it do?
It prevents the fallback render method/class to be loaded twice by registering it to the array cache to prevent double loading of the class.

### Why is it needed?
To fix a PHP Fatal error: Cannot declare class modTemplateVarInputRenderText.

### How to test
- Make sure you have a Template without TV's assigned to it.
- First create a TV with a valid Input type and assign it to the template.
- Create a second TV with Input Typ `text` and assign it to the template.
- Create a new resource with this Template
- Editing it works like expected
- Now adjust the first Template Variable via the database and give it an invalid input type.
- Edit the resource again 

### Related issue(s)/PR(s)
Resolves #16402