### PR TITLE
Add missing WebP Lexicon entry

### DIFF
--- a/core/lexicon/en/source.inc.php
+++ b/core/lexicon/en/source.inc.php
@@ -86,3 +86,4 @@ $_lang['prop_s3.region_desc'] = 'Region of the bucket. Example: us-west-1';
 $_lang['PNG'] = 'PNG';
 $_lang['JPG'] = 'JPG';
 $_lang['GIF'] = 'GIF';
+$_lang['WebP'] = 'WebP';


### PR DESCRIPTION
### What does it do?
Adds new entry to source Lexicon file.

### Why is it needed?
Prevent debug notices of missing array key.

### How to test
Before applying this PR...
1. Set logging level to Debug
2. Visit the Media Browser. You should see multiple debug messages stating: _Language string not found: "WebP"_

After applying this PR...

3. Revisit the Media Browser. You should no longer see the referenced debug messages

### Related issue(s)/PR(s)
Resolves #16622