### PR TITLE
Add categoryId condition in GetListElement processor

### DIFF
--- a/core/src/Revolution/Processors/Element/GetList.php
+++ b/core/src/Revolution/Processors/Element/GetList.php
@@ -37,10 +37,19 @@ abstract class GetList extends GetListProcessor
         $c->select([
             'category_name' => 'Category.category',
         ]);
+        
         $id = $this->getProperty('id', '');
+        $categoryId = $this->getProperty('categoryId','');
+        
         if (!empty($id)) {
             $c->where([
                 $c->getAlias() . '.id:IN' => is_string($id) ? explode(',', $id) : $id,
+            ]);
+        }
+
+        if (!empty($categoryId)) {
+            $c->where([
+                'Category.id:IN' => is_string($categoryId) ? explode(',', $categoryId) : $categoryId,
             ]);
         }
 


### PR DESCRIPTION
### What does it do?
More powerful processor

### Why is it needed?
In CMP or custom Resources sometimes need filter elements by categoryId in GetListElement Processor.