### PR TITLE
Add an asterisk to label of required TVs

### DIFF
--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -36,6 +36,7 @@ Ext.extend(MODx,Ext.Component,{
 
     ,startup: function() {
         this.initQuickTips();
+        this.initMarkRequiredTVs();
         this.request = this.getURLParameters();
         this.Ajax = this.load({ xtype: 'modx-ajax' });
         Ext.override(Ext.form.Field,{
@@ -93,6 +94,35 @@ Ext.extend(MODx,Ext.Component,{
             dismissDelay: 2300
             ,interceptTitles: true
         });
+    }
+
+    ,initMarkRequiredTVs: function() {
+        var markdom = '<span class=\"required\">*</span> ';
+
+        var MarkRequiredTVPlugin = function (config) {
+            config = config || {};
+            Ext.apply(config, {
+                init: function(cmp) {
+                    if (cmp.allowBlank !== false) return;
+
+                    var tv = cmp.applyTo || cmp.id;
+                    if (tv && tv.match(/^tv[\d]*$/i)) {
+                        var label = document.getElementById(tv+'-caption');
+                        var html = label.innerHTML+markdom;
+                        label.innerHTML = html;
+                    }
+                }
+            });
+            MarkRequiredTVPlugin.superclass.constructor.call(this, config);
+        }
+        Ext.extend(MarkRequiredTVPlugin, Ext.BoxComponent);
+        Ext.ComponentMgr.registerPlugin('markrequiredfields',MarkRequiredTVPlugin);
+
+        if (!Array.isArray(Ext.form.Field.prototype.plugins)) {
+            Ext.form.Field.prototype.plugins = [];
+        }
+        var plugins = Ext.form.Field.prototype.plugins;
+        Ext.form.Field.prototype.plugins = Ext.form.Field.prototype.plugins.concat(['markrequiredfields'], plugins);
     }
 
     ,getURLParameters: function() {


### PR DESCRIPTION
### What does it do?
Adds asterix automatically to a TV that has `allowBlank: false` set.

![tv_req_1](https://github.com/user-attachments/assets/5f9029ca-b076-4f56-b545-c40ffcd3fa32)

![tv_req_2](https://github.com/user-attachments/assets/296eac3a-d0ea-4ace-a336-284dfdd42f87)

### Why is it needed?
Required TVs are no different from regular ones. Only when saving the resource, required TVs are marked with a message, **which is inconvenient**.

p.s. For the 3.x branch, this behavior already exists, and it would not be superfluous for 2.x as well.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/16593
https://github.com/modxcms/revolution/pull/14522
