### PR TITLE
Fix for non-functioning Remember Me login feature

### DIFF
--- a/core/src/Revolution/Processors/Security/Login.php
+++ b/core/src/Revolution/Processors/Security/Login.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Security;
-
 
 use MODX\Revolution\modContext;
 use MODX\Revolution\Processors\Processor;
@@ -22,7 +22,6 @@ use MODX\Revolution\modUserSetting;
  */
 class Login extends Processor
 {
-
     /** @var modUser */
     public $user;
 
@@ -54,8 +53,10 @@ class Login extends Processor
         }
 
         $this->rememberme = ($this->getProperty('rememberme', false) === true);
-        $this->lifetime = (int)$this->getProperty('lifetime',
-            $this->modx->getOption('session_cookie_lifetime', null, 0));
+        $this->lifetime = (int)$this->getProperty(
+            'lifetime',
+            $this->modx->getOption('session_cookie_lifetime', null, 0)
+        );
         $this->loginContext = $this->getProperty('login_context', $this->modx->context->get('key'));
         $this->addContexts = $this->getProperty('add_contexts', []);
         $this->addContexts = empty($this->addContexts) ? [] : explode(',', $this->addContexts);
@@ -286,7 +287,7 @@ class Login extends Processor
         if (!isset($_SESSION['login_failed'])) {
             $_SESSION['login_failed'] = 0;
         }
-        $flc = ((integer)$this->user->Profile->get('failedlogincount')) + 1;
+        $flc = ((int)$this->user->Profile->get('failedlogincount')) + 1;
         $this->user->Profile->set('failedlogincount', $flc);
         $this->user->Profile->save();
         $_SESSION['login_failed']++;
@@ -305,7 +306,7 @@ class Login extends Processor
                 $this->failedLogin();
                 return $this->modx->lexicon('login_username_password_incorrect');
             }
-        } else if ($rt && (is_array($rt) && !in_array(true, $rt, true))) {
+        } elseif ($rt && (is_array($rt) && !in_array(true, $rt, true))) {
             $error = '';
             foreach ($rt as $msg) {
                 if (!empty($msg)) {

--- a/core/src/Revolution/Processors/Security/Login.php
+++ b/core/src/Revolution/Processors/Security/Login.php
@@ -52,7 +52,7 @@ class Login extends Processor
             return $this->modx->lexicon('login_cannot_locate_account');
         }
 
-        $this->rememberme = ($this->getProperty('rememberme', false) === true);
+        $this->rememberme = (bool)$this->getProperty('rememberme', false) === true;
         $this->lifetime = (int)$this->getProperty(
             'lifetime',
             $this->modx->getOption('session_cookie_lifetime', null, 0)


### PR DESCRIPTION
### What does it do?
Casts `rememberme` property to boolean to ensure proper functionality.

### Why is it needed?
User sessions are not persisted even when use checks _Remember Me_ during login.

### How to test
1. Set your `session_cookie_lifetime` system setting to a short time (I set it to 180 [3 minutes]).
2. Login without checking _Remember Me_  and verify that, when quitting the browser (while still logged in), you are NOT automatically logged in when re-opening the browser and revisiting the manager
3. Login with _Remember Me_ checked and, within the 3 minutes (or whatever lifetime you set), quit and re-open the browser to verify automatic login is functioning.
4. Again, before your 3 minute session lifetime has expired, quit the browser (while still logged in).
5. After the 3 minutes has elapsed, open your browser again to verify you are NOT automatically logged in.

### Related issue(s)/PR(s)
Resolves #16518
