### PR TITLE
[2.x] modConnectorResponse — allow dynamic properties

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -17,6 +17,7 @@ require_once MODX_CORE_PATH . 'model/modx/modresponse.class.php';
  * @package modx
  * @extends modResponse
  */
+#[\AllowDynamicProperties]
 class modConnectorResponse extends modResponse {
     /**
      * The base location of the processors called by the connectors.


### PR DESCRIPTION
### What does it do?
Added `#[\AllowDynamicProperties]` PHP attribute to the `modConnectorResponse`.


### Why is it needed?
This change silences a deprecation warning in PHP 8.2 because of dynamic property assignments in this class. This also fixes issues with the package management, because the response now contains valid JSON instead of HTML.


### Related issue(s)/PR(s)
- related https://github.com/modxcms/xpdo/issues/256
