### PR TITLE
Fix: Syntax error when creating TV

### DIFF
--- a/manager/assets/modext/widgets/element/modx.panel.tv.js
+++ b/manager/assets/modext/widgets/element/modx.panel.tv.js
@@ -6,7 +6,8 @@
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-tv
  */
-MODx.panel.TV = function(config = {}) {
+MODx.panel.TV = function(config) {
+    config = config || {};
     config.record = config.record || {};
     config = MODx.setStaticElementsConfig(config, 'tv');
 
@@ -942,7 +943,8 @@ Ext.reg('modx-panel-tv', MODx.panel.TV);
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-tv-input-properties
  */
-MODx.panel.TVInputProperties = function(config = {}) {
+MODx.panel.TVInputProperties = function(config) {
+    config = config || {};
     Ext.applyIf(config, {
         id: 'modx-panel-tv-input-properties',
         title: _('tv_tab_input_options'),
@@ -1499,7 +1501,8 @@ Ext.reg('modx-panel-tv-input-properties', MODx.panel.TVInputProperties);
  * @param {Object} config An object of configuration properties
  * @xtype modx-panel-tv-output-properties
  */
-MODx.panel.TVOutputProperties = function(config = {}) {
+MODx.panel.TVOutputProperties = function(config) {
+    config = config || {};
     Ext.applyIf(config, {
         id: 'modx-panel-tv-output-properties',
         title: _('tv_tab_output_options'),
@@ -1646,7 +1649,8 @@ Ext.reg('modx-panel-tv-output-properties', MODx.panel.TVOutputProperties);
  * @param {Object} config An object of configuration properties
  * @xtype modx-grid-element-sources
  */
-MODx.grid.ElementSources = function(config = {}) {
+MODx.grid.ElementSources = function(config) {
+    config = config || {};
     const src = new MODx.combo.MediaSource();
     src.getStore().load();
     Ext.applyIf(config, {


### PR DESCRIPTION
### What does it do?
Replaces the ES6 default parameter in the `MODx.panel.TV` constructor with an ES5-compatible pattern. Instead of `function(config = {})`, the code now uses `function(config)` with `config = config || {}` inside the function body.

### Why is it needed?
The MODX Manager runs on ExtJS 3 (ES5). The `config = {}` default parameter syntax is not supported and triggers `SyntaxError: missing ) in parenthetical` when loading the TV creation page. As a result, the header and Save, Cancel, and ? buttons do not appear.

### How to test
1. Install MODX 3.2.0.
2. In the Manager, go to Elements → Template Variables.
3. Click "Create Template Variable".
4. Confirm the page loads without console errors and that the header and Save, Cancel, and ? buttons are visible.

### Related issue(s)/PR(s)
Resolves #16823