### PR TITLE
Filter special characters in error messages

### DIFF
--- a/core/src/Revolution/modDashboardWidgetInterface.php
+++ b/core/src/Revolution/modDashboardWidgetInterface.php
@@ -83,8 +83,11 @@ abstract class modDashboardWidgetInterface
             $output = $this->render();
         } catch (Throwable $t) {
             $this->controller->setPlaceholder('_e', [
-                'message' => $t->getMessage(),
-                'errors' => explode("\n", $t->getTraceAsString()),
+                'message' => htmlspecialchars($t->getMessage(), ENT_QUOTES),
+                'errors' => htmlspecialchars(
+                    explode("\n", $t->getTraceAsString()),
+                    ENT_QUOTES
+                ),
             ]);
             $output = $this->controller->fetchTemplate('error.tpl');
         }

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -205,7 +205,12 @@ abstract class modManagerController
 
         $tpl = $this->getTemplateFile();
         if ($this->isFailure) {
-            $this->setPlaceholder('_e', $this->modx->error->failure($this->failureMessage));
+            $this->setPlaceholder('_e',
+                filter_var_array(
+                    $this->modx->error->failure($this->failureMessage),
+                    FILTER_SANITIZE_FULL_SPECIAL_CHARS
+                )
+            );
             $content = $this->fetchTemplate('error.tpl');
         } else {
             if (!empty($tpl)) {

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -205,7 +205,8 @@ abstract class modManagerController
 
         $tpl = $this->getTemplateFile();
         if ($this->isFailure) {
-            $this->setPlaceholder('_e',
+            $this->setPlaceholder(
+                '_e',
                 filter_var_array(
                     $this->modx->error->failure($this->failureMessage),
                     FILTER_SANITIZE_FULL_SPECIAL_CHARS

--- a/core/src/Revolution/modManagerResponse.php
+++ b/core/src/Revolution/modManagerResponse.php
@@ -185,7 +185,8 @@ class modManagerResponse extends modResponse
     public function send()
     {
         if (is_array($this->body)) {
-            $this->modx->smarty->assign('_e',
+            $this->modx->smarty->assign(
+                '_e',
                 filter_var_array(
                     $this->body,
                     FILTER_SANITIZE_FULL_SPECIAL_CHARS

--- a/core/src/Revolution/modManagerResponse.php
+++ b/core/src/Revolution/modManagerResponse.php
@@ -185,7 +185,12 @@ class modManagerResponse extends modResponse
     public function send()
     {
         if (is_array($this->body)) {
-            $this->modx->smarty->assign('_e', $this->body);
+            $this->modx->smarty->assign('_e',
+                filter_var_array(
+                    $this->body,
+                    FILTER_SANITIZE_FULL_SPECIAL_CHARS
+                )
+            );
             if (!file_exists($this->modx->smarty->template_dir . 'error.tpl')) {
                 $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
                 $this->modx->smarty->setTemplatePath($templatePath);


### PR DESCRIPTION
### What does it do?
Add filtering to messages sent to the smarty error template

### Why is it needed?
Prevent special characters from being added to error messages