### PR TITLE
Bug fix "Form Customization" (Constraint)

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -621,10 +621,12 @@ class modTemplateVar extends modElement {
 
                     $constraintClass = $rule->get('constraint_class');
                     if (!empty($constraintClass)) {
-                        if (!($resource instanceof $constraintClass)) continue;
+                        if (empty($resource) || !($resource instanceof $constraintClass)) continue;
                         $constraintField = $rule->get('constraint_field');
                         $constraint = $rule->get('constraint');
-                        if ($resource->get($constraintField) != $constraint) {
+                        $constraintList = explode(',', $constraint);
+                        $constraintList = array_map('trim', $constraintList);
+                        if (($resource->get($constraintField) != $constraint) && (!in_array($resource->get($constraintField), $constraintList))) {
                             continue;
                         }
                     }


### PR DESCRIPTION
When using comma delimited list of constraints, customizations for TVs doesn't work.

Example setup:
- create any TV and assign it to template
- create FC with constraint field = id and constraint = 1,2
- Change Label for pagetitle (or any other field)
- Change Label for the previously created TV
- Open resource 1 or 2, pagetitle will have the new label set from FC, but TV won't


original content
---
In the "Form Customization" tool, in the rule settings, in the "Constraint" field, you can specify multiple ids separated by commas. The rule worked for all fields except TV.

I copied the code from here:
https://github.com/modxcms/revolution/blob/v2.8.4-pl/core/model/modx/modmanagercontroller.class.php#L840

