### PR TITLE
Fix undefined variable error in modTemplateVar

### DIFF
--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -1136,9 +1136,9 @@ class modTemplateVar extends modElement
         $enabled = ($catEnabled || $rgEnabled);
         if ($enabled) {
             if (empty($this->_policies) || !isset($this->_policies[$context])) {
+                $policyTable = $this->xpdo->getTableName(modAccessPolicy::class);
                 if ($rgEnabled) {
                     $accessTable = $this->xpdo->getTableName(modAccessResourceGroup::class);
-                    $policyTable = $this->xpdo->getTableName(modAccessPolicy::class);
                     $resourceGroupTable = $this->xpdo->getTableName(modTemplateVarResourceGroup::class);
                     $sql = "SELECT Acl.target, Acl.principal, Acl.authority, Acl.policy, Policy.data FROM {$accessTable} Acl " .
                         "LEFT JOIN {$policyTable} Policy ON Policy.id = Acl.policy " .


### PR DESCRIPTION


### What does it do?
Move `$policyTable` statement up in scope to avoid error that occurs when `$rgEnabled` is false and `$catEnabled` is true.

### Why is it needed?
In certain scenarios the condition above happens and the error log can quickly fill up with the following warning:
`[...server_path]/core/src/Revolution/modTemplateVar.php : 1141) PHP warning: Undefined variable $policyTable`

### How to test
It's a bit of a needle in the haystack, so I don't have a suggested way to trigger the problematic condition. However, logically, the change made should be done regardless.

### Related issue(s)/PR(s)
This is a port of the same change made for 2.x some time ago (PR #16427).

