### PR TITLE
3.x - Add request parameters to MODX Browser page

### DIFF
--- a/manager/controllers/default/media/browser.class.php
+++ b/manager/controllers/default/media/browser.class.php
@@ -36,7 +36,11 @@ class MediaBrowserManagerController extends modManagerController
 // <![CDATA[
     Ext.onReady(function() {
         Ext.getCmp('modx-layout').hideLeftbar(true, false);
-        MODx.add({ xtype: 'modx-media-view', source: MODx.request.source });
+        MODx.add({
+            xtype: 'modx-media-view',
+            source: MODx.request.source,
+            openTo: MODx.request.openTo,
+        });
     });
 // ]]>
 </script>

--- a/manager/controllers/default/media/browser.class.php
+++ b/manager/controllers/default/media/browser.class.php
@@ -36,7 +36,7 @@ class MediaBrowserManagerController extends modManagerController
 // <![CDATA[
     Ext.onReady(function() {
         Ext.getCmp('modx-layout').hideLeftbar(true, false);
-        MODx.add('modx-media-view');
+        MODx.add({ xtype: 'modx-media-view', source: MODx.request.source });
     });
 // ]]>
 </script>


### PR DESCRIPTION
### What does it do?
Adds the ability to pass a source ID and/or directory to the media browser page.

### Why is it needed?
Currently when you open the media browser page it just opens the default source at the root level. This change allows people to create menu links that open to a specific source and/or directory.

### How to test
Create a secondary media source and then specify it with the source parameter: /manager/?a=media/browser&source=2

Specify a folder in your system with the openTo parameter:  /manager/?a=media/browser&openTo=assets

Specify both:  /manager/?a=media/browser&source=2&openTo=assets

### Related issue(s)/PR(s)
Client request
