### PR TITLE
[2.x] Fix functionality in the section "Categories" of the elements tree

### DIFF
--- a/manager/assets/modext/widgets/element/modx.tree.element.js
+++ b/manager/assets/modext/widgets/element/modx.tree.element.js
@@ -181,6 +181,9 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
 
     ,removeElement: function(itm,e) {
         var id = this.cm.activeNode.id.substr(2);
+        if (id.startsWith('c_')){
+            id = id.substr(2);
+        }
         var oar = id.split('_');
         MODx.msg.confirm({
             title: _('warning')
@@ -207,6 +210,9 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
 
     ,activatePlugin: function(itm,e) {
         var id = this.cm.activeNode.id.substr(2);
+        if (id.startsWith('c_')){
+            id = id.substr(2);
+        }
         var oar = id.split('_');
         MODx.Ajax.request({
             url: MODx.config.connector_url
@@ -224,6 +230,9 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
 
     ,deactivatePlugin: function(itm,e) {
         var id = this.cm.activeNode.id.substr(2);
+        if (id.startsWith('c_')){
+            id = id.substr(2);
+        }
         var oar = id.split('_');
         MODx.Ajax.request({
             url: MODx.config.connector_url
@@ -296,6 +305,9 @@ Ext.extend(MODx.tree.Element,MODx.tree.Tree,{
 
     ,_createElement: function(itm,e,t) {
         var id = this.cm.activeNode.id.substr(2);
+        if (id.startsWith('c_')){
+            id = id.substr(2);
+        }
         var oar = id.split('_');
         var type = oar[0] == 'type' ? oar[1] : oar[0];
         var cat_id = oar[0] == 'type' ? 0 : (oar[1] == 'category' ? oar[2] : oar[3]);


### PR DESCRIPTION
### What does it do?
In some handler-functions, the information about the clicked item (type and id) gets extracted from the **node-ID** in the tree.
In most sections, the IDs have the prefix `n_`.
In the "Categories" section, nodes for other types have the prefix `n_c_` instead:

https://github.com/modxcms/revolution/blob/3f887dc6494fe32d3b2a52da20ec76a63bc8fb7d/core/model/modx/processors/element/getnodes.class.php#L480

This is now taken into account.

### Why is it needed?
Some context menu items don't work correctly, when executed for element types (other than "Category") in the "Categories" section of the elements tree.

![modx_manager_elements_categories_tv_remove](https://github.com/modxcms/revolution/assets/85392304/6264c0a1-8d82-49fb-931c-ca08c5b0e302)




### How to test
Go to the section "Categories" in the elements tree and check that the following options (in the context menu) now work:

- Remove `<type>` (for the types "Template", "TV", "Chunk", "Snippet" and "Plugin")
- Activate and Deactivate Plugin (for type "Plugin")
- Create a New `<type>` here (for the types "Template", "TV", "Chunk", "Snippet" and "Plugin")

### Related issue(s)/PR(s)
Resolves #16487 for MODX 2.x
