### PR TITLE
Make regClientScript and regClientHTMLBlock work in the manager

### DIFF
--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -787,7 +787,6 @@ abstract class modManagerController
             $cssjs[] = $scr;
         }
 
-
         $lastjs = [];
         foreach ($this->head['lastjs'] as $js) {
             $lastjs[] = $js;
@@ -798,8 +797,14 @@ abstract class modManagerController
             }
         }
 
-
         $this->modx->smarty->assign('cssjs', $cssjs);
+
+        $jsbody = [];
+        foreach ($this->modx->jscripts as $scr) {
+            $scr = $this->_postfixVersionToScript($scr, $versionPostFix);
+            $jsbody[] = $scr;
+        }
+        $this->modx->smarty->assign('jsbody', $jsbody);
     }
 
     /**

--- a/manager/templates/default/footer.tpl
+++ b/manager/templates/default/footer.tpl
@@ -4,5 +4,9 @@
 </div>
 <!-- #modx-container -->
 
+{foreach from=$jsbody item=scr}
+    {$scr}
+{/foreach}
+
 </body>
 </html>


### PR DESCRIPTION
### What does it do?
Adds scripts registered with `regClientScript()` or `regClientHTMLBlock()` to the output in the manager.

### Why is it needed?
There is some inconsistency:
The _modX_ class has the 4 functions `regClientScript()`, `regClientHTMLBlock()`, `regClientStartupScript()` and `regClientStartupHTMLBlock()`.
On the _frontend_ (outputting a resource) all 4 functions work.
In the _manager_, the functions `regClientStartupScript()` and `regClientStartupHTMLBlock()` work, but scripts registered with `regClientScript()` and `regClientHTMLBlock()` are ignored.

---

If there is a reason why these functions shouldn't work in the manager, then at least the MODX documentation (and the source code) should be updated to clearly state that this is the case.

### How to test
* Create a plugin that uses the functions `$modx->regClientScript()` and `$modx->regClientHTMLBlock()` on a manager event (like e.g. `OnManagerPageBeforeRender`).
* Make sure the scripts get added to the HTML output.

### Related issue(s)/PR(s)
Related discussion in the MODX forum: https://community.modx.com/t/13-years-and-6-months-regclientscript-still-not-working/8282
