### PR TITLE
Fix undefined global variable $_SESSION in a CLI connector

### DIFF
--- a/core/src/Revolution/modConnectorRequest.php
+++ b/core/src/Revolution/modConnectorRequest.php
@@ -38,7 +38,7 @@ class modConnectorRequest extends modManagerRequest
         if ($this->modx && is_object($this->modx->context) && $this->modx->context instanceof modContext) {
             $ctx = $this->modx->context->get('key');
             if (!empty($ctx) && $ctx == 'mgr') {
-                $ml = $this->modx->getOption('manager_language', $_SESSION,
+                $ml = $this->modx->getOption('manager_language', $_SESSION ?? [],
                     $this->modx->getOption('cultureKey', null, 'en'));
                 if (!empty($ml)) {
                     $this->modx->setOption('cultureKey', $ml);


### PR DESCRIPTION
### What does it do?
Use an empty array, if the global $_SESSION variable does not exist

### Why is it needed?
Fix the warning `(ERROR @ /www/core/src/Revolution/modConnectorRequest.php : 41) PHP warning: Undefined global variable $_SESSION`, when a connector is called via CLI. The issue occurred first with the more strict checks of PHP 8.

### How to test
It currently occurs with CronManager, when `assets/components/cronmanager/cron.php` is executed by CLI. Agenda has the same issue.

### Related issue(s)/PR(s)
None known.