### PR TITLE
Only assign user if instance of modX in modAccessibleObject::checkPolicy

### DIFF
--- a/core/src/Revolution/modAccessibleObject.php
+++ b/core/src/Revolution/modAccessibleObject.php
@@ -249,10 +249,10 @@ class modAccessibleObject extends xPDOObject
      */
     public function checkPolicy($criteria, $targets = null, modUser $user = null)
     {
-        if (!$user) {
-            $user = &$this->xpdo->user;
-        }
         if ($criteria && $this->xpdo instanceof modX && $this->xpdo->getSessionState() == modX::SESSION_STATE_INITIALIZED) {
+            if (!$user) {
+                $user = $this->xpdo->user;
+            }
             if ($user->get('sudo')) {
                 return true;
             }


### PR DESCRIPTION
### What does it do?
Avoids the unnecessary assignment of the $user variable from $this->xpdo->user unless the other conditions are met for executing the logic in modAccessibleObject::checkPolicy().

### Why is it needed?
This triggered a deprecation warning regarding dynamic properties when executed on installation in PHP 8.2 because xPDO does not contain the user property unless it is an instance of modX.

### How to test
You will need to run a new installation and verify no deprecation warning is emitted.

### Related issue(s)/PR(s)
This will also be resolved once modxcms/xpdo#252 is integrated into MODX.