### PR TITLE
Add missing system setting for profile photo media source

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -434,6 +434,15 @@ $settings['default_media_source_type']->fromArray([
     'area' => 'manager',
     'editedon' => null,
 ], '', true, true);
+$settings['photo_profile_source'] = $xpdo->newObject(modSystemSetting::class);
+$settings['photo_profile_source']->fromArray([
+  'key' => 'photo_profile_source',
+  'value' => null,
+  'xtype' => 'modx-combo-source',
+  'namespace' => 'core',
+  'area' => 'manager',
+  'editedon' => null,
+], '', true, true);
 $settings['default_per_page'] = $xpdo->newObject(modSystemSetting::class);
 $settings['default_per_page']->fromArray([
   'key' => 'default_per_page',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -234,6 +234,9 @@ $_lang['setting_default_media_source_desc'] = 'The default Media Source to load.
 $_lang['setting_default_media_source_type'] = 'Default Media Source Type';
 $_lang['setting_default_media_source_type_desc'] = 'The default selected Media Source Type when creating a new Media Source.';
 
+$_lang['setting_photo_profile_source'] = 'User Profile Photo Source';
+$_lang['setting_photo_profile_source_desc'] = 'Specifies the Media Source to use for storing and retrieving profile photos/avatars. If not specified, the default Media Source will be used.';
+
 $_lang['setting_default_template'] = 'Default Template';
 $_lang['setting_default_template_desc'] = 'Select the default Template you wish to use for new Resources. You can still select a different template in the Resource editor, this setting just pre-selects one of your Templates for you.';
 
@@ -503,9 +506,6 @@ $_lang['setting_proxy_port_desc'] = 'The port for your proxy server.';
 
 $_lang['setting_proxy_username'] = 'Proxy Username';
 $_lang['setting_proxy_username_desc'] = 'The username to authenticate against with your proxy server.';
-
-$_lang['setting_photo_profile_source'] = 'User photo Media Source';
-$_lang['setting_photo_profile_source_desc'] = 'The Media Source used to store users profiles photos. Defaults to default Media Source.';
 
 $_lang['setting_phpthumb_allow_src_above_docroot'] = 'phpThumb Allow src Above Document Root';
 $_lang['setting_phpthumb_allow_src_above_docroot_desc'] = 'Indicates if the src path is allowed outside the document root. This is useful for multi-context deployments with multiple virtual hosts.';


### PR DESCRIPTION
### What does it do?
Adds a long-missing setting for specifying user's profile photo media source. Also, moves up (and tweaks) the associated Lexicon entries.

### Why is it needed?
The logic has been present in the backend to specify a Media Source other that the default for user profile photos since they were introduced nearly 10 years ago. However, the system setting was never added to the build, making it virtually unknown that this functionality existed.

### How to test
Run `_build/transport.core.php` to install the new setting. Then search for `photo_profile_source` in the system settings, change its value, and verify that the Media Source shown in the Media Browser (when editing/adding a user profile photo) matches that which you specified in the setting.

### Related issue(s)/PR(s)
Resolves #16510
