### PR TITLE
PHP 8.5 Compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout

--- a/_build/test/MODxTestHarness.php
+++ b/_build/test/MODxTestHarness.php
@@ -54,7 +54,7 @@ class MODxTestHarness {
             include dirname(__FILE__) . '/properties.inc.php';
             self::$properties = $properties;
             if (array_key_exists('debug', self::$properties)) {
-                self::$debug = (boolean) self::$properties['debug'];
+                self::$debug = (bool) self::$properties['debug'];
             }
 
             $fixture = null;

--- a/core/src/Revolution/Error/modError.php
+++ b/core/src/Revolution/Error/modError.php
@@ -146,7 +146,7 @@ class modError
                 $message = $s;
             }
         }
-        $this->status = (boolean) $status;
+        $this->status =  $status;
 
         if ($message != '') {
             $this->message = $message;

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -45,7 +45,7 @@ class modOutputFilter
      */
     public function filter(&$element)
     {
-        $usemb = function_exists('mb_strlen') && (boolean)$this->modx->getOption('use_multibyte', null, false);
+        $usemb = function_exists('mb_strlen') && (bool)$this->modx->getOption('use_multibyte', null, false);
         $encoding = $this->modx->getOption('modx_charset', null, 'UTF-8');
 
         $output = &$element->_output;

--- a/core/src/Revolution/Hashing/modPBKDF2.php
+++ b/core/src/Revolution/Hashing/modPBKDF2.php
@@ -41,8 +41,8 @@ class modPBKDF2 extends modHash
         $derivedKey = false;
         $salt = $this->getOption('salt', $options, false);
         if (is_string($salt) && strlen($salt) > 0) {
-            $iterations = (integer)$this->getOption('iterations', $options, 1000);
-            $derivedKeyLength = (integer)$this->getOption('derived_key_length', $options, 32);
+            $iterations = (int)$this->getOption('iterations', $options, 1000);
+            $derivedKeyLength = (int)$this->getOption('derived_key_length', $options, 32);
             $algorithm = $this->getOption('algorithm', $options, 'sha256');
 
             $hashLength = strlen(hash($algorithm, null, true));

--- a/core/src/Revolution/Processors/Element/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/Duplicate.php
@@ -25,7 +25,7 @@ class Duplicate extends DuplicateProcessor
     public function cleanup()
     {
         $fields = $this->newObject->get(['id', 'name', 'description', 'category', 'locked']);
-        $fields['redirect'] = (boolean)$this->getProperty('redirect', false);
+        $fields['redirect'] = (bool)$this->getProperty('redirect', false);
 
         return $this->success('', $fields);
     }

--- a/core/src/Revolution/Processors/Element/Plugin/Update.php
+++ b/core/src/Revolution/Processors/Element/Plugin/Update.php
@@ -43,7 +43,7 @@ class Update extends \MODX\Revolution\Processors\Element\Update
 
     public function beforeSave()
     {
-        $disabled = (boolean)$this->getProperty('disabled', false);
+        $disabled = (bool)$this->getProperty('disabled', false);
         $this->object->set('disabled', $disabled);
 
         $isStatic = intval($this->getProperty('static', 0));

--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -208,7 +208,7 @@ class Create extends CreateProcessor
         }
         $this->setMenuIndex();
 
-        $reloaded = (boolean)$this->getProperty('reloaded', false);
+        $reloaded = (bool)$this->getProperty('reloaded', false);
         if ($reloaded && !$this->hasErrors() && !$this->checkForAllowableCreateToken()) {
             return $this->modx->lexicon('resource_err_save');
         }
@@ -247,15 +247,15 @@ class Create extends CreateProcessor
     public function setFieldDefaults()
     {
         $scriptProperties = $this->getProperties();
-        $scriptProperties['template'] = !isset($scriptProperties['template']) ? (integer)$this->workingContext->getOption('default_template', 0) : (integer)$scriptProperties['template'];
-        $scriptProperties['hidemenu'] = !isset($scriptProperties['hidemenu']) ? (integer)$this->workingContext->getOption('hidemenu_default', 0) : (empty($scriptProperties['hidemenu']) ? 0 : 1);
+        $scriptProperties['template'] = !isset($scriptProperties['template']) ? (int)$this->workingContext->getOption('default_template', 0) : (int)$scriptProperties['template'];
+        $scriptProperties['hidemenu'] = !isset($scriptProperties['hidemenu']) ? (int)$this->workingContext->getOption('hidemenu_default', 0) : (empty($scriptProperties['hidemenu']) ? 0 : 1);
         $scriptProperties['isfolder'] = empty($scriptProperties['isfolder']) ? 0 : 1;
-        $scriptProperties['richtext'] = !isset($scriptProperties['richtext']) ? (integer)$this->workingContext->getOption('richtext_default', 1) : (empty($scriptProperties['richtext']) ? 0 : 1);
+        $scriptProperties['richtext'] = !isset($scriptProperties['richtext']) ? (int)$this->workingContext->getOption('richtext_default', 1) : (empty($scriptProperties['richtext']) ? 0 : 1);
         $scriptProperties['donthit'] = empty($scriptProperties['donthit']) ? 0 : 1;
-        $scriptProperties['published'] = !isset($scriptProperties['published']) ? (integer)$this->workingContext->getOption('publish_default', 0) : (empty($scriptProperties['published']) ? 0 : 1);
-        $scriptProperties['cacheable'] = !isset($scriptProperties['cacheable']) ? (integer)$this->workingContext->getOption('cache_default', 1) : (empty($scriptProperties['cacheable']) ? 0 : 1);
-        $scriptProperties['searchable'] = !isset($scriptProperties['searchable']) ? (integer)$this->workingContext->getOption('search_default', 1) : (empty($scriptProperties['searchable']) ? 0 : 1);
-        $scriptProperties['content_type'] = !isset($scriptProperties['content_type']) ? (integer)$this->workingContext->getOption('default_content_type', 1) : (integer)$scriptProperties['content_type'];
+        $scriptProperties['published'] = !isset($scriptProperties['published']) ? (int)$this->workingContext->getOption('publish_default', 0) : (empty($scriptProperties['published']) ? 0 : 1);
+        $scriptProperties['cacheable'] = !isset($scriptProperties['cacheable']) ? (int)$this->workingContext->getOption('cache_default', 1) : (empty($scriptProperties['cacheable']) ? 0 : 1);
+        $scriptProperties['searchable'] = !isset($scriptProperties['searchable']) ? (int)$this->workingContext->getOption('search_default', 1) : (empty($scriptProperties['searchable']) ? 0 : 1);
+        $scriptProperties['content_type'] = !isset($scriptProperties['content_type']) ? (int)$this->workingContext->getOption('default_content_type', 1) : (int)$scriptProperties['content_type'];
         $scriptProperties['syncsite'] = empty($scriptProperties['syncsite']) ? 0 : 1;
         $scriptProperties['menuindex'] = empty($scriptProperties['menuindex']) ? 0 : $scriptProperties['menuindex'];
         $scriptProperties['deleted'] = empty($scriptProperties['deleted']) ? 0 : 1;

--- a/core/src/Revolution/Processors/Resource/Duplicate.php
+++ b/core/src/Revolution/Processors/Resource/Duplicate.php
@@ -86,7 +86,7 @@ class Duplicate extends Processor
 
         return $this->success('', [
             'id' => $this->newResource->get('id'),
-            'redirect' => (boolean)$this->getProperty('redirect', false),
+            'redirect' => (bool)$this->getProperty('redirect', false),
         ]);
     }
 

--- a/core/src/Revolution/Processors/Resource/ResourceGroup/GetList.php
+++ b/core/src/Revolution/Processors/Resource/ResourceGroup/GetList.php
@@ -87,7 +87,7 @@ class GetList extends Processor
         /** @var modResourceGroup $resourceGroup */
         foreach ($resourceGroups as $resourceGroup) {
             $resourceGroupArray = $resourceGroup->toArray();
-            $resourceGroupArray['access'] = (boolean)$resourceGroupArray['access'];
+            $resourceGroupArray['access'] = (bool)$resourceGroupArray['access'];
             if (!empty($parent) && $mode == 'create') {
                 $resourceGroupArray['access'] = in_array($resourceGroupArray['id'], $parentGroups) ? true : false;
             }

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -63,7 +63,7 @@ class Search extends Processor
      */
     protected function searchInContent()
     {
-        return (boolean)$this->modx->getOption('quick_search_in_content', null, true);
+        return (bool)$this->modx->getOption('quick_search_in_content', null, true);
     }
 
     /**

--- a/core/src/Revolution/Processors/Security/Access/Policy/Import.php
+++ b/core/src/Revolution/Processors/Security/Access/Policy/Import.php
@@ -55,7 +55,7 @@ class Import extends ImportProcessor
     {
         $permissions = [];
         foreach ($this->xml->permissions->permission as $permissionXml) {
-            $v = (integer)$permissionXml->value;
+            $v = (int)$permissionXml->value;
             $permissions[(string)$permissionXml->name] = (!empty($v) ? true : false);
         }
         $this->object->set('data', $permissions);

--- a/core/src/Revolution/Processors/Security/Forms/Profile/Update.php
+++ b/core/src/Revolution/Processors/Security/Forms/Profile/Update.php
@@ -33,7 +33,7 @@ class Update extends UpdateProcessor
     {
         $active = $this->getProperty('active');
         if ($active !== null) {
-            $this->object->set('active', (boolean)$active);
+            $this->object->set('active', (bool)$active);
         }
         return parent::beforeSave();
     }

--- a/core/src/Revolution/Processors/Security/Profile/ChangePassword.php
+++ b/core/src/Revolution/Processors/Security/Profile/ChangePassword.php
@@ -50,7 +50,7 @@ class ChangePassword extends Processor
 
         $password = $this->getProperty('password_new');
         if (!$this->getProperty('password_method_screen')) {
-            $length = (integer)$this->modx->getOption('password_min_length', null, 8);
+            $length = (int)$this->modx->getOption('password_min_length', null, 8);
             $password = str_repeat('*', mt_rand($length, strlen($this->getProperty('password_new')) * 2));
         }
 

--- a/core/src/Revolution/Registry/modDbRegister.php
+++ b/core/src/Revolution/Registry/modDbRegister.php
@@ -137,8 +137,8 @@ class modDbRegister extends modRegister
         $timeLimit = isset($options['time_limit']) ? intval($options['time_limit']) : ini_get('max_execution_time');
         $pollLimit = isset($options['poll_limit']) ? intval($options['poll_limit']) : 0;
         $pollInterval = isset($options['poll_interval']) ? intval($options['poll_interval']) : 0;
-        $removeRead = isset($options['remove_read']) ? (boolean)$options['remove_read'] : true;
-        $includeKeys = isset($options['include_keys']) ? (boolean)$options['include_keys'] : false;
+        $removeRead = isset($options['remove_read']) ? (bool)$options['remove_read'] : true;
+        $includeKeys = isset($options['include_keys']) ? (bool)$options['include_keys'] : false;
         $startTime = microtime(true);
         $time = $timeLimit <= 0 ? -1 : $startTime;
         $expires = $startTime + $timeLimit;
@@ -291,7 +291,7 @@ class modDbRegister extends modRegister
                             default :
                                 $timestamp = isset($options['delay']) ? time() + intval($options['delay']) : time();
                                 $expires = isset($options['ttl']) && intval($options['ttl']) ? time() + intval($options['ttl']) : 0;
-                                $kill = isset($options['kill']) ? (boolean)$options['kill'] : false;
+                                $kill = isset($options['kill']) ? (bool)$options['kill'] : false;
                                 if (!is_int($msgIdx)) {
                                     $msgKey = $msgIdx;
                                 } else {

--- a/core/src/Revolution/Registry/modFileRegister.php
+++ b/core/src/Revolution/Registry/modFileRegister.php
@@ -112,8 +112,8 @@ class modFileRegister extends modRegister
         $timeLimit = isset($options['time_limit']) ? intval($options['time_limit']) : ini_get('time_limit');
         $pollLimit = isset($options['poll_limit']) ? intval($options['poll_limit']) : 0;
         $pollInterval = isset($options['poll_interval']) ? intval($options['poll_interval']) : 0;
-        $removeRead = isset($options['remove_read']) ? (boolean)$options['remove_read'] : true;
-        $includeKeys = isset($options['include_keys']) ? (boolean)$options['include_keys'] : false;
+        $removeRead = isset($options['remove_read']) ? (bool)$options['remove_read'] : true;
+        $includeKeys = isset($options['include_keys']) ? (bool)$options['include_keys'] : false;
         $startTime = microtime(true);
         $time = $timeLimit <= 0 ? -1 : $startTime;
         $expires = $startTime + $timeLimit;
@@ -279,7 +279,7 @@ class modFileRegister extends modRegister
                         default :
                             $timestamp = isset($options['delay']) ? time() + intval($options['delay']) : time();
                             $expires = isset($options['ttl']) && !empty($options['ttl']) ? time() + intval($options['ttl']) : 0;
-                            $kill = isset($options['kill']) ? (boolean)$options['kill'] : false;
+                            $kill = isset($options['kill']) ? (bool)$options['kill'] : false;
                             if (!is_int($msgIdx)) {
                                 if (strpos($msgIdx, '../') !== false) {
                                     $this->modx->log(modX::LOG_LEVEL_ERROR, "Directory traversal attempt in register message key; message skipped with key {$msgIdx}");

--- a/core/src/Revolution/Sources/modAccessMediaSource.php
+++ b/core/src/Revolution/Sources/modAccessMediaSource.php
@@ -37,9 +37,9 @@ class modAccessMediaSource extends modAccess
         if (empty($context)) {
             $context = $modx->context->get('key');
         }
-        $enabled = (boolean)$modx->getOption('access_media_source_enabled', null, true);
+        $enabled = (bool)$modx->getOption('access_media_source_enabled', null, true);
         if ($context !== $modx->context->get('key') && $modx->getContext($context)) {
-            $enabled = (boolean)$modx->contexts[$context]->getOption('access_media_source_enabled', $enabled);
+            $enabled = (bool)$modx->contexts[$context]->getOption('access_media_source_enabled', $enabled);
         }
         if ($enabled) {
             $accessTable = $modx->getTableName(modAccessMediaSource::class);

--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -151,7 +151,7 @@ class modTransportProvider extends xPDOSimpleObject
                 'url' => (string)$xml->url,
                 'id' => (string)$package->id,
                 'name' => (string)$package->name,
-                'downloads' => number_format((integer)$package->downloads, 0),
+                'downloads' => number_format((int)$package->downloads, 0),
             ];
         }
         /** @var SimpleXMLElement $package */
@@ -382,13 +382,13 @@ class modTransportProvider extends xPDOSimpleObject
                 'createdon' => (string)$package->createdon,
                 'editedon' => (string)$package->editedon,
                 'name' => (string)$package->name,
-                'downloads' => number_format((integer)$package->downloads, 0),
+                'downloads' => number_format((int)$package->downloads, 0),
                 'releasedon' => $releasedon,
                 'screenshot' => (string)$package->screenshot,
                 'thumbnail' => !empty($package->thumbnail) ? (string)$package->thumbnail : (string)$package->screenshot,
                 'license' => (string)$package->license,
                 'minimum_supports' => (string)$package->minimum_supports,
-                'breaks_at' => (integer)$package->breaks_at != 10000000 ? (string)$package->breaks_at : '',
+                'breaks_at' => (int)$package->breaks_at != 10000000 ? (string)$package->breaks_at : '',
                 'supports_db' => (string)$package->supports_db,
                 'location' => (string)$package->location,
                 'version-compiled' => $versionCompiled,

--- a/core/src/Revolution/modAccessCategory.php
+++ b/core/src/Revolution/modAccessCategory.php
@@ -31,9 +31,9 @@ class modAccessCategory extends modAccess
         if (empty($context)) {
             $context = $modx->context->get('key');
         }
-        $enabled = (boolean)$modx->getOption('access_category_enabled', null, true);
+        $enabled = (bool)$modx->getOption('access_category_enabled', null, true);
         if ($context !== $modx->context->get('key') && $modx->getContext($context)) {
-            $enabled = (boolean)$modx->contexts[$context]->getOption('access_category_enabled', $enabled);
+            $enabled = (bool)$modx->contexts[$context]->getOption('access_category_enabled', $enabled);
         }
         if ($enabled) {
             $accessTable = $modx->getTableName(modAccessCategory::class);

--- a/core/src/Revolution/modAccessContext.php
+++ b/core/src/Revolution/modAccessContext.php
@@ -29,9 +29,9 @@ class modAccessContext extends modAccess
         if (empty($context)) {
             $context = $modx->context->get('key');
         }
-        $enabled = (boolean)$modx->getOption('access_context_enabled', null, true);
+        $enabled = (bool)$modx->getOption('access_context_enabled', null, true);
         if ($context !== $modx->context->get('key') && $modx->getContext($context)) {
-            $enabled = (boolean)$modx->contexts[$context]->getOption('access_context_enabled', $enabled);
+            $enabled = (bool)$modx->contexts[$context]->getOption('access_context_enabled', $enabled);
         }
         if ($enabled) {
             $accessTable = $modx->getTableName(modAccessContext::class);

--- a/core/src/Revolution/modAccessResourceGroup.php
+++ b/core/src/Revolution/modAccessResourceGroup.php
@@ -33,9 +33,9 @@ class modAccessResourceGroup extends modAccess
         if (empty($context)) {
             $context = $modx->context->get('key');
         }
-        $enabled = (boolean)$modx->getOption('access_resource_group_enabled', null, true);
+        $enabled = (bool)$modx->getOption('access_resource_group_enabled', null, true);
         if ($context !== $modx->context->get('key') && $modx->getContext($context)) {
-            $enabled = (boolean)$modx->contexts[$context]->getOption('access_resource_group_enabled', $enabled);
+            $enabled = (bool)$modx->contexts[$context]->getOption('access_resource_group_enabled', $enabled);
         }
         if ($enabled) {
             $accessTable = $modx->getTableName(modAccessResourceGroup::class);

--- a/core/src/Revolution/modAccessibleObject.php
+++ b/core/src/Revolution/modAccessibleObject.php
@@ -166,7 +166,7 @@ class modAccessibleObject extends xPDOObject
         }
         $rows = false;
         $fromCache = false;
-        $collectionCaching = (integer)$xpdo->getOption(xPDO::OPT_CACHE_DB_COLLECTIONS, [], 1);
+        $collectionCaching = (int)$xpdo->getOption(xPDO::OPT_CACHE_DB_COLLECTIONS, [], 1);
         if (!is_object($criteria)) {
             $criteria = $xpdo->getCriteria($className, $criteria, $cacheFlag);
         }

--- a/core/src/Revolution/modCacheManager.php
+++ b/core/src/Revolution/modCacheManager.php
@@ -112,17 +112,17 @@ class modCacheManager extends xPDOCacheManager
                 if ($collResources) {
                     /** @var Object $r */
                     while ($r = $collResources->fetch(PDO::FETCH_OBJ)) {
-                        if (!isset($results['resourceMap'][(integer)$r->parent])) {
-                            $results['resourceMap'][(integer)$r->parent] = [];
+                        if (!isset($results['resourceMap'][(int)$r->parent])) {
+                            $results['resourceMap'][(int)$r->parent] = [];
                         }
-                        $results['resourceMap'][(integer)$r->parent][] = (integer)$r->id;
+                        $results['resourceMap'][(int)$r->parent][] = (int)$r->id;
                         if ($friendlyUrls && $cacheAliasMap) {
                             if (array_key_exists($r->uri, $results['aliasMap'])) {
                                 $this->modx->log(xPDO::LOG_LEVEL_ERROR,
                                     "Resource URI {$r->uri} already exists for resource id = {$results['aliasMap'][$r->uri]}; skipping duplicate resource URI for resource id = {$r->id}");
                                 continue;
                             }
-                            $results['aliasMap'][$r->uri] = (integer)$r->id;
+                            $results['aliasMap'][$r->uri] = (int)$r->id;
                         }
                     }
                 }
@@ -132,7 +132,7 @@ class modCacheManager extends xPDOCacheManager
                 $results['webLinkMap'] = [];
                 if ($collWebLinks) {
                     while ($wl = $collWebLinks->fetch(PDO::FETCH_OBJ)) {
-                        $results['webLinkMap'][(integer)$wl->id] = $wl->content;
+                        $results['webLinkMap'][(int)$wl->id] = $wl->content;
                     }
                 }
 
@@ -175,20 +175,20 @@ class modCacheManager extends xPDOCacheManager
             $results = $this->getOption("{$key}_results", $options, []);
             $cacheKey = "{$key}/context";
             $options['cache_context_settings'] = array_key_exists('cache_context_settings',
-                $results) ? (boolean)$results : false;
+                $results) ? (bool)$results : false;
         }
         if ($this->getOption('cache_context_settings', $options, true) && is_array($results) && !empty($results)) {
             $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_context_settings_key', $options,
                 'context_settings');
             $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_context_settings_handler', $options,
                 $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-            $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_context_settings_format', $options,
+            $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_context_settings_format', $options,
                 $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-            $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_context_settings_attempts', $options,
+            $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_context_settings_attempts', $options,
                 $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 10));
-            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_context_settings_attempt_delay',
+            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_context_settings_attempt_delay',
                 $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
-            $lifetime = (integer)$this->getOption('cache_context_settings_expires', $options,
+            $lifetime = (int)$this->getOption('cache_context_settings_expires', $options,
                 $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
             if (!$this->set($cacheKey, $results, $lifetime, $options)) {
                 $this->modx->log(modX::LOG_LEVEL_WARN, 'Could not cache context settings for ' . $key . '.');
@@ -203,11 +203,11 @@ class modCacheManager extends xPDOCacheManager
         $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_media_sources_key', $options, 'media_sources');
         $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_media_sources_handler', $options,
             $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-        $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_media_sources_format', $options,
+        $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_media_sources_format', $options,
             $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-        $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_media_sources_attempts', $options,
+        $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_media_sources_attempts', $options,
             $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 10));
-        $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_media_sources_attempt_delay',
+        $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_media_sources_attempt_delay',
             $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
         $cacheKey = $contextKey . '/source';
         $sourceCache = $this->get($cacheKey, $options);
@@ -247,7 +247,7 @@ class modCacheManager extends xPDOCacheManager
                 $sourceArray['object'] = $source->get('object');
                 $sourceCache[$sourceArray['object']] = $sourceArray;
             }
-            $lifetime = (integer)$this->getOption('cache_media_sources_expires', $options,
+            $lifetime = (int)$this->getOption('cache_media_sources_expires', $options,
                 $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
             if (!$this->set($cacheKey, $sourceCache, $lifetime, $options)) {
                 $this->modx->log(modX::LOG_LEVEL_WARN, 'Could not cache source data for ' . $element->get('id') . '.');
@@ -289,13 +289,13 @@ class modCacheManager extends xPDOCacheManager
             $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_system_settings_key', $options, 'system_settings');
             $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_system_settings_handler', $options,
                 $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-            $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_system_settings_format', $options,
+            $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_system_settings_format', $options,
                 $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-            $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_system_settings_attempts', $options,
+            $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_system_settings_attempts', $options,
                 $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 10));
-            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_system_settings_attempt_delay',
+            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_system_settings_attempt_delay',
                 $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
-            $lifetime = (integer)$this->getOption('cache_system_settings_expires', $options,
+            $lifetime = (int)$this->getOption('cache_system_settings_expires', $options,
                 $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
             if (!$this->set('config', $config, $lifetime, $options)) {
                 $this->modx->log(modX::LOG_LEVEL_WARN, 'Could not cache system settings.');
@@ -362,13 +362,13 @@ class modCacheManager extends xPDOCacheManager
                 $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_resource_key', $options, 'resource');
                 $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_resource_handler', $options,
                     $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-                $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_resource_format', $options,
+                $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_resource_format', $options,
                     $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-                $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_resource_attempts', $options,
+                $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_resource_attempts', $options,
                     $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 1));
-                $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_resource_attempt_delay',
+                $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_resource_attempt_delay',
                     $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
-                $lifetime = (integer)$this->getOption('cache_resource_expires', $options,
+                $lifetime = (int)$this->getOption('cache_resource_expires', $options,
                     $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
                 if (!$this->set($obj->getCacheKey(), $results, $lifetime, $options)) {
                     $this->modx->log(modX::LOG_LEVEL_WARN, 'Could not cache resource ' . $obj->get('id'));
@@ -401,13 +401,13 @@ class modCacheManager extends xPDOCacheManager
             $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_lexicon_topics_key', $options, 'lexicon_topics');
             $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_lexicon_topics_handler', $options,
                 $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-            $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_lexicon_topics_format', $options,
+            $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_lexicon_topics_format', $options,
                 $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-            $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_lexicon_topics_attempts', $options,
+            $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_lexicon_topics_attempts', $options,
                 $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 1));
-            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_lexicon_topics_attempt_delay',
+            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_lexicon_topics_attempt_delay',
                 $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
-            $lifetime = (integer)$this->getOption('cache_lexicon_topics_expires', $options,
+            $lifetime = (int)$this->getOption('cache_lexicon_topics_expires', $options,
                 $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
             if (!$this->set($cacheKey, $entries, $lifetime, $options)) {
                 $this->modx->log(modX::LOG_LEVEL_WARN, 'Error caching lexicon topic ' . $cacheKey);
@@ -444,13 +444,13 @@ class modCacheManager extends xPDOCacheManager
             $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_namespaces_key', $options, 'namespaces');
             $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_namespaces_handler', $options,
                 $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-            $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_namespaces_format', $options,
+            $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_namespaces_format', $options,
                 $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-            $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_namespaces_attempts', $options,
+            $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_namespaces_attempts', $options,
                 $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 1));
-            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_namespaces_attempt_delay',
+            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_namespaces_attempt_delay',
                 $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
-            $lifetime = (integer)$this->getOption('cache_namespaces_expires', $options,
+            $lifetime = (int)$this->getOption('cache_namespaces_expires', $options,
                 $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
             if (!$this->set($cacheKey, $results, $lifetime, $options)) {
                 $this->modx->log(modX::LOG_LEVEL_WARN, 'Error caching namespaces ' . $cacheKey);
@@ -501,13 +501,13 @@ class modCacheManager extends xPDOCacheManager
             $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_extension_packages_key', $options, 'namespaces');
             $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_extension_packages_handler', $options,
                 $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-            $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_extension_packages_format', $options,
+            $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_extension_packages_format', $options,
                 $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-            $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_extension_packages_attempts',
+            $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_extension_packages_attempts',
                 $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 1));
-            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_extension_packages_attempt_delay',
+            $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_extension_packages_attempt_delay',
                 $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
-            $lifetime = (integer)$this->getOption('cache_extension_packages_expires', $options,
+            $lifetime = (int)$this->getOption('cache_extension_packages_expires', $options,
                 $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
             if (!$this->set($cacheKey, $results, $lifetime, $options)) {
                 $this->modx->log(modX::LOG_LEVEL_WARN, 'Error caching extension packages ' . $cacheKey);
@@ -542,13 +542,13 @@ class modCacheManager extends xPDOCacheManager
                 $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_scripts_key', $options, 'scripts');
                 $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_scripts_handler', $options,
                     $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-                $options[xPDO::OPT_CACHE_FORMAT] = (integer)$this->getOption('cache_scripts_format', $options,
+                $options[xPDO::OPT_CACHE_FORMAT] = (int)$this->getOption('cache_scripts_format', $options,
                     $this->getOption(xPDO::OPT_CACHE_FORMAT, $options, xPDOCacheManager::CACHE_PHP));
-                $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_scripts_attempts', $options,
+                $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_scripts_attempts', $options,
                     $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 1));
-                $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_scripts_attempt_delay',
+                $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_scripts_attempt_delay',
                     $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
-                $lifetime = (integer)$this->getOption('cache_scripts_expires', $options,
+                $lifetime = (int)$this->getOption('cache_scripts_expires', $options,
                     $this->getOption(xPDO::OPT_CACHE_EXPIRES, $options, 0));
                 if (empty($results) || !$this->set($objElement->getScriptCacheKey(), $results, $lifetime, $options)) {
                     $this->modx->log(modX::LOG_LEVEL_WARN, 'Error caching script ' . $objElement->getScriptCacheKey());
@@ -753,9 +753,9 @@ class modCacheManager extends xPDOCacheManager
         $options[xPDO::OPT_CACHE_KEY] = $this->getOption('cache_auto_publish_key', $options, 'auto_publish');
         $options[xPDO::OPT_CACHE_HANDLER] = $this->getOption('cache_auto_publish_handler', $options,
             $this->getOption(xPDO::OPT_CACHE_HANDLER, $options));
-        $options[xPDO::OPT_CACHE_ATTEMPTS] = (integer)$this->getOption('cache_auto_publish_attempts', $options,
+        $options[xPDO::OPT_CACHE_ATTEMPTS] = (int)$this->getOption('cache_auto_publish_attempts', $options,
             $this->getOption(xPDO::OPT_CACHE_ATTEMPTS, $options, 1));
-        $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (integer)$this->getOption('cache_auto_publish_attempt_delay',
+        $options[xPDO::OPT_CACHE_ATTEMPT_DELAY] = (int)$this->getOption('cache_auto_publish_attempt_delay',
             $options, $this->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, $options, 1000));
         if (!$this->set('auto_publish', $nextevent, 0, $options)) {
             $this->modx->log(modX::LOG_LEVEL_WARN, 'Error caching time of next auto publishing event.');

--- a/core/src/Revolution/modCategory.php
+++ b/core/src/Revolution/modCategory.php
@@ -173,9 +173,9 @@ class modCategory extends modAccessibleSimpleObject
         $enabled = true;
         $context = !empty($context) ? $context : $this->xpdo->context->get('key');
         if ($context === $this->xpdo->context->get('key')) {
-            $enabled = (boolean)$this->xpdo->getOption('access_category_enabled', null, true);
+            $enabled = (bool)$this->xpdo->getOption('access_category_enabled', null, true);
         } elseif ($this->xpdo->getContext($context)) {
-            $enabled = (boolean)$this->xpdo->contexts[$context]->getOption('access_category_enabled', true);
+            $enabled = (bool)$this->xpdo->contexts[$context]->getOption('access_category_enabled', true);
         }
         if ($enabled) {
             if (empty($this->_policies) || !isset($this->_policies[$context])) {

--- a/core/src/Revolution/modContext.php
+++ b/core/src/Revolution/modContext.php
@@ -130,7 +130,7 @@ class modContext extends modAccessibleObject
                             'context_settings'),
                         xPDO::OPT_CACHE_HANDLER => $this->xpdo->getOption('cache_context_settings_handler', null,
                             $this->xpdo->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDO\Cache\xPDOFileCache')),
-                        xPDO::OPT_CACHE_FORMAT => (integer)$this->xpdo->getOption('cache_context_settings_format', null,
+                        xPDO::OPT_CACHE_FORMAT => (int)$this->xpdo->getOption('cache_context_settings_format', null,
                             $this->xpdo->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
                     ]))) {
                     $context = $this->xpdo->cacheManager->generateContext($this->get('key'), $options);
@@ -202,9 +202,9 @@ class modContext extends modAccessibleObject
         $enabled = true;
         $context = !empty($context) ? $context : $this->xpdo->context->get('key');
         if (!is_object($this->xpdo->context) || $context === $this->xpdo->context->get('key')) {
-            $enabled = (boolean)$this->xpdo->getOption('access_context_enabled', null, true);
+            $enabled = (bool)$this->xpdo->getOption('access_context_enabled', null, true);
         } elseif ($this->xpdo->getContext($context)) {
-            $enabled = (boolean)$this->xpdo->contexts[$context]->getOption('access_context_enabled', true);
+            $enabled = (bool)$this->xpdo->contexts[$context]->getOption('access_context_enabled', true);
         }
         if ($enabled) {
             if (empty($this->_policies) || !isset($this->_policies[$context])) {
@@ -284,7 +284,7 @@ class modContext extends modAccessibleObject
             }
 
             if ($config['friendly_urls'] == 1) {
-                if ((integer)$id === (integer)$config['site_start']) {
+                if ((int)$id === (int)$config['site_start']) {
                     $alias = ($scheme === '' || $scheme === -1) ? $config['base_url'] : '';
                     $found = true;
                 } else {

--- a/core/src/Revolution/modExtensionPackage.php
+++ b/core/src/Revolution/modExtensionPackage.php
@@ -68,7 +68,7 @@ class modExtensionPackage extends xPDOSimpleObject
             xPDO::OPT_CACHE_KEY => $modx->getOption('cache_extension_packages_key', null, 'namespaces'),
             xPDO::OPT_CACHE_HANDLER => $modx->getOption('cache_extension_packages_handler', null,
                 $modx->getOption(xPDO::OPT_CACHE_HANDLER)),
-            xPDO::OPT_CACHE_FORMAT => (integer)$modx->getOption('cache_extension_packages_format', null,
+            xPDO::OPT_CACHE_FORMAT => (int)$modx->getOption('cache_extension_packages_format', null,
                 $modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
         ]);
         if (empty($cache)) {
@@ -85,7 +85,7 @@ class modExtensionPackage extends xPDOSimpleObject
             xPDO::OPT_CACHE_KEY => $modx->getOption('cache_extension_packages_key', null, 'namespaces'),
             xPDO::OPT_CACHE_HANDLER => $modx->getOption('cache_extension_packages_handler', null,
                 $modx->getOption(xPDO::OPT_CACHE_HANDLER)),
-            xPDO::OPT_CACHE_FORMAT => (integer)$modx->getOption('cache_extension_packages_format', null,
+            xPDO::OPT_CACHE_FORMAT => (int)$modx->getOption('cache_extension_packages_format', null,
                 $modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
         ]);
 

--- a/core/src/Revolution/modLinkTag.php
+++ b/core/src/Revolution/modLinkTag.php
@@ -78,7 +78,7 @@ class modLinkTag extends modTag
                             $scheme = $this->_properties['scheme'];
                             unset($this->_properties['scheme']);
                             if (is_numeric($scheme)) {
-                                $scheme = (integer)$scheme;
+                                $scheme = (int)$scheme;
                             }
                         }
                         if (array_key_exists('use_weblink_target', $this->_properties)) {

--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -73,7 +73,7 @@ class modMenu extends modAccessibleObject
             xPDO::OPT_CACHE_KEY => $this->xpdo->cacheManager->getOption('cache_menu_key', null, 'menu'),
             xPDO::OPT_CACHE_HANDLER => $this->xpdo->cacheManager->getOption('cache_menu_handler', null,
                 $this->xpdo->getOption(xPDO::OPT_CACHE_HANDLER)),
-            xPDO::OPT_CACHE_FORMAT => (integer)$this->xpdo->getOption('cache_menu_format', null,
+            xPDO::OPT_CACHE_FORMAT => (int)$this->xpdo->getOption('cache_menu_format', null,
                 $this->xpdo->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
         ]);
         if ($cached === false) {

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -68,7 +68,7 @@ class modParser
      */
     public function isProcessingUncacheable() {
         $result = false;
-        if ($this->isProcessingTag() || $this->isProcessingElement()) $result = (boolean) $this->_processingUncacheable;
+        if ($this->isProcessingTag() || $this->isProcessingElement()) $result = (bool) $this->_processingUncacheable;
         return $result;
     }
 
@@ -86,7 +86,7 @@ class modParser
      */
     public function isRemovingUnprocessed() {
         $result = false;
-        if ($this->isProcessingTag() || $this->isProcessingElement()) $result = (boolean) $this->_removingUnprocessed;
+        if ($this->isProcessingTag() || $this->isProcessingElement()) $result = (bool) $this->_removingUnprocessed;
         return $result;
     }
 
@@ -95,7 +95,7 @@ class modParser
      * @return bool
      */
     public function isProcessingTag() {
-        return (boolean) $this->_processingTag;
+        return (bool) $this->_processingTag;
     }
 
     /**
@@ -103,7 +103,7 @@ class modParser
      * @return bool
      */
     public function isProcessingElement() {
-        return (boolean) $this->_processingElement;
+        return (bool) $this->_processingElement;
     }
 
     public function setProcessingElement($arg = null) {
@@ -112,7 +112,7 @@ class modParser
         } elseif ($arg === null) {
             $this->_processingElement = !$this->_processingElement ? true : false;
         } else {
-            $this->_processingElement = (boolean)$arg;
+            $this->_processingElement = (bool)$arg;
         }
     }
 
@@ -190,8 +190,8 @@ class modParser
         $_processingUncacheable = $this->_processingUncacheable;
         $_removingUnprocessed = $this->_removingUnprocessed;
         $this->_processingTag = true;
-        $this->_processingUncacheable = (boolean) $processUncacheable;
-        $this->_removingUnprocessed = (boolean) $removeUnprocessed;
+        $this->_processingUncacheable = (bool) $processUncacheable;
+        $this->_removingUnprocessed = (bool) $removeUnprocessed;
         $depth = $depth > 0 ? $depth - 1 : 0;
         $processed= 0;
         $tags= [];

--- a/core/src/Revolution/modPhpThumb.php
+++ b/core/src/Revolution/modPhpThumb.php
@@ -54,7 +54,7 @@ class modPhpThumb extends phpthumb
         $this->setCacheDirectory();
 
         $this->setParameter('config_allow_src_above_docroot',
-            (boolean)$this->modx->getOption('phpthumb_allow_src_above_docroot', $this->config, false));
+            (bool)$this->modx->getOption('phpthumb_allow_src_above_docroot', $this->config, false));
         $this->setParameter('config_cache_maxage',
             (float)$this->modx->getOption('phpthumb_cache_maxage', $this->config, 30) * 86400);
         $this->setParameter('config_cache_maxsize',
@@ -68,24 +68,24 @@ class modPhpThumb extends phpthumb
         $this->setParameter('config_error_fontsize',
             (int)$this->modx->getOption('phpthumb_error_fontsize', $this->config, 1));
         $this->setParameter('config_nohotlink_enabled',
-            (boolean)$this->modx->getOption('phpthumb_nohotlink_enabled', $this->config, true));
+            (bool)$this->modx->getOption('phpthumb_nohotlink_enabled', $this->config, true));
         $this->setParameter('config_nohotlink_valid_domains', explode(',',
             $this->modx->getOption('phpthumb_nohotlink_valid_domains', $this->config,
                 $this->modx->getOption('http_host'))));
         $this->setParameter('config_nohotlink_erase_image',
-            (boolean)$this->modx->getOption('phpthumb_nohotlink_erase_image', $this->config, true));
+            (bool)$this->modx->getOption('phpthumb_nohotlink_erase_image', $this->config, true));
         $this->setParameter('config_nohotlink_text_message',
             (string)$this->modx->getOption('phpthumb_nohotlink_text_message', $this->config,
                 'Off-server thumbnailing is not allowed'));
         $this->setParameter('config_nooffsitelink_enabled',
-            (boolean)$this->modx->getOption('phpthumb_nooffsitelink_enabled', $this->config, false));
+            (bool)$this->modx->getOption('phpthumb_nooffsitelink_enabled', $this->config, false));
         $this->setParameter('config_nooffsitelink_valid_domains', explode(',',
             $this->modx->getOption('phpthumb_nooffsitelink_valid_domains', $this->config,
                 $this->modx->getOption('http_host'))));
         $this->setParameter('config_nooffsitelink_require_refer',
-            (boolean)$this->modx->getOption('phpthumb_nooffsitelink_require_refer', $this->config, false));
+            (bool)$this->modx->getOption('phpthumb_nooffsitelink_require_refer', $this->config, false));
         $this->setParameter('config_nooffsitelink_erase_image',
-            (boolean)$this->modx->getOption('phpthumb_nooffsitelink_erase_image', $this->config, true));
+            (bool)$this->modx->getOption('phpthumb_nooffsitelink_erase_image', $this->config, true));
         $this->setParameter('config_nooffsitelink_watermark_src',
             (string)$this->modx->getOption('phpthumb_nooffsitelink_watermark_src', $this->config, ''));
         $this->setParameter('config_nooffsitelink_text_message',
@@ -97,7 +97,7 @@ class modPhpThumb extends phpthumb
             (string)$this->modx->getOption('phpthumb_imagemagick_path', $this->config, null));
 
         $this->setParameter('cache_source_enabled',
-            (boolean)$this->modx->getOption('phpthumb_cache_source_enabled', $this->config, false));
+            (bool)$this->modx->getOption('phpthumb_cache_source_enabled', $this->config, false));
         $this->setParameter('cache_source_directory', $cachePath . 'source/');
         $this->setParameter('allow_local_http_src', true);
         $this->setParameter('zc',

--- a/core/src/Revolution/modPropertySet.php
+++ b/core/src/Revolution/modPropertySet.php
@@ -174,7 +174,7 @@ class modPropertySet extends xPDOSimpleObject
                 }
 
                 if ($propertyArray['type'] == 'combo-boolean' && is_numeric($propertyArray['value'])) {
-                    $propertyArray['value'] = (boolean)$propertyArray['value'];
+                    $propertyArray['value'] = (bool)$propertyArray['value'];
                 }
 
                 /* handle translations of properties (temp fix until modLocalizableObject in 2.1 and beyond) */

--- a/core/src/Revolution/modRequest.php
+++ b/core/src/Revolution/modRequest.php
@@ -99,7 +99,7 @@ class modRequest
                     false) && $this->modx->getOption('request_method_strict', null, false)) {
                 $uri = $this->modx->context->getResourceURI($this->modx->resourceIdentifier);
                 if (!empty($uri)) {
-                    if ((integer)$this->modx->resourceIdentifier === (integer)$this->modx->getOption('site_start', null,
+                    if ((int)$this->modx->resourceIdentifier === (int)$this->modx->getOption('site_start', null,
                             1)) {
                         $url = $this->modx->getOption('site_url', null, MODX_SITE_URL);
                     } else {
@@ -207,7 +207,7 @@ class modRequest
             xPDO::OPT_CACHE_KEY => $this->modx->getOption('cache_resource_key', null, 'resource'),
             xPDO::OPT_CACHE_HANDLER => $this->modx->getOption('cache_resource_handler', null,
                 $this->modx->getOption(xPDO::OPT_CACHE_HANDLER)),
-            xPDO::OPT_CACHE_FORMAT => (integer)$this->modx->getOption('cache_resource_format', null,
+            xPDO::OPT_CACHE_FORMAT => (int)$this->modx->getOption('cache_resource_format', null,
                 $this->modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
         ]);
         if (is_array($cachedResource) && array_key_exists('resource',
@@ -379,7 +379,7 @@ class modRequest
                         ['responseCode' => $_SERVER['SERVER_PROTOCOL'] . ' 301 Moved Permanently']);
                 }
                 $this->modx->resourceMethod = 'alias';
-            } elseif ((integer)$this->modx->getOption('site_start', null, 1) === $found) {
+            } elseif ((int)$this->modx->getOption('site_start', null, 1) === $found) {
                 $parameters = $this->getParameters();
                 unset($parameters[$this->modx->getOption('request_param_alias')]);
                 $url = $this->modx->makeUrl($this->modx->getOption('site_start', null, 1),
@@ -548,7 +548,7 @@ class modRequest
             $this->modx->getOption(xPDO::OPT_CACHE_HANDLER));
         $partOptions = [xPDO::OPT_CACHE_KEY => $partKey, xPDO::OPT_CACHE_HANDLER => $partHandler];
 
-        $cacheRefreshTime = (integer)$this->modx->cacheManager->get('auto_publish', [
+        $cacheRefreshTime = (int)$this->modx->cacheManager->get('auto_publish', [
             xPDO::OPT_CACHE_KEY => $partKey,
             xPDO::OPT_CACHE_HANDLER => $partHandler,
         ]);

--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -178,17 +178,17 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     {
         /* setup the various options */
         $iconv = function_exists('iconv');
-        $mbext = function_exists('mb_strlen') && (boolean)$xpdo->getOption('use_multibyte', $options, false);
+        $mbext = function_exists('mb_strlen') && (bool)$xpdo->getOption('use_multibyte', $options, false);
         $charset = strtoupper((string)$xpdo->getOption('modx_charset', $options, 'UTF-8'));
         $delimiter = $xpdo->getOption('friendly_alias_word_delimiter', $options, '-');
         $delimiters = $xpdo->getOption('friendly_alias_word_delimiters', $options, '-_');
-        $maxlength = (integer)$xpdo->getOption('friendly_alias_max_length', $options, 0);
-        $stripElementTags = (boolean)$xpdo->getOption('friendly_alias_strip_element_tags', $options, true);
+        $maxlength = (int)$xpdo->getOption('friendly_alias_max_length', $options, 0);
+        $stripElementTags = (bool)$xpdo->getOption('friendly_alias_strip_element_tags', $options, true);
         $trimchars = $xpdo->getOption('friendly_alias_trim_chars', $options, '/.' . $delimiters);
         $restrictchars = $xpdo->getOption('friendly_alias_restrict_chars', $options, 'pattern');
         $restrictcharspattern = $xpdo->getOption('friendly_alias_restrict_chars_pattern', $options,
             '/[\0\x0B\t\n\r\f\a&=+%#<>"~`@\?\[\]\{\}\|\^\'\\\\]/');
-        $lowercase = (boolean)$xpdo->getOption('friendly_alias_lowercase_only', $options, true);
+        $lowercase = (bool)$xpdo->getOption('friendly_alias_lowercase_only', $options, true);
         $translit = $xpdo->getOption('friendly_alias_translit', $options, $iconv ? 'iconv' : 'none');
         $translitClass = $xpdo->getOption('friendly_alias_translit_class', $options, 'translit.modTransliterate');
 
@@ -394,7 +394,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      */
     public static function refreshURIs(modX &$modx, $parent = 0, array $options = [])
     {
-        $resetOverrides = array_key_exists('resetOverrides', $options) ? (boolean)$options['resetOverrides'] : false;
+        $resetOverrides = array_key_exists('resetOverrides', $options) ? (bool)$options['resetOverrides'] : false;
         $contexts = array_key_exists('contexts', $options) ? explode(',', $options['contexts']) : null;
         $criteria = $modx->newQuery(modResource::class, ['parent' => $parent]);
         if (!$resetOverrides) {
@@ -735,7 +735,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
      */
     public function setProcessed($processed)
     {
-        $this->_processed = (boolean)$processed;
+        $this->_processed = (bool)$processed;
     }
 
     /**
@@ -835,9 +835,9 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $enabled = true;
         $context = !empty($context) ? $context : $this->xpdo->context->get('key');
         if ($context === $this->xpdo->context->get('key')) {
-            $enabled = (boolean)$this->xpdo->getOption('access_resource_group_enabled', null, true);
+            $enabled = (bool)$this->xpdo->getOption('access_resource_group_enabled', null, true);
         } elseif ($this->xpdo->getContext($context)) {
-            $enabled = (boolean)$this->xpdo->contexts[$context]->getOption('access_resource_group_enabled', true);
+            $enabled = (bool)$this->xpdo->contexts[$context]->getOption('access_resource_group_enabled', true);
         }
         if ($enabled) {
             if (empty($this->_policies) || !isset($this->_policies[$context])) {
@@ -1059,7 +1059,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $criteria->prepare();
         $duplicate = $this->xpdo->getValue($criteria->stmt);
 
-        return $duplicate > 0 ? (integer)$duplicate : false;
+        return $duplicate > 0 ? (int)$duplicate : false;
     }
 
     /**
@@ -1519,13 +1519,13 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
             [
                 xPDO::OPT_CACHE_HANDLER => $this->xpdo->getOption('cache_resource_handler', null,
                     $this->xpdo->getOption(xPDO::OPT_CACHE_HANDLER, null, 'xPDO\Cache\xPDOFileCache')),
-                xPDO::OPT_CACHE_EXPIRES => (integer)$this->xpdo->getOption('cache_resource_expires', null,
+                xPDO::OPT_CACHE_EXPIRES => (int)$this->xpdo->getOption('cache_resource_expires', null,
                     $this->xpdo->getOption(xPDO::OPT_CACHE_EXPIRES, null, 0)),
-                xPDO::OPT_CACHE_FORMAT => (integer)$this->xpdo->getOption('cache_resource_format', null,
+                xPDO::OPT_CACHE_FORMAT => (int)$this->xpdo->getOption('cache_resource_format', null,
                     $this->xpdo->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
-                xPDO::OPT_CACHE_ATTEMPTS => (integer)$this->xpdo->getOption('cache_resource_attempts', null,
+                xPDO::OPT_CACHE_ATTEMPTS => (int)$this->xpdo->getOption('cache_resource_attempts', null,
                     $this->xpdo->getOption(xPDO::OPT_CACHE_ATTEMPTS, null, 10)),
-                xPDO::OPT_CACHE_ATTEMPT_DELAY => (integer)$this->xpdo->getOption('cache_resource_attempt_delay', null,
+                xPDO::OPT_CACHE_ATTEMPT_DELAY => (int)$this->xpdo->getOption('cache_resource_attempt_delay', null,
                     $this->xpdo->getOption(xPDO::OPT_CACHE_ATTEMPT_DELAY, null, 1000)),
             ]
         );

--- a/core/src/Revolution/modResponse.php
+++ b/core/src/Revolution/modResponse.php
@@ -214,7 +214,7 @@ class modResponse
     public function sendRedirect($url, $options = false, $type = '', $responseCode = '')
     {
         if (!is_array($options)) {
-            $options = ['count_attempts' => (boolean)$options];
+            $options = ['count_attempts' => (bool)$options];
         }
 
         if ($type) {

--- a/core/src/Revolution/modScript.php
+++ b/core/src/Revolution/modScript.php
@@ -173,7 +173,7 @@ class modScript extends modElement
                     xPDO::OPT_CACHE_KEY => $this->xpdo->getOption('cache_scripts_key', null, 'scripts'),
                     xPDO::OPT_CACHE_HANDLER => $this->xpdo->getOption('cache_scripts_handler', null,
                         $this->xpdo->getOption(xPDO::OPT_CACHE_HANDLER)),
-                    xPDO::OPT_CACHE_FORMAT => (integer)$this->xpdo->getOption('cache_scripts_format', null,
+                    xPDO::OPT_CACHE_FORMAT => (int)$this->xpdo->getOption('cache_scripts_format', null,
                         $this->xpdo->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
                 ]);
             }

--- a/core/src/Revolution/modSessionHandler.php
+++ b/core/src/Revolution/modSessionHandler.php
@@ -45,16 +45,16 @@ class modSessionHandler implements \SessionHandlerInterface
     public function __construct(modX &$modx)
     {
         $this->modx = &$modx;
-        $gcMaxlifetime = (integer)$this->modx->getOption('session_gc_maxlifetime');
+        $gcMaxlifetime = (int)$this->modx->getOption('session_gc_maxlifetime');
         if ($gcMaxlifetime > 0) {
             $this->gcMaxLifetime = $gcMaxlifetime;
         } else {
-            $this->gcMaxLifetime = (integer)@ini_get('session.gc_maxlifetime');
+            $this->gcMaxLifetime = (int)@ini_get('session.gc_maxlifetime');
         }
         if ($this->modx->getOption('cache_db_session', null, false)) {
             $cacheLifetime = $this->modx->getOption('cache_db_session_lifetime', null, false);
-            if ((integer)$cacheLifetime > 0) {
-                $this->cacheLifetime = (integer)$cacheLifetime;
+            if ((int)$cacheLifetime > 0) {
+                $this->cacheLifetime = (int)$cacheLifetime;
             } elseif ($cacheLifetime !== false && $this->gcMaxLifetime > 0) {
                 $this->cacheLifetime = $this->gcMaxLifetime / 4;
             }

--- a/core/src/Revolution/modTag.php
+++ b/core/src/Revolution/modTag.php
@@ -486,7 +486,7 @@ abstract class modTag
      */
     public function setCacheable($cacheable = true)
     {
-        $this->_cacheable = (boolean)$cacheable;
+        $this->_cacheable = (bool)$cacheable;
     }
 
     /**

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -79,7 +79,7 @@ class modUser extends modPrincipal
      */
     public function setSudo($sudo)
     {
-        $this->_fields['sudo'] = (boolean)$sudo;
+        $this->_fields['sudo'] = (bool)$sudo;
         $this->setDirty('sudo');
 
         return true;

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -323,7 +323,7 @@ class modX extends xPDO {
             } elseif (is_string($value)) {
                 if (!empty($patterns)) {
                     $iteration = 1;
-                    $nesting = ((integer) $nesting ? (integer) $nesting : 10);
+                    $nesting = ((int) $nesting ? (int) $nesting : 10);
                     while ($iteration <= $nesting) {
                         $matched = false;
                         foreach ($patterns as $pattern) {
@@ -532,7 +532,7 @@ class modX extends xPDO {
                 'username' => $database_user,
                 'password' => $database_password,
                 'options' => [
-                    xPDO::OPT_CONN_MUTABLE => isset($data[xPDO::OPT_CONN_MUTABLE]) ? (boolean) $data[xPDO::OPT_CONN_MUTABLE] : true,
+                    xPDO::OPT_CONN_MUTABLE => isset($data[xPDO::OPT_CONN_MUTABLE]) ? (bool) $data[xPDO::OPT_CONN_MUTABLE] : true,
                 ],
                 'driverOptions' => $driver_options,
             ];
@@ -542,7 +542,7 @@ class modX extends xPDO {
             array_unshift($data[xPDO::OPT_CONNECTIONS], $primaryConnection);
             if (!empty($site_id)) $this->site_id = $site_id;
             if (!empty($uuid)) $this->uuid = $uuid;
-            if ((boolean)$data['load_deprecated_global_class_aliases']) {
+            if ((bool)$data['load_deprecated_global_class_aliases']) {
                 include_once MODX_CORE_PATH . 'include/deprecated.php';
             }
 
@@ -1103,14 +1103,14 @@ class modX extends xPDO {
         $resourceId = false;
         if (empty($context) && isset($this->context)) $context = $this->context->get('key');
         if (!empty($context) && (!empty($uri) || $uri === '0')) {
-            $useAliasMap = (boolean) $this->getOption('cache_alias_map', null, false);
+            $useAliasMap = (bool) $this->getOption('cache_alias_map', null, false);
             if ($useAliasMap) {
                 if (isset($this->context) && $this->context->get('key') === $context && is_array($this->aliasMap) && array_key_exists($uri, $this->aliasMap)) {
-                    $resourceId = (integer) $this->aliasMap[$uri];
+                    $resourceId = (int) $this->aliasMap[$uri];
                 } elseif ($ctx = $this->getContext($context)) {
                     $useAliasMap = $ctx->getOption('cache_alias_map', false) && is_array($ctx->aliasMap) && array_key_exists($uri, $ctx->aliasMap);
                     if ($useAliasMap && array_key_exists($uri, $ctx->aliasMap)) {
-                        $resourceId = (integer) $ctx->aliasMap[$uri];
+                        $resourceId = (int) $ctx->aliasMap[$uri];
                     }
                 }
             }
@@ -1180,7 +1180,7 @@ class modX extends xPDO {
             $this->log(modX::LOG_LEVEL_FATAL, "Could not load response class.");
         }
         if (!is_array($options)) {
-            $options = ['count_attempts' => (boolean) $options];
+            $options = ['count_attempts' => (bool) $options];
         }
         if ($type) {
             $this->deprecated('2.0.5', 'Use type in options array instead.', 'sendRedirect method parameter $type');
@@ -1999,7 +1999,7 @@ class modX extends xPDO {
                 $patterns = $this->sanitizePatterns;
             }
             foreach ($patterns as $pattern) {
-                $depth = ((integer) $depth ? (integer) $depth : 10);
+                $depth = ((int) $depth ? (int) $depth : 10);
                 $iteration = 1;
                 while ($iteration <= $depth && preg_match($pattern, $stripped)) {
                     $stripped= preg_replace($pattern, '', $stripped);
@@ -2039,7 +2039,7 @@ class modX extends xPDO {
 
         /** @var modManagerLog $ml */
         $ml = $this->newObject(modManagerLog::class);
-        $ml->set('user', (integer) $userId);
+        $ml->set('user', (int) $userId);
         $ml->set('occurred', date('Y-m-d H:i:s'));
         $ml->set('action', empty($action) ? 'unknown' : $action);
         $ml->set('classKey', empty($class_key) ? '' : $class_key);
@@ -2588,7 +2588,7 @@ class modX extends xPDO {
             }
         }
         if ($this->context) {
-            if (!$this->context->prepare((boolean) $regenerate, is_array($options) ? $options : [])) {
+            if (!$this->context->prepare((bool) $regenerate, is_array($options) ? $options : [])) {
                 $this->context= null;
                 $this->log(modX::LOG_LEVEL_ERROR, 'Could not prepare context: ' . $contextKey);
             } else {
@@ -2860,7 +2860,7 @@ class modX extends xPDO {
                     $this->getUser($contextKey);
                     $cookieExpiration = 0;
                     if (isset ($_SESSION['modx.' . $contextKey . '.session.cookie.lifetime'])) {
-                        $sessionCookieLifetime = (integer)$_SESSION['modx.' . $contextKey . '.session.cookie.lifetime'];
+                        $sessionCookieLifetime = (int)$_SESSION['modx.' . $contextKey . '.session.cookie.lifetime'];
                         if ($sessionCookieLifetime !== $cookieLifetime) {
                             if ($sessionCookieLifetime) {
                                 $cookieExpiration = time() + $sessionCookieLifetime;
@@ -2902,7 +2902,7 @@ class modX extends xPDO {
         $config = $this->cacheManager->get('config', [
             xPDO::OPT_CACHE_KEY => $this->getOption('cache_system_settings_key', null, 'system_settings'),
             xPDO::OPT_CACHE_HANDLER => $this->getOption('cache_system_settings_handler', null, $this->getOption(xPDO::OPT_CACHE_HANDLER)),
-            xPDO::OPT_CACHE_FORMAT => (integer) $this->getOption('cache_system_settings_format', null, $this->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
+            xPDO::OPT_CACHE_FORMAT => (int) $this->getOption('cache_system_settings_format', null, $this->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)),
         ]
         );
         if (empty($config)) {

--- a/manager/controllers/default/element/chunk/update.class.php
+++ b/manager/controllers/default/element/chunk/update.class.php
@@ -70,7 +70,7 @@ class ElementChunkUpdateManagerController extends modManagerController {
         $placeholders = [];
 
         /* grab chunk */
-        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
+        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((int)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('chunk_err_ns'));
         }
         $this->chunk = $this->modx->getObject(modChunk::class, ['id' => $scriptProperties['id']]);

--- a/manager/controllers/default/element/plugin/update.class.php
+++ b/manager/controllers/default/element/plugin/update.class.php
@@ -74,7 +74,7 @@ class ElementPluginUpdateManagerController extends modManagerController {
         $placeholders = [];
 
         /* load plugin */
-        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
+        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((int)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('plugin_err_ns'));
         }
         $this->plugin = $this->modx->getObject(modPlugin::class, ['id' => $scriptProperties['id']]);

--- a/manager/controllers/default/element/snippet/update.class.php
+++ b/manager/controllers/default/element/snippet/update.class.php
@@ -73,7 +73,7 @@ class ElementSnippetUpdateManagerController extends modManagerController {
         $placeholders = [];
 
         /* load snippet */
-        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
+        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((int)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('snippet_err_ns'));
         }
         $this->snippet = $this->modx->getObject(modSnippet::class, ['id' => $scriptProperties['id']]);

--- a/manager/controllers/default/element/template/update.class.php
+++ b/manager/controllers/default/element/template/update.class.php
@@ -74,7 +74,7 @@ class ElementTemplateUpdateManagerController extends modManagerController {
         $placeholders = [];
 
         /* load template */
-        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
+        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((int)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('template_err_ns'));
         }
         $this->template = $this->modx->getObject(modTemplate::class, ['id' => $scriptProperties['id']]);

--- a/manager/controllers/default/element/tv/update.class.php
+++ b/manager/controllers/default/element/tv/update.class.php
@@ -78,7 +78,7 @@ class ElementTVUpdateManagerController extends modManagerController {
         $placeholders = [];
 
         /* load tv */
-        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
+        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((int)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('tv_err_ns'));
         }
         $this->tv = $this->modx->getObject(modTemplateVar::class, ['id' => $scriptProperties['id']]);

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -66,7 +66,7 @@ class TopMenu
     {
         $this->controller =& $controller;
         $this->modx =& $controller->modx;
-        $this->showDescriptions = (boolean) $this->modx->getOption('topmenu_show_descriptions', null, true);
+        $this->showDescriptions = (bool) $this->modx->getOption('topmenu_show_descriptions', null, true);
     }
 
     /**
@@ -232,7 +232,7 @@ class TopMenu
                 null,
                 $this->modx->getOption(xPDO::OPT_CACHE_HANDLER)
             ),
-            xPDO::OPT_CACHE_FORMAT => (integer) $this->modx->getOption(
+            xPDO::OPT_CACHE_FORMAT => (int) $this->modx->getOption(
                 'cache_menu_format',
                 null,
                 $this->modx->getOption(xPDO::OPT_CACHE_FORMAT, null, xPDOCacheManager::CACHE_PHP)

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -80,7 +80,7 @@ abstract class ResourceManagerController extends modManagerController
             $resourceClass = in_array($_REQUEST['class_key'], [modDocument::class, modResource::class]) ? modDocument::class
                 : $_REQUEST['class_key'];
             if ($resourceClass == modResource::class) $resourceClass = modDocument::class;
-        } elseif (!empty($_REQUEST['id']) && $_REQUEST['id'] != 'undefined' && strlen($_REQUEST['id']) === strlen((integer)$_REQUEST['id'])) {
+        } elseif (!empty($_REQUEST['id']) && $_REQUEST['id'] != 'undefined' && strlen($_REQUEST['id']) === strlen((int)$_REQUEST['id'])) {
             /** @var modResource $resource */
             $resource = $modx->getObject(modResource::class, ['id' => $_REQUEST['id']]);
             if ($resource && !in_array($resource->get('class_key'), [modDocument::class, modResource::class])) {
@@ -548,7 +548,7 @@ abstract class ResourceManagerController extends modManagerController
         $resourceGroups = $this->resource->getGroupsList(['name' => 'ASC'], 0, 0);
         /** @var modResourceGroup $resourceGroup */
         foreach ($resourceGroups['collection'] as $resourceGroup) {
-            $access = (boolean)$resourceGroup->get('access');
+            $access = (bool)$resourceGroup->get('access');
             if (!empty($parent) && $this->resource->get('id') == 0) {
                 $access = in_array($resourceGroup->get('id'), $parentGroups) ? true : false;
             }

--- a/manager/controllers/default/security/access/policy/template/update.class.php
+++ b/manager/controllers/default/security/access/policy/template/update.class.php
@@ -38,7 +38,7 @@ class SecurityAccessPolicyTemplateUpdateManagerController extends modManagerCont
      * @return void
      */
     public function initialize() {
-        if (!empty($this->scriptProperties['id']) && strlen($this->scriptProperties['id']) === strlen((integer)$this->scriptProperties['id'])) {
+        if (!empty($this->scriptProperties['id']) && strlen($this->scriptProperties['id']) === strlen((int)$this->scriptProperties['id'])) {
             $this->template = $this->modx->getObject(modAccessPolicyTemplate::class, ['id' => $this->scriptProperties['id']]);
         }
     }

--- a/manager/controllers/default/security/access/policy/update.class.php
+++ b/manager/controllers/default/security/access/policy/update.class.php
@@ -58,7 +58,7 @@ class SecurityAccessPolicyUpdateManagerController extends modManagerController {
     public function process(array $scriptProperties = []) {
         $placeholders = [];
 
-        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
+        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((int)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('access_policy_err_ns'));
         }
         $policy = $this->modx->getObject(modAccessPolicy::class, ['id' => $scriptProperties['id']]);

--- a/manager/controllers/default/security/forms/profile/update.class.php
+++ b/manager/controllers/default/security/forms/profile/update.class.php
@@ -61,7 +61,7 @@ class SecurityFormsProfileUpdateManagerController extends modManagerController {
     public function process(array $scriptProperties = []) {
         $placeholders = [];
 
-        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((integer)$scriptProperties['id'])) {
+        if (empty($scriptProperties['id']) || strlen($scriptProperties['id']) !== strlen((int)$scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('profile_err_ns'));
         }
         $profile = $this->modx->getObject(modFormCustomizationProfile::class, ['id' => $scriptProperties['id']]);

--- a/manager/controllers/default/source/update.class.php
+++ b/manager/controllers/default/source/update.class.php
@@ -60,7 +60,7 @@ class SourceUpdateManagerController extends modManagerController {
      * @return mixed
      */
     public function process(array $scriptProperties = []) {
-        if (empty($this->scriptProperties['id']) || strlen($this->scriptProperties['id']) !== strlen((integer)$this->scriptProperties['id'])) {
+        if (empty($this->scriptProperties['id']) || strlen($this->scriptProperties['id']) !== strlen((int)$this->scriptProperties['id'])) {
             return $this->failure($this->modx->lexicon('source_err_ns'));
         }
         $this->source = $this->modx->getObject(modMediaSource::class, ['id' => $this->scriptProperties['id']]);

--- a/manager/controllers/default/system/dashboards/update.class.php
+++ b/manager/controllers/default/system/dashboards/update.class.php
@@ -41,7 +41,7 @@ class SystemDashboardsUpdateManagerController extends modManagerController {
      * @return array
      */
     public function process(array $scriptProperties = []) {
-        if (empty($this->scriptProperties['id']) || strlen($this->scriptProperties['id']) !== strlen((integer)$this->scriptProperties['id'])) {
+        if (empty($this->scriptProperties['id']) || strlen($this->scriptProperties['id']) !== strlen((int)$this->scriptProperties['id'])) {
             $this->failure($this->modx->lexicon('dashboard_err_ns'));
             return [];
         }

--- a/manager/controllers/default/system/dashboards/widget/update.class.php
+++ b/manager/controllers/default/system/dashboards/widget/update.class.php
@@ -40,7 +40,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
      * @return void
      */
     public function initialize() {
-        if (!empty($this->scriptProperties['id']) && strlen($this->scriptProperties['id']) === strlen((integer)$this->scriptProperties['id'])) {
+        if (!empty($this->scriptProperties['id']) && strlen($this->scriptProperties['id']) === strlen((int)$this->scriptProperties['id'])) {
             $this->widget = $this->modx->getObject(modDashboardWidget::class, ['id' => $this->scriptProperties['id']]);
         }
     }
@@ -166,7 +166,7 @@ class SystemDashboardsWidgetUpdateManagerController extends modManagerController
         if (!$remoteData) {
             return [];
         }
-        $usemb = function_exists('mb_strlen') && (boolean)$this->modx->getOption('use_multibyte', null, false);
+        $usemb = function_exists('mb_strlen') && (bool)$this->modx->getOption('use_multibyte', null, false);
         $encoding = $this->modx->getOption('modx_charset', null, 'UTF-8');
         $fields = [];
         foreach ($remoteData as $key => $value) {

--- a/manager/controllers/default/workspaces/index.class.php
+++ b/manager/controllers/default/workspaces/index.class.php
@@ -68,7 +68,7 @@ class WorkspacesManagerController extends modManagerController {
         $this->addHtml("<script>
             Ext.onReady(function() {
                 MODx.errors = ".$this->modx->toJSON($this->errors).";
-                MODx.defaultProvider = '".$this->providerId."';MODx.provider = '".$this->providerId."';MODx.providerName = '".$this->providerName."';MODx.curlEnabled = ".(integer)$this->curlEnabled."; Ext.ux.Lightbox.register('a.lightbox');
+                MODx.defaultProvider = '".$this->providerId."';MODx.provider = '".$this->providerId."';MODx.providerName = '".$this->providerName."';MODx.curlEnabled = ".(int)$this->curlEnabled."; Ext.ux.Lightbox.register('a.lightbox');
                 MODx.add('modx-page-workspace');
             });</script>");
         $this->addJavascript($mgrUrl.'assets/modext/workspace/index.js');

--- a/setup/includes/error/modinstallerror.class.php
+++ b/setup/includes/error/modinstallerror.class.php
@@ -123,7 +123,7 @@ abstract class modInstallError {
                 $message = $s;
             }
         }
-        $this->status = (boolean) $status;
+        $this->status = (bool) $status;
 
         if ($message != '') {
             $this->message = $message;

--- a/setup/includes/request/modinstallclirequest.class.php
+++ b/setup/includes/request/modinstallclirequest.class.php
@@ -323,7 +323,7 @@ class modInstallCLIRequest extends modInstallRequest {
             if ($stmt) {
                 $row = $stmt->fetch(PDO::FETCH_ASSOC);
                 if ($row) {
-                    $count = (integer) $row['ct'];
+                    $count = (int) $row['ct'];
                 }
                 $stmt->closeCursor();
             }

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -356,7 +356,7 @@ if ($provider && $newProvider && $provider->get('id') != $newProvider->get('id')
 /* Set session_gc_maxlifetime equal to session_cookie_lifetime or session.gc_maxlifetime if empty */
 $setting = $modx->getObject(modSystemSetting::class, ['key' => 'session_gc_maxlifetime']);
 if ($setting && $setting->get('value') == '') {
-    $session_gc_maxlifetime = (integer) $modx->getOption('session_cookie_lifetime', null, @ini_get('session.gc_maxlifetime'));
+    $session_gc_maxlifetime = (int) $modx->getOption('session_cookie_lifetime', null, @ini_get('session.gc_maxlifetime'));
     if ($session_gc_maxlifetime < 1) {
         $session_gc_maxlifetime = 604800;
     }

--- a/setup/processors/database/connection.php
+++ b/setup/processors/database/connection.php
@@ -134,7 +134,7 @@ $stmt = $xpdo->query($install->driver->testTablePrefix($database,$prefix));
 if ($stmt) {
     $row = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($row) {
-        $count = (integer) $row['ct'];
+        $count = (int) $row['ct'];
     }
     $stmt->closeCursor();
 }


### PR DESCRIPTION
### What does it do?
Improves PHP 8.5 compatibility.

### Why is it needed?
PHP 8.5 introduces some deprecations that resulted in a large number of deprecation warnings.

### How to test
Apply, make sure to composer update, and then check for deprecation warnings concerning usages of non-canonical cast names.

### Related issue(s)/PR(s)
N/A