### PR TITLE
Fix max parser iterations for resources without a template

### DIFF
--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -487,7 +487,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                 }
             } else {
                 $this->_content = $this->getContent();
-                $maxIterations = intval($this->xpdo->getOption('parser_max_iterations', 10));
+                $maxIterations = intval($this->xpdo->getOption('parser_max_iterations', null, 10));
                 $this->xpdo->parser->processElementTags('', $this->_content, false, false, '[[', ']]', [],
                     $maxIterations);
                 $this->_processed = true;


### PR DESCRIPTION
### Why is it needed?
Currently for resources without an assigned template ("Uses Template" = `(empty)` in the manager), the parser is called with a `$depth` (maximum iterations) of `0`.

---

The second parameter of the `getOption()` function is an array of `$options` and not the default value:
https://github.com/modxcms/xpdo/blob/ffa5d883ef44bd684db748a3e454071672913e48/src/xPDO/xPDO.php#L705-L711


