### PR TITLE
Added proxy options for PSR-7 Service

### DIFF
--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -62,6 +62,11 @@ class Feed extends Processor
             $this->modx->cacheManager->writeTree($cachePath);
         }
 
+        $proxy_config = $this->buildProxyOptions();
+        if (!empty($proxy_config)) {
+            $feed->set_curl_options($proxy_config);
+        }
+
         $feed->set_cache_location($cachePath);
         $feed->set_useragent($this->modx->getVersionData()['full_version']);
         $feed->set_feed_url($url);
@@ -114,5 +119,29 @@ class Feed extends Processor
         }
 
         return $output;
+    }
+
+    /**
+     * Build configuration for the SimplePie client based on configuration settings.
+     *
+     * @return array The proxy configuration.
+     */
+    private function buildProxyOptions() 
+    {
+        $config = [];
+        $proxyHost = $this->modx->getOption('proxy_host', null, '');
+        if (!empty($proxyHost)) {
+            $config['CURLOPT_PROXY'] = $proxyHost;
+            $proxyPort = $this->modx->getOption('proxy_port', null, '');
+            if (!empty($proxyPort)) {
+                $config['CURLOPT_PROXY'] .= ':' . $proxyPort;
+            }
+            $proxyUsername = $this->modx->getOption('proxy_username', null, '');
+            if (!empty($proxyUsername)) {
+                $proxyPassword = $this->modx->getOption('proxy_password', null, '');
+                $config['CURLOPT_PROXYUSERPWD'] = $proxyUsername . ':' . $proxyPassword;
+            }
+        }
+        return $config;
     }
 }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2700,7 +2700,8 @@ class modX extends xPDO {
             // Http Client is created as a factory, so that repeat calls get a fresh client. This is done to make sure
             // mutable clients (perhaps they allow setting options after instantiation) do not cause side-effects elsewhere
             $this->services->add(ClientInterface::class, $this->services->factory(function() {
-                return new Client();
+                $opts = $this->buildHttpClientOptions();
+                return new Client($opts);
             }));
         }
         if (!$this->services->has(ServerRequestFactoryInterface::class)) {
@@ -2718,6 +2719,30 @@ class modX extends xPDO {
                 return new HttpFactory();
             });
         }
+    }
+
+    /**
+     * Build options for the HTTP client based on configuration settings.
+     *
+     * @return array The HTTP client options.
+     */
+    private function buildHttpClientOptions() {
+        $opts = [];
+        $proxyHost = $this->getOption('proxy_host', null, '');
+        if (!empty($proxyHost)) {
+            $proxy_str = $proxyHost;
+            $proxyPort = $this->getOption('proxy_port', null, '');
+            if (!empty($proxyPort)) {
+                $proxy_str .= ':' . $proxyPort;
+            }
+            $proxyUsername = $this->getOption('proxy_username', null, '');
+            if (!empty($proxyUsername)) {
+                $proxyPassword = $this->getOption('proxy_password', null, '');
+                $proxy_str = $proxyUsername . ':' . $proxyPassword . '@' . $proxy_str;
+            }
+            $opts['proxy'] = $proxy_str;
+        }
+        return $opts;
     }
 
     /**


### PR DESCRIPTION
### What does it do?
It uses the MODX proxy system settings for the PSR-7 service.

### Why is it needed?
When behind a proxy, this allows search/listing of Extras.

### How to test
Set all required proxy settings, open the Extras manager. If access to the Internet is only available via a proxy, it should work as expected.

### Related issue(s)/PR(s)
Resolves #16538 
