### PR TITLE
Enhancement: Outline icons for unpublished and deleted resources in tree

### DIFF
--- a/_build/templates/default/sass/_colors-and-vars.scss
+++ b/_build/templates/default/sass/_colors-and-vars.scss
@@ -132,7 +132,7 @@ $treeHeaderBorder: 1px solid #CDCDCD;
 $treeHeaderBg: $lightestGray;
 $treeBg: $lightestGray;
 $treeBgSelected: #D6E7F8;
-$treeColor: $darkGray;
+$treeColor: darken($darkGray,10%);
 $treeColorDesaturated: lighten(desaturate($treeColor,100%), 25%);
 $treeColor_2: #728DA7;
 $treePseudoRootBg: #F1F1F1;
@@ -145,17 +145,16 @@ $treeItemBg: $white;
 $treeItemColor: $mediumGray;
 
 $iconColor: $treeText;
+$unpublished: $treeText;
 
 $deactivatedTextColor: lighten($treeColor, 35%); // do not use 50% here - makes base color nearly invisible
 $disabledTextColor: $deactivatedTextColor;
 
-$unpublished: lighten($treeText, 10%) !important;
-$hidden: $treeText;
-$unpubText: normal;
-$hiddenText: italic;
-// locked is already signaled with lock-icon, no need to use other semantic style here
-// as italic is used for "unpublished"
-$lockedText: inherit; // italic;
+$hidden: darken($treeText,5%) !important;
+$unpubText: italic;
+/* locked is already signaled with lock-icon, no need to use other semantic style here
+   as italic is used for "unpublished" */
+$lockedText: inherit; //italic;
 
 $delTextColor: fade-out(darken(lighten(desaturate($red,50%), 33%), 25%), 0.5) !important;
 $delTextStyle: normal;

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -219,15 +219,20 @@
 
   i.icon,
   i.icon-large {
-    color: $unpublished;
     font-style: normal;
+    color: $treeColor;
   }
 }
 
 .hidemenu,
 .hidemenu a span {
   color: $hidden;
-  font-style: $hiddenText;
+  font-style: normal;
+
+  &.unpublished,
+  &.unpublished a span {
+    font-style: $unpubText;
+  }
 
   i.icon,
   i.icon-large {
@@ -241,8 +246,7 @@
 
   i.icon,
   i.icon-large {
-    color: $delTextColor;
-    font-style: normal;
+    color: $delTextColor; // font-style: normal;
   }
 
   a span {

--- a/_build/templates/default/sass/_tree.scss
+++ b/_build/templates/default/sass/_tree.scss
@@ -211,7 +211,16 @@
     vertical-align: 0;
   }
 }
-
+.published,
+.published a span{
+  i.icon,
+  i.icon-large {
+    color: $treeColor !important;
+    &::before {
+      color: $treeColor !important;
+    }
+  }
+}
 .unpublished,
 .unpublished a span {
   color: $unpublished;
@@ -221,6 +230,10 @@
   i.icon-large {
     font-style: normal;
     color: $treeColor;
+
+    &::before {
+      font-weight: 400;
+    }
   }
 }
 
@@ -232,12 +245,16 @@
   &.unpublished,
   &.unpublished a span {
     font-style: $unpubText;
-  }
 
+    i.icon,
+    i.icon-large {
+      color: $hidden;
+    }
+  }
   i.icon,
   i.icon-large {
-    color: $hidden;
     font-style: normal;
+    color: $treeColor;
   }
 }
 
@@ -247,6 +264,10 @@
   i.icon,
   i.icon-large {
     color: $delTextColor; // font-style: normal;
+
+    &::before {
+      font-weight: 400;
+    }
   }
 
   a span {

--- a/_build/templates/default/sass/index.scss
+++ b/_build/templates/default/sass/index.scss
@@ -128,7 +128,7 @@ hr {
 
 .not-installed {
   color: $mediumGray;
-  font-style: $hiddenText;
+  font-style: $hidden;
 }
 
 .yellow {
@@ -1640,28 +1640,19 @@ iframe[classname="x-hidden"] {
         font: normal 18px $bodyfonts;
         text-decoration: none;
 
-        &.menu_hidden {
-          font-style: $hiddenText;
-
-          &:hover {
-            color: darken($colorSplash, 10%);
-          }
-        }
-
         &.not_published {
-          color: $unpublished;
+          font-style: $unpubText;
 
           &:hover {
             color: darken($colorSplash, 10%);
           }
         }
 
-        &.deleted {
-          color: $delTextColor;
-          text-decoration: $delTextDeco;
+        &.menu_hidden {
+          color: $hidden;
 
           &:hover {
-            color: darken($colorSplash, 10%);
+            color: darken($colorSplash, 10%) !important;
           }
         }
       }


### PR DESCRIPTION
### What does it do?

This PR updates the resource tree icons to make unpublished and deleted resources easier to distinguish at a glance:

- **Published resources** use the standard dark icon color.
- **Unpublished and deleted resources** use an outlined version of the icon.

The outlined style visually separates them from published items without relying solely on color or status labels. 

It factors in @rthrash's comments here: https://github.com/modxcms/revolution/issues/16465#issuecomment-2661140710


---
### Screenshot
<img width="388" height="1014" alt="enhanced-tree-icons" src="https://github.com/user-attachments/assets/2944ddaf-4e8b-4c1a-9376-6f4a77929195" />

---

### Why is it needed?

This is a potential enhancement to the visual updates introduced in [#16759](https://github.com/modxcms/revolution/pull/16759). While that PR introduced more consistent icon styling, this change improves visual clarity by making unpublished and deleted resources more visually distinct. It helps users quickly spot content that isn't live.

---

### How to test

1. Go to the resource tree in the manager.
2. Create or locate:
   - A **published** resource
   - An **unpublished** resource
   - A **deleted** resource (that is still in the trash)
3. Confirm that:
   - Published resources use the solid dark icon.
   - Unpublished and deleted resources show the outline version of the icon.
4. Try switching publish status and check that the icon updates correctly.

---

### Related issue(s)/PR(s)

- Enhancement to PR: [#16759](https://github.com/modxcms/revolution/pull/16759)
