### PR TITLE
Fix empty attributes with i.e. german umlaut in the transport package readme

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Packages/GetAttribute.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetAttribute.php
@@ -78,7 +78,7 @@ class GetAttribute extends Processor
         foreach ($attributesToGet as $attribute) {
             $data = $this->transport->getAttribute($attribute);
             $attributes[$attribute] = in_array($attribute,
-                ['changelog', 'license', 'readme']) ? $parseDown->text(htmlentities($data)) : $data;
+                ['changelog', 'license', 'readme']) ? $parseDown->text(htmlspecialchars($data)) : $data;
 
             /* if setup options, include setup file */
             if ($attribute === 'setup-options') {


### PR DESCRIPTION
### What does it do?
Change htmlentities to htmlspecialchars

### Why is it needed?
In one of my packages I have used a `ß` in the readme for the transport package. When this transport package is installed, the result the of `Workspace/Packages/GetAttribute` processor is empty for some reason inside of the Parsedown class in combination with the processor response and the package can't be installed anymore.

### How to test
Add a `ß` in the readme of a transport package.

### Related issue(s)/PR(s)
None known
