### PR TITLE
Fix addEventListener in core/components/*/bootstrap.php and allow anonymous functions

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -119,6 +119,14 @@ class modX extends xPDO {
      * @var array A map of elements registered to specific events.
      */
     public $eventMap= null;
+    /** 
+     * @var array<string, array<int, string>> Runtime listeners added via addEventListener() 
+     */
+    protected $runtimeEventMap = [];
+    /**
+     *  @var array<string, array<int, \Closure>> Closure-based listeners added via addEventListenerClosure() 
+     */
+    protected $closureEventMap = [];
     /**
      * @var array A map of already processed Elements.
      */
@@ -1679,61 +1687,94 @@ class modX extends xPDO {
      * @param array $params Optional params provided to the elements registered with an event.
      * @return bool|array
      */
-    public function invokeEvent($eventName, array $params= []) {
-        if (!$eventName)
-            return false;
-        if ($this->eventMap === null && $this->context instanceof modContext)
+    public function invokeEvent($eventName, array $params = []) {
+        if (!$eventName) return false;
+    
+        // Initialize the map from the database if necessary
+        if ($this->eventMap === null && $this->context instanceof modContext) {
             $this->_initEventMap($this->context->get('key'));
-        if (!isset ($this->eventMap[$eventName])) {
-            //$this->log(modX::LOG_LEVEL_DEBUG,'System event '.$eventName.' was executed but does not exist.');
-            return false;
         }
-        $results= [];
-        if (count($this->eventMap[$eventName])) {
-            $this->event= new modSystemEvent();
-            foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
+    
+        $results = [];
+    
+        // 1) Build a combined list of plugins: persistent (from the database) + runtime
+        $persistent = (isset($this->eventMap[$eventName]) && is_array($this->eventMap[$eventName]))
+            ? $this->eventMap[$eventName]
+            : [];
+    
+        $runtime = (!empty($this->runtimeEventMap[$eventName]) && is_array($this->runtimeEventMap[$eventName]))
+            ? $this->runtimeEventMap[$eventName]
+            : [];
+    
+        // Combine them so that persistent ones have priority (we do not allow duplicates for the same pluginId)
+        $combinedPlugins = $persistent + $runtime;
+    
+        // 2) Calling plugins (as before), but now using $combinedPlugins
+        if (!empty($combinedPlugins)) {
+            $this->event = new modSystemEvent();
+    
+            foreach ($combinedPlugins as $pluginId => $pluginPropset) {
                 /** @var modPlugin $plugin */
-                $plugin= null;
+                $plugin = null;
                 $this->Event = clone $this->event;
                 $this->event->resetEventObject();
-                $this->event->name= $eventName;
-                if (isset ($this->pluginCache[$pluginId])) {
-                    $plugin= $this->newObject(modPlugin::class);
+                $this->event->name = $eventName;
+    
+                if (isset($this->pluginCache[$pluginId])) {
+                    $plugin = $this->newObject(modPlugin::class);
                     $plugin->fromArray($this->pluginCache[$pluginId], '', true, true);
                     $plugin->_processed = false;
                     if ($plugin->get('disabled')) {
-                        $plugin= null;
+                        $plugin = null;
                     }
                 } else {
-                    $plugin= $this->getObject(modPlugin::class, ['id' => intval($pluginId), 'disabled' => '0'], true);
+                    $plugin = $this->getObject(modPlugin::class, ['id' => intval($pluginId), 'disabled' => '0'], true);
                 }
+    
                 if ($plugin && !$plugin->get('disabled')) {
                     $this->event->plugin =& $plugin;
-                    $this->event->activated= true;
-                    $this->event->activePlugin= $plugin->get('name');
-                    $this->event->propertySet= (($pspos = strpos($pluginPropset, ':')) >= 1) ? substr($pluginPropset, $pspos + 1) : '';
-
-                    /* merge in plugin properties */
-                    $eventParams = array_merge($plugin->getProperties(),$params);
-
-                    $msg= $plugin->process($eventParams);
-                    $results[]= $this->event->_output;
+                    $this->event->activated = true;
+                    $this->event->activePlugin = $plugin->get('name');
+                    $this->event->propertySet = (($pspos = strpos($pluginPropset, ':')) >= 1) ? substr($pluginPropset, $pspos + 1) : '';
+    
+                    $eventParams = array_merge($plugin->getProperties(), $params);
+    
+                    $msg = $plugin->process($eventParams);
+                    $results[] = $this->event->_output;
+    
                     if ($msg && is_string($msg)) {
                         $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . ']' . $msg);
                     } elseif ($msg === false) {
                         $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . '] Plugin ' . $plugin->name . ' failed!');
                     }
+    
                     $this->event->plugin = null;
-                    $this->event->activePlugin= '';
-                    $this->event->propertySet= '';
+                    $this->event->activePlugin = '';
+                    $this->event->propertySet = '';
                     if (!$this->event->isPropagatable()) {
                         break;
                     }
                 }
             }
         }
-        return $results;
+    
+        if (!empty($this->closureEventMap[$eventName])) {
+            usort($this->closureEventMap[$eventName], function ($a, $b) {
+                return $a['priority'] <=> $b['priority'];
+            });
+        
+            foreach ($this->closureEventMap[$eventName] as $listener) {
+                try {
+                    $results[] = $listener['callback']($params, $this);
+                } catch (\Throwable $e) {
+                    $this->log(modX::LOG_LEVEL_ERROR, "[{$eventName}] Closure failed: " . $e->getMessage());
+                }
+            }
+        }
+    
+        return $results ?: false;
     }
+    
 
     /**
      * Loads and runs a specific processor.
@@ -2062,16 +2103,36 @@ class modX extends xPDO {
      */
     public function removeEventListener($event, $pluginId = 0) {
         $removed = false;
+    
+        // Remove from persistent map (as before)
         if (!empty($event) && isset($this->eventMap[$event])) {
             if (intval($pluginId)) {
-                unset ($this->eventMap[$event][$pluginId]);
+                unset($this->eventMap[$event][$pluginId]);
             } else {
-                unset ($this->eventMap[$event]);
+                unset($this->eventMap[$event]);
             }
             $removed = true;
         }
+    
+        // Remove from runtime map
+        if (!empty($event) && isset($this->runtimeEventMap[$event])) {
+            if (intval($pluginId)) {
+                unset($this->runtimeEventMap[$event][$pluginId]);
+            } else {
+                unset($this->runtimeEventMap[$event]);
+            }
+            $removed = true;
+        }
+    
+        // Closures are removed only by event (no point comparison of Closures)
+        if (!empty($event) && isset($this->closureEventMap[$event]) && !intval($pluginId)) {
+            unset($this->closureEventMap[$event]);
+            $removed = true;
+        }
+    
         return $removed;
     }
+    
 
     /**
      * Remove all registered events for the current request.
@@ -2079,6 +2140,41 @@ class modX extends xPDO {
     public function removeAllEventListener() {
         unset ($this->eventMap);
         $this->eventMap= [];
+        $this->runtimeEventMap = [];
+        $this->closureEventMap = [];
+    }
+
+    /**
+     * Remove all runtime event listeners added via addEventListener() or addEventListenerClosure()
+     */
+    public function removeAllRuntimeEventListeners() {
+        $this->runtimeEventMap = [];
+        $this->closureEventMap = [];
+    }
+    
+    /** 
+     * Remove all closure listeners for a specific event (and optionally by priority)
+     * @param string $event
+     * @param int|null $priority
+     * @return boolean
+     */
+    public function removeEventListenerClosure(string $event, ?int $priority = null): bool
+    {
+        if (empty($event) || !isset($this->closureEventMap[$event])) {
+            return false;
+        }
+
+        if ($priority === null) {
+            unset($this->closureEventMap[$event]);
+            return true;
+        }
+
+        $this->closureEventMap[$event] = array_filter(
+            $this->closureEventMap[$event],
+            fn($listener) => $listener['priority'] !== $priority
+        );
+
+        return true;
     }
 
     /**
@@ -2092,15 +2188,43 @@ class modX extends xPDO {
     public function addEventListener($event, $pluginId, $propertySetName = '') {
         $added = false;
         $pluginId = intval($pluginId);
+    
         if ($event && $pluginId) {
-            if (!isset($this->eventMap[$event]) || empty ($this->eventMap[$event])) {
-                $this->eventMap[$event]= [];
+            if (!isset($this->runtimeEventMap[$event]) || empty($this->runtimeEventMap[$event])) {
+                $this->runtimeEventMap[$event] = [];
             }
-            $this->eventMap[$event][$pluginId]= $pluginId . (!empty($propertySetName) ? ':' . $propertySetName : '');
+            $this->runtimeEventMap[$event][$pluginId] = $pluginId . (!empty($propertySetName) ? ':' . $propertySetName : '');
             $added = true;
         }
         return $added;
     }
+
+    /**
+     * Add a closure-based listener for a system event (runtime only).
+     *
+     * @param string   $event
+     * @param \Closure $callback function(array $params, modX $modx): mixed
+     * @param int      $priority Lower value = earlier execution (default 10)
+     * @return bool
+     */
+    public function addEventListenerClosure(string $event, \Closure $callback, int $priority = 0): bool
+    {
+        if (!$event || !$callback) {
+            return false;
+        }
+
+        if (!isset($this->closureEventMap[$event])) {
+            $this->closureEventMap[$event] = [];
+        }
+
+        $this->closureEventMap[$event][] = [
+            'priority' => $priority,
+            'callback' => $callback,
+        ];
+
+        return true;
+    }
+
 
     /**
      * Switches the primary Context for the modX instance.

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -122,11 +122,15 @@ class modX extends xPDO {
     /** 
      * @var array<string, array<int, string>> Runtime listeners added via addEventListener() 
      */
-    protected $runtimeEventMap = [];
+    public $runtimeEventMap = [];
     /**
      *  @var array<string, array<int, \Closure>> Closure-based listeners added via addEventListenerClosure() 
      */
-    protected $closureEventMap = [];
+    public $closureEventMap = [];
+    /** 
+     * @var int Monotonic sequence to keep stable order for same priority 
+     */
+    public $closureEventSeq = 0;
     /**
      * @var array A map of already processed Elements.
      */
@@ -1759,9 +1763,13 @@ class modX extends xPDO {
         }
     
         if (!empty($this->closureEventMap[$eventName])) {
-            usort($this->closureEventMap[$eventName], function ($a, $b) {
-                return $a['priority'] <=> $b['priority'];
-            });
+            usort(
+                $this->closureEventMap[$eventName],
+                static function (array $a, array $b) {
+                    $byPrio = $a['priority'] <=> $b['priority'];
+                    return $byPrio !== 0 ? $byPrio : ($a['seq'] <=> $b['seq']);
+                }
+            );
         
             foreach ($this->closureEventMap[$eventName] as $listener) {
                 try {
@@ -2152,30 +2160,60 @@ class modX extends xPDO {
         $this->closureEventMap = [];
     }
     
-    /** 
-     * Remove all closure listeners for a specific event (and optionally by priority)
-     * @param string $event
-     * @param int|null $priority
-     * @return boolean
+    /**
+     * Remove closure listeners.
+     *
+     * @param ?string $event    If set, remove only in this event.
+     *                          If null/empty, and $name provided — remove in all events.
+     *                          If null/empty, and $name=null — clear entire closureEventMap.
+     * @param ?int    $priority If set, remove only listeners with this priority.
+     * @param ?string $name     If set, remove only listeners with this name.
+     * @return bool True if something was removed.
      */
-    public function removeEventListenerClosure(string $event, ?int $priority = null): bool
+    public function removeEventListenerClosure(?string $event = null, ?int $priority = null, ?string $name = null): bool
     {
-        if (empty($event) || !isset($this->closureEventMap[$event])) {
-            return false;
-        }
+        $removed = false;
 
-        if ($priority === null) {
-            unset($this->closureEventMap[$event]);
+        // Ветка 1: полный wipe
+        if (empty($event) && $name === null && $priority === null) {
+            $this->closureEventMap = [];
             return true;
         }
 
-        $this->closureEventMap[$event] = array_filter(
-            $this->closureEventMap[$event],
-            fn($listener) => $listener['priority'] !== $priority
-        );
+        // Ветка 2: поиск по всем событиям (если event пустой, а имя или приоритет заданы)
+        $eventsToCheck = empty($event) ? array_keys($this->closureEventMap) : [$event];
 
-        return true;
+        foreach ($eventsToCheck as $ev) {
+            if (!isset($this->closureEventMap[$ev])) {
+                continue;
+            }
+
+            $before = count($this->closureEventMap[$ev]);
+            $this->closureEventMap[$ev] = array_values(array_filter(
+                $this->closureEventMap[$ev],
+                static function (array $l) use ($priority, $name) {
+                    if ($priority !== null && (int)$l['priority'] !== $priority) {
+                        return true; // оставляем
+                    }
+                    if ($name !== null && ($l['name'] ?? null) !== $name) {
+                        return true; // оставляем
+                    }
+                    return false; // совпал — удаляем
+                }
+            ));
+
+            if (empty($this->closureEventMap[$ev])) {
+                unset($this->closureEventMap[$ev]);
+            }
+
+            if ($before !== count($this->closureEventMap[$ev] ?? [])) {
+                $removed = true;
+            }
+        }
+
+        return $removed;
     }
+
 
     /**
      * Add a plugin to the eventMap within the current execution cycle.
@@ -2204,20 +2242,35 @@ class modX extends xPDO {
      *
      * @param string   $event
      * @param \Closure $callback function(array $params, modX $modx): mixed
-     * @param int      $priority Lower value = earlier execution (default 10)
+     * @param int      $priority  Lower = earlier execution (default 10)
+     * @param ?string  $name      Optional logical name to manage/remove listener
+     * @param bool     $replace   If true and $name exists — replace it (default true)
      * @return bool
      */
-    public function addEventListenerClosure(string $event, \Closure $callback, int $priority = 0): bool
-    {
-        if (!$event || !$callback) {
-            return false;
-        }
+    public function addEventListenerClosure(
+        string $event,
+        \Closure $callback,
+        int $priority = 10,
+        ?string $name = null,
+        bool $replace = true
+    ): bool {
+        if (!$event || !$callback) return false;
 
         if (!isset($this->closureEventMap[$event])) {
             $this->closureEventMap[$event] = [];
         }
 
+        // If a name is provided and replace is true — remove existing with that name
+        if ($name !== null && $replace) {
+            $this->closureEventMap[$event] = array_values(array_filter(
+                $this->closureEventMap[$event],
+                static fn(array $l) => ($l['name'] ?? null) !== $name
+            ));
+        }
+
         $this->closureEventMap[$event][] = [
+            'seq'      => ++$this->closureEventSeq, // keep stable order for same priority
+            'name'     => $name,                    // can be null
             'priority' => $priority,
             'callback' => $callback,
         ];


### PR DESCRIPTION
### What does it do?

This PR introduces **runtime and closure-based event listeners** with support for **priority** and **optional names** in `modX`.

I tried to leave 100% backward compatibility - we get a similar addEventListener syntax and correct operation of plugins and events, while getting a powerful tool for managing listeners in packages.

Main technical changes:

* Added two new internal maps:

  * `runtimeEventMap` — stores runtime listeners added via `addEventListener()` so they are not overwritten by `_initEventMap()`.
  * `closureEventMap` — stores closure-based listeners with `priority`, `name`, and `callback`.

* Added new method:

  ```php
  public function addEventListenerClosure(
      string $event,
      \Closure $callback,
      int $priority = 0,
      ?string $name = null,
      bool $replace = true
  ): bool
  ```

  This allows developers to register closure-based listeners with configurable execution order and optional unique names.

* Updated `invokeEvent()`:

  1. Executes persistent DB plugins (`eventMap`) as before.
  2. Executes runtime listeners (`runtimeEventMap`).
  3. Executes closure listeners (`closureEventMap`), sorted by priority (lower = earlier).

* Added universal removal method:

  ```php
  public function removeEventListenerClosure(
      ?string $event = null,
      ?int $priority = null,
      ?string $name = null
  ): bool
  ```

  Behavior:

  * If only `$event` is provided → remove listeners for that event.
  * If `$event` is null and `$name` provided → remove all listeners with that name across all events.
  * If `$event` is null and `$priority` provided → remove all listeners with that priority across all events.
  * If everything is null → clear all closure listeners.
  
 * Improved the `removeEventListener` method:
   - It can now remove listeners by plugin ID or all handlers if the plugin ID is not specified.
   - It also removes from the new runtime and closure event maps.
  
 * Clearing of `runtimeEventMap` and `closureEventMap` has been added to the old `removeAllEventListener` method.
  
 * Added `removeAllRuntimeEventListeners` method which clears new event maps `runtimeEventMap` and `closureEventMap`.

### Why is it needed?

Currently, `addEventListener()` writes into `$eventMap`, which is later reset by `_initEventMap()` when loading from DB. As a result, listeners registered in `bootstrap.php` or other runtime code are lost.

With this PR:

* Runtime listeners persist throughout the request lifecycle.
* Developers can attach closures without needing to define plugins in the database.
* Execution order is predictable thanks to `priority`.
* Closure Listeners can be easily replaced or removed by `name`, which simplifies package development and testing.

This feature makes it possible to extend MODX in a more lightweight and programmatic way.

---

### How to test

- Use regular modx project

- Go to project `core` directory and change `modX.php` file from my repo
  ```
  cd yourmodxroot/core
  curl https://raw.githubusercontent.com/OlegAnTo2000/revolution/fix-bootstrap-events/core/src/Revolution/modX.php -o src/Revolution/modX.php
  ```

- Download and install (or create your own) package with `bootstrap.php` file, for example pdoTools.

- **Register a closure listener in `core/components/yourextra/bootstrap.php`:**

   ```php
   $modx->addEventListenerClosure(
       'OnWebPagePrerender',
       function (array $params, \MODX\Revolution\modX $modx) {
           $output = &$modx->resource->_output;
           $output .= "\n<!-- TEST CLOSURE: " . date('Y-m-d H:i:s') . " -->";
           return null;
       },
       priority: 5,
       name: 'appendTestComment'
   );
   ```

   * Open any frontend page.
   * View page source.
   * Expected: the HTML ends with a comment like:

     ```html
     <!-- TEST CLOSURE: 2025-09-17 20:45:00 -->
     ```

- **Verify priority order:**

   ```php
   $modx->addEventListenerClosure(
       'OnWebPagePrerender',
       function (array $params, \MODX\Revolution\modX $modx) {
           $output = &$modx->resource->_output;
           $output .= "\n<!-- TEST CLOSURE 1: " . date('Y-m-d H:i:s') . " -->";
           return null;
       },
       priority: 5,
       name: 'appendTestComment',
       replace: false
   );
   $modx->addEventListenerClosure(
       'OnWebPagePrerender',
       function (array $params, \MODX\Revolution\modX $modx) {
           $output = &$modx->resource->_output;
           $output .= "\n<!-- TEST CLOSURE 2: " . date('Y-m-d H:i:s') . " -->";
           return null;
       },
       priority: 10,
       name: 'appendTestComment',
       replace: false
   );
   ```

   * Refresh the page.
   * Expected order:

     ```
     <!-- TEST CLOSURE 1 ... -->
     <!-- TEST CLOSURE 2 ... -->
     ```

   Swap priorities and confirm that order changes accordingly.
   
- **Test replace by name:**
   ```php
   $modx->addEventListenerClosure(
       'OnWebPagePrerender',
       function (array $params, \MODX\Revolution\modX $modx) {
           $output = &$modx->resource->_output;
           $output .= "\n<!-- TEST CLOSURE 1: " . date('Y-m-d H:i:s') . " -->";
           return null;
       },
       priority: 5,
       name: 'appendTestComment',
       replace: true // can be replaced
   );
   $modx->addEventListenerClosure(
       'OnWebPagePrerender',
       function (array $params, \MODX\Revolution\modX $modx) {
           $output = &$modx->resource->_output;
           $output .= "\n<!-- TEST CLOSURE 2: " . date('Y-m-d H:i:s') . " -->";
           return null;
       },
       priority: 10,
       name: 'appendTestComment',
       replace: true // can be replaced
   );
   ```
   * Refresh the page.
   * Only the second comment was expected:

     ```
     <!-- TEST CLOSURE 2 ... -->
     ```

- **Test removal by event:**

   ```php
   $modx->removeEventListenerClosure('OnWebPagePrerender');
   ```

   * Refresh the page.
   * Expected: no closure-based comments at all.

- **Test removal by name (global):**

   ```php
   $modx->removeEventListenerClosure(null, null, 'appendTestComment');
   ```

   * Only listeners named `appendComment` should be removed across all events.

- **Test removal by priority:**

   ```php
   $modx->removeEventListenerClosure(null, 5, null);
   ```

   * All closure listeners with priority 5 should be removed.

- **Test error handling:**

   ```php
   $modx->addEventListenerClosure('OnWebPagePrerender', function () {
       throw new \Exception("Boom!");
   }, name: 'errorTest');
   ```

   * Refresh the page.
   * Expected: page renders normally, but error log contains:

     ```
     [OnWebPagePrerender] Closure failed: Boom!
     ```

---

### Related issue(s)/PR(s)

Closes #16768
