### PR TITLE
Fix saving time for date TVs created in MODX 2.x

### DIFF
--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -510,7 +510,7 @@ class Create extends CreateProcessor
                         $tvProperties = $tv->get('input_properties');
                         if (!empty($value)) {
                             $dateTime = new \DateTime($value);
-                            if (array_key_exists('hideTime', $tvProperties) && (bool)$tvProperties['hideTime']) {
+                            if (array_key_exists('hideTime', $tvProperties) && (bool)$tvProperties['hideTime'] && $tvProperties['hideTime'] != 'false') {
                                 $dateTime->setTime(0, 0, 0, 0);
                             }
                             $value = $dateTime->format('Y-m-d H:i:s');
@@ -769,4 +769,3 @@ class Create extends CreateProcessor
         return $clear;
     }
 }
-

--- a/core/src/Revolution/Processors/Resource/Update.php
+++ b/core/src/Revolution/Processors/Resource/Update.php
@@ -748,7 +748,7 @@ class Update extends UpdateProcessor
                         $tvProperties = $tv->get('input_properties');
                         if (!empty($value)) {
                             $dateTime = new \DateTime($value);
-                            if (array_key_exists('hideTime', $tvProperties) && (bool)$tvProperties['hideTime']) {
+                            if (array_key_exists('hideTime', $tvProperties) && (bool)$tvProperties['hideTime'] && $tvProperties['hideTime'] != 'false') {
                                 $dateTime->setTime(0, 0, 0, 0);
                             }
                             $value = $dateTime->format('Y-m-d H:i:s');


### PR DESCRIPTION
### What does it do?
Fixes the code in the "Resource/Create" and "Resource/Update" processors (that was added in #16398) to also work for date TVs that were created in MODX 2.x.

### Why is it needed?
In MODX 2.x, the input property **"hideTime"** of a Date-TV is stored as the value "false" (or "true") -> `s:8:"hideTime";s:5:"false";`
In MODX 3, the same property is stored as the value "0" (or "1") -> `s:8:"hideTime";s:1:"0";`

In MODX installations, that were updated from MODX 2.x to MODX 3, the time part of the date-TV-value always gets deleted.

### How to test

- Create a TV of type "date".
- Change the value of "hideTime" from `s:1:"0";` to `s:5:"false";` in the column "input_properties".
- Make sure, that the time part of the TV value still gets saved correctly.

### Related topic in the MODX forum
https://community.modx.com/t/date-tv-time-wont-save/7335
