### PR TITLE
Moved logic to add/remove collapsed (left bar) css class in appropriate event handlers

### DIFF
--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -427,18 +427,25 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                 },
                 afterrender: function() {
                     const trigger = Ext.get('modx-leftbar-trigger');
-                    if (this.collapsed) {
-                        trigger.addClass('collapsed');
-                    }
                     trigger.on('click', function() {
                         if (this.collapsed) {
-                            trigger.removeClass('collapsed');
                             this.expand(true);
                         } else {
-                            trigger.addClass('collapsed');
                             this.collapse(true);
                         }
                     }, this);
+                },
+                expand: function () {
+                    const trigger = Ext.get('modx-leftbar-trigger');
+                    if (trigger && trigger.hasClass('collapsed')) {
+                        trigger.removeClass('collapsed');
+                    }
+                },
+                collapse: function () {
+                    const trigger = Ext.get('modx-leftbar-trigger');
+                    if (trigger && !trigger.hasClass('collapsed')) {
+                        trigger.addClass('collapsed');
+                    }
                 }
             }
         };


### PR DESCRIPTION
### What does it do?

Moved the logic to add/remove the `collapsed` CSS class on the "trigger" to collapse/expand the manager left bar (trees)

### Why is it needed?

The logic was initially set in a "click" handler, making it only happening when clicking on the trigger (arrow).
However, ExtJS code (`Ext.getCmp('modx-layout').toggleLeftbar()`, `Ext.getCmp('modx-layout').hideLeftbar()`, `Ext.getCmp('modx-layout').showLeftbar()`) could also be executed to perform the same action without "clicking" on the trigger, resulting in visual contraction like having the tree collapsed, but the trigger offering to collapsed it anyway.

### How to test

Once the manager is loaded, in the browser console, execute `Ext.getCmp('modx-layout').toggleLeftbar()`

Without this patch, the "trigger" arrow should not change direction. With this patch applied, it should reflect the tree state (collapsed or expanded)
