### PR TITLE
Fix manager menu for sql_mode "ANSI_QUOTES"

### DIFF
--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -135,7 +135,7 @@ class modMenu extends modAccessibleObject
 
         if ($this->xpdo->getOption('package_installer_at_top', null, true)) {
             // make sure installer is always on top
-            $c->sortby('FIELD(modMenu.text, "installer")', 'DESC');
+            $c->sortby('FIELD(modMenu.text, \'installer\')', 'DESC');
         }
 
         $c->sortby($this->xpdo->getSelectColumns(modMenu::class, 'modMenu', '', ['menuindex']), 'ASC');

--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -134,7 +134,7 @@ class modMenu extends modAccessibleObject
         ]);
 
         if ($this->xpdo->getOption('package_installer_at_top', null, true)) {
-            // make sure installer is always on top
+            // To support ANSI_QUOTES sql mode, string literals must be single quoted
             $c->sortby('FIELD(modMenu.text, \'installer\')', 'DESC');
         }
 


### PR DESCRIPTION
### What does it do?
Fixes the SQL query that is used for the manager submenus.

### Why is it needed?
With the sql_mode `ANSI_QUOTES`, the generated SQL query returns the error `Unknown column 'installer' in 'order clause'`.

### How to test
* Add `ANSI_QUOTES` to the `sql_mode` setting in the MySQL config file `my.ini`
* Clear the cache
* Make sure the manager menu displays all submenus

### Related issue(s)/PR(s)
Related forum topic: https://community.modx.com/t/3-1-0-missing-left-side-menu/8236