### PR TITLE
calling a modx instance via getInstance

### DIFF
--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -71,7 +71,7 @@ class MODxTestHarness {
                     if (!defined('MODX_CONFIG_KEY')) {
                         define('MODX_CONFIG_KEY', array_key_exists('config_key', self::$properties) ? self::$properties['config_key'] : 'test');
                     }
-                    $fixture = \MODX\Revolution\modX::getInstance(null, self::$properties["{$driver}_array_options"]);
+                    $fixture = modX::getInstance(null, self::$properties["{$driver}_array_options"]);
                     if ($fixture instanceof modX) {
                         $logLevel = array_key_exists('logLevel', self::$properties) ? self::$properties['logLevel'] : modX::LOG_LEVEL_WARN;
                         $logTarget = array_key_exists('logTarget', self::$properties) ? self::$properties['logTarget'] : (XPDO_CLI_MODE ? 'ECHO' : 'HTML');

--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -71,10 +71,7 @@ class MODxTestHarness {
                     if (!defined('MODX_CONFIG_KEY')) {
                         define('MODX_CONFIG_KEY', array_key_exists('config_key', self::$properties) ? self::$properties['config_key'] : 'test');
                     }
-                    $fixture = new modX(
-                        null,
-                        self::$properties["{$driver}_array_options"]
-                    );
+                    $fixture = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, null, self::$properties["{$driver}_array_options"]);
                     if ($fixture instanceof modX) {
                         $logLevel = array_key_exists('logLevel', self::$properties) ? self::$properties['logLevel'] : modX::LOG_LEVEL_WARN;
                         $logTarget = array_key_exists('logTarget', self::$properties) ? self::$properties['logTarget'] : (XPDO_CLI_MODE ? 'ECHO' : 'HTML');

--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -71,7 +71,7 @@ class MODxTestHarness {
                     if (!defined('MODX_CONFIG_KEY')) {
                         define('MODX_CONFIG_KEY', array_key_exists('config_key', self::$properties) ? self::$properties['config_key'] : 'test');
                     }
-                    $fixture = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, null, self::$properties["{$driver}_array_options"]);
+                    $fixture = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, self::$properties["{$driver}_array_options"]);
                     if ($fixture instanceof modX) {
                         $logLevel = array_key_exists('logLevel', self::$properties) ? self::$properties['logLevel'] : modX::LOG_LEVEL_WARN;
                         $logTarget = array_key_exists('logTarget', self::$properties) ? self::$properties['logTarget'] : (XPDO_CLI_MODE ? 'ECHO' : 'HTML');

--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -71,7 +71,7 @@ class MODxTestHarness {
                     if (!defined('MODX_CONFIG_KEY')) {
                         define('MODX_CONFIG_KEY', array_key_exists('config_key', self::$properties) ? self::$properties['config_key'] : 'test');
                     }
-                    $fixture = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, self::$properties["{$driver}_array_options"]);
+                    $fixture = \MODX\Revolution\modX::getInstance(null, self::$properties["{$driver}_array_options"]);
                     if ($fixture instanceof modX) {
                         $logLevel = array_key_exists('logLevel', self::$properties) ? self::$properties['logLevel'] : modX::LOG_LEVEL_WARN;
                         $logTarget = array_key_exists('logTarget', self::$properties) ? self::$properties['logTarget'] : (XPDO_CLI_MODE ? 'ECHO' : 'HTML');

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -95,8 +95,8 @@ class modXTest extends MODxTestCase
      */
     public function testSingleInstance()
     {
-        $this->modx->setOption('site_url', 'test');
-        $this->assertTrue($this->modx->getOption('site_url') === modX::getInstance()->getOption('site_url'));
+        $this->modx->setOption('test_option', 'test');
+        $this->assertTrue($this->modx->getOption('test_option') === modX::getInstance()->getOption('test_option'));
     }
 
     /**

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -88,6 +88,16 @@ class modXTest extends MODxTestCase
     }
 
 
+    /**
+     * Check the call to a single instance
+     *
+     * @after
+     */
+    public function testSingleInstance()
+    {
+        $this->modx->setOption('site_url', 'test');
+        $this->assertTrue($this->modx->getOption('site_url') === modX::getInstance()->getOption('site_url'));
+    }
 
     /**
      * Tear down fixtures after each test.

--- a/_build/transport.data.php
+++ b/_build/transport.data.php
@@ -19,7 +19,7 @@ if (!defined('MODX_CONFIG_KEY'))
 
 require MODX_CORE_PATH . 'vendor/autoload.php';
 
-$modx= new \MODX\Revolution\modX();
+$modx= \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
 $modx->initialize('mgr');
 
 $cacheManager= $modx->getCacheManager();

--- a/_build/transport.data.php
+++ b/_build/transport.data.php
@@ -19,7 +19,7 @@ if (!defined('MODX_CONFIG_KEY'))
 
 require MODX_CORE_PATH . 'vendor/autoload.php';
 
-$modx= \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
+$modx= \MODX\Revolution\modX::getInstance();
 $modx->initialize('mgr');
 
 $cacheManager= $modx->getCacheManager();

--- a/_build/transport.data.php
+++ b/_build/transport.data.php
@@ -19,7 +19,7 @@ if (!defined('MODX_CONFIG_KEY'))
 
 require MODX_CORE_PATH . 'vendor/autoload.php';
 
-$modx= \MODX\Revolution\modX::getInstance();
+$modx = \MODX\Revolution\modX::getInstance();
 $modx->initialize('mgr');
 
 $cacheManager= $modx->getCacheManager();

--- a/connectors/index.php
+++ b/connectors/index.php
@@ -41,7 +41,7 @@ if (!require_once(MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* load modX instance */
-$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
+$modx = \MODX\Revolution\modX::getInstance(null, [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 
 /* initialize the proper context */
 $ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) && is_string($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';

--- a/connectors/index.php
+++ b/connectors/index.php
@@ -41,7 +41,7 @@ if (!require_once(MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* load modX instance */
-$modx = new \MODX\Revolution\modX('', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
+$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, '', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 
 /* initialize the proper context */
 $ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) && is_string($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';

--- a/connectors/index.php
+++ b/connectors/index.php
@@ -41,7 +41,7 @@ if (!require_once(MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* load modX instance */
-$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, '', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
+$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 
 /* initialize the proper context */
 $ctx = isset($_REQUEST['ctx']) && !empty($_REQUEST['ctx']) && is_string($_REQUEST['ctx']) ? $_REQUEST['ctx'] : 'mgr';
@@ -62,10 +62,10 @@ if (defined('MODX_REQP') && MODX_REQP === false) {
 
 /* set manager language in manager context */
 if ($ctx == 'mgr') {
-    $ml = $modx->getOption('cultureKey',null,'en');
+    $ml = $modx->getOption('cultureKey', null, 'en');
     if ($ml != 'en') {
-        $modx->lexicon->load($ml.':core:default');
-        $modx->setOption('cultureKey',$ml);
+        $modx->lexicon->load($ml . ':core:default');
+        $modx->setOption('cultureKey', $ml);
     }
 }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -407,7 +407,7 @@ class modX extends xPDO {
      * @throws xPDOException
      */
     public static function getInstance($id = null, $config = null, $forceNew = false) {
-        $class = class_exists($id) ? $id : __CLASS__;
+        $class = __CLASS__;
         if (is_null($id)) {
             if (!is_null($config) || $forceNew || empty(self::$instances)) {
                 $id = uniqid($class);

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -407,7 +407,7 @@ class modX extends xPDO {
      * @throws xPDOException
      */
     public static function getInstance($id = null, $config = null, $forceNew = false) {
-        $class = __CLASS__;
+        $class = class_exists($id) ? $id : __CLASS__;
         if (is_null($id)) {
             if (!is_null($config) || $forceNew || empty(self::$instances)) {
                 $id = uniqid($class);

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -403,11 +403,11 @@ class modX extends xPDO {
      * @param array|null $config An optional array of config data for the instance.
      * @param bool $forceNew If true a new instance will be created even if an instance
      * with the provided $id already exists in modX::$instances.
-     * @return modX An instance of modX.
+     * @return static An instance of modX.
      * @throws xPDOException
      */
     public static function getInstance($id = null, $config = null, $forceNew = false) {
-        $class = __CLASS__;
+        $class = static::class;
         if (is_null($id)) {
             if (!is_null($config) || $forceNew || empty(self::$instances)) {
                 $id = uniqid($class);

--- a/index.php
+++ b/index.php
@@ -38,7 +38,7 @@ if (!@require_once MODX_CORE_PATH . "vendor/autoload.php") {
 ob_start();
 
 /* Create an instance of the modX class */
-$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
+$modx = \MODX\Revolution\modX::getInstance();
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     ob_get_level() && @ob_end_flush();
     $errorMessage = '<a href="setup/">MODX not installed. Install now?</a>';

--- a/index.php
+++ b/index.php
@@ -38,7 +38,7 @@ if (!@require_once MODX_CORE_PATH . "vendor/autoload.php") {
 ob_start();
 
 /* Create an instance of the modX class */
-$modx = new \MODX\Revolution\modX();
+$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     ob_get_level() && @ob_end_flush();
     $errorMessage = '<a href="setup/">MODX not installed. Install now?</a>';

--- a/manager/index.php
+++ b/manager/index.php
@@ -42,7 +42,7 @@ if (!(require_once MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* @var \MODX\Revolution\modX $modx create the modX object */
-$modx = \MODX\Revolution\modX::getInstance(null,[\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
+$modx = \MODX\Revolution\modX::getInstance(null, [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     $errorMessage = '<a href="../setup/">MODX not installed. Install now?</a>';
     include MODX_CORE_PATH . 'error/unavailable.include.php';

--- a/manager/index.php
+++ b/manager/index.php
@@ -42,7 +42,7 @@ if (!(require_once MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* @var \MODX\Revolution\modX $modx create the modX object */
-$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class,'', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
+$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class,[\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     $errorMessage = '<a href="../setup/">MODX not installed. Install now?</a>';
     include MODX_CORE_PATH . 'error/unavailable.include.php';

--- a/manager/index.php
+++ b/manager/index.php
@@ -42,7 +42,7 @@ if (!(require_once MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* @var \MODX\Revolution\modX $modx create the modX object */
-$modx= new \MODX\Revolution\modX('', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
+$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class,'', [\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     $errorMessage = '<a href="../setup/">MODX not installed. Install now?</a>';
     include MODX_CORE_PATH . 'error/unavailable.include.php';

--- a/manager/index.php
+++ b/manager/index.php
@@ -42,7 +42,7 @@ if (!(require_once MODX_CORE_PATH . 'vendor/autoload.php')) {
 }
 
 /* @var \MODX\Revolution\modX $modx create the modX object */
-$modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class,[\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
+$modx = \MODX\Revolution\modX::getInstance(null,[\xPDO\xPDO::OPT_CONN_INIT => [\xPDO\xPDO::OPT_CONN_MUTABLE => true]]);
 if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     $errorMessage = '<a href="../setup/">MODX not installed. Install now?</a>';
     include MODX_CORE_PATH . 'error/unavailable.include.php';

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -375,7 +375,7 @@ class modInstall {
 
         /* instantiate the modX class */
         if (class_exists('MODX\Revolution\modX')) {
-            $modx = new modX(MODX_CORE_PATH . 'config/');
+            $modx = \MODX\Revolution\modX::getInstance(MODX_CORE_PATH . 'config/');
             if (!is_object($modx) || !($modx instanceof modX)) {
                 $errors[] = '<p>'.$this->lexicon('modx_err_instantiate').'</p>';
             } else {
@@ -415,7 +415,7 @@ class modInstall {
 
         /* instantiate the modX class */
         if (@ require_once (MODX_CORE_PATH . 'model/modx/modx.class.php')) {
-            $modx = new modX(MODX_CORE_PATH . 'config/');
+            $modx = \MODX\Revolution\modX::getInstance(MODX_CORE_PATH . 'config/');
             if (is_object($modx) && $modx instanceof modX) {
                 /* try to initialize the mgr context */
                 $modx->initialize('mgr');
@@ -498,10 +498,9 @@ class modInstall {
 
         /* to validate installation, instantiate the modX class and run a few tests */
         if (class_exists(modX::class)) {
-            $modx = new modX(MODX_CORE_PATH . 'config/', [
+            $modx = \MODX\Revolution\modX::getInstance(MODX_CORE_PATH . 'config/', [
                 xPDO::OPT_SETUP => true,
-            ]
-            );
+            ]);
             if (!is_object($modx) || !($modx instanceof modX)) {
                 $errors[] = '<p>'.$this->lexicon('modx_err_instantiate').'</p>';
             } else {

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -375,11 +375,7 @@ class modInstall {
 
         /* instantiate the modX class */
         if (class_exists('MODX\Revolution\modX')) {
-
-
-            $modx = new modX(MODX_CORE_PATH . 'config/');
-
-            $modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
+            $modx = \MODX\Revolution\modX::getInstance();
             if (!is_object($modx) || !($modx instanceof modX)) {
                 $errors[] = '<p>'.$this->lexicon('modx_err_instantiate').'</p>';
             } else {
@@ -419,7 +415,7 @@ class modInstall {
 
         /* instantiate the modX class */
         if (@ require_once (MODX_CORE_PATH . 'model/modx/modx.class.php')) {
-            $modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
+            $modx = \MODX\Revolution\modX::getInstance();
             if (is_object($modx) && $modx instanceof modX) {
                 /* try to initialize the mgr context */
                 $modx->initialize('mgr');
@@ -502,7 +498,7 @@ class modInstall {
 
         /* to validate installation, instantiate the modX class and run a few tests */
         if (class_exists(modX::class)) {
-            $modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, [
+            $modx = \MODX\Revolution\modX::getInstance(null, [
                 xPDO::OPT_SETUP => true,
             ]);
             if (!is_object($modx) || !($modx instanceof modX)) {

--- a/setup/includes/modinstall.class.php
+++ b/setup/includes/modinstall.class.php
@@ -375,7 +375,11 @@ class modInstall {
 
         /* instantiate the modX class */
         if (class_exists('MODX\Revolution\modX')) {
-            $modx = \MODX\Revolution\modX::getInstance(MODX_CORE_PATH . 'config/');
+
+
+            $modx = new modX(MODX_CORE_PATH . 'config/');
+
+            $modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
             if (!is_object($modx) || !($modx instanceof modX)) {
                 $errors[] = '<p>'.$this->lexicon('modx_err_instantiate').'</p>';
             } else {
@@ -415,7 +419,7 @@ class modInstall {
 
         /* instantiate the modX class */
         if (@ require_once (MODX_CORE_PATH . 'model/modx/modx.class.php')) {
-            $modx = \MODX\Revolution\modX::getInstance(MODX_CORE_PATH . 'config/');
+            $modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
             if (is_object($modx) && $modx instanceof modX) {
                 /* try to initialize the mgr context */
                 $modx->initialize('mgr');
@@ -498,7 +502,7 @@ class modInstall {
 
         /* to validate installation, instantiate the modX class and run a few tests */
         if (class_exists(modX::class)) {
-            $modx = \MODX\Revolution\modX::getInstance(MODX_CORE_PATH . 'config/', [
+            $modx = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class, [
                 xPDO::OPT_SETUP => true,
             ]);
             if (!is_object($modx) || !($modx instanceof modX)) {


### PR DESCRIPTION
`
\MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class)
`

### What does it do?
Calling a modx instance without having to pass it through __construct(modX &$modx)
this method will be useful in cases where you need to access an instance of the modX class from different parts of your application

### Why is it needed?
The problem is reusing classes from composer as well as shortening for writing code in various classes

### How to test
The feature was tested on real modx 2.8 projects with a high load and a large backend
\MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class)
phpunit tests pass successfully

### Related issue(s)/PR(s)
[#14555](https://github.com/modxcms/revolution/pull/14574)
https://github.com/modxcms/revolution/pull/16569#issuecomment-2108080253


## Functions app
I didn’t immediately add the app() function
to shorten the call code
I wanted to clarify where it would be better to add it?
It might be worth renaming it to appModx()
Although app() would obviously be better

```
if (!function_exists('app')) {

    /**
     * Get the available modx instance.
     * @return mixed|\MODX\Revolution\modX
     */
    function app()
    {
        return \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class);
    }
}
```

## Example

```
require 'index.php';

# Old
$example1 = $modx->getOption('site_name');
# New
$example2 = \MODX\Revolution\modX::getInstance(\MODX\Revolution\modX::class)->getOption('site_name');
$example3 = app()->getOption('site_name');
```


ide code highlighting works immediately

![CleanShot 2024-05-14 at 01 47 01](https://github.com/modxcms/revolution/assets/5019138/c190a04b-ff78-415d-be39-eb57c0701c5f)
