### PR TITLE
PHP 8.4 compatibility updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout

--- a/_build/lexicon/checklexicon.php
+++ b/_build/lexicon/checklexicon.php
@@ -14,7 +14,7 @@ unset($mtime);
 /* get rid of time limit */
 set_time_limit(0);
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', true);
 
 $buildConfig = dirname(dirname(__FILE__)) . '/build.config.php';

--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -12,7 +12,7 @@ $tstart = microtime(true);
 /* get rid of time limit */
 set_time_limit(0);
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', true);
 
 /* buildImage can be defined for running against a specific build image

--- a/core/src/Revolution/Error/modErrorHandler.php
+++ b/core/src/Revolution/Error/modErrorHandler.php
@@ -37,7 +37,7 @@ class modErrorHandler
      * @param array $stack A stack of errors that can be passed in.  Send a non-array value to
      *                     prevent any errors from being recorded in the stack.
      */
-    function __construct(modX &$modx, array $stack = [])
+    public function __construct(modX &$modx, array $stack = [])
     {
         $this->modx = &$modx;
         $this->stack = $stack;
@@ -94,13 +94,6 @@ class modErrorHandler
                 $errmsg = 'User notice: ' . $errstr;
                 $this->modx->log(modX::LOG_LEVEL_WARN, $errmsg, '', '', $errfile, $errline);
                 break;
-            case E_STRICT:
-                $handled = true;
-                $errmsg = 'E_STRICT information: ' . $errstr;
-                $this->modx->log(modX::LOG_LEVEL_INFO, $errmsg, '', '', $errfile, $errline);
-
-                return $handled;
-                break;
             case E_RECOVERABLE_ERROR:
                 $handled = true;
                 $errmsg = 'Recoverable error: ' . $errstr;
@@ -117,6 +110,13 @@ class modErrorHandler
                 $this->modx->log(modX::LOG_LEVEL_WARN, $errmsg, '', '', $errfile, $errline);
                 break;
             default:
+                if (version_compare(PHP_VERSION, '8.4.0', '<') && $errno == E_STRICT) {
+                    $handled = true;
+                    $errmsg = 'E_STRICT information: ' . $errstr;
+                    $this->modx->log(modX::LOG_LEVEL_INFO, $errmsg, '', '', $errfile, $errline);
+                    break;
+                }
+
                 $handled = false;
                 $errmsg = 'Un-recoverable error ' . $errno . ': ' . $errstr;
                 $this->modx->log(modX::LOG_LEVEL_ERROR, $errmsg, '', '', $errfile, $errline);

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1173,7 +1173,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                     $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
                 }
             }
-            
+
             $objects[$key] = $file;
         }
 
@@ -1672,11 +1672,11 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      *
      * @param string|array $criteria
      * @param array $targets
-     * @param modUser $user
+     * @param modUser|null $user
      *
      * @return bool
      */
-    public function checkPolicy($criteria, $targets = null, modUser $user = null)
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null)
     {
         if ($criteria == 'load') {
             $success = true;

--- a/core/src/Revolution/modAccessibleObject.php
+++ b/core/src/Revolution/modAccessibleObject.php
@@ -242,12 +242,12 @@ class modAccessibleObject extends xPDOObject
      *                               class names to limit the check. In most cases, this does not need to be
      *                               set; derivatives should typically determine what targets to include in
      *                               the findPolicy() implementation.
-     * @param modUser      $user
+     * @param modUser|null $user
      *
      * @return boolean Returns true if the policy is satisfied or no policy
      * exists.
      */
-    public function checkPolicy($criteria, $targets = null, modUser $user = null)
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null)
     {
         if ($criteria && $this->xpdo instanceof modX && $this->xpdo->getSessionState() == modX::SESSION_STATE_INITIALIZED) {
             if (!$user) {

--- a/core/src/Revolution/modDeprecatedMethod.php
+++ b/core/src/Revolution/modDeprecatedMethod.php
@@ -17,7 +17,7 @@ class modDeprecatedMethod extends \xPDO\Om\xPDOSimpleObject
 {
     private $callers = [];
 
-    public function addCaller(string $class, string $function, string $file = null, int $line = null)
+    public function addCaller(string $class, string $function, ?string $file = null, ?int $line = null)
     {
         $def = "{$class}::{$function}::{$file}::{$line}";
 

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -108,7 +108,7 @@ class modNamespace extends modAccessibleObject
         ], $path);
     }
 
-    public function checkPolicy($criteria, $targets = null, modUser $user = null)
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null)
     {
         return parent::checkPolicy($criteria, $targets, $user);
     }

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -16,7 +16,7 @@ namespace MODX\Revolution;
  *
  * @package MODX\Revolution
  */
-class modSessionHandler
+class modSessionHandler implements \SessionHandlerInterface
 {
     /**
      * @var modX A reference to the modX instance controlling this session
@@ -42,7 +42,7 @@ class modSessionHandler
      *
      * @param modX &$modx A reference to a {@link modX} instance.
      */
-    function __construct(modX &$modx)
+    public function __construct(modX &$modx)
     {
         $this->modx = &$modx;
         $gcMaxlifetime = (integer)$this->modx->getOption('session_gc_maxlifetime');
@@ -64,11 +64,14 @@ class modSessionHandler
     /**
      * Opens the connection for the session handler.
      *
+     * @param $path
+     * @param $name
      * @access public
      * @return boolean Always returns true; actual connection is managed by
      * {@link modX}.
      */
-    public function open()
+    #[\ReturnTypeWillChange]
+    public function open($path, $name)
     {
         return true;
     }
@@ -80,6 +83,7 @@ class modSessionHandler
      * @return boolean Always returns true; actual connection is managed by
      * {@link modX}
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -94,6 +98,7 @@ class modSessionHandler
      *
      * @return string The data read from the {@link modSession} object.
      */
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         if ($this->_getSession($id)) {
@@ -115,6 +120,7 @@ class modSessionHandler
      *
      * @return boolean True if successfully written.
      */
+    #[\ReturnTypeWillChange]
     public function write($id, $data)
     {
         $written = false;
@@ -138,6 +144,7 @@ class modSessionHandler
      *
      * @return boolean True if the session record was destroyed.
      */
+    #[\ReturnTypeWillChange]
     public function destroy($id)
     {
         if ($this->_getSession($id)) {
@@ -159,6 +166,7 @@ class modSessionHandler
      *
      * @return boolean True if session records were removed.
      */
+    #[\ReturnTypeWillChange]
     public function gc($max)
     {
         $maxtime = time() - $this->gcMaxLifetime;

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -29,6 +29,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use SessionHandlerInterface;
 use xPDO\Cache\xPDOFileCache;
 use xPDO\xPDO;
 use xPDO\xPDOException;
@@ -2754,14 +2755,18 @@ class modX extends xPDO {
                 if ($sessionHandlerClass = $this->getOption('session_handler_class', $options)) {
                     if ($shClass = $this->loadClass($sessionHandlerClass, '', false, true)) {
                         if ($sh = new $shClass($this)) {
-                            session_set_save_handler(
-                                [& $sh, 'open'],
-                                [& $sh, 'close'],
-                                [& $sh, 'read'],
-                                [& $sh, 'write'],
-                                [& $sh, 'destroy'],
-                                [& $sh, 'gc']
-                            );
+                            if ($sh instanceof SessionHandlerInterface) {
+                                session_set_save_handler($sh);
+                            } else {
+                                session_set_save_handler(
+                                    [& $sh, 'open'],
+                                    [& $sh, 'close'],
+                                    [& $sh, 'read'],
+                                    [& $sh, 'write'],
+                                    [& $sh, 'destroy'],
+                                    [& $sh, 'gc']
+                                );
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### What does it do?
Removes usage of deprecated features and updates dependencies with available PHP8.4 compatibility releases.

### Why is it needed?
Resolves various deprecation warnings for PHP 8.4 compatibility.

### How to test
Test everything (including unit tests) in PHP 8.4

### Related issue(s)/PR(s)
n/a