### PR TITLE
Fix sanity check in resource/create controller

### DIFF
--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -249,14 +249,20 @@ class ResourceCreateManagerController extends ResourceManagerController {
             'FCSet.active' => true,
             'Profile.active' => true,
         ));
+
+        $criteriaUserGroups = [];
+
+        if(!empty($userGroups)){
+            $criteriaUserGroups['ProfileUserGroup.usergroup:IN'] = $userGroups;
+        }
+
+        $criteriaUserGroups[] = array(
+            'OR:ProfileUserGroup.usergroup:IS' => null,
+            'AND:UGProfile.active:=' => true,
+        );
+
         $c->where(array(
-            array(
-                'ProfileUserGroup.usergroup:IN' => $userGroups,
-                array(
-                    'OR:ProfileUserGroup.usergroup:IS' => null,
-                    'AND:UGProfile.active:=' => true,
-                ),
-            ),
+            $criteriaUserGroups,
             'OR:ProfileUserGroup.usergroup:=' => null,
         ),xPDOQuery::SQL_AND,null,2);
         /** @var modActionDom $fcDt see http://tracker.modx.com/issues/9592 */


### PR DESCRIPTION
### What does it do?
Add sanity check for $userGroups in XPDO query during creating a new resource.

### Why is it needed?
In the case the user is a sudo user and isn't assigned to any groups, the $userGroups which is a reflection of the user assigned groups can be empty. This cause a SQL error during creating a new resource.

```
Array
(
    [0] => 42000
    [1] => 1064
    [2] => You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') OR  ( `ProfileUserGroup`.`usergroup` IS NULL AND `UGProfile`.`active` = 1 )  )' at line 1
)
```

### How to test

1. Login in the manager with only sudo rights.
2. Create a new resource
3. See error log for the SQL error.

### Related issue(s)/PR(s)
#16376
