### PR TITLE
Avoid fatal error when Rest request fails in Package Browser

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Packages/Rest/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Rest/GetList.php
@@ -73,7 +73,9 @@ class GetList extends Processor
     {
         $data = $this->provider->find($this->getProperties());
 
-        if (empty($data) || count($data) !== 2) {
+        if (is_string($data)){
+            return $this->failure($data);
+        } elseif (!(is_array($data) && count($data) === 2)) {
             return $this->failure($this->modx->lexicon('provider_err_connect'));
         }
 


### PR DESCRIPTION
### What does it do?
Better error handling in the `Workspace/Packages/Rest/GetList` processor.

### Why is it needed?
While searching for extras in the "Package Browser", the code throws a fatal error when there is a problem with the connection.

```
Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, string given
```

---

The `find()` function of the class `modTransportProvider` returns a string if there is a error:

https://github.com/modxcms/revolution/blob/11d96669133bab7f1095c96be63368f841d8dbd7/core/src/Revolution/Transport/modTransportProvider.php#L333