### PR TITLE
Fix ability to rename content field

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -664,23 +664,13 @@ Ext.extend(MODx,Ext.Component,{
      * @return {void}
      */
     ,renameLabel: function(containerId, fieldId, newLabel) {
-        let container;
-        if (containerId == 'modx-panel-resource' && fieldId.indexOf('modx-resource-content') != -1) {
-            container = Ext.getCmp('modx-resource-content');
-            if (!container) {
-                return;
+        if (fieldId.indexOf('modx-resource-content') !== -1) {
+            const contentCmp = Ext.getCmp('ta');
+            if (contentCmp) {
+                contentCmp.label.update(newLabel);
             }
-            if (container.setTitle) {
-                container.setTitle(newLabel);
-                return;
-            }
-            if (container.setLabel) {
-                container.setLabel(fieldId, newLabel);
-                return;
-            }
-            container.label.update(newLabel);
         } else {
-            container = Ext.getCmp(containerId);
+            const container = Ext.getCmp(containerId);
             if (container) {
                 container.setLabel(fieldId, newLabel);
             }


### PR DESCRIPTION
### What does it do?
Updated `renameLabel` method to look for the correct component when specifying a label change for `modx-resource-content`.

### Why is it needed?
The change in MODX 3 to allow TVs to be placed above and below the main content field resulted in the inability to rename the content field’s label via Form Customization (FC) due to the new structure of components.

### How to test
Create FC rule for a test template, enter a new Label for the `modx-resource-content`, and verify the change appears when editing a Resource with that rule applied.

### Related issue(s)/PR(s)
Resolves #16441 