### PR TITLE
Fix modManagerLog MySQL > 5.7.8

### DIFF
--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -646,7 +646,7 @@
 
     <object class="modManagerLog" table="manager_log" extends="xPDO\Om\xPDOSimpleObject">
         <field key="user" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
-        <field key="occurred" dbtype="datetime" phptype="datetime" null="true" default="NULL" />
+        <field key="occurred" dbtype="datetime" phptype="datetime" null="false" default="CURRENT_TIMESTAMP" />
         <field key="action" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="classKey" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="item" dbtype="varchar" precision="255" phptype="string" null="false" default="0" />

--- a/core/src/Revolution/Registry/Db/mysql/modDbRegisterMessage.php
+++ b/core/src/Revolution/Registry/Db/mysql/modDbRegisterMessage.php
@@ -13,11 +13,11 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
         'version' => '3.0',
         'table' => 'register_messages',
         'extends' => 'xPDO\\Om\\xPDOObject',
-        'tableMeta' =>
+        'tableMeta' => 
         array (
             'engine' => 'InnoDB',
         ),
-        'fields' =>
+        'fields' => 
         array (
             'topic' => NULL,
             'id' => NULL,
@@ -29,9 +29,9 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
             'payload' => NULL,
             'kill' => 0,
         ),
-        'fieldMeta' =>
+        'fieldMeta' => 
         array (
-            'topic' =>
+            'topic' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -40,7 +40,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'null' => false,
                 'index' => 'pk',
             ),
-            'id' =>
+            'id' => 
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
@@ -48,28 +48,28 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'null' => false,
                 'index' => 'pk',
             ),
-            'created' =>
+            'created' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'valid' =>
+            'valid' => 
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
                 'null' => false,
                 'index' => 'index',
             ),
-            'accessed' =>
+            'accessed' => 
             array (
                 'dbtype' => 'timestamp',
                 'phptype' => 'timestamp',
                 'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
                 'index' => 'index',
             ),
-            'accesses' =>
+            'accesses' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '10',
@@ -79,7 +79,7 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
                 'index' => 'index',
             ),
-            'expires' =>
+            'expires' => 
             array (
                 'dbtype' => 'integer',
                 'precision' => '20',
@@ -88,13 +88,13 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
                 'index' => 'index',
             ),
-            'payload' =>
+            'payload' => 
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'string',
                 'null' => false,
             ),
-            'kill' =>
+            'kill' => 
             array (
                 'dbtype' => 'tinyint',
                 'precision' => '1',
@@ -104,23 +104,23 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 'default' => 0,
             ),
         ),
-        'indexes' =>
+        'indexes' => 
         array (
-            'PRIMARY' =>
+            'PRIMARY' => 
             array (
                 'alias' => 'PRIMARY',
                 'primary' => true,
                 'unique' => true,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'topic' =>
+                    'topic' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
                         'null' => false,
                     ),
-                    'id' =>
+                    'id' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -128,15 +128,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'created' =>
+            'created' => 
             array (
                 'alias' => 'created',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'created' =>
+                    'created' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -144,15 +144,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'valid' =>
+            'valid' => 
             array (
                 'alias' => 'valid',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'valid' =>
+                    'valid' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -160,15 +160,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accessed' =>
+            'accessed' => 
             array (
                 'alias' => 'accessed',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'accessed' =>
+                    'accessed' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -176,15 +176,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'accesses' =>
+            'accesses' => 
             array (
                 'alias' => 'accesses',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'accesses' =>
+                    'accesses' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -192,15 +192,15 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                     ),
                 ),
             ),
-            'expires' =>
+            'expires' => 
             array (
                 'alias' => 'expires',
                 'primary' => false,
                 'unique' => false,
                 'type' => 'BTREE',
-                'columns' =>
+                'columns' => 
                 array (
-                    'expires' =>
+                    'expires' => 
                     array (
                         'length' => '',
                         'collation' => 'A',
@@ -209,9 +209,9 @@ class modDbRegisterMessage extends \MODX\Revolution\Registry\Db\modDbRegisterMes
                 ),
             ),
         ),
-        'aggregates' =>
+        'aggregates' => 
         array (
-            'Topic' =>
+            'Topic' => 
             array (
                 'class' => 'MODX\\Revolution\\Registry\\Db\\modDbRegisterTopic',
                 'local' => 'topic',

--- a/core/src/Revolution/mysql/modManagerLog.php
+++ b/core/src/Revolution/mysql/modManagerLog.php
@@ -18,7 +18,7 @@ class modManagerLog extends \MODX\Revolution\modManagerLog
         'fields' => 
         array (
             'user' => 0,
-            'occurred' => NULL,
+            'occurred' => 'CURRENT_TIMESTAMP',
             'action' => '',
             'classKey' => '',
             'item' => '0',
@@ -38,8 +38,8 @@ class modManagerLog extends \MODX\Revolution\modManagerLog
             array (
                 'dbtype' => 'datetime',
                 'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
+                'null' => false,
+                'default' => 'CURRENT_TIMESTAMP',
             ),
             'action' => 
             array (

--- a/setup/includes/upgrades/common/3.1.0-db-changes.php
+++ b/setup/includes/upgrades/common/3.1.0-db-changes.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Database changes for 3.1
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$manager = $modx->getManager();
+
+$manager->alterField(\MODX\Revolution\modManagerLog::class, 'occurred');

--- a/setup/includes/upgrades/mysql/3.1.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.1.0-pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.1.0-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.1.0-db-changes.php';


### PR DESCRIPTION
### What does it do?
Add right default value for datatime-type column in modx_manager_log table

Re-up of #15736 with migration

### Why is it needed?
Beginning with MySQL > 5.7.8 added strict modes ERROR_FOR_DIVISION_BY_ZERO, NO_ZERO_DATE, NO_ZERO_IN_DATE. In this strict modes datatime default value cannot be NULL and must be > '0000-00-00'.

### How to test
Install/update on MySQL 5.7.8

### Related issue(s)/PR(s)
Re-up of #15736 

