### PR TITLE
Fix wrong check of checkRequirement method

### DIFF
--- a/core/src/Revolution/Rest/modRestController.php
+++ b/core/src/Revolution/Rest/modRestController.php
@@ -668,8 +668,8 @@ abstract class modRestController
         $properties = $this->getProperties();
 
         if (!empty($this->postRequiredFields)) {
-            if (!$this->checkRequiredFields($this->postRequiredFields)) {
-                return $this->failure($this->modx->lexicon('error'));
+            if ($result = $this->checkRequiredFields($this->postRequiredFields) !== true) {
+                return $this->failure($result);
             }
         }
 
@@ -744,8 +744,8 @@ abstract class modRestController
         }
 
         if (!empty($this->putRequiredFields)) {
-            if (!$this->checkRequiredFields($this->putRequiredFields)) {
-                return $this->failure();
+            if ($result = $this->checkRequiredFields($this->putRequiredFields) !== true) {
+                return $this->failure($result);
             }
         }
 
@@ -819,8 +819,8 @@ abstract class modRestController
         }
 
         if (!empty($this->deleteRequiredFields)) {
-            if (!$this->checkRequiredFields($this->deleteRequiredFields)) {
-                return $this->failure();
+            if ($result = $this->checkRequiredFields($this->deleteRequiredFields) !== true) {
+                return $this->failure($result);
             }
         }
 

--- a/core/src/Revolution/Rest/modRestController.php
+++ b/core/src/Revolution/Rest/modRestController.php
@@ -745,7 +745,8 @@ abstract class modRestController
         }
 
         if (!empty($this->putRequiredFields)) {
-            if ($result = $this->checkRequiredFields($this->putRequiredFields) !== true) {
+            $result = $this->checkRequiredFields($this->putRequiredFields);
+            if ($result !== true) {
                 return $this->failure($result);
             }
         }
@@ -820,7 +821,8 @@ abstract class modRestController
         }
 
         if (!empty($this->deleteRequiredFields)) {
-            if ($result = $this->checkRequiredFields($this->deleteRequiredFields) !== true) {
+            $result = $this->checkRequiredFields($this->deleteRequiredFields);
+            if ($result !== true) {
                 return $this->failure($result);
             }
         }

--- a/core/src/Revolution/Rest/modRestController.php
+++ b/core/src/Revolution/Rest/modRestController.php
@@ -668,7 +668,8 @@ abstract class modRestController
         $properties = $this->getProperties();
 
         if (!empty($this->postRequiredFields)) {
-            if ($result = $this->checkRequiredFields($this->postRequiredFields) !== true) {
+            $result = $this->checkRequiredFields($this->postRequiredFields);
+            if ($result !== true) {
                 return $this->failure($result);
             }
         }


### PR DESCRIPTION
### What does it do?
Fix wrong check of checkRequirement method

### Why is it needed?
checkRequirement result contains a string or true. So the check will never have a false result and the error is not sent.

### Related issue(s)/PR(s)
None known.
