### PR TITLE
Containerization of services

### DIFF
--- a/core/src/Revolution/Services/Container.php
+++ b/core/src/Revolution/Services/Container.php
@@ -22,9 +22,20 @@ class Container extends \Pimple\Container implements ContainerInterface
     public static function getInstance()
     {
         if (is_null(static::$instance)) {
-            static::$instance = new static;
+            static::$instance = new static();
         }
         return static::$instance;
+    }
+
+    /**
+     * Set the shared instance of the container.
+     *
+     * @param Container|null $container
+     * @return static
+     */
+    public static function setInstance(ContainerInterface $container = null)
+    {
+        return static::$instance = $container;
     }
 
     /**

--- a/core/src/Revolution/Services/Container.php
+++ b/core/src/Revolution/Services/Container.php
@@ -8,6 +8,26 @@ use Psr\Container\ContainerInterface;
 class Container extends \Pimple\Container implements ContainerInterface
 {
     /**
+     * The current globally available container (if any).
+     *
+     * @var static
+     */
+    protected static $instance;
+
+    /**
+     * Get the globally available instance of the container.
+     *
+     * @return static
+     */
+    public static function getInstance()
+    {
+        if (is_null(static::$instance)) {
+            static::$instance = new static;
+        }
+        return static::$instance;
+    }
+
+    /**
      * Add an entry to the container.
      *
      * @param string $id

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -525,7 +525,8 @@ class modX extends xPDO {
                 include_once MODX_CORE_PATH . 'include/deprecated.php';
             }
 
-            $container = new Container();
+            $container = \MODX\Revolution\Services\Container::getInstance();
+            $container['modx'] = $this;
             $container['config'] = $data;
 
             return $container;

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -525,7 +525,7 @@ class modX extends xPDO {
                 include_once MODX_CORE_PATH . 'include/deprecated.php';
             }
 
-            $container = \MODX\Revolution\Services\Container::getInstance();
+            $container = Container::setInstance(new Container());
             $container['modx'] = $this;
             $container['config'] = $data;
 


### PR DESCRIPTION
### What does it do?
added the ability to call containers from any part of the code without the need to connect an instance with modx

### Why is it needed?
Describe the issue you are solving.
```
# example №1
echo \MODX\Revolution\Services\Container::getInstance()->get('modx')->getOption('site_name');

# example №2
class App
{
    public function site_name()
    {
        $custom = \MODX\Revolution\Services\Container::getInstance()->get('modx')->getOption('site_name');
        return  mb_strtoupper($custom);
    }

    public static function service()
    {
        return \MODX\Revolution\Services\Container::getInstance()->get('app');
    }
}

\MODX\Revolution\Services\Container::getInstance()->add('app', new App());

$App = \MODX\Revolution\Services\Container::getInstance()->get('app')->site_name();

echo App::service()->site_name();
```

The main feature is the full use of the composer without the need to additionally pass an instance of $modx to the class
```
public function __construct(modX $modx = null)
{
      $this->modx = $modx;   
}
```


In the future, you can simplify the call to modx through the function
```
if (!function_exists('modxApp')) {
    function modxApp()
    {
        return \MODX\Revolution\Services\Container::getInstance()->get('modx');
    }
}

```

Works similarly in Laravel
https://packagist.org/packages/illuminate/container
does not cause any problems


the code was taken from illuminate/container,
https://github.com/illuminate/container/blob/a0796471eff9649592d7b5bdc8f705c134ceaaac/Container.php#L1407

is a public singleton pattern

```
 /**
     * The current globally available container (if any).
     *
     * @var static
     */
    protected static $instance;

    /**
     * Get the globally available instance of the container.
     *
     * @return static
     */
    public static function getInstance()
    {
        if (is_null(static::$instance)) {
            static::$instance = new static();
        }
        return static::$instance;
    }

    /**
     * Set the shared instance of the container.
     *
     * @param Container|null $container
     * @return static
     */
    public static function setInstance(ContainerInterface $container = null)
    {
        return static::$instance = $container;
    }
```
### How to test
Tested the web interface and with using the code above
phpunit tests via Github Actions completed successfully


### Related issue(s)/PR(s)
Have not found
