### PR TITLE
Increase default minimum and generated passsword lengths

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1240,7 +1240,7 @@ $settings['proxy_username']->fromArray([
 $settings['password_generated_length'] = $xpdo->newObject(modSystemSetting::class);
 $settings['password_generated_length']->fromArray([
   'key' => 'password_generated_length',
-  'value' => 10,
+  'value' => 16,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'authentication',
@@ -1249,7 +1249,7 @@ $settings['password_generated_length']->fromArray([
 $settings['password_min_length'] = $xpdo->newObject(modSystemSetting::class);
 $settings['password_min_length']->fromArray([
   'key' => 'password_min_length',
-  'value' => 8,
+  'value' => 12,
   'xtype' => 'numberfield',
   'namespace' => 'core',
   'area' => 'authentication',

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -109,24 +109,24 @@ class modUserTest extends MODxTestCase {
         $this->assertNotEmpty($password);
         $this->assertNotEquals(12, strlen($password));
 
-        $this->modx->setOption('password_generated_length',12);
+        $this->modx->setOption('password_generated_length', 12);
         $anotherPassword = $this->user->generatePassword();
         $this->assertNotEmpty($anotherPassword);
         $this->assertEquals(12, strlen($anotherPassword));
 
-        $this->modx->setOption('password_generated_length','');
+        $this->modx->setOption('password_generated_length', '');
         $yetAnotherPassword = $this->user->generatePassword();
         $this->assertNotEmpty($yetAnotherPassword);
-        $this->assertEquals(10, strlen($yetAnotherPassword));
+        $this->assertEquals(16, strlen($yetAnotherPassword));
     }
 
     public function testGeneratePasswordMinLength()
     {
-        $defaultPasswordMinLength = $this->modx->getOption('password_min_length', 8);
+        $defaultPasswordMinLength = $this->modx->getOption('password_min_length', 12);
         $password = $this->user->generatePassword();
         $this->assertGreaterThanOrEqual($defaultPasswordMinLength, strlen($password));
 
-        $passwordGeneratedLength = 10;
+        $passwordGeneratedLength = 16;
         $passwordMinLength = 12;
         $this->modx->setOption('password_generated_length', $passwordGeneratedLength);
         $this->modx->setOption('password_min_length', $passwordMinLength);

--- a/_build/test/Tests/Model/Security/modUserTest.php
+++ b/_build/test/Tests/Model/Security/modUserTest.php
@@ -88,18 +88,18 @@ class modUserTest extends MODxTestCase {
      * @param array $options
      * @dataProvider providerGeneratePassword
      */
-    public function testGeneratePassword($length,array $options = []) {
-        $password = $this->user->generatePassword($length,$options);
+    public function testGeneratePassword($length, array $options = []) {
+        $password = $this->user->generatePassword($length, $options);
         $this->assertNotEmpty($password);
-        $this->assertEquals($length,strlen($password));
+        $this->assertEquals($length, strlen($password));
     }
     /**
      * @return array
      */
     public function providerGeneratePassword() {
         return [
-            [10],
-            [8],
+            [12],
+            [18],
         ];
     }
 

--- a/core/src/Revolution/Processors/Security/Profile/ChangePassword.php
+++ b/core/src/Revolution/Processors/Security/Profile/ChangePassword.php
@@ -50,7 +50,7 @@ class ChangePassword extends Processor
 
         $password = $this->getProperty('password_new');
         if (!$this->getProperty('password_method_screen')) {
-            $length = (int)$this->modx->getOption('password_min_length', null, 8);
+            $length = (int)$this->modx->getOption('password_min_length', null, 12);
             $password = str_repeat('*', mt_rand($length, strlen($this->getProperty('password_new')) * 2));
         }
 
@@ -68,7 +68,7 @@ class ChangePassword extends Processor
             $this->addFieldError('password_old', $this->modx->lexicon('user_err_password_invalid_old'));
         }
 
-        if (empty($newPassword) || strlen($newPassword) < $this->modx->getOption('password_min_length', null, 8)) {
+        if (empty($newPassword) || strlen($newPassword) < $this->modx->getOption('password_min_length', null, 12)) {
             $this->addFieldError('password_new', $this->modx->lexicon('user_err_password_too_short'));
         } else {
             if (!preg_match('/^[^\'\x3c\x3e\(\);\x22\x7b\x7d\x2f\x5c]+$/', $newPassword)) {

--- a/core/src/Revolution/Processors/Security/Profile/Update.php
+++ b/core/src/Revolution/Processors/Security/Profile/Update.php
@@ -117,7 +117,7 @@ class Update extends Processor
             if (!$this->modx->user->passwordMatches($oldPassword)) {
                 $this->addFieldError('password_old', $this->modx->lexicon('user_err_password_invalid_old'));
             }
-            if (empty($newPassword) || strlen($newPassword) < $this->modx->getOption('password_min_length', null, 8)) {
+            if (empty($newPassword) || strlen($newPassword) < $this->modx->getOption('password_min_length', null, 12)) {
                 $this->addFieldError('password_new', $this->modx->lexicon('user_err_password_too_short'));
             } elseif (!preg_match('/^[^\'\x3c\x3e\(\);\x22\x7b\x7d\x2f\x5c]+$/', $newPassword)) {
                 $this->addFieldError('password_new', $this->modx->lexicon('user_err_password_invalid'));

--- a/core/src/Revolution/Processors/Security/User/Validation.php
+++ b/core/src/Revolution/Processors/Security/User/Validation.php
@@ -101,7 +101,7 @@ class Validation
                     $this->processor->addFieldError('specifiedpassword', $this->modx->lexicon('user_err_not_specified_password'));
                 } elseif ($specifiedPassword != $confirmPassword) {
                     $this->processor->addFieldError('confirmpassword', $this->modx->lexicon('user_err_password_no_match'));
-                } elseif (strlen($specifiedPassword) < $this->modx->getOption('password_min_length', null, 8, true)) {
+                } elseif (strlen($specifiedPassword) < $this->modx->getOption('password_min_length', null, 12, true)) {
                     $this->processor->addFieldError('specifiedpassword', $this->modx->lexicon('user_err_password_too_short'));
                 } elseif (!preg_match('/^[^\'\x3c\x3e\(\);\x22\x7b\x7d\x2f\x5c]+$/', $specifiedPassword)) {
                     $this->processor->addFieldError('specifiedpassword', $this->modx->lexicon('user_err_password_invalid'));

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -897,10 +897,10 @@ class modUser extends modPrincipal
     public function generatePassword($length = null, array $options = [])
     {
         if ($length === null) {
-            $length = (int)$this->xpdo->getOption('password_generated_length', null, 10, true);
+            $length = (int)$this->xpdo->getOption('password_generated_length', null, 16, true);
         }
 
-        $passwordMinimumLength = (int)$this->xpdo->getOption('password_min_length', null, 8, true);
+        $passwordMinimumLength = (int)$this->xpdo->getOption('password_min_length', null, 12, true);
         if ($length < $passwordMinimumLength) {
             $length = $passwordMinimumLength;
         }

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -249,7 +249,7 @@ class SecurityLoginManagerController extends modManagerController
                 $this->scriptProperties['modhash'] = $this->modx->sanitizeString($hash);
                 // Reassign lexicons to smarty so we could use system setting here
                 $this->placeholders['_lang']['login_new_password_note'] = $this->modx->lexicon('login_new_password_note', [
-                    'length' =>$this->modx->getOption('password_min_length')
+                    'length' => $this->modx->getOption('password_min_length', null, 12)
                 ]);
                 $this->modx->smarty->assign('_lang', $this->placeholders['_lang']);
             } else {


### PR DESCRIPTION
### What does it do?
Increases the default minimum and generated password lengths.

### Why is it needed?
The National Institute of Standards and Technology (NIST) has updated its 2025 guidelines, moving away from mandatory resets and complex character requirements towards practices like longer passwords, real-time blocklists, and Multi-Factor Authentication (MFA).

### How to test
Make sure the defaults are respected if you set the values to empty strings in system settings and that new installs get the new default values.

### Related issue(s)/PR(s)
Resolves #16756 