### PR TITLE
Changed the order of variables in config.inc.php

### DIFF
--- a/core/docs/config.inc.tpl
+++ b/core/docs/config.inc.tpl
@@ -4,11 +4,11 @@
  */
 $database_type = '{database_type}';
 $database_server = '{database_server}';
+$database_connection_charset = '{database_connection_charset}';
+$table_prefix = '{table_prefix}';
+$dbase = '{dbase}';
 $database_user = '{database_user}';
 $database_password = '{database_password}';
-$database_connection_charset = '{database_connection_charset}';
-$dbase = '{dbase}';
-$table_prefix = '{table_prefix}';
 $database_dsn = '{database_dsn}';
 $config_options = {config_options};
 $driver_options = {driver_options};

--- a/core/docs/config.inc.tpl
+++ b/core/docs/config.inc.tpl
@@ -20,25 +20,11 @@ $site_sessionname = '{site_sessionname}';
 $https_port = '{https_port}';
 $uuid = '{uuid}';
 
-if (!defined('MODX_CORE_PATH')) {
-    $modx_core_path= '{core_path}';
-    define('MODX_CORE_PATH', $modx_core_path);
-}
-if (!defined('MODX_PROCESSORS_PATH')) {
-    $modx_processors_path= '{processors_path}';
-    define('MODX_PROCESSORS_PATH', $modx_processors_path);
-}
-if (!defined('MODX_CONNECTORS_PATH')) {
-    $modx_connectors_path= '{connectors_path}';
-    $modx_connectors_url= '{connectors_url}';
-    define('MODX_CONNECTORS_PATH', $modx_connectors_path);
-    define('MODX_CONNECTORS_URL', $modx_connectors_url);
-}
-if (!defined('MODX_MANAGER_PATH')) {
-    $modx_manager_path= '{mgr_path}';
-    $modx_manager_url= '{mgr_url}';
-    define('MODX_MANAGER_PATH', $modx_manager_path);
-    define('MODX_MANAGER_URL', $modx_manager_url);
+if (!defined('MODX_ASSETS_PATH')) {
+    $modx_assets_path= '{assets_path}';
+    $modx_assets_url= '{assets_url}';
+    define('MODX_ASSETS_PATH', $modx_assets_path);
+    define('MODX_ASSETS_URL', $modx_assets_url);
 }
 if (!defined('MODX_BASE_PATH')) {
     $modx_base_path= '{web_path}';
@@ -46,23 +32,45 @@ if (!defined('MODX_BASE_PATH')) {
     define('MODX_BASE_PATH', $modx_base_path);
     define('MODX_BASE_URL', $modx_base_url);
 }
+if (!defined('MODX_CONNECTORS_PATH')) {
+    $modx_connectors_path= '{connectors_path}';
+    $modx_connectors_url= '{connectors_url}';
+    define('MODX_CONNECTORS_PATH', $modx_connectors_path);
+    define('MODX_CONNECTORS_URL', $modx_connectors_url);
+}
+if (!defined('MODX_CORE_PATH')) {
+    $modx_core_path= '{core_path}';
+    define('MODX_CORE_PATH', $modx_core_path);
+}
+if (!defined('MODX_MANAGER_PATH')) {
+    $modx_manager_path= '{mgr_path}';
+    $modx_manager_url= '{mgr_url}';
+    define('MODX_MANAGER_PATH', $modx_manager_path);
+    define('MODX_MANAGER_URL', $modx_manager_url);
+}
+if (!defined('MODX_PROCESSORS_PATH')) {
+    $modx_processors_path= '{processors_path}';
+    define('MODX_PROCESSORS_PATH', $modx_processors_path);
+}
+
 if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
     $isSecureRequest = false;
 } else {
     $isSecureRequest = ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') || $_SERVER['SERVER_PORT'] == $https_port);
 }
+
 if (!defined('MODX_URL_SCHEME')) {
     $url_scheme=  $isSecureRequest ? 'https://' : 'http://';
     define('MODX_URL_SCHEME', $url_scheme);
 }
 if (!defined('MODX_HTTP_HOST')) {
     if(defined('PHP_SAPI') && (PHP_SAPI == "cli" || PHP_SAPI == "embed")) {
-        $http_host='{http_host}';
+        $http_host= '{http_host}';
         define('MODX_HTTP_HOST', $http_host);
     } else {
         $http_host= array_key_exists('HTTP_HOST', $_SERVER) ? htmlspecialchars($_SERVER['HTTP_HOST'], ENT_QUOTES) : '{http_host}';
         if ($_SERVER['SERVER_PORT'] != 80) {
-            $http_host = str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
+            $http_host= str_replace(':' . $_SERVER['SERVER_PORT'], '', $http_host); // remove port from HTTP_HOST
         }
         $http_host .= in_array($_SERVER['SERVER_PORT'], [80, 443]) ? '' : ':' . $_SERVER['SERVER_PORT'];
         define('MODX_HTTP_HOST', $http_host);
@@ -72,12 +80,7 @@ if (!defined('MODX_SITE_URL')) {
     $site_url= $url_scheme . $http_host . MODX_BASE_URL;
     define('MODX_SITE_URL', $site_url);
 }
-if (!defined('MODX_ASSETS_PATH')) {
-    $modx_assets_path= '{assets_path}';
-    $modx_assets_url= '{assets_url}';
-    define('MODX_ASSETS_PATH', $modx_assets_path);
-    define('MODX_ASSETS_URL', $modx_assets_url);
-}
+
 if (!defined('MODX_LOG_LEVEL_FATAL')) {
     define('MODX_LOG_LEVEL_FATAL', 0);
     define('MODX_LOG_LEVEL_ERROR', 1);


### PR DESCRIPTION
### What does it do?
Changed the order of variables in config.inc.php:

1) Changed the order of db connection variables.
For example, `$dbase` and `$database_user`, since the fields often have the same values and it will be easier to edit them visually.

3) Changed the order of path constant.
Sorted them alphabetically, just like the MODX folders located on the server.

p.s. PR does not change anything, but when transferring a site from server to server or changing the config file, such inconsistency is striking.

### Why is it needed?
Fewer edits and fewer possible bugs in config.inc.php.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/10479#issuecomment-568462571
