### PR TITLE
Fix for MODX updates widget

### DIFF
--- a/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
+++ b/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
@@ -92,7 +92,7 @@ class GetList extends Base
                 $upgradesCount = count($upgrades);
                 if ($upgradesCount === 1) {
                     $categoryData['updateable'] = 1;
-                    $selectedUpgrade = $upgrades;
+                    $selectedUpgrade = $upgrades[array_key_first($upgrades)];
                 } else {
                     foreach ($upgrades as $upgrade) {
                         $selectedUpgrade = $upgrade;


### PR DESCRIPTION
### What does it do?
Fixes error in array selection when only one update is available.

### Why is it needed?
MODX update status is not showing properly (both when there is an update and when MODX _is_ up to date) when the software update API only returns one option.

### How to test

1. Verify software status displays "Up to Date" on this dev branch
2. Manually apply this change on the 3.0.x branch to verify the 3.1.0 update shows and is downloadable via the widget

### Related issue(s)/PR(s)
None
