### PR TITLE
Update checkout and setup-node actions

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -15,10 +15,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -   name: Install Node.js
-                uses: actions/setup-node@v2
+                uses: actions/setup-node@v4
                 with:
                     node-version: '14'
                     cache: 'npm'

--- a/_build/templates/default/README.md
+++ b/_build/templates/default/README.md
@@ -47,7 +47,7 @@ Install the [grunt-cli](http://gruntjs.com/getting-started#installing-the-cli) p
 npm install -g grunt-cli
 ```
 
-Make sure you have `grunt`installed by testing:
+Make sure you have `grunt` installed by testing:
 
 ```bash
 grunt --version
@@ -93,7 +93,7 @@ Compile Sass using expanded output style for development by running:
 ```bash
 grunt expand
 ```
-_Note: do not check in uncompressed CSS._
+_Note: do not commit uncompressed CSS._
 
 Using Sourcemaps
 ----------------------------


### PR DESCRIPTION
### What does it do?
Updates the checkout and setup-node actions to v4.

### Why is it needed?
The assets workflow is broken because v2 of checkout and setup-node actions rely on an old unsupported version of the cache workflow.

### How to test
n/a

### Related issue(s)/PR(s)
n/a