### PR TITLE
Fix sorting logic in Security/Group/GetList.php

### DIFF
--- a/core/src/Revolution/Processors/Security/Group/GetList.php
+++ b/core/src/Revolution/Processors/Security/Group/GetList.php
@@ -106,8 +106,8 @@ class GetList extends GetListProcessor
                 'OR:description:LIKE' => '%' . $query . '%',
             ]);
         }
-        $sortby = $this->getProperty('sort','name');
-        $dir = $this->getProperty('dir','ASC');
+        $sortby = $this->getProperty('sort', 'name');
+        $dir = $this->getProperty('dir', 'ASC');
         $c->sortby('parent', 'asc');
         $c->sortby($sortby, $dir);
         return $c;

--- a/core/src/Revolution/Processors/Security/Group/GetList.php
+++ b/core/src/Revolution/Processors/Security/Group/GetList.php
@@ -106,9 +106,10 @@ class GetList extends GetListProcessor
                 'OR:description:LIKE' => '%' . $query . '%',
             ]);
         }
+        $sortby = $this->getProperty('sort','name');
+        $dir = $this->getProperty('dir','ASC');
         $c->sortby('parent', 'asc');
-        $c->sortby('id', 'asc');
-        
+        $c->sortby($sortby, $dir);
         return $c;
     }
 }


### PR DESCRIPTION
According to the header comment, `$sort` and `$dir` should be used to configure the **sort by** column and the sort direction.

## What does it do?
The header file comment states:

```php
@param string $sort (optional) The column to sort by. Defaults to name.
@param string $dir  (optional) The direction of the sort. Defaults to ASC.
```
However, the actual implementation was sorting by id, without using $sort or $dir, and the sort direction was always ASC.

## Why is it needed?

This PR fixes the issue by using name as the default sort column and $dir to properly configure the sort direction.

## How to test

Open the Groups ACL and check that groups are now sorted by their names.

### Related issue(s)/PR(s) 

not found