### PR TITLE
Fix error in User validation that blocks creation of new Users

### DIFF
--- a/core/src/Revolution/Processors/Security/User/Validation.php
+++ b/core/src/Revolution/Processors/Security/User/Validation.php
@@ -87,10 +87,10 @@ class Validation
         $passwordGenerationMethod = $this->processor->getProperty('passwordgenmethod', 'g');
         if ($passwordGenerationMethod !== 'user_email_specify' && ($newPassword !== null && $newPassword != 'false' || empty($id))) {
             $passwordNotifyMethod = $this->processor->getProperty('passwordnotifymethod', null);
-            if (empty($passwordNotifyMethod)) {
-                $this->processor->addFieldError('password_notify_method', $this->modx->lexicon('user_err_not_specified_notification_method'));
-            }
-            if ($passwordGenerationMethod == 'g') {
+            if ($passwordGenerationMethod === 'g') {
+                if (empty($passwordNotifyMethod)) {
+                    $this->processor->addFieldError('password_notify_method', $this->modx->lexicon('user_err_not_specified_notification_method'));
+                }
                 $autoPassword = $this->user->generatePassword();
                 $this->user->set('password', $autoPassword);
                 $this->processor->newPassword = $autoPassword;


### PR DESCRIPTION
### What does it do?
Restricts check for `password notification method` to only run when appropriate.

### Why is it needed?
A silent error occurs when `password notification method` is empty (when options other than "Let MODX generate a password" are chosen), preventing User creation without any visible validation error.

### How to test
Verify a User is successfully created using each of the three password creation methods.

### Related issue(s)/PR(s)
Resolves #16709
