### PR TITLE
Fallback for dashboard widgets in custom manager theme

### DIFF
--- a/manager/controllers/default/dashboard/widget.buttons.php
+++ b/manager/controllers/default/dashboard/widget.buttons.php
@@ -21,7 +21,7 @@ class modDashboardWidgetButtons extends modDashboardWidgetInterface
             $this->modx->smarty->assign($key, $value);
         }
 
-        return $this->modx->smarty->fetch('dashboard/buttons.tpl');
+        return $this->controller->fetchTemplate('dashboard/buttons.tpl');
     }
 
 

--- a/manager/controllers/default/dashboard/widget.configcheck.php
+++ b/manager/controllers/default/dashboard/widget.configcheck.php
@@ -35,7 +35,7 @@ class modDashboardWidgetConfigCheck extends modDashboardWidgetInterface
         $this->modx->getService('smarty', modSmarty::class);
         $this->modx->smarty->assign('warnings', $response->getObject());
 
-        return $this->modx->smarty->fetch('dashboard/configcheck.tpl');
+        return $this->controller->fetchTemplate('dashboard/configcheck.tpl');
     }
 }
 

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -40,7 +40,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 
-        return $this->modx->smarty->fetch('dashboard/onlineusers.tpl');
+        return $this->controller->fetchTemplate('dashboard/onlineusers.tpl');
     }
 }
 

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -43,7 +43,7 @@ class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterf
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 
-        return $this->modx->smarty->fetch('dashboard/recentlyeditedresources.tpl');
+        return $this->controller->fetchTemplate('dashboard/recentlyeditedresources.tpl');
     }
 }
 

--- a/manager/controllers/default/dashboard/widget.updates.php
+++ b/manager/controllers/default/dashboard/widget.updates.php
@@ -60,7 +60,7 @@ class modDashboardWidgetUpdates extends modDashboardWidgetInterface
             $this->modx->smarty->assign($key, $value);
         }
 
-        return $this->modx->smarty->fetch('dashboard/updates.tpl');
+        return $this->controller->fetchTemplate('dashboard/updates.tpl');
     }
 }
 


### PR DESCRIPTION
### What does it do?
Loads the dashboard widget templates from the default theme, if they don't exist in the custom manager theme.

### Why is it needed?
The [documentation](https://docs.modx.com/current/en/building-sites/client-proofing/custom-manager-themes) states that "The Manager will fall back to the default theme templates for any that have not been overridden."
This is currently not the case for the dashboard widgets (that load a Smarty template).

### How to test
* Create a new folder in `manager/templates` for a custom manager theme and change the system setting `manager_theme`.
* **DON'T** create copies of the files in `manager/templates/default/dashboard` in your own custom theme folder.
* Make sure the dashboard widgets get displayed on the manager welcome page.

### Related issue(s)/PR(s)
Related topic in the MODX forum: https://community.modx.com/t/manager-theme-customization-problem/8261
