### PR TITLE
Add missing validation and lexicon for Roles

### DIFF
--- a/core/lexicon/en/user.inc.php
+++ b/core/lexicon/en/user.inc.php
@@ -39,6 +39,7 @@ $_lang['role_desc_authority'] = 'The Authority level of the role. Lower Authorit
 $_lang['role_desc_name'] = 'A name for the Role, such as Content Editor, Publisher, System Administrator, etc.';
 $_lang['role_desc_description'] = 'A short description of the Role.';
 $_lang['role_err_ae'] = 'A role already exists with that name.';
+$_lang['role_err_authority_exists'] = 'The specified Authority level is being used by another Role. (Authority levels must be unique.)';
 $_lang['role_err_duplicate'] = 'An error occurred while duplicating the role.';
 $_lang['role_err_has_users'] = 'There are users with this role. It cannot be deleted.';
 $_lang['role_err_nf'] = 'Role not found.';

--- a/core/src/Revolution/Processors/Security/Role/Create.php
+++ b/core/src/Revolution/Processors/Security/Role/Create.php
@@ -31,12 +31,17 @@ class Create extends CreateProcessor
     public function beforeSave()
     {
         $name = $this->getProperty('name');
+        $authority = (int)$this->getProperty('authority', 0);
+
         if (empty($name)) {
             $this->addFieldError('name', $this->modx->lexicon('role_err_ns_name'));
         }
 
         if ($this->alreadyExists($name)) {
             $this->addFieldError('name', $this->modx->lexicon('role_err_ae'));
+        }
+        if ($this->authorityExists($authority)) {
+            $this->addFieldError('authority', $this->modx->lexicon('role_err_authority_exists'));
         }
 
         return parent::beforeSave();
@@ -50,5 +55,15 @@ class Create extends CreateProcessor
     public function alreadyExists($name)
     {
         return $this->modx->getCount(modUserGroupRole::class, ['name' => $name]) > 0;
+    }
+
+    /**
+     * Check whether the specified authority level already exists
+     * @param int $authority
+     * @return boolean
+     */
+    public function authorityExists(int $authority)
+    {
+        return $this->modx->getCount(modUserGroupRole::class, ['authority' => $authority]) > 0;
     }
 }

--- a/core/src/Revolution/Processors/Security/Role/Create.php
+++ b/core/src/Revolution/Processors/Security/Role/Create.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Security\Role;
-
 
 use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\modUserGroupRole;

--- a/core/src/Revolution/Processors/Security/Role/Update.php
+++ b/core/src/Revolution/Processors/Security/Role/Update.php
@@ -32,10 +32,44 @@ class Update extends UpdateProcessor
     public function beforeSave()
     {
         $name = $this->getProperty('name');
+        $authority = (int)$this->getProperty('authority', 0);
+
         if (empty($name)) {
             $this->addFieldError('name', $this->modx->lexicon('role_err_ns_name'));
         }
+        if ($this->alreadyExists($name)) {
+            $this->addFieldError('name', $this->modx->lexicon('role_err_ae'));
+        }
+        if ($this->authorityExists($authority)) {
+            $this->addFieldError('authority', $this->modx->lexicon('role_err_authority_exists'));
+        }
 
         return parent::beforeSave();
+    }
+
+    /**
+     * Check to see if a role already exists with the specified name
+     * @param string $name
+     * @return boolean
+     */
+    public function alreadyExists($name)
+    {
+        return $this->modx->getCount(
+            modUserGroupRole::class,
+            ['name' => $name, 'id:!=' => $this->getProperty('id')]
+        ) > 0;
+    }
+
+    /**
+     * Check whether the specified authority level already exists
+     * @param int $authority
+     * @return boolean
+     */
+    public function authorityExists(int $authority)
+    {
+        return $this->modx->getCount(
+            modUserGroupRole::class,
+            ['authority' => $authority, 'id:!=' => $this->getProperty('id')]
+        ) > 0;
     }
 }

--- a/core/src/Revolution/Processors/Security/Role/Update.php
+++ b/core/src/Revolution/Processors/Security/Role/Update.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Security\Role;
-
 
 use MODX\Revolution\Processors\Model\UpdateProcessor;
 use MODX\Revolution\modUserGroupRole;

--- a/manager/assets/modext/widgets/security/modx.grid.role.js
+++ b/manager/assets/modext/widgets/security/modx.grid.role.js
@@ -153,7 +153,8 @@ MODx.window.CreateRole = function(config = {}) {
         action: 'Security/Role/Create',
         formDefaults: {
             allowBlank: false,
-            anchor: '100%'
+            anchor: '100%',
+            msgTarget: 'under'
         },
         fields: [{
             name: 'name',


### PR DESCRIPTION
### What does it do?
Added new `authorityExists` method for Create/Update processors and related lexicon error message. Also added missing `alreadyExists` to Update processor.

### Why is it needed?
A recent introduction of the requirement for Role Authorities to be unique failed to add specific validation checks and messaging.

### How to test
Create and update Roles, attempting to specify already-used names and authority levels. Verify error messaging is clear.

### Related issue(s)/PR(s)
Resolves #16784. 
