### PR TITLE
Fix undefined global variable $_SESSION in a CLI connector (#16422)

### DIFF
--- a/core/model/modx/modconnectorrequest.class.php
+++ b/core/model/modx/modconnectorrequest.class.php
@@ -33,7 +33,8 @@ class modConnectorRequest extends modManagerRequest {
         if ($this->modx && is_object($this->modx->context) && $this->modx->context instanceof modContext) {
             $ctx = $this->modx->context->get('key');
             if (!empty($ctx) && $ctx == 'mgr') {
-                $ml = $this->modx->getOption('manager_language',null,$this->modx->getOption('cultureKey',null,'en'));
+                $ml = $this->modx->getOption('manager_language', isset($_SESSION) ? $_SESSION : [],
+                    $this->modx->getOption('cultureKey', null, 'en'));
                 if (!empty($ml)) {
                     $this->modx->setOption('cultureKey',$ml);
                 }


### PR DESCRIPTION
### What does it do?
Use an empty array, if the global $_SESSION variable does not exist

### Why is it needed?
Fix the warning `PHP warning: Undefined global variable $_SESSION`, when a connector is called via CLI. The issue occurred first with the more strict checks of PHP 8.

### How to test
It currently occurs with CronManager, when `assets/components/cronmanager/cron.php` is executed by CLI. Agenda has the same issue.

### Related issue(s)/PR(s)
This is a port of #16422 to 2.x