### PR TITLE
Make “root” a reserved (restricted) key for Contexts

### DIFF
--- a/core/lexicon/en/context.inc.php
+++ b/core/lexicon/en/context.inc.php
@@ -18,6 +18,7 @@ $_lang['context_err_nfs'] = 'Context not found with key: [[+key]]';
 $_lang['context_err_ns'] = 'Context not specified.';
 $_lang['context_err_ns_key'] = 'Please specify a valid key for the Context.';
 $_lang['context_err_remove'] = 'An error occurred while trying to delete the Context.';
+$_lang['context_err_reserved'] = 'The Context key you chose is reserved for system use only. Please specify a different key.';
 $_lang['context_err_save'] = 'An error occurred while saving the Context.';
 $_lang['context_id'] = 'Ctx ID';
 $_lang['context_key'] = 'Context Key';

--- a/core/src/Revolution/Processors/Context/Create.php
+++ b/core/src/Revolution/Processors/Context/Create.php
@@ -40,7 +40,7 @@ class Create extends CreateProcessor
             case empty($key):
                 $this->addFieldError('key', $this->modx->lexicon('context_err_ns_key'));
                 break;
-            case in_array($key, $this->classKey::RESERVED_KEYS):
+            case in_array(strtolower($key), $this->classKey::RESERVED_KEYS):
                 $this->addFieldError('key', $this->modx->lexicon('context_err_reserved'));
                 break;
             case $this->alreadyExists($key):

--- a/core/src/Revolution/Processors/Context/Create.php
+++ b/core/src/Revolution/Processors/Context/Create.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Context;
-
 
 use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPolicy;
@@ -35,15 +35,24 @@ class Create extends CreateProcessor
     public function beforeSave()
     {
         $key = $this->getProperty('key');
-        if (empty($key)) {
-            $this->addFieldError('key', $this->modx->lexicon('context_err_ns_key'));
+
+        switch (true) {
+            case empty($key):
+                $this->addFieldError('key', $this->modx->lexicon('context_err_ns_key'));
+                break;
+            case in_array($key, $this->classKey::RESERVED_KEYS):
+                $this->addFieldError('key', $this->modx->lexicon('context_err_reserved'));
+                break;
+            case $this->alreadyExists($key):
+                $this->addFieldError('key', $this->modx->lexicon('context_err_ae'));
+            // no default
         }
-        if ($this->alreadyExists($key)) {
-            $this->addFieldError('key', $this->modx->lexicon('context_err_ae'));
+        if ($this->hasErrors()) {
+            return false;
         }
         $this->object->set('key', $key);
 
-        return !$this->hasErrors();
+        return true;
     }
 
     /**

--- a/core/src/Revolution/Processors/Context/GetList.php
+++ b/core/src/Revolution/Processors/Context/GetList.php
@@ -163,7 +163,7 @@ class GetList extends GetListProcessor
         if ($this->canEdit) {
             $contextArray['perm'][] = 'pedit';
         }
-        if (!in_array($object->get('key'), ['mgr', 'web']) && $this->canRemove) {
+        if (!in_array($object->get('key'), $this->classKey::RESERVED_KEYS) && $this->canRemove) {
             $contextArray['perm'][] = 'premove';
         }
 

--- a/core/src/Revolution/modContext.php
+++ b/core/src/Revolution/modContext.php
@@ -24,6 +24,13 @@ use xPDO\xPDO;
 class modContext extends modAccessibleObject
 {
     /**
+     * A set of Context keys that are restricted to system use only
+     *
+     *  @var array RESERVED_KEYS
+     */
+    public const RESERVED_KEYS = ['mgr', 'web', 'root'];
+
+    /**
      * An array of configuration options for this context
      *
      * @var array $config


### PR DESCRIPTION
### What does it do?

1. Prevents "root" from being specified as a Context key.
2. Slightly refactors the `Create->beforeSave() `error testing conditional to use a `switch` statement so only relevant code will execute in that block.
3. Additionally, in the second commit, leverages the newly-added `RESERVED_KEYS` constant (in the `modContext` base class) in the Context processor `GetList` class.

### Why is it needed?
The keyword "root" is used as the default id for all trees in the core. As such, attempting to create a Context with that key results in errors in the rendering of the Resources tree.

### How to test
Attempt to create a new Context with the key "root." You should receive an error message indicating the key is reserved.

### Related issue(s)/PR(s)
Resolves #16457
