### PR TITLE
Fix empty WHERE clause in resourcelist TV input (2.x)  

### DIFF
--- a/core/model/modx/processors/element/tv/renders/mgr/input/resourcelist.class.php
+++ b/core/model/modx/processors/element/tv/renders/mgr/input/resourcelist.class.php
@@ -52,8 +52,14 @@ class modTemplateVarInputRenderResourceList extends modTemplateVarInputRender {
             $c->where(array('modResource.parent' => 0));
         }
         if (!empty($params['where'])) {
-            $params['where'] = $this->modx->fromJSON($params['where']);
-            $c->where($params['where']);
+            if (is_string($params['where'])) {
+                $where = $this->modx->fromJSON($params['where']);
+                if (!empty($where)) {
+                    $c->where($where);
+                }
+            } elseif (is_array($params['where'])) {
+                $c->where($params['where']);
+            }
         }
     	if (!empty($params['limitRelatedContext']) && ($params['limitRelatedContext'] == 1 || $params['limitRelatedContext'] == 'true')) {
 			$context_key = $this->modx->resource->get('context_key');


### PR DESCRIPTION
### What does it do?
Fixes SQL syntax generation in resourcelist TV render when:

- where parameter contains complex JSON conditions (e.g., [{"published":"1"}, {"hidemenu":"0"}])
- Used in MIGx configurations with direct JSON input
- Maintains compatibility with standard MODX TV settings

### Why is it needed?

- Prevents SQL errors when resourcelist TV uses array-style where conditions
- Critical for MIGx configurations where TV parameters are defined via JSON
- Original bug: Broken SQL query when where contains nested objects

### How to test

The error was observed in MODx version 2.8.8-pl
**1. Configuration for resourcelist TV in MIGx** 

```json
{"allowBlank":1,"showNone":1,"parents":"1,2,3","includeParent":1,"where":[{"published":"1"},{"hidemenu":"0"}],"limit":"0"}
```

**Verify:**
- Resources load without SQL errors in MIGxDB interface (`?a=index&namespace=migx&configs=...`)
- Filters by `published=1` and `hidemenu=0` are applied correctly

**2. Standard MODX TV:**
- Create TV with `resourcelist` input type
- Set "Where Conditions" to:
```json
  [{"published":"1"}, {"hidemenu":"0"}]
```

Check resource selection in manager.
