### PR TITLE
Trim context setting keys on creation

### DIFF
--- a/core/model/modx/processors/context/setting/create.class.php
+++ b/core/model/modx/processors/context/setting/create.class.php
@@ -54,7 +54,7 @@ class modContextSettingCreateProcessor extends modObjectCreateProcessor {
     public function beforeSave() {
         $this->object->set('context_key', $this->context->key);
 
-        $key = $this->getProperty('key');
+        $key = trim($this->getProperty('key', ''));
         $this->object->set('key', $key);
 
         // Make sure the key's there and valid


### PR DESCRIPTION
### What does it do?
Trim the context setting key.

### Why is it needed?
System and user settings keys are trimmed, but not the context setting key.

### Related issue
The issue occurred in CrossContextsSettings. It uses the core context settings processor:
https://community.modx.com/t/langrouter-issues/7262