### PR TITLE
Do not dynamically assign modProcessorResponse to modConnectorResponse

### DIFF
--- a/core/model/modx/modconnectorresponse.class.php
+++ b/core/model/modx/modconnectorresponse.class.php
@@ -140,15 +140,15 @@ class modConnectorResponse extends modResponse {
                 $scriptProperties = array_merge($scriptProperties,$_FILES);
             }
 
-            /* run processor */
-            $this->response = $this->modx->runProcessor($target,$scriptProperties,$options);
-            if (!$this->response) {
+            /** @var modProcessorResponse $response */
+            $response = $this->modx->runProcessor($target,$scriptProperties,$options);
+            if (!$response) {
                 $this->responseCode = 404;
                 $this->body = $this->modx->error->failure($this->modx->lexicon('processor_err_nf',array(
                     'target' => $target,
                 )));
             } else {
-                $this->body = $this->response->getResponse();
+                $this->body = $response->getResponse();
             }
         }
         /* if files sent, this means that the browser needs it in text/plain,


### PR DESCRIPTION
### What does it do?
Assign the processor result to a local variable rather than dynamically creating a "response" property on the modConnectorResponse class.

### Why is it needed?
In PHP 8.2, dynamically assigning a property to a class is deprecated. When calling runProcessor, the result is only used within the `outputContent()` method, so there is no need to assign the result from runProcessor to a property of modConnectorResponse dynamically or add a property to modConnectorResponse to hold the result.

### How to test
Confirm no deprecated warnings are logged when running a processor in a connector.

### Related issue(s)/PR(s)
Alternative solution to #16562 