### PR TITLE
Update Minimum PHP Version in phpcs.xml

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,7 +8,7 @@
     <arg name="colors" />
 
     <config name="installed_paths" value="core/vendor/phpcompatibility/php-compatibility" />
-    <config name="testVersion" value="7.2-"/>
+    <config name="testVersion" value="7.4-"/>
 
     <file>_build</file>
     <file>connectors</file>


### PR DESCRIPTION
### What does it do?
Aligns php requirement for PHPCS to that specified in composer config.

### Why is it needed?
Ensure sniffer reports errors/warnings for php 7.4+ (as opposed to 7.2+).

### How to test
Currently the sniffer will show an error if a class has typed properties. After this update, it will not.

### Related issue(s)/PR(s)
n/a
