### PR TITLE
Deprecate modUserProfile->sessionid and do not set value

### DIFF
--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -1341,7 +1341,7 @@
         <field key="lastlogin" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="thislogin" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
         <field key="failedlogincount" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
-        <field key="sessionid" dbtype="varchar" precision="100" phptype="string" null="false" default="" />
+        <field key="sessionid" dbtype="varchar" precision="100" phptype="string" null="false" default="" /> <!-- deprecated - to be removed in 3.2 -->
         <field key="dob" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
         <field key="gender" dbtype="tinyint" precision="1" phptype="integer" null="false" default="0" />
         <field key="address" dbtype="text" phptype="string" null="false" default="" />

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -400,7 +400,6 @@ class modUser extends modPrincipal
                     $ua->set('logincount', $ua->logincount + 1);
                     $ua->set('lastlogin', $ua->thislogin);
                     $ua->set('thislogin', time());
-                    /*$ua->set('sessionid', session_id());*/
                     $ua->save();
                 }
             }

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -400,7 +400,7 @@ class modUser extends modPrincipal
                     $ua->set('logincount', $ua->logincount + 1);
                     $ua->set('lastlogin', $ua->thislogin);
                     $ua->set('thislogin', time());
-                    $ua->set('sessionid', session_id());
+                    /*$ua->set('sessionid', session_id());*/
                     $ua->save();
                 }
             }

--- a/core/src/Revolution/modUserProfile.php
+++ b/core/src/Revolution/modUserProfile.php
@@ -19,7 +19,7 @@ use xPDO\Om\xPDOSimpleObject;
  * @property int     $lastlogin        A UNIX timestamp showing the last time the User logged in
  * @property int     $thislogin        A UNIX timestamp showing the time this User currently logged in
  * @property int     $failedlogincount The number of failed logins this User has accumulated
- * @property int     $sessionid        The PHP sessionid of the User
+ * @property int     $sessionid        The PHP sessionid of the User (deprecated—to be removed in 3.2)
  * @property int     $dob              The date of birth of the User, in UNIX timestamp format
  * @property int     gender            The gender of the user; 1 for male, 2 for female, 0 for unknown
  * @property string  $address          The address of the User

--- a/setup/includes/upgrades/common/3.1.1-clear-sessionids.php
+++ b/setup/includes/upgrades/common/3.1.1-clear-sessionids.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Removes data from modUserProfile.sessionid field
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+$modx->updateCollection(\MODX\Revolution\modUserProfile::class, ['sessionid' => '']);

--- a/setup/includes/upgrades/mysql/3.1.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.1.1-pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.1.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.1.1-clear-sessionids.php';


### PR DESCRIPTION
### What does it do?
Marks the modUserProfile->sessionid field as deprecated and does not set the value when a user session is initiated or session id changes.

### Why is it needed?
Security enhancement.

### How to test
Make sure data is not added to the field for new users or updated for existing users when sessions are utilized.

### Related issue(s)/PR(s)
n/a