### PR TITLE
Add Help! label to Menu Item

### DIFF
--- a/_build/data/transport.core.menus.php
+++ b/_build/data/transport.core.menus.php
@@ -511,7 +511,7 @@ $userNavMenus[2]= $xpdo->newObject(modMenu::class);
 $userNavMenus[2]->fromArray([
   'menuindex' => 8,
   'text' => 'about',
-  'description' => '',
+  'description' => 'about_desc',
   'parent' => 'usernav',
   'permissions' => 'help',
   'action' => 'help',

--- a/core/lexicon/en/topmenu.inc.php
+++ b/core/lexicon/en/topmenu.inc.php
@@ -7,6 +7,7 @@
  * @subpackage lexicon
  */
 $_lang['about'] = 'About';
+$_lang['about_desc'] = 'Help!';
 $_lang['access_permissions'] = 'Access Permissions';
 $_lang['access_permissions_desc'] = 'Manage user group access to Resources and Contexts';
 $_lang['acls'] = 'Access Control Lists';

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -166,6 +166,7 @@ class TopMenu
             $label = '';
             $description = '';
             $title = ' title="' . $menu['description'] .'"';
+            $ariaLabel = !empty($menu['description']) ? ' aria-label="' . $menu['description'] .'"' : '';
 
             if (!empty($menu['icon'])) {
                 $label = $menu['icon'];
@@ -188,11 +189,11 @@ class TopMenu
                     $menu['action'] .= '&namespace='.$menu['namespace'];
                 }
                 $onclick = (!empty($menu['handler'])) ? ' onclick="'.str_replace('"','\'',$menu['handler']).'"' : '';
-                $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.( $top ? ' class="top-link"': '' ).$onclick.$title.'>'.$label.$description.'</a>'."\n";
+                $menuTpl .= '<a href="?a='.$menu['action'].$menu['params'].'"'.( $top ? ' class="top-link"': '' ).$onclick.$title.$ariaLabel.'>'.$label.$description.'</a>'."\n";
             } elseif (!empty($menu['handler'])) {
-                $menuTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'"'.$title.'>'.$label.$description.'</a>'."\n";
+                $menuTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'"'.$title.$ariaLabel.'>'.$label.$description.'</a>'."\n";
             } else {
-                $menuTpl .= '<a href="javascript:;"'.$title.'>'.$label.$description.'</a>'."\n";
+                $menuTpl .= '<a href="javascript:;"'.$title.$ariaLabel.'>'.$label.$description.'</a>'."\n";
             }
             $menuTpl .= '</li>'."\n";
 


### PR DESCRIPTION
Added Help! label to the Help Menu Item that was previously represented by the just an icon.

This was to fix for #13485

### What does it do?
Provides accessible label for the Help button in the header #13485 

### Why is it needed?
The current link has no link text and no value for screen readers

### How to test
This may require a build and or rerunning setup. 

### Related issue(s)/PR(s)
Should resolve #13485 by adding aria-label and corresponding text via lexicon to the `a` of the Help button in the header. 
