### PR TITLE
Make modNamespace's translatePath method null-safe

### DIFF
--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -97,6 +97,9 @@ class modNamespace extends modAccessibleObject
 
     public static function translatePath(xPDO &$xpdo, $path)
     {
+        if ($path === null) {
+            $path = '';
+        }
         return str_replace([
             '{core_path}',
             '{base_path}',

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -11,17 +11,17 @@ use xPDO\xPDO;
  * Represents a Component in the MODX framework. Isolates controllers, lexicons and other logic into the virtual
  * containment space defined by the path of the namespace.
  *
- * @property string                $name The key of the namespace
- * @property string                $path The absolute path of the namespace. May use {core_path}, {base_path} or {assets_path} as
+ * @property string $name The key of the namespace
+ * @property string $path The absolute path of the namespace. May use {core_path}, {base_path} or {assets_path} as
  * placeholders for the path.
- * @property string                $assets_path
+ * @property string $assets_path
  *
- * @property modLexiconEntry[]     $LexiconEntries
- * @property modSystemSetting[]    $SystemSettings
- * @property modContextSetting[]   $ContextSettings
- * @property modUserSetting[]      $UserSettings
+ * @property modLexiconEntry[] $LexiconEntries
+ * @property modSystemSetting[] $SystemSettings
+ * @property modContextSetting[] $ContextSettings
+ * @property modUserSetting[] $UserSettings
  * @property modExtensionPackage[] $ExtensionPackages
- * @property modAccessNamespace[]  $Acls
+ * @property modAccessNamespace[] $Acls
  *
  * @package MODX\Revolution
  */
@@ -55,10 +55,16 @@ class modNamespace extends modAccessibleObject
         $cacheKey = 'namespaces';
         $cache = $modx->cacheManager->get($cacheKey, [
             xPDO::OPT_CACHE_KEY => $modx->getOption('cache_namespaces_key', null, 'namespaces'),
-            xPDO::OPT_CACHE_HANDLER => $modx->getOption('cache_namespaces_handler', null,
-                $modx->getOption(xPDO::OPT_CACHE_HANDLER)),
-            xPDO::OPT_CACHE_FORMAT => (integer)$modx->getOption('cache_namespaces_format', null,
-                $modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
+            xPDO::OPT_CACHE_HANDLER => $modx->getOption(
+                'cache_namespaces_handler',
+                null,
+                $modx->getOption(xPDO::OPT_CACHE_HANDLER)
+            ),
+            xPDO::OPT_CACHE_FORMAT => (int)$modx->getOption(
+                'cache_namespaces_format',
+                null,
+                $modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)
+            ),
         ]);
         if (empty($cache)) {
             $cache = $modx->cacheManager->generateNamespacesCache($cacheKey);
@@ -72,10 +78,16 @@ class modNamespace extends modAccessibleObject
         $cacheKey = 'namespaces';
         $cleared = $modx->cacheManager->delete($cacheKey, [
             xPDO::OPT_CACHE_KEY => $modx->getOption('cache_namespaces_key', null, 'namespaces'),
-            xPDO::OPT_CACHE_HANDLER => $modx->getOption('cache_namespaces_handler', null,
-                $modx->getOption(xPDO::OPT_CACHE_HANDLER)),
-            xPDO::OPT_CACHE_FORMAT => (integer)$modx->getOption('cache_namespaces_format', null,
-                $modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
+            xPDO::OPT_CACHE_HANDLER => $modx->getOption(
+                'cache_namespaces_handler',
+                null,
+                $modx->getOption(xPDO::OPT_CACHE_HANDLER)
+            ),
+            xPDO::OPT_CACHE_FORMAT => (int)$modx->getOption(
+                'cache_namespaces_format',
+                null,
+                $modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)
+            ),
         ]);
 
         return $cleared;

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -98,7 +98,7 @@ class modNamespace extends modAccessibleObject
     public static function translatePath(xPDO &$xpdo, $path)
     {
         if ($path === null) {
-            $path = '';
+            return '';
         }
         return str_replace([
             '{core_path}',


### PR DESCRIPTION
### What does it do?
Replaces NULL `$path` with empty string.

### Why is it needed?
The `str_replace` fn no longer quietly allows a null value to be passed to its subject param. Deprecation notices show in php logs when null is passed in php 8.1+.

### How to test

1. Change a namespace's core or assets path to NULL via sql query. 
2. Observe the php logs after clearing modx's cache (before loading this PR); you should see the deprecation notice(s). 
3. Load the PR and clear cache again. There should be no deprecation notices (of the type seen in step 2).

### Future Consideration
This could also be avoided by altering the _path_ and _assets_path_ columns in the namespaces table to be not null with default of empty string.

### Related issue(s)/PR(s)
No related issue.
