### PR TITLE
Fix ability to view Manager Actions

### DIFF
--- a/manager/controllers/default/system/logs/index.class.php
+++ b/manager/controllers/default/system/logs/index.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -16,12 +17,14 @@ use MODX\Revolution\modManagerController;
  * @package modx
  * @subpackage manager.controllers
  */
-class SystemLogsManagerController extends modManagerController {
+class SystemLogsManagerController extends modManagerController
+{
     /**
      * Check for any permissions or requirements to load page
      * @return bool
      */
-    public function checkPermissions() {
+    public function checkPermissions()
+    {
         return $this->modx->hasPermission('mgr_log_view');
     }
 
@@ -29,9 +32,10 @@ class SystemLogsManagerController extends modManagerController {
      * Register custom CSS/JS for the page
      * @return void
      */
-    public function loadCustomCssJs() {
-        $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/system/modx.grid.manager.log.js');
-        $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/logs.js');
+    public function loadCustomCssJs()
+    {
+        $this->addJavascript($this->modx->getOption('manager_url') . 'assets/modext/widgets/system/modx.grid.manager.log.js');
+        $this->addJavascript($this->modx->getOption('manager_url') . 'assets/modext/sections/system/logs.js');
         $this->addHtml("<script>
             Ext.onReady(function() {
                 MODx.add('modx-page-manager-log');
@@ -43,14 +47,17 @@ class SystemLogsManagerController extends modManagerController {
      * @param array $scriptProperties
      * @return mixed
      */
-    public function process(array $scriptProperties = []) {}
+    public function process(array $scriptProperties = [])
+    {
+    }
 
     /**
      * Return the pagetitle
      *
      * @return string
      */
-    public function getPageTitle() {
+    public function getPageTitle()
+    {
         return $this->modx->lexicon('manager_log');
     }
 
@@ -58,7 +65,8 @@ class SystemLogsManagerController extends modManagerController {
      * Return the location of the template file
      * @return string
      */
-    public function getTemplateFile() {
+    public function getTemplateFile()
+    {
         return '';
     }
 
@@ -66,7 +74,8 @@ class SystemLogsManagerController extends modManagerController {
      * Specify the language topics to load
      * @return array
      */
-    public function getLanguageTopics() {
+    public function getLanguageTopics()
+    {
         return ['manager_log'];
     }
 }

--- a/manager/controllers/default/system/logs/index.class.php
+++ b/manager/controllers/default/system/logs/index.class.php
@@ -22,7 +22,7 @@ class SystemLogsManagerController extends modManagerController {
      * @return bool
      */
     public function checkPermissions() {
-        return $this->modx->hasPermission('logs');
+        return $this->modx->hasPermission('mgr_log_view');
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Update view permissions key in logs controller.

### Why is it needed?
The old 2.x key was still being specified in this controller, making it impossible for those without sudo permissions to view the Manager Actions log.

### How to test
Test against a user having the `mgr_log_view` (and without sudo permissions) to verify Manager Actions can be viewed and navigated.

### Related issue(s)/PR(s)
Resolves #16445