### PR TITLE
Change default gravatar type for user

### DIFF
--- a/core/model/modx/moduser.class.php
+++ b/core/model/modx/moduser.class.php
@@ -918,7 +918,7 @@ class modUser extends modPrincipal {
      *
      * @return string The Gravatar photo URL
      */
-    public function getGravatar($size = 128, $default = 'mm') {
+    public function getGravatar($size = 128, $default = 'retro') {
         $gravemail = md5(
             strtolower(
                 trim($this->Profile->email)


### PR DESCRIPTION
### What does it do?
In the 2.x branch, the gravatar image is enabled by default, BUT, because in code set `mm` gravatar type - the picture is always the same, which is not very useful for UI\UX.

Changed the type to `retro`, which generates a unique gravatar by email hash, and now you can better see which user is logged into the manager panel.

Before:
![gravatar_1](https://github.com/modxcms/revolution/assets/12523676/4430aad0-f680-4b8c-9bd0-25fb778a48f6)

After:
![gravatar_2](https://github.com/modxcms/revolution/assets/12523676/12b13277-f45f-4455-925e-8f8d1146da3e)

![gravatar_3](https://github.com/modxcms/revolution/assets/12523676/b5da513e-2362-456d-874b-228ab584f995)

### Why is it needed?
UI\UX

### Related issue(s)/PR(s)
N\A
