### PR TITLE
Fix file size calculation in modTransportPackage

### DIFF
--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -747,8 +747,10 @@ class modTransportPackage extends xPDOObject
     protected function _bytes($value)
     {
         $value = trim($value);
-        $modifier = strtolower($value[strlen($value) - 1]);
-        switch ($modifier) {
+        $modifier = substr($value, -1);
+        $value = (int)str_replace($modifier, '', $value);
+
+        switch (strtolower($modifier)) {
             case 'g':
                 $value *= 1024;
                 // no break

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -747,10 +747,15 @@ class modTransportPackage extends xPDOObject
     protected function _bytes($value)
     {
         $value = trim($value);
-        $modifier = substr($value, -1);
-        $value = (int)str_replace($modifier, '', $value);
+        $modifiers = ['g', 'm', 'k'];
+        $lastChar = substr($value, -1);
+        $modifier = strtolower($lastChar);
+        if (!in_array($modifier, $modifiers)) {
+            return (int)$value;
+        }
+        $value = (int)rtrim($value, $lastChar);
 
-        switch (strtolower($modifier)) {
+        switch ($modifier) {
             case 'g':
                 $value *= 1024;
                 // no break


### PR DESCRIPTION
### What does it do?
Strips size modifier (K,M,G) before calculation performed in the `_bytes` method.

### Why is it needed?
A php warning occurs (and gets logged in MODX as an error) because the `_bytes` function attempts to use the ini `memory_limit` value in a calculation without removing the modifier string (_e.g._, 128M *= 1024). This triggers the “A non-numeric value encountered” warning.

### How to test

1. Download any package before applying this PR fix. Note the warning in your MODX error log
2. Apply this PR and verify the warning no longer appears and that package downloads work as expected

### Related issue(s)/PR(s)
Resolves #16504. 

Note that the second warning re filesize could not be replicated (for my environ at least), although there needs to be a bit of redesign done in general with how files are read and stats are accessed; basically, everywhere that uses error suppression via the @ operator should be refactored to avoid these errors and warnings in general. This should be done in a different PR though.
