### PR TITLE
Avoid modLexicon deprecation warning in PHP 8.2+

### DIFF
--- a/core/model/modx/modlexicon.class.php
+++ b/core/model/modx/modlexicon.class.php
@@ -47,7 +47,14 @@ class modLexicon {
      * @var array $_loadedTopics
      */
     protected $_loadedTopics = array();
-
+    
+    /**
+     * An array of configuration properties
+     *
+     * @var array $config
+     */
+    protected $config = array();
+    
     /**
      * Creates the modLexicon instance.
      *

--- a/core/model/modx/modlexicon.class.php
+++ b/core/model/modx/modlexicon.class.php
@@ -47,7 +47,6 @@ class modLexicon {
      * @var array $_loadedTopics
      */
     protected $_loadedTopics = array();
-    
     /**
      * An array of configuration properties
      *


### PR DESCRIPTION
### What does it do?
Adds the `config` property to the `modlexicon.class.php` class, to not to rely on a dynamic property.


### Why is it needed?
PHP 8 deprecates dynamic properties and an error may show up in the UI when error reporting is turned on.


### Related issue(s)/PR(s)
- https://github.com/modxcms/revolution/pull/16482