### PR TITLE
Make all JS files editable in the MODX manager in PHP 8.4

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2420,6 +2420,7 @@ QTIP;
                     'application/xhtml+xml',
                     'application/xml',
                     'application/x-empty',
+                    'application/javascript'
                 ), true);
         } catch (Exception $e) {
             // pass


### PR DESCRIPTION
### What does it do?
Adds `application/javascript` to the list of non-binary MIME types.

### Why is it needed?
In PHP 8.4 _some_ `*.js` files return the MIME type `application/javascript`. The same files used to return `text/plain` in previous PHP versions.
(I believe `finfo::file` is used in the code to determine the MIME type, but I couldn't figure out what exactly changed in the new PHP version.)

### How to test
* Use PHP 8.4
* Create a new JS file in the default file system, e.g. `test.js`
* Enter the following content:
```js
(function() {
	console.log('test');
}());
```
* Make sure that this file is still editable in the MODX manager ("Files" tab).

### Related issue(s)/PR(s)
Resolves #16730
