### PR TITLE
Register missing PSR interfaces to services

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -28,8 +28,11 @@ use PDO;
 use PDOStatement;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 use xPDO\Cache\xPDOFileCache;
 use xPDO\xPDO;
 use xPDO\xPDOException;
@@ -2742,8 +2745,23 @@ class modX extends xPDO {
                 return new HttpFactory();
             });
         }
+        if (!$this->services->has(ResponseFactoryInterface::class)) {
+            $this->services->add(ResponseFactoryInterface::class, function() {
+                return new HttpFactory();
+            });
+        }
         if (!$this->services->has(StreamFactoryInterface::class)) {
             $this->services->add(StreamFactoryInterface::class, function() {
+                return new HttpFactory();
+            });
+        }
+        if (!$this->services->has(UploadedFileFactoryInterface::class)) {
+            $this->services->add(UploadedFileFactoryInterface::class, function() {
+                return new HttpFactory();
+            });
+        }
+        if (!$this->services->has(UriFactoryInterface::class)) {
+            $this->services->add(UriFactoryInterface::class, function() {
                 return new HttpFactory();
             });
         }


### PR DESCRIPTION
### What does it do?
Registers the Guzzlehttp implementations of PSR interfaces ResponseFactoryInterface, UploadedFileFactoryInterface, and UriFactoryInterface into the services container.

### Why is it needed?

While we offer [a bunch of interfaces as part of the core services already](https://docs.modx.com/3.x/en/extending-modx/services/http), I ran into needing the ResponseFactoryInterface to create response classes on a project. 

I then double checked what other interfaces we can already provide through guzzlehttp/psr7 and made sure we're adding them all in. 

### How to test

```
        $factory = $this->modx->services->get(ResponseFactoryInterface::class);
        $response = $factory->createResponse($statusCode)
            ->withHeader('Content-Type', 'application/json')
            ->withHeader('Access-Control-Allow-Origin', '*');
        $response->getBody()->write(json_encode($data));
```

### Related issue(s)/PR(s)

N/a
