### PR TITLE
Fix default value for modManagerLog.occurred column

### DIFF
--- a/core/model/modx/mysql/modmanagerlog.map.inc.php
+++ b/core/model/modx/mysql/modmanagerlog.map.inc.php
@@ -15,7 +15,7 @@ $xpdo_meta_map['modManagerLog']= array (
   'fields' => 
   array (
     'user' => 0,
-    'occurred' => NULL,
+    'occurred' => 'CURRENT_TIMESTAMP',
     'action' => '',
     'classKey' => '',
     'item' => '0',
@@ -35,8 +35,8 @@ $xpdo_meta_map['modManagerLog']= array (
     array (
       'dbtype' => 'datetime',
       'phptype' => 'datetime',
-      'null' => true,
-      'default' => NULL,
+      'null' => false,
+      'default' => 'CURRENT_TIMESTAMP',
     ),
     'action' => 
     array (

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -679,7 +679,7 @@
 
     <object class="modManagerLog" table="manager_log" extends="xPDOSimpleObject">
         <field key="user" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
-        <field key="occurred" dbtype="datetime" phptype="datetime" null="true" default="NULL" />
+        <field key="occurred" dbtype="datetime" phptype="datetime" null="false" default="CURRENT_TIMESTAMP" />
         <field key="action" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="classKey" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
         <field key="item" dbtype="varchar" precision="191" phptype="string" null="false" default="0" />

--- a/setup/includes/upgrades/mysql/2.8.7-pl.php
+++ b/setup/includes/upgrades/mysql/2.8.7-pl.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * MySQL upgrade script for 2.8.7
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$class = 'modManagerLog';
+$table = $modx->getTableName($class);
+
+$description = $this->install->lexicon('alter_column', array('column' => 'occurred', 'table' => $table));
+$this->processResults($class, $description, array($modx->manager, 'alterField'), array($class, 'occurred'));


### PR DESCRIPTION
### What does it do?
Adds a default value for the datetime column in the modx_manager_log table that is compatible with strict modes, which may be enabled in some environments.

Re-up of #15736 with migration

### Why is it needed?
Beginning with MySQL > 5.7.8 added strict modes ERROR_FOR_DIVISION_BY_ZERO, NO_ZERO_DATE, NO_ZERO_IN_DATE. With these strict modes enabled, a datetime default value cannot be NULL and must be > '0000-00-00'.

### How to test
Install/update on MySQL 5.7.8

### Related issue(s)/PR(s)
Re-up of #15736
Backport of #16526 