### PR TITLE
Harden security/profile/get processor

### DIFF
--- a/core/model/modx/processors/security/profile/get.class.php
+++ b/core/model/modx/processors/security/profile/get.class.php
@@ -29,13 +29,11 @@ class modProfileGetProcessor extends modProcessor {
     }
 
     public function initialize() {
-        $id = $this->getProperty('id');
-        if (empty($id)) return $this->modx->lexicon('user_err_ns');
-        $this->user = $this->modx->getObject('modUser',$id);
+        $this->user = $this->modx->user;
         if (!$this->user) return $this->modx->lexicon('user_err_not_found');
         return true;
     }
-    
+
     public function process() {
         /* if set, get groups for user */
         if ($this->getProperty('getGroups',false)) {
@@ -53,6 +51,7 @@ class modProfileGetProcessor extends modProcessor {
         $userArray['blockedafter'] = !empty($userArray['blockedafter']) ? strftime('%m/%d/%Y %I:%M %p',$userArray['blockedafter']) : '';
         $userArray['lastlogin'] = !empty($userArray['lastlogin']) ? strftime('%m/%d/%Y',$userArray['lastlogin']) : '';
 
+        unset($userArray['password'], $userArray['cachepwd'], $userArray['sessionid'], $userArray['salt']);
         return $this->success('',$userArray);
     }
 


### PR DESCRIPTION
### What does it do?
Prevents unauthorized users from accessing potentially sensitive profile data of other users.

### Why is it needed?
The security/profile/get processor currently accepts an id property and looks up a user by id. It also responds with fields that could then be used to hijack another user's session. This process should not:

- allow loading a user other than the currently authenticated user
- return sensitive data in the response such as sessionid or the password hash

### How to test
Call the security/profile/get processor when logged in to the manager and attempt to access another user's profile by id. Also, verify the response does not include password or sessionid fields even when returning your own profile.

### Related issue(s)/PR(s)
2.x backport of #16437