### PR TITLE
Update phpcs.xml to allow non-namespaced classes in select areas

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -33,5 +33,10 @@
     <rule ref="PSR12">
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
     </rule>
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/</exclude-pattern>
+        <exclude-pattern>core/src/Revolution/Processors/Element/TemplateVar/Renders/web/</exclude-pattern>
+        <exclude-pattern>manager/controllers/default/</exclude-pattern>
+    </rule>
     <rule ref="PHPCompatibility"/>
 </ruleset>


### PR DESCRIPTION
### What does it do?
Adds targeted rule to exclude the PSR1 MissingNamespace error.

### Why is it needed?
Two areas of the core—the TV renders and manager controllers—do not declare a namespace in their classes and cause an unfixable code quality error in those files. This is particularly problematic when submitting PRs with changes to those files. Under the assumption that there was good reason to not namespace those files, I opted to adjust the ruleset.

### How to test
Simply compare a handful of classes in the noted areas (look at the added rules to see the base paths to those areas) to others in the main core (not components, etc.). Note how the currently non-namespaced classes will not show an error for the rule in question, while ones that do have a namespace will show an error if you delete the namespace declaration.

### Related issue(s)/PR(s)
None. Actually was motivated to make the change because my most recent PR (#16469) is failing checks because of the rule issue.
