### PR TITLE
Fix deprecation of dynamic properties

### DIFF
--- a/core/src/Revolution/Hashing/modHashing.php
+++ b/core/src/Revolution/Hashing/modHashing.php
@@ -19,6 +19,7 @@ use xPDO\xPDO;
  *
  * @package MODX\Revolution\Hashing
  */
+#[\AllowDynamicProperties]
 class modHashing
 {
     /**
@@ -54,27 +55,6 @@ class modHashing
         if (is_array($options)) {
             $this->options = $options;
         }
-    }
-
-    /**
-     * Define magic method to avoid 'Creation of dynamic property' message in PHP 8.2+
-     *
-     * @param string $name
-     * @return void
-     */
-    public function __get(string $name)
-    {
-    }
-
-    /**
-     * Define magic method to avoid 'Creation of dynamic property' message in PHP 8.2+
-     *
-     * @param string $name
-     * @param mixed $value
-     * @return void
-     */
-    public function __set(string $name, $value)
-    {
     }
 
     /**

--- a/core/src/Revolution/Hashing/modHashing.php
+++ b/core/src/Revolution/Hashing/modHashing.php
@@ -125,7 +125,7 @@ class modHashing
                 $hash = new $className($this, $options);
                 if ($hash instanceof $className) {
                     $this->_hashes[$key] = $hash;
-                    $this->$key =& $this->_hashes[$key];
+                    $this->$key = $this->_hashes[$key];
                 }
             }
             if (array_key_exists($key, $this->_hashes)) {

--- a/core/src/Revolution/Hashing/modHashing.php
+++ b/core/src/Revolution/Hashing/modHashing.php
@@ -57,6 +57,27 @@ class modHashing
     }
 
     /**
+     * Define magic method to avoid 'Creation of dynamic property' message in PHP 8.2+
+     *
+     * @param string $name
+     * @return void
+     */
+    public function __get(string $name)
+    {
+    }
+
+    /**
+     * Define magic method to avoid 'Creation of dynamic property' message in PHP 8.2+
+     *
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     */
+    public function __set(string $name, $value)
+    {
+    }
+
+    /**
      * Get an option for the MODX hashing service.
      *
      * Searches for local options and then prefixes keys with encrypt_ to look for


### PR DESCRIPTION
### What does it do?
Define magic method __set and __get in the class to avoid the deprecation message. See: https://php.watch/versions/8.2/dynamic-properties-deprecated#__get-__set

There is also a fix included for an uncaught error: `Cannot assign by reference to overloaded object in /core/src/Revolution/Hashing/modHashing.php:107`.

### Why is it needed?
Avoid the message `Creation of dynamic property MODX\Revolution\Hashing\modHashing::$native is deprecated in core/src/Revolution/Hashing/modHashing.php on line 107`

### How to test
Those messages seem to occur during installing MODX 3.0.3 on PHP 8.2. See the screenshot from Slack:

![image](https://github.com/modxcms/revolution/assets/148371/66b3bf8f-08af-4044-8c0e-8c9f94c3da7e)

There are other similar issues xPDO and modAccessibleObject that screenshot.

### Related issue(s)/PR(s)
None known
