### PR TITLE
Fix image rotation on upload

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1182,6 +1182,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
             }
 
+            // Check if Orientation is correct due to EXIF issues in JPG/JPEG and rotate if needed.
             try {
                 $image_extensions = ['jpg', 'jpeg'];
                 $file_extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -32,6 +32,7 @@ use PDO;
 use xPDO\Cache\xPDOCacheManager;
 use xPDO\Om\xPDOCriteria;
 use xPDO\xPDO;
+use MODX\Revolution\modPhpThumb;
 
 /**
  * An abstract base class extend to implement loading your League\Flysystem\AbstractAdapter
@@ -1182,7 +1183,27 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             }
 
             try {
-                $this->filesystem->write($newPath, file_get_contents($file['tmp_name']));
+                $image_extensions = ['jpg', 'jpeg'];
+                $file_extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+
+                if (in_array($file_extension, $image_extensions)) {
+                    $exif = @exif_read_data($file['tmp_name']);
+                    if (!empty($exif['Orientation']) && $exif['Orientation'] > 1) {
+                        $phpThumb = new modPhpThumb($this->xpdo, []);
+                        $phpThumb->setSourceFilename($file['tmp_name']);
+                        $phpThumb->setParameter('ar', 'x');
+                        if ($phpThumb->GenerateThumbnail()) {
+                            $image_string = $phpThumb->OutputThumbnailData();
+                            $this->filesystem->write($newPath, $image_string);
+                        } else {
+                            $this->filesystem->write($newPath, file_get_contents($file['tmp_name']));
+                        }
+                    } else {
+                        $this->filesystem->write($newPath, file_get_contents($file['tmp_name']));
+                    }
+                } else {
+                    $this->filesystem->write($newPath, file_get_contents($file['tmp_name']));
+                }
             } catch (FilesystemException | UnableToWriteFile $e) {
                 $this->addError('path', $this->xpdo->lexicon('file_err_upload'));
                 $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());


### PR DESCRIPTION
### What does it do?
Added an Exif check for edited images and if the have been Orientated.
If Orientated, make sure the image is also saved with the correct data.

### Why is it needed?
Certain software doesn't save the edit data correctly which will cause rotated imaged to be reverted back after upload.

### How to test
Rotate an image, upload it to the site, check if the image is still in correct position.

### Related issue(s)/PR(s)
Resolves: #16785 and also resolves https://github.com/modxcms/revolution/pull/15484
