### PR TITLE
Update ci workflow to use ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   mysql-check:
     name: MySQL Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     services:
       mysql:


### PR DESCRIPTION
### What does it do?
Update ci workflow to utilize ubuntu-latest

### Why is it needed?
The current ci workflow is using ubuntu-20.04, which is unsupported after March.

### How to test
See if the ci workflow passes.

### Related issue(s)/PR(s)
n/a