### PR TITLE
Fix classes for modWebLink/modSymLink in quick search

### DIFF
--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -51,6 +51,18 @@ MODx.SearchBar = function(config) {
                  * @returns {string}
                  */
                 getClass: function(values) {
+                    // Always return default classes for modWebLink/modSymLink
+                    if (values.class) {
+                        switch (values.class) {
+                            case 'MODX\\Revolution\\modSymLink':
+                                return 'files-o';
+                            case 'MODX\\Revolution\\modWebLink':
+                                return 'link';
+                            default:
+                                break;
+                        }
+                    }
+
                     if (values.icon) {
                         return values.icon;
                     }
@@ -59,10 +71,6 @@ MODx.SearchBar = function(config) {
                         switch (values.class) {
                             case 'MODX\\Revolution\\modDocument':
                                 return 'file';
-                            case 'MODX\\Revolution\\modSymLink':
-                                return 'files-o';
-                            case 'MODX\\Revolution\\modWebLink':
-                                return 'link';
                             case 'MODX\\Revolution\\modStaticResource':
                                 return 'file-text-o';
                             default:


### PR DESCRIPTION
### What does it do?
Fix classes for modWebLink/modSymLink in quick search.
Since links are not exactly resources, we shouldn't apply a template icon to them in search; it's difficult to find the resource you need, especially if the names of the link and resource are the same.
p.s. In the tree, links are already displayed with default icons, not template icons.

Before:
![before](https://github.com/user-attachments/assets/dee50f3e-fdd4-4706-a0e3-9b4b53b0a701)

After:
![after](https://github.com/user-attachments/assets/0f619de0-ff3c-448c-9742-68d1a73f1240)

### Why is it needed?
UX: It is easier to understand now which resource is a link.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/issues/16644
