### PR TITLE
Form Customization: Reveal Content Above & Below Regions

### DIFF
--- a/core/model/schema/modx.action.fields.schema.xml
+++ b/core/model/schema/modx.action.fields.schema.xml
@@ -25,6 +25,8 @@
         <tab name="modx-resource-content">
             <field name="modx-resource-content" />
         </tab>
+        <tab name="modx-resource-content-above" />
+        <tab name="modx-resource-content-below" />
         <tab name="modx-resource-main-right">
         </tab>
         <tab name="modx-resource-main-right-top">

--- a/core/src/Revolution/modActionDom.php
+++ b/core/src/Revolution/modActionDom.php
@@ -39,10 +39,21 @@ class modActionDom extends modAccessibleSimpleObject
         $ruleType = $this->get('rule');
 
         $container = json_encode($this->get('container'));
-        $itemId = json_encode($this->get('name'));
+        $itemId = $this->get('name');
+        $value = $this->get('value');
+
+        /** Backward compat: Support for legacy tab ids for above/below content regions */
+        foreach (['itemId', 'value'] as $identifier) {
+            $$identifier = in_array($$identifier, ['modx-content-above', 'modx-content-below'])
+            ? str_replace('modx-', 'modx-resource-', $$identifier)
+            : $$identifier
+            ;
+        }
+
+        $itemId = json_encode($itemId);
         $value = in_array($ruleType, $boolRules)
             ? (int)$this->get('value')
-            : json_encode(htmlspecialchars($this->get('value'), ENT_COMPAT, $encoding))
+            : json_encode(htmlspecialchars($value, ENT_COMPAT, $encoding))
             ;
 
         switch ($ruleType) {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -1046,7 +1046,9 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,hideMode: 'offsets'
             ,items: [{
                 id: 'modx-resource-content-above'
-                ,border: false
+            },{
+                /** @deprecated To be removed in 3.3, reference new region id 'modx-resource-content-above' */
+                id: 'modx-content-above'
             },{
                 xtype: 'textarea'
                 ,name: 'ta'
@@ -1057,8 +1059,10 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 ,grow: false
                 ,value: (config.record.content || config.record.ta) || ''
             },{
+                /** @deprecated To be removed in 3.3, reference new region id 'modx-resource-content-below' */
+                id: 'modx-content-below'
+            },{
                 id: 'modx-resource-content-below'
-                ,border: false
             }]
         };
     }

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -1045,7 +1045,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
             ,autoHeight: true
             ,hideMode: 'offsets'
             ,items: [{
-                id: 'modx-content-above'
+                id: 'modx-resource-content-above'
                 ,border: false
             },{
                 xtype: 'textarea'
@@ -1057,7 +1057,7 @@ Ext.extend(MODx.panel.Resource,MODx.FormPanel,{
                 ,grow: false
                 ,value: (config.record.content || config.record.ta) || ''
             },{
-                id: 'modx-content-below'
+                id: 'modx-resource-content-below'
                 ,border: false
             }]
         };


### PR DESCRIPTION
### What does it do?
Adds missing regions to FC set schema and renames those regions’ IDs to be more consistent with current naming convention.

### Why is it needed?
It's unclear that two additional regions exist above and below the main content field. Also, even though you can currently assign TVs to these regions, you can not control the overall visibility of those regions.

### How to test

1. Because there's a change to a schema, a full rebuild (_build/transport.core.php) and running of the setup (install) must first be done
2. Create at least one TV for testing
3. Create a Form Customization set, and note that the `modx-resource-content-above` and `modx-resource-content-below` now show in the Regions tab
4. Move a TV to both of these regions and verify they appear in the expected position in a Resource
5. Uncheck each of these regions in the FC Set Region tab and verify each region is hidden when viewing a Resource
6. Also, verify that usage of the legacy Region IDs work as well (`modx-content-above` and `modx-content-below`)

### Related issue(s)/PR(s)
Resolves #16442