### PR TITLE
Add secondary regex option for transliterated file uploads

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1896,6 +1896,15 @@ $settings['upload_translit']->fromArray([
   'area' => 'file',
   'editedon' => null,
 ], '', true, true);
+$settings['upload_translit_restrict_chars_pattern'] = $xpdo->newObject(modSystemSetting::class);
+$settings['upload_translit_restrict_chars_pattern']->fromArray([
+  'key' => 'upload_translit_restrict_chars_pattern',
+  'value' => '/[\0\x0B\t\n\r\f\a&=+%#<>"~:`@\?\[\]\{\}\|\^\'\\\\]/',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'file',
+  'editedon' => null,
+], '', true, true);
 $settings['use_alias_path'] = $xpdo->newObject(modSystemSetting::class);
 $settings['use_alias_path']->fromArray([
   'key' => 'use_alias_path',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -765,6 +765,9 @@ $_lang['setting_upload_maxsize_desc'] = 'Enter the maximum file size that can be
 $_lang['setting_upload_translit'] = 'Transliterate names of uploaded files?';
 $_lang['setting_upload_translit_desc'] = 'If this option is enabled, the name of an uploaded file will be transliterated according to the global transliteration rules.';
 
+$_lang['setting_upload_translit_restrict_chars_pattern'] = 'File Name Character Restriction Pattern';
+$_lang['setting_upload_translit_restrict_chars_pattern_desc'] = 'A valid RegEx pattern for restricting characters used in an uploaded file’s name.';
+
 $_lang['setting_use_alias_path'] = 'Use Friendly Alias Path';
 $_lang['setting_use_alias_path_desc'] = 'Setting this option to \'yes\' will display the full path to the Resource if the Resource has an alias. For example, if a Resource with an alias called \'child\' is located inside a container Resource with an alias called \'parent\', then the full alias path to the Resource will be displayed as \'/parent/child.html\'.<br /><strong>NOTE: When setting this option to \'Yes\' (turning on alias paths), reference items (such as images, CSS, JavaScripts, etc.) use the absolute path, e.g., \'/assets/images\' as opposed to \'assets/images\'. By doing so you will prevent the browser (or web server) from appending the relative path to the alias path.</strong>';
 

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1148,7 +1148,15 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             }
 
             if ((bool)$this->xpdo->getOption('upload_translit')) {
-                $newName = $this->xpdo->filterPathSegment($file['name']);
+                $uploadRegex = $this->xpdo->getOption('upload_translit_restrict_chars_pattern');
+                $options = !empty($uploadRegex)
+                    ? [
+                        'friendly_alias_restrict_chars' => 'pattern',
+                        'friendly_alias_restrict_chars_pattern' => $uploadRegex
+                    ]
+                    : []
+                    ;
+                $newName = $this->xpdo->filterPathSegment($file['name'], $options);
 
                 // If the file name is different after filtering, call OnFileManagerFileRename
                 // so the change can be tracked by plugins


### PR DESCRIPTION
### What does it do?
Adds a new system setting that allows transliterated uploads to override the regex restriction used for file names (currently the same as with Resource aliases).

### Why is it needed?
See the referenced issue. The request made there would be the most common use-case, but I'd imagine there could be others where a user wants the naming convention to be different between file names and Resource aliases.

### How to test

1. Rebuild the core via `/_build/transport.core.php`
2. Run `/setup` (required to update the db based on the new build)
3. Test differing settings for Resources (`friendly_alias_restrict_chars_pattern`) and the new setting for files (`upload_translit_restrict_chars_pattern`). On a fresh install both settings regex patterns will be the same, so be sure to change at least one and verify the desired effect.

### Related issue(s)/PR(s)
Resolves #16551
