### PR TITLE
Harden Security/Profile/Get processor

### DIFF
--- a/core/src/Revolution/Processors/Security/Profile/Get.php
+++ b/core/src/Revolution/Processors/Security/Profile/Get.php
@@ -47,11 +47,7 @@ class Get extends Processor
      */
     public function initialize()
     {
-        $id = $this->getProperty('id');
-        if (empty($id)) {
-            return $this->modx->lexicon('user_err_ns');
-        }
-        $this->user = $this->modx->getObject(modUser::class, $id);
+        $this->user = $this->modx->user;
         if (!$this->user) {
             return $this->modx->lexicon('user_err_not_found');
         }
@@ -78,6 +74,7 @@ class Get extends Processor
             $userArray['blockedafter']) : '';
         $userArray['lastlogin'] = !empty($userArray['lastlogin']) ? date('m/d/Y', $userArray['lastlogin']) : '';
 
+        unset($userArray['password'], $userArray['cachepwd'], $userArray['sessionid'], $userArray['salt']);
         return $this->success('', $userArray);
     }
 


### PR DESCRIPTION
### What does it do?
Prevents unauthorized users from accessing potentially sensitive profile data of other users.

### Why is it needed?
The Security/Profile/Get processor currently accepts an id property and looks up a user by id. It also responds with fields that could then be used to hijack another user's session. This process should not:

- allow loading a user other than the currently authenticated user
- return sensitive data in the response such as sessionid or the password hash

### How to test
Call the Security/Profile/Get processor when logged in to the manager and attempt to access another user's profile by id. Also, verify the response does not include password or session_id fields even when returning your own profile.

### Related issue(s)/PR(s)
This was an issue brought up in a security report.