### PR TITLE
Update Smarty to 3.1.48

### DIFF
--- a/core/model/modx/smarty/modsmarty.class.php
+++ b/core/model/modx/smarty/modsmarty.class.php
@@ -74,7 +74,7 @@ class modSmarty extends SmartyBC {
 
         $this->_blocks = array();
         $this->_derived = null;
-        
+
         $this->muteExpectedErrors();
     }
 
@@ -91,7 +91,7 @@ class modSmarty extends SmartyBC {
             $this->modx->getCacheManager();
             $this->modx->cacheManager->writeTree($path);
         }
-        $this->compile_dir = $path;
+        $this->setCompileDir($path);
     }
 
     /**

--- a/core/model/smarty/Smarty.class.php
+++ b/core/model/smarty/Smarty.class.php
@@ -111,7 +111,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * smarty version
      */
-    const SMARTY_VERSION = '3.1.44';
+    const SMARTY_VERSION = '3.1.48';
     /**
      * define variable scopes
      */

--- a/core/model/smarty/plugins/function.html_select_date.php
+++ b/core/model/smarty/plugins/function.html_select_date.php
@@ -101,6 +101,7 @@ function smarty_function_html_select_date($params, Smarty_Internal_Template $tem
     $field_separator = "\n";
     $option_separator = "\n";
     $time = null;
+
     // $all_empty = null;
     // $day_empty = null;
     // $month_empty = null;
@@ -113,17 +114,7 @@ function smarty_function_html_select_date($params, Smarty_Internal_Template $tem
     foreach ($params as $_key => $_value) {
         switch ($_key) {
             case 'time':
-                if (!is_array($_value) && $_value !== null) {
-                    $template->_checkPlugins(
-                        array(
-                            array(
-                                'function' => 'smarty_make_timestamp',
-                                'file'     => SMARTY_PLUGINS_DIR . 'shared.make_timestamp.php'
-                            )
-                        )
-                    );
-                    $time = smarty_make_timestamp($_value);
-                }
+                $$_key = $_value; // we'll handle conversion below
                 break;
             case 'month_names':
                 if (is_array($_value) && count($_value) === 12) {
@@ -178,43 +169,59 @@ function smarty_function_html_select_date($params, Smarty_Internal_Template $tem
     }
     // Note: date() is faster than strftime()
     // Note: explode(date()) is faster than date() date() date()
-    if (isset($params[ 'time' ]) && is_array($params[ 'time' ])) {
-        if (isset($params[ 'time' ][ $prefix . 'Year' ])) {
+
+    if (isset($time) && is_array($time)) {
+        if (isset($time[$prefix . 'Year'])) {
             // $_REQUEST[$field_array] given
             foreach (array(
-                'Y' => 'Year',
-                'm' => 'Month',
-                'd' => 'Day'
-            ) as $_elementKey => $_elementName) {
+                         'Y' => 'Year',
+                         'm' => 'Month',
+                         'd' => 'Day'
+                     ) as $_elementKey => $_elementName) {
                 $_variableName = '_' . strtolower($_elementName);
                 $$_variableName =
-                    isset($params[ 'time' ][ $prefix . $_elementName ]) ? $params[ 'time' ][ $prefix . $_elementName ] :
+                    isset($time[$prefix . $_elementName]) ? $time[$prefix . $_elementName] :
                         date($_elementKey);
             }
-        } elseif (isset($params[ 'time' ][ $field_array ][ $prefix . 'Year' ])) {
+        } elseif (isset($time[$field_array][$prefix . 'Year'])) {
             // $_REQUEST given
             foreach (array(
-                'Y' => 'Year',
-                'm' => 'Month',
-                'd' => 'Day'
-            ) as $_elementKey => $_elementName) {
+                         'Y' => 'Year',
+                         'm' => 'Month',
+                         'd' => 'Day'
+                     ) as $_elementKey => $_elementName) {
                 $_variableName = '_' . strtolower($_elementName);
-                $$_variableName = isset($params[ 'time' ][ $field_array ][ $prefix . $_elementName ]) ?
-                    $params[ 'time' ][ $field_array ][ $prefix . $_elementName ] : date($_elementKey);
+                $$_variableName = isset($time[$field_array][$prefix . $_elementName]) ?
+                    $time[$field_array][$prefix . $_elementName] : date($_elementKey);
             }
         } else {
             // no date found, use NOW
-            list($_year, $_month, $_day) = $time = explode('-', date('Y-m-d'));
+            list($_year, $_month, $_day) = explode('-', date('Y-m-d'));
         }
+    } elseif (isset($time) && preg_match("/(\d*)-(\d*)-(\d*)/", $time, $matches)) {
+        $_year = $_month = $_day = null;
+        if ($matches[1] > '') $_year = (int) $matches[1];
+        if ($matches[2] > '') $_month = (int) $matches[2];
+        if ($matches[3] > '') $_day = (int) $matches[3];
     } elseif ($time === null) {
         if (array_key_exists('time', $params)) {
-            $_year = $_month = $_day = $time = null;
+            $_year = $_month = $_day = null;
         } else {
-            list($_year, $_month, $_day) = $time = explode('-', date('Y-m-d'));
+            list($_year, $_month, $_day) = explode('-', date('Y-m-d'));
         }
     } else {
-        list($_year, $_month, $_day) = $time = explode('-', date('Y-m-d', $time));
+        $template->_checkPlugins(
+            array(
+                array(
+                    'function' => 'smarty_make_timestamp',
+                    'file'     => SMARTY_PLUGINS_DIR . 'shared.make_timestamp.php'
+                )
+            )
+        );
+        $time = smarty_make_timestamp($time);
+	    list($_year, $_month, $_day) = explode('-', date('Y-m-d', $time));
     }
+
     // make syntax "+N" or "-N" work with $start_year and $end_year
     // Note preg_match('!^(\+|\-)\s*(\d+)$!', $end_year, $match) is slower than trim+substr
     foreach (array(

--- a/core/model/smarty/plugins/function.mailto.php
+++ b/core/model/smarty/plugins/function.mailto.php
@@ -48,8 +48,13 @@
  */
 function smarty_function_mailto($params)
 {
-    static $_allowed_encoding =
-        array('javascript' => true, 'javascript_charcode' => true, 'hex' => true, 'none' => true);
+    static $_allowed_encoding = array(
+        'javascript' => true,
+        'javascript_charcode' => true,
+        'hex' => true,
+        'none' => true
+    );
+
     $extra = '';
     if (empty($params[ 'address' ])) {
         trigger_error("mailto: missing 'address' parameter", E_USER_WARNING);
@@ -57,11 +62,11 @@ function smarty_function_mailto($params)
     } else {
         $address = $params[ 'address' ];
     }
+
     $text = $address;
+
     // netscape and mozilla do not decode %40 (@) in BCC field (bug?)
     // so, don't encode it.
-    $search = array('%40', '%2C');
-    $replace = array('@', ',');
     $mail_parms = array();
     foreach ($params as $var => $value) {
         switch ($var) {
@@ -69,7 +74,7 @@ function smarty_function_mailto($params)
             case 'bcc':
             case 'followupto':
                 if (!empty($value)) {
-                    $mail_parms[] = $var . '=' . str_replace($search, $replace, rawurlencode($value));
+                    $mail_parms[] = $var . '=' . str_replace(array('%40', '%2C'), array('@', ','), rawurlencode($value));
                 }
                 break;
             case 'subject':
@@ -83,6 +88,7 @@ function smarty_function_mailto($params)
             default:
         }
     }
+
     if ($mail_parms) {
         $address .= '?' . join('&', $mail_parms);
     }
@@ -94,19 +100,26 @@ function smarty_function_mailto($params)
         );
         return;
     }
+
+    $flags = ENT_QUOTES;
+    if (defined('ENT_SUBSTITUTE') && defined('ENT_HTML401')) {
+        $flags |= ENT_SUBSTITUTE | ENT_HTML401;
+    }
+
+    $string = '<a href="mailto:' . htmlspecialchars($address, $flags, Smarty::$_CHARSET) .
+        '" ' . $extra . '>' . htmlspecialchars($text, $flags, Smarty::$_CHARSET) . '</a>';
+
     if ($encode === 'javascript') {
-	    $string = '<a href="mailto:' . $address . '" ' . $extra . '>' . $text . '</a>';
         $js_encode = '';
         for ($x = 0, $_length = strlen($string); $x < $_length; $x++) {
             $js_encode .= '%' . bin2hex($string[ $x ]);
         }
         return '<script type="text/javascript">document.write(unescape(\'' . $js_encode . '\'))</script>';
     } elseif ($encode === 'javascript_charcode') {
-        $string = '<a href="mailto:' . $address . '" ' . $extra . '>' . $text . '</a>';
         for ($x = 0, $_length = strlen($string); $x < $_length; $x++) {
             $ord[] = ord($string[ $x ]);
         }
-	    return '<script type="text/javascript">document.write(String.fromCharCode(' . implode(',', $ord) . '))</script>';
+        return '<script type="text/javascript">document.write(String.fromCharCode(' . implode(',', $ord) . '))</script>';
     } elseif ($encode === 'hex') {
         preg_match('!^(.*)(\?.*)$!', $address, $match);
         if (!empty($match[ 2 ])) {
@@ -129,6 +142,6 @@ function smarty_function_mailto($params)
         return '<a href="' . $mailto . $address_encode . '" ' . $extra . '>' . $text_encode . '</a>';
     } else {
         // no encoding
-        return '<a href="mailto:' . $address . '" ' . $extra . '>' . $text . '</a>';
+        return $string;
     }
 }

--- a/core/model/smarty/plugins/function.math.php
+++ b/core/model/smarty/plugins/function.math.php
@@ -69,8 +69,8 @@ function smarty_function_math($params, $template)
     // Adapted from https://www.php.net/manual/en/function.eval.php#107377
     $number = '(?:\d+(?:[,.]\d+)?|pi|π)'; // What is a number
     $functionsOrVars = '((?:0x[a-fA-F0-9]+)|([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*))';
-    $operators = '[+\/*\^%-]'; // Allowed math operators
-    $regexp = '/^(('.$number.'|'.$functionsOrVars.'|('.$functionsOrVars.'\s*\((?1)+\)|\((?1)+\)))(?:'.$operators.'(?1))?)+$/';
+    $operators = '[,+\/*\^%-]'; // Allowed math operators
+    $regexp = '/^(('.$number.'|'.$functionsOrVars.'|('.$functionsOrVars.'\s*\((?1)*\)|\((?1)*\)))(?:'.$operators.'(?1))?)+$/';
 
     if (!preg_match($regexp, $equation)) {
         trigger_error("math: illegal characters", E_USER_WARNING);

--- a/core/model/smarty/plugins/modifier.escape.php
+++ b/core/model/smarty/plugins/modifier.escape.php
@@ -188,7 +188,9 @@ function smarty_modifier_escape($string, $esc_type = 'html', $char_set = null, $
                     // see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
                     '<!--' => '<\!--',
                     '<s'   => '<\s',
-                    '<S'   => '<\S'
+                    '<S'   => '<\S',
+	                "`" => "\\\\`",
+	                "\${" => "\\\\\\$\\{"
                 )
             );
         case 'mail':

--- a/core/model/smarty/plugins/modifiercompiler.escape.php
+++ b/core/model/smarty/plugins/modifiercompiler.escape.php
@@ -92,7 +92,9 @@ function smarty_modifiercompiler_escape($params, Smarty_Internal_TemplateCompile
                 // see https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
                 return 'strtr(' .
                        $params[ 0 ] .
-                       ', array("\\\\" => "\\\\\\\\", "\'" => "\\\\\'", "\"" => "\\\\\"", "\\r" => "\\\\r", "\\n" => "\\\n", "</" => "<\/", "<!--" => "<\!--", "<s" => "<\s", "<S" => "<\S" ))';
+                       ', array("\\\\" => "\\\\\\\\", "\'" => "\\\\\'", "\"" => "\\\\\"", "\\r" => "\\\\r", 
+                       "\\n" => "\\\n", "</" => "<\/", "<!--" => "<\!--", "<s" => "<\s", "<S" => "<\S",
+                       "`" => "\\\\`", "\${" => "\\\\\\$\\{"))';
         }
     } catch (SmartyException $e) {
         // pass through to regular plugin fallback

--- a/core/model/smarty/plugins/modifiercompiler.unescape.php
+++ b/core/model/smarty/plugins/modifiercompiler.unescape.php
@@ -14,20 +14,28 @@
  * @author Rodney Rehm
  *
  * @param array $params parameters
+ * @param Smarty_Internal_TemplateCompilerBase $compiler
  *
  * @return string with compiled code
  */
-function smarty_modifiercompiler_unescape($params)
+function smarty_modifiercompiler_unescape($params, Smarty_Internal_TemplateCompilerBase $compiler)
 {
-    if (!isset($params[ 1 ])) {
-        $params[ 1 ] = 'html';
-    }
+    $compiler->template->_checkPlugins(
+        array(
+            array(
+                'function' => 'smarty_literal_compiler_param',
+                'file'     => SMARTY_PLUGINS_DIR . 'shared.literal_compiler_param.php'
+            )
+        )
+    );
+
+    $esc_type = smarty_literal_compiler_param($params, 1, 'html');
+
     if (!isset($params[ 2 ])) {
         $params[ 2 ] = '\'' . addslashes(Smarty::$_CHARSET) . '\'';
-    } else {
-        $params[ 2 ] = "'{$params[ 2 ]}'";
     }
-    switch (trim($params[ 1 ], '"\'')) {
+
+    switch ($esc_type) {
         case 'entity':
         case 'htmlall':
             if (Smarty::$_MBSTRING) {

--- a/core/model/smarty/plugins/shared.mb_str_replace.php
+++ b/core/model/smarty/plugins/shared.mb_str_replace.php
@@ -44,9 +44,43 @@ if (!function_exists('smarty_mb_str_replace')) {
                 }
             }
         } else {
+            $mb_reg_charset = mb_regex_encoding();
+            // Check if mbstring regex is using UTF-8
+            $reg_is_unicode = !strcasecmp($mb_reg_charset, "UTF-8");
+            if(!$reg_is_unicode) {
+                // ...and set to UTF-8 if not
+                mb_regex_encoding("UTF-8");
+            }
+
+            // See if charset used by Smarty is matching one used by regex...
+            $current_charset = mb_regex_encoding();
+            $convert_result = (bool)strcasecmp(Smarty::$_CHARSET, $current_charset);
+            if($convert_result) {
+                // ...convert to it if not.
+                $subject = mb_convert_encoding($subject, $current_charset, Smarty::$_CHARSET);
+                $search = mb_convert_encoding($search, $current_charset, Smarty::$_CHARSET);
+                $replace = mb_convert_encoding($replace, $current_charset, Smarty::$_CHARSET);
+            }
+
             $parts = mb_split(preg_quote($search), $subject);
+            // If original regex encoding was not unicode...
+            if(!$reg_is_unicode) {
+                // ...restore original regex encoding to avoid breaking the system.
+                mb_regex_encoding($mb_reg_charset);
+            }
+            if($parts === false) {
+                // This exception is thrown if call to mb_split failed.
+                // Usually it happens, when $search or $replace are not valid for given mb_regex_encoding().
+                // There may be other cases for it to fail, please file an issue if you find a reproducible one.
+                throw new SmartyException("Source string is not a valid $current_charset sequence (probably)");
+            }
+
             $count = count($parts) - 1;
             $subject = implode($replace, $parts);
+            // Convert results back to charset used by Smarty, if needed.
+            if($convert_result) {
+                $subject = mb_convert_encoding($subject, Smarty::$_CHARSET, $current_charset);
+            }
         }
         return $subject;
     }

--- a/core/model/smarty/sysplugins/smarty_internal_compile_block.php
+++ b/core/model/smarty/sysplugins/smarty_internal_compile_block.php
@@ -125,7 +125,7 @@ class Smarty_Internal_Compile_Blockclose extends Smarty_Internal_Compile_Shared_
         // setup buffer for template function code
         $compiler->parser->current_buffer = new Smarty_Internal_ParseTree_Template();
         $output = "<?php\n";
-        $output .= "/* {block {$_name}} */\n";
+        $output .= $compiler->cStyleComment(" {block {$_name}} ") . "\n";
         $output .= "class {$_className} extends Smarty_Internal_Block\n";
         $output .= "{\n";
         foreach ($_block as $property => $value) {
@@ -155,7 +155,7 @@ class Smarty_Internal_Compile_Blockclose extends Smarty_Internal_Compile_Shared_
         }
         $output .= "}\n";
         $output .= "}\n";
-        $output .= "/* {/block {$_name}} */\n\n";
+        $output .= $compiler->cStyleComment(" {/block {$_name}} ") . "\n\n";
         $output .= "?>\n";
         $compiler->parser->current_buffer->append_subtree(
             $compiler->parser,

--- a/core/model/smarty/sysplugins/smarty_internal_compile_function.php
+++ b/core/model/smarty/sysplugins/smarty_internal_compile_function.php
@@ -134,7 +134,7 @@ class Smarty_Internal_Compile_Functionclose extends Smarty_Internal_CompileBase
         if ($compiler->template->compiled->has_nocache_code) {
             $compiler->parent_compiler->tpl_function[ $_name ][ 'call_name_caching' ] = $_funcNameCaching;
             $output = "<?php\n";
-            $output .= "/* {$_funcNameCaching} */\n";
+            $output .= $compiler->cStyleComment(" {$_funcNameCaching} ") . "\n";
             $output .= "if (!function_exists('{$_funcNameCaching}')) {\n";
             $output .= "function {$_funcNameCaching} (Smarty_Internal_Template \$_smarty_tpl,\$params) {\n";
             $output .= "ob_start();\n";
@@ -159,7 +159,7 @@ class Smarty_Internal_Compile_Functionclose extends Smarty_Internal_CompileBase
             $output .= "/*/%%SmartyNocache:{$compiler->template->compiled->nocache_hash}%%*/\";\n?>";
             $output .= "<?php echo str_replace('{$compiler->template->compiled->nocache_hash}', \$_smarty_tpl->compiled->nocache_hash, ob_get_clean());\n";
             $output .= "}\n}\n";
-            $output .= "/*/ {$_funcName}_nocache */\n\n";
+            $output .= $compiler->cStyleComment("/ {$_funcName}_nocache ") . "\n\n";
             $output .= "?>\n";
             $compiler->parser->current_buffer->append_subtree(
                 $compiler->parser,
@@ -179,7 +179,7 @@ class Smarty_Internal_Compile_Functionclose extends Smarty_Internal_CompileBase
         }
         $compiler->parent_compiler->tpl_function[ $_name ][ 'call_name' ] = $_funcName;
         $output = "<?php\n";
-        $output .= "/* {$_funcName} */\n";
+        $output .= $compiler->cStyleComment(" {$_funcName} ") . "\n";
         $output .= "if (!function_exists('{$_funcName}')) {\n";
         $output .= "function {$_funcName}(Smarty_Internal_Template \$_smarty_tpl,\$params) {\n";
         $output .= $_paramsCode;
@@ -196,7 +196,7 @@ class Smarty_Internal_Compile_Functionclose extends Smarty_Internal_CompileBase
         );
         $compiler->parser->current_buffer->append_subtree($compiler->parser, $_functionCode);
         $output = "<?php\n}}\n";
-        $output .= "/*/ {$_funcName} */\n\n";
+        $output .= $compiler->cStyleComment("/ {$_funcName} ") . "\n\n";
         $output .= "?>\n";
         $compiler->parser->current_buffer->append_subtree(
             $compiler->parser,

--- a/core/model/smarty/sysplugins/smarty_internal_compile_include.php
+++ b/core/model/smarty/sysplugins/smarty_internal_compile_include.php
@@ -318,14 +318,14 @@ class Smarty_Internal_Compile_Include extends Smarty_Internal_CompileBase
             }
             // get compiled code
             $compiled_code = "<?php\n\n";
-            $compiled_code .= "/* Start inline template \"{$sourceInfo}\" =============================*/\n";
+            $compiled_code .= $compiler->cStyleComment(" Start inline template \"{$sourceInfo}\" =============================") . "\n";
             $compiled_code .= "function {$tpl->compiled->unifunc} (Smarty_Internal_Template \$_smarty_tpl) {\n";
             $compiled_code .= "?>\n" . $tpl->compiler->compileTemplateSource($tpl, null, $compiler->parent_compiler);
             $compiled_code .= "<?php\n";
             $compiled_code .= "}\n?>\n";
             $compiled_code .= $tpl->compiler->postFilter($tpl->compiler->blockOrFunctionCode);
             $compiled_code .= "<?php\n\n";
-            $compiled_code .= "/* End inline template \"{$sourceInfo}\" =============================*/\n";
+            $compiled_code .= $compiler->cStyleComment(" End inline template \"{$sourceInfo}\" =============================") . "\n";
             $compiled_code .= '?>';
             unset($tpl->compiler);
             if ($tpl->compiled->has_nocache_code) {

--- a/core/model/smarty/sysplugins/smarty_internal_config_file_compiler.php
+++ b/core/model/smarty/sysplugins/smarty_internal_config_file_compiler.php
@@ -157,10 +157,12 @@ class Smarty_Internal_Config_File_Compiler
             $this->smarty->_debug->end_compile($this->template);
         }
         // template header code
-        $template_header =
-            "<?php /* Smarty version " . Smarty::SMARTY_VERSION . ", created on " . strftime("%Y-%m-%d %H:%M:%S") .
-            "\n";
-        $template_header .= "         compiled from '{$this->template->source->filepath}' */ ?>\n";
+        $template_header = sprintf(
+            "<?php /* Smarty version %s, created on %s\n         compiled from '%s' */ ?>\n",
+            Smarty::SMARTY_VERSION,
+            date("Y-m-d H:i:s"),
+            str_replace('*/', '* /' , $this->template->source->filepath)
+        );
         $code = '<?php $_smarty_tpl->smarty->ext->configLoad->_loadConfigVars($_smarty_tpl, ' .
                 var_export($this->config_data, true) . '); ?>';
         return $template_header . $this->template->smarty->ext->_codeFrame->create($this->template, $code);

--- a/core/model/smarty/sysplugins/smarty_internal_runtime_codeframe.php
+++ b/core/model/smarty/sysplugins/smarty_internal_runtime_codeframe.php
@@ -44,9 +44,12 @@ class Smarty_Internal_Runtime_CodeFrame
             $properties[ 'file_dependency' ] = $_template->cached->file_dependency;
             $properties[ 'cache_lifetime' ] = $_template->cache_lifetime;
         }
-        $output = "<?php\n";
-        $output .= "/* Smarty version {$properties[ 'version' ]}, created on " . strftime("%Y-%m-%d %H:%M:%S") .
-                   "\n  from '" . str_replace('*/', '* /', $_template->source->filepath) . "' */\n\n";
+        $output = sprintf(
+            "<?php\n/* Smarty version %s, created on %s\n  from '%s' */\n\n",
+            $properties[ 'version' ],
+            date("Y-m-d H:i:s"),
+            str_replace('*/', '* /', $_template->source->filepath)
+        );
         $output .= "/* @var Smarty_Internal_Template \$_smarty_tpl */\n";
         $dec = "\$_smarty_tpl->_decodeProperties(\$_smarty_tpl, " . var_export($properties, true) . ',' .
                ($cache ? 'true' : 'false') . ')';

--- a/core/model/smarty/sysplugins/smarty_internal_templatebase.php
+++ b/core/model/smarty/sysplugins/smarty_internal_templatebase.php
@@ -246,7 +246,15 @@ abstract class Smarty_Internal_TemplateBase extends Smarty_Internal_Data
                 error_reporting($_smarty_old_error_level);
             }
             return $result;
-        } catch (Exception $e) {
+        } catch (Exception $e) { // PHP 5.x specific
+            while (ob_get_level() > $level) {
+                ob_end_clean();
+            }
+            if (isset($_smarty_old_error_level)) {
+                error_reporting($_smarty_old_error_level);
+            }
+            throw $e;
+        } catch (Throwable $e) { // For PHP ^7.0 this can also catch Errors
             while (ob_get_level() > $level) {
                 ob_end_clean();
             }

--- a/core/model/smarty/sysplugins/smarty_internal_templatecompilerbase.php
+++ b/core/model/smarty/sysplugins/smarty_internal_templatecompilerbase.php
@@ -1455,6 +1455,10 @@ abstract class Smarty_Internal_TemplateCompilerBase
      */
     abstract protected function doCompile($_content, $isTemplateSource = false);
 
+    public function cStyleComment($string) {
+        return '/*' . str_replace('*/', '* /' , $string) . '*/';
+    }
+
     /**
      * Compile Tag
      *


### PR DESCRIPTION
### What does it do?
Update the Smarty class to 3.1.48 in MODX Revolution 2.x

### Why is it needed?
Deprecation issues being logged on PHP 8+. 

### How to test
General navigation through the manager should result in the error log containing warnings and deprecation notices as a result of the Smarty class. 
E.g.
```
/www/core/model/smarty/sysplugins/smarty_internal_runtime_codeframe.php PHP deprecated: Function strftime() is deprecated
```

### Not quite good enough
Unfortunately, this doesn't fix the warnings. Smarty 3.x is geared towards PHP 5.2 - 7.4, and the warnings are fixed in the updated version of Smarty 4.x.  However, Smarty 4.x doesn't support PHP < 7.2, which MODX Revo 2.x currently has as the target. The only way to really get rid of the warnings in 2.x while supporting older versions of PHP is to unfortunately modify your error handler or start customizing the Smarty code and deviate from the provided library. 

### Related issue(s)/PR(s)
Related to issue #15792 but unable to fully fix that.

