### PR TITLE
S3 Speed Up

### DIFF
--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -677,7 +677,9 @@ class modS3MediaSource extends modMediaSource
             'xml',
         ];
         foreach ($binary_extensions as $a) {
-            if (stripos($file,$a) !== false) return true;
+            if (stripos($file, $a) !== false) {
+                return true;
+            }
         }
         return false;
     }
@@ -685,7 +687,9 @@ class modS3MediaSource extends modMediaSource
     protected function isFileImage($file, $image_extensions = [])
     {
         foreach ($image_extensions as $a) {
-            if (stripos($file,$a) !== false) return true;
+            if (stripos($file, $a) !== false) {
+                return true;
+            }
         }
         return false;
     }
@@ -707,7 +711,10 @@ class modS3MediaSource extends modMediaSource
         $page = null;
         if (!$this->isFileBinary($path)) {
             $page = !empty($editAction)
-                ? '?a=' . $editAction . '&file=' . $path . '&wctx=' . $this->ctx->get('key') . '&source=' . $this->get('id')
+                ? '?a=' . $editAction .
+                    '&file=' . $path .
+                    '&wctx=' . $this->ctx->get('key') .
+                    '&source=' . $this->get('id')
                 : null;
         }
 

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -200,6 +200,9 @@ class modS3MediaSource extends modMediaSource
     {
         $menu = parent::getListDirContextMenu();
         foreach ($menu as $k => $v) {
+            if (gettype($v) !== 'array') {
+                continue;
+            }
             if ($v['handler'] === 'this.renameDirectory') {
                 unset($menu[$k]);
                 $menu = array_values($menu);

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -373,7 +373,6 @@ class modS3MediaSource extends modMediaSource
             ) {
                 $cls = $this->getExtJSDirClasses();
                 $dirNames[] = strtoupper($file_name);
-                $visibility = true;
                 $directories[$file_name] = [
                         'id' => $id,
                         'sid' => $this->get('id'),
@@ -384,11 +383,10 @@ class modS3MediaSource extends modMediaSource
                         'leaf' => false,
                         'path' => $object['path'],
                         'pathRelative' => $object['path'],
-                        'menu' => [],
+                        'menu' => [
+                            'items' => $this->getListDirContextMenu(),
+                        ],
                         'visibility' => true
-                    ];
-                $directories[$file_name]['menu'] = [
-                        'items' => $this->getListDirContextMenu(),
                     ];
             } elseif (
                     $object['type'] === 'file' &&
@@ -647,5 +645,119 @@ class modS3MediaSource extends modMediaSource
     {
         // S3 Set visibility always returns false
         return false;
+    }
+
+    protected function getImageDimensions($path, $ext)
+    {
+        return false;
+    }
+
+    protected function isFileBinary($file)
+    {
+        $binary_extensions = [
+            'css',
+            'csv',
+            'htm',
+            'html',
+            'ics',
+            'ini',
+            'js',
+            'json',
+            'less',
+            'log',
+            'md',
+            'mjs',
+            'php',
+            'sh',
+            'scss',
+            'sql',
+            'tpl',
+            'tsv',
+            'txt',
+            'xml',
+        ];
+        foreach ($binary_extensions as $a) {
+            if (stripos($file,$a) !== false) return true;
+        }
+        return false;
+    }
+
+    protected function isFileImage($file, $image_extensions = [])
+    {
+        foreach ($image_extensions as $a) {
+            if (stripos($file,$a) !== false) return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * @param string $path
+     * @param string $ext
+     * @param array $image_extensions
+     * @param array $bases
+     * @param array $properties
+     *
+     * @return array
+     */
+    protected function buildFileBrowserViewList($path, $ext, $image_extensions, $bases, $properties)
+    {
+        $editAction = $this->getEditActionId();
+
+        $page = null;
+        if (!$this->isFileBinary($path)) {
+            $page = !empty($editAction)
+                ? '?a=' . $editAction . '&file=' . $path . '&wctx=' . $this->ctx->get('key') . '&source=' . $this->get('id')
+                : null;
+        }
+
+        $width = $this->ctx->getOption('filemanager_image_width', 800);
+        $height = $this->ctx->getOption('filemanager_image_height', 600);
+
+        $thumb_width = $this->ctx->getOption('filemanager_thumb_width', 100);
+        $thumb_height = $this->ctx->getOption('filemanager_thumb_height', 80);
+
+        $preview = 0;
+        if ($this->isFileImage($path, $image_extensions)) {
+            $preview = 1;
+            $preview_image_info = $this->buildManagerImagePreview($path, $ext, $width, $height, $bases, $properties);
+        }
+
+        $visibility = $this->visibility_files ? $this->getVisibility($path) : false;
+
+        $lastmod = 0;
+        $size = 0;
+        $file_list = [
+            'id' => $path,
+            'sid' => $this->get('id'),
+            'name' => basename($path),
+            'cls' => 'icon-' . $ext,
+            // preview
+            'preview' => $preview,
+            'image' => $preview_image_info['src'] ?? '',
+            // thumb
+            'thumb' => $preview_image_info['src'] ?? '',
+            'thumb_width' => $thumb_width,
+            'thumb_height' => $thumb_height,
+
+            'url' => $path,
+            'relativeUrl' => ltrim($path, DIRECTORY_SEPARATOR),
+            'fullRelativeUrl' => rtrim($bases['url']) . ltrim($path, DIRECTORY_SEPARATOR),
+            'ext' => $ext,
+            'pathname' => $path,
+            'pathRelative' => rawurlencode($path),
+
+            'lastmod' => $lastmod,
+            'disabled' => false,
+            'leaf' => true,
+            'page' => $page,
+            'size' => $size,
+            'menu' => $this->getListFileContextMenu($path, !empty($page)),
+        ];
+        if ($this->visibility_files && $visibility) {
+            $file_list['visibility'] = $visibility;
+        }
+
+        return $file_list;
     }
 }


### PR DESCRIPTION
### What does it do?
Removed the functions that process each file individually when listing files, e.g. lastModified, fileSize, mimeType, e.g. 

### Why is it needed?
Currently, the S3 bucket will time out as you grow the contents of your folders. This dramatically increases the responses and has been tested on folders containing hundreds of files. 

### How to test
The best way to test is with an S3 bucket with numerous sample files. The file size doesn't matter, just a large number. As the number grows, the response time increases. 

### Related issue(s)/PR(s)
No related public issues, just personal experience
