### PR TITLE
Fix wrong check of checkRequirement method

### DIFF
--- a/core/model/modx/rest/modrestcontroller.class.php
+++ b/core/model/modx/rest/modrestcontroller.class.php
@@ -583,8 +583,9 @@ abstract class modRestController {
         }
 
         if (!empty($this->postRequiredRelatedObjects)) {
-            if (!$this->checkRequiredRelatedObjects($this->postRequiredRelatedObjects)) {
-                return $this->failure();
+            $result = $this->checkRequiredFields($this->postRequiredFields);
+            if ($result !== true) {
+                return $this->failure($result);
             }
         }
 
@@ -650,8 +651,9 @@ abstract class modRestController {
         }
 
         if (!empty($this->putRequiredRelatedObjects)) {
-            if (!$this->checkRequiredRelatedObjects($this->putRequiredRelatedObjects)) {
-                return $this->failure();
+            $result = $this->checkRequiredFields($this->putRequiredFields);
+            if ($result !== true) {
+                return $this->failure($result);
             }
         }
 
@@ -710,8 +712,9 @@ abstract class modRestController {
         }
 
         if (!empty($this->deleteRequiredFields)) {
-            if (!$this->checkRequiredFields($this->deleteRequiredFields)) {
-                return $this->failure();
+            $result = $this->checkRequiredFields($this->deleteRequiredFields);
+            if ($result !== true) {
+                return $this->failure($result);
             }
         }
 


### PR DESCRIPTION
What does it do?
Fix wrong check of checkRequirement method

Why is it needed?
checkRequirement result contains a string or true. So the check will never have a false result and the error is not sent.

Related issue(s)/PR(s)
2.x Port of #16718