### PR TITLE
Replace use of deprecated date function in setup

### DIFF
--- a/setup/templates/footer.tpl
+++ b/setup/templates/footer.tpl
@@ -6,7 +6,7 @@
     <footer>
         <div class="wrapper">
             <div class="copyrite">
-                <p>{$_lang.modx_footer1|replace:'[[+current_year]]':{'Y'|date}}</p>
+                <p>{$_lang.modx_footer1|replace:'[[+current_year]]':{$smarty.now|date_format:"%Y"}}</p>
             </div>
             <div class="copyrite_info">
                 <p>{$_lang.modx_footer2}</p>


### PR DESCRIPTION
### What does it do?
Replace use of date function in smarty footer tpl in setup with smarty.now|date_format

### Why is it needed?
Use of the date function in smarty templates triggers a deprecated warning

### How to test
Run setup on PHP 8.3 and ensure deprecated warning does not appear

### Related issue(s)/PR(s)
none