### PR TITLE
Fix issues with extending modSessionHandler and flushing all sessions

### DIFF
--- a/core/src/Revolution/Processors/Security/Flush.php
+++ b/core/src/Revolution/Processors/Security/Flush.php
@@ -19,6 +19,14 @@ use MODX\Revolution\modSessionHandler;
  */
 class Flush extends Processor
 {
+    /**
+     * @return array
+     */
+    public function getLanguageTopics()
+    {
+        return ['topmenu'];
+    }
+
     public function checkPermissions()
     {
         return $this->modx->hasPermission('flush_sessions');
@@ -26,14 +34,14 @@ class Flush extends Processor
 
     public function process()
     {
-        if ($this->modx->getOption('session_handler_class',null,modSessionHandler::class) === modSessionHandler::class) {
-            if (!$this->flushSessions()) {
-                return $this->failure($this->modx->lexicon('flush_sessions_err'));
-            }
-        } else {
+        $sessionHandler = $this->modx->services->get('session_handler');
+        if (!$sessionHandler instanceof modSessionHandler) {
             return $this->failure($this->modx->lexicon('flush_sessions_not_supported'));
         }
-        return $this->success();
+
+        return $this->flushSessions()
+            ? $this->success()
+            : $this->failure($this->modx->lexicon('flush_sessions_err'));
     }
 
     public function flushSessions()

--- a/core/src/Revolution/Processors/Security/Flush.php
+++ b/core/src/Revolution/Processors/Security/Flush.php
@@ -35,24 +35,13 @@ class Flush extends Processor
     public function process()
     {
         $sessionHandler = $this->modx->services->get('session_handler');
-        if (!$sessionHandler instanceof modSessionHandler) {
+        if (!method_exists($sessionHandler, 'flushSessions')) {
             return $this->failure($this->modx->lexicon('flush_sessions_not_supported'));
         }
-
-        return $this->flushSessions()
-            ? $this->success()
-            : $this->failure($this->modx->lexicon('flush_sessions_err'));
-    }
-
-    public function flushSessions()
-    {
-        $flushed = true;
-        $sessionTable = $this->modx->getTableName(modSession::class);
-        if ($this->modx->query("TRUNCATE TABLE {$sessionTable}") == false) {
-            $flushed = false;
-        } else {
-            $this->modx->user->endSession();
+        $flushed = call_user_func_array([$sessionHandler, 'flushSessions'], [&$this->modx]);
+        if (!$flushed) {
+            return $this->failure($this->modx->lexicon('flush_sessions_err'));
         }
-        return $flushed;
+        return $this->success();
     }
 }

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -16,7 +16,7 @@ namespace MODX\Revolution;
  *
  * @package MODX\Revolution
  */
-class modSessionHandler
+class modSessionHandler implements \SessionHandlerInterface
 {
     /**
      * @var modX A reference to the modX instance controlling this session
@@ -68,7 +68,7 @@ class modSessionHandler
      * @return boolean Always returns true; actual connection is managed by
      * {@link modX}.
      */
-    public function open()
+    public function open($path, $name)
     {
         return true;
     }

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -42,7 +42,7 @@ class modSessionHandler implements \SessionHandlerInterface
      *
      * @param modX &$modx A reference to a {@link modX} instance.
      */
-    function __construct(modX &$modx)
+    public function __construct(modX &$modx)
     {
         $this->modx = &$modx;
         $gcMaxlifetime = (integer)$this->modx->getOption('session_gc_maxlifetime');
@@ -164,6 +164,23 @@ class modSessionHandler implements \SessionHandlerInterface
         $maxtime = time() - $this->gcMaxLifetime;
 
         return $this->modx->removeCollection(modSession::class, ["{$this->modx->escape('access')} < {$maxtime}"]);
+    }
+
+    /**
+     * Removes all sessions, logging out all users.
+     *
+     * @param modX $modx
+     * @return boolean
+     */
+    public static function flushSessions(modX $modx)
+    {
+        $sessionTable = $modx->getTableName(modSession::class);
+        if ($modx->query("TRUNCATE TABLE {$sessionTable}") == false) {
+            return false;
+        }
+
+        $modx->user->endSession();
+        return true;
     }
 
     /**

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2740,25 +2740,15 @@ class modX extends xPDO {
         $contextKey= $this->context instanceof modContext ? $this->context->get('key') : null;
         if ($this->getOption('session_enabled', $options, true) || isset($_GET['preview'])) {
             if (!in_array($this->getSessionState(), [modX::SESSION_STATE_INITIALIZED, modX::SESSION_STATE_EXTERNAL, modX::SESSION_STATE_UNAVAILABLE], true)) {
-                $sh = false;
-                if ($sessionHandlerClass = $this->getOption('session_handler_class', $options)) {
-                    if ($shClass = $this->loadClass($sessionHandlerClass, '', false, true)) {
-                        if ($sh = new $shClass($this)) {
-                            session_set_save_handler(
-                                [& $sh, 'open'],
-                                [& $sh, 'close'],
-                                [& $sh, 'read'],
-                                [& $sh, 'write'],
-                                [& $sh, 'destroy'],
-                                [& $sh, 'gc']
-                            );
-                        }
+                $sessionHandlerClass = $this->getOption('session_handler_class', $options);
+                if (is_string($sessionHandlerClass) && !empty($sessionHandlerClass) && class_exists($sessionHandlerClass)) {
+                    $sh = new $sessionHandlerClass($this);
+                    if ($sh instanceof \SessionHandlerInterface) {
+                        $this->services->add('session_handler', $sh);
+                        session_set_save_handler($sh);
                     }
                 }
-                if (
-                    (is_string($sessionHandlerClass) && !$sh instanceof $sessionHandlerClass) ||
-                    !is_string($sessionHandlerClass)
-                ) {
+                if (!$this->services->has('session_handler')) {
                     $sessionSavePath = $this->getOption('session_save_path', $options);
                     if ($sessionSavePath && is_writable($sessionSavePath)) {
                         session_save_path($sessionSavePath);


### PR DESCRIPTION
### What does it do?

- Fixes the bugs from #15928, per #15934
- Refactored inititialization of the session handler and adopt the PHP core SessionHandlerInterface, per #15934 
- Move flushing sessions logic into the session handler to optionally allow that to be extended, per #15957

### Why is it needed?

In two stale PRs #15928 and #15957 we have two proposals for dealing with some bugs and extending session handlers. While trying to figure out which one to use, I found both to have a solid approach, and wanting to use one bit of one and another part of other PR. 

This proposal replaces both those PRs as a middle ground, taking the most benefit from both approachs. 

### Breaking changes

This change includes a small breaking change in order to adopt the PHP standard SessionHandlerInterface, namely adding parameters into the open() method. There's not really any way around that in order to adopt the standard. 

As extending session handlers is a pretty advanced thing that I assume not many people have done, I suggest we accept that for the sake of getting closer to the standards, but make special note of this breaking change in the docs for 3.1 and the announcement to make sure people learn about it in case custom handlers need to be adjusted. 

### How to test
Flush sessions

### Related issue(s)/PR(s)

Replaces #15934 and #15957
Fixes #15928
