### PR TITLE
Adding missing class for checkbox TVs

### DIFF
--- a/manager/templates/default/resource/sections/tvs.tpl
+++ b/manager/templates/default/resource/sections/tvs.tpl
@@ -8,7 +8,7 @@
     <div id="modx-tv-tab{$category.id}" class="x-tab{if $category.hidden}-hidden{/if}" title="{$category.category}">
     {foreach from=$category.tvs item=tv name='tv'}
 {if $tv->type NEQ "hidden"}
-    <div class="modx-tv-type-{$tv->type} x-form-item x-tab-item {cycle values=",alt"} modx-tv{if $smarty.foreach.tv.first} tv-first{/if}{if $smarty.foreach.tv.last} tv-last{/if}" id="tv{$tv->id}-tr">
+    <div class="modx-tv-type-{$tv->type} {if $tv->type EQ "checkbox"} display-switch {/if} x-form-item x-tab-item {cycle values=",alt"} modx-tv{if $smarty.foreach.tv.first} tv-first{/if}{if $smarty.foreach.tv.last} tv-last{/if}" id="tv{$tv->id}-tr">
         <label for="tv{$tv->id}" class="x-form-item-label modx-tv-label">
             <div class="modx-tv-label-title">
                 {if $showCheckbox|default}<input type="checkbox" name="tv{$tv->id}-checkbox" class="modx-tv-checkbox" value="1" />{/if}


### PR DESCRIPTION
### What does it do?
Fixes regression bug when new display-switch class was introduced. At least, if was not meant to be introduced.

I upgraded from MODX 3.0.1 to 3.0.5 and noticed the changes.

Before 3.0.1
![Screenshot 2024-09-27 at 16 41 51](https://github.com/user-attachments/assets/1aa7fa3a-e9bf-40fe-bd82-f5062c804488)


After 3.0.5
![Screenshot 2024-09-27 at 16 41 20](https://github.com/user-attachments/assets/86e48a60-52e5-4d14-8a1e-bf29902a14d6)


### Why is it needed?
Checkboxes were no longer being rendered as switches / toggles

### How to test
For example: add a MODX TV via Form Customisation to modx-resource-main-right-top region


