### PR TITLE
Send mails with Office 365 SMTP accounts

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -920,36 +920,36 @@ $settings['mail_smtp_auth_type']->fromArray([
     'area' => 'mail',
     'editedon' => null,
 ], '', true, true);
-$settings['mail_smtp_outh2_azure_client_id'] = $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_outh2_azure_client_id']->fromArray([
-    'key' => 'mail_smtp_outh2_azure_client_id',
+$settings['mail_smtp_oauth2_azure_client_id'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_oauth2_azure_client_id']->fromArray([
+    'key' => 'mail_smtp_oauth2_azure_client_id',
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'mail',
     'editedon' => null,
 ], '', true, true);
-$settings['mail_smtp_outh2_azure_tenant_id'] = $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_outh2_azure_tenant_id']->fromArray([
-    'key' => 'mail_smtp_outh2_azure_tenant_id',
+$settings['mail_smtp_oauth2_azure_tenant_id'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_oauth2_azure_tenant_id']->fromArray([
+    'key' => 'mail_smtp_oauth2_azure_tenant_id',
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'mail',
     'editedon' => null,
 ], '', true, true);
-$settings['mail_smtp_outh2_azure_client_secret'] = $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_outh2_azure_client_secret']->fromArray([
-    'key' => 'mail_smtp_outh2_azure_client_secret',
+$settings['mail_smtp_oauth2_azure_client_secret'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_oauth2_azure_client_secret']->fromArray([
+    'key' => 'mail_smtp_oauth2_azure_client_secret',
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',
     'area' => 'mail',
     'editedon' => null,
 ], '', true, true);
-$settings['mail_smtp_outh2_azure_refresh_token'] = $xpdo->newObject(modSystemSetting::class);
-$settings['mail_smtp_outh2_azure_refresh_token']->fromArray([
-    'key' => 'mail_smtp_outh2_azure_refresh_token',
+$settings['mail_smtp_oauth2_azure_refresh_token'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_oauth2_azure_refresh_token']->fromArray([
+    'key' => 'mail_smtp_oauth2_azure_refresh_token',
     'value' => '',
     'xtype' => 'textfield',
     'namespace' => 'core',

--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -911,6 +911,51 @@ $settings['mail_smtp_user']->fromArray([
   'area' => 'mail',
   'editedon' => null,
 ], '', true, true);
+$settings['mail_smtp_auth_type'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_auth_type']->fromArray([
+    'key' => 'mail_smtp_auth_type',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'mail',
+    'editedon' => null,
+], '', true, true);
+$settings['mail_smtp_outh2_azure_client_id'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_outh2_azure_client_id']->fromArray([
+    'key' => 'mail_smtp_outh2_azure_client_id',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'mail',
+    'editedon' => null,
+], '', true, true);
+$settings['mail_smtp_outh2_azure_tenant_id'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_outh2_azure_tenant_id']->fromArray([
+    'key' => 'mail_smtp_outh2_azure_tenant_id',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'mail',
+    'editedon' => null,
+], '', true, true);
+$settings['mail_smtp_outh2_azure_client_secret'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_outh2_azure_client_secret']->fromArray([
+    'key' => 'mail_smtp_outh2_azure_client_secret',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'mail',
+    'editedon' => null,
+], '', true, true);
+$settings['mail_smtp_outh2_azure_refresh_token'] = $xpdo->newObject(modSystemSetting::class);
+$settings['mail_smtp_outh2_azure_refresh_token']->fromArray([
+    'key' => 'mail_smtp_outh2_azure_refresh_token',
+    'value' => '',
+    'xtype' => 'textfield',
+    'namespace' => 'core',
+    'area' => 'mail',
+    'editedon' => null,
+], '', true, true);
 
 $settings['mail_dkim_selector'] = $xpdo->newObject(modSystemSetting::class);
 $settings['mail_dkim_selector']->fromArray([

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "psr/http-factory": "^1.0",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2.0",
+        "greew/oauth2-azure-provider": "^2.0",
         "ext-curl": "*",
         "ext-dom": "*",
         "ext-gd": "*",

--- a/core/lexicon/en/mail.inc.php
+++ b/core/lexicon/en/mail.inc.php
@@ -7,6 +7,19 @@
  * @subpackage lexicon
  */
 $_lang['mail_err_address_ns'] = 'You must provide an email address to send to.';
-$_lang['mail_err_derive_getmailer'] = 'Attempt to call abstract function _getMailer() in modMail class. You must implement this function in a derivative of modMail.';
 $_lang['mail_err_attr_nv'] = '[[+attr]] is not a valid PHPMailer attribute and is being ignored by the implementation.';
+$_lang['mail_err_derive_getmailer'] = 'Attempt to call abstract function _getMailer() in modMail class. You must implement this function in a derivative of modMail.';
 $_lang['mail_err_unset_spec'] = 'modPHPMailer does not support unsetting specific addresses. Use reset() to clear all recipients and add back the ones you want to send to.';
+$_lang['mail_oauth2'] = 'Email OAuth2';
+$_lang['mail_oauth2.azure'] = 'Azure';
+$_lang['mail_oauth2.get_token'] = 'Get OAuth2 Token';
+$_lang['mail_oauth2.intro_msg'] = 'Please get the OAuth2 token to send mails with PHPMailer using [[+auth_type]].';
+$_lang['mail_oauth2.invalid_authorization'] = 'The authorization code is invalid.';
+$_lang['mail_oauth2.invalid_connection'] = 'The connection to the OAuth2 token server could not be established.';
+$_lang['mail_oauth2.invalid_provider'] = 'A valid provider is missing. Please check the value of the system setting "mail_smtp_auth_type".';
+$_lang['mail_oauth2.invalid_state'] = 'The OAuth2 state is invalid.';
+$_lang['mail_oauth2.redirect_url'] = 'Redirect URL';
+$_lang['mail_oauth2.tab'] = 'OAuth2 Token';
+$_lang['mail_oauth2.update_settings'] = 'Update Settings';
+$_lang['mail_oauth2.update_successful'] = 'Update successful.';
+$_lang['mail_oauth2.url_missing'] = 'The url to retrieve the OAuth2 token is empty!';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -411,14 +411,14 @@ $_lang['setting_mail_smtp_auth_type_desc'] = 'The auth type the server authentic
 $_lang['setting_mail_smtp_oauth2_azure_client_id'] = 'SMTP Azure Client ID';
 $_lang['setting_mail_smtp_oauth2_azure_client_id_desc'] = 'The Azure Client ID for the server authentication.';
 
+$_lang['setting_mail_smtp_oauth2_azure_client_secret'] = 'SMTP Azure Client Secret';
+$_lang['setting_mail_smtp_oauth2_azure_client_secret_desc'] = 'The optional Azure Client Secret for the server authentication.';
+
 $_lang['setting_mail_smtp_oauth2_azure_tenant_id'] = 'SMTP Azure Tenant ID';
 $_lang['setting_mail_smtp_oauth2_azure_tenant_id_desc'] = 'The Azure Tenant ID for the server authentication.';
 
-$_lang['setting_mail_smtp_oauth2_azure_client_secret'] = 'SMTP Azure Client Secret Value';
-$_lang['setting_mail_smtp_oauth2_azure_client_secret_desc'] = 'The optional Azure Client Secret Value for the server authentication.';
-
-$_lang['setting_mail_smtp_oauth2_azure_refresh_token'] = 'SMTP User';
-$_lang['setting_mail_smtp_oauth2_azure_refresh_token_desc'] = 'The Azure refresh token for the server authentication.';
+$_lang['setting_mail_smtp_oauth2_azure_refresh_token'] = 'SMTP Azure Refresh Token';
+$_lang['setting_mail_smtp_oauth2_azure_refresh_token_desc'] = 'The Azure Refresh Token for the server authentication.';
 
 $_lang['setting_mail_dkim_selector'] = 'DKIM Selector';
 $_lang['setting_mail_dkim_selector_desc'] = 'The DKIM domain selector where the public key stored.';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -405,6 +405,21 @@ $_lang['setting_mail_smtp_timeout_desc'] = 'Sets the SMTP server timeout in seco
 $_lang['setting_mail_smtp_user'] = 'SMTP User';
 $_lang['setting_mail_smtp_user_desc'] = 'The user to authenticate to SMTP against.';
 
+$_lang['setting_mail_smtp_auth_type'] = 'SMTP Auth Type';
+$_lang['setting_mail_smtp_auth_type_desc'] = 'The auth type the server authentication is restricted with. Can be set to "AZURE".';
+
+$_lang['setting_mail_smtp_outh2_azure_client_id'] = 'SMTP Azure Client ID';
+$_lang['setting_mail_smtp_outh2_azure_client_id_desc'] = 'The Azure Client ID for the server authentication.';
+
+$_lang['setting_mail_smtp_outh2_azure_tenant_id'] = 'SMTP Azure Tenant ID';
+$_lang['setting_mail_smtp_outh2_azure_tenant_id_desc'] = 'The Azure Tenant ID for the server authentication.';
+
+$_lang['setting_mail_smtp_outh2_azure_client_secret'] = 'SMTP Azure Client Secret Value';
+$_lang['setting_mail_smtp_outh2_azure_client_secret_desc'] = 'The optional Azure Client Secret Value for the server authentication.';
+
+$_lang['setting_mail_smtp_outh2_azure_refresh_token'] = 'SMTP User';
+$_lang['setting_mail_smtp_outh2_azure_refresh_token_desc'] = 'The Azure refresh token for the server authentication.';
+
 $_lang['setting_mail_dkim_selector'] = 'DKIM Selector';
 $_lang['setting_mail_dkim_selector_desc'] = 'The DKIM domain selector where the public key stored.';
 

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -408,17 +408,17 @@ $_lang['setting_mail_smtp_user_desc'] = 'The user to authenticate to SMTP agains
 $_lang['setting_mail_smtp_auth_type'] = 'SMTP Auth Type';
 $_lang['setting_mail_smtp_auth_type_desc'] = 'The auth type the server authentication is restricted with. Can be set to "AZURE".';
 
-$_lang['setting_mail_smtp_outh2_azure_client_id'] = 'SMTP Azure Client ID';
-$_lang['setting_mail_smtp_outh2_azure_client_id_desc'] = 'The Azure Client ID for the server authentication.';
+$_lang['setting_mail_smtp_oauth2_azure_client_id'] = 'SMTP Azure Client ID';
+$_lang['setting_mail_smtp_oauth2_azure_client_id_desc'] = 'The Azure Client ID for the server authentication.';
 
-$_lang['setting_mail_smtp_outh2_azure_tenant_id'] = 'SMTP Azure Tenant ID';
-$_lang['setting_mail_smtp_outh2_azure_tenant_id_desc'] = 'The Azure Tenant ID for the server authentication.';
+$_lang['setting_mail_smtp_oauth2_azure_tenant_id'] = 'SMTP Azure Tenant ID';
+$_lang['setting_mail_smtp_oauth2_azure_tenant_id_desc'] = 'The Azure Tenant ID for the server authentication.';
 
-$_lang['setting_mail_smtp_outh2_azure_client_secret'] = 'SMTP Azure Client Secret Value';
-$_lang['setting_mail_smtp_outh2_azure_client_secret_desc'] = 'The optional Azure Client Secret Value for the server authentication.';
+$_lang['setting_mail_smtp_oauth2_azure_client_secret'] = 'SMTP Azure Client Secret Value';
+$_lang['setting_mail_smtp_oauth2_azure_client_secret_desc'] = 'The optional Azure Client Secret Value for the server authentication.';
 
-$_lang['setting_mail_smtp_outh2_azure_refresh_token'] = 'SMTP User';
-$_lang['setting_mail_smtp_outh2_azure_refresh_token_desc'] = 'The Azure refresh token for the server authentication.';
+$_lang['setting_mail_smtp_oauth2_azure_refresh_token'] = 'SMTP User';
+$_lang['setting_mail_smtp_oauth2_azure_refresh_token_desc'] = 'The Azure refresh token for the server authentication.';
 
 $_lang['setting_mail_dkim_selector'] = 'DKIM Selector';
 $_lang['setting_mail_dkim_selector_desc'] = 'The DKIM domain selector where the public key stored.';

--- a/core/src/Revolution/Mail/modMail.php
+++ b/core/src/Revolution/Mail/modMail.php
@@ -132,6 +132,26 @@ abstract class modMail
      */
     const MAIL_SMTP_USER = 'mail_smtp_user';
     /**
+     * @const An option for setting the mail SMTP auth type
+     */
+    const MAIL_SMTP_AUTH_TYPE = 'mail_smtp_auth_type';
+    /**
+     * @const An option for setting the mail SMTP username
+     */
+    const MAIL_SMTP_OUTH2_AZURE_CLIENT_ID = 'mail_smtp_outh2_azure_client_id';
+    /**
+     * @const An option for setting the mail SMTP username
+     */
+    const MAIL_SMTP_OUTH2_AZURE_TENANT_ID = 'mail_smtp_outh2_azure_tenant_id';
+    /**
+     * @const An option for setting the mail SMTP username
+     */
+    const MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET = 'mail_smtp_outh2_azure_client_secret';
+    /**
+     * @const An option for setting the mail SMTP username
+     */
+    const MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN = 'mail_smtp_outh2_azure_refresh_token';
+    /**
      * @const An option for setting the mail subject
      */
     const MAIL_SUBJECT = 'mail_subject';
@@ -242,7 +262,7 @@ abstract class modMail
     public function getDefaultAttributes(array $attributes = [])
     {
         $default = [];
-        if ($this->modx->getOption('mail_use_smtp', false)) {
+        if ($this->modx->getOption('mail_use_smtp', null, false)) {
             $default[modMail::MAIL_ENGINE] = 'smtp';
             $default[modMail::MAIL_SMTP_AUTH] = $this->modx->getOption('mail_smtp_auth', null, false);
             $helo = $this->modx->getOption('mail_smtp_helo', '');
@@ -258,6 +278,13 @@ abstract class modMail
             $default[modMail::MAIL_SMTP_SINGLE_TO] = $this->modx->getOption('mail_smtp_single_to', null, false);
             $default[modMail::MAIL_SMTP_TIMEOUT] = $this->modx->getOption('mail_smtp_timeout', null, 10);
             $default[modMail::MAIL_SMTP_USER] = $this->modx->getOption('mail_smtp_user', null, '');
+        }
+        if ($this->modx->getOption('mail_smtp_auth_type', null, '') === 'AZURE') {
+            $default[modMail::MAIL_SMTP_AUTH_TYPE] = 'AZURE';
+            $default[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_ID] = $this->modx->getOption('mail_smtp_outh2_azure_client_id', null, '');
+            $default[modMail::MAIL_SMTP_OUTH2_AZURE_TENANT_ID] = $this->modx->getOption('mail_smtp_outh2_azure_tenant_id', null, '');
+            $default[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET] = $this->modx->getOption('mail_smtp_outh2_azure_client_secret', null, '');
+            $default[modMail::MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN] = $this->modx->getOption('mail_smtp_outh2_azure_refresh_token', null, '');
         }
         $default[modMail::MAIL_DKIM_SELECTOR] = $this->modx->getOption('mail_dkim_selector', null, '');
         $default[modMail::MAIL_DKIM_IDENTITY] = $this->modx->getOption('mail_dkim_identity', null, '');

--- a/core/src/Revolution/Mail/modMail.php
+++ b/core/src/Revolution/Mail/modMail.php
@@ -138,19 +138,19 @@ abstract class modMail
     /**
      * @const An option for setting the mail SMTP username
      */
-    public const MAIL_SMTP_OUTH2_AZURE_CLIENT_ID = 'mail_smtp_outh2_azure_client_id';
+    public const MAIL_SMTP_OAUTH2_AZURE_CLIENT_ID = 'mail_smtp_oauth2_azure_client_id';
     /**
      * @const An option for setting the mail SMTP username
      */
-    public const MAIL_SMTP_OUTH2_AZURE_TENANT_ID = 'mail_smtp_outh2_azure_tenant_id';
+    public const MAIL_SMTP_OAUTH2_AZURE_TENANT_ID = 'mail_smtp_oauth2_azure_tenant_id';
     /**
      * @const An option for setting the mail SMTP username
      */
-    public const MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET = 'mail_smtp_outh2_azure_client_secret';
+    public const MAIL_SMTP_OAUTH2_AZURE_CLIENT_SECRET = 'mail_smtp_oauth2_azure_client_secret';
     /**
      * @const An option for setting the mail SMTP username
      */
-    public const MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN = 'mail_smtp_outh2_azure_refresh_token';
+    public const MAIL_SMTP_OAUTH2_AZURE_REFRESH_TOKEN = 'mail_smtp_oauth2_azure_refresh_token';
     /**
      * @const An option for setting the mail subject
      */
@@ -281,10 +281,10 @@ abstract class modMail
         }
         if ($this->modx->getOption('mail_smtp_auth_type', null, '') === 'AZURE') {
             $default[modMail::MAIL_SMTP_AUTH_TYPE] = 'AZURE';
-            $default[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_ID] = $this->modx->getOption('mail_smtp_outh2_azure_client_id', null, '');
-            $default[modMail::MAIL_SMTP_OUTH2_AZURE_TENANT_ID] = $this->modx->getOption('mail_smtp_outh2_azure_tenant_id', null, '');
-            $default[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET] = $this->modx->getOption('mail_smtp_outh2_azure_client_secret', null, '');
-            $default[modMail::MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN] = $this->modx->getOption('mail_smtp_outh2_azure_refresh_token', null, '');
+            $default[modMail::MAIL_SMTP_OAUTH2_AZURE_CLIENT_ID] = $this->modx->getOption('mail_smtp_oauth2_azure_client_id', null, '');
+            $default[modMail::MAIL_SMTP_OAUTH2_AZURE_TENANT_ID] = $this->modx->getOption('mail_smtp_oauth2_azure_tenant_id', null, '');
+            $default[modMail::MAIL_SMTP_OAUTH2_AZURE_CLIENT_SECRET] = $this->modx->getOption('mail_smtp_oauth2_azure_client_secret', null, '');
+            $default[modMail::MAIL_SMTP_OAUTH2_AZURE_REFRESH_TOKEN] = $this->modx->getOption('mail_smtp_oauth2_azure_refresh_token', null, '');
         }
         $default[modMail::MAIL_DKIM_SELECTOR] = $this->modx->getOption('mail_dkim_selector', null, '');
         $default[modMail::MAIL_DKIM_IDENTITY] = $this->modx->getOption('mail_dkim_identity', null, '');

--- a/core/src/Revolution/Mail/modMail.php
+++ b/core/src/Revolution/Mail/modMail.php
@@ -26,159 +26,159 @@ abstract class modMail
     /**
      * @const An option for setting the mail body
      */
-    const MAIL_BODY = 'mail_body';
+    public const MAIL_BODY = 'mail_body';
     /**
      * @const An option for setting the mail body text
      */
-    const MAIL_BODY_TEXT = 'mail_body_text';
+    public const MAIL_BODY_TEXT = 'mail_body_text';
     /**
      * @const An option for setting the mail charset
      */
-    const MAIL_CHARSET = 'mail_charset';
+    public const MAIL_CHARSET = 'mail_charset';
     /**
      * @const An option for setting the mail content type
      */
-    const MAIL_CONTENT_TYPE = 'mail_content_type';
+    public const MAIL_CONTENT_TYPE = 'mail_content_type';
     /**
      * @const An option for setting the mail encoding
      */
-    const MAIL_ENCODING = 'mail_encoding';
+    public const MAIL_ENCODING = 'mail_encoding';
     /**
      * @const An option for setting the mail engine
      */
-    const MAIL_ENGINE = 'mail_engine';
+    public const MAIL_ENGINE = 'mail_engine';
     /**
      * @const An option for setting the mail engine path
      */
-    const MAIL_ENGINE_PATH = 'mail_engine_path';
+    public const MAIL_ENGINE_PATH = 'mail_engine_path';
     /**
      * @const An option for setting the mail error information
      */
-    const MAIL_ERROR_INFO = 'mail_error_info';
+    public const MAIL_ERROR_INFO = 'mail_error_info';
     /**
      * @const An option for setting the mail From address
      */
-    const MAIL_FROM = 'mail_from';
+    public const MAIL_FROM = 'mail_from';
     /**
      * @const An option for setting the mail From name
      */
-    const MAIL_FROM_NAME = 'mail_from_name';
+    public const MAIL_FROM_NAME = 'mail_from_name';
     /**
      * @const An option for setting the mail hostname
      */
-    const MAIL_HOSTNAME = 'mail_hostname';
+    public const MAIL_HOSTNAME = 'mail_hostname';
     /**
      * @const An option for setting the mail language
      */
-    const MAIL_LANGUAGE = 'mail_language';
+    public const MAIL_LANGUAGE = 'mail_language';
     /**
      * @const An option for setting the mail priority header
      */
-    const MAIL_PRIORITY = 'mail_priority';
+    public const MAIL_PRIORITY = 'mail_priority';
     /**
      * @const An option for setting the mail read to header
      */
-    const MAIL_READ_TO = 'mail_read_to';
+    public const MAIL_READ_TO = 'mail_read_to';
     /**
      * @const An option for setting the mail sender
      */
-    const MAIL_SENDER = 'mail_sender';
+    public const MAIL_SENDER = 'mail_sender';
     /**
      * @const An option for setting the mail service
      */
-    const MAIL_SERVICE = 'mail_service';
+    public const MAIL_SERVICE = 'mail_service';
     /**
      * @const An option for setting the mail SMTP auth type
      */
-    const MAIL_SMTP_AUTH = 'mail_smtp_auth';
+    public const MAIL_SMTP_AUTH = 'mail_smtp_auth';
     /**
      * @const An option for setting the mail SMTP HELO boolean
      */
-    const MAIL_SMTP_HELO = 'mail_smtp_helo';
+    public const MAIL_SMTP_HELO = 'mail_smtp_helo';
     /**
      * @const An option for setting the mail SMTP hosts
      */
-    const MAIL_SMTP_HOSTS = 'mail_smtp_hosts';
+    public const MAIL_SMTP_HOSTS = 'mail_smtp_hosts';
     /**
      * @const An option for setting the mail SMTP Keep-Alive boolean
      */
-    const MAIL_SMTP_KEEPALIVE = 'mail_smtp_keepalive';
+    public const MAIL_SMTP_KEEPALIVE = 'mail_smtp_keepalive';
     /**
      * @const An option for setting the mail SMTP password
      */
-    const MAIL_SMTP_PASS = 'mail_smtp_pass';
+    public const MAIL_SMTP_PASS = 'mail_smtp_pass';
     /**
      * @const An option for setting the mail SMTP port
      */
-    const MAIL_SMTP_PORT = 'mail_smtp_port';
+    public const MAIL_SMTP_PORT = 'mail_smtp_port';
     /**
      * @const An option for setting the mail SMTP secure encryption type
      */
-    const MAIL_SMTP_SECURE = 'mail_smtp_secure';
+    public const MAIL_SMTP_SECURE = 'mail_smtp_secure';
     /**
      * @const An option for setting the mail SMTP AutoTLS option
      */
-    const MAIL_SMTP_AUTOTLS = 'mail_smtp_autotls';
+    public const MAIL_SMTP_AUTOTLS = 'mail_smtp_autotls';
     /**
      * @const An option for setting the mail SMTP Single-To option
      */
-    const MAIL_SMTP_SINGLE_TO = 'mail_smtp_single_to';
+    public const MAIL_SMTP_SINGLE_TO = 'mail_smtp_single_to';
     /**
      * @const An option for setting the mail SMTP timeout
      */
-    const MAIL_SMTP_TIMEOUT = 'mail_smtp_timeout';
+    public const MAIL_SMTP_TIMEOUT = 'mail_smtp_timeout';
     /**
      * @const An option for setting the mail SMTP username
      */
-    const MAIL_SMTP_USER = 'mail_smtp_user';
+    public const MAIL_SMTP_USER = 'mail_smtp_user';
     /**
      * @const An option for setting the mail SMTP auth type
      */
-    const MAIL_SMTP_AUTH_TYPE = 'mail_smtp_auth_type';
+    public const MAIL_SMTP_AUTH_TYPE = 'mail_smtp_auth_type';
     /**
      * @const An option for setting the mail SMTP username
      */
-    const MAIL_SMTP_OUTH2_AZURE_CLIENT_ID = 'mail_smtp_outh2_azure_client_id';
+    public const MAIL_SMTP_OUTH2_AZURE_CLIENT_ID = 'mail_smtp_outh2_azure_client_id';
     /**
      * @const An option for setting the mail SMTP username
      */
-    const MAIL_SMTP_OUTH2_AZURE_TENANT_ID = 'mail_smtp_outh2_azure_tenant_id';
+    public const MAIL_SMTP_OUTH2_AZURE_TENANT_ID = 'mail_smtp_outh2_azure_tenant_id';
     /**
      * @const An option for setting the mail SMTP username
      */
-    const MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET = 'mail_smtp_outh2_azure_client_secret';
+    public const MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET = 'mail_smtp_outh2_azure_client_secret';
     /**
      * @const An option for setting the mail SMTP username
      */
-    const MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN = 'mail_smtp_outh2_azure_refresh_token';
+    public const MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN = 'mail_smtp_outh2_azure_refresh_token';
     /**
      * @const An option for setting the mail subject
      */
-    const MAIL_SUBJECT = 'mail_subject';
+    public const MAIL_SUBJECT = 'mail_subject';
     /**
      * @const An option for setting the mail DKIM selector
      */
-    const MAIL_DKIM_SELECTOR = 'mail_dkim_selector';
+    public const MAIL_DKIM_SELECTOR = 'mail_dkim_selector';
     /**
      * @const An option for setting the DKIM identity you're signing as - usually your From address
      */
-    const MAIL_DKIM_IDENTITY = 'mail_dkim_identity';
+    public const MAIL_DKIM_IDENTITY = 'mail_dkim_identity';
     /**
      * @const An option for setting DKIM domain name
      */
-    const MAIL_DKIM_DOMAIN = 'mail_dkim_domain';
+    public const MAIL_DKIM_DOMAIN = 'mail_dkim_domain';
     /**
      * @const An option for setting DKIM private key file path
      */
-    const MAIL_DKIM_PRIVATEKEYFILE = 'mail_dkim_privatekeyfile';
+    public const MAIL_DKIM_PRIVATEKEYFILE = 'mail_dkim_privatekeyfile';
     /**
      * @const An option for setting DKIM private key string - takes precedence over MAIL_DKIM_PRIVATEKEYFILE
      */
-    const MAIL_DKIM_PRIVATEKEYSTRING = 'mail_dkim_privatekeystring';
+    public const MAIL_DKIM_PRIVATEKEYSTRING = 'mail_dkim_privatekeystring';
     /**
      * @const An option for setting DKIM passphrase - used if your private key has a passphrase
      */
-    const MAIL_DKIM_PASSPHRASE = 'mail_dkim_passphrase';
+    public const MAIL_DKIM_PASSPHRASE = 'mail_dkim_passphrase';
 
     /**
      * A reference to the modX instance communicating with this service instance.

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -51,104 +51,104 @@ class modPHPMailer extends modMail
     {
         parent:: set($key, $value);
         switch ($key) {
-            case modMail::MAIL_BODY :
+            case modMail::MAIL_BODY:
                 $this->mailer->Body = $this->attributes[$key];
                 break;
-            case modMail::MAIL_BODY_TEXT :
+            case modMail::MAIL_BODY_TEXT:
                 $this->mailer->AltBody = $this->attributes[$key];
                 break;
-            case modMail::MAIL_CHARSET :
+            case modMail::MAIL_CHARSET:
                 $this->mailer->CharSet = $this->attributes[$key];
                 break;
-            case modMail::MAIL_CONTENT_TYPE :
+            case modMail::MAIL_CONTENT_TYPE:
                 $this->mailer->ContentType = $this->attributes[$key];
                 break;
-            case modMail::MAIL_ENCODING :
+            case modMail::MAIL_ENCODING:
                 $this->mailer->Encoding = $this->attributes[$key];
                 break;
-            case modMail::MAIL_ENGINE :
+            case modMail::MAIL_ENGINE:
                 $this->mailer->Mailer = $this->attributes[$key];
                 break;
-            case modMail::MAIL_ENGINE_PATH :
+            case modMail::MAIL_ENGINE_PATH:
                 $this->mailer->Sendmail = $this->attributes[$key];
                 break;
-            case modMail::MAIL_FROM :
+            case modMail::MAIL_FROM:
                 $this->mailer->From = $this->attributes[$key];
                 $this->mailer->Sender = $this->attributes[$key];
                 break;
-            case modMail::MAIL_FROM_NAME :
+            case modMail::MAIL_FROM_NAME:
                 $this->mailer->FromName = $this->attributes[$key];
                 break;
-            case modMail::MAIL_HOSTNAME :
+            case modMail::MAIL_HOSTNAME:
                 $this->mailer->Hostname = $this->attributes[$key];
                 break;
-            case modMail::MAIL_LANGUAGE :
+            case modMail::MAIL_LANGUAGE:
                 $this->mailer->setLanguage($this->attributes[$key]);
                 break;
-            case modMail::MAIL_PRIORITY :
+            case modMail::MAIL_PRIORITY:
                 $this->mailer->Priority = $this->attributes[$key];
                 break;
-            case modMail::MAIL_READ_TO :
+            case modMail::MAIL_READ_TO:
                 $this->mailer->ConfirmReadingTo = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SENDER :
+            case modMail::MAIL_SENDER:
                 $this->mailer->Sender = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_AUTH :
+            case modMail::MAIL_SMTP_AUTH:
                 $this->mailer->SMTPAuth = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_HELO :
+            case modMail::MAIL_SMTP_HELO:
                 $this->mailer->Helo = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_HOSTS :
+            case modMail::MAIL_SMTP_HOSTS:
                 $this->mailer->Host = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_KEEPALIVE :
+            case modMail::MAIL_SMTP_KEEPALIVE:
                 $this->mailer->SMTPKeepAlive = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_PASS :
+            case modMail::MAIL_SMTP_PASS:
                 $this->mailer->Password = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_PORT :
+            case modMail::MAIL_SMTP_PORT:
                 $this->mailer->Port = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_SECURE :
+            case modMail::MAIL_SMTP_SECURE:
                 $this->mailer->SMTPSecure = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_AUTOTLS :
+            case modMail::MAIL_SMTP_AUTOTLS:
                 $this->mailer->SMTPAutoTLS= $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_SINGLE_TO :
+            case modMail::MAIL_SMTP_SINGLE_TO:
                 $this->mailer->SingleTo = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_TIMEOUT :
+            case modMail::MAIL_SMTP_TIMEOUT:
                 $this->mailer->Timeout = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_USER :
+            case modMail::MAIL_SMTP_USER:
                 $this->mailer->Username = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SUBJECT :
+            case modMail::MAIL_SUBJECT:
                 $this->mailer->Subject = $this->attributes[$key];
                 break;
-            case modMail::MAIL_DKIM_SELECTOR :
+            case modMail::MAIL_DKIM_SELECTOR:
                 $this->mailer->DKIM_selector = $this->attributes[$key];
                 break;
-            case modMail::MAIL_DKIM_IDENTITY :
+            case modMail::MAIL_DKIM_IDENTITY:
                 $this->mailer->DKIM_identity = $this->attributes[$key];
                 break;
-            case modMail::MAIL_DKIM_DOMAIN :
+            case modMail::MAIL_DKIM_DOMAIN:
                 $this->mailer->DKIM_domain = $this->attributes[$key];
                 break;
-            case modMail::MAIL_DKIM_PRIVATEKEYFILE :
+            case modMail::MAIL_DKIM_PRIVATEKEYFILE:
                 $this->mailer->DKIM_private = $this->attributes[$key];
                 break;
-            case modMail::MAIL_DKIM_PRIVATEKEYSTRING :
+            case modMail::MAIL_DKIM_PRIVATEKEYSTRING:
                 $this->mailer->DKIM_private_string = $this->attributes[$key];
                 break;
-            case modMail::MAIL_DKIM_PASSPHRASE :
+            case modMail::MAIL_DKIM_PASSPHRASE:
                 $this->mailer->DKIM_passphrase = $this->attributes[$key];
                 break;
-            default :
+            default:
                 $this->modx->log(modX::LOG_LEVEL_WARN, $this->modx->lexicon('mail_err_attr_nv', ['attr' => $key]));
                 break;
         }
@@ -171,16 +171,16 @@ class modPHPMailer extends modMail
             if ($set) {
                 $type = strtolower($type);
                 switch ($type) {
-                    case 'to' :
+                    case 'to':
                         $this->mailer->addAddress($email, $name);
                         break;
-                    case 'cc' :
+                    case 'cc':
                         $this->mailer->addCC($email, $name);
                         break;
-                    case 'bcc' :
+                    case 'bcc':
                         $this->mailer->addBCC($email, $name);
                         break;
-                    case 'reply-to' :
+                    case 'reply-to':
                         $this->mailer->addReplyTo($email, $name);
                         break;
                 }

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -237,13 +237,13 @@ class modPHPMailer extends modMail
                 $this->mailer->AuthType = 'XOAUTH2';
                 $this->mailer->setOAuth(new OAuth([
                     'provider' => new Azure([
-                        'clientId' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_ID],
-                        'tenantId' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_TENANT_ID],
-                        'clientSecret' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET]
+                        'clientId' => $this->attributes[modMail::MAIL_SMTP_OAUTH2_AZURE_CLIENT_ID],
+                        'tenantId' => $this->attributes[modMail::MAIL_SMTP_OAUTH2_AZURE_TENANT_ID],
+                        'clientSecret' => $this->attributes[modMail::MAIL_SMTP_OAUTH2_AZURE_CLIENT_SECRET]
                     ]),
-                    'clientId' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_ID],
-                    'refreshToken' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN],
-                    'clientSecret' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET],
+                    'clientId' => $this->attributes[modMail::MAIL_SMTP_OAUTH2_AZURE_CLIENT_ID],
+                    'refreshToken' => $this->attributes[modMail::MAIL_SMTP_OAUTH2_AZURE_REFRESH_TOKEN],
+                    'clientSecret' => $this->attributes[modMail::MAIL_SMTP_OAUTH2_AZURE_CLIENT_SECRET],
                     'userName' => $this->attributes[modMail::MAIL_SMTP_USER],
                 ]));
             }

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -12,8 +12,10 @@ namespace MODX\Revolution\Mail;
 
 
 use Exception;
-use MODX\Revolution\modX;
+use Greew\OAuth2\Client\Provider\Azure;
 use InlineStyle\InlineStyle;
+use MODX\Revolution\modX;
+use PHPMailer\PHPMailer\OAuth;
 use PHPMailer\PHPMailer\PHPMailer;
 
 /**
@@ -230,6 +232,20 @@ class modPHPMailer extends modMail
                 /** @noinspection PhpParamsInspection */
                 $html->applyStylesheet($html->extractStylesheets());
                 $this->mailer->Body = $html->getHTML();
+            }
+            if ($this->attributes[modMail::MAIL_SMTP_AUTH_TYPE] === 'AZURE') {
+                $this->mailer->AuthType = 'XOAUTH2';
+                $this->mailer->setOAuth(new OAuth([
+                    'provider' => new Azure([
+                        'clientId' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_ID],
+                        'tenantId' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_TENANT_ID],
+                        'clientSecret' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET]
+                    ]),
+                    'clientId' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_ID],
+                    'refreshToken' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_REFRESH_TOKEN],
+                    'clientSecret' => $this->attributes[modMail::MAIL_SMTP_OUTH2_AZURE_CLIENT_SECRET],
+                    'userName' => $this->attributes[modMail::MAIL_SMTP_USER],
+                ]));
             }
             $sent = $this->mailer->send();
         } catch (Exception $e) {

--- a/core/src/Revolution/Processors/System/Email/Oauth2/GetToken.php
+++ b/core/src/Revolution/Processors/System/Email/Oauth2/GetToken.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *

--- a/core/src/Revolution/Processors/System/Email/Oauth2/GetToken.php
+++ b/core/src/Revolution/Processors/System/Email/Oauth2/GetToken.php
@@ -1,0 +1,110 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\System\Email\Oauth2;
+
+//use League\OAuth2\Client\Provider\Google;
+//use Hayageek\OAuth2\Client\Provider\Yahoo;
+//use Stevenmaguire\OAuth2\Client\Provider\Microsoft;
+use Greew\OAuth2\Client\Provider\Azure;
+use GuzzleHttp\Exception\GuzzleException;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use MODX\Revolution\Processors\Processor;
+use xPDO\xPDO;
+
+/**
+ * Get the phpMailer OAuth2 token
+ * @package MODX\Revolution\Processors\System\Email\Oauth2
+ */
+class GetToken extends Processor
+{
+    /**
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('settings');
+    }
+
+    /**
+     * @return array|mixed|string
+     */
+    public function process()
+    {
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, $this->modx->lexicon('mail_oauth2.get_token'));
+
+        $providerName = strtolower($this->modx->getOption('mail_smtp_auth_type'));
+        $clientId = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_client_id');
+        $clientSecret = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_client_secret');
+        $tenantId = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_tenant_id');
+
+        $redirectUri = MODX_URL_SCHEME . MODX_HTTP_HOST . MODX_MANAGER_URL . '?a=system/email/oauth2';
+
+        $params = [
+            'clientId' => $clientId,
+            'clientSecret' => $clientSecret,
+            'redirectUri' => $redirectUri,
+            'accessType' => 'offline'
+        ];
+
+        $options = [];
+        $provider = null;
+
+        switch ($providerName) {
+//            case 'google':
+//                $provider = new Google($params);
+//                $options = [
+//                    'scope' => [
+//                        'https://mail.google.com/'
+//                    ]
+//                ];
+//                break;
+//            case 'yahoo':
+//                $provider = new Yahoo($params);
+//                break;
+//            case 'microsoft':
+//                $provider = new Microsoft($params);
+//                $options = [
+//                    'scope' => [
+//                        'wl.imap',
+//                        'wl.offline_access'
+//                    ]
+//                ];
+//                break;
+            case 'azure':
+                $params['tenantId'] = $tenantId;
+
+                $provider = new Azure($params);
+                $options = [
+                    'scope' => [
+                        'https://outlook.office.com/SMTP.Send',
+                        'offline_access'
+                    ]
+                ];
+                break;
+        }
+
+        if (null === $provider) {
+            return $this->failure($this->modx->lexicon('mail_oauth2.invalid_provider'));
+        }
+
+        $this->runAfterEvents();
+
+        // Get the authorization url
+        $authUrl = $provider->getAuthorizationUrl($options);
+        $_SESSION['oauth2state'] = $provider->getState();
+        return $this->success('', ['auth_url' => $authUrl]);
+    }
+
+    public function runAfterEvents()
+    {
+        $this->modx->logManagerAction('get_oauth2_token', '', $this->modx->context->key);
+    }
+}

--- a/core/src/Revolution/Processors/System/Email/Oauth2/GetToken.php
+++ b/core/src/Revolution/Processors/System/Email/Oauth2/GetToken.php
@@ -46,7 +46,7 @@ class GetToken extends Processor
         $clientSecret = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_client_secret');
         $tenantId = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_tenant_id');
 
-        $redirectUri = MODX_URL_SCHEME . MODX_HTTP_HOST . MODX_MANAGER_URL . '?a=system/email/oauth2';
+        $redirectUri = MODX_URL_SCHEME . MODX_HTTP_HOST . MODX_MANAGER_URL . '?a=system/settings&tab=2';
 
         $params = [
             'clientId' => $clientId,

--- a/core/src/Revolution/Processors/System/Email/Oauth2/UpdateSettings.php
+++ b/core/src/Revolution/Processors/System/Email/Oauth2/UpdateSettings.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *

--- a/core/src/Revolution/Processors/System/Email/Oauth2/UpdateSettings.php
+++ b/core/src/Revolution/Processors/System/Email/Oauth2/UpdateSettings.php
@@ -58,8 +58,8 @@ class UpdateSettings extends Processor
         ]);
         if (!$setting) {
             $setting = $this->modx->newObject(modSystemSetting::class);
+            $setting->set('key', $key);
             $setting->fromArray([
-                'key' => $key,
                 'value' => '',
                 'xtype' => 'textfield',
                 'namespace' => 'core',

--- a/core/src/Revolution/Processors/System/Email/Oauth2/UpdateSettings.php
+++ b/core/src/Revolution/Processors/System/Email/Oauth2/UpdateSettings.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\System\Email\Oauth2;
+
+use MODX\Revolution\modSystemSetting;
+use MODX\Revolution\Processors\Processor;
+
+/**
+ * Update the phpMailer OAuth2 settings
+ * @package MODX\Revolution\Processors\System\Email\Oauth2
+ */
+class UpdateSettings extends Processor
+{
+    /**
+     * @return bool
+     */
+    public function checkPermissions()
+    {
+        return $this->modx->hasPermission('settings');
+    }
+
+    /**
+     * @return array|mixed|string
+     */
+    public function process()
+    {
+        $providerName = strtolower($this->modx->getOption('mail_smtp_auth_type'));
+        $clientIdName = 'mail_smtp_oauth2_' . $providerName . '_client_id';
+        $clientSecretName = 'mail_smtp_oauth2_' . $providerName . '_client_secret';
+        $tenantIdName = 'mail_smtp_oauth2_' . $providerName . '_tenant_id';
+
+        $this->updateMailSystemsetting($clientIdName, $this->getProperty('clientId'));
+        $this->updateMailSystemsetting($clientSecretName, $this->getProperty('clientSecret'));
+        switch ($providerName) {
+            case 'azure':
+                $this->updateMailSystemsetting($tenantIdName, $this->getProperty('tenantId'));
+                break;
+        }
+
+        $this->modx->reloadConfig();
+
+        return $this->success();
+    }
+
+    private function updateMailSystemsetting($key, $value)
+    {
+        $setting = $this->modx->getObject(modSystemSetting::class, [
+            'key' => $key
+        ]);
+        if (!$setting) {
+            $setting = $this->modx->newObject(modSystemSetting::class);
+            $setting->fromArray([
+                'key' => $key,
+                'value' => '',
+                'xtype' => 'textfield',
+                'namespace' => 'core',
+                'area' => 'mail'
+            ]);
+        }
+        $setting->set('value', $value);
+        $setting->save();
+    }
+}

--- a/manager/assets/modext/widgets/system/modx.panel.oauth2email.js
+++ b/manager/assets/modext/widgets/system/modx.panel.oauth2email.js
@@ -72,7 +72,7 @@ MODx.panel.OAuth2Email = function (config) {
                     xtype: 'textfield',
                     anchor: '100%',
                     readOnly: true,
-                    fieldLabel: _('mail_oauth2.refresh_token'),
+                    fieldLabel: _('setting_mail_smtp_oauth2_' + config.auth_type + '_refresh_token'),
                     value: config.refresh_token
                 }]
             }, {

--- a/manager/assets/modext/widgets/system/modx.panel.oauth2email.js
+++ b/manager/assets/modext/widgets/system/modx.panel.oauth2email.js
@@ -11,6 +11,7 @@ MODx.panel.OAuth2Email = function (config) {
     config.client_secret = MODx.config['mail_smtp_oauth2_' + config.auth_type + '_client_secret'];
     config.tenant_id = MODx.config['mail_smtp_oauth2_' + config.auth_type + '_tenant_id'];
     config.redirect_url = MODx.config.http_host_remote + MODx.config.manager_url + '?a=system/settings&tab=2';
+    config.refresh_token = MODx.config['mail_smtp_oauth2_' + config.auth_type + '_refresh_token'];
 
     if (MODx.siteSettingsMessage !== '') {
         MODx.msg.alert(_('error'), MODx.siteSettingsMessage);
@@ -67,6 +68,12 @@ MODx.panel.OAuth2Email = function (config) {
                     readOnly: true,
                     fieldLabel: _('mail_oauth2.redirect_url'),
                     value: config.redirect_url
+                }, {
+                    xtype: 'textfield',
+                    anchor: '100%',
+                    readOnly: true,
+                    fieldLabel: _('mail_oauth2.refresh_token'),
+                    value: config.refresh_token
                 }]
             }, {
                 xtype: 'toolbar',

--- a/manager/assets/modext/widgets/system/modx.panel.oauth2email.js
+++ b/manager/assets/modext/widgets/system/modx.panel.oauth2email.js
@@ -1,0 +1,170 @@
+/**
+ * @class MODx.panel.OAuth2Email
+ * @extends MODx.FormPanel
+ * @param {Object} config An object of configuration properties
+ * @xtype modx-panel-email
+ */
+MODx.panel.OAuth2Email = function (config) {
+    config = config || {};
+    config.auth_type = MODx.config.mail_smtp_auth_type.toLowerCase();
+    config.client_id = MODx.config['mail_smtp_oauth2_' + config.auth_type + '_client_id'];
+    config.client_secret = MODx.config['mail_smtp_oauth2_' + config.auth_type + '_client_secret'];
+    config.tenant_id = MODx.config['mail_smtp_oauth2_' + config.auth_type + '_tenant_id'];
+    config.redirect_url = MODx.config.http_host_remote + MODx.config.manager_url + '?a=system/settings&tab=2';
+
+    if (MODx.siteSettingsMessage !== '') {
+        MODx.msg.alert(_('error'), MODx.siteSettingsMessage);
+    }
+
+    Ext.applyIf(config, {
+        id: 'modx-panel-oauth2-email',
+        url: MODx.config.connector_url,
+        baseParams: {
+            action: 'System/Email/Oauth2/GetToken'
+        },
+        bodyStyle: {},
+        cls: 'container',
+        defaults: {
+            collapsible: false,
+            autoHeight: true
+        },
+        items: [{
+            xtype: 'panel',
+            id: 'modx-email-panel',
+            labelAlign: 'top',
+            style: 'padding-top: 0',
+            items: [{
+                xtype: 'fieldset',
+                cls: 'main-wrapper',
+                style: 'margin: 0 0 15px',
+                bodyStyle: 'padding: 0',
+                items: [{
+                    xtype: 'textfield',
+                    id: 'modx-email-client-id',
+                    anchor: '100%',
+                    name: 'clien_id',
+                    fieldLabel: _('setting_mail_smtp_oauth2_' + config.auth_type + '_client_id'),
+                    labelStyle: 'margin-top: 0',
+                    value: config.client_id
+                }, {
+                    xtype: 'textfield',
+                    id: 'modx-email-client-secret',
+                    anchor: '100%',
+                    name: 'client_secret',
+                    fieldLabel: _('setting_mail_smtp_oauth2_' + config.auth_type + '_client_secret'),
+                    value: config.client_secret
+                }, {
+                    xtype: 'textfield',
+                    id: 'modx-email-tenant-id',
+                    anchor: '100%',
+                    name: 'tenant_id',
+                    fieldLabel: _('setting_mail_smtp_oauth2_' + config.auth_type + '_tenant_id'),
+                    value: config.tenant_id,
+                    hidden: config.auth_type !== 'azure'
+                }, {
+                    xtype: 'textfield',
+                    anchor: '100%',
+                    readOnly: true,
+                    fieldLabel: _('mail_oauth2.redirect_url'),
+                    value: config.redirect_url
+                }]
+            }, {
+                xtype: 'toolbar',
+                style: {
+                    backgroundColor: 'transparent',
+                    borderColor: 'transparent',
+                    margin: '10px 0 0 -3px'
+                },
+                items: [{
+                    xtype: 'button',
+                    id: 'modx-email-oauth-button',
+                    text: _('mail_oauth2.get_token'),
+                    cls: 'primary-button',
+                    listeners: {
+                        click: {
+                            fn: this.getToken,
+                            scope: this
+                        }
+                    }
+                }, {
+                    xtype: 'button',
+                    id: 'modx-email-update-settings-button',
+                    text: _('mail_oauth2.update_settings'),
+                    listeners: {
+                        click: {
+                            fn: this.updateSettings,
+                            scope: this
+                        }
+                    }
+                }]
+            }]
+        }]
+    });
+    MODx.panel.OAuth2Email.superclass.constructor.call(this, config);
+};
+Ext.extend(MODx.panel.OAuth2Email, MODx.Panel, {
+    getToken: function () {
+        var panel = Ext.getCmp('modx-email-panel');
+        panel.el.mask(_('working'));
+        MODx.Ajax.request({
+            url: MODx.config.connector_url,
+            params: {
+                action: 'System/Email/Oauth2/GetToken'
+            },
+            listeners: {
+                success: {
+                    fn: function (r) {
+                        panel.el.unmask();
+                        url = r.object.auth_url;
+                        if (url) {
+                            location.href = url;
+                        } else {
+                            MODx.msg.alert(_('error'), _('mail_oauth2.url_missing'));
+                        }
+                    }
+                },
+                failure: {
+                    fn: function (r) {
+                        panel.el.unmask();
+                        MODx.msg.alert(_('error'), r.message);
+                    }
+                }
+            }
+        });
+    },
+    updateSettings: function () {
+        var panel = Ext.getCmp('modx-email-panel'),
+            clientId = Ext.getCmp('modx-email-client-id'),
+            clientSecret = Ext.getCmp('modx-email-client-secret'),
+            tenantId = Ext.getCmp('modx-email-tenant-id');
+        panel.el.mask(_('working'));
+        MODx.Ajax.request({
+            url: MODx.config.connector_url,
+            params: {
+                action: 'System/Email/Oauth2/UpdateSettings',
+                clientId: clientId.getValue(),
+                clientSecret: clientSecret.getValue(),
+                tenantId: tenantId.getValue()
+            },
+            listeners: {
+                success: {
+                    fn: function (r) {
+                        panel.el.unmask();
+                        MODx.msg.status({
+                            title: _('success'),
+                            message: _('mail_oauth2.update_successful'),
+                            dontHide: r.message !== ''
+                        });
+                    }
+                },
+                failure: {
+                    fn: function (r) {
+                        panel.el.unmask();
+                        MODx.msg.alert(_('error'), r.message);
+                    }
+                }
+            }
+        });
+    }
+});
+Ext.reg('modx-panel-oauth2-email', MODx.panel.OAuth2Email);

--- a/manager/assets/modext/widgets/system/modx.panel.system.settings.js
+++ b/manager/assets/modext/widgets/system/modx.panel.system.settings.js
@@ -44,7 +44,17 @@ MODx.panel.SystemSettings = function(config) {
                     ,cls: 'main-wrapper'
                     ,preventSaveRefresh: true
                 }]
-        }],{
+        }, (MODx.config.mail_smtp_auth_type === 'AZURE') ? {
+            title: _('mail_oauth2.tab')
+            ,layout: 'form'
+            ,items:[{
+                    html: '<p>' + _('mail_oauth2.intro_msg', {'auth_type': _('mail_oauth2.' + MODx.config.mail_smtp_auth_type.toLowerCase())}) + '</p>'
+                    ,xtype: 'modx-description'
+                },{
+                    xtype: 'modx-panel-oauth2-email'
+                    ,cls: 'main-wrapper'
+                }]
+        }: undefined].filter(x => x !== undefined),{
             id: 'modx-system-settings-tabs'
         })]
     });

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -176,6 +176,8 @@ class SystemSettingsManagerController extends modManagerController {
                 $setting->set('value', $token->getRefreshToken());
                 $setting->save();
 
+                $this->modx->reloadConfig();
+
                 return '';
             }
         }

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -110,46 +110,31 @@ class SystemSettingsManagerController extends modManagerController {
         $clientSecret = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_client_secret');
         $tenantId = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_tenant_id');
 
+        $redirectUri = MODX_URL_SCHEME . MODX_HTTP_HOST . MODX_MANAGER_URL . '?a=system/settings&tab=2';
+
         $params = [
             'clientId' => $clientId,
             'clientSecret' => $clientSecret,
+            'redirectUri' => $redirectUri,
             'accessType' => 'offline'
         ];
 
-        $options = [];
         $provider = null;
 
         switch ($providerName) {
 //            case 'google':
 //                $provider = new Google($params);
-//                $options = [
-//                    'scope' => [
-//                        'https://mail.google.com/'
-//                    ]
-//                ];
 //                break;
 //            case 'yahoo':
 //                $provider = new Yahoo($params);
 //                break;
 //            case 'microsoft':
 //                $provider = new Microsoft($params);
-//                $options = [
-//                    'scope' => [
-//                        'wl.imap',
-//                        'wl.offline_access'
-//                    ]
-//                ];
 //                break;
             case 'azure':
                 $params['tenantId'] = $tenantId;
 
                 $provider = new Azure($params);
-                $options = [
-                    'scope' => [
-                        'https://outlook.office.com/SMTP.Send',
-                        'offline_access'
-                    ]
-                ];
                 break;
         }
 

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -15,6 +15,7 @@ use Greew\OAuth2\Client\Provider\Azure;
 use GuzzleHttp\Exception\GuzzleException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use MODX\Revolution\modManagerController;
+use MODX\Revolution\modSystemSetting;
 
 /**
  * Loads the system settings page
@@ -178,9 +179,9 @@ class SystemSettingsManagerController extends modManagerController {
                     'key' => 'mail_smtp_oauth2_azure_refresh_token'
                 ]);
                 if (!$setting) {
-                    $setting = $this->modx->newObject('modSystemSetting');
+                    $setting = $this->modx->newObject(modSystemSetting::class);
+                    $setting->set('key', 'mail_smtp_oauth2_azure_refresh_token');
                     $setting->fromArray([
-                        'key' => 'mail_smtp_oauth2_azure_refresh_token',
                         'value' => '',
                         'xtype' => 'textfield',
                         'namespace' => 'core',

--- a/manager/controllers/default/system/settings.class.php
+++ b/manager/controllers/default/system/settings.class.php
@@ -8,6 +8,12 @@
  * files found in the top-level directory of this distribution.
  */
 
+//use League\OAuth2\Client\Provider\Google;
+//use Hayageek\OAuth2\Client\Provider\Yahoo;
+//use Stevenmaguire\OAuth2\Client\Provider\Microsoft;
+use Greew\OAuth2\Client\Provider\Azure;
+use GuzzleHttp\Exception\GuzzleException;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use MODX\Revolution\modManagerController;
 
 /**
@@ -18,6 +24,8 @@ use MODX\Revolution\modManagerController;
  */
 class SystemSettingsManagerController extends modManagerController {
     public $onSiteSettingsRender = '';
+    public $siteSettingsMessage = '';
+
     /**
      * Check for any permissions or requirements to load page
      * @return bool
@@ -37,11 +45,13 @@ class SystemSettingsManagerController extends modManagerController {
             MODx.add("modx-page-system-settings");
         });
         MODx.onSiteSettingsRender = "'.$this->onSiteSettingsRender.'";
+        MODx.siteSettingsMessage = "'. $this->siteSettingsMessage.'";
         // ]]>
         </script>');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/core/modx.grid.settings.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/system/modx.grid.system.event.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/system/modx.panel.system.settings.js');
+        $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/widgets/system/modx.panel.oauth2email.js');
         $this->addJavascript($this->modx->getOption('manager_url').'assets/modext/sections/system/settings.js');
     }
 
@@ -51,6 +61,8 @@ class SystemSettingsManagerController extends modManagerController {
      * @return mixed
      */
     public function process(array $scriptProperties = []) {
+        $this->siteSettingsMessage = $this->processOauth2Token();
+
         $onSiteSettingsRender = $this->modx->invokeEvent('OnSiteSettingsRender');
         if (is_array($onSiteSettingsRender)) {
             $this->onSiteSettingsRender = implode("\"\n+ \"",$onSiteSettingsRender);
@@ -79,7 +91,7 @@ class SystemSettingsManagerController extends modManagerController {
      * @return array
      */
     public function getLanguageTopics() {
-        return ['setting','events'];
+        return ['setting','events','mail'];
     }
 
     /**
@@ -88,5 +100,98 @@ class SystemSettingsManagerController extends modManagerController {
      */
     public function getHelpUrl() {
         return 'Settings';
+    }
+
+    private function processOauth2Token()
+    {
+        $providerName = strtolower($this->modx->getOption('mail_smtp_auth_type'));
+        $clientId = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_client_id');
+        $clientSecret = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_client_secret');
+        $tenantId = $this->modx->getOption('mail_smtp_oauth2_' . $providerName . '_tenant_id');
+
+        $params = [
+            'clientId' => $clientId,
+            'clientSecret' => $clientSecret,
+            'accessType' => 'offline'
+        ];
+
+        $options = [];
+        $provider = null;
+
+        switch ($providerName) {
+//            case 'google':
+//                $provider = new Google($params);
+//                $options = [
+//                    'scope' => [
+//                        'https://mail.google.com/'
+//                    ]
+//                ];
+//                break;
+//            case 'yahoo':
+//                $provider = new Yahoo($params);
+//                break;
+//            case 'microsoft':
+//                $provider = new Microsoft($params);
+//                $options = [
+//                    'scope' => [
+//                        'wl.imap',
+//                        'wl.offline_access'
+//                    ]
+//                ];
+//                break;
+            case 'azure':
+                $params['tenantId'] = $tenantId;
+
+                $provider = new Azure($params);
+                $options = [
+                    'scope' => [
+                        'https://outlook.office.com/SMTP.Send',
+                        'offline_access'
+                    ]
+                ];
+                break;
+        }
+
+        if (null === $provider) {
+            return $this->modx->lexicon('mail_oauth2.invalid_provider');
+        }
+
+        if (!empty($_GET['code'])) {
+            if (empty($_GET['state']) || ($_GET['state'] !== $_SESSION['oauth2state'])) {
+                // Check given state against previously stored one to mitigate CSRF attack
+                unset($_SESSION['oauth2state']);
+                return $this->modx->lexicon('mail_oauth2.invalid_state');
+            } else {
+                // Try to get an access token (using the authorization code grant)
+                try {
+                    $token = $provider->getAccessToken('authorization_code', [
+                        'code' => $_GET['code']
+                    ]);
+                } catch (GuzzleException $e) {
+                    $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'Could not get the email OAuth2 access token: ' . $e->getMessage());
+                    return $this->modx->lexicon('mail_oauth2.invalid_connection');
+                } catch (IdentityProviderException $e) {
+                    $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'Could not get the email OAuth2 access token: ' . $e->getMessage());
+                    return $this->modx->lexicon('mail_oauth2.invalid_authorization');
+                }
+                $setting = $this->modx->getObject('modSystemSetting', [
+                    'key' => 'mail_smtp_oauth2_azure_refresh_token'
+                ]);
+                if (!$setting) {
+                    $setting = $this->modx->newObject('modSystemSetting');
+                    $setting->fromArray([
+                        'key' => 'mail_smtp_oauth2_azure_refresh_token',
+                        'value' => '',
+                        'xtype' => 'textfield',
+                        'namespace' => 'core',
+                        'area' => 'mail'
+                    ]);
+                }
+                $setting->set('value', $token->getRefreshToken());
+                $setting->save();
+
+                return '';
+            }
+        }
     }
 }


### PR DESCRIPTION
### What does it do?

Add an option to send mails with Office 365 SMTP accounts using OAuth2.

### Why is it needed?

It is currently not possible to connect with these SMTP accounts.

### How to test

The code is the result of the examples in the [MailTrap blog](https://mailtrap.io/blog/phpmailer-office-365/) and in the [PhpMailer docs](https://github.com/PHPMailer/PHPMailer/blob/master/examples/azure_xoauth2.phps).

It can be extended with other OAuth providers by uncommenting the other provider classes in the [GetToken processor](https://github.com/Jako/revolution/blob/phpmailer-azure/core/src/Revolution/Processors/System/Email/Oauth2/GetToken.php) and in the [settings controller](https://github.com/Jako/revolution/blob/phpmailer-azure/manager/controllers/default/system/settings.class.php) and adding other types in `mail_smtp_auth_type` and changing the OAuth provider class and other settings with the value in there.

To configure the options, a new tab is available on the system settings page, when the `mail_smtp_auth_type` system setting is not empty.

Since it uses additional composer packages, these have to be installed before the tests.
