### PR TITLE
Add OnContextInit System Event

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -1025,7 +1025,7 @@ $events['OnChunkFormDelete']->fromArray([
 
 
 /* Contexts */
-$events['OnContextInit']= $xpdo->newObject(modEvent::class);
+$events['OnContextInit'] = $xpdo->newObject(modEvent::class);
 $events['OnContextInit']->fromArray([
     'name' => 'OnContextInit',
     'service' => 1,

--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -1025,6 +1025,12 @@ $events['OnChunkFormDelete']->fromArray([
 
 
 /* Contexts */
+$events['OnContextInit']= $xpdo->newObject(modEvent::class);
+$events['OnContextInit']->fromArray([
+    'name' => 'OnContextInit',
+    'service' => 1,
+    'groupname' => 'Contexts',
+], '', true, true);
 $events['OnContextSave']= $xpdo->newObject(modEvent::class);
 $events['OnContextSave']->fromArray([
     'name' => 'OnContextSave',

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2623,6 +2623,14 @@ class modX extends xPDO {
             if (!is_null($debug) && $debug !== '') {
                 $this->setDebug($debug);
             }
+
+            $this->invokeEvent(
+                'OnContextInit',
+                [
+                    'contextKey' => $contextKey,
+                    'options' => $options,
+                ]
+            );
         }
         return $initialized;
     }


### PR DESCRIPTION
### What does it do?
Adds a new core system event `OnContextInit`, invoked after each successful context initialization (includes those when `switchContext()` is called.

### Why is it needed?
We are having a project where we need to populate some data, that is context specific. To do so, we added a plugin to run each time a (new) context is initialized. Previously this was only possible via the event `OnMODXInit`, however this is only fired after the very first initialization of MODX. If you programmatically call `switchContext()` to init another context, there was no existing event to hook into.

### How to test
Add a plugin with a log line and activate the new system event `OnContextInit`. Log gets printed during modx initialization and when you programmatically call `switchContext()` with another context key.

### Related issue(s)/PR(s)
-
