### PR TITLE
Hopefully fixed recently edited resources (sub)query

### DIFF
--- a/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
+++ b/core/src/Revolution/Processors/Security/User/GetRecentlyEditedResources.php
@@ -60,22 +60,21 @@ class GetRecentlyEditedResources extends GetListProcessor
     {
         $user = $this->getProperty('user');
         $q = $this->modx->newQuery($this->classKey, ['classKey:IN' => $this->classKeys]);
-        $q->select('MAX(id), item');
+        $q->select('MAX(id)');
         if (!empty($user)) {
             $q->where(['user' => $user]);
-            $c->where(['user' => $user]);
         }
         $q->groupby('item');
-        $q->limit($this->getProperty('limit', 10));
-        if ($q->prepare() && $q->stmt->execute()) {
-            if ($ids = $q->stmt->fetchAll(PDO::FETCH_COLUMN)) {
-                $c->where(['id:IN' => $ids]);
-            } else {
-                $c->where(['id' => -1]);
-            }
-        }
 
+        $sql = '-1';
+        if ($q->prepare()) {
+            $sql = $q->toSQL();
+        }
         $c->select($this->modx->getSelectColumns(modManagerLog::class, 'modManagerLog'));
+        $c->where(<<<SQL
+id in ({$sql})
+SQL
+        );
 
         return $c;
     }


### PR DESCRIPTION
### What does it do?
Adjusted the (sub) query to retrieve last edited resources

### Why is it needed?
When having many manager log records, the existing query already returned "outdated" recently edited resources

### How to test
* Generate a bunch of manager log entries (we tested with 500) for resource edition
* manually edit a resource
* check the Recently edited dashboard widget (or `/?a=security/profile`) and confirm last edited resource is not accurate
* apply patch and confirm last edited resource is correct ;)

### Related issue(s)/PR(s)
none found
