### PR TITLE
Bump minimum PHP requirement to 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "vendor-dir": "core/vendor"
     },
     "require": {
-        "php": ">=7.4.0",
+        "php": ">=8.1",
         "xpdo/xpdo": "~3.1.0",
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",


### PR DESCRIPTION
### What does it do?
Bumps the minimum PHP requirement to the 8.1 release.

### Why is it needed?
A security vulnerability in the AWS-SDK-PHP dependency was fixed only in releases that require PHP >= 8.1 which prevents installation of dependencies via composer without ignorning vulnerabilities. I believe the best course of action is dropping support for PHP < 8.1.

### How to test
Make sure everything still works with all of the dependency updates that will come with bumping our minimum PHP to >= 8.1.

### Related issue(s)/PR(s)
N/A