### PR TITLE
Add settings for inline styles in modPHPMailer

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -966,6 +966,25 @@ $settings['mail_dkim_passphrase']->fromArray([
   'area' => 'mail',
   'editedon' => null,
 ], '', true, true);
+$settings['mail_inlinestyle_inline'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_inlinestyle_inline']->fromArray([
+  'key' => 'mail_inlinestyle_inline',
+  'value' => true,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'mail',
+  'editedon' => null,
+], '', true, true);
+
+$settings['mail_inlinestyle_remove_style_tags'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_inlinestyle_remove_style_tags']->fromArray([
+  'key' => 'mail_inlinestyle_remove_style_tags',
+  'value' => false,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'mail',
+  'editedon' => null,
+], '', true, true);
 $settings['manager_date_format'] = $xpdo->newObject(modSystemSetting::class);
 $settings['manager_date_format']->fromArray([
   'key' => 'manager_date_format',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -423,6 +423,12 @@ $_lang['setting_mail_dkim_privatekeystring_desc'] = 'Takes precedence over DKIM 
 $_lang['setting_mail_dkim_passphrase'] = 'DKIM Passphrase';
 $_lang['setting_mail_dkim_passphrase_desc'] = 'Used only if your key is encrypted.';
 
+$_lang['mail_inlinestyle_inline'] = 'InlineStyle: Enable style inlining for HTML emails';
+$_lang['mail_inlinestyle_inline_desc'] = 'All styles from &#x3C;style&#x3E; tags will be inlined for HTML emails.';
+
+$_lang['mail_inlinestyle_remove_style_tags'] = 'InlineStyle: Remove &#x3C;style&#x3E; tags';
+$_lang['mail_inlinestyle_remove_style_tags_desc'] = 'After inlining styles, all &#x3C;style&#x3E; tags will be removed. <strong>Warning: This can cause issues with responsive email templates.</strong>';
+
 $_lang['setting_main_nav_parent'] = 'Main menu parent';
 $_lang['setting_main_nav_parent_desc'] = 'The container used to pull all records for the main menu.';
 

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -222,13 +222,19 @@ class modPHPMailer extends modMail
 
         $sent = false;
         try {
-            if (!empty($this->mailer->Body) && (strpos($this->mailer->ContentType, 'html') !== false)) {
+            $inlineStyleEnabled = $this->modx->getOption('mail_inlinestyle_inline', null, true, true);
+            if (
+                $inlineStyleEnabled &&
+                !empty($this->mailer->Body) &&
+                (strpos($this->mailer->ContentType, 'html') !== false)
+            ) {
                 $body = $this->mailer->Body;
                 // Turn UTF-8 characters into entities
                 $body = mb_convert_encoding($body, 'HTML-ENTITIES', 'UTF-8');
                 $html = new InlineStyle($body);
+                $removeStyleTags = (bool) $this->modx->getOption('mail_inlinestyle_remove_style_tags', null, false, true);
                 /** @noinspection PhpParamsInspection */
-                $html->applyStylesheet($html->extractStylesheets());
+                $html->applyStylesheet($html->extractStylesheets(remove: $removeStyleTags));
                 $this->mailer->Body = $html->getHTML();
             }
             $sent = $this->mailer->send();

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -234,7 +234,9 @@ class modPHPMailer extends modMail
                 $html = new InlineStyle($body);
                 $removeStyleTags = (bool) $this->modx->getOption('mail_inlinestyle_remove_style_tags', null, false, true);
                 /** @noinspection PhpParamsInspection */
-                $html->applyStylesheet($html->extractStylesheets(remove: $removeStyleTags));
+                $html->applyStylesheet(
+                    $html->extractStylesheets(null, '', ['all', 'screen', 'handheld'], $removeStyleTags),
+                );
                 $this->mailer->Body = $html->getHTML();
             }
             $sent = $this->mailer->send();


### PR DESCRIPTION
### What does it do?
Adds 2 new system settings:
- `mail_inlinestyle_inline` (yes/no) – default yes (existing behavior)
- `mail_inlinestyle_remove_style_tags` (yes/no) – default no (this is a change in behavior, but also fixes current unexpected behavior - see discussion in #16715 )

### Why is it needed?
Fixes issues with `<style>` tags in HTML email templates and gives website owners more control. Styles should be inlined but `<style>` tags should be left in the markup and not removed. This is needed for example for email templates that involve media queries.

### How to test
See https://github.com/modxcms/revolution/issues/16715

### Related issue(s)/PR(s)
Resolves https://github.com/modxcms/revolution/issues/16715
