### PR TITLE
[2.x] Remove deprecation warning during setup for PHP 8.2

### DIFF
--- a/setup/includes/modinstalllexicon.class.php
+++ b/setup/includes/modinstalllexicon.class.php
@@ -24,6 +24,9 @@ class modInstallLexicon {
      * @var modInstall $install Reference to the modInstall instance.
      */
     public $install = null;
+
+    public $config = [];
+
     /**
      * @var array $_lexicon The translated lexicon array
      */


### PR DESCRIPTION
### What does it do?
Adds the property `$config` to the class, so not to rely on dynamic properties.

### Why is it needed?
In PHP 8.2 the deprecation warning
```
Deprecated: Creation of dynamic property modInstallLexicon::$config is deprecated in .../setup/includes/modinstalllexicon.class.php on line 35
```
may get shown on screen during the installation.

### How to test
Install MODX with PHP 8.2 and `display_errors` = `On` and verify that the deprecation warning is not shown.

### Related issue(s)/PR(s)
https://community.modx.com/t/error-message-on-upgrade-from-modx2-8-5-to-modx2-8-6/7099
