### PR TITLE
S3 Update: Add No Bucket Check

### DIFF
--- a/core/lexicon/en/source.inc.php
+++ b/core/lexicon/en/source.inc.php
@@ -84,6 +84,7 @@ $_lang['prop_s3.url_desc'] = 'The URL of the Amazon S3 instance.';
 $_lang['prop_s3.endpoint_desc'] = 'Alternative S3-compatible endpoint URL, e.g., "https://s3.<region>.example.com". Review your S3-compatible provider’s documentation for the endpoint location. Leave empty for Amazon S3';
 $_lang['prop_s3.region_desc'] = 'Region of the bucket. Example: us-west-1';
 $_lang['prop_s3.prefix_desc'] = 'Optional path/folder prefix';
+$_lang['prop_s3.no_bucket_check_desc'] = 'If set, don\'t attempt to check the bucket exists. It can be needed if the access key you are using does not have bucket creation/list permissions.';
 $_lang['s3_no_move_folder'] = 'The S3 driver does not support moving of folders at this time.';
 
 /* ftp source type */

--- a/core/lexicon/en/source.inc.php
+++ b/core/lexicon/en/source.inc.php
@@ -84,7 +84,7 @@ $_lang['prop_s3.url_desc'] = 'The URL of the Amazon S3 instance.';
 $_lang['prop_s3.endpoint_desc'] = 'Alternative S3-compatible endpoint URL, e.g., "https://s3.<region>.example.com". Review your S3-compatible provider’s documentation for the endpoint location. Leave empty for Amazon S3';
 $_lang['prop_s3.region_desc'] = 'Region of the bucket. Example: us-west-1';
 $_lang['prop_s3.prefix_desc'] = 'Optional path/folder prefix';
-$_lang['prop_s3.no_bucket_check_desc'] = 'If set, don\'t attempt to check the bucket exists. It can be needed if the access key you are using does not have bucket creation/list permissions.';
+$_lang['prop_s3.no_check_bucket_desc'] = 'If set, don\'t attempt to check the bucket exists. It can be needed if the access key you are using does not have bucket creation/list permissions.';
 $_lang['s3_no_move_folder'] = 'The S3 driver does not support moving of folders at this time.';
 
 /* ftp source type */

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -161,9 +161,9 @@ class modS3MediaSource extends modMediaSource
                 'value' => '',
                 'lexicon' => 'core:source',
             ],
-            'no_bucket_check' => [
-                'name' => 'no_bucket_check',
-                'desc' => 'prop_s3.no_bucket_check_desc',
+            'no_check_bucket' => [
+                'name' => 'no_check_bucket',
+                'desc' => 'prop_s3.no_check_bucket_desc',
                 'type' => 'combo-boolean',
                 'options' => '',
                 'value' => false,

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -55,15 +55,13 @@ class modS3MediaSource extends modMediaSource
 
         try {
             $client = new S3Client($config);
-            if (!$noBucketCheck) {
-                if (!$client->doesBucketExist($bucket)) {
-                    $this->xpdo->log(
-                        xPDO::LOG_LEVEL_ERROR,
-                        $this->xpdo->lexicon('source_err_init', ['source' => $this->get('name')])
-                    );
+            if (!$noBucketCheck && !$client->doesBucketExist($bucket)) {
+                $this->xpdo->log(
+                    xPDO::LOG_LEVEL_ERROR,
+                    $this->xpdo->lexicon('source_err_init', ['source' => $this->get('name')])
+                );
 
-                    return false;
-                }
+                return false;
             }
             $adapter = new AwsS3V3Adapter(new S3Client($config), $bucket, $prefix);
             $this->loadFlySystem($adapter);

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -38,6 +38,7 @@ class modS3MediaSource extends modMediaSource
         $bucket = $this->xpdo->getOption('bucket', $properties, '');
         $prefix = $this->xpdo->getOption('prefix', $properties, '');
         $endpoint = $this->xpdo->getOption('endpoint', $properties, '');
+        $noBucketCheck = $this->xpdo->getOption('no_check_bucket', $properties, false);
 
         $config = [
             'credentials' => [
@@ -54,13 +55,15 @@ class modS3MediaSource extends modMediaSource
 
         try {
             $client = new S3Client($config);
-            if (!$client->doesBucketExist($bucket)) {
-                $this->xpdo->log(
-                    xPDO::LOG_LEVEL_ERROR,
-                    $this->xpdo->lexicon('source_err_init', ['source' => $this->get('name')])
-                );
+            if (!$noBucketCheck) {
+                if (!$client->doesBucketExist($bucket)) {
+                    $this->xpdo->log(
+                        xPDO::LOG_LEVEL_ERROR,
+                        $this->xpdo->lexicon('source_err_init', ['source' => $this->get('name')])
+                    );
 
-                return false;
+                    return false;
+                }
             }
             $adapter = new AwsS3V3Adapter(new S3Client($config), $bucket, $prefix);
             $this->loadFlySystem($adapter);
@@ -156,6 +159,14 @@ class modS3MediaSource extends modMediaSource
                 'type' => 'password',
                 'options' => '',
                 'value' => '',
+                'lexicon' => 'core:source',
+            ],
+            'no_bucket_check' => [
+                'name' => 'no_bucket_check',
+                'desc' => 'prop_s3.no_bucket_check_desc',
+                'type' => 'combo-boolean',
+                'options' => '',
+                'value' => false,
                 'lexicon' => 'core:source',
             ],
             'imageExtensions' => [


### PR DESCRIPTION
### What does it do?
Add a "No Bucket Check" option for users with limited access.

### Why is it needed?
Some access keys aren't authorized to list buckets, so will fail to initialize the S3 source when it checks if the bucket exists.

### How to test
This would take some set up. Primarily, this is addressing an issue we are facing with updating our internal S3 provider. However, it is a common feature and the logic was ported from rclone https://rclone.org/s3/#s3-no-check-bucket
