### PR TITLE
Missing language string 'WebP' fills error log

### DIFF
--- a/core/lexicon/en/source.inc.php
+++ b/core/lexicon/en/source.inc.php
@@ -101,3 +101,4 @@ $_lang['prop_ftp.timeout_desc'] = 'Timeout for connection in seconds.';
 $_lang['PNG'] = 'PNG';
 $_lang['JPG'] = 'JPG';
 $_lang['GIF'] = 'GIF';
+$_lang['WebP'] = 'WebP';


### PR DESCRIPTION
The missing language string 'WebP' in source.inc.php fills the error log. See this forums post 
https://community.modx.com/t/strings-not-found-in-lexicon/6609

### What does it do?
Describe the technical changes you made.

### Why is it needed?
Describe the issue you are solving.

### How to test
Describe how to test the changes you made.

### Related issue(s)/PR(s)
Provide any issue that's addressed by this change in the format "Resolves #<issue number>", and mention other issues/pull requests with relevant information. 
