### PR TITLE
Do not dynamically assign modProcessorResponse to modConnectorResponse

### DIFF
--- a/core/src/Revolution/modConnectorResponse.php
+++ b/core/src/Revolution/modConnectorResponse.php
@@ -148,14 +148,14 @@ class modConnectorResponse extends modResponse
                         }
 
                         /* run processor */
-                        $this->response = $this->modx->runProcessor($target, $scriptProperties, $options);
-                        if (!$this->response) {
+                        $response = $this->modx->runProcessor($target, $scriptProperties, $options);
+                        if (!$response) {
                             $this->responseCode = 404;
                             $this->body = $this->modx->error->failure($this->modx->lexicon('processor_err_nf', [
                                 'target' => $target,
                             ]));
                         } else {
-                            $this->body = $this->response->getResponse();
+                            $this->body = $response->getResponse();
                         }
                     }
                 }


### PR DESCRIPTION
### What does it do?
Assign the processor result to a local variable rather than dynamically creating a "response" property on the modConnectorResponse class.

### Why is it needed?
In PHP 8.2, dynamically assigning a property to a class is deprecated. When calling runProcessor, the result is only used within the `outputContent()` method, so there is no need to assign the result from runProcessor to a property of modConnectorResponse dynamically or add a property to modConnectorResponse to hold the result.

### How to test
Confirm no deprecated warnings are logged when running a processor in a connector.

### Related issue(s)/PR(s)
Port of #16563 to 3.0.x/3.x