### PR TITLE
Fix preview thumbnailing for images with ampersand (&) in file name

### DIFF
--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/image.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/image.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -21,24 +22,27 @@ use MODX\Revolution\Sources\modMediaSource;
  * @package modx
  * @subpackage processors.element.tv.renders.mgr.input
  */
-class modTemplateVarInputRenderImage extends modTemplateVarInputRender {
+class modTemplateVarInputRenderImage extends modTemplateVarInputRender
+{
     public function process($value, array $params = [])
     {
         $this->modx->getService('fileHandler', modFileHandler::class, '', ['context' => $this->modx->context->get('key')]);
 
         /** @var modMediaSource $source */
         $source = $this->tv->getSource($this->modx->resource->get('context_key'));
-        if (!$source) return '';
-        if (!$source->getWorkingContext()) {
+        if (!$source || !$source->getWorkingContext()) {
             return '';
         }
+
         $source->setRequestProperties($_REQUEST);
         $source->initialize();
         $this->modx->controller->setPlaceholder('source', $source->get('id'));
         $params = array_merge($source->getPropertyList(), $params);
 
         $value = $this->tv->get('value');
+        $this->setPlaceholder('preview', rawurlencode($value));
         $this->tv->set('relativeValue', $value);
+
         if (!$source->checkPolicy('view')) {
             $this->setPlaceholder('disabled', true);
             $this->tv->set('disabled', true);
@@ -60,7 +64,8 @@ class modTemplateVarInputRenderImage extends modTemplateVarInputRender {
         $this->setPlaceholder('params', $params);
         $this->setPlaceholder('tv', $this->tv);
     }
-    public function getTemplate() {
+    public function getTemplate()
+    {
         return 'element/tv/renders/input/image.tpl';
     }
 }

--- a/manager/templates/default/element/tv/renders/input/image.tpl
+++ b/manager/templates/default/element/tv/renders/input/image.tpl
@@ -1,7 +1,7 @@
 <div id="tv-image-{$tv->id}"></div>
 
 <div id="tv-image-preview-{$tv->id}" class="modx-tv-image-preview">
-    {if $tv->value}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src={$tv->value}&source={$source}" alt="" />{/if}
+    {if $preview}<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&source={$source}&src={$preview}" alt="">{/if}
 </div>
 
 {if $disabled}
@@ -56,8 +56,9 @@
                         if (Ext.isEmpty(data.url)) {
                             d.update('');
                         } else {
+                            const url = encodeURIComponent(data.url);
                             {/literal}
-                            d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src='+data.url+'&wctx={$ctx}&source={$source}&version={$hash}" alt="" />');
+                            d.update('<img src="{$_config.connectors_url}system/phpthumb.php?w=400&h=400&aoe=0&far=0&f=png&src='+url+'&wctx={$ctx}&source={$source}&version={$hash}" alt="">');
                             {literal}
                         }
                     }


### PR DESCRIPTION
### What does it do?
URL encodes the src property used in building the image TV type’s phpthumb preview link.

### Why is it needed?
The unencoded property was mangling the request when an ampersand was present in the file source path, preventing the creation of preview images.

### How to test

1. Create at least one folder and one image with '&' in the name.
2. Create an image TV, assign it to a Template/Resource, and select the images you’ve created via the TV.
3. Verify that the preview shows and also shown when selecting a different image via the TV.

### Related issue(s)/PR(s)
For 3.x:
Resolves #14264
Resolves #13412
