### PR TITLE
A11y: make tabs focusable

### DIFF
--- a/_build/templates/default/sass/_a11y.scss
+++ b/_build/templates/default/sass/_a11y.scss
@@ -1,0 +1,15 @@
+.ext-webkit {
+  // #modx-header {
+    * {
+
+      &:focus-visible {
+        outline: auto !important;
+        outline-offset: .1em;
+
+        &.x-form-focus {
+          outline: none !important;
+        }
+      }
+    }
+  // }
+}

--- a/manager/assets/modext/widgets/core/modx.tabs.js
+++ b/manager/assets/modext/widgets/core/modx.tabs.js
@@ -45,7 +45,15 @@ MODx.Tabs = function(config = {}) {
         border: false,
         autoScroll: true,
         autoHeight: true,
-        cls: 'modx-tabs'
+        cls: 'modx-tabs',
+        itemTpl: new Ext.XTemplate(
+            '<li class="{cls}" id="{id}">',
+                '<a class="x-tab-strip-close"></a>',
+                '<a href="#">',
+                    '<span class="x-tab-strip-text">{text}</span>',
+                '</a>',
+            '</li>'
+        )
     });
     MODx.Tabs.superclass.constructor.call(this, config);
     this.config = config;


### PR DESCRIPTION
### What does it do?
Make the MODX tabs in the Manager focusable when using the keyboard (WIP 🧑‍🏭 ).

### How to test
Minify CSS and compress JS using grunt first. Use the tab key to navigate through the tabs. For example, on the resource tree or on a resource form.

### Related issue(s)/PR(s)
See https://github.com/modxcms/revolution/issues/16612
