### PR TITLE
Add namespaces partition to cache refresh process

### DIFF
--- a/core/src/Revolution/Processors/System/ClearCache.php
+++ b/core/src/Revolution/Processors/System/ClearCache.php
@@ -133,6 +133,7 @@ class ClearCache extends Processor
 
         $partitions['system_settings'] = [];
         $partitions['context_settings'] = ['contexts' => $contextKeys];
+        $partitions['namespaces'] = [];
 
         if ($this->modx->getOption('cache_db', null, false)) {
             $partitions['db'] = [];

--- a/core/src/Revolution/modCacheManager.php
+++ b/core/src/Revolution/modCacheManager.php
@@ -580,6 +580,7 @@ class modCacheManager extends xPDOCacheManager
                 'auto_publish' => ['contexts' => array_diff($contexts, ['mgr'])],
                 'system_settings' => [],
                 'context_settings' => ['contexts' => $contexts],
+                'namespaces' => [],
                 'db' => [],
                 'media_sources' => [],
                 'lexicon_topics' => [],


### PR DESCRIPTION
### What does it do?
Ensures that the namespaces cache partition is refreshed when modCacheManager::refresh() is called without specific partitions and that the ClearCache processor includes the namespaces partition.

### Why is it needed?
The namespaces cache partition was not being refreshed which caused problems when injecting teleport snapshots or other processes that affect namespaces when xPDO::OPT_SETUP is enabled.

### How to test
Inject a snapshot with teleport that includes various namespaces in 3.x that add their component src directories to the autoloader. Ensure that those components work after injection without manually deleting the cache directory or reinstalling MODX.

### Related issue(s)/PR(s)
N/A