### PR TITLE
Fix undefined variable error in Template Variable class

### DIFF
--- a/core/model/modx/modtemplatevar.class.php
+++ b/core/model/modx/modtemplatevar.class.php
@@ -990,9 +990,9 @@ class modTemplateVar extends modElement {
         $enabled = ($catEnabled || $rgEnabled);
         if ($enabled) {
             if (empty($this->_policies) || !isset($this->_policies[$context])) {
+                $policyTable = $this->xpdo->getTableName('modAccessPolicy');
                 if ($rgEnabled) {
                     $accessTable = $this->xpdo->getTableName('modAccessResourceGroup');
-                    $policyTable = $this->xpdo->getTableName('modAccessPolicy');
                     $resourceGroupTable = $this->xpdo->getTableName('modTemplateVarResourceGroup');
                     $sql = "SELECT Acl.target, Acl.principal, Acl.authority, Acl.policy, Policy.data FROM {$accessTable} Acl " .
                             "LEFT JOIN {$policyTable} Policy ON Policy.id = Acl.policy " .


### PR DESCRIPTION
### What does it do?
Move `$policyTable` statement up in scope to avoid error that occurs when `$rgEnabled` (~L993) is false and `$catEnabled` (~L1019) is true.

### Why is it needed?
In certain scenarios the condition above happens and the error log can quickly fill up with the following warning:
`[...server_path]/core/model/modx/modtemplatevar.class.php : 1023) PHP warning: Undefined variable $policyTable`

### How to test
It's a bit of a needle in the haystack, so I don't have a suggested way to trigger the problematic condition. However, logically, the change made should be done regardless.

### Related issue(s)/PR(s)
None.
