### PR TITLE
Fix Textarea TV Input Options

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -409,7 +409,7 @@ class modX extends xPDO {
      */
     public function paramValueIsTrue(array $params, $key, bool $returnBoolAsString = false)
     {
-        if (isset($params[$key]) && in_array($params[$key], ['true', true, '1', 1])) {
+        if (isset($params[$key]) && in_array($params[$key], ['true', true, '1', 1], true)) {
             return $returnBoolAsString ? 'true' : true ;
         }
         return $returnBoolAsString ? 'false' : false ;


### PR DESCRIPTION
### What does it do?
Makes array checking strict in the method used for evaluating boolean option types.

### Why is it needed?
Autogrow and Resizable option settings were not displaying/saving correctly. 

I have no idea how/why this issue did not crop up when these options were added originally, not too long ago :-/

### How to test
Create a textarea TV and change these input options to verify they persist as expected.

### Related issue(s)/PR(s)
Resolves #16746
