### PR TITLE
Log an error when resources can't be loaded in context cache generation

### DIFF
--- a/core/src/Revolution/mysql/modContext.php
+++ b/core/src/Revolution/mysql/modContext.php
@@ -196,8 +196,14 @@ class modContext extends \MODX\Revolution\modContext
             }
 
             $criteria = new xPDOCriteria($context->xpdo, $sql, $bindings, false);
-            if ($criteria && $criteria->stmt && $criteria->stmt->execute()) {
-                $stmt =& $criteria->stmt;
+            if ($criteria && $criteria->stmt) {
+                if ($criteria->stmt->execute()) {
+                    $stmt =& $criteria->stmt;
+                }
+
+                if ($criteria->stmt->errorCode() !== '00000') {
+                    $context->xpdo->log(modX::LOG_LEVEL_ERROR, '[modContext_mysql] Encountered error loading resources for cache map generation: ' . $criteria->stmt->errorCode() . ' // ' . print_r($criteria->stmt->errorInfo(), true));
+                }
             }
 
             // output warning if query is too slow


### PR DESCRIPTION
### What does it do?
Checks for errors loading resources in the generation of the context cache. 

### Why is it needed?
This is used in the aliasMap and resourceMap, but would fail silently if the query failed.  In the specific case preceding this PR, the problem was a borked migration, but it took too much sleuthing to figure out where it was failing exactly due to this information not being available. 

### How to test
Make sure no message gets logged in normal use. 

### Related issue(s)/PR(s)
N/a
