### PR TITLE
Fix namespaces getlist processor when cache_db is active

### DIFF
--- a/core/src/Revolution/Processors/Workspace/PackageNamespace/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/PackageNamespace/GetList.php
@@ -114,7 +114,7 @@ class GetList extends GetListProcessor
                     if ($foreignKeyWhere) {
                         $nsSubquery->where($foreignKeyWhere);
                     }
-                    $namespaces = $this->modx->getObject($settingsClass, $nsSubquery)->get('namespaces');
+                    $namespaces = $this->modx->getObject($settingsClass, $nsSubquery, false)->get('namespaces');
 
                     $c->where(
                         "`{$c->getAlias()}`.`name` IN (\"{$namespaces}\")"


### PR DESCRIPTION
### What does it do?
Makes sure the code doesn't try to cache this specific query.

### Why is it needed?
When `cache_db` is active, the processor throws an error (`Code: 0 communication failure`).

### How to test
* Set the system setting `cache_db` to `Yes`
* Make sure that on the system settings page (`manager/?a=system/settings`), the dropdown "Filter by namespace..." displays the list of namespaces.

### Related issue(s)/PR(s)
Resolves #16674
