### PR TITLE
Fix the query that is generated to purge the old installed extras

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Packages/Purge.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Purge.php
@@ -96,7 +96,7 @@ class Purge extends Processor
             $c = $this->modx->newQuery(modTransportPackage::class, [
                 'package_name' => $package->get('package_name'),
             ]);
-            $c->where(array('installed:IS NOT' => NULL));
+            $c->where(['installed:IS NOT' => NULL]);
             $c->sortby('installed', 'desc');
             $c->limit(1000, 1);
             $purgedPackages = $this->modx->getIterator(modTransportPackage::class, $c);

--- a/core/src/Revolution/Processors/Workspace/Packages/Purge.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Purge.php
@@ -96,7 +96,7 @@ class Purge extends Processor
             $c = $this->modx->newQuery(modTransportPackage::class, [
                 'package_name' => $package->get('package_name'),
             ]);
-            $c->where(['installed:!=' => '0000-00-00 00:00:00']);
+            $c->where(array('installed:!=' => 0, 'installed:IS NOT' => NULL));
             $c->sortby('installed', 'desc');
             $c->limit(1000, 1);
             $purgedPackages = $this->modx->getIterator(modTransportPackage::class, $c);

--- a/core/src/Revolution/Processors/Workspace/Packages/Purge.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Purge.php
@@ -96,7 +96,7 @@ class Purge extends Processor
             $c = $this->modx->newQuery(modTransportPackage::class, [
                 'package_name' => $package->get('package_name'),
             ]);
-            $c->where(['installed:IS NOT' => NULL]);
+            $c->where(['installed:IS NOT' => null]);
             $c->sortby('installed', 'desc');
             $c->limit(1000, 1);
             $purgedPackages = $this->modx->getIterator(modTransportPackage::class, $c);

--- a/core/src/Revolution/Processors/Workspace/Packages/Purge.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Purge.php
@@ -96,7 +96,7 @@ class Purge extends Processor
             $c = $this->modx->newQuery(modTransportPackage::class, [
                 'package_name' => $package->get('package_name'),
             ]);
-            $c->where(array('installed:!=' => 0, 'installed:IS NOT' => NULL));
+            $c->where(array('installed:IS NOT' => NULL));
             $c->sortby('installed', 'desc');
             $c->limit(1000, 1);
             $purgedPackages = $this->modx->getIterator(modTransportPackage::class, $c);


### PR DESCRIPTION
### What does it do?
Fix incorrect DATETIME value: '0000-00-00 00:00:00' error in the query

### Why is it needed?
The generated query is wrong for MySQL installations that have NO_ZERO_DATE/NO_ZERO_IN_DATE activated.

### Related issue(s)/PR(s)
MODX 3.x port of #16716 
