### PR TITLE
Add generic return type to Container::get PHPDoc

### DIFF
--- a/core/src/Revolution/Services/Container.php
+++ b/core/src/Revolution/Services/Container.php
@@ -21,6 +21,11 @@ class Container extends \Pimple\Container implements ContainerInterface
 
     /**
      * @inheritDoc
+     * @template T of object
+     * @param class-string<T>|string $id
+     * @return T|null
+     * @throws NotFoundException
+     * @throws ContainerException
      */
     public function get(string $id)
     {


### PR DESCRIPTION
### What does it do?

Updates the PHPDoc for `Container::get()` to include a generic template type, a typed `class-string` parameter, and an explicit nullable return type:

```php
@template T of object
@param class-string<T>|string $id
@return T|null
```

The existing `@inheritDoc` annotation is retained, and no runtime logic is changed.

### Why is it needed?

`Container::get()` already supports resolving services by class name, but IDEs and static analysis tools currently infer its return type as `object|null`. This loses valuable type information for consumers and degrades autocomplete and static analysis.

Adding a generic PHPDoc allows tools such as PhpStorm, Psalm, and PHPStan to correctly infer the concrete service type when a class-string is passed, improving developer experience without altering behaviour.

### How to test

No runtime testing is required as this change only affects documentation.

To verify the improvement:

1. Call `Container::get()` with a class name (e.g. `Foo::class`)
2. Confirm that the returned variable is inferred as the correct type in the IDE
3. Ensure no static analysis errors are introduced

### Related issue(s)/PR(s)

None (documentation-only improvement).

