### PR TITLE
Convert invalid dates to NULL in modTransportPackage.installed

### DIFF
--- a/setup/includes/upgrades/mysql/3.1.2-pl.php
+++ b/setup/includes/upgrades/mysql/3.1.2-pl.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Specific upgrades for Revolution 3.1.2-pl
+ *
+ * @var modX $modx
+ * @var modInstallVersion $this
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* Repair any datetime data that can trigger errors when
+      NO_ZERO_DATE/NO_ZERO_IN_DATE sql_modes are enabled */
+
+$updated = $modx->updateCollection(
+    \MODX\Revolution\Transport\modTransportPackage::class,
+    [
+        'installed' => null
+    ],
+    [
+        'installed:<' => '1000-01-01 00:00:00.000000'
+    ]
+);
+if ($updated === false) {
+    $this->runner->addResult(modInstallRunner::RESULT_FAILURE, $this->install->lexicon('transport_package_installed_update_invalid_dates_error'));
+} else {
+    $this->runner->addResult(modInstallRunner::RESULT_SUCCESS, $this->install->lexicon('transport_package_installed_update_invalid_dates_success'));
+}

--- a/setup/lang/en/upgrades.inc.php
+++ b/setup/lang/en/upgrades.inc.php
@@ -60,3 +60,5 @@ $_lang['system_setting_update_success'] = 'System Setting `[[+key]]` updated.';
 $_lang['system_setting_update_failed'] = 'System Setting `[[+key]]` could not be updated.';
 $_lang['system_setting_rename_key_success'] = 'Successfully renamed the System Setting key from `[[+old_key]]` to `[[+new_key]]`.';
 $_lang['system_setting_rename_key_failure'] = 'Failed to rename the System Setting key from `[[+old_key]]` to `[[+new_key]]`.';
+$_lang['transport_package_installed_update_invalid_dates_failure'] = 'Failed to repair invalid dates in the Transport Package installed column.';
+$_lang['transport_package_installed_update_invalid_dates_success'] = 'Successfully repaired invalid dates in the Transport Package installed column.';


### PR DESCRIPTION
### What does it do?
Converts any invalid dates in the modTransportPackage.installed column to NULL.

### Why is it needed?
Empty dates should have been saved as NULL in the column and their presence can cause errors when NO_ZERO_DATE/NO_ZERO_IN_DATE sql_modes are enabled in an environment.

### How to test
In an environment with NO_ZERO_DATE/NO_ZERO_DATE sql_modes enabled, build the transport and run the upgrade process, confirming that the process completes and that any invalid dates in the modTransportPackage.installed column are now NULL. You will need to have invalid dates in that column before enabling the strict sql_modes if you want to verify that this works properly.

### Related issue(s)/PR(s)
Required for #16717 to be merged.