### PR TITLE
Fix Trash Manager infinite loading error

### DIFF
--- a/core/model/modx/processors/resource/trash/getlist.class.php
+++ b/core/model/modx/processors/resource/trash/getlist.class.php
@@ -56,6 +56,7 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
             $c->where(['modResource.id:IN' => $deleted]);
         } else {
             $c->where(['modResource.id' => 0]);
+            return $c;
         }
 
         if (!empty($query)) {

--- a/core/model/modx/processors/resource/trash/getlist.class.php
+++ b/core/model/modx/processors/resource/trash/getlist.class.php
@@ -55,7 +55,7 @@ class modResourceTrashGetListProcessor extends modObjectGetListProcessor
         if ($deleted = $this->getDeleted()) {
             $c->where(['modResource.id:IN' => $deleted]);
         } else {
-            return;
+            $c->where(['modResource.id' => 0]);
         }
 
         if (!empty($query)) {


### PR DESCRIPTION
### What is he doing?
Fixes the "infinite list loading" error.


### Where did this error come from?
https://github.com/modxcms/revolution/pull/16228
This change causes an error when starting the processor "resource/trash/getlist".


### How to test
Option 1: Delete the document and go to the trash. Then clean it. There will be an "infinite loading" of the list due to an error. Option 2: Go to the shopping cart and click on the "Update list" icon. There will be an "infinite loading" of the list due to an error.


### Decision
It is necessary to return the sorting so that the xPDOQuery object is returned
