### PR TITLE
Fix non-existent snippet tags broken up by @

### DIFF
--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -11,7 +11,9 @@
  */
 namespace MODX\Revolution\Tests\Model;
 
-
+use MODX\Revolution\modElementPropertySet;
+use MODX\Revolution\modPropertySet;
+use MODX\Revolution\modSnippet;
 use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\MODxTestHarness;
@@ -764,23 +766,188 @@ class modParserTest extends MODxTestCase {
             ],
             // tags directly within brackets
             // @todo this test fails
-//            [
-//                [
-//                    'processed' => 1,
-//                    'content' => '<input type="text" name="item[Tag2][name]" />'
-//                ],
-//                '[[+tag1:notempty=`<input type="text" name="item[[[+tag2]]][name]" />`]]',
-//                [
-//                    'parentTag' => '',
-//                    'processUncacheable' => true,
-//                    'removeUnprocessed' => false,
-//                    'prefix' => '[[',
-//                    'suffix' => ']]',
-//                    'tokens' => [],
-//                    'depth' => 1
-//                ]
-//            ],
+            // [
+            //     [
+            //         'processed' => 1,
+            //         'content' => '<input type="text" name="item[Tag2][name]" />'
+            //     ],
+            //     '[[+tag1:notempty=`<input type="text" name="item[[[+tag2]]][name]" />`]]',
+            //     [
+            //         'parentTag' => '',
+            //         'processUncacheable' => true,
+            //         'removeUnprocessed' => false,
+            //         'prefix' => '[[',
+            //         'suffix' => ']]',
+            //         'tokens' => [],
+            //         'depth' => 1
+            //     ]
+            // ],
+
+            // #16318 parsing tags with @ in the value causes it to break the tag
+            [
+                [
+                    'processed' => 1,
+                    'content' => "aaa
+[[nonExistentSnippet? &x=`bbb@ccc`]]
+ddd
+eee"
+                ],
+                "[[+empty_content:empty=`aaa
+[[nonExistentSnippet? &x=`bbb@ccc`]]
+ddd
+`]]eee",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 0
+                ]
+            ]
         ];
+    }
+
+    /**
+     * @dataProvider providerPropertySetCall
+     * @param $content
+     * @param $expected
+     * @param $propertySet
+     * @param $params
+     * @return void
+     */
+    public function testPropertySetCall($content, $expected, $propertySet, $params)
+    {
+        /** @var modPropertySet $set */
+        $set = $this->modx->newObject(modPropertySet::class);
+        $set->set('name', 'propset_' . bin2hex(random_bytes(4)));
+        $set->setProperties($propertySet);
+        self::assertTrue($set->save());
+
+        /** @var modSnippet $set */
+        $snippet = $this->modx->newObject(modSnippet::class);
+        $snippet->set('name', 'snippet_' . bin2hex(random_bytes(4)));
+        $snippet->set('content', '<?php
+        return $scriptProperties["prop"] ?? "";');
+        self::assertTrue($snippet->save());
+
+        $join = $this->modx->newObject(modElementPropertySet::class);
+        $join->fromArray([
+            'element' => $snippet->get('id'),
+            'element_class' => $snippet->_class,
+            'property_set' => $set->get('id'),
+        ], '', true);
+        $join->save();
+        self::assertTrue($join->save());
+
+        $content = str_replace('propSetName', $set->get('name'), $content);
+        $content = str_replace('snippetName', $snippet->get('name'), $content);
+
+        $c = $content;
+
+        $this->modx->parser->processElementTags(
+            $params['parentTag'],
+            $content,
+            $params['processUncacheable'],
+            $params['removeUnprocessed'],
+            $params['prefix'],
+            $params['suffix'],
+            $params['tokens'],
+            $params['depth']
+        );
+
+        $set->remove();
+        $snippet->remove();
+        $join->remove();
+
+        $this->assertEquals($expected, $content, "Did not get expected results from parsing {$c}.");
+    }
+    public function providerPropertySetCall()
+    {
+        // In this test, snippetName and propSetName are replaced with a random string
+        // for each run
+        return [
+            [
+                '[[snippetName? &prop=`123`]]',
+                '123',
+                [],
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 10
+                ]
+            ],
+            [
+                '[[snippetName@propSetName]]',
+                '123',
+                [
+                    'prop' => '123',
+                ],
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 10
+                ]
+            ],
+            [
+                '[[snippetName@propSetName? &otherProp=`foo`]]',
+                '789',
+                [
+                    'prop' => '789',
+                ],
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 10
+                ]
+            ],
+            [
+                '[[snippetName@propSetName? &prop=`123`]]',
+                '123',
+                [
+                    'prop' => '456', // needs to be ignored because &prop is specified as override
+                ],
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 10
+                ]
+            ],
+            [
+                'This is a [[snippetName@propSetName:default=`default value`]]',
+                'This is a default value',
+                [
+                    'otherProp' => 'not this one', // props other than the test 'prop' should have no effect on output
+                ],
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 10
+                ]
+            ],
+        ];
+
     }
 
     /**

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -730,8 +730,8 @@ class modElement extends modAccessibleSimpleObject
         $startFiltersIndex = strpos($name, ':');
 
         if ($startFiltersIndex !== false) {
-            $tagStart = mb_substr($name, 0, $startFiltersIndex);
-            $tagEnd = mb_substr($name, $startFiltersIndex);
+            $tagStart = substr($name, 0, $startFiltersIndex);
+            $tagEnd = substr($name, $startFiltersIndex);
         } else {
             $tagStart = $name;
             $tagEnd = '';

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -316,8 +316,6 @@ class modElement extends modAccessibleSimpleObject
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Instance of ' . get_class($this) . ' produced an empty tag!');
         }
 
-        
-
         return $this->_tag;
     }
 

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -316,6 +316,8 @@ class modElement extends modAccessibleSimpleObject
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Instance of ' . get_class($this) . ' produced an empty tag!');
         }
 
+        
+
         return $this->_tag;
     }
 
@@ -726,19 +728,23 @@ class modElement extends modAccessibleSimpleObject
     {
         $propertySet = null;
         $name = $this->get('name');
-        if (strpos($name, '@') !== false) {
-            $psName = '';
-            $split = xPDO:: escSplit('@', $name);
-            if ($split && isset($split[1])) {
-                $name = $split[0];
-                $psName = $split[1];
-                $filters = xPDO:: escSplit(':', $setName);
-                if ($filters && isset($filters[1]) && !empty($filters[1])) {
-                    $psName = $filters[0];
-                    $name .= ':' . $filters[1];
-                }
-                $this->set('name', $name);
-            }
+
+        $startFiltersIndex = strpos($name, ':');
+
+        if ($startFiltersIndex !== false) {
+            $tagStart = mb_substr($name, 0, $startFiltersIndex);
+            $tagEnd = mb_substr($name, $startFiltersIndex);
+        } else {
+            $tagStart = $name;
+            $tagEnd = '';
+        }
+
+        if (strpos($tagStart, '@') !== false) {
+            $split = xPDO:: escSplit('@', $tagStart);
+            $psName = $split[1];
+
+            $this->set('name', $split[0] . $tagEnd);
+
             if (!empty($psName)) {
                 $psObj = $this->xpdo->getObjectGraph(modPropertySet::class, '{"Elements":{}}', [
                     'Elements.element' => $this->id,

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -276,8 +276,10 @@ class modElement extends modAccessibleSimpleObject
                     if (is_scalar($value)) {
                         $propTemp[$key] = $key . '=`' . $value . '`';
                     } else {
+                        /** @disregard P1009 */
                         if (is_array($value)) {
                             $func = function ($item) use (&$func) {
+                                /** @disregard P1009 */
                                 if (is_array($item)) {
                                     return array_map($func, $item);
                                 } elseif ($item instanceof \xPDOObject) {

--- a/core/src/Revolution/modTag.php
+++ b/core/src/Revolution/modTag.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution;
-
 
 use MODX\Revolution\Filters\modInputFilter;
 use MODX\Revolution\Filters\modOutputFilter;
@@ -119,7 +119,7 @@ abstract class modTag
      *
      * @param modX $modx A reference to the modX object
      */
-    function __construct(modX &$modx)
+    public function __construct(modX &$modx)
     {
         $this->modx =& $modx;
         $this->name =& $this->_fields['name'];
@@ -266,11 +266,12 @@ abstract class modTag
         $this->getTag();
         $this->filterInput();
         if ($this->modx->getDebug() === true) {
-            $this->modx->log(xPDO::LOG_LEVEL_DEBUG,
-                "Processing Element: " . $this->get('name') . ($this->_tag ? "\nTag: {$this->_tag}" : "\n") . "\nProperties: " . print_r($this->_properties,
-                    true));
+            $this->modx->log(
+                xPDO::LOG_LEVEL_DEBUG,
+                "Processing Element: " . $this->get('name') . ($this->_tag ? "\nTag: {$this->_tag}" : "\n") . "\nProperties: " . print_r($this->_properties, true)
+            );
         }
-        if ($this->isCacheable() && isset ($this->modx->elementCache[$this->_tag])) {
+        if ($this->isCacheable() && isset($this->modx->elementCache[$this->_tag])) {
             $this->_output = $this->modx->elementCache[$this->_tag];
             $this->_processed = true;
         } else {
@@ -287,7 +288,7 @@ abstract class modTag
      */
     public function & getInputFilter()
     {
-        if (!isset ($this->_filters['input']) || !($this->_filters['input'] instanceof modInputFilter)) {
+        if (!isset($this->_filters['input']) || !($this->_filters['input'] instanceof modInputFilter)) {
             if (!$inputFilterClass = $this->get('input_filter')) {
                 $inputFilterClass = $this->modx->getOption('input_filter', null, modInputFilter::class);
             }
@@ -308,7 +309,7 @@ abstract class modTag
      */
     public function & getOutputFilter()
     {
-        if (!isset ($this->_filters['output']) || !($this->_filters['output'] instanceof modOutputFilter)) {
+        if (!isset($this->_filters['output']) || !($this->_filters['output'] instanceof modOutputFilter)) {
             if (!$outputFilterClass = $this->get('output_filter')) {
                 $outputFilterClass = $this->modx->getOption('output_filter', null, modOutputFilter::class);
             }
@@ -486,7 +487,7 @@ abstract class modTag
      */
     public function setCacheable($cacheable = true)
     {
-        $this->_cacheable = (boolean)$cacheable;
+        $this->_cacheable = (bool)$cacheable;
     }
 
     /**
@@ -539,8 +540,10 @@ abstract class modTag
             $propertySetObj = $this->modx->getObject(modPropertySet::class, ['name' => $setName]);
             if ($propertySetObj) {
                 if (is_array($propertySet)) {
-                    $propertySet = array_merge($propertySet,
-                        $this->modx->parser->parseProperties($propertySetObj->get('properties')));
+                    $propertySet = array_merge(
+                        $propertySet,
+                        $this->modx->parser->parseProperties($propertySetObj->get('properties'))
+                    );
                 } else {
                     $propertySet = $this->modx->parser->parseProperties($propertySetObj->get('properties'));
                 }

--- a/core/src/Revolution/modTag.php
+++ b/core/src/Revolution/modTag.php
@@ -511,19 +511,23 @@ abstract class modTag
     {
         $propertySet = null;
         $name = $this->get('name');
-        if (strpos($name, '@') !== false) {
-            $psName = '';
-            $split = xPDO:: escSplit('@', $name);
-            if ($split && isset($split[1])) {
-                $name = $split[0];
-                $psName = $split[1];
-                $filters = xPDO:: escSplit(':', $setName);
-                if ($filters && isset($filters[1]) && !empty($filters[1])) {
-                    $psName = $filters[0];
-                    $name .= ':' . $filters[1];
-                }
-                $this->set('name', $name);
-            }
+
+        $startFiltersIndex = strpos($name, ':');
+
+        if ($startFiltersIndex !== false) {
+            $tagStart = mb_substr($name, 0, $startFiltersIndex);
+            $tagEnd = mb_substr($name, $startFiltersIndex);
+        } else {
+            $tagStart = $name;
+            $tagEnd = '';
+        }
+
+        if (strpos($tagStart, '@') !== false) {
+            $split = xPDO:: escSplit('@', $tagStart);
+            $psName = $split[1];
+
+            $this->set('name', $split[0] . $tagEnd);
+
             if (!empty($psName)) {
                 $psObj = $this->modx->getObject(modPropertySet::class, ['name' => $psName]);
                 if ($psObj) {

--- a/core/src/Revolution/modTag.php
+++ b/core/src/Revolution/modTag.php
@@ -515,8 +515,8 @@ abstract class modTag
         $startFiltersIndex = strpos($name, ':');
 
         if ($startFiltersIndex !== false) {
-            $tagStart = mb_substr($name, 0, $startFiltersIndex);
-            $tagEnd = mb_substr($name, $startFiltersIndex);
+            $tagStart = substr($name, 0, $startFiltersIndex);
+            $tagEnd = substr($name, $startFiltersIndex);
         } else {
             $tagStart = $name;
             $tagEnd = '';


### PR DESCRIPTION
### What does it do?
Identifies and fixes a problem present in the getPropertySet method where the Element name is re-set, but without the necessary colon between the actual Element name and the rest of its tag.

### Why It's Needed / How to Test
See PR #16322

### Note
This is by and large the result of @Mark-H's work -- although it did take the better part of a night to track down the issue he was asking for help on ;-)
