### PR TITLE
Fix user messages GetList processor

### DIFF
--- a/core/src/Revolution/Processors/Security/Message/GetList.php
+++ b/core/src/Revolution/Processors/Security/Message/GetList.php
@@ -40,8 +40,8 @@ class GetList extends GetListProcessor
     {
         $c->innerJoin(modUser::class, 'Sender');
         $c->innerJoin(modUser::class, 'Recipient');
-        $c->innerJoin(modUserProfile::class, 'SenderProfile', 'SenderProfile.id = modUserMessage.sender');
-        $c->innerJoin(modUserProfile::class, 'RecipientProfile', 'RecipientProfile.id = modUserMessage.recipient');
+        $c->innerJoin(modUserProfile::class, 'SenderProfile', 'SenderProfile.internalKey = modUserMessage.sender');
+        $c->innerJoin(modUserProfile::class, 'RecipientProfile', 'RecipientProfile.internalKey = modUserMessage.recipient');
 
         switch ($this->getProperty('type')) {
             case 'outbox':


### PR DESCRIPTION
### What does it do?
Fixes the join condition in the processor query.

### Why is it needed?
The result is incorrect, if in the user profile the `id` is different from the `internalKey`.

### How to test
Make sure that on your installation, the (auto-increment) ID column of the `modUserProfile` is out-of-sync with the `modUser` ID.
Test that all messages are visible and the values of `username` and `fullname` (in the columns "Sender" and "Recipient") correspond to each other.

### Related issue(s)/PR(s)
Resolves #16634 for MODX 3.x
