### PR TITLE
Fix fatal error in trim output filter

### DIFF
--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -48,7 +48,7 @@ class modOutputFilter
         if (!is_scalar($element->_output)) {
             return;
         }
-        
+
         $usemb = function_exists('mb_strlen') && (boolean)$this->modx->getOption('use_multibyte', null, false);
         $encoding = $this->modx->getOption('modx_charset', null, 'UTF-8');
 

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -63,7 +63,7 @@ class modOutputFilter
 
                 $this->log('Processing Modifier: ' . $m_cmd . ' (parameters: ' . $m_val . ')');
 
-                $output = trim((string) $output);
+                $output = is_string($output) ? trim($output) : $output;
 
                 try {
                     switch ($m_cmd) {

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -63,7 +63,7 @@ class modOutputFilter
 
                 $this->log('Processing Modifier: ' . $m_cmd . ' (parameters: ' . $m_val . ')');
 
-                $output = trim($output);
+                $output = trim((string) $output);
 
                 try {
                     switch ($m_cmd) {

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -46,10 +46,6 @@ class modOutputFilter
      */
     public function filter(&$element)
     {
-        if (!is_scalar($element->_output)) {
-            return;
-        }
-
         $usemb = function_exists('mb_strlen') && (boolean)$this->modx->getOption('use_multibyte', null, false);
         $encoding = $this->modx->getOption('modx_charset', null, 'UTF-8');
 

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -45,6 +45,10 @@ class modOutputFilter
      */
     public function filter(&$element)
     {
+        if (!is_scalar($element->_output)) {
+            return;
+        }
+        
         $usemb = function_exists('mb_strlen') && (boolean)$this->modx->getOption('use_multibyte', null, false);
         $encoding = $this->modx->getOption('modx_charset', null, 'UTF-8');
 


### PR DESCRIPTION
This solves a PHP fatal error that occurs when using something like this:

`[[!#SESSION.user.password:trim]]`

### PHP Error

```
Fatal error: Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, array given in core/src/Revolution/Filters/modOutputFilter.php:66 Stack trace: #0 core/src/Revolution/Filters/modOutputFilter.php(66): trim(Array) #1 core/src/Revolution/modTag.php(354): MODX\Revolution\Filters\modOutputFilter->filter(Object(ModxPro\PdoTools\Parsing\Tag)) #2 core/components/pdotools/src/Parsing/Tag.php(32): MODX\Revolution\modTag->filterOutput() #3 core/components/pdotools/src/Parsing/Parser.php(264): ModxPro\PdoTools\Parsing\Tag->process() #4 core/src/Revolution/modParser.php(221): ModxPro\PdoTools\Parsing\Parser->processTag(Array, true) #5 core/components/pdotools/src/Parsing/Parser.php(73): MODX\Revolution\modParser->processElementTags('', '<!DOCTYPE html>...', true, false, '[[', ']]', Array, 9) #6 core/src/Revolution/modResource.php(520): ModxPro\PdoTools\Parsing\Parser->processElementTags('', '<!DOCTYPE html>...', true, false, '[[', ']]', Array, 10) #7 core/src/Revolution/modResource.php(468): MODX\Revolution\modResource->parseContent() #8 core/src/Revolution/modResponse.php(72): MODX\Revolution\modResource->prepare() #9 core/src/Revolution/modRequest.php(154): MODX\Revolution\modResponse->outputContent(Array) #10 core/src/Revolution/modRequest.php(138): MODX\Revolution\modRequest->prepareResponse() #11 core/src/Revolution/modX.php(1509): MODX\Revolution\modRequest->handleRequest() #12 index.php(63): MODX\Revolution\modX->handleRequest() #13 {main} thrown in core/src/Revolution/Filters/modOutputFilter.php on line 66
```

### System

- MODX 3.1.2
- PHP Version 8.3.21
- Extras: pdoTools 3.0.2-pl