### PR TITLE
fix(3.x): Fix improper error message sanitization added in 16792

### DIFF
--- a/core/src/Revolution/modDashboardWidgetInterface.php
+++ b/core/src/Revolution/modDashboardWidgetInterface.php
@@ -84,9 +84,9 @@ abstract class modDashboardWidgetInterface
         } catch (Throwable $t) {
             $this->controller->setPlaceholder('_e', [
                 'message' => htmlspecialchars($t->getMessage(), ENT_QUOTES),
-                'errors' => htmlspecialchars(
+                'errors' => filter_var_array(
                     explode("\n", $t->getTraceAsString()),
-                    ENT_QUOTES
+                    FILTER_SANITIZE_FULL_SPECIAL_CHARS
                 ),
             ]);
             $output = $this->controller->fetchTemplate('error.tpl');


### PR DESCRIPTION
### What does it do?
Change htmlspechailchars to filter_var_array

### Why is it needed?
If a dashboard widget breaks, it takes down the whole dashboard due to passing an array to `htmlspecialchars()`

### How to test
I found it by having a broken dashboard widget. You could just create a PHP widget and put in a broken code. 

### Related issue(s)/PR(s)
#16792
