### PR TITLE
Remove JSONP callback support in modConnectorResponse

### DIFF
--- a/core/src/Revolution/modConnectorResponse.php
+++ b/core/src/Revolution/modConnectorResponse.php
@@ -192,9 +192,6 @@ class modConnectorResponse extends modResponse
                 'object' => isset($this->body['object']) ? $this->body['object'] : [],
             ]);
 
-            if (!empty($_GET['callback'])) {
-                $json = $modx->stripTags($_GET['callback']) . '(' . $json . ')';
-            }
             die($json);
         } else {
             @session_write_close();


### PR DESCRIPTION
### What does it do?
Removes the JSONP callback support in modConnectorResponse.

### Why is it needed?
This feature is potentially vulnerable to JSONP injection.

### How to test
Make sure any callback parameters to a connector request are ignored.

### Related issue(s)/PR(s)
#12420 and #13051 — vulnerability was reported privately.