### PR TITLE
Fix PHP warning: Constant IMG_AVIF already defined

### DIFF
--- a/core/model/phpthumb/modphpthumb.class.php
+++ b/core/model/phpthumb/modphpthumb.class.php
@@ -41,8 +41,10 @@ class modPhpThumb extends phpThumb
         }
 
         if (version_compare(PHP_VERSION, '8.1.0', '<=')) {
-            // The constant IMG_AVIF is available as of PHP 8.1.
-            define('IMG_AVIF', 256);
+            // The constant IMG_AVIF is available as of PHP 8.1.            
+            if (!defined('IMG_AVIF')) {
+                define('IMG_AVIF', 256);
+            }
         }
 
         parent::__construct();


### PR DESCRIPTION
### What does it do?
Fixes unnecessary PHP warning entries in the Modx  Error log about an already defined IMG_AVIF constant. 

### Why is it needed?
Some phpThumb operations on images produce this line in the error log. Let's keep the error log clean(er).




