### PR TITLE
Update subMenuBuilder so "installer-entry" is always at the top [v3.x]

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1073,6 +1073,15 @@ $settings['modx_charset']->fromArray([
   'area' => 'language',
   'editedon' => null,
 ], '', true, true);
+$settings['package_installer_at_top'] = $xpdo->newObject('modSystemSetting');
+$settings['package_installer_at_top']->fromArray(array (
+  'key' => 'package_installer_at_top',
+  'value' => true,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+), '', true, true);
 $settings['principal_targets'] = $xpdo->newObject(modSystemSetting::class);
 $settings['principal_targets']->fromArray([
   'key' => 'principal_targets',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1073,15 +1073,15 @@ $settings['modx_charset']->fromArray([
   'area' => 'language',
   'editedon' => null,
 ], '', true, true);
-$settings['package_installer_at_top'] = $xpdo->newObject('modSystemSetting');
-$settings['package_installer_at_top']->fromArray(array (
+$settings['package_installer_at_top'] = $xpdo->newObject(modSystemSetting::class);
+$settings['package_installer_at_top']->fromArray([
   'key' => 'package_installer_at_top',
   'value' => true,
   'xtype' => 'combo-boolean',
   'namespace' => 'core',
   'area' => 'manager',
   'editedon' => null,
-), '', true, true);
+], '', true, true);
 $settings['principal_targets'] = $xpdo->newObject(modSystemSetting::class);
 $settings['principal_targets']->fromArray([
   'key' => 'principal_targets',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -471,6 +471,9 @@ $_lang['setting_new_file_permissions_desc'] = 'When uploading a new file in the 
 $_lang['setting_new_folder_permissions'] = 'New Folder Permissions';
 $_lang['setting_new_folder_permissions_desc'] = 'When creating a new folder in the File Manager, the File Manager will attempt to change the folder permissions to those entered in this setting. This may not work on some setups, such as IIS, in which case you will need to manually change the permissions.';
 
+$_lang['setting_package_installer_at_top'] = 'Pin Package-Installer at top';
+$_lang['setting_package_installer_at_top_desc'] = 'If enabled, the package-installer menu-entry inside the Extras-menu will be pinned at the top - regardless of its "menuindex"-attribute. If disabled, the package-installer will be positioned according to its menuindex.';
+
 $_lang['setting_parser_recurse_uncacheable'] = 'Delay Uncacheable Parsing';
 $_lang['setting_parser_recurse_uncacheable_desc'] = 'If disabled, uncacheable elements may have their output cached inside cacheable element content. Disable this ONLY if you are having problems with complex nested parsing which stopped working as expected.';
 

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -472,7 +472,7 @@ $_lang['setting_new_folder_permissions'] = 'New Folder Permissions';
 $_lang['setting_new_folder_permissions_desc'] = 'When creating a new folder in the File Manager, the File Manager will attempt to change the folder permissions to those entered in this setting. This may not work on some setups, such as IIS, in which case you will need to manually change the permissions.';
 
 $_lang['setting_package_installer_at_top'] = 'Pin Package-Installer at top';
-$_lang['setting_package_installer_at_top_desc'] = 'If enabled, the package-installer menu-entry inside the Extras-menu will be pinned at the top - regardless of its "menuindex"-attribute. If disabled, the package-installer will be positioned according to its menuindex.';
+$_lang['setting_package_installer_at_top_desc'] = 'If enabled, the Installer entry will be pinned to the top of the Extras menu. Otherwise it will be positioned according to its menuindex.';
 
 $_lang['setting_parser_recurse_uncacheable'] = 'Delay Uncacheable Parsing';
 $_lang['setting_parser_recurse_uncacheable_desc'] = 'If disabled, uncacheable elements may have their output cached inside cacheable element content. Disable this ONLY if you are having problems with complex nested parsing which stopped working as expected.';

--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -132,12 +132,12 @@ class modMenu extends modAccessibleObject
         $c->where([
             'modMenu.parent' => $start,
         ]);
-        
+
         if ($this->xpdo->getOption('package_installer_at_top', null, true)) {
             // make sure installer is always on top
-            $c->sortby('FIELD(modMenu.text, "installer")','DESC');
+            $c->sortby('FIELD(modMenu.text, "installer")', 'DESC');
         }
-        
+
         $c->sortby($this->xpdo->getSelectColumns(modMenu::class, 'modMenu', '', ['menuindex']), 'ASC');
         $menus = $this->xpdo->getCollection(modMenu::class, $c);
         if (count($menus) < 1) {

--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -132,6 +132,12 @@ class modMenu extends modAccessibleObject
         $c->where([
             'modMenu.parent' => $start,
         ]);
+        
+        if ($this->xpdo->getOption('package_installer_at_top', null, true)) {
+            // make sure installer is always on top
+            $c->sortby('FIELD(modMenu.text, "installer")','DESC');
+        }
+        
         $c->sortby($this->xpdo->getSelectColumns(modMenu::class, 'modMenu', '', ['menuindex']), 'ASC');
         $menus = $this->xpdo->getCollection(modMenu::class, $c);
         if (count($menus) < 1) {


### PR DESCRIPTION
### What does it do?
Due to the default-value of menuindex in menu-entries of newly installed extras being most of the time "0", the installer entry will jump up and/or down after an extra gets installed/updated.

Therefore it should at least be fixed at the top of the dropdown-menu, if the User wishes.

### Related issue(s)/PR(s)
Fixes https://github.com/modxcms/revolution/issues/11694 pragmatically
Related PR for v2.x #14482 
