### PR TITLE
Avoid errors and incorrect listings in Trash Manager

### DIFF
--- a/core/src/Revolution/Processors/Resource/Trash/GetList.php
+++ b/core/src/Revolution/Processors/Resource/Trash/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -111,7 +112,9 @@ class GetList extends GetListProcessor
         // this is a strange workaround: obviously we can access the resources even if we don't have access to the context! Check that
         // TODO check if that is the same for resource groups
         $context = $this->modx->getContext($object->get('context_key'));
-        if (!$context) return [];
+        if (!$context) {
+            return [];
+        }
 
         $charset = $this->modx->getOption('modx_charset', null, 'UTF-8');
         $objectArray = $object->toArray();
@@ -129,17 +132,16 @@ class GetList extends GetListProcessor
             if ($parentObject) {
                 $parents[] = $parentObject;
                 $parent = $parentObject->get('parent');
-            }
-            else {
+            } else {
                 break;
             }
         }
 
-        $parentPath = "";
+        $parentPath = '';
         foreach ($parents as $parent) {
-            $parentPath = $parent->get('pagetitle') . " (" . $parent->get('id') . ") > " . $parentPath;
+            $parentPath = $parent->get('pagetitle') . ' (' . $parent->get('id') . ') > ' . $parentPath;
         }
-        $objectArray['parentPath'] = "[" . $objectArray['context_key'] . "] " . $parentPath;
+        $objectArray['parentPath'] = '[' . $objectArray['context_key'] . '] ' . $parentPath;
 
         //  TODO implement permission checks for every resource and return only resources user is allowed to see
 


### PR DESCRIPTION
### What does it do?
Changed where condition to correctly group `$query` search targets (pagetitle | longtitle) and perform early return of criteria if no deletable resources exist.

### Why is it needed?
Ensures the trash manager list only shows deleted items when additional filtering is applied.

### How to test
Clear all caches and experiment with deleting resources and purging them in the trash manager. Also, use the search field in the trash manager to verify all works as expected.

### Related issue(s)/PR(s)
Provides a more reliable solution attempted in #16228 and avoids the issue #16415 is trying to solve. Note that while both #16228 and #16415 are targeted to 2.x, the `prepareQueryBeforeCount` in the changed `GetList` processor is identical for both 2.x and 3.x, so this solution can be directly backported.
