### PR TITLE
Return skipExtensions directly instead of exploding

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2073,7 +2073,7 @@ QTIP;
             $skipExtensions = explode(',', $skipExtensions);
         }
 
-        return !empty($skipExtensions) ? explode(',', $skipExtensions) : [];
+        return $skipExtensions;
     }
 
 


### PR DESCRIPTION
### What does it do?
Fixes `modMediaSource::getSkipExtensionsArray()` so it returns the already-parsed `$skipExtensions` array directly instead of calling `explode()` a second time. Since `$skipExtensions` is already converted to an array earlier in the method, re-exploding it is redundant and can cause runtime errors.

### Why is it needed?
Calling `explode(',', $skipExtensions)` after `$skipExtensions` has already been converted to an array can lead to a runtime error, especially on PHP 8+, where `explode()` requires a string. This change ensures the method consistently returns an array of extensions and avoids PHP errors.

### How to test
1. In the Manager, create or edit a Media Source that uses `modMediaSource` (or a derivative).
2. Set the `skipExtensions` property to a comma-separated list (e.g. `zip,rar,psd`).
3. Open the Media Browser or perform any action that relies on this property.
4. Verify that:
   - No PHP error related to `explode()` occurs.
   - The skip extensions are applied correctly.

### Related issue(s)/PR(s)
- None yet.