### PR TITLE
Support dot followed by space in directories

### DIFF
--- a/core/src/Revolution/Processors/Browser/Browser.php
+++ b/core/src/Revolution/Processors/Browser/Browser.php
@@ -143,8 +143,11 @@ abstract class Browser extends Processor
     {
         $file = rawurldecode($file);
         $file = strip_tags($file);
-        $file = preg_replace('#\.(?![\w\-\~])#u', '', $file);
-        $file = preg_replace('#\/{2,}#', '/', $file);
+        if (strpos($file, '.') === 0) {
+            $file = preg_replace('/^(\.)([\s\/]*)(.*)/', '$1$3', $file);
+        }
+        $file = preg_replace('/\.(?![\w\-\~\s])/u', '', $file);
+        $file = preg_replace('/\/{2,}/', '/', $file);
         $file = strip_tags($file);
 
         return $file;


### PR DESCRIPTION
### What does it do?
Refined regex in Browser class to allow dot-space (e.g., `1. Folder Name`) within directory, but not when directory/file begins with a dot (e.g., .htaccess, .hidden-dir, etc).

### Why is it needed?
Responding to community member request.

### How to test
Create various directories and files with dot(s) and space(s) within to verify desired behavior.

### Related issue(s)/PR(s)
Resolves #16351