### PR TITLE
3.x Fix TV Category not found issue in Template and TV editing panels

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,10 @@ module.exports = {
         'one-var': ['error', 'consecutive'],
         'prefer-arrow-callback': 'warn',
         'prefer-rest-params': 'warn',
+        'semi-spacing': ['warn', {
+            before: false,
+            after: true
+        }],
         'semi-style': ['warn', 'last'],
         'space-before-function-paren': ['error', 'never']
     }

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -89,7 +89,9 @@ MODx.grid.TemplateTV = function(config = {}) {
                 xtype: 'modx-combo-category'
                 ,itemId: 'filter-category'
                 ,emptyText: _('filter_by_category')
-                ,value: MODx.request.category || null
+                ,value: MODx.request.category !== 'undefined' ? MODx.request.category : null
+                ,submitValue: false
+                ,hiddenName: ''
                 ,width: 200
                 ,listeners: {
                     select: {

--- a/manager/assets/modext/widgets/element/modx.grid.template.tv.js
+++ b/manager/assets/modext/widgets/element/modx.grid.template.tv.js
@@ -6,18 +6,19 @@
  * @param {Object} config An object of options.
  * @xtype modx-grid-template-tv
  */
+// eslint-disable-next-line func-names
 MODx.grid.TemplateTV = function(config = {}) {
-    const tt = new Ext.ux.grid.CheckColumn({
-        header: _('access')
-        ,dataIndex: 'access'
-        ,width: 70
-        ,sortable: true
+    const accessCheckboxCol = new Ext.ux.grid.CheckColumn({
+        header: _('access'),
+        dataIndex: 'access',
+        width: 70,
+        sortable: true
     });
-    Ext.applyIf(config,{
-        title: _('template_assignedtv_tab')
-        ,id: 'modx-grid-template-tv'
-        ,url: MODx.config.connector_url
-        ,fields: [
+    Ext.applyIf(config, {
+        title: _('template_assignedtv_tab'),
+        id: 'modx-grid-template-tv',
+        url: MODx.config.connector_url,
+        fields: [
             'id',
             'name',
             'caption',
@@ -26,76 +27,80 @@ MODx.grid.TemplateTV = function(config = {}) {
             'perm',
             'category_name',
             'category'
-        ]
-        ,baseParams: {
-            action: 'Element/Template/TemplateVar/GetList'
-            ,template: config.template
-            ,sort: 'tv_rank'
-            ,category: MODx.request.category || null
-        }
-        ,saveParams: {
+        ],
+        baseParams: {
+            action: 'Element/Template/TemplateVar/GetList',
+            template: config.template,
+            sort: 'tv_rank',
+            category: MODx.request.category || null
+        },
+        saveParams: {
             template: config.template
-        }
-        ,width: 800
-        ,paging: true
-        ,plugins: tt
-        ,remoteSort: true
-        ,sortBy: 'category_name, tv_rank'
-        ,grouping: true
-        ,groupBy: 'category_name'
-        ,singleText: _('tv')
-        ,pluralText: _('tvs')
-        ,enableDragDrop: true
-        ,ddGroup : 'template-tvs-ddsort'
-        ,sm: new Ext.grid.RowSelectionModel({
-            singleSelect: true
-            ,listeners: {
+        },
+        width: 800,
+        paging: true,
+        plugins: accessCheckboxCol,
+        remoteSort: true,
+        sortBy: 'category_name, tv_rank',
+        grouping: true,
+        groupBy: 'category_name',
+        singleText: _('tv'),
+        pluralText: _('tvs'),
+        enableDragDrop: true,
+        ddGroup: 'template-tvs-ddsort',
+        sm: new Ext.grid.RowSelectionModel({
+            singleSelect: true,
+            listeners: {
                 beforerowselect: function(sm, idx, keep, record) {
-                    sm.grid.ddText = '<div>'+ record.data.name +'</div>';
+                    // eslint-disable-next-line no-param-reassign
+                    sm.grid.ddText = `<div>${record.data.name}</div>`;
                 }
             }
-        })
-        ,columns: [{
-            header: _('name')
-            ,dataIndex: 'name'
-            ,width: 150
-            ,sortable: true
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=element/tv/update&id=' + record.data.id
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        },{
-            header: _('category')
-            ,dataIndex: 'category_name'
-            ,width: 150
-            ,sortable: true
-        },{
-            header: _('caption')
-            ,dataIndex: 'caption'
-            ,width: 350
-            ,sortable: false
-        },tt,{
-            header: _('rank')
-            ,dataIndex: 'tv_rank'
-            ,width: 100
-            ,editor: { xtype: 'textfield' ,allowBlank: false }
-            ,sortable: true
-        }]
-        ,tbar: [
+        }),
+        columns: [{
+            header: _('name'),
+            dataIndex: 'name',
+            width: 150,
+            sortable: true,
+            renderer: {
+                fn: function(value, metadata, record) {
+                    return this.renderLink(value, {
+                        href: `?a=element/tv/update&id=${record.data.id}`,
+                        target: '_blank'
+                    });
+                },
+                scope: this
+            }
+        }, {
+            header: _('category'),
+            dataIndex: 'category_name',
+            width: 150,
+            sortable: true
+        }, {
+            header: _('caption'),
+            dataIndex: 'caption',
+            width: 350,
+            sortable: false
+        }, accessCheckboxCol, {
+            header: _('rank'),
+            dataIndex: 'tv_rank',
+            width: 100,
+            editor: { xtype: 'textfield', allowBlank: false },
+            sortable: true
+        }],
+        tbar: [
             '->',
             {
-                xtype: 'modx-combo-category'
-                ,itemId: 'filter-category'
-                ,emptyText: _('filter_by_category')
-                ,value: MODx.request.category !== 'undefined' ? MODx.request.category : null
-                ,submitValue: false
-                ,hiddenName: ''
-                ,width: 200
-                ,listeners: {
+                xtype: 'modx-combo-category',
+                itemId: 'filter-category',
+                emptyText: _('filter_by_category'),
+                value: MODx.request.category !== 'undefined' ? MODx.request.category : null,
+                submitValue: false,
+                hiddenName: '',
+                width: 200,
+                listeners: {
                     select: {
-                        fn: function (cmp, record, selectedIndex) {
+                        fn: function(cmp, record, selectedIndex) {
                             this.applyGridFilter(cmp, 'category');
                         },
                         scope: this
@@ -106,83 +111,88 @@ MODx.grid.TemplateTV = function(config = {}) {
             this.getClearFiltersButton('filter-category, filter-query')
         ]
     });
-    MODx.grid.TemplateTV.superclass.constructor.call(this,config);
+    MODx.grid.TemplateTV.superclass.constructor.call(this, config);
     this.on('render', this.prepareDDSort, this);
 };
-Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
+Ext.extend(MODx.grid.TemplateTV, MODx.grid.Grid, {
     getMenu: function() {
-        var r = this.getSelectionModel().getSelected();
-        var p = r.data.perm;
-        var m = [];
-
-        if (p.indexOf('pedit') != -1) {
-            m.push({
-                text: _('edit')
-                ,handler: this.updateTV
+        const
+            record = this.getSelectionModel().getSelected(),
+            permissions = record.data.perm,
+            menu = []
+        ;
+        if (permissions.indexOf('pedit') !== -1) {
+            menu.push({
+                text: _('edit'),
+                handler: this.updateTV
             });
         }
-        return m;
-    }
+        return menu;
+    },
 
-    ,updateTV: function(itm,e) {
-        MODx.loadPage('element/tv/update', 'id='+this.menu.record.id);
-    }
+    updateTV: function(itm, e) {
+        MODx.loadPage('element/tv/update', `id=${this.menu.record.id}`);
+    },
 
-    ,sortTVs: function(sourceNode, targetNode) {
-        var store = this.getStore();
-        var sourceIdx = store.indexOf(sourceNode);
-        var targetIdx = store.indexOf(targetNode);
-
+    sortTVs: function(sourceNode, targetNode) {
+        const
+            store = this.getStore(),
+            sourceIdx = store.indexOf(sourceNode),
+            targetIdx = store.indexOf(targetNode)
+        ;
         // Insert the selection to the target (and remove original selection)
         store.removeAt(sourceIdx);
         store.insert(targetIdx, sourceNode);
 
         // Extract the store items with the same category_name as the sourceNode to start the index at 0 for each category
-        var filteredStore = store.queryBy(function(rec, id) {
-            if (rec.get('category_name') === sourceNode.get('category_name')) {
+        // eslint-disable-next-line func-names, prefer-arrow-callback
+        const filteredStore = store.queryBy(function(record, id) {
+            if (record.get('category_name') === sourceNode.get('category_name')) {
                 return true;
             }
             return false;
         }, this);
 
         // Loop trough the filtered store and re-apply the re-calculated ranks to the store records
+        // eslint-disable-next-line func-names, prefer-arrow-callback
         Ext.each(filteredStore.items, function(item, index, allItems) {
             if (sourceNode.get('category_name') === item.get('category_name')) {
-                var record = store.getById(item.id);
+                const record = store.getById(item.id);
                 record.set('tv_rank', index);
             }
         }, this);
-    }
+    },
 
-    ,prepareDDSort: function(grid) {
+    prepareDDSort: function(grid) {
         this.dropTarget = new Ext.dd.DropTarget(grid.getView().mainBody, {
-            ddGroup: 'template-tvs-ddsort'
-            ,copy: false
-            ,notifyOver: function(dragSource, e, data) {
+            ddGroup: 'template-tvs-ddsort',
+            copy: false,
+            notifyOver: function(dragSource, e, data) {
                 if (dragSource.getDragData(e)) {
-                    var targetNode = dragSource.getDragData(e).selections[0];
-                    var sourceNode = data.selections[0];
-
-                    if ((sourceNode.data['category_name'] != targetNode.data['category_name']) ||
-                        !sourceNode.data['access'] ||
-                        !targetNode.data['access'] ||
-                        (sourceNode.data['id'] == targetNode.data['id'])
-                        ) {
+                    const
+                        targetNode = dragSource.getDragData(e).selections[0],
+                        sourceNode = data.selections[0]
+                    ;
+                    if ((sourceNode.data.category_name !== targetNode.data.category_name)
+                        || !sourceNode.data.access
+                        || !targetNode.data.access
+                        || (sourceNode.data.id === targetNode.data.id)
+                    ) {
                         return this.dropNotAllowed;
                     }
-
                     return this.dropAllowed;
                 }
-
                 return this.dropNotAllowed;
-            }
-            ,notifyDrop : function(dragSource, e, data) {
+            },
+            notifyDrop: function(dragSource, e, data) {
                 if (dragSource.getDragData(e)) {
-                    var targetNode = dragSource.getDragData(e).selections[0];
-                    var sourceNode = data.selections[0];
-                    if ((targetNode.id != sourceNode.id) &&
-                        (targetNode.get('category_name') === sourceNode.get('category_name')) &&
-                        sourceNode.get('access')
+                    const
+                        targetNode = dragSource.getDragData(e).selections[0],
+                        sourceNode = data.selections[0]
+                    ;
+                    if ((targetNode.id !== sourceNode.id)
+                        && (targetNode.get('category_name') === sourceNode.get('category_name'))
+                        && sourceNode.get('access')
                     ) {
                         grid.sortTVs(sourceNode, targetNode);
                     }
@@ -191,4 +201,4 @@ Ext.extend(MODx.grid.TemplateTV,MODx.grid.Grid,{
         });
     }
 });
-Ext.reg('modx-grid-template-tv',MODx.grid.TemplateTV);
+Ext.reg('modx-grid-template-tv', MODx.grid.TemplateTV);

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -65,7 +65,9 @@ MODx.grid.TemplateVarTemplate = function(config) {
                 xtype: 'modx-combo-category'
                 ,itemId: 'filter-category'
                 ,emptyText: _('filter_by_category')
-                ,value: MODx.request.category || null
+                ,value: MODx.request.category !== 'undefined' ? MODx.request.category : null
+                ,submitValue: false
+                ,hiddenName: ''
                 ,width: 200
                 ,listeners: {
                     select: {

--- a/manager/assets/modext/widgets/element/modx.grid.tv.template.js
+++ b/manager/assets/modext/widgets/element/modx.grid.tv.template.js
@@ -6,18 +6,18 @@
  * @param {Object} config An object of options.
  * @xtype modx-grid-tv-template
  */
-MODx.grid.TemplateVarTemplate = function(config) {
-    config = config || {};
-    var tt = new Ext.ux.grid.CheckColumn({
-        header: _('access')
-        ,dataIndex: 'access'
-        ,width: 60
-        ,sortable: true
+// eslint-disable-next-line func-names
+MODx.grid.TemplateVarTemplate = function(config = {}) {
+    const accessCheckboxCol = new Ext.ux.grid.CheckColumn({
+        header: _('access'),
+        dataIndex: 'access',
+        width: 60,
+        sortable: true
     });
-    Ext.applyIf(config,{
-        id: 'modx-grid-tv-template'
-        ,url: MODx.config.connector_url
-        ,fields: [
+    Ext.applyIf(config, {
+        id: 'modx-grid-tv-template',
+        url: MODx.config.connector_url,
+        fields: [
             'id',
             'templatename',
             'category',
@@ -25,53 +25,56 @@ MODx.grid.TemplateVarTemplate = function(config) {
             'description',
             'access',
             'menu'
-        ]
-        ,showActionsColumn: false
-        ,baseParams: {
-            action: 'Element/TemplateVar/Template/GetList'
-            ,tv: config.tv
-            ,category: MODx.request.category || null
-        }
-        ,saveParams: {
+        ],
+        showActionsColumn: false,
+        baseParams: {
+            action: 'Element/TemplateVar/Template/GetList',
+            tv: config.tv,
+            category: MODx.request.category || null
+        },
+        saveParams: {
             tv: config.tv
-        }
-        ,width: 800
-        ,paging: true
-        ,plugins: tt
-        ,remoteSort: true
-        ,columns: [{
-            header: _('name')
-            ,dataIndex: 'templatename'
-            ,width: 150
-            ,sortable: true
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=element/template/update&id=' + record.data.id
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        },{
-            header: _('category')
-            ,dataIndex: 'category_name'
-            ,width: 300
-        },{
-            header: _('description')
-            ,dataIndex: 'description'
-            ,width: 300
-        },tt]
-        ,tbar: [
+        },
+        width: 800,
+        paging: true,
+        plugins: accessCheckboxCol,
+        remoteSort: true,
+        columns: [{
+            header: _('name'),
+            dataIndex: 'templatename',
+            width: 150,
+            sortable: true,
+            renderer: {
+                fn: function(value, metadata, record) {
+                    return this.renderLink(value, {
+                        href: `?a=element/template/update&id=${record.data.id}`,
+                        target: '_blank'
+                    });
+                },
+                scope: this
+            }
+        }, {
+            header: _('category'),
+            dataIndex: 'category_name',
+            width: 300
+        }, {
+            header: _('description'),
+            dataIndex: 'description',
+            width: 300
+        }, accessCheckboxCol],
+        tbar: [
             '->',
             {
-                xtype: 'modx-combo-category'
-                ,itemId: 'filter-category'
-                ,emptyText: _('filter_by_category')
-                ,value: MODx.request.category !== 'undefined' ? MODx.request.category : null
-                ,submitValue: false
-                ,hiddenName: ''
-                ,width: 200
-                ,listeners: {
+                xtype: 'modx-combo-category',
+                itemId: 'filter-category',
+                emptyText: _('filter_by_category'),
+                value: MODx.request.category !== 'undefined' ? MODx.request.category : null,
+                submitValue: false,
+                hiddenName: '',
+                width: 200,
+                listeners: {
                     select: {
-                        fn: function (cmp, record, selectedIndex) {
+                        fn: function(cmp, record, selectedIndex) {
                             this.applyGridFilter(cmp, 'category');
                         },
                         scope: this
@@ -82,7 +85,7 @@ MODx.grid.TemplateVarTemplate = function(config) {
             this.getClearFiltersButton('filter-category, filter-query')
         ]
     });
-    MODx.grid.TemplateVarTemplate.superclass.constructor.call(this,config);
+    MODx.grid.TemplateVarTemplate.superclass.constructor.call(this, config);
 };
-Ext.extend(MODx.grid.TemplateVarTemplate,MODx.grid.Grid);
-Ext.reg('modx-grid-tv-template',MODx.grid.TemplateVarTemplate);
+Ext.extend(MODx.grid.TemplateVarTemplate, MODx.grid.Grid);
+Ext.reg('modx-grid-tv-template', MODx.grid.TemplateVarTemplate);

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -7,244 +7,249 @@
  * @xtype modx-panel-template
  */
 
-MODx.panel.Template = function(config) {
-    config = config || {record:{}};
+MODx.panel.Template = function(config = { record: {} }) {
     config.record = config.record || {};
     config = MODx.setStaticElementsConfig(config, 'template');
 
-    Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,baseParams: {
+    Ext.applyIf(config, {
+        url: MODx.config.connector_url,
+        baseParams: {
             action: 'Element/Template/Get'
-        }
-        ,id: 'modx-panel-template'
-        ,cls: 'container form-with-labels'
-        ,class_key: 'modTemplate'
-        ,template: ''
-        ,bodyStyle: ''
-        ,previousFileSource: config.record.source != null ? config.record.source : MODx.config.default_media_source
-        ,items: [{
+        },
+        id: 'modx-panel-template',
+        cls: 'container form-with-labels',
+        class_key: 'modTemplate',
+        template: '',
+        bodyStyle: '',
+        previousFileSource: config.record.source != null ? config.record.source : MODx.config.default_media_source,
+        items: [{
             id: 'modx-template-header',
             xtype: 'modx-header'
         }, MODx.getPageStructure([{
-            title: _('general_information')
-            ,layout: 'form'
-            ,id: 'modx-template-form'
-            ,labelWidth: 150
-            ,defaults: {
-                border: false
-                ,layout: 'form'
-				,labelAlign: 'top'
-                ,labelSeparator: ''
-                ,msgTarget: 'side'
-            }
-            ,items: [{
-                html: '<p>'+_('template_tab_general_desc')+'</p>'
-                ,id: 'modx-template-msg'
-                ,xtype: 'modx-description'
-            },{
-                cls: 'main-wrapper'
-                ,items: [{
+            title: _('general_information'),
+            layout: 'form',
+            id: 'modx-template-form',
+            labelWidth: 150,
+            defaults: {
+                border: false,
+                layout: 'form',
+                labelAlign: 'top',
+                labelSeparator: '',
+                msgTarget: 'side'
+            },
+            items: [{
+                html: `<p>${_('template_tab_general_desc')}</p>`,
+                id: 'modx-template-msg',
+                xtype: 'modx-description'
+            }, {
+                cls: 'main-wrapper',
+                items: [{
                     // row 1
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'hidden'
-                                ,name: 'id'
-                                ,id: 'modx-template-id'
-                                ,value: config.record.id || MODx.request.id
-                            },{
-                                xtype: 'hidden'
-                                ,name: 'props'
-                                ,id: 'modx-template-props'
-                                ,value: config.record.props || null
-                            },{
-                                xtype: 'textfield'
-                                ,fieldLabel: _('name')
-                                ,description: MODx.expandHelp ? '' : _('template_name_desc')
-                                ,name: 'templatename'
-                                ,id: 'modx-template-templatename'
-                                ,maxLength: 50
-                                ,enableKeyEvents: true
-                                ,allowBlank: false
-                                ,value: config.record.templatename
-                                ,tabIndex: 1
-                                ,listeners: {
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'hidden',
+                                name: 'id',
+                                id: 'modx-template-id',
+                                value: config.record.id || MODx.request.id
+                            }, {
+                                xtype: 'hidden',
+                                name: 'props',
+                                id: 'modx-template-props',
+                                value: config.record.props || null
+                            }, {
+                                xtype: 'textfield',
+                                fieldLabel: _('name'),
+                                description: MODx.expandHelp ? '' : _('template_name_desc'),
+                                name: 'templatename',
+                                id: 'modx-template-templatename',
+                                maxLength: 50,
+                                enableKeyEvents: true,
+                                allowBlank: false,
+                                value: config.record.templatename,
+                                tabIndex: 1,
+                                listeners: {
                                     keyup: {
                                         fn: function(cmp, e) {
                                             this.formatMainPanelTitle('template', this.config.record, cmp.getValue());
                                             MODx.setStaticElementPath('template');
-                                        }
-                                        ,scope: this
+                                        },
+                                        scope: this
                                     }
                                 }
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-templatename'
-                                ,html: _('template_name_desc')
-                                ,cls: 'desc-under'
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('template_name_desc'),
+                                cls: 'desc-under'
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                            }
-                            ,items: [{
-                                xtype: 'modx-combo-category'
-                                ,fieldLabel: _('category')
-                                ,description: MODx.expandHelp ? '' : _('template_category_desc')
-                                ,name: 'category'
-                                ,id: 'modx-template-category'
-                                ,value: config.record.category || 0
-                                ,tabIndex: 2
-                                ,listeners: {
-                                    afterrender: {scope:this,fn:function(f,e) {
-                                        setTimeout(function(){
+                        }, {
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under'
+                            },
+                            items: [{
+                                xtype: 'modx-combo-category',
+                                fieldLabel: _('category'),
+                                description: MODx.expandHelp ? '' : _('template_category_desc'),
+                                name: 'category',
+                                id: 'modx-template-category',
+                                value: config.record.category || 0,
+                                tabIndex: 2,
+                                listeners: {
+                                    afterrender: {
+                                        scope: this,
+                                        fn: function(f, e) {
+                                            setTimeout(() => {
+                                                MODx.setStaticElementPath('template');
+                                            }, 200);
+                                        }
+                                    },
+                                    change: {
+                                        scope: this,
+                                        fn: function(f, e) {
                                             MODx.setStaticElementPath('template');
-                                        }, 200);
-                                    }}
-                                    ,change: {scope:this,fn:function(f,e) {
-                                        MODx.setStaticElementPath('template');
-                                    }}
+                                        }
+                                    }
                                 }
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-category'
-                                ,html: _('template_category_desc')
-                                ,cls: 'desc-under'
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('template_category_desc'),
+                                cls: 'desc-under'
                             }]
                         }]
                     }]
-                },{
+                }, {
                     // row 2
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'textarea'
-                                ,fieldLabel: _('description')
-                                ,description: MODx.expandHelp ? '' : _('template_description_desc')
-                                ,name: 'description'
-                                ,id: 'modx-template-description'
-                                ,maxLength: 255
-                                ,tabIndex: 5
-                                ,value: config.record.description || ''
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-description'
-                                ,html: _('template_description_desc')
-                                ,cls: 'desc-under'
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'textarea',
+                                fieldLabel: _('description'),
+                                description: MODx.expandHelp ? '' : _('template_description_desc'),
+                                name: 'description',
+                                id: 'modx-template-description',
+                                maxLength: 255,
+                                tabIndex: 5,
+                                value: config.record.description || ''
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('template_description_desc'),
+                                cls: 'desc-under'
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,cls: 'switch-container'
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'xcheckbox'
-                                ,hideLabel: true
-                                ,boxLabel: _('element_lock')
-                                ,description: MODx.expandHelp ? '' : _('template_lock_desc')
-                                ,name: 'locked'
-                                ,id: 'modx-template-locked'
-                                ,inputValue: 1
-                                ,tabIndex: 6
-                                ,checked: config.record.locked || false
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-locked'
-                                ,html: _('template_lock_desc')
-                                ,cls: 'desc-under toggle-slider-above'
-                            },{
-                                xtype: 'xcheckbox'
-                                ,hideLabel: true
-                                ,boxLabel: _('clear_cache_on_save')
-                                ,description: MODx.expandHelp ? '' : _('clear_cache_on_save_desc')
-                                ,name: 'clearCache'
-                                ,id: 'modx-template-clear-cache'
-                                ,inputValue: 1
-                                ,tabIndex: 7
-                                ,checked: Ext.isDefined(config.record.clearCache) || true
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-clear-cache'
-                                ,html: _('clear_cache_on_save_desc')
-                                ,cls: 'desc-under toggle-slider-above'
+                        }, {
+                            columnWidth: 0.5,
+                            cls: 'switch-container',
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'xcheckbox',
+                                hideLabel: true,
+                                boxLabel: _('element_lock'),
+                                description: MODx.expandHelp ? '' : _('template_lock_desc'),
+                                name: 'locked',
+                                id: 'modx-template-locked',
+                                inputValue: 1,
+                                tabIndex: 6,
+                                checked: config.record.locked || false
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('template_lock_desc'),
+                                cls: 'desc-under toggle-slider-above'
+                            }, {
+                                xtype: 'xcheckbox',
+                                hideLabel: true,
+                                boxLabel: _('clear_cache_on_save'),
+                                description: MODx.expandHelp ? '' : _('clear_cache_on_save_desc'),
+                                name: 'clearCache',
+                                id: 'modx-template-clear-cache',
+                                inputValue: 1,
+                                tabIndex: 7,
+                                checked: Ext.isDefined(config.record.clearCache) || true
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('clear_cache_on_save_desc'),
+                                cls: 'desc-under toggle-slider-above'
                             }]
                         }]
                     }]
-                },{
+                }, {
                     // row 3 preview fields
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'modx-combo-source'
-                                ,fieldLabel: _('template_preview_source')
-                                ,description: MODx.expandHelp ? '' : _('template_preview_source_desc')
-                                ,name: 'preview_source'
-                                ,id: 'modx-template-preview-source'
-                                ,maxLength: 255
-                                ,submitValue: false
-                                ,hiddenName: 'source'
-                                ,value: config.record.source != null ? config.record.source : MODx.config.default_media_source
-                                ,baseParams: {
-                                    action: 'Source/GetList'
-                                    ,showNone: true
-                                    ,streamsOnly: true
-                                }
-                                ,listeners: {
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'modx-combo-source',
+                                fieldLabel: _('template_preview_source'),
+                                description: MODx.expandHelp ? '' : _('template_preview_source_desc'),
+                                name: 'preview_source',
+                                id: 'modx-template-preview-source',
+                                maxLength: 255,
+                                submitValue: false,
+                                hiddenName: 'source',
+                                value: config.record.source != null ? config.record.source : MODx.config.default_media_source,
+                                baseParams: {
+                                    action: 'Source/GetList',
+                                    showNone: true,
+                                    streamsOnly: true
+                                },
+                                listeners: {
                                     select: {
                                         fn: function(cmp, record, selectedIndex) {
                                             this.onChangeStaticSource(cmp, 'template');
@@ -253,149 +258,149 @@ MODx.panel.Template = function(config) {
                                         scope: this
                                     }
                                 }
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-preview-source'
-                                ,html: _('template_preview_source_desc')
-                                ,cls: 'desc-under'
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('template_preview_source_desc'),
+                                cls: 'desc-under'
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [
-                                this.getTemplatePreviewImageField(config.record),{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden',
-                                forId: 'modx-template-preview-file',
-                                html: _('template_preview_desc'),
+                        }, {
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [
+                                this.getTemplatePreviewImageField(config.record), {
+                                    xtype: 'box',
+                                    hidden: !MODx.expandHelp,
+                                    html: _('template_preview_desc'),
+                                    cls: 'desc-under'
+                                }]
+                        }]
+                    }]
+                }, {
+                    // row 4 icon field
+                    cls: 'form-row-wrapper',
+                    defaults: {
+                        layout: 'column'
+                    },
+                    items: [{
+                        defaults: {
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 1,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'textfield',
+                                fieldLabel: _('template_icon'),
+                                description: MODx.expandHelp ? '' : _('template_icon_desc'),
+                                name: 'icon',
+                                id: 'modx-template-icon',
+                                anchor: '100%',
+                                maxLength: 100,
+                                enableKeyEvents: true,
+                                allowBlank: true,
+                                value: config.record.icon
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('template_icon_desc'),
                                 cls: 'desc-under'
                             }]
                         }]
                     }]
-                },{
-                    // row 4 icon field
-                    cls:'form-row-wrapper'
-                    ,defaults: {
-                        layout: 'column'
-                    }
-                    ,items: [{
-                        defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 1
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'textfield'
-                                ,fieldLabel: _('template_icon')
-                                ,description: MODx.expandHelp ? '' : _('template_icon_desc')
-                                ,name: 'icon'
-                                ,id: 'modx-template-icon'
-                                ,anchor: '100%'
-                                ,maxLength: 100
-                                ,enableKeyEvents: true
-                                ,allowBlank: true
-                                ,value: config.record.icon
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-icon'
-                                ,html: _('template_icon_desc')
-                                ,cls: 'desc-under'
-                            }]
-                        }]
-                    }]
-                },{
+                }, {
                     // row 4
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 1
-                            ,cls: 'fs-toggle'
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'xcheckbox'
-                                ,hideLabel: true
-                                ,boxLabel: _('is_static')
-                                ,description: MODx.expandHelp ? '' : _('is_static_desc')
-                                ,name: 'static'
-                                ,id: 'modx-template-static'
-                                ,inputValue: 1
-                                ,checked: config.record['static'] || false
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-static'
-                                ,id: 'modx-template-static-help'
-                                ,html: _('is_static_desc')
-                                ,cls: 'desc-under toggle-slider-above'
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 1,
+                            cls: 'fs-toggle',
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'xcheckbox',
+                                hideLabel: true,
+                                boxLabel: _('is_static'),
+                                description: MODx.expandHelp ? '' : _('is_static_desc'),
+                                name: 'static',
+                                id: 'modx-template-static',
+                                inputValue: 1,
+                                checked: config.record.static || false
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                id: 'modx-template-static-help',
+                                html: _('is_static_desc'),
+                                cls: 'desc-under toggle-slider-above'
                             }]
                         }]
                     }]
-                },{
+                }, {
                     // row 5
-                    xtype: 'fieldset'
-                    ,layout: 'form'
-                    ,title: 'Static File Options'
-                    ,autoHeight: true
-                    ,cls: 'form-row-wrapper'
-                    ,id: 'element-static-options-fs'
-                    ,defaults: {
+                    xtype: 'fieldset',
+                    layout: 'form',
+                    title: 'Static File Options',
+                    autoHeight: true,
+                    cls: 'form-row-wrapper',
+                    id: 'element-static-options-fs',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                                ,hideMode: 'visibility'
-                            }
-                            ,items: [{
-                                xtype: 'modx-combo-source'
-                                ,fieldLabel: _('static_source')
-                                ,description: MODx.expandHelp ? '' : _('static_source_desc')
-                                ,name: 'static_source'
-                                ,id: 'modx-template-static-source'
-                                ,maxLength: 255
-                                ,submitValue: false
-                                ,hiddenName: 'source'
-                                ,value: config.record.source != null ? config.record.source : MODx.config.default_media_source
-                                ,baseParams: {
-                                    action: 'Source/GetList'
-                                    ,showNone: true
-                                    ,streamsOnly: true
-                                }
-                                ,listeners: {
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false,
+                                hideMode: 'visibility'
+                            },
+                            items: [{
+                                xtype: 'modx-combo-source',
+                                fieldLabel: _('static_source'),
+                                description: MODx.expandHelp ? '' : _('static_source_desc'),
+                                name: 'static_source',
+                                id: 'modx-template-static-source',
+                                maxLength: 255,
+                                submitValue: false,
+                                hiddenName: 'source',
+                                value: config.record.source != null ? config.record.source : MODx.config.default_media_source,
+                                baseParams: {
+                                    action: 'Source/GetList',
+                                    showNone: true,
+                                    streamsOnly: true
+                                },
+                                listeners: {
                                     select: {
                                         fn: function(cmp, record, selectedIndex) {
                                             this.onChangeStaticSource(cmp, 'template');
@@ -404,122 +409,123 @@ MODx.panel.Template = function(config) {
                                         scope: this
                                     }
                                 }
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-static-source'
-                                ,id: 'modx-template-static-source-help'
-                                ,html: _('static_source_desc')
-                                ,cls: 'desc-under'
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                id: 'modx-template-static-source-help',
+                                html: _('static_source_desc'),
+                                cls: 'desc-under'
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                                ,hideMode: 'visibility'
-                            }
-                            ,items: [
-                                this.getStaticFileField('template', config.record),{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-template-static-file'
-                                ,id: 'modx-template-static-file-help'
-                                ,html: _('static_file_desc')
-                                ,cls: 'desc-under'
-                            }]
+                        }, {
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false,
+                                hideMode: 'visibility'
+                            },
+                            items: [
+                                this.getStaticFileField('template', config.record), {
+                                    xtype: 'box',
+                                    hidden: !MODx.expandHelp,
+                                    id: 'modx-template-static-file-help',
+                                    html: _('static_file_desc'),
+                                    cls: 'desc-under'
+                                }]
                         }]
-                    }]
-                    ,listeners: {
+                    }],
+                    listeners: {
                         afterrender: function(cmp) {
                             const isStaticCmp = Ext.getCmp('modx-template-static');
                             if (isStaticCmp) {
                                 this.isStatic = isStaticCmp.checked;
-                                const   switchField = 'modx-template-static',
-                                        toggleFields = ['modx-template-static-file','modx-template-static-source']
-                                        ;
-                                isStaticCmp.on('check', function(){
+                                const
+                                    switchField = 'modx-template-static',
+                                    toggleFields = ['modx-template-static-file', 'modx-template-static-source']
+                                ;
+                                // eslint-disable-next-line func-names
+                                isStaticCmp.on('check', function() {
                                     this.toggleFieldVisibility(switchField, cmp.id, toggleFields);
                                 }, this);
-                                if(!this.isStatic) {
+                                if (!this.isStatic) {
                                     this.toggleFieldVisibility(switchField, cmp.id, toggleFields);
                                 }
                             }
-                        }
-                        ,scope: this
+                        },
+                        scope: this
                     }
                 }]
-            },{
-                xtype: 'panel'
-                ,border: false
-                ,layout: 'form'
-                ,cls:'main-wrapper'
-                ,labelAlign: 'top'
-                ,items: [{
-                    xtype: 'textarea'
-                    ,fieldLabel: _('template_code')
-                    ,name: 'content'
-                    ,id: 'modx-template-content'
-                    ,anchor: '100%'
-                    ,height: 400
-                    ,value: config.record.content || ''
+            }, {
+                xtype: 'panel',
+                border: false,
+                layout: 'form',
+                cls: 'main-wrapper',
+                labelAlign: 'top',
+                items: [{
+                    xtype: 'textarea',
+                    fieldLabel: _('template_code'),
+                    name: 'content',
+                    id: 'modx-template-content',
+                    anchor: '100%',
+                    height: 400,
+                    value: config.record.content || ''
                 }]
             }]
-        },{
-            title: _('template_variables')
-            ,itemId: 'form-template'
-            ,defaults: {
+        }, {
+            title: _('template_variables'),
+            itemId: 'form-template',
+            defaults: {
                 autoHeight: true
-            }
-            ,layout: 'form'
-            ,items: [{
-                html: '<p>'+_('template_tv_msg')+'</p>'
-                ,xtype: 'modx-description'
-            },{
-                xtype: 'modx-grid-template-tv'
-                ,cls:'main-wrapper'
-                ,preventRender: true
-                ,anchor: '100%'
-                ,template: config.template
-                ,listeners: {
-                    rowclick: {fn:this.markDirty,scope:this}
-                    ,afterEdit: {fn:this.markDirty,scope:this}
-                    ,afterRemoveRow: {fn:this.markDirty,scope:this}
+            },
+            layout: 'form',
+            items: [{
+                html: `<p>${_('template_tv_msg')}</p>`,
+                xtype: 'modx-description'
+            }, {
+                xtype: 'modx-grid-template-tv',
+                cls: 'main-wrapper',
+                preventRender: true,
+                anchor: '100%',
+                template: config.template,
+                listeners: {
+                    rowclick: { fn: this.markDirty, scope: this },
+                    afterEdit: { fn: this.markDirty, scope: this },
+                    afterRemoveRow: { fn: this.markDirty, scope: this }
                 }
             }]
-        },{
-            xtype: 'modx-panel-element-properties'
-            ,preventRender: true
-            ,collapsible: true
-            ,elementPanel: 'modx-panel-template'
-            ,elementId: config.template
-            ,elementType: 'MODX\\Revolution\\modTemplate'
-            ,record: config.record
-        }],{
+        }, {
+            xtype: 'modx-panel-element-properties',
+            preventRender: true,
+            collapsible: true,
+            elementPanel: 'modx-panel-template',
+            elementId: config.template,
+            elementType: 'MODX\\Revolution\\modTemplate',
+            record: config.record
+        }], {
             id: 'modx-template-tabs'
-        })]
-        ,useLoadingMask: true
-        ,listeners: {
-            setup: {fn:this.setup,scope:this}
-            ,success: {fn:this.success,scope:this}
-            ,failure: {fn:this.failure,scope:this}
-            ,beforeSubmit: {fn:this.beforeSubmit,scope:this}
-            ,failureSubmit: {
+        })],
+        useLoadingMask: true,
+        listeners: {
+            setup: { fn: this.setup, scope: this },
+            success: { fn: this.success, scope: this },
+            failure: { fn: this.failure, scope: this },
+            beforeSubmit: { fn: this.beforeSubmit, scope: this },
+            failureSubmit: {
                 fn: function() {
-                    this.showErroredTab(this.errorHandlingTabs, 'modx-template-tabs')
+                    this.showErroredTab(this.errorHandlingTabs, 'modx-template-tabs');
                 },
                 scope: this
             }
         }
     });
-    MODx.panel.Template.superclass.constructor.call(this,config);
+    MODx.panel.Template.superclass.constructor.call(this, config);
 };
-Ext.extend(MODx.panel.Template,MODx.FormPanel,{
+Ext.extend(MODx.panel.Template, MODx.FormPanel, {
 
-    initialized: false
+    initialized: false,
 
-    ,setup: function() {
-
+    setup: function() {
         if (this.initialized) {
             this.clearDirty();
             return true;
@@ -529,12 +535,12 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
             keys in each tab component's items property
         */
         this.errorHandlingTabs = ['modx-template-form'];
-        this.errorHandlingIgnoreTabs = ['modx-panel-element-properties','form-template'];
+        this.errorHandlingIgnoreTabs = ['modx-panel-element-properties', 'form-template'];
         this.getForm().setValues(this.config.record);
 
         this.formatMainPanelTitle('template', this.config.record);
         this.getElementProperties(this.config.record.properties);
-        this.fireEvent('ready',this.config.record);
+        this.fireEvent('ready', this.config.record);
 
         if (MODx.onLoadEditor) {
             MODx.onLoadEditor(this);
@@ -543,9 +549,9 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         this.clearDirty();
         this.initialized = true;
         MODx.fireEvent('ready');
-    }
+    },
 
-    ,beforeSubmit: function(o) {
+    beforeSubmit: function(o) {
         const
             assignedTvsCmp = Ext.getCmp('modx-grid-template-tv'),
             propertiesCmp = Ext.getCmp('modx-grid-element-properties'),
@@ -557,42 +563,54 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
         });
         this.cleanupEditor();
         return this.fireEvent('save', {
-            values: formValues
-            ,stay: MODx.config.stay
+            values: formValues,
+            stay: MODx.config.stay
         });
-    }
-    ,success: function(r) {
-        if (MODx.request.id) Ext.getCmp('modx-grid-element-properties').save();
-        Ext.getCmp('modx-grid-template-tv').getStore().commitChanges();
-        this.getForm().setValues(r.result.object);
-
-        var t = Ext.getCmp('modx-tree-element');
-        if (t) {
-            var c = Ext.getCmp('modx-template-category').getValue();
-            var u = c != '' && c != null && c != 0 ? 'n_template_category_'+c : 'n_type_template';
-            var node = t.getNodeById('n_template_element_' + Ext.getCmp('modx-template-id').getValue() + '_' + r.result.object.previous_category);
-            if (node) node.destroy();
-            t.refreshNode(u,true);
+    },
+    success: function(response) {
+        const
+            data = response.result.object,
+            tree = Ext.getCmp('modx-tree-element')
+        ;
+        if (MODx.request.id) {
+            Ext.getCmp('modx-grid-element-properties').save();
         }
-    }
+        Ext.getCmp('modx-grid-template-tv').getStore().commitChanges();
+        this.getForm().setValues(data);
+        if (tree) {
+            const
+                category = Ext.getCmp('modx-template-category').getValue(),
+                nodeId = ['', null, 0, '0'].includes(category) ? 'n_type_template' : `n_template_category_${category}`,
+                templateId = Ext.getCmp('modx-template-id').getValue(),
+                node = tree.getNodeById(`n_template_element_${templateId}_${data.previous_category}`)
+            ;
+            if (node) {
+                node.destroy();
+            }
+            tree.refreshNode(nodeId, true);
+        }
+    },
 
-    ,changeEditor: function() {
+    changeEditor: function() {
         this.cleanupEditor();
-        this.on('success',function(o) {
-            var id = o.result.object.id;
-            var w = Ext.getCmp('modx-template-which-editor').getValue();
+        // eslint-disable-next-line prefer-arrow-callback, func-names
+        this.on('success', function(o) {
+            const
+                { id } = o.result.object,
+                editorId = Ext.getCmp('modx-template-which-editor').getValue()
+            ;
             MODx.request.a = 'element/template/update';
-            location.href = '?'+Ext.urlEncode(MODx.request)+'&which_editor='+w+'&id='+id;
+            window.location.href = `?${Ext.urlEncode(MODx.request)}&which_editor=${editorId}&id=${id}`;
         });
         this.submit();
-    }
+    },
 
-    ,cleanupEditor: function() {
+    cleanupEditor: function() {
         if (MODx.onSaveEditor) {
-            var fld = Ext.getCmp('modx-template-content');
-            MODx.onSaveEditor(fld);
+            const contentCmp = Ext.getCmp('modx-template-content');
+            MODx.onSaveEditor(contentCmp);
         }
     }
 
 });
-Ext.reg('modx-panel-template',MODx.panel.Template);
+Ext.reg('modx-panel-template', MODx.panel.Template);

--- a/manager/assets/modext/widgets/element/modx.panel.template.js
+++ b/manager/assets/modext/widgets/element/modx.panel.template.js
@@ -546,14 +546,18 @@ Ext.extend(MODx.panel.Template,MODx.FormPanel,{
     }
 
     ,beforeSubmit: function(o) {
-        var g = Ext.getCmp('modx-grid-template-tv');
-        Ext.apply(o.form.baseParams,{
-            tvs: g.encodeModified()
-            ,propdata: Ext.getCmp('modx-grid-element-properties').encode()
+        const
+            assignedTvsCmp = Ext.getCmp('modx-grid-template-tv'),
+            propertiesCmp = Ext.getCmp('modx-grid-element-properties'),
+            formValues = this.getForm().getFieldValues()
+        ;
+        Ext.apply(o.form.baseParams, {
+            tvs: assignedTvsCmp.encodeModified(),
+            propdata: propertiesCmp.encode()
         });
         this.cleanupEditor();
-        return this.fireEvent('save',{
-            values: this.getForm().getValues()
+        return this.fireEvent('save', {
+            values: formValues
             ,stay: MODx.config.stay
         });
     }

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -6,363 +6,369 @@
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-tv
  */
-MODx.panel.TV = function(config) {
-    config = config || {};
+MODx.panel.TV = function(config = {}) {
     config.record = config.record || {};
     config = MODx.setStaticElementsConfig(config, 'tv');
 
-    Ext.applyIf(config,{
-        url: MODx.config.connector_url
-        ,baseParams: {
+    Ext.applyIf(config, {
+        url: MODx.config.connector_url,
+        baseParams: {
             action: 'Element/TemplateVar/Get'
-        }
-        ,id: 'modx-panel-tv'
-        ,cls: 'container form-with-labels'
-        ,class_key: 'modTemplateVar'
-        ,tv: ''
-        ,bodyStyle: ''
-        ,autoWidth: true
-        ,monitorResize: true
-        ,previousFileSource: config.record.source != null ? config.record.source : MODx.config.default_media_source
-        ,items: [{
+        },
+        id: 'modx-panel-tv',
+        cls: 'container form-with-labels',
+        class_key: 'modTemplateVar',
+        tv: '',
+        bodyStyle: '',
+        autoWidth: true,
+        monitorResize: true,
+        previousFileSource: config.record.source != null ? config.record.source : MODx.config.default_media_source,
+        items: [{
             id: 'modx-tv-header',
             xtype: 'modx-header'
         }, MODx.getPageStructure([{
-            title: _('general_information')
-            ,layout: 'form'
-            ,id: 'modx-tv-form'
-            ,itemId: 'form-tv'
-            ,labelWidth: 150
-            ,forceLayout: true
-            ,defaults: {
-                border: false
-                ,msgTarget: 'side'
-                ,layout: 'form'
-            }
-            ,items: [{
-                html: '<p>'+_('tv_tab_general_desc')+'</p>'
-                ,id: 'modx-tv-msg'
-                ,xtype: 'modx-description'
-            },{
-                cls: 'main-wrapper'
-                ,items: [{
+            title: _('general_information'),
+            layout: 'form',
+            id: 'modx-tv-form',
+            itemId: 'form-tv',
+            labelWidth: 150,
+            forceLayout: true,
+            defaults: {
+                border: false,
+                msgTarget: 'side',
+                layout: 'form'
+            },
+            items: [{
+                html: `<p>${_('tv_tab_general_desc')}</p>`,
+                id: 'modx-tv-msg',
+                xtype: 'modx-description'
+            }, {
+                cls: 'main-wrapper',
+                items: [{
                     // row 1
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'hidden'
-                                ,name: 'id'
-                                ,id: 'modx-tv-id'
-                                ,value: config.record.id || MODx.request.id
-                            },{
-                                xtype: 'hidden'
-                                ,name: 'props'
-                                ,id: 'modx-tv-props'
-                                ,value: config.record.props || null
-                            },{
-                                xtype: 'textfield'
-                                ,fieldLabel: _('name')
-                                ,description: MODx.expandHelp ? '' : _('tv_name_desc', {
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'hidden',
+                                name: 'id',
+                                id: 'modx-tv-id',
+                                value: config.record.id || MODx.request.id
+                            }, {
+                                xtype: 'hidden',
+                                name: 'props',
+                                id: 'modx-tv-props',
+                                value: config.record.props || null
+                            }, {
+                                xtype: 'textfield',
+                                fieldLabel: _('name'),
+                                description: MODx.expandHelp ? '' : _('tv_name_desc', {
                                     tag: `<span class="copy-this">[[*<span class="example-replace-name">${_('example_tag_tv_name')}</span>]]</span>`
-                                })
-                                ,name: 'name'
-                                ,id: 'modx-tv-name'
-                                ,maxLength: 50
-                                ,enableKeyEvents: true
-                                ,allowBlank: false
-                                ,value: config.record.name
-                                ,tabIndex: 1
-                                ,listeners: {
+                                }),
+                                name: 'name',
+                                id: 'modx-tv-name',
+                                maxLength: 50,
+                                enableKeyEvents: true,
+                                allowBlank: false,
+                                value: config.record.name,
+                                tabIndex: 1,
+                                listeners: {
                                     keyup: {
                                         fn: function(cmp, e) {
-                                            const   title = this.formatMainPanelTitle('tv', this.config.record, cmp.getValue(), true),
-                                                    tagTitle = title && title.length > 0 ? title : _('example_tag_tv_name')
-                                                ;
+                                            const
+                                                title = this.formatMainPanelTitle('tv', this.config.record, cmp.getValue(), true),
+                                                tagTitle = title && title.length > 0 ? title : _('example_tag_tv_name')
+                                            ;
                                             cmp.nextSibling().getEl().child('.example-replace-name').update(tagTitle);
                                             MODx.setStaticElementPath('tv');
-                                        }
-                                        ,scope: this
+                                        },
+                                        scope: this
                                     }
                                 }
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-name'
-                                ,html: _('tv_name_desc', {
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('tv_name_desc', {
                                     tag: `<span class="copy-this">[[*<span class="example-replace-name">${_('example_tag_tv_name')}</span>]]</span>`
-                                })
-                                ,cls: 'desc-under'
-                                ,listeners: {
+                                }),
+                                cls: 'desc-under',
+                                listeners: {
                                     afterrender: {
                                         fn: function(cmp) {
                                             this.insertTagCopyUtility(cmp, 'tv');
-                                        }
-                                        ,scope: this
+                                        },
+                                        scope: this
                                     }
                                 }
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                            }
-                            ,items: [{
-                                xtype: 'modx-combo-category'
-                                ,fieldLabel: _('category')
-                                ,description: MODx.expandHelp ? '' : _('tv_category_desc')
-                                ,name: 'category'
-                                ,id: 'modx-tv-category'
-                                ,value: config.record.category || 0
-                                ,tabIndex: 2
-                                ,listeners: {
-                                    afterrender: {scope:this,fn:function(f,e) {
-                                        MODx.setStaticElementPath('tv');
-                                    }}
-                                    ,select: {scope:this,fn:function(f,e) {
-                                        MODx.setStaticElementPath('tv');
-                                    }}
+                        }, {
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under'
+                            },
+                            items: [{
+                                xtype: 'modx-combo-category',
+                                fieldLabel: _('category'),
+                                description: MODx.expandHelp ? '' : _('tv_category_desc'),
+                                name: 'category',
+                                id: 'modx-tv-category',
+                                value: config.record.category || 0,
+                                tabIndex: 2,
+                                listeners: {
+                                    afterrender: {
+                                        scope: this,
+                                        fn: function(f, e) {
+                                            MODx.setStaticElementPath('tv');
+                                        }
+                                    },
+                                    select: {
+                                        scope: this,
+                                        fn: function(f, e) {
+                                            MODx.setStaticElementPath('tv');
+                                        }
+                                    }
                                 }
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-category'
-                                ,html: _('tv_category_desc')
-                                ,cls: 'desc-under'
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('tv_category_desc'),
+                                cls: 'desc-under'
                             }]
                         }]
                     }]
-                },{
+                }, {
                     // row 2
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'textfield'
-                                ,fieldLabel: _('tv_caption')
-                                ,description: MODx.expandHelp ? '' : _('tv_caption_desc')
-                                ,name: 'caption'
-                                ,id: 'modx-tv-caption'
-                                ,tabIndex: 3
-                                ,value: config.record.caption
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-caption'
-                                ,html: _('tv_caption_desc')
-                                ,cls: 'desc-under'
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'textfield',
+                                fieldLabel: _('tv_caption'),
+                                description: MODx.expandHelp ? '' : _('tv_caption_desc'),
+                                name: 'caption',
+                                id: 'modx-tv-caption',
+                                tabIndex: 3,
+                                value: config.record.caption
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('tv_caption_desc'),
+                                cls: 'desc-under'
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'numberfield'
-                                ,fieldLabel: _('tv_rank')
-                                ,description: MODx.expandHelp ? '' : _('tv_rank_desc')
-                                ,name: 'rank'
-                                ,id: 'modx-tv-rank'
-                                ,maxLength: 4
-                                ,allowNegative: false
-                                ,allowBlank: false
-                                ,tabIndex: 4
-                                ,value: config.record.rank || 0
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-rank'
-                                ,html: _('tv_rank_desc')
-                                ,cls: 'desc-under'
+                        }, {
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'numberfield',
+                                fieldLabel: _('tv_rank'),
+                                description: MODx.expandHelp ? '' : _('tv_rank_desc'),
+                                name: 'rank',
+                                id: 'modx-tv-rank',
+                                maxLength: 4,
+                                allowNegative: false,
+                                allowBlank: false,
+                                tabIndex: 4,
+                                value: config.record.rank || 0
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('tv_rank_desc'),
+                                cls: 'desc-under'
                             }]
                         }]
                     }]
-                },{
+                }, {
                     // row 3
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'textarea'
-                                ,fieldLabel: _('description')
-                                ,description: MODx.expandHelp ? '' : _('tv_description_desc')
-                                ,name: 'description'
-                                ,id: 'modx-tv-description'
-                                ,maxLength: 255
-                                ,tabIndex: 5
-                                ,value: config.record.description || ''
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-description'
-                                ,html: _('tv_description_desc')
-                                ,cls: 'desc-under'
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'textarea',
+                                fieldLabel: _('description'),
+                                description: MODx.expandHelp ? '' : _('tv_description_desc'),
+                                name: 'description',
+                                id: 'modx-tv-description',
+                                maxLength: 255,
+                                tabIndex: 5,
+                                value: config.record.description || ''
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('tv_description_desc'),
+                                cls: 'desc-under'
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,cls: 'switch-container'
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'xcheckbox'
-                                ,hideLabel: true
-                                ,boxLabel: _('tv_lock')
-                                ,description: MODx.expandHelp ? '' : _('tv_lock_desc')
-                                ,name: 'locked'
-                                ,id: 'modx-tv-locked'
-                                ,inputValue: 1
-                                ,tabIndex: 6
-                                ,checked: config.record.locked || false
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-locked'
-                                ,html: _('tv_lock_desc')
-                                ,cls: 'desc-under toggle-slider-above'
-                            },{
-                                xtype: 'xcheckbox'
-                                ,hideLabel: true
-                                ,boxLabel: _('clear_cache_on_save')
-                                ,description: MODx.expandHelp ? '' : _('clear_cache_on_save_desc')
-                                ,name: 'clearCache'
-                                ,id: 'modx-tv-clear-cache'
-                                ,inputValue: 1
-                                ,tabIndex: 7
-                                ,checked: Ext.isDefined(config.record.clearCache) || true
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-clear-cache'
-                                ,html: _('clear_cache_on_save_desc')
-                                ,cls: 'desc-under toggle-slider-above'
+                        }, {
+                            columnWidth: 0.5,
+                            cls: 'switch-container',
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'xcheckbox',
+                                hideLabel: true,
+                                boxLabel: _('tv_lock'),
+                                description: MODx.expandHelp ? '' : _('tv_lock_desc'),
+                                name: 'locked',
+                                id: 'modx-tv-locked',
+                                inputValue: 1,
+                                tabIndex: 6,
+                                checked: config.record.locked || false
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('tv_lock_desc'),
+                                cls: 'desc-under toggle-slider-above'
+                            }, {
+                                xtype: 'xcheckbox',
+                                hideLabel: true,
+                                boxLabel: _('clear_cache_on_save'),
+                                description: MODx.expandHelp ? '' : _('clear_cache_on_save_desc'),
+                                name: 'clearCache',
+                                id: 'modx-tv-clear-cache',
+                                inputValue: 1,
+                                tabIndex: 7,
+                                checked: Ext.isDefined(config.record.clearCache) || true
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                html: _('clear_cache_on_save_desc'),
+                                cls: 'desc-under toggle-slider-above'
                             }]
                         }]
                     }]
-                },{
+                }, {
                     // row 4
-                    cls:'form-row-wrapper'
-                    ,defaults: {
+                    cls: 'form-row-wrapper',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 1
-                            ,cls: 'fs-toggle'
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                            }
-                            ,items: [{
-                                xtype: 'xcheckbox'
-                                ,hideLabel: true
-                                ,boxLabel: _('is_static')
-                                ,description: MODx.expandHelp ? '' : _('is_static_tv_desc')
-                                ,name: 'static'
-                                ,id: 'modx-tv-static'
-                                ,inputValue: 1
-                                ,checked: config.record['static'] || false
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-static'
-                                ,id: 'modx-tv-static-help'
-                                ,html: _('is_static_tv_desc')
-                                ,cls: 'desc-under toggle-slider-above'
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 1,
+                            cls: 'fs-toggle',
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false
+                            },
+                            items: [{
+                                xtype: 'xcheckbox',
+                                hideLabel: true,
+                                boxLabel: _('is_static'),
+                                description: MODx.expandHelp ? '' : _('is_static_tv_desc'),
+                                name: 'static',
+                                id: 'modx-tv-static',
+                                inputValue: 1,
+                                checked: config.record.static || false
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                id: 'modx-tv-static-help',
+                                html: _('is_static_tv_desc'),
+                                cls: 'desc-under toggle-slider-above'
                             }]
                         }]
                     }]
-                },{
+                }, {
                     // row 5
-                    xtype: 'fieldset'
-                    ,layout: 'form'
-                    ,title: 'Static File Options'
-                    ,autoHeight: true
-                    ,cls: 'form-row-wrapper'
-                    ,id: 'tv-static-options-fs'
-                    ,defaults: {
+                    xtype: 'fieldset',
+                    layout: 'form',
+                    title: 'Static File Options',
+                    autoHeight: true,
+                    cls: 'form-row-wrapper',
+                    id: 'tv-static-options-fs',
+                    defaults: {
                         layout: 'column'
-                    }
-                    ,items: [{
+                    },
+                    items: [{
                         defaults: {
-                            layout: 'form'
-                            ,labelSeparator: ''
-                            ,labelAlign: 'top'
-                        }
-                        ,items: [{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                                ,hideMode: 'visibility'
-                            }
-                            ,items: [{
-                                xtype: 'modx-combo-source'
-                                ,fieldLabel: _('static_source')
-                                ,description: MODx.expandHelp ? '' : _('static_source_desc')
-                                ,name: 'source'
-                                ,id: 'modx-tv-static-source'
-                                ,maxLength: 255
-                                ,value: config.record.source != null ? config.record.source : MODx.config.default_media_source
-                                ,baseParams: {
-                                    action: 'Source/GetList'
-                                    ,showNone: true
-                                    ,streamsOnly: true
-                                }
-                                ,listeners: {
+                            layout: 'form',
+                            labelSeparator: '',
+                            labelAlign: 'top'
+                        },
+                        items: [{
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false,
+                                hideMode: 'visibility'
+                            },
+                            items: [{
+                                xtype: 'modx-combo-source',
+                                fieldLabel: _('static_source'),
+                                description: MODx.expandHelp ? '' : _('static_source_desc'),
+                                name: 'source',
+                                id: 'modx-tv-static-source',
+                                maxLength: 255,
+                                value: config.record.source != null ? config.record.source : MODx.config.default_media_source,
+                                baseParams: {
+                                    action: 'Source/GetList',
+                                    showNone: true,
+                                    streamsOnly: true
+                                },
+                                listeners: {
                                     select: {
                                         fn: function(cmp, record, selectedIndex) {
                                             this.onChangeStaticSource(cmp, 'tv');
@@ -370,176 +376,177 @@ MODx.panel.TV = function(config) {
                                         scope: this
                                     }
                                 }
-                            },{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-static-source'
-                                ,id: 'modx-tv-static-source-help'
-                                ,html: _('static_source_desc')
-                                ,cls: 'desc-under'
+                            }, {
+                                xtype: 'box',
+                                hidden: !MODx.expandHelp,
+                                id: 'modx-tv-static-source-help',
+                                html: _('static_source_desc'),
+                                cls: 'desc-under'
                             }]
-                        },{
-                            columnWidth: 0.5
-                            ,defaults: {
-                                anchor: '100%'
-                                ,msgTarget: 'under'
-                                ,validationEvent: 'change'
-                                ,validateOnBlur: false
-                                ,hideMode: 'visibility'
-                            }
-                            ,items: [
-                                this.getStaticFileField('tv', config.record),{
-                                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                                ,forId: 'modx-tv-static-file'
-                                ,id: 'modx-tv-static-file-help'
-                                ,html: _('static_file_desc')
-                                ,cls: 'desc-under'
-                            }]
+                        }, {
+                            columnWidth: 0.5,
+                            defaults: {
+                                anchor: '100%',
+                                msgTarget: 'under',
+                                validationEvent: 'change',
+                                validateOnBlur: false,
+                                hideMode: 'visibility'
+                            },
+                            items: [
+                                this.getStaticFileField('tv', config.record), {
+                                    xtype: 'box',
+                                    hidden: !MODx.expandHelp,
+                                    id: 'modx-tv-static-file-help',
+                                    html: _('static_file_desc'),
+                                    cls: 'desc-under'
+                                }]
                         }]
-                    }]
-                    ,listeners: {
+                    }],
+                    listeners: {
                         afterrender: function(cmp) {
                             const isStaticCmp = Ext.getCmp('modx-tv-static');
                             if (isStaticCmp) {
                                 this.isStatic = isStaticCmp.checked;
-                                const   switchField = 'modx-tv-static',
-                                        toggleFields = ['modx-tv-static-file','modx-tv-static-source']
-                                        ;
-                                isStaticCmp.on('check', function(){
+                                const
+                                    switchField = 'modx-tv-static',
+                                    toggleFields = ['modx-tv-static-file', 'modx-tv-static-source']
+                                ;
+                                isStaticCmp.on('check', function() {
                                     this.toggleFieldVisibility(switchField, cmp.id, toggleFields);
                                 }, this);
-                                if(!this.isStatic) {
+                                if (!this.isStatic) {
                                     this.toggleFieldVisibility(switchField, cmp.id, toggleFields);
                                 }
                             }
-                        }
-                        ,scope: this
+                        },
+                        scope: this
                     }
                 }]
             }]
-        },{
-            xtype: 'modx-panel-tv-input-properties'
-            ,record: config.record
-        },{
-            xtype: 'modx-panel-tv-output-properties'
-            ,record: config.record
-        },{
-            title: _('tv_tmpl_access')
-            ,itemId: 'form-template'
-            ,hideMode: 'offsets'
-            ,defaults: {autoHeight: true}
-            ,layout: 'form'
-            ,items: [{
-                html: '<p>'+_('tv_tab_tmpl_access_desc')+'</p>'
-                ,xtype: 'modx-description'
-            },{
-                xtype: 'modx-grid-tv-template'
-                ,itemId: 'grid-template'
-                ,cls:'main-wrapper'
-                ,tv: config.tv
-                ,preventRender: true
-                ,anchor: '100%'
-                ,listeners: {
-                    rowclick: {fn:this.markDirty,scope:this}
-                    ,afteredit: {fn:this.markDirty,scope:this}
-                    ,afterRemoveRow: {fn:this.markDirty,scope:this}
+        }, {
+            xtype: 'modx-panel-tv-input-properties',
+            record: config.record
+        }, {
+            xtype: 'modx-panel-tv-output-properties',
+            record: config.record
+        }, {
+            title: _('tv_tmpl_access'),
+            itemId: 'form-template',
+            hideMode: 'offsets',
+            defaults: { autoHeight: true },
+            layout: 'form',
+            items: [{
+                html: `<p>${_('tv_tab_tmpl_access_desc')}</p>`,
+                xtype: 'modx-description'
+            }, {
+                xtype: 'modx-grid-tv-template',
+                itemId: 'grid-template',
+                cls: 'main-wrapper',
+                tv: config.tv,
+                preventRender: true,
+                anchor: '100%',
+                listeners: {
+                    rowclick: { fn: this.markDirty, scope: this },
+                    afteredit: { fn: this.markDirty, scope: this },
+                    afterRemoveRow: { fn: this.markDirty, scope: this }
                 }
             }]
-        },{
-            title: _('sources')
-            ,id: 'modx-tv-sources-form'
-            ,itemId: 'form-sources'
-            ,defaults: {autoHeight: true}
-            ,layout: 'form'
-            ,hideMode: 'offsets'
-            ,items: [{
-                html: '<p>'+_('tv_tab_sources_desc')+'</p>'
-                ,id: 'modx-tv-sources-msg'
-                ,xtype: 'modx-description'
-            },{
-                xtype: 'modx-grid-element-sources'
-                ,itemId: 'grid-sources'
-                ,cls:'main-wrapper'
-                ,id: 'modx-grid-element-sources'
-                ,tv: config.tv
-                ,preventRender: true
-                ,listeners: {
-                    rowclick: {fn:this.markDirty,scope:this}
-                    ,afteredit: {fn:this.markDirty,scope:this}
-                    ,afterRemoveRow: {fn:this.markDirty,scope:this}
+        }, {
+            title: _('sources'),
+            id: 'modx-tv-sources-form',
+            itemId: 'form-sources',
+            defaults: { autoHeight: true },
+            layout: 'form',
+            hideMode: 'offsets',
+            items: [{
+                html: `<p>${_('tv_tab_sources_desc')}</p>`,
+                id: 'modx-tv-sources-msg',
+                xtype: 'modx-description'
+            }, {
+                xtype: 'modx-grid-element-sources',
+                itemId: 'grid-sources',
+                cls: 'main-wrapper',
+                id: 'modx-grid-element-sources',
+                tv: config.tv,
+                preventRender: true,
+                listeners: {
+                    rowclick: { fn: this.markDirty, scope: this },
+                    afteredit: { fn: this.markDirty, scope: this },
+                    afterRemoveRow: { fn: this.markDirty, scope: this }
                 }
             }]
-        },{
-            title: _('access_permissions')
-            ,id: 'modx-tv-access-form'
-            ,itemId: 'form-access'
-            ,forceLayout: true
-            ,hideMode: 'offsets'
-            ,defaults: {autoHeight: true}
-            ,layout: 'form'
-            ,items: [{
-                html: '<p>'+_('tv_tab_access_desc')+'</p>'
-                ,id: 'modx-tv-access-msg'
-                ,xtype: 'modx-description'
-            },{
-                xtype: 'modx-grid-tv-security'
-                ,itemId: 'grid-access'
-                ,cls:'main-wrapper'
-                ,tv: config.tv
-                ,preventRender: true
-                ,anchor: '100%'
-                ,listeners: {
-                    rowclick: {fn:this.markDirty,scope:this}
-                    ,afteredit: {fn:this.markDirty,scope:this}
-                    ,afterRemoveRow: {fn:this.markDirty,scope:this}
+        }, {
+            title: _('access_permissions'),
+            id: 'modx-tv-access-form',
+            itemId: 'form-access',
+            forceLayout: true,
+            hideMode: 'offsets',
+            defaults: { autoHeight: true },
+            layout: 'form',
+            items: [{
+                html: `<p>${_('tv_tab_access_desc')}</p>`,
+                id: 'modx-tv-access-msg',
+                xtype: 'modx-description'
+            }, {
+                xtype: 'modx-grid-tv-security',
+                itemId: 'grid-access',
+                cls: 'main-wrapper',
+                tv: config.tv,
+                preventRender: true,
+                anchor: '100%',
+                listeners: {
+                    rowclick: { fn: this.markDirty, scope: this },
+                    afteredit: { fn: this.markDirty, scope: this },
+                    afterRemoveRow: { fn: this.markDirty, scope: this }
                 }
             }]
-        },{
-            xtype: 'modx-panel-element-properties'
-            ,itemId: 'panel-properties'
-            ,elementPanel: 'modx-panel-tv'
-            ,elementId: config.tv
-            ,elementType: 'MODX\\Revolution\\modTemplateVar'
-            ,record: config.record
-        }],{
-            id: 'modx-tv-editor-tabs'
-            ,deferredRender: false
-        })]
-        ,useLoadingMask: true
-        ,listeners: {
-            setup: {fn:this.setup,scope:this}
-            ,success: {fn:this.success,scope:this}
-            ,failure: {fn:this.failure,scope:this}
-            ,beforeSubmit: {fn:this.beforeSubmit,scope:this}
-            ,failureSubmit: {
+        }, {
+            xtype: 'modx-panel-element-properties',
+            itemId: 'panel-properties',
+            elementPanel: 'modx-panel-tv',
+            elementId: config.tv,
+            elementType: 'MODX\\Revolution\\modTemplateVar',
+            record: config.record
+        }], {
+            id: 'modx-tv-editor-tabs',
+            deferredRender: false
+        })],
+        useLoadingMask: true,
+        listeners: {
+            setup: { fn: this.setup, scope: this },
+            success: { fn: this.success, scope: this },
+            failure: { fn: this.failure, scope: this },
+            beforeSubmit: { fn: this.beforeSubmit, scope: this },
+            failureSubmit: {
                 fn: function() {
-                    this.showErroredTab(this.errorHandlingTabs, 'modx-tv-editor-tabs')
+                    this.showErroredTab(this.errorHandlingTabs, 'modx-tv-editor-tabs');
                 },
                 scope: this
             }
         }
     });
-    MODx.panel.TV.superclass.constructor.call(this,config);
+    MODx.panel.TV.superclass.constructor.call(this, config);
 };
-Ext.extend(MODx.panel.TV,MODx.FormPanel,{
+Ext.extend(MODx.panel.TV, MODx.FormPanel, {
 
-    initialized: false
+    initialized: false,
 
     /**
      * @property {String} currentTvType - Used to store tv type (xtype) for easy reference by other methods
      */
-    ,currentTvType: null
+    currentTvType: null,
 
     /**
      * @property {Number} tvId - Used to store this record's id for easy reference by other methods
      */
-    ,tvId: null
+    tvId: null,
 
     /**
      * @property {Object} nativeTypes - Defines the standard, built-in tv types so we can automate transformations
      * and visibility properties for those standard types and allow custom tv types to specify their own requirements
      * (such as whether or not to show Input Option Values and the Default Value fields)
      */
-    ,nativeTypes: {
+    nativeTypes: {
         input: [
             'autotag',
             'checkbox',
@@ -571,7 +578,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
             'text',
             'url'
         ]
-    }
+    },
 
     /**
      * @property {Object} newLoaderTypes - Extras that want to use the new input and output options loader
@@ -579,10 +586,10 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
      * values that may already exist, following the same data scheme used above in the nativeTypes property.
      * Using apply/applyIf is not advisable here, as it's the inner properties' array values that need to be appended.
      */
-    ,newLoaderTypes: {
+    newLoaderTypes: {
         input: [],
         output: []
-    }
+    },
 
     /**
      * @property {Function} addNewLoaderType - Inserts given tv type, and optionally output render type, into newLoaderTypes object
@@ -596,8 +603,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
      * addNewLoaderType(['tvName', 'renderName'], ['input', 'output']); OR simply addNewLoaderType(['tvName', 'renderName']); - adds tvName' to newLoaderTypes.input array and 'renderName' to newLoaderTypes.output array
      *
      */
-    ,addNewLoaderType: function(renderTypeKeys, propTypes) {
-
+    addNewLoaderType: function(renderTypeKeys, propTypes) {
         propTypes = propTypes || ['input', 'output'];
 
         if (typeof propTypes === 'string') {
@@ -607,27 +613,25 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
                 return false;
             }
             this.newLoaderTypes[propTypes].push(renderTypeKeys);
-        } else {
+        } else if (Ext.isArray(propTypes) && propTypes.length > 0) {
             // Let's just make sure this is an array and it's not empty
-            if(Ext.isArray(propTypes) && propTypes.length > 0) {
-                const matchKeystoTypes = Ext.isArray(renderTypeKeys) && renderTypeKeys.length == propTypes.length ? true : false ;
-                Ext.each(propTypes, function(type, i) {
-                    if (!this.newLoaderTypes.hasOwnProperty(type)) {
-                        this.newLoaderTypes[type] = [];
-                    }
-                    if (matchKeystoTypes) {
-                        this.newLoaderTypes[type].push(renderTypeKeys[i]);
-                    } else {
-                        this.newLoaderTypes[type].push(renderTypeKeys);
-                    }
-                }, this);
-            } else {
-                console.error('addNewLoaderType: There was a problem matching the renderTypeKeys to the propTypes');
-                console.error('addNewLoaderType: renderTypeKeys - ', renderTypeKeys);
-                console.error('addNewLoaderType: propTypes, - ', propTypes);
-            }
+            const matchKeystoTypes = Ext.isArray(renderTypeKeys) && renderTypeKeys.length === propTypes.length;
+            Ext.each(propTypes, function(type, i) {
+                if (!Object.hasOwn(this.newLoaderTypes, type)) {
+                    this.newLoaderTypes[type] = [];
+                }
+                if (matchKeystoTypes) {
+                    this.newLoaderTypes[type].push(renderTypeKeys[i]);
+                } else {
+                    this.newLoaderTypes[type].push(renderTypeKeys);
+                }
+            }, this);
+        } else {
+            console.error('addNewLoaderType: There was a problem matching the renderTypeKeys to the propTypes');
+            console.error('addNewLoaderType: renderTypeKeys - ', renderTypeKeys);
+            console.error('addNewLoaderType: propTypes, - ', propTypes);
         }
-    }
+    },
 
     /**
      * @property {Function} useLegacyLoader - Provides backward compatibility for non-native (community-authored)
@@ -637,63 +641,62 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
      * @param {String} propType - The properties panel being loaded (currently either 'input' or 'output')
      * @returns {Boolean}
      */
-    ,useLegacyLoader: function(tvType, propType) {
+    useLegacyLoader: function(tvType, propType) {
         let allNewLoaderTypes;
-        if (this.newLoaderTypes.hasOwnProperty(propType) && this.newLoaderTypes[propType].length > 0) {
-            allNewLoaderTypes = [...this.nativeTypes[propType], ...this.newLoaderTypes[propType]]
+        if (Object.hasOwn(this.newLoaderTypes, propType) && this.newLoaderTypes[propType].length > 0) {
+            allNewLoaderTypes = [...this.nativeTypes[propType], ...this.newLoaderTypes[propType]];
         } else {
             allNewLoaderTypes = this.nativeTypes[propType];
         }
-        return allNewLoaderTypes.indexOf(tvType) === -1 ? true : false ;
-    }
+        return allNewLoaderTypes.indexOf(tvType) === -1;
+    },
 
     /**
      * @property {Object} validatorRefMap - Provides an easy way to map differently named fields to a
      * common validator method, by tv type, without the need to pass in variables to the target method
      * from the field item's validator config
      */
-    ,validatorRefMap: {
+    validatorRefMap: {
         text: {
             minLtMax: {
-                compareTo: "inopt_maxLength",
-                errMsg: _("ext_minlenmaxfield")
+                compareTo: 'inopt_maxLength',
+                errMsg: _('ext_minlenmaxfield')
             },
             maxGtMin: {
-                compareTo: "inopt_minLength",
-                errMsg: _("ext_maxlenminfield")
+                compareTo: 'inopt_minLength',
+                errMsg: _('ext_maxlenminfield')
             }
         },
         email: {
             minLtMax: {
-                compareTo: "inopt_maxLength",
-                errMsg: _("ext_minlenmaxfield")
+                compareTo: 'inopt_maxLength',
+                errMsg: _('ext_minlenmaxfield')
             },
             maxGtMin: {
-                compareTo: "inopt_minLength",
-                errMsg: _("ext_maxlenminfield")
+                compareTo: 'inopt_minLength',
+                errMsg: _('ext_maxlenminfield')
             }
         },
         number: {
             minLtMax: {
-                compareTo: "inopt_maxValue",
-                errMsg: _("ext_minvalmaxfield")
+                compareTo: 'inopt_maxValue',
+                errMsg: _('ext_minvalmaxfield')
             },
             maxGtMin: {
-                compareTo: "inopt_minValue",
-                errMsg: _("ext_maxvalminfield")
+                compareTo: 'inopt_minValue',
+                errMsg: _('ext_maxvalminfield')
             }
         }
-    }
+    },
 
     /**
      * @property {Object} sharedComponentOverrides - Entry point for user-contributed TV
      * overrides of the global input properties (currently input options [elements] and
      * default value [default_text]).
      */
-    ,sharedComponentOverrides: {}
+    sharedComponentOverrides: {},
 
-    ,setup: function() {
-
+    setup: function() {
         if (this.initialized) {
             this.clearDirty();
             return true;
@@ -703,7 +706,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
             keys in each tab component's items property
         */
         this.errorHandlingTabs = ['form-tv'];
-        this.errorHandlingIgnoreTabs = ['panel-properties','form-template','form-access','form-sources'];
+        this.errorHandlingIgnoreTabs = ['panel-properties', 'form-template', 'form-access', 'form-sources'];
 
         this.getForm().setValues(this.config.record);
         this.formatMainPanelTitle('tv', this.config.record);
@@ -716,7 +719,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
         Ext.getCmp('modx-panel-tv-output-properties').showOutputProperties(Ext.getCmp('modx-tv-display'));
         Ext.getCmp('modx-panel-tv-input-properties').showInputProperties(Ext.getCmp('modx-tv-type'));
 
-        this.fireEvent('ready',this.config.record);
+        this.fireEvent('ready', this.config.record);
 
         if (MODx.onLoadEditor) {
             MODx.onLoadEditor(this);
@@ -725,9 +728,9 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
         this.clearDirty();
         this.initialized = true;
         MODx.fireEvent('ready');
-    }
+    },
 
-    ,beforeSubmit: function(o) {
+    beforeSubmit: function(o) {
         const
             templateAccessCmp = Ext.getCmp('modx-grid-tv-template'),
             resourceGroupAccessCmp = Ext.getCmp('modx-grid-tv-security'),
@@ -746,38 +749,39 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
             values: formValues,
             stay: MODx.config.stay
         });
-    }
+    },
 
-    ,success: function(r) {
+    success: function(r) {
         Ext.getCmp('modx-grid-tv-template').getStore().commitChanges();
         Ext.getCmp('modx-grid-tv-security').getStore().commitChanges();
         Ext.getCmp('modx-grid-element-sources').getStore().commitChanges();
-        if (MODx.request.id) Ext.getCmp('modx-grid-element-properties').save();
+        if (MODx.request.id) { Ext.getCmp('modx-grid-element-properties').save(); }
         this.getForm().setValues(r.result.object);
 
-        var t = Ext.getCmp('modx-tree-element');
+        const t = Ext.getCmp('modx-tree-element');
         if (t) {
-            var c = Ext.getCmp('modx-tv-category').getValue();
-            var u = c != '' && c != null && c != 0 ? 'n_tv_category_'+c : 'n_type_tv';
-            var node = t.getNodeById('n_tv_element_' + Ext.getCmp('modx-tv-id').getValue() + '_' + r.result.object.previous_category);
-            if (node) node.destroy();
-            t.refreshNode(u,true);
+            const
+                c = Ext.getCmp('modx-tv-category').getValue(),
+                u = c !== '' && c != null && c !== 0 ? `n_tv_category_${c}` : 'n_type_tv',
+                node = t.getNodeById(`n_tv_element_${Ext.getCmp('modx-tv-id').getValue()}_${r.result.object.previous_category}`);
+            if (node) { node.destroy(); }
+            t.refreshNode(u, true);
         }
-    }
+    },
 
-    ,changeEditor: function() {
+    changeEditor: function() {
         this.cleanupEditor();
         this.submit();
-    }
+    },
 
-    ,cleanupEditor: function() {
+    cleanupEditor: function() {
         if (MODx.onSaveEditor) {
-            var fld = Ext.getCmp('modx-tv-default-text');
+            const fld = Ext.getCmp('modx-tv-default-text');
             MODx.onSaveEditor(fld);
         }
-    }
+    },
 
-    ,validatorCustomDefs: {}
+    validatorCustomDefs: {},
 
     /**
      * @property {Function} getValidatorDefs - Establishes special built-in validators and provides
@@ -787,17 +791,19 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
      * @param {String} type - The TV type (e.g., 'date')
      * @returns {Object} - The currently-available set of validator methods
      */
-    ,getValidatorDefs: function(tvId, type) {
+    getValidatorDefs: function(tvId, type) {
         // Here, 'this' refers to the current class (MODx.panel.TV)
         const tvp = this;
         // Within each validator, 'this' refers to the input element triggering the given method
-        let validatorDefs = Ext.applyIf({
-            minLtMax: function (v) {
-                const maxFld = tvp.validatorRefMap[type][this.validator.name].compareTo + tvId;
-                let max = Ext.getCmp(maxFld),
+        // eslint-disable-next-line one-var
+        const validatorDefs = Ext.applyIf({
+            minLtMax: function(v) {
+                const
+                    maxFld = tvp.validatorRefMap[type][this.validator.name].compareTo + tvId,
+                    max = Ext.getCmp(maxFld),
                     maxVal = Number(max.getValue())
-                    ;
-                if(maxVal > 0){
+                ;
+                if (maxVal > 0) {
                     if (Number(v) > maxVal) {
                         return tvp.validatorRefMap[type][this.validator.name].errMsg;
                     }
@@ -806,24 +812,25 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
                 return true;
             },
             maxGtMin: function(v) {
-                const minFld = tvp.validatorRefMap[type][this.validator.name].compareTo + tvId;
-                let min = Ext.getCmp(minFld),
+                const
+                    minFld = tvp.validatorRefMap[type][this.validator.name].compareTo + tvId,
+                    min = Ext.getCmp(minFld),
                     minVal = Number(min.getValue())
-                    ;
-                if(minVal > 0){
+                ;
+                if (minVal > 0) {
                     if (v && Number(v) < minVal) {
                         return tvp.validatorRefMap[type][this.validator.name].errMsg;
                     }
                     min.clearInvalid();
                 }
                 return true;
-            },
+            }
         }, this.validatorCustomDefs);
 
         return validatorDefs;
-    }
+    },
 
-    ,listenerCustomDefs: {}
+    listenerCustomDefs: {},
 
     /**
      * @property {Function} getListenerDefs - Establishes special built-in listeners and provides
@@ -833,23 +840,22 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
      * @param {Object} propsPanel - A reference to the MODx.panel.TVInputProperties instance
      * @returns {Object} - The currently-available set of listener methods
      */
-    ,getListenerDefs: function(tvId, propsPanel) {
-
-        const tvp = this;
-
-        let listenerDefs = Ext.applyIf({
-            insertHelpExampleOnClick: {
-                render: {
-                    fn: function(el) {
-                        this.insertHelpExample(el);
-                    },
-                    scope: tvp
+    getListenerDefs: function(tvId, propsPanel) {
+        const
+            tvp = this,
+            listenerDefs = Ext.applyIf({
+                insertHelpExampleOnClick: {
+                    render: {
+                        fn: function(el) {
+                            this.insertHelpExample(el);
+                        },
+                        scope: tvp
+                    }
                 }
-            }
-        }, this.listenerCustomDefs);
+            }, this.listenerCustomDefs);
 
         return listenerDefs;
-    }
+    },
 
     /**
      * @property {Function} insertHelpExample - Places highlighted code sample from field description
@@ -857,72 +863,70 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
      *
      * @param {Object} cmp - The Ext.Component object containing the description field
      */
-    ,insertHelpExample: function(cmp) {
+    insertHelpExample: function(cmp) {
         return cmp.getEl().on({
-            click: function(el) {
-                const targetEl = arguments[1];
-                if(targetEl.classList.contains('example-input')) {
-                    const   exampleTxt = targetEl.textContent,
-                            inputEl = cmp.previousSibling()
-                        ;
+            click: function(event, targetEl, options) {
+                if (targetEl.classList.contains('example-input')) {
+                    const
+                        exampleTxt = targetEl.textContent,
+                        inputEl = cmp.previousSibling()
+                    ;
                     inputEl.setValue(exampleTxt);
                 }
             },
             scope: cmp
         });
-    }
+    },
 
     /**
      * @property {Function} updateFieldConfigs - Recursively examine properties in items object
      * and replace named listeners and validator with their full methods, as well as other
      * transformations to ensure full functionality. Used by input and output properties panels.
      *
-     * @param {Object} items - The array of Ext component fields to work on
-     * @param {Object} listenerDefs - The currently-available set of listeners available
-     * @param {Object} validatorDefs - The currently-available set of validators available
+     * @param {Object} items The array of Ext component fields to work on
+     * @param {Object} listenerDefs The currently-available set of listeners available
+     * @param {Object} validatorDefs The currently-available set of validators available
      *
      */
-    ,updateFieldConfigs: function(items, listenerDefs, validatorDefs) {
+    updateFieldConfigs: function(items, listenerDefs, validatorDefs) {
         const me = this;
-        Ext.each(items, function(obj, i){
-            if (obj.hasOwnProperty('items') && obj.items.length > 0) {
+        Ext.each(items, function(obj, i) {
+            if (Object.hasOwn(obj, 'items') && obj.items.length > 0) {
                 me.updateFieldConfigs(obj.items, listenerDefs, validatorDefs);
             } else {
                 // Replace named listener(s) with its/their associated class method(s)
-                if (this.hasOwnProperty("listeners")) {
-                    let listenersCfg = this.listeners.replace(/\s/g, "");
-                    if(listenersCfg.indexOf(",") > 0){
-                        listenersCfg = listenersCfg.split(",");
-                        let listenerList = [];
-                        listenersCfg.forEach(function(itm, i){
-                            if(listenerDefs.hasOwnProperty(itm)){
+                if (Object.hasOwn(this, 'listeners')) {
+                    let listenersCfg = this.listeners.replace(/\s/g, '');
+                    if (listenersCfg.indexOf(',') > 0) {
+                        listenersCfg = listenersCfg.split(',');
+                        const listenerList = [];
+                        listenersCfg.forEach(itm => {
+                            if (Object.hasOwn(listenerDefs, itm)) {
                                 listenerList.push(listenerDefs[itm]);
                             }
                         });
                         this.listeners = Object.assign({}, ...listenerList);
                     } else {
-                        this.listeners = listenerDefs.hasOwnProperty(listenersCfg) ? listenerDefs[listenersCfg] : null ;
+                        this.listeners = Object.hasOwn(listenerDefs, listenersCfg) ? listenerDefs[listenersCfg] : null ;
                     }
-                } else {
+                } else if (this.xtype && this.xtype === 'label') {
                     // Add default listener for help items
-                    if (this.xtype && this.xtype === 'label') {
-                        this.listeners = listenerDefs.insertHelpExampleOnClick;
-                    }
+                    this.listeners = listenerDefs.insertHelpExampleOnClick;
                 }
 
                 // Replace named validator with its associated class method
-                if(this.hasOwnProperty("validator")){
-                    let fsv = this.validator.trim();
-                    this.validator = validatorDefs.hasOwnProperty(fsv) ? validatorDefs[fsv] : null ;
+                if (Object.hasOwn(this, 'validator')) {
+                    const fsv = this.validator.trim();
+                    this.validator = Object.hasOwn(validatorDefs, fsv) ? validatorDefs[fsv] : null ;
                 }
 
                 // Transform all regex type property values from string to usable expression
-                if(this.hasOwnProperty("regex")){
-                    let rx = this.regex.trim();
+                if (Object.hasOwn(this, 'regex')) {
+                    const rx = this.regex.trim();
                     this.regex = new RegExp(rx);
                 }
-                if(this.hasOwnProperty("maskRe")){
-                    let mr = this.maskRe.trim();
+                if (Object.hasOwn(this, 'maskRe')) {
+                    const mr = this.maskRe.trim();
                     this.maskRe = new RegExp(mr);
                 }
             }
@@ -930,7 +934,7 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
     }
 
 });
-Ext.reg('modx-panel-tv',MODx.panel.TV);
+Ext.reg('modx-panel-tv', MODx.panel.TV);
 
 /**
  * @class MODx.panel.TVInputProperties
@@ -938,73 +942,72 @@ Ext.reg('modx-panel-tv',MODx.panel.TV);
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-tv-input-properties
  */
-MODx.panel.TVInputProperties = function(config) {
-    config = config || {};
-    Ext.applyIf(config,{
-        id: 'modx-panel-tv-input-properties'
-        ,title: _('tv_tab_input_options')
-        ,header: false
-        ,border: false
-        ,defaults: {
-            border: false
-            ,defaults: {
-                labelSeparator: ''
-                ,msgTarget: 'under'
-                ,validationEvent: 'change'
-                ,validateOnBlur: false
-        }
-        }
-        ,cls: 'form-with-labels'
-        ,items: [{
-            html: _('tv_tab_input_options_desc')
-            ,itemId: 'desc-tv-input-properties'
-            ,xtype: 'modx-description'
-        },{
-            layout: 'form'
-            ,border: false
-            ,cls:'main-wrapper'
-            ,labelAlign: 'top'
-            ,labelSeparator: ''
-            ,defaults: {
-                anchor: '100%'
-                ,msgTarget: 'under'
+MODx.panel.TVInputProperties = function(config = {}) {
+    Ext.applyIf(config, {
+        id: 'modx-panel-tv-input-properties',
+        title: _('tv_tab_input_options'),
+        header: false,
+        border: false,
+        defaults: {
+            border: false,
+            defaults: {
+                labelSeparator: '',
+                msgTarget: 'under',
+                validationEvent: 'change',
+                validateOnBlur: false
             }
-            ,items: [{
-                xtype: 'modx-combo-tv-input-type'
-                ,fieldLabel: _('tv_type')
-                ,description: MODx.expandHelp ? '' : _('tv_type_desc')
-                ,name: 'type'
-                ,id: 'modx-tv-type'
-                ,itemid: 'fld-type'
-                ,value: config.record.type || 'text'
-                ,listeners: {
-                    'select': {fn:this.showInputProperties,scope:this}
+        },
+        cls: 'form-with-labels',
+        items: [{
+            html: _('tv_tab_input_options_desc'),
+            itemId: 'desc-tv-input-properties',
+            xtype: 'modx-description'
+        }, {
+            layout: 'form',
+            border: false,
+            cls: 'main-wrapper',
+            labelAlign: 'top',
+            labelSeparator: '',
+            defaults: {
+                anchor: '100%',
+                msgTarget: 'under'
+            },
+            items: [{
+                xtype: 'modx-combo-tv-input-type',
+                fieldLabel: _('tv_type'),
+                description: MODx.expandHelp ? '' : _('tv_type_desc'),
+                name: 'type',
+                id: 'modx-tv-type',
+                itemid: 'fld-type',
+                value: config.record.type || 'text',
+                listeners: {
+                    select: { fn: this.showInputProperties, scope: this }
                 }
-            },{
-                xtype: 'label'
-                ,forId: 'modx-tv-type'
-                ,html: _('tv_type_desc')
-                ,cls: 'desc-under'
-            },{
+            }, {
+                xtype: 'box',
+                hidden: !MODx.expandHelp,
+                html: _('tv_type_desc'),
+                cls: 'desc-under'
+            }, {
                 /*
                     Reducing this and next 3 items' initial config to bare-bones minimum,
                     as they will be dynamically replaced via updateSharedComponent each time
                     the tv type is changed
                 */
-                xtype: 'textarea'
-                ,id: 'modx-tv-elements'
-                ,itemId: 'fld-elements'
-            },{
-                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                ,forId: 'modx-tv-elements'
-            },{
-                xtype: 'textarea'
-                ,id: 'modx-tv-default-text'
-                ,itemId: 'fld-default-text'
-            },{
-                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                ,forId: 'modx-tv-default-text'
-            },{
+                xtype: 'textarea',
+                id: 'modx-tv-elements',
+                itemId: 'fld-elements'
+            }, {
+                xtype: 'box',
+                forId: 'modx-tv-elements'
+            }, {
+                xtype: 'textarea',
+                id: 'modx-tv-default-text',
+                itemId: 'fld-default-text'
+            }, {
+                xtype: 'box',
+                forId: 'modx-tv-default-text'
+            }, {
                 xtype: 'fieldset',
                 id: 'tv-input-opts-fs',
                 autoHeight: true,
@@ -1017,20 +1020,20 @@ MODx.panel.TVInputProperties = function(config) {
                     msgTarget: 'under'
                 },
                 items: []
-    		},{
-				id: 'modx-input-props',
+            }, {
+                id: 'modx-input-props',
                 autoHeight: true
             }]
         }]
     });
-    MODx.panel.TVInputProperties.superclass.constructor.call(this,config);
+    MODx.panel.TVInputProperties.superclass.constructor.call(this, config);
 };
-Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
+Ext.extend(MODx.panel.TVInputProperties, MODx.Panel, {
     markPanelDirty: function() {
         Ext.getCmp('modx-panel-tv').markDirty();
-    }
+    },
 
-    ,isNativeType: true
+    isNativeType: true,
 
     /**
      * @property {Function} updateSharedComponent - Allows manipulation of input property components common to all tv types
@@ -1041,21 +1044,22 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
      * @param {mixed} value - The field's currently stored value
      * @param {Boolean} updateSibling - Whether to alter the sibling component (inline help); default is true
      */
-    ,updateSharedComponent: function(type, fieldCmp, value, updateSibling) {
-
+    updateSharedComponent: function(type, fieldCmp, value, updateSibling) {
         value = typeof value !== 'undefined' ? value : '' ;
-        updateSibling = typeof updateSibling === 'undefined' || updateSibling === true ? true : false ;
+        updateSibling = typeof updateSibling === 'undefined' || updateSibling === true;
 
-        const   tvPanel = Ext.getCmp('modx-panel-tv'),
-                container = fieldCmp.ownerCt,
-                fieldId = fieldCmp.id,
-                fieldItemId = fieldCmp.itemId,
-                itemKey = container.items.keys.indexOf(fieldItemId),
-                siblingKey = itemKey + 1,
-                siblingCmp = fieldCmp.nextSibling(),
-                optsDbExample_1 = '@SELECT `pagetitle`,`id` FROM `[[+PREFIX]]site_content` WHERE `published`=1 AND `deleted`=0 AND `template`=1',
-                optsDbExample_2 = '@SELECT "-none-" AS `pagetitle`, 0 AS `id` UNION ALL SELECT `pagetitle`,`id` FROM `[[+PREFIX]]site_content` WHERE `published`=1 AND `deleted`=0 AND `template`=1'
-                ;
+        const
+            tvPanel = Ext.getCmp('modx-panel-tv'),
+            container = fieldCmp.ownerCt,
+            fieldId = fieldCmp.id,
+            fieldItemId = fieldCmp.itemId,
+            itemKey = container.items.keys.indexOf(fieldItemId),
+            siblingKey = itemKey + 1,
+            siblingCmp = fieldCmp.nextSibling(),
+            optsDbExample1 = '@SELECT `pagetitle`,`id` FROM `[[+PREFIX]]site_content` WHERE `published`=1 AND `deleted`=0 AND `template`=1',
+            // eslint-disable-next-line max-len
+            optsDbExample2 = '@SELECT "-none-" AS `pagetitle`, 0 AS `id` UNION ALL SELECT `pagetitle`,`id` FROM `[[+PREFIX]]site_content` WHERE `published`=1 AND `deleted`=0 AND `template`=1'
+        ;
         let defaultProps = {},
             typeProps = {},
             defaultHelp = {},
@@ -1064,49 +1068,53 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
             helpLexKey,
             helpUseLexKey,
             helpText
-            ;
+        ;
         if (this.isNativeType) {
-            switch(fieldId) {
+            switch (fieldId) {
                 case 'modx-tv-elements':
-                    helpLexKey = 'tv_elements_'+type+'_desc';
+                    helpLexKey = `tv_elements_${type}_desc`;
                     break;
                 case 'modx-tv-default-text':
-                    helpLexKey = 'tv_default_'+type+'_desc';
+                    helpLexKey = `tv_default_${type}_desc`;
                     break;
+                // no default
             }
         } else {
-            switch(fieldId) {
+            switch (fieldId) {
                 case 'modx-tv-elements':
                     helpLexKey = 'tv_elements_desc';
                     break;
                 case 'modx-tv-default-text':
                     helpLexKey = 'tv_default_desc';
                     break;
+                // no default
             }
         }
+        // eslint-disable-next-line prefer-const
         helpUseLexKey = typeof _(helpLexKey) !== 'undefined' ? helpLexKey : helpUseLexKey ;
         helpText = _(helpUseLexKey);
 
-        switch(fieldId) {
+        switch (fieldId) {
             case 'modx-tv-elements':
                 defaultProps = {
-                    xtype: 'textarea'
-                    ,fieldLabel: _('tv_elements')
-                    ,description: MODx.expandHelp ? '' : _(helpUseLexKey, { example_1: optsDbExample_1, example_2: optsDbExample_2})
-                    ,name: 'els'
-                    ,id: 'modx-tv-elements'
-                    ,itemId: 'fld-elements'
-                    ,grow: true
-                    ,maxHeight: 160
-                    ,value: value
-                    ,plugins: new AddFieldUtilities.plugin.Class
+                    xtype: 'textarea',
+                    fieldLabel: _('tv_elements'),
+                    description: MODx.expandHelp ? '' : _(helpUseLexKey, { example_1: optsDbExample1, example_2: optsDbExample2 }),
+                    name: 'els',
+                    id: 'modx-tv-elements',
+                    itemId: 'fld-elements',
+                    grow: true,
+                    maxHeight: 160,
+                    value: value,
+                    // eslint-disable-next-line new-parens, no-undef
+                    plugins: new AddFieldUtilities.plugin.Class
                 };
                 defaultHelp = {
-                    xtype: MODx.expandHelp ? 'label' : 'hidden'
-                    ,forId: 'modx-tv-elements'
-                    ,html: _(helpUseLexKey, { example_1: optsDbExample_1, example_2: optsDbExample_2})
-                    ,cls: 'desc-under'
-                    ,listeners: {
+                    xtype: 'box',
+                    hidden: !MODx.expandHelp,
+                    html: _(helpUseLexKey, { example_1: optsDbExample1, example_2: optsDbExample2 }),
+                    cls: 'desc-under',
+                    listeners: {
                         render: {
                             fn: function(el) {
                                 this.insertHelpExample(el);
@@ -1145,27 +1153,28 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
                                 fieldLabel: _('tv_elements_tag')
                             };
                             break;
+                        // no default
                     }
                 }
                 break;
 
             case 'modx-tv-default-text':
                 defaultProps = {
-                    xtype: 'textfield'
-                    ,fieldLabel: _('tv_default')
-                    ,description: MODx.expandHelp ? '' : _('tv_default_desc')
-                    ,name: 'default_text'
-                    ,id: 'modx-tv-default-text'
-                    ,itemId: 'fld-default-text'
-                    ,anchor: '100%'
-                    ,value: value
+                    xtype: 'textfield',
+                    fieldLabel: _('tv_default'),
+                    description: MODx.expandHelp ? '' : _('tv_default_desc'),
+                    name: 'default_text',
+                    id: 'modx-tv-default-text',
+                    itemId: 'fld-default-text',
+                    anchor: '100%',
+                    value: value
                 };
                 defaultHelp = {
-                    xtype: MODx.expandHelp ? 'label' : 'hidden'
-                    ,forId: 'modx-tv-default-text'
-                    ,html: helpText
-                    ,cls: 'desc-under'
-                    ,listeners: {
+                    xtype: 'box',
+                    hidden: !MODx.expandHelp,
+                    html: helpText,
+                    cls: 'desc-under',
+                    listeners: {
                         render: {
                             fn: function(el) {
                                 this.insertHelpExample(el);
@@ -1183,72 +1192,75 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
                             break;
                         case 'email':
                             typeProps = {
-                                fieldLabel: _('tv_default_email')
-                                ,vtype: 'email'
+                                fieldLabel: _('tv_default_email'),
+                                vtype: 'email'
                             };
                             break;
-                        case 'date':
-                            const   now = new Date(),
-                                    datetimeNow = Ext.util.Format.date(now, MODx.config.manager_date_format + ' ' + MODx.config.manager_time_format)
+                        case 'date': {
+                            const
+                                now = new Date(),
+                                datetimeNow = Ext.util.Format.date(now, `${MODx.config.manager_date_format} ${MODx.config.manager_time_format}`)
                             ;
-                            helpText = _(helpUseLexKey, {example_1: '+24', example_2: '-24', example_3: datetimeNow});
+                            helpText = _(helpUseLexKey, { example_1: '+24', example_2: '-24', example_3: datetimeNow });
                             typeProps = {
-                                xtype: 'combo'
-                                ,fieldLabel: _('tv_default_date')
-                                ,description: MODx.expandHelp ? '' : helpText
-                                ,hiddenName: 'default_text'
-                                ,store: new Ext.data.SimpleStore({
-                                    fields: ['v','d']
-                                    ,data: [
-                                        ['',_('none')],
-                                        ['now',_('default_date_now')],
-                                        ['today',_('default_date_today')],
-                                        ['yesterday',_('default_date_yesterday')],
-                                        ['tomorrow',_('default_date_tomorrow')],
-                                        ['custom',_('default_date_custom')]
+                                xtype: 'combo',
+                                fieldLabel: _('tv_default_date'),
+                                description: MODx.expandHelp ? '' : helpText,
+                                hiddenName: 'default_text',
+                                store: new Ext.data.SimpleStore({
+                                    fields: ['v', 'd'],
+                                    data: [
+                                        ['', _('none')],
+                                        ['now', _('default_date_now')],
+                                        ['today', _('default_date_today')],
+                                        ['yesterday', _('default_date_yesterday')],
+                                        ['tomorrow', _('default_date_tomorrow')],
+                                        ['custom', _('default_date_custom')]
                                     ]
-                                })
-                                ,displayField: 'd'
-                                ,valueField: 'v'
-                                ,mode: 'local'
-                                ,editable: true
-                                ,forceSelection: false
-                                ,typeAhead: false
-                                ,triggerAction: 'all'
-                                ,anchor: '50%'
-                                ,plugins: new AddFieldUtilities.plugin.Class
+                                }),
+                                displayField: 'd',
+                                valueField: 'v',
+                                mode: 'local',
+                                editable: true,
+                                forceSelection: false,
+                                typeAhead: false,
+                                triggerAction: 'all',
+                                anchor: '50%',
+                                // eslint-disable-next-line new-parens, no-undef
+                                plugins: new AddFieldUtilities.plugin.Class
                             };
                             helpProps = {
                                 html: helpText
                             };
                             break;
+                        }
                         case 'file':
                             typeProps = {
-                                xtype: 'modx-combo-browser'
-                                ,browserEl: 'modx-browser'
-                                ,fieldLabel: _('tv_default_file')
-                                ,openTo: this.record.openTo || ''
-                                ,source: this.record.source
-                                ,allowedFileTypes: MODx.config.upload_files
-                                ,triggerClass: 'x-form-code-trigger'
-                                ,maxLength: 255
-                                ,hideMode: 'offsets'
-                                ,anchor: '50%'
+                                xtype: 'modx-combo-browser',
+                                browserEl: 'modx-browser',
+                                fieldLabel: _('tv_default_file'),
+                                openTo: this.record.openTo || '',
+                                source: this.record.source,
+                                allowedFileTypes: MODx.config.upload_files,
+                                triggerClass: 'x-form-code-trigger',
+                                maxLength: 255,
+                                hideMode: 'offsets',
+                                anchor: '50%'
                             };
                             break;
                         // TBD: Would be nice to provide preview
                         case 'image':
                             typeProps = {
-                                xtype: 'modx-combo-browser'
-                                ,browserEl: 'modx-browser'
-                                ,fieldLabel: _('tv_default_image')
-                                ,openTo: this.record.openTo || ''
-                                ,source: this.record.source
-                                ,allowedFileTypes: MODx.config.upload_files
-                                ,triggerClass: 'x-form-code-trigger'
-                                ,maxLength: 255
-                                ,hideMode: 'offsets'
-                                ,anchor: '50%'
+                                xtype: 'modx-combo-browser',
+                                browserEl: 'modx-browser',
+                                fieldLabel: _('tv_default_image'),
+                                openTo: this.record.openTo || '',
+                                source: this.record.source,
+                                allowedFileTypes: MODx.config.upload_files,
+                                triggerClass: 'x-form-code-trigger',
+                                maxLength: 255,
+                                hideMode: 'offsets',
+                                anchor: '50%'
                             };
                             break;
                         case 'listbox':
@@ -1264,9 +1276,9 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
                             break;
                         case 'number':
                             typeProps = {
-                                xtype: 'numberfield'
-                                ,fieldLabel: _('tv_default_number')
-                                ,anchor: '50%'
+                                xtype: 'numberfield',
+                                fieldLabel: _('tv_default_number'),
+                                anchor: '50%'
                             };
                             break;
                         case 'option':
@@ -1277,16 +1289,16 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
                             break;
                         case 'resourcelist':
                             typeProps = {
-                                xtype: 'numberfield'
-                                ,fieldLabel: _('tv_default_resource')
+                                xtype: 'numberfield',
+                                fieldLabel: _('tv_default_resource')
                             };
                             break;
                         case 'richtext':
                             typeProps = {
-                                xtype: 'textarea'
-                                ,fieldLabel: _('tv_default_text')
-                                ,grow: true
-                                ,maxHeight: 250
+                                xtype: 'textarea',
+                                fieldLabel: _('tv_default_text'),
+                                grow: true,
+                                maxHeight: 250
                             };
                             break;
                         case 'tag':
@@ -1296,36 +1308,38 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
                             break;
                         case 'text':
                             typeProps = {
-                                fieldLabel: _('tv_default_text')
-                                ,anchor: '50%'
+                                fieldLabel: _('tv_default_text'),
+                                anchor: '50%'
                             };
                             break;
                         case 'textarea':
                             typeProps = {
-                                xtype: 'textarea'
-                                ,fieldLabel: _('tv_default_text')
-                                ,grow: true
-                                ,maxHeight: 250
-                                ,anchor: '50%'
+                                xtype: 'textarea',
+                                fieldLabel: _('tv_default_text'),
+                                grow: true,
+                                maxHeight: 250,
+                                anchor: '50%'
                             };
                             break;
                         case 'url':
                             typeProps = {
-                                vtype: 'url'
-                                ,fieldLabel: _('tv_default_url')
+                                vtype: 'url',
+                                fieldLabel: _('tv_default_url')
                             };
                             break;
+                        // no default
                     }
                 }
                 break;
+                // no default
         }
 
-        if (!this.isNativeType && tvPanel.sharedComponentOverrides.hasOwnProperty(type)) {
+        if (!this.isNativeType && Object.hasOwn(tvPanel.sharedComponentOverrides, type)) {
             const overrides = tvPanel.sharedComponentOverrides[type][fieldId];
             if (typeof overrides !== 'undefined') {
-                const help = overrides.help;
+                const { help } = overrides;
                 typeProps = overrides.config || {};
-                if (typeProps.hasOwnProperty('hidden') && typeProps.hidden === true || help === false) {
+                if ((Object.hasOwn(typeProps, 'hidden') && typeProps.hidden === true) || help === false) {
                     helpProps.hidden = true;
                 }
                 if (!Ext.isEmpty(help)) {
@@ -1348,39 +1362,39 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
             siblingCmp.destroy();
             container.insert(siblingKey, item);
         }
-    }
+    },
 
-    ,showInputProperties: function(cb,rc,i) {
-
+    showInputProperties: function(cb, rc, i) {
         /*
             NOTE: The ext property 'startValue' gets applied to a component only after its has been changed, and
             is thus the most direct way of assessing whether the tvtype has been chosen and/or changed. We can't
             simply test for isDirty, as it would return false when changing from a new type back to the original one.
         */
-        const   formCmp = this.getComponent(1),
-                tvPanel = Ext.getCmp('modx-panel-tv'),
-                typeChanged = cb.hasOwnProperty('startValue') ? true : false ,
-                type = cb.getValue(),
-                tvId = this.config.record.id || '',
-                listenerDefs = tvPanel.getListenerDefs(tvId, this),
-                validatorDefs = tvPanel.getValidatorDefs(tvId, type),
-                optsFieldset = Ext.getCmp('tv-input-opts-fs'),
-                legacyOpts = Ext.get('modx-input-props'),
-                useLegacyLoader = tvPanel.useLegacyLoader(type, 'input'),
-                inputOptValsItem = Ext.getCmp('modx-tv-elements'),
-                inputOptValsItemVal = typeChanged ? inputOptValsItem.getValue() : this.config.record.elements,
-                inputDefaultValItem = Ext.getCmp('modx-tv-default-text'),
-                inputDefaultValItemVal = typeChanged ? inputDefaultValItem.getValue() : this.config.record.default_text,
-                hideInputOptValsItemFor = ['autotag','date','email','file','hidden','image','number','resourcelist','richtext','text','textarea','url'],
-                hideInputDefaultValItemFor = ['autotag']
+        const
+            formCmp = this.getComponent(1),
+            tvPanel = Ext.getCmp('modx-panel-tv'),
+            typeChanged = Object.hasOwn(cb, 'startValue'),
+            type = cb.getValue(),
+            tvId = this.config.record.id || '',
+            listenerDefs = tvPanel.getListenerDefs(tvId, this),
+            validatorDefs = tvPanel.getValidatorDefs(tvId, type),
+            optsFieldset = Ext.getCmp('tv-input-opts-fs'),
+            legacyOpts = Ext.get('modx-input-props'),
+            useLegacyLoader = tvPanel.useLegacyLoader(type, 'input'),
+            inputOptValsItem = Ext.getCmp('modx-tv-elements'),
+            inputOptValsItemVal = typeChanged ? inputOptValsItem.getValue() : this.config.record.elements,
+            inputDefaultValItem = Ext.getCmp('modx-tv-default-text'),
+            inputDefaultValItemVal = typeChanged ? inputDefaultValItem.getValue() : this.config.record.default_text,
+            hideInputOptValsItemFor = ['autotag', 'date', 'email', 'file', 'hidden', 'image', 'number', 'resourcelist', 'richtext', 'text', 'textarea', 'url'],
+            hideInputDefaultValItemFor = ['autotag']
         ;
 
         tvPanel.currentTvType = type;
         tvPanel.tvId = tvId;
-        this.isNativeType = tvPanel.nativeTypes['input'].indexOf(type) !== -1 ? true : false ;
+        this.isNativeType = tvPanel.nativeTypes.input.indexOf(type) !== -1;
 
-        if(inputOptValsItem){
-            if(hideInputOptValsItemFor.indexOf(type) !== -1){
+        if (inputOptValsItem) {
+            if (hideInputOptValsItemFor.indexOf(type) !== -1) {
                 inputOptValsItem.allowBlank = true;
                 inputOptValsItem.hide().nextSibling().hide();
             } else {
@@ -1393,17 +1407,17 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
                 */
                 if (typeChanged) {
                     Ext.getCmp('modx-tv-elements').clearInvalid();
-                    if(this.isNativeType){
+                    if (this.isNativeType) {
                         inputOptValsItem.allowBlank = false;
                     }
                 }
             }
         }
-        if(inputDefaultValItem){
-            if(hideInputDefaultValItemFor.indexOf(type) !== -1){
+        if (inputDefaultValItem) {
+            if (hideInputDefaultValItemFor.indexOf(type) !== -1) {
                 inputDefaultValItem.hide().nextSibling().hide();
                 // composite field labels have to be explicitly hidden
-                if (inputDefaultValItem.initialConfig.xtype == 'xdatetime') {
+                if (inputDefaultValItem.initialConfig.xtype === 'xdatetime') {
                     inputDefaultValItem.getEl().up('.x-form-item').addClass('x-hide-display');
                 }
             } else {
@@ -1413,76 +1427,71 @@ Ext.extend(MODx.panel.TVInputProperties,MODx.Panel,{
         }
 
         if (useLegacyLoader) {
-            let pu = legacyOpts.getUpdater();
+            const pu = legacyOpts.getUpdater();
             pu.loadScripts = true;
             optsFieldset.removeAll();
             try {
                 pu.update({
-                    url: MODx.config.connector_url
-                    ,method: 'GET'
-                    ,params: {
-                           action: 'Element/TemplateVar/Renders/GetInputProperties'
-                           ,context: 'mgr'
-                           ,tv: this.config.record.id
-                           ,type: type || 'default'
-                    }
-                    ,scripts: true
+                    url: MODx.config.connector_url,
+                    method: 'GET',
+                    params: {
+                        action: 'Element/TemplateVar/Renders/GetInputProperties',
+                        context: 'mgr',
+                        tv: this.config.record.id,
+                        type: type || 'default'
+                    },
+                    scripts: true
                 });
-            } catch(e) {
+            } catch (e) {
                 MODx.debug(e);
             }
-
         } else {
             legacyOpts.update('');
             try {
                 MODx.Ajax.request({
-                    url: MODx.config.connector_url
-                    ,params: {
-                       action: 'Element/TemplateVar/Configs/GetInputPropertyConfigs'
-                       ,context: 'mgr'
-                       ,tv: this.config.record.id
-                       ,type: type || 'default'
-                       ,expandHelp: MODx.expandHelp
-                   }
-                   ,listeners: {
+                    url: MODx.config.connector_url,
+                    params: {
+                        action: 'Element/TemplateVar/Configs/GetInputPropertyConfigs',
+                        context: 'mgr',
+                        tv: this.config.record.id,
+                        type: type || 'default',
+                        expandHelp: MODx.expandHelp
+                    },
+                    listeners: {
                         success: {
-                            fn: function(r) {
-
+                            fn: function(response) {
                                 // Make adjustments to returned config
-                                if (r.hasOwnProperty('optsItems') && r.optsItems.length > 0) {
-                                    tvPanel.updateFieldConfigs(r.optsItems, listenerDefs, validatorDefs);
-                                    if(typeChanged){
+                                if (Object.hasOwn(response, 'optsItems') && response.optsItems.length > 0) {
+                                    tvPanel.updateFieldConfigs(response.optsItems, listenerDefs, validatorDefs);
+                                    if (typeChanged) {
                                         optsFieldset.removeAll();
                                     }
-                                    optsFieldset.add(r.optsItems);
-
-                                // No option items exist for certain fields (file, hidden, etc.),
-                                } else {
-                                    if(typeChanged){
-                                        optsFieldset.removeAll();
-                                    }
+                                    optsFieldset.add(response.optsItems);
+                                } else if (typeChanged) {
+                                    // No option items exist for certain fields (file, hidden, etc.)
+                                    optsFieldset.removeAll();
                                 }
-                                if(typeChanged){
+                                if (typeChanged) {
                                     formCmp.doLayout();
                                 }
-                            }
-                            ,scope: this
-                        }
-                        ,failure: {
-                            fn: function(r) {
-                                console.error(`showInputProperties failed to fetch the config for ${type} due to an error.`, r);
-                            }
-                            ,scope: this
+                            },
+                            scope: this
+                        },
+                        failure: {
+                            fn: function(response) {
+                                console.error(`showInputProperties failed to fetch the config for ${type} due to an error.`, response);
+                            },
+                            scope: this
                         }
                     }
                 });
-            } catch(e) {
+            } catch (e) {
                 MODx.debug(e);
             }
         }
     }
 });
-Ext.reg('modx-panel-tv-input-properties',MODx.panel.TVInputProperties);
+Ext.reg('modx-panel-tv-input-properties', MODx.panel.TVInputProperties);
 
 /**
  * @class MODx.panel.TVOutputProperties
@@ -1490,44 +1499,43 @@ Ext.reg('modx-panel-tv-input-properties',MODx.panel.TVInputProperties);
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-tv-output-properties
  */
-MODx.panel.TVOutputProperties = function(config) {
-    config = config || {};
-    Ext.applyIf(config,{
-        id: 'modx-panel-tv-output-properties'
-        ,title: _('tv_tab_output_options')
-        ,header: false
-        ,layout: 'form'
-        ,cls: 'form-with-labels'
-        ,defaults: {
+MODx.panel.TVOutputProperties = function(config = {}) {
+    Ext.applyIf(config, {
+        id: 'modx-panel-tv-output-properties',
+        title: _('tv_tab_output_options'),
+        header: false,
+        layout: 'form',
+        cls: 'form-with-labels',
+        defaults: {
             border: false
-        }
-        ,items: [{
-            html: _('tv_tab_output_options_desc')
-            ,itemId: 'desc-tv-output-properties'
-            ,xtype: 'modx-description'
-        },{
-            layout: 'form'
-            ,cls:'main-wrapper'
-            ,labelAlign: 'top'
-            ,labelSeparator: ''
-            ,items: [{
-                xtype: 'modx-combo-tv-widget'
-                ,fieldLabel: _('tv_output_type')
-                ,name: 'display'
-                ,hiddenName: 'display'
-                ,id: 'modx-tv-display'
-                ,itemId: 'fld-display'
-                ,value: config.record.display || 'default'
-                ,anchor: '100%'
-                ,listeners: {
-                    'select': {fn:this.showOutputProperties,scope:this}
+        },
+        items: [{
+            html: _('tv_tab_output_options_desc'),
+            itemId: 'desc-tv-output-properties',
+            xtype: 'modx-description'
+        }, {
+            layout: 'form',
+            cls: 'main-wrapper',
+            labelAlign: 'top',
+            labelSeparator: '',
+            items: [{
+                xtype: 'modx-combo-tv-widget',
+                fieldLabel: _('tv_output_type'),
+                name: 'display',
+                hiddenName: 'display',
+                id: 'modx-tv-display',
+                itemId: 'fld-display',
+                value: config.record.display || 'default',
+                anchor: '100%',
+                listeners: {
+                    select: { fn: this.showOutputProperties, scope: this }
                 }
-            },{
-                xtype: MODx.expandHelp ? 'label' : 'hidden'
-                ,forId: 'modx-tv-display'
-                ,html: _('tv_output_type_desc')
-                ,cls: 'desc-under'
-            },{
+            }, {
+                xtype: 'box',
+                hidden: !MODx.expandHelp,
+                html: _('tv_output_type_desc'),
+                cls: 'desc-under'
+            }, {
                 xtype: 'fieldset',
                 id: 'tv-output-opts-fs',
                 autoHeight: true,
@@ -1539,101 +1547,98 @@ MODx.panel.TVOutputProperties = function(config) {
                     msgTarget: 'under'
                 },
                 items: []
-    		},{
-                id: 'modx-widget-props'
-                ,autoHeight: true
+            }, {
+                id: 'modx-widget-props',
+                autoHeight: true
             }]
         }]
     });
-    MODx.panel.TVOutputProperties.superclass.constructor.call(this,config);
+    MODx.panel.TVOutputProperties.superclass.constructor.call(this, config);
 };
-Ext.extend(MODx.panel.TVOutputProperties,MODx.Panel,{
+Ext.extend(MODx.panel.TVOutputProperties, MODx.Panel, {
 
-    isNativeType: true
+    isNativeType: true,
 
-    ,showOutputProperties: function(cb,rc,i) {
-
-        const   formCmp = this.getComponent(1),
-                tvPanel = Ext.getCmp('modx-panel-tv'),
-                typeChanged = cb.hasOwnProperty('startValue') ? true : false ,
-                type = cb.getValue(),
-                tvId = this.config.record.id || '',
-                listenerDefs = tvPanel.getListenerDefs(tvId, this),
-                validatorDefs = tvPanel.getValidatorDefs(tvId, type),
-                optsFieldset = Ext.getCmp('tv-output-opts-fs'),
-                legacyOpts = Ext.get('modx-widget-props'),
-                useLegacyLoader = tvPanel.useLegacyLoader(type, 'output')
+    showOutputProperties: function(cb, rc, i) {
+        const
+            formCmp = this.getComponent(1),
+            tvPanel = Ext.getCmp('modx-panel-tv'),
+            typeChanged = Object.hasOwn(cb, 'startValue'),
+            type = cb.getValue(),
+            tvId = this.config.record.id || '',
+            listenerDefs = tvPanel.getListenerDefs(tvId, this),
+            validatorDefs = tvPanel.getValidatorDefs(tvId, type),
+            optsFieldset = Ext.getCmp('tv-output-opts-fs'),
+            legacyOpts = Ext.get('modx-widget-props'),
+            useLegacyLoader = tvPanel.useLegacyLoader(type, 'output')
         ;
-        this.isNativeType = tvPanel.nativeTypes['output'].indexOf(type) !== -1 ? true : false ;
+        this.isNativeType = tvPanel.nativeTypes.output.indexOf(type) !== -1;
 
         if (useLegacyLoader) {
-            let pu = legacyOpts.getUpdater();
+            const pu = legacyOpts.getUpdater();
             pu.loadScripts = true;
             optsFieldset.removeAll();
             try {
                 pu.update({
-                    url: MODx.config.connector_url
-                    ,method: 'GET'
-                    ,params: {
-                           action: 'Element/TemplateVar/Renders/GetProperties'
-                           ,context: 'mgr'
-                           ,tv: this.config.record.id
-                           ,type: type || 'default'
-                    }
-                    ,scripts: true
+                    url: MODx.config.connector_url,
+                    method: 'GET',
+                    params: {
+                        action: 'Element/TemplateVar/Renders/GetProperties',
+                        context: 'mgr',
+                        tv: this.config.record.id,
+                        type: type || 'default'
+                    },
+                    scripts: true
                 });
-            } catch(e) {
+            } catch (e) {
                 MODx.debug(e);
             }
         } else {
             legacyOpts.update('');
             try {
                 MODx.Ajax.request({
-                    url: MODx.config.connector_url
-                    ,params: {
-                       action: 'Element/TemplateVar/Configs/GetOutputPropertyConfigs'
-                       ,context: 'mgr'
-                       ,tv: this.config.record.id
-                       ,type: type || 'default'
-                       ,expandHelp: MODx.expandHelp
-                   }
-                   ,listeners: {
+                    url: MODx.config.connector_url,
+                    params: {
+                        action: 'Element/TemplateVar/Configs/GetOutputPropertyConfigs',
+                        context: 'mgr',
+                        tv: this.config.record.id,
+                        type: type || 'default',
+                        expandHelp: MODx.expandHelp
+                    },
+                    listeners: {
                         success: {
-                            fn: function(r) {
-
+                            fn: function(response) {
                                 // Make adjustments to returned config
-                                if (r.hasOwnProperty('optsItems') && r.optsItems.length > 0) {
-                                    tvPanel.updateFieldConfigs(r.optsItems, listenerDefs, validatorDefs);
-                                    if(typeChanged){
+                                if (Object.hasOwn(response, 'optsItems') && response.optsItems.length > 0) {
+                                    tvPanel.updateFieldConfigs(response.optsItems, listenerDefs, validatorDefs);
+                                    if (typeChanged) {
                                         optsFieldset.removeAll();
                                     }
-                                    optsFieldset.add(r.optsItems);
-                                } else {
-                                    if(typeChanged){
-                                        optsFieldset.removeAll();
-                                    }
+                                    optsFieldset.add(response.optsItems);
+                                } else if (typeChanged) {
+                                    optsFieldset.removeAll();
                                 }
-                                if(typeChanged){
+                                if (typeChanged) {
                                     formCmp.doLayout();
                                 }
-                            }
-                            ,scope: this
-                        }
-                        ,failure: {
+                            },
+                            scope: this
+                        },
+                        failure: {
                             fn: function(r) {
                                 console.error(`MODx.panel.TVOutputProperties: showOutputProperties failed to fetch the config for ${type} due to an error.`, r);
-                            }
-                            ,scope: this
+                            },
+                            scope: this
                         }
                     }
                 });
-            } catch(e) {
+            } catch (e) {
                 MODx.debug(e);
             }
         }
     }
 });
-Ext.reg('modx-panel-tv-output-properties',MODx.panel.TVOutputProperties);
+Ext.reg('modx-panel-tv-output-properties', MODx.panel.TVOutputProperties);
 
 /**
  * @class MODx.grid.ElementSources
@@ -1641,40 +1646,41 @@ Ext.reg('modx-panel-tv-output-properties',MODx.panel.TVOutputProperties);
  * @param {Object} config An object of configuration properties
  * @xtype modx-grid-element-sources
  */
-MODx.grid.ElementSources = function(config) {
-    var src = new MODx.combo.MediaSource();
+MODx.grid.ElementSources = function(config = {}) {
+    const src = new MODx.combo.MediaSource();
     src.getStore().load();
-
-    config = config || {};
-    Ext.applyIf(config,{
-        id: 'modx-grid-element-sources'
-        ,fields: ['context_key','source','name']
-        ,showActionsColumn: false
-        ,autoHeight: true
-        ,primaryKey: 'id'
-        ,columns: [{
-            header: _('context')
-            ,dataIndex: 'context_key'
-            ,renderer: { fn: function(v,md,record) {
-                return this.renderLink(v, {
-                    href: '?a=context/update&key=' + v
-                    ,target: '_blank'
-                });
-            }, scope: this }
-        },{
-            header: _('source')
-            ,dataIndex: 'source'
-            ,xtype: 'combocolumn'
-            ,editor: src
-            ,gridId: 'modx-grid-element-sources'
+    Ext.applyIf(config, {
+        id: 'modx-grid-element-sources',
+        fields: ['context_key', 'source', 'name'],
+        showActionsColumn: false,
+        autoHeight: true,
+        primaryKey: 'id',
+        columns: [{
+            header: _('context'),
+            dataIndex: 'context_key',
+            renderer: {
+                fn: function(v, md, record) {
+                    return this.renderLink(v, {
+                        href: `?a=context/update&key=${v}`,
+                        target: '_blank'
+                    });
+                },
+                scope: this
+            }
+        }, {
+            header: _('source'),
+            dataIndex: 'source',
+            xtype: 'combocolumn',
+            editor: src,
+            gridId: 'modx-grid-element-sources'
         }]
     });
-    MODx.grid.ElementSources.superclass.constructor.call(this,config);
-    this.propRecord = Ext.data.Record.create(['context_key','source']);
+    MODx.grid.ElementSources.superclass.constructor.call(this, config);
+    this.propRecord = Ext.data.Record.create(['context_key', 'source']);
 };
-Ext.extend(MODx.grid.ElementSources,MODx.grid.LocalGrid,{
+Ext.extend(MODx.grid.ElementSources, MODx.grid.LocalGrid, {
     getMenu: function() {
         return [];
     }
 });
-Ext.reg('modx-grid-element-sources',MODx.grid.ElementSources);
+Ext.reg('modx-grid-element-sources', MODx.grid.ElementSources);

--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -132,7 +132,7 @@ MODx.panel.TV = function(config) {
                                 ,tabIndex: 2
                                 ,listeners: {
                                     afterrender: {scope:this,fn:function(f,e) {
-                                            MODx.setStaticElementPath('tv');
+                                        MODx.setStaticElementPath('tv');
                                     }}
                                     ,select: {scope:this,fn:function(f,e) {
                                         MODx.setStaticElementPath('tv');
@@ -728,19 +728,23 @@ Ext.extend(MODx.panel.TV,MODx.FormPanel,{
     }
 
     ,beforeSubmit: function(o) {
-        var g = Ext.getCmp('modx-grid-tv-template');
-        var rg = Ext.getCmp('modx-grid-tv-security');
-        var sg = Ext.getCmp('modx-grid-element-sources');
-        Ext.apply(o.form.baseParams,{
-            templates: g.encodeModified()
-            ,resource_groups: rg.encodeModified()
-            ,sources: sg.encode()
-            ,propdata: Ext.getCmp('modx-grid-element-properties').encode()
+        const
+            templateAccessCmp = Ext.getCmp('modx-grid-tv-template'),
+            resourceGroupAccessCmp = Ext.getCmp('modx-grid-tv-security'),
+            sourcesCmp = Ext.getCmp('modx-grid-element-sources'),
+            propertiesCmp = Ext.getCmp('modx-grid-element-properties'),
+            formValues = this.getForm().getFieldValues()
+        ;
+        Ext.apply(o.form.baseParams, {
+            templates: templateAccessCmp.encodeModified(),
+            resource_groups: resourceGroupAccessCmp.encodeModified(),
+            sources: sourcesCmp.encode(),
+            propdata: propertiesCmp.encode()
         });
         this.cleanupEditor();
-        return this.fireEvent('save',{
-            values: this.getForm().getValues()
-            ,stay: MODx.config.stay
+        return this.fireEvent('save', {
+            values: formValues,
+            stay: MODx.config.stay
         });
     }
 


### PR DESCRIPTION
### What does it do?
Changed the (grid filtering) category combo configs to:
1. Prevent submission of their values on post
2. Not create a hidden submit field
3. Ignore the initial request value of "undefined" when creating a new Template/TV

The first commit contains the functional changes, while the remaining ones provide code style and quality fixes.

### Why is it needed?
A change somewhere in the current development branch created a condition where form panel pages with both a Category field and a Category grid filter would not save properly. (This is seen only in the current 3.1.0-dev branch.)

**Note:** I added the "Urgent" label to this PR because we'll need it incorporated into 3.1 _before_ its -pl release, as the issue it solves prevents proper operation of the referenced panels.

### How to test

1. Before pulling down this PR, observe that when trying to create a new TV or Template, you are prevented from doing so. The Category field will always have an error, not matter what you do. Also, if you go to the Template Access tab of a TV and filter the grid by Category using the dropdown and then immediately save, note how the Category of the TV itself will have been changed to the one you chose in the grid filter (not what you want).
2. After applying this PR, create and edit a Template and a TV to verify you are able to save and update each as expected, and that filtering on the TV/Template Access grids within each does not affect the saved Element's Category.

### Related issue(s)/PR(s)
None, I discovered this issue when I was working on another PR.
