### PR TITLE
Fix error suppression for PHP 8+

### DIFF
--- a/core/src/Revolution/Error/modErrorHandler.php
+++ b/core/src/Revolution/Error/modErrorHandler.php
@@ -58,7 +58,7 @@ class modErrorHandler
      */
     public function handleError($errno, $errstr, $errfile = null, $errline = null, $errcontext = null)
     {
-        if (error_reporting() == 0) {
+        if (error_reporting() == 0 || ($errno === E_WARNING && (error_reporting() & E_WARNING) === 0 )) {
             return false;
         }
 

--- a/core/src/Revolution/Error/modErrorHandler.php
+++ b/core/src/Revolution/Error/modErrorHandler.php
@@ -58,7 +58,7 @@ class modErrorHandler
      */
     public function handleError($errno, $errstr, $errfile = null, $errline = null, $errcontext = null)
     {
-        if (error_reporting() == 0 || ($errno === E_WARNING && (error_reporting() & E_WARNING) === 0 )) {
+        if (error_reporting() == 0 || !(error_reporting() & $errno)) {
             return false;
         }
 


### PR DESCRIPTION
### What does it do?
Adds a check to the custom error handler function, to see if a warning has to be handled.

### Why is it needed?
MODX has a custom error handler function. When the error control operator (`@`) is used (e.g. `@exif_read_data()`), the custom error handler still gets called.

With **PHP 7.4,** when the error was suppressed by the `@` operator, `error_reporting()` called inside the custom error handler always returned 0. This gets checked here:

https://github.com/modxcms/revolution/blob/9e7bb63615f8a9921e657027501f2aaf1be07454/core/src/Revolution/Error/modErrorHandler.php#L61-L63

With **PHP 8**, this is no longer the case:
> As of PHP 8.0.0, it returns the value of this (bitwise) expression: E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE.

https://www.php.net/manual/en/language.operators.errorcontrol.php

### How to test

For example:
- Use PHP 8.0 (or higher)
- Open the media browser and navigate to a folder with a picture that doesn't have EXIF headers.
- Make sure, that the warning `PHP warning: exif_read_data(...): File not supported` doesn't get logged to the MODX error log anymore.

### Related issue(s)/PR(s)
#16420