### PR TITLE
fix return type GetProcessor.php

### DIFF
--- a/core/src/Revolution/Processors/Model/GetProcessor.php
+++ b/core/src/Revolution/Processors/Model/GetProcessor.php
@@ -28,7 +28,7 @@ abstract class GetProcessor extends ModelProcessor
 
     /**
      * {@inheritDoc}
-     * @return boolean
+     * @return boolean|string
      */
     public function initialize()
     {


### PR DESCRIPTION
### What does it do?
add string type to return types initialize method

### Why is it needed?
method initialize GetProcessor.php can return bool or string value.

### How to test
Create a inherited class of GetProcessor.php. Add return types in initialize method `function initialize() :bool`. Now in all cases will returned `true`. If add return types `function initialize() :bool|true` (as php DocBlock) everything will be alright.
