### PR TITLE
Resolve various deprecation warnings

### DIFF
--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -123,14 +123,14 @@ class modRequestTest extends MODxTestCase {
      * @dataProvider providerGetResourceIdentifier
      */
     public function testGetResourceIdentifier($expected,$requestKey,$requestValue,$method = 'alias',$paramAlias = 'q',$paramId = 'id') {
-        $_REQUEST[$requestKey] = $requestValue;
+        $_REQUEST[(string)$requestKey] = $requestValue;
         $this->modx->setOption('request_param_alias',$paramAlias);
         $this->modx->setOption('request_param_id',$paramId);
         $this->modx->setOption('site_start',1);
         $identifier = $this->request->getResourceIdentifier($method);
 
         $this->assertEquals($expected,$identifier,'The Resource Identifier did not match the expected value.');
-        unset($_REQUEST[$requestKey]);
+        unset($_REQUEST[(string)$requestKey]);
     }
     /**
      * @return array

--- a/core/src/Revolution/Filters/modInputFilter.php
+++ b/core/src/Revolution/Filters/modInputFilter.php
@@ -46,7 +46,7 @@ class modInputFilter
     public function filter(&$element)
     {
         /* split commands and modifiers and store them as properties for the output filtering */
-        $output = $element->get('name');
+        $output = (string)$element->get('name');
         $name = $output;
         $splitPos = strpos($output, ':');
         if ($splitPos !== false && $splitPos > 0) {

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -63,7 +63,7 @@ class modOutputFilter
 
                 $this->log('Processing Modifier: ' . $m_cmd . ' (parameters: ' . $m_val . ')');
 
-                $output = trim($output);
+                $output = trim((string)$output);
 
                 try {
                     switch ($m_cmd) {

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -63,7 +63,7 @@ class modOutputFilter
 
                 $this->log('Processing Modifier: ' . $m_cmd . ' (parameters: ' . $m_val . ')');
 
-                $output = trim((string)$output);
+                $output = is_string($output) ? trim($output) : $output;
 
                 try {
                     switch ($m_cmd) {

--- a/core/src/Revolution/Hashing/modPBKDF2.php
+++ b/core/src/Revolution/Hashing/modPBKDF2.php
@@ -45,7 +45,7 @@ class modPBKDF2 extends modHash
             $derivedKeyLength = (int)$this->getOption('derived_key_length', $options, 32);
             $algorithm = $this->getOption('algorithm', $options, 'sha256');
 
-            $hashLength = strlen(hash($algorithm, null, true));
+            $hashLength = strlen(hash($algorithm, '', true));
             $keyBlocks = ceil($derivedKeyLength / $hashLength);
             $derivedKey = '';
             for ($block = 1; $block <= $keyBlocks; $block++) {

--- a/core/src/Revolution/Mail/modMail.php
+++ b/core/src/Revolution/Mail/modMail.php
@@ -12,6 +12,7 @@ namespace MODX\Revolution\Mail;
 
 
 use MODX\Revolution\Error\modError;
+use MODX\Revolution\modLexicon;
 use MODX\Revolution\modX;
 
 /**
@@ -214,6 +215,12 @@ abstract class modMail
      * @var modError
      */
     protected $error = null;
+    /**
+     * The default attributes to initialize or reset the service with.
+     *
+     * @var array
+     */
+    private array $defaultAttributes = [];
 
     /**
      * Constructs a new instance of the modMail class.
@@ -221,11 +228,12 @@ abstract class modMail
      * @param modX &$modx       A reference to the modX instance
      * @param array $attributes An array of attributes to assign to the new mail instance
      */
-    function __construct(modX &$modx, array $attributes = [])
+    public function __construct(modX &$modx, array $attributes = [])
     {
         $this->modx = &$modx;
         if (!$this->modx->lexicon) {
-            $this->modx->getService('lexicon', 'modLexicon');
+            $this->modx->services->add('lexicon', new modLexicon($this->modx));
+            $this->modx->lexicon = $this->modx->services->get('lexicon');
         }
         $this->modx->lexicon->load('mail');
         $this->defaultAttributes = is_array($attributes) ? $attributes : [];

--- a/core/src/Revolution/Processors/System/ConfigCheck.php
+++ b/core/src/Revolution/Processors/System/ConfigCheck.php
@@ -113,7 +113,6 @@ class ConfigCheck extends Processor
         curl_exec($curl);
         $response = curl_getinfo($curl);
         $err = curl_errno($curl);
-        curl_close($curl);
 
         return !$err ? $response : false;
     }

--- a/core/src/Revolution/Registry/modRegistry.php
+++ b/core/src/Revolution/Registry/modRegistry.php
@@ -31,6 +31,7 @@ use MODX\Revolution\modX;
  *
  * @package MODX\Revolution\Registry
  */
+#[\AllowDynamicProperties]
 class modRegistry
 {
     /**

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -306,8 +306,9 @@ class modElement extends modAccessibleSimpleObject
                 }
             }
             $tag = '[[';
+            $name = (string)$this->get('name');
             $tag .= $this->getToken();
-            $tag .= strlen((string)$this->get('name')) > 0 ? $this->get('name') : md5(uniqid(rand()));
+            $tag .= strlen($name) > 0 ? $name : md5(uniqid(rand()));
             if (!empty($this->_propertyString)) {
                 $tag .= $this->_propertyString;
             }

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -307,7 +307,7 @@ class modElement extends modAccessibleSimpleObject
             }
             $tag = '[[';
             $tag .= $this->getToken();
-            $tag .= strlen($this->get('name')) > 0 ? $this->get('name') : md5(uniqid(rand()));
+            $tag .= strlen((string)$this->get('name')) > 0 ? $this->get('name') : md5(uniqid(rand()));
             if (!empty($this->_propertyString)) {
                 $tag .= $this->_propertyString;
             }
@@ -727,7 +727,7 @@ class modElement extends modAccessibleSimpleObject
     public function getPropertySet($setName = null)
     {
         $propertySet = null;
-        $name = $this->get('name');
+        $name = (string)$this->get('name');
 
         $startFiltersIndex = strpos($name, ':');
 

--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -36,6 +36,12 @@ class modLexicon
      * @access protected
      */
     public $modx = null;
+
+    /**
+     * @var array|null
+     */
+    public $config = null;
+
     /**
      * The actual language array.
      *

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -405,7 +405,7 @@ class modParser
 
         $tagParts= xPDO :: escSplit('?', $innerTag, '`', 2);
         $tagName= trim($tagParts[0]);
-        $tagPropString= null;
+        $tagPropString= '';
         if (isset ($tagParts[1])) {
             $tagPropString= trim($tagParts[1]);
         }


### PR DESCRIPTION
### What does it do?
Resolves various deprecation warnings in PHP 8.1+

### Why is it needed?
When running the unit tests in various PHP 8.x releases, a number of deprecation warnings are encountered.

### How to test
Run the phpunit test suite in the latest PHP releases. Note that there are a number of warnings still being emitted by the league/flysystem dependency.

### Related issue(s)/PR(s)
n/a
