### PR TITLE
Fix incorrect return type

### DIFF
--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -896,7 +896,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      *
      * @param mixed $pk Either the ID of the TV, or the name of the TV.
      *
-     * @return null/mixed The value of the TV for the Resource, or null if the
+     * @return null|mixed The value of the TV for the Resource, or null if the
      * TV is not found.
      */
     public function getTVValue($pk)


### PR DESCRIPTION
Correct the union of return types in documentation, so it's understood by IDEs.

### What does it do?
IDEs like PhpStorm saw this method as returning only `null`. This change gets them to see `null` or `mixed` as the return types.

### Why is it needed?
Described above.

### How to test
Use this method in an IDE; confirm it doesn't have any red lines under the usages.

### Related issue(s)/PR(s)
N/A
