### PR TITLE
PHP 8.4 compatibility updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['5.6', '7.0', '7.1', '7.2', '7.3']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout

--- a/_build/test/MODxControllerTestCase.php
+++ b/_build/test/MODxControllerTestCase.php
@@ -30,7 +30,8 @@ abstract class MODxControllerTestCase extends MODxTestCase {
      */
     public $controllerName;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
 
         /* load smarty template engine */
@@ -57,7 +58,8 @@ abstract class MODxControllerTestCase extends MODxTestCase {
         }
     }
 
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->controller = null;
     }

--- a/_build/test/MODxTestCase.php
+++ b/_build/test/MODxTestCase.php
@@ -28,7 +28,8 @@ abstract class MODxTestCase extends \PHPUnit\Framework\TestCase {
     /**
      * Ensure all tests have a reference to the MODX object
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         $this->modx =& MODxTestHarness::getFixture('modX', 'modx');
         if ($this->modx->request) {
             $this->modx->request->loadErrorHandler();
@@ -43,7 +44,7 @@ abstract class MODxTestCase extends \PHPUnit\Framework\TestCase {
     /**
      * Remove reference at end of test case
      */
-    public function tearDown() {}
+    public function tearDown(): void {}
 
     /**
      * Check a MODX return result for a success flag

--- a/_build/test/Tests/Cases/Request/MakeUrlTest.php
+++ b/_build/test/Tests/Cases/Request/MakeUrlTest.php
@@ -19,7 +19,8 @@
  * @group MakeUrl
  */
 class MakeUrlTest extends MODxTestCase {
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
 
         /** @var modResource $resource */
@@ -82,7 +83,8 @@ class MakeUrlTest extends MODxTestCase {
         //$this->modx->context->prepare(true);
         $this->modx->context->aliasMap = null;
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         /** @var modResource $resource */
         $resource = $this->modx->getObject('modResource',array('pagetitle' => 'Unit Test Resource'));

--- a/_build/test/Tests/Controllers/Context/ContextUpdateControllerTest.php
+++ b/_build/test/Tests/Controllers/Context/ContextUpdateControllerTest.php
@@ -26,7 +26,8 @@ class ContextUpdateControllerTest extends MODxControllerTestCase {
     public $controllerName = 'ContextUpdateManagerController';
     public $controllerPath = 'context/update';
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->controller->setProperty('key','web');
     }

--- a/_build/test/Tests/Controllers/DeprecatedControllerTest.php
+++ b/_build/test/Tests/Controllers/DeprecatedControllerTest.php
@@ -9,12 +9,14 @@ class DeprecatedControllerTest extends MODxTestCase {
      */
     public $controller;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
 
         $this->controller = new modManagerControllerDeprecated($this->modx);
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->controller = null;
     }

--- a/_build/test/Tests/Controllers/WelcomeControllerTest.php
+++ b/_build/test/Tests/Controllers/WelcomeControllerTest.php
@@ -25,7 +25,8 @@ class WelcomeControllerTest extends MODxControllerTestCase {
     public $controllerName = 'WelcomeManagerController';
     public $controllerPath = 'welcome';
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
 
         /** @var modDashboard $dashboard */
@@ -71,7 +72,8 @@ class WelcomeControllerTest extends MODxControllerTestCase {
 
     }
 
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $userGroups = $this->modx->getCollection('modUserGroup',array('name:LIKE' => '%Unit Test%'));
         /** @var modUserGroup $userGroup */

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -24,7 +24,8 @@ class modDashboardTest extends MODxTestCase {
      * Load some utility classes this case uses
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->loadClass('modDashboard');
         $this->modx->loadClass('modManagerController',MODX_CORE_PATH.'model/modx/',true,true);

--- a/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardWidgetTest.php
@@ -26,7 +26,8 @@ class modDashboardWidgetTest extends MODxTestCase {
      * Load some utility classes this case uses
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->loadClass('modDashboard');
         $this->modx->loadClass('modDashboardWidget');

--- a/_build/test/Tests/Model/Element/modChunkTest.php
+++ b/_build/test/Tests/Model/Element/modChunkTest.php
@@ -25,7 +25,8 @@ class modChunkTest extends MODxTestCase {
     /** @var modChunk $chunk */
     public $chunk;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->chunk = $this->modx->newObject('modChunk');
         $this->chunk->fromArray(array(
@@ -39,7 +40,8 @@ class modChunkTest extends MODxTestCase {
         $this->chunk->setProperties(array('name' => 'John'));
         $this->chunk->setCacheable(false);
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->chunk = null;
     }

--- a/_build/test/Tests/Model/Element/modPluginTest.php
+++ b/_build/test/Tests/Model/Element/modPluginTest.php
@@ -25,7 +25,8 @@ class modPluginTest extends MODxTestCase {
     /** @var modPlugin $plugin */
     public $plugin;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->plugin = $this->modx->newObject('modPlugin');
         $this->plugin->fromArray(array(
@@ -40,7 +41,8 @@ class modPluginTest extends MODxTestCase {
         $this->plugin->setProperties(array('name' => 'John'));
         $this->plugin->setCacheable(false);
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->plugin = null;
     }

--- a/_build/test/Tests/Model/Element/modSnippetTest.php
+++ b/_build/test/Tests/Model/Element/modSnippetTest.php
@@ -25,7 +25,8 @@ class modSnippetTest extends MODxTestCase {
     /** @var modSnippet $snippet */
     public $snippet;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->snippet = $this->modx->newObject('modSnippet');
         $this->snippet->fromArray(array(
@@ -40,7 +41,8 @@ class modSnippetTest extends MODxTestCase {
         $this->snippet->save();
         $this->modx->event= new modSystemEvent();
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->snippet->remove();
         $this->snippet = null;

--- a/_build/test/Tests/Model/Element/modTagTest.php
+++ b/_build/test/Tests/Model/Element/modTagTest.php
@@ -20,7 +20,8 @@
  * @group modTag
  */
 class modTagTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void
+    {
         $modx =& MODxTestHarness::getFixture('modX', 'modx');
         include dirname(__FILE__) . '/modtagelement.mock.php';
     }

--- a/_build/test/Tests/Model/Element/modTemplateTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateTest.php
@@ -24,7 +24,8 @@ class modTemplateTest extends MODxTestCase {
     /** @var modTemplate $template */
     public $template;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->template = $this->modx->newObject('modTemplate');
         $this->template->fromArray(array(
@@ -38,7 +39,8 @@ class modTemplateTest extends MODxTestCase {
         $this->template->setProperties(array('name' => 'John'));
         $this->template->setCacheable(false);
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->template = null;
     }

--- a/_build/test/Tests/Model/Element/modTemplateVarTest.php
+++ b/_build/test/Tests/Model/Element/modTemplateVarTest.php
@@ -24,7 +24,8 @@ class modTemplateVarTest extends MODxTestCase {
     /** @var modTemplateVar $tv */
     public $tv;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->tv = $this->modx->newObject('modTemplateVar');
         $this->tv->fromArray(array(
@@ -39,7 +40,8 @@ class modTemplateVarTest extends MODxTestCase {
         $this->tv->setProperties(array('name' => 'John'));
         $this->tv->setCacheable(false);
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->tv = null;
     }

--- a/_build/test/Tests/Model/Error/modErrorTest.php
+++ b/_build/test/Tests/Model/Error/modErrorTest.php
@@ -26,7 +26,8 @@ class modErrorTest extends MODxTestCase {
     /**
      * Instantiate the modError instance for each test
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->error = $this->modx->getService('error','error.modError');
     }
@@ -34,7 +35,8 @@ class modErrorTest extends MODxTestCase {
     /**
      * Ensure that the error class is reset on each load
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->modx->services['error'] = null;
         $this->modx->error = null;

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -23,7 +23,8 @@ class modOutputFilterTest extends MODxTestCase {
     /** @var modPlaceholderTag $tag */
     public $tag;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->getParser();
         $this->tag = new modPlaceholderTag($this->modx);

--- a/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
+++ b/_build/test/Tests/Model/FormCustomization/modActionDomTest.php
@@ -20,7 +20,8 @@
  * @group modActionDom
  */
 class modActionDomTest extends MODxTestCase {
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
     }
 

--- a/_build/test/Tests/Model/Lexicon/modLexiconTest.php
+++ b/_build/test/Tests/Model/Lexicon/modLexiconTest.php
@@ -23,13 +23,15 @@ class modLexiconTest extends MODxTestCase {
     /** @var modLexicon $lexicon */
     public $lexicon;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->loadClass('modLexicon',null,true,true);
         $this->lexicon = new modLexicon($this->modx);
     }
 
-    public function tearDown() {
+    public function tearDown(): void
+    {
         $this->lexicon->clear();
     }
 

--- a/_build/test/Tests/Model/Mail/modMailTest.php
+++ b/_build/test/Tests/Model/Mail/modMailTest.php
@@ -25,7 +25,8 @@ class modMailTest extends MODxTestCase {
      */
     public $mail;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->loadClass('mail.modMail',MODX_CORE_PATH.'model/modx/',true,true);
         $this->mail = $this->getMockForAbstractClass('modMail',array(&$this->modx));

--- a/_build/test/Tests/Model/Registry/modFileRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modFileRegisterTest.php
@@ -21,14 +21,16 @@
  * @group modFileRegister
  */
 class modFileRegisterTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void
+    {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture('modX', 'modx');
         $modx->getService('registry', 'registry.modRegistry');
         $modx->registry->addRegister('register', 'registry.modFileRegister', array('directory' => 'register'));
     }
 
-    public static function tearDownAfterClass() {
+    public static function tearDownAfterClass(): void
+    {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture('modX', 'modx');
         $modx->getService('registry', 'registry.modRegistry');

--- a/_build/test/Tests/Model/Registry/modRegisterTest.php
+++ b/_build/test/Tests/Model/Registry/modRegisterTest.php
@@ -20,7 +20,8 @@
  * @group modRegister
  */
 class modRegisterTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void
+    {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture('modX', 'modx');
         $modx->getService('registry', 'registry.modRegistry');
@@ -29,7 +30,8 @@ class modRegisterTest extends MODxTestCase {
         $modx->registry->addRegister('register', 'modMemoryRegister', array('directory' => 'register'));
     }
 
-    public static function tearDownAfterClass() {
+    public static function tearDownAfterClass(): void
+    {
         /** @var modX $modx */
         $modx =& MODxTestHarness::getFixture('modX', 'modx');
         $modx->getService('registry', 'registry.modRegistry');

--- a/_build/test/Tests/Model/Registry/modRegistryTest.php
+++ b/_build/test/Tests/Model/Registry/modRegistryTest.php
@@ -20,7 +20,8 @@
  * @group modRegistry
  */
 class modRegistryTest extends MODxTestCase {
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void
+    {
         parent::setUpBeforeClass();
         $modx =& MODxTestHarness::getFixture('modX', 'modx');
         $modx->getService('registry', 'registry.modRegistry');

--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -26,7 +26,8 @@ class modRequestTest extends MODxTestCase {
     /**
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modNamespace $namespace */
         $namespace = $this->modx->newObject('modNamespace');
@@ -57,7 +58,8 @@ class modRequestTest extends MODxTestCase {
     /**
      * @return void
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
 
         /** @var modNamespace $namespace */
@@ -317,9 +319,9 @@ class modRequestTest extends MODxTestCase {
             array("MODX [[\$chunk? &property=`test`\n &across=`lines
 
                    `&test=1]] Tags",'MODX  Tags'),
-            array("Nested MODX [[test? 
-                   &ids = `[[!getids 
-                   &field=`id` 
+            array("Nested MODX [[test?
+                   &ids = `[[!getids
+                   &field=`id`
                    &resource=`[[+resource]]`
                    ]]`
                    &parents=`2`

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -23,7 +23,8 @@ class modUserTest extends MODxTestCase {
     /** @var modUser $user */
     public $user;
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->user = $this->modx->newObject('modUser');
         $this->user->fromArray(array(

--- a/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modFileMediaSourceTest.php
@@ -26,7 +26,8 @@ class modFileMediaSourceTest extends MODxTestCase {
     /**
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
 
         $this->modx->loadClass('sources.modMediaSource');
@@ -39,7 +40,8 @@ class modFileMediaSourceTest extends MODxTestCase {
             'properties' => array(),
         ),'',true);
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->source = null;
     }

--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -26,7 +26,8 @@ class modMediaSourceTest extends MODxTestCase {
     /**
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
 
         $this->modx->loadClass('sources.modMediaSource');
@@ -38,7 +39,8 @@ class modMediaSourceTest extends MODxTestCase {
             'properties' => array(),
         ),'',true);
     }
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->source = null;
     }

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -21,13 +21,15 @@
 class modParserTest extends MODxTestCase {
     public static $scope = array();
 
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void
+    {
         $modx =& MODxTestHarness::getFixture('modX', 'modx');
         $placeholders = array('tag' => 'Tag', 'tag1' => 'Tag1', 'tag2' => 'Tag2');
         self::$scope = $modx->toPlaceholders($placeholders, '', '.', true);
     }
 
-    public static function tearDownAfterClass() {
+    public static function tearDownAfterClass(): void
+    {
         if (!empty(self::$scope)) {
             $modx =& MODxTestHarness::getFixture('modX', 'modx');
             if (array_key_exists('keys', self::$scope)) {

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -20,7 +20,7 @@
  */
 class modXTest extends MODxTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -78,7 +78,8 @@ class modXTest extends MODxTestCase
 
 
 
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->modx->placeholders = array();
         $this->modx->resourceMap = array(array(1));

--- a/_build/test/Tests/Processors/Browser/DirectoryTest.php
+++ b/_build/test/Tests/Processors/Browser/DirectoryTest.php
@@ -21,7 +21,8 @@
 class BrowserDirectoryProcessorsTest extends MODxTestCase {
     const PROCESSOR_LOCATION = 'browser/directory/';
 
-    public static function setUpBeforeClass() {
+    public static function setUpBeforeClass(): void
+    {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
@@ -29,12 +30,14 @@ class BrowserDirectoryProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test case.
      */
-    public static function tearDownAfterClass() {
+    public static function tearDownAfterClass(): void
+    {
         @rmdir(MODX_BASE_PATH.'assets/test2/');
         @rmdir(MODX_BASE_PATH.'assets/test3/');
         @rmdir(MODX_BASE_PATH.'assets/test4/');
     }
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         try {
 

--- a/_build/test/Tests/Processors/Context/ContextSettingTest.php
+++ b/_build/test/Tests/Processors/Context/ContextSettingTest.php
@@ -28,7 +28,8 @@ class ContextSettingProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modContext $ctx */
         $ctx = $this->modx->newObject('modContext');
@@ -40,7 +41,8 @@ class ContextSettingProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         /** @var modContext $ctx */
         $ctx = $this->modx->getObject('modContext','unittest');

--- a/_build/test/Tests/Processors/Context/ContextTest.php
+++ b/_build/test/Tests/Processors/Context/ContextTest.php
@@ -27,7 +27,8 @@ class ContextProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modContext $ctx */
         $ctx = $this->modx->newObject('modContext');
@@ -45,7 +46,8 @@ class ContextProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $contexts = $this->modx->getCollection('modContext',array(
             'key:LIKE' => '%unittest%'

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -26,7 +26,8 @@ class CategoryProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modCategory $category */
         $category = $this->modx->newObject('modCategory');
@@ -41,7 +42,8 @@ class CategoryProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         /** @var modCategory $category */
         $categories = $this->modx->getCollection('modCategory',array(

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -26,7 +26,8 @@ class ChunkProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->lexicon->load('chunk');
         /** @var modChunk $chunk */
@@ -44,7 +45,8 @@ class ChunkProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after each test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $chunks = $this->modx->getCollection('modChunk',array('name:LIKE' => '%UnitTest%'));
         /** @var modChunk $chunk */

--- a/_build/test/Tests/Processors/Element/PluginTest.php
+++ b/_build/test/Tests/Processors/Element/PluginTest.php
@@ -26,7 +26,8 @@ class PluginProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modPlugin $plugin */
         $plugin = $this->modx->newObject('modPlugin');
@@ -39,7 +40,8 @@ class PluginProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $plugins = $this->modx->getCollection('modPlugin',array('name:LIKE' => '%UnitTest%'));
         /** @var modPlugin $plugin */

--- a/_build/test/Tests/Processors/Element/PropertySetTest.php
+++ b/_build/test/Tests/Processors/Element/PropertySetTest.php
@@ -26,7 +26,8 @@ class PropertySetProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modPropertySet $propertySet */
         $propertySet = $this->modx->newObject('modPropertySet');
@@ -37,7 +38,8 @@ class PropertySetProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $propertySets = $this->modx->getCollection('modPropertySet',array('name:LIKE' => '%UnitTest%'));
         /** @var modPropertySet $propertySet */

--- a/_build/test/Tests/Processors/Element/SnippetTest.php
+++ b/_build/test/Tests/Processors/Element/SnippetTest.php
@@ -26,7 +26,8 @@ class SnippetProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modSnippet $snippet */
         $snippet = $this->modx->newObject('modSnippet');
@@ -37,7 +38,8 @@ class SnippetProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         $snippets = $this->modx->getCollection('modSnippet',array('name:LIKE' => '%UnitTest%'));
         /** @var modSnippet $snippet */
         foreach ($snippets as $snippet) {

--- a/_build/test/Tests/Processors/Element/TemplateTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateTest.php
@@ -26,7 +26,8 @@ class TemplateProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->error->reset();
         /** @var modTemplate $template */
@@ -39,7 +40,8 @@ class TemplateProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $templates = $this->modx->getCollection('modTemplate',array('templatename:LIKE' => '%UnitTest%'));
         /** @var modTemplate $template */

--- a/_build/test/Tests/Processors/Element/TemplateVarTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateVarTest.php
@@ -26,7 +26,8 @@ class TemplateVarProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modTemplateVar $tv */
         $tv = $this->modx->newObject('modTemplateVar');
@@ -37,7 +38,8 @@ class TemplateVarProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         $tvs = $this->modx->getCollection('modTemplateVar',array('name:LIKE' => '%UnitTest%'));
         /** @var modTemplateVar $tv */
         foreach ($tvs as $tv) {

--- a/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
+++ b/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
@@ -27,7 +27,8 @@ class ResourceCreateProcessorTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->eventMap = array();
         if ($this->modx instanceof modX) {
@@ -44,7 +45,8 @@ class ResourceCreateProcessorTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         if ($this->modx instanceof modX) {
             $resources = $this->modx->getCollection('modResource',array(

--- a/_build/test/Tests/Processors/System/ActionTest.php
+++ b/_build/test/Tests/Processors/System/ActionTest.php
@@ -27,7 +27,8 @@ class ActionProcessorsTest extends MODxTestCase {
     /**
      * Setup some basic data for this test.
      */
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         /** @var modNamespace $namespace */
         $namespace = $this->modx->newObject('modNamespace');
@@ -51,7 +52,8 @@ class ActionProcessorsTest extends MODxTestCase {
     /**
      * Cleanup data after this test.
      */
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         /** @var modNamespace $namespace */
         $namespace = $this->modx->getObject('modNamespace',array('name' => 'unittest'));

--- a/_build/test/Tests/Processors/modProcessorTes-skip-t.php
+++ b/_build/test/Tests/Processors/modProcessorTes-skip-t.php
@@ -27,14 +27,16 @@ class modProcessorTest extends MODxTestCase {
     public $processor;
     const MODX_TEST_PROCESSOR = '_build/test/data/processors/demo.processor.php';
 
-    public function setUp() {
+    public function setUp(): void
+    {
         parent::setUp();
         $this->modx->loadClass('modProcessor',MODX_CORE_PATH.'model/modx/',true,true);
         $this->processor = new modProcessor($this->modx);
         $this->processor->setPath(MODX_BASE_PATH.self::MODX_TEST_PROCESSOR);
     }
 
-    public function tearDown() {
+    public function tearDown(): void
+    {
         parent::tearDown();
         $this->processor = null;
     }

--- a/_build/test/Tests/Transport/TransportCoreTest.php
+++ b/_build/test/Tests/Transport/TransportCoreTest.php
@@ -20,7 +20,7 @@
 class TransportCoreTest extends MODxTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +37,7 @@ class TransportCoreTest extends MODxTestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         @unlink(MODX_PACKAGES_PATH. "core.transport.zip");
     }

--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -13,7 +13,7 @@ unset($mtime);
 /* get rid of time limit */
 set_time_limit(0);
 
-error_reporting(E_ALL | E_STRICT); ini_set('display_errors',true);
+error_reporting(E_ALL); ini_set('display_errors',true);
 
 /* buildImage can be defined for running against a specific build image
     wc default means it is run against working copy */
@@ -169,7 +169,7 @@ $collection['1']->fromArray(array (
     'name' => 'modx.com',
     'description' => 'The official MODX transport provider for 3rd party components.',
     'service_url' => 'https://rest.modx.com/extras/',
-    'created' => strftime('%Y-%m-%d %H:%M:%S'),
+    'created' => date('Y-m-d H:i:s'),
 ), '', true, true);
 $attributes = array (
     xPDOTransport::PRESERVE_KEYS => false,

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "~5.7|~6.5",
+        "phpunit/phpunit": "~8.5",
         "php-coveralls/php-coveralls": "~2.1"
     },
     "require": {
-        "php": ">=5.6"
+        "php": ">=7.4"
     }
 }

--- a/core/model/modx/error/moderrorhandler.class.php
+++ b/core/model/modx/error/moderrorhandler.class.php
@@ -92,12 +92,6 @@ class modErrorHandler {
                 $errmsg= 'User notice: ' . $errstr;
                 $this->modx->log(modX::LOG_LEVEL_WARN, $errmsg, '', '', $errfile, $errline);
                 break;
-            case E_STRICT:
-                $handled= true;
-                $errmsg= 'E_STRICT information: ' . $errstr;
-                $this->modx->log(modX::LOG_LEVEL_INFO, $errmsg, '','',$errfile,$errline);
-                return $handled;
-                break;
             case E_RECOVERABLE_ERROR:
                 $handled= true;
                 $errmsg= 'Recoverable error: ' . $errstr;

--- a/core/model/modx/modaccessibleobject.class.php
+++ b/core/model/modx/modaccessibleobject.class.php
@@ -203,11 +203,11 @@ class modAccessibleObject extends xPDOObject {
      * class names to limit the check. In most cases, this does not need to be
      * set; derivatives should typically determine what targets to include in
      * the findPolicy() implementation.
-     * @param modUser $user
+     * @param modUser|null $user
      * @return boolean Returns true if the policy is satisfied or no policy
      * exists.
      */
-    public function checkPolicy($criteria, $targets = null, modUser $user = null) {
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null) {
         if(!$user){
             $user = & $this->xpdo->user;
         }

--- a/core/model/modx/modnamespace.class.php
+++ b/core/model/modx/modnamespace.class.php
@@ -83,7 +83,7 @@ class modNamespace extends modAccessibleObject {
         ),$path);
     }
 
-    public function checkPolicy($criteria, $targets = null, modUser $user = null)
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null)
     {
         return parent::checkPolicy($criteria, $targets, $user);
     }

--- a/core/model/modx/modsessionhandler.class.php
+++ b/core/model/modx/modsessionhandler.class.php
@@ -13,7 +13,7 @@
  *
  * @package modx
  */
-class modSessionHandler {
+class modSessionHandler implements SessionHandlerInterface {
     /**
      * @var modX A reference to the modX instance controlling this session
      * handler.
@@ -60,11 +60,14 @@ class modSessionHandler {
     /**
      * Opens the connection for the session handler.
      *
+     * @param $path
+     * @param $name
      * @access public
      * @return boolean Always returns true; actual connection is managed by
      * {@link modX}.
      */
-    public function open() {
+    #[\ReturnTypeWillChange]
+    public function open($path, $name) {
         return true;
     }
 
@@ -75,6 +78,7 @@ class modSessionHandler {
      * @return boolean Always returns true; actual connection is managed by
      * {@link modX}
      */
+    #[\ReturnTypeWillChange]
     public function close() {
         return true;
     }
@@ -86,6 +90,7 @@ class modSessionHandler {
      * @param integer $id The pk of the {@link modSession} object.
      * @return string The data read from the {@link modSession} object.
      */
+    #[\ReturnTypeWillChange]
     public function read($id) {
         if ($this->_getSession($id)) {
             $data= $this->session->get('data');
@@ -103,6 +108,7 @@ class modSessionHandler {
      * @param mixed $data The data to write to the session.
      * @return boolean True if successfully written.
      */
+    #[\ReturnTypeWillChange]
     public function write($id, $data) {
         $written= false;
         if ($this->_getSession($id, true)) {
@@ -122,6 +128,7 @@ class modSessionHandler {
      * @param integer $id
      * @return boolean True if the session record was destroyed.
      */
+    #[\ReturnTypeWillChange]
     public function destroy($id) {
         if ($this->_getSession($id)) {
             $destroyed= $this->session->remove();
@@ -139,6 +146,7 @@ class modSessionHandler {
      * longer than.
      * @return boolean True if session records were removed.
      */
+    #[\ReturnTypeWillChange]
     public function gc($max) {
         $maxtime= time() - $this->gcMaxLifetime;
         return $this->modx->removeCollection('modSession', array("{$this->modx->escape('access')} < {$maxtime}"));

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -2564,14 +2564,18 @@ class modX extends xPDO {
                 if ($sessionHandlerClass = $this->getOption('session_handler_class', $options)) {
                     if ($shClass = $this->loadClass($sessionHandlerClass, '', false, true)) {
                         if ($sh = new $shClass($this)) {
-                            session_set_save_handler(
-                                array (& $sh, 'open'),
-                                array (& $sh, 'close'),
-                                array (& $sh, 'read'),
-                                array (& $sh, 'write'),
-                                array (& $sh, 'destroy'),
-                                array (& $sh, 'gc')
-                            );
+                            if ($sh instanceof SessionHandlerInterface) {
+                                session_set_save_handler($sh);
+                            } elseif (version_compare(phpversion(), '8.4.0', '<')) {
+                                session_set_save_handler(
+                                    [& $sh, 'open'],
+                                    [& $sh, 'close'],
+                                    [& $sh, 'read'],
+                                    [& $sh, 'write'],
+                                    [& $sh, 'destroy'],
+                                    [& $sh, 'gc']
+                                );
+                            }
                         }
                     }
                 }

--- a/core/model/modx/modx.class.php
+++ b/core/model/modx/modx.class.php
@@ -1966,7 +1966,7 @@ class modX extends xPDO {
 
         $ml = $this->newObject('modManagerLog');
         $ml->set('user', (integer) $userId);
-        $ml->set('occurred', strftime('%Y-%m-%d %H:%M:%S'));
+        $ml->set('occurred', date('Y-m-d H:i:s'));
         $ml->set('action', empty($action) ? 'unknown' : $action);
         $ml->set('classKey', empty($class_key) ? '' : $class_key);
         $ml->set('item', empty($item) ? 'unknown' : $item);
@@ -2714,7 +2714,7 @@ class modX extends xPDO {
                 if ($targetObj == 'FILE' && $cacheManager= $this->getCacheManager()) {
                     $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
                     $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
-                    $cacheManager->writeFile($filepath . $filename, '[' . strftime('%Y-%m-%d %H:%M:%S') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''), 'a');
+                    $cacheManager->writeFile($filepath . $filename, '[' . date('Y-m-d H:i:s') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''), 'a');
                 }
                 $this->sendError('fatal');
             }
@@ -2734,7 +2734,7 @@ class modX extends xPDO {
      * @param string $line The line number of the file that the message occurs for
      */
     protected function _logInRegister($register, $level, $msg, $def, $file, $line) {
-        $timestamp = strftime('%Y-%m-%d %H:%M:%S');
+        $timestamp = date('Y-m-d H:i:s');
         $messageKey = (string) time();
         $messageKey .= '-' . sprintf("%06d", $this->_logSequence);
         $message = array(

--- a/core/model/modx/sources/modmediasource.class.php
+++ b/core/model/modx/sources/modmediasource.class.php
@@ -686,10 +686,10 @@ class modMediaSource extends modAccessibleSimpleObject implements modMediaSource
      *
      * @param string|array $criteria
      * @param array $targets
-     * @param modUser $user
+     * @param modUser|null $user
      * @return bool
      */
-    public function checkPolicy($criteria, $targets = null, modUser $user = null) {
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null) {
         if ($criteria == 'load') {
             $success = true;
         } else {

--- a/setup/includes/request/modinstallrequest.class.php
+++ b/setup/includes/request/modinstallrequest.class.php
@@ -20,7 +20,7 @@
  * @package setup
  */
 
-error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 @ ini_set('display_errors', 1);
 
 class modInstallRequest {

--- a/setup/processors/connector.php
+++ b/setup/processors/connector.php
@@ -22,7 +22,7 @@
 session_start();
 
 /* set error reporting */
-error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 $setupPath= strtr(realpath(dirname(__DIR__)), '\\', '/') . '/';
 define('MODX_SETUP_PATH', $setupPath);


### PR DESCRIPTION
### What does it do?
Removes usage of deprecated features, updates minimum PHP support to >= 7.4, and updates PHPUnit to version 8.5.

### Why is it needed?
Resolves various deprecation warnings for PHP 8.4 compatibility.

### How to test
Test everything (including unit tests) in PHP 8.4

### Related issue(s)/PR(s)
n/a