### PR TITLE
Update modx.panel.resource.weblink.js

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.weblink.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.weblink.js
@@ -34,7 +34,7 @@ Ext.extend(MODx.panel.WebLink,MODx.panel.Resource,{
             ,name: 'content'
             ,id: 'modx-weblink-content'
             ,anchor: '100%'
-            ,value: (config.record.content || config.record.ta) || 'http://'
+            ,value: (config.record.content || config.record.ta) || 'https://'
         });
         return its;
     }


### PR DESCRIPTION
Change weblink default to https://

### What does it do?
Just changed the default protocol to https instead of http

### Why is it needed?
To link to the secure version of websites.
