### PR TITLE
feat(2.x): Filter special characters in error messages

### DIFF
--- a/core/model/modx/modmanagercontroller.class.php
+++ b/core/model/modx/modmanagercontroller.class.php
@@ -180,7 +180,12 @@ abstract class modManagerController {
 
         $tpl = $this->getTemplateFile();
         if ($this->isFailure) {
-            $this->setPlaceholder('_e', $this->modx->error->failure($this->failureMessage));
+            $this->setPlaceholder('_e',
+                filter_var_array(
+                    $this->modx->error->failure($this->failureMessage),
+                    FILTER_SANITIZE_FULL_SPECIAL_CHARS
+                )
+            );
             $content = $this->fetchTemplate('error.tpl');
         } else if (!empty($tpl)) {
             $content = $this->fetchTemplate($tpl);

--- a/core/model/modx/modmanagercontrollerdeprecated.class.php
+++ b/core/model/modx/modmanagercontrollerdeprecated.class.php
@@ -76,7 +76,12 @@ class modManagerControllerDeprecated extends modManagerController {
 
         /* assign later to allow for css/js registering */
         if (is_array($cbody)) {
-            $this->setPlaceholder('_e', $cbody);
+            $this->setPlaceholder('_e',
+                filter_var_array(
+                    $cbody,
+                    FILTER_SANITIZE_FULL_SPECIAL_CHARS
+                )
+            );
             $cbody = $this->fetchTemplate('error.tpl');
         }
         $this->body .= $cbody;

--- a/core/model/modx/modmanagerresponse.class.php
+++ b/core/model/modx/modmanagerresponse.class.php
@@ -120,7 +120,12 @@ class modManagerResponse extends modResponse {
      */
     public function send() {
         if (is_array($this->body)) {
-            $this->modx->smarty->assign('_e', $this->body);
+            $this->modx->smarty->assign('_e',
+                filter_var_array(
+                    $this->body,
+                    FILTER_SANITIZE_FULL_SPECIAL_CHARS
+                )
+            );
             if (!file_exists($this->modx->smarty->template_dir.'error.tpl')) {
                 $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
                 $this->modx->smarty->setTemplatePath($templatePath);


### PR DESCRIPTION
### What does it do?
Add filtering to messages sent to the smarty error template

### Why is it needed?
Prevent special characters from being added to error messages
