### PR TITLE
Make authority a unique index on modUserGroupRole

### DIFF
--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1284,12 +1284,12 @@
     <object class="modUserGroupRole" table="user_group_roles" extends="xPDO\Om\xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="191" phptype="string" null="false" index="unique" />
         <field key="description" dbtype="mediumtext" phptype="string" />
-        <field key="authority" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="9999" index="index" />
+        <field key="authority" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="9999" index="unique" />
 
         <index alias="name" name="name" primary="false" unique="true" type="BTREE">
             <column key="name" length="" collation="A" null="false" />
         </index>
-        <index alias="authority" name="authority" primary="false" unique="false" type="BTREE">
+        <index alias="authority" name="authority" primary="false" unique="true" type="BTREE">
             <column key="authority" length="" collation="A" null="false" />
         </index>
 

--- a/core/src/Revolution/mysql/modUserGroupRole.php
+++ b/core/src/Revolution/mysql/modUserGroupRole.php
@@ -44,7 +44,7 @@ class modUserGroupRole extends \MODX\Revolution\modUserGroupRole
                 'phptype' => 'integer',
                 'null' => false,
                 'default' => 9999,
-                'index' => 'index',
+                'index' => 'unique',
             ),
         ),
         'indexes' => 
@@ -69,7 +69,7 @@ class modUserGroupRole extends \MODX\Revolution\modUserGroupRole
             array (
                 'alias' => 'authority',
                 'primary' => false,
-                'unique' => false,
+                'unique' => true,
                 'type' => 'BTREE',
                 'columns' => 
                 array (

--- a/setup/includes/upgrades/common/3.1.0-modify-usergrouprole-authority-index.php
+++ b/setup/includes/upgrades/common/3.1.0-modify-usergrouprole-authority-index.php
@@ -1,0 +1,19 @@
+<?php
+
+/* convert the authority index to be unique on modUserGroupRole */
+
+/**
+ * @var modX $modx
+ * @var modInstallVersion $this
+ */
+
+$class = \MODX\Revolution\modUserGroupRole::class;
+$table = $modx->getTableName(\MODX\Revolution\modUserGroupRole::class);
+
+$description = $this->install->lexicon('drop_index', ['index' => 'authority', 'table' => $table]);
+$this->processResults($class, $description, [$modx->manager, 'removeIndex'], [$class, 'authority']);
+$description = $this->install->lexicon('add_index', ['index' => 'authority', 'table' => $table]);
+if (!$this->processResults($class, $description, [$modx->manager, 'addIndex'], [$class, 'authority']))
+{
+    $this->runner->addResult(modInstallRunner::RESULT_FAILURE, $this->install->lexicon('authority_unique_index_error'));
+}

--- a/setup/includes/upgrades/mysql/3.1.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.1.0-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(__DIR__) . '/common/3.1.0-remove-deprecated-resource-fields.php';
+include dirname(__DIR__) . '/common/3.1.0-modify-usergrouprole-authority-index.php';

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -16,6 +16,7 @@ $_lang['alter_activeuser_action'] = 'Modified modActiveUser `action` field to al
 $_lang['alter_usermessage_messageread'] = 'Changed modUserMessage `messageread` field to `read`.';
 $_lang['alter_usermessage_postdate'] = 'Changed modUserMessage `postdate` field from an INT to a DATETIME and to name `date_sent`.';
 $_lang['alter_usermessage_subject'] = 'Changed modUserMessage `subject` field from VARCHAR(60) to VARCHAR(255).';
+$_lang['authority_unique_index_error'] = 'Multiple modUserGroup records with the same authority were found. You will need to update these to have unique authority values and then re-run the upgrade.';
 $_lang['change_column'] = 'Changed `[[+old]]` field to `[[+new]]` on table [[+table]].';
 $_lang['change_default_value'] = 'Changed default value for column `[[+column]]` to "[[+value]]" on table [[+table]].';
 $_lang['connector_acls_removed'] = 'Removed connector context ACLs.';


### PR DESCRIPTION
### What does it do?
Adds a unique index to the modUserGroupRole.authority field.

### Why is it needed?
modUserGroupRole records are linked to ACLs via the authority value, so those MUST be unique or referential integrity is lost.

### How to test
Run the transport build, execute the setup, and verify that after adding a modUserGroupRole record with a non-unique authority value, the upgrade stops with a failure describing what you need to do in order to resolve the situation before re-running the setup. After removing the non-unique record, verify that setup then runs successfully and a unique index is added to the authority column.

### Related issue(s)/PR(s)
This is related to and should be adopted along with #16568 — see discussion on that PR.