### PR TITLE
PHP 8.4 compatibility updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Checkout

--- a/_build/lexicon/checklexicon.php
+++ b/_build/lexicon/checklexicon.php
@@ -14,7 +14,7 @@ unset($mtime);
 /* get rid of time limit */
 set_time_limit(0);
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', true);
 
 $buildConfig = dirname(dirname(__FILE__)) . '/build.config.php';

--- a/_build/transport.core.php
+++ b/_build/transport.core.php
@@ -12,7 +12,7 @@ $tstart = microtime(true);
 /* get rid of time limit */
 set_time_limit(0);
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', true);
 
 /* buildImage can be defined for running against a specific build image

--- a/core/src/Revolution/Error/modErrorHandler.php
+++ b/core/src/Revolution/Error/modErrorHandler.php
@@ -37,7 +37,7 @@ class modErrorHandler
      * @param array $stack A stack of errors that can be passed in.  Send a non-array value to
      *                     prevent any errors from being recorded in the stack.
      */
-    function __construct(modX &$modx, array $stack = [])
+    public function __construct(modX &$modx, array $stack = [])
     {
         $this->modx = &$modx;
         $this->stack = $stack;
@@ -94,13 +94,6 @@ class modErrorHandler
                 $errmsg = 'User notice: ' . $errstr;
                 $this->modx->log(modX::LOG_LEVEL_WARN, $errmsg, '', '', $errfile, $errline);
                 break;
-            case E_STRICT:
-                $handled = true;
-                $errmsg = 'E_STRICT information: ' . $errstr;
-                $this->modx->log(modX::LOG_LEVEL_INFO, $errmsg, '', '', $errfile, $errline);
-
-                return $handled;
-                break;
             case E_RECOVERABLE_ERROR:
                 $handled = true;
                 $errmsg = 'Recoverable error: ' . $errstr;
@@ -117,6 +110,13 @@ class modErrorHandler
                 $this->modx->log(modX::LOG_LEVEL_WARN, $errmsg, '', '', $errfile, $errline);
                 break;
             default:
+                if (version_compare(PHP_VERSION, '8.4.0', '<') && $errno == E_STRICT) {
+                    $handled = true;
+                    $errmsg = 'E_STRICT information: ' . $errstr;
+                    $this->modx->log(modX::LOG_LEVEL_INFO, $errmsg, '', '', $errfile, $errline);
+                    break;
+                }
+
                 $handled = false;
                 $errmsg = 'Un-recoverable error ' . $errno . ': ' . $errstr;
                 $this->modx->log(modX::LOG_LEVEL_ERROR, $errmsg, '', '', $errfile, $errline);

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1696,11 +1696,11 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      *
      * @param string|array $criteria
      * @param array $targets
-     * @param modUser $user
+     * @param modUser|null $user
      *
      * @return bool
      */
-    public function checkPolicy($criteria, $targets = null, modUser $user = null)
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null)
     {
         if ($criteria == 'load') {
             $success = true;

--- a/core/src/Revolution/modAccessibleObject.php
+++ b/core/src/Revolution/modAccessibleObject.php
@@ -242,12 +242,12 @@ class modAccessibleObject extends xPDOObject
      *                               class names to limit the check. In most cases, this does not need to be
      *                               set; derivatives should typically determine what targets to include in
      *                               the findPolicy() implementation.
-     * @param modUser      $user
+     * @param modUser|null $user
      *
      * @return boolean Returns true if the policy is satisfied or no policy
      * exists.
      */
-    public function checkPolicy($criteria, $targets = null, modUser $user = null)
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null)
     {
         if ($criteria && $this->xpdo instanceof modX && $this->xpdo->getSessionState() == modX::SESSION_STATE_INITIALIZED) {
             if (!$user) {

--- a/core/src/Revolution/modDeprecatedMethod.php
+++ b/core/src/Revolution/modDeprecatedMethod.php
@@ -17,7 +17,7 @@ class modDeprecatedMethod extends \xPDO\Om\xPDOSimpleObject
 {
     private $callers = [];
 
-    public function addCaller(string $class, string $function, string $file = null, int $line = null)
+    public function addCaller(string $class, string $function, ?string $file = null, ?int $line = null)
     {
         $def = "{$class}::{$function}::{$file}::{$line}";
 

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -108,7 +108,7 @@ class modNamespace extends modAccessibleObject
         ], $path);
     }
 
-    public function checkPolicy($criteria, $targets = null, modUser $user = null)
+    public function checkPolicy($criteria, $targets = null, ?modUser $user = null)
     {
         return parent::checkPolicy($criteria, $targets, $user);
     }

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -68,6 +68,7 @@ class modSessionHandler implements \SessionHandlerInterface
      * @return boolean Always returns true; actual connection is managed by
      * {@link modX}.
      */
+    #[\ReturnTypeWillChange]
     public function open($path, $name)
     {
         return true;
@@ -80,6 +81,7 @@ class modSessionHandler implements \SessionHandlerInterface
      * @return boolean Always returns true; actual connection is managed by
      * {@link modX}
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -94,6 +96,7 @@ class modSessionHandler implements \SessionHandlerInterface
      *
      * @return string The data read from the {@link modSession} object.
      */
+    #[\ReturnTypeWillChange]
     public function read($id)
     {
         if ($this->_getSession($id)) {
@@ -115,6 +118,7 @@ class modSessionHandler implements \SessionHandlerInterface
      *
      * @return boolean True if successfully written.
      */
+    #[\ReturnTypeWillChange]
     public function write($id, $data)
     {
         $written = false;
@@ -138,6 +142,7 @@ class modSessionHandler implements \SessionHandlerInterface
      *
      * @return boolean True if the session record was destroyed.
      */
+    #[\ReturnTypeWillChange]
     public function destroy($id)
     {
         if ($this->_getSession($id)) {
@@ -159,6 +164,7 @@ class modSessionHandler implements \SessionHandlerInterface
      *
      * @return boolean True if session records were removed.
      */
+    #[\ReturnTypeWillChange]
     public function gc($max)
     {
         $maxtime = time() - $this->gcMaxLifetime;


### PR DESCRIPTION
### What does it do?
Removes usage of deprecated features and updates dependencies with available PHP8.4 compatibility releases.

### Why is it needed?
Resolves various deprecation warnings for PHP 8.4 compatibility.

### How to test
Test everything (including unit tests) in PHP 8.4

### Related issue(s)/PR(s)
Port of #16648 for 3.x branch