### PR TITLE
Update phpThumb to v1.7.22-202312071641

### DIFF
--- a/core/model/phpthumb/phpthumb.class.php
+++ b/core/model/phpthumb/phpthumb.class.php
@@ -265,7 +265,7 @@ class phpthumb {
 	public $issafemode       = null;
 	public $php_memory_limit = null;
 
-	public $phpthumb_version = '1.7.21-202307141720';
+	public $phpthumb_version = '1.7.22-202312071641';
 
 	//////////////////////////////////////////////////////////////////////
 
@@ -314,7 +314,7 @@ class phpthumb {
 		$this->purgeTempFiles();
 	}
 
-	public function __set(string $name, mixed $value): void {
+	public function __set(string $name, $value): void {
 	}
 
 	// public:


### PR DESCRIPTION
### What does it do?
Updates phpThumb to v1.7.22-202312071641

### Why is it needed?
Fixes the issue with thumbnails not being generated when running on PHP 7.4 (or earlier).

### How to test
Make sure thumbnails are being generated in the media browser when running on PHP 7.4.

### Related issue(s)/PR(s)
Resolves #16468 for the 2.x branch