### PR TITLE
Fix default class_key value for new resources in MODX 3

### DIFF
--- a/core/src/Revolution/modDocument.php
+++ b/core/src/Revolution/modDocument.php
@@ -22,7 +22,7 @@ class modDocument extends modResource
     function __construct(& $xpdo)
     {
         parent:: __construct($xpdo);
-        $this->set('class_key', 'modDocument');
+        $this->set('class_key', self::class);
         $this->showInContextMenu = true;
     }
 


### PR DESCRIPTION
### What does it do?
Changes the default value of the `class_key` field from `modDocument` to `MODX\Revolution\modDocument`.

### Why is it needed?
When you create a new resource with the `resource/create` processor and don't provide a value for the `class_key` field, the default value misses the namespace.

### How to test
Run the `resource/create` processor without supplying a value for the field `class_key`.
```
$modx->runProcessor('resource/create', ['pagetitle' => 'test']);
```
Verify that the `class_key` value of the newly created resource is equal to the one from resources created manually in the manager.
