### PR TITLE
Send all args to provider download endpoints

### DIFF
--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -414,10 +414,9 @@ class modTransportProvider extends xPDOSimpleObject
 
         $uri = $location;
         $uri .= (strpos($uri, '?') > 0) ? '&' : '?';
-        $uri .= http_build_query([
-            'revolution_version' => $this->arg('revolution_version', $this->args($args)),
+        $uri .= http_build_query(array_merge($this->args($args), [
             'getUrl' => true,
-        ]);
+        ]));
         $request = $requestFactory->createRequest('GET', $uri)
             ->withHeader('Accept', 'text/plain');
 

--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -376,13 +376,13 @@ class modTransportProvider extends xPDOSimpleObject
                 'createdon' => (string)$package->createdon,
                 'editedon' => (string)$package->editedon,
                 'name' => (string)$package->name,
-                'downloads' => number_format((integer)$package->downloads, 0),
+                'downloads' => number_format((int)$package->downloads, 0),
                 'releasedon' => $releasedon,
                 'screenshot' => (string)$package->screenshot,
                 'thumbnail' => !empty($package->thumbnail) ? (string)$package->thumbnail : (string)$package->screenshot,
                 'license' => (string)$package->license,
                 'minimum_supports' => (string)$package->minimum_supports,
-                'breaks_at' => (integer)$package->breaks_at != 10000000 ? (string)$package->breaks_at : '',
+                'breaks_at' => (int)$package->breaks_at != 10000000 ? (string)$package->breaks_at : '',
                 'supports_db' => (string)$package->supports_db,
                 'location' => (string)$package->location,
                 'version-compiled' => $versionCompiled,
@@ -414,9 +414,11 @@ class modTransportProvider extends xPDOSimpleObject
 
         $uri = $location;
         $uri .= (strpos($uri, '?') > 0) ? '&' : '?';
-        $uri .= http_build_query(array_merge($this->args($args), [
-            'getUrl' => true,
-        ]));
+        $uri .= http_build_query(
+            array_merge($this->args($args), [
+                'getUrl' => true,
+            ])
+        );
         $request = $requestFactory->createRequest('GET', $uri)
             ->withHeader('Accept', 'text/plain');
 
@@ -467,8 +469,11 @@ class modTransportProvider extends xPDOSimpleObject
             'supports' => $this->xpdo->version['code_name'] . '-' . $this->xpdo->version['full_version'],
             'http_host' => $this->xpdo->getOption('http_host'),
             'php_version' => PHP_VERSION,
-            'language' => $this->xpdo->getOption('manager_language', $_SESSION,
-                $this->xpdo->getOption('cultureKey', null, 'en')),
+            'language' => $this->xpdo->getOption(
+                'manager_language',
+                $_SESSION,
+                $this->xpdo->getOption('cultureKey', null, 'en')
+            ),
         ];
 
         return array_merge($baseArgs, $args);


### PR DESCRIPTION
### What does it do?
Sends all of the arguments sent to other provider endpoints to the download endpoint.

### Why is it needed?
The UUID and other important information were not sent to provider download endpoints (seemingly the only endpoint not receiving these arguments). Having that information can be useful to a package provider implementation.

### How to test
Provider implementation owners can validate that `uuid` and the other arguments sent to most provider endpoints are being received on download endpoint requests.

### Related issue(s)/PR(s)
N/A