### PR TITLE
Fix memory_limit calculation in modTransportPackage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "ext-xmlwriter": "*",
-        "ext-fileinfo": "*"
+        "ext-fileinfo": "*",
+        "symfony/polyfill-php82": "^1.33"
     },
     "suggest": {
         "ext-imagick": "To process images in a more advanced way",

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -746,20 +746,7 @@ class modTransportPackage extends xPDOObject
      */
     protected function _bytes($value)
     {
-        $value = trim($value);
-        $modifier = strtolower($value[strlen($value) - 1]);
-        switch ($modifier) {
-            case 'g':
-                $value *= 1024;
-                // no break
-            case 'm':
-                $value *= 1024;
-                // no break
-            case 'k':
-                $value *= 1024;
-        }
-
-        return $value;
+        return ini_parse_quantity(trim($value));
     }
 
     /**


### PR DESCRIPTION
### What does it do?
Re-implements the `_bytes` method using `ini_parse_quantity` introduced in PHP 8.2, providing a polyfill for use in PHP 8.1.

### Why is it needed?
A php warning occurs (and gets logged in MODX as an error) because the `_bytes` function attempts to use the ini `memory_limit` value in a calculation without removing the modifier string (_e.g._, 128M *= 1024). This triggers the “A non-numeric value encountered” warning.

### How to test

1. Download any package before applying this PR fix. Note the warning in your MODX error log
2. Apply this PR and verify the warning no longer appears and that package downloads work as expected

### Related issue(s)/PR(s)
Resolves #16504. Alternate solution for #16797 that supports all valid quantities that might appear in the ini `memory_limit` value.
