### PR TITLE
Fix mail reset method call in modUser.php

### DIFF
--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -958,7 +958,7 @@ class modUser extends modPrincipal
             $err = $this->xpdo->lexicon('error_sending_email_to') . $profile->get('email') . ': ' . $mail->mailer->ErrorInfo;
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $err);
         }
-        $this->xpdo->mail->reset();
+        $mail->reset();
 
         return $sent;
     }


### PR DESCRIPTION
### What does it do?

This fixes an issue that occurred when sending a user a link to choose or reset their password.

### Why is it needed?

The following error occurs when trying to use both features:

```
Error: Call to a member function reset() on null

/MODX/site/core/src/Revolution/modUser.php:961
 SecurityLoginManagerController->handleForgotLogin() in /MODX/site/manager/controllers/default/security/login.class.php:366
 SecurityLoginManagerController->handlePost() in /MODX/site/manager/controllers/default/security/login.class.php:60
 SecurityLoginManagerController->process(Array ( [username_reset] => ***@***.de [forgotlogin] => 1 ) ) in /MODX/site/core/src/Revolution/modManagerController.php:180
 MODX\Revolution\modManagerController->render() in /MODX/site/core/src/Revolution/modManagerResponse.php:114
 MODX\Revolution\modManagerResponse->outputContent(Array ( ) ) in /MODX/site/core/src/Revolution/modManagerRequest.php:173
 MODX\Revolution\modManagerRequest->prepareResponse() in /MODX/site/core/src/Revolution/modManagerRequest.php:143
 MODX\Revolution\modManagerRequest->handleRequest() in /MODX/site/manager/index.php:60
```

MODX 3.1.2
PHP 8.3.25
