### PR TITLE
Fix: array_diff_key() TypeError in upgrade.install.php

### DIFF
--- a/core/lexicon/en/policy.inc.php
+++ b/core/lexicon/en/policy.inc.php
@@ -34,6 +34,7 @@ $_lang['policy_err_nf'] = 'Policy not found.';
 $_lang['policy_err_ns'] = 'Policy not specified.';
 $_lang['policy_err_remove'] = 'An error occurred while trying to delete the Policy.';
 $_lang['policy_err_save'] = 'An error occurred while trying to save the Policy.';
+$_lang['policy_err_invalid_data'] = 'Policy data must be a valid JSON object.';
 $_lang['policy_import_msg'] = 'Select an XML file to import a Policy from. It must be in the correct XML Policy format.';
 $_lang['policy_management'] = 'Access Policies';
 $_lang['policy_management_msg'] = 'Access Policies manage how MODX handles permissions for specified actions.';

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -133,6 +133,9 @@
         <aggregate alias="Parent" class="MODX\Revolution\modAccessPolicy" local="parent" foreign="id" owner="foreign" cardinality="one" />
         <aggregate alias="Template" class="MODX\Revolution\modAccessPolicyTemplate" local="template" foreign="id" owner="foreign" cardinality="one" />
         <composite alias="Children" class="MODX\Revolution\modAccessPolicy" local="id" foreign="parent" owner="local" cardinality="many" />
+        <validation>
+            <rule field="data" name="jsonArray" type="xPDOValidationRule" rule="MODX\Revolution\Validation\JsonArrayValidationRule" message="policy_err_invalid_data" />
+        </validation>
     </object>
 
     <object class="modAccessPolicyTemplate" table="access_policy_templates" extends="xPDO\Om\xPDOSimpleObject">

--- a/core/src/Revolution/Validation/JsonArrayValidationRule.php
+++ b/core/src/Revolution/Validation/JsonArrayValidationRule.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MODX\Revolution\Validation;
+
+use xPDO\Validation\xPDOValidationRule;
+
+/**
+ * Validates that a field value is an array or a JSON string that decodes to an array.
+ *
+ * @package MODX\Revolution\Validation
+ */
+class JsonArrayValidationRule extends xPDOValidationRule
+{
+    /**
+     * @param mixed $value The field value.
+     * @param array $options Rule options.
+     * @return bool True if valid.
+     */
+    public function isValid($value, array $options = [])
+    {
+        if (is_array($value)) {
+            return true;
+        }
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                return true;
+            }
+        }
+        $this->validator->addMessage($this->field, $this->name, $this->message);
+        return false;
+    }
+}

--- a/core/src/Revolution/modAccessPolicy.php
+++ b/core/src/Revolution/modAccessPolicy.php
@@ -79,6 +79,9 @@ class modAccessPolicy extends xPDOSimpleObject
     {
         $value = parent::get($k, $format, $formatTemplate);
         if (is_array($k)) {
+            if (!is_array($value)) {
+                return $value;
+            }
             if (array_key_exists('data', $value) && !is_array($value['data'])) {
                 $value['data'] = [];
             }
@@ -113,6 +116,7 @@ class modAccessPolicy extends xPDOSimpleObject
         $list = [];
         /** @var modAccessPermission $permission */
         foreach ($permissions as $permission) {
+            $permissionName = $permission->get('name');
             $desc = $permission->get('description');
             if (!empty($lexicon) && $this->xpdo->lexicon) {
                 if (strpos($lexicon, ':') !== false) {
@@ -122,9 +126,9 @@ class modAccessPolicy extends xPDOSimpleObject
                 }
                 $desc = $this->xpdo->lexicon($desc);
             }
-            $active = array_key_exists($permission->get('name'), $data) && $data[$permission->get('name')] ? 1 : 0;
+            $active = array_key_exists($permissionName, $data) && $data[$permissionName] ? 1 : 0;
             $list[] = [
-                $permission->get('name'),
+                $permissionName,
                 $permission->get('description'),
                 $desc,
                 $permission->get('value'),

--- a/core/src/Revolution/modAccessPolicy.php
+++ b/core/src/Revolution/modAccessPolicy.php
@@ -13,7 +13,7 @@ use xPDO\xPDO;
  * @property int               $parent      The parent Policy of this Policy. Not currently used.
  * @property int               $template    The Access Policy Template this Policy belongs to
  * @property string            $class       Deprecated
- * @property array             $data        A JSON object that contains all Permissions loaded in this Policy
+ * @property array             $data        JSON object with all Permissions for this Policy
  * @property string            $lexicon     Optional. The lexicon to load to provide the translated names/descriptions for the
  * Permissions included
  *
@@ -69,6 +69,25 @@ class modAccessPolicy extends xPDOSimpleObject
     public function isCorePolicy(string $name): bool
     {
         return in_array($name, static::getCorePolicies(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     * Ensures 'data' always returns an array per @property contract (xPDO json type may return string/null).
+     */
+    public function get($k, $format = null, $formatTemplate = null)
+    {
+        $value = parent::get($k, $format, $formatTemplate);
+        if (is_array($k)) {
+            if (array_key_exists('data', $value) && !is_array($value['data'])) {
+                $value['data'] = [];
+            }
+            return $value;
+        }
+        if ($k === 'data') {
+            return is_array($value) ? $value : [];
+        }
+        return $value;
     }
 
     /**

--- a/core/src/Revolution/modAccessPolicy.php
+++ b/core/src/Revolution/modAccessPolicy.php
@@ -14,8 +14,7 @@ use xPDO\xPDO;
  * @property int               $template    The Access Policy Template this Policy belongs to
  * @property string            $class       Deprecated
  * @property array             $data        JSON object with all Permissions for this Policy
- * @property string            $lexicon     Optional. The lexicon to load to provide the translated names/descriptions for the
- * Permissions included
+ * @property string            $lexicon     Optional. Lexicon for translated names/descriptions of Permissions
  *
  * @property modAccessPolicy[] $Children
  *
@@ -51,7 +50,7 @@ class modAccessPolicy extends xPDOSimpleObject
             self::POLICY_LOAD_ONLY,
             self::POLICY_LOAD_LIST_VIEW,
             self::POLICY_OBJECT,
-            self::POLICY_ELEMENT ,
+            self::POLICY_ELEMENT,
             self::POLICY_CONTENT_EDITOR,
             self::POLICY_MEDIA_SOURCE_ADMIN,
             self::POLICY_MEDIA_SOURCE_USER,
@@ -117,19 +116,20 @@ class modAccessPolicy extends xPDOSimpleObject
         /** @var modAccessPermission $permission */
         foreach ($permissions as $permission) {
             $permissionName = $permission->get('name');
-            $desc = $permission->get('description');
+            $descriptionKey = $permission->get('description');
+            $desc = $descriptionKey;
             if (!empty($lexicon) && $this->xpdo->lexicon) {
                 if (strpos($lexicon, ':') !== false) {
                     $this->xpdo->lexicon->load($lexicon);
                 } else {
                     $this->xpdo->lexicon->load('core:' . $lexicon);
                 }
-                $desc = $this->xpdo->lexicon($desc);
+                $desc = $this->xpdo->lexicon($descriptionKey);
             }
             $active = array_key_exists($permissionName, $data) && $data[$permissionName] ? 1 : 0;
             $list[] = [
                 $permissionName,
-                $permission->get('description'),
+                $descriptionKey,
                 $desc,
                 $permission->get('value'),
                 $active,

--- a/core/src/Revolution/mysql/modAccessPolicy.php
+++ b/core/src/Revolution/mysql/modAccessPolicy.php
@@ -193,6 +193,21 @@ class modAccessPolicy extends \MODX\Revolution\modAccessPolicy
                 'cardinality' => 'one',
             ),
         ),
+        'validation' => 
+        array (
+            'rules' => 
+            array (
+                'data' => 
+                array (
+                    'jsonArray' => 
+                    array (
+                        'type' => 'xPDOValidationRule',
+                        'rule' => 'MODX\\Revolution\\Validation\\JsonArrayValidationRule',
+                        'message' => 'policy_err_invalid_data',
+                    ),
+                ),
+            ),
+        ),
     );
 
 }

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -69,10 +70,10 @@ $settings_version = $modx->getObject(modSystemSetting::class, [
 ]);
 if ($settings_version == null) {
     $settings_version = $modx->newObject(modSystemSetting::class);
-    $settings_version->set('key','settings_version');
-    $settings_version->set('xtype','textfield');
-    $settings_version->set('namespace','core');
-    $settings_version->set('area','system');
+    $settings_version->set('key', 'settings_version');
+    $settings_version->set('xtype', 'textfield');
+    $settings_version->set('namespace', 'core');
+    $settings_version->set('area', 'system');
 }
 $settings_version->set('value', $currentVersion['full_version']);
 $settings_version->save();
@@ -83,10 +84,10 @@ $settings_distro = $modx->getObject(modSystemSetting::class, [
 ]);
 if ($settings_distro == null) {
     $settings_distro = $modx->newObject(modSystemSetting::class);
-    $settings_distro->set('key','settings_distro');
-    $settings_distro->set('xtype','textfield');
-    $settings_distro->set('namespace','core');
-    $settings_distro->set('area','system');
+    $settings_distro->set('key', 'settings_distro');
+    $settings_distro->set('xtype', 'textfield');
+    $settings_distro->set('namespace', 'core');
+    $settings_distro->set('area', 'system');
 }
 $settings_distro->set('value', trim($currentVersion['distro'], '@'));
 $settings_distro->save();
@@ -115,7 +116,7 @@ $adminGroup = $modx->getObject(modUserGroup::class, [
     'name' => 'Administrator',
 ]);
 if ($adminPolicy && $adminGroup) {
-    $access= $modx->getObject(modAccessContext::class, [
+    $access = $modx->getObject(modAccessContext::class, [
         'target' => 'mgr',
         'principal_class' => modUserGroup::class,
         'principal' => $adminGroup->get('id'),
@@ -143,7 +144,7 @@ if ($adminPolicy && $adminGroup) {
       'policy' => $adminPolicy->get('id'),
     ]);
     if (!$access) {
-        $access= $modx->newObject(modAccessContext::class);
+        $access = $modx->newObject(modAccessContext::class);
         $access->fromArray([
           'target' => 'web',
           'principal_class' => modUserGroup::class,
@@ -155,7 +156,7 @@ if ($adminPolicy && $adminGroup) {
     }
     unset($access);
 }
-unset($adminPolicy,$adminGroup);
+unset($adminPolicy, $adminGroup);
 
 /* Access Policy changes (have to happen post package install) */
 
@@ -165,8 +166,9 @@ $setting = $modx->getObject(modSystemSetting::class, [
     'value' => '1.0',
 ]);
 if (!$setting) {
-    /* truncate permissions in modAccessPermission and migrate to modAccessPolicyTemplate objects from modAccessPolicy.data
-     * first get the standard policies, and then array_diff with Admin policy and unknown policies
+    /* truncate permissions in modAccessPermission and migrate to modAccessPolicyTemplate
+     * objects from modAccessPolicy.data. First get the standard policies, then array_diff
+     * with Admin policy and unknown policies.
      * if an unknown policy doesnt contain any new permissions that arent in Admin policy,
      * just switch it to the Admin Policy Template. Otherwise, create a new AP template
      * based on the Policy's name (first look for an existing one).
@@ -178,20 +180,22 @@ if (!$setting) {
 
     $adminPolicyTpl = $modx->getObject(modAccessPolicyTemplate::class, ['name' => 'AdministratorTemplate']);
     if (!$adminPolicyTpl) {
-        $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find Administrator Access Policy Template');
+        $modx->log(xPDO::LOG_LEVEL_ERROR, 'Could not find Administrator Access Policy Template');
     }
     $adminPolicyTplGroup = $adminPolicyTpl ? $adminPolicyTpl->get('template_group') : 1;
 
     /* get all existing policies */
     $c = $modx->newQuery(modAccessPolicy::class);
-    $c->sortby('name','ASC');
+    $c->sortby('name', 'ASC');
     $policies = $modx->getCollection(modAccessPolicy::class, $c);
 
     /** @var modAccessPolicy $policy */
     foreach ($policies as $policy) {
         /* standard policies */
-        if (in_array($policy->get('name'),$standards)) {
-            if ($policy->get('template') != 0) continue;
+        if (in_array($policy->get('name'), $standards)) {
+            if ($policy->get('template') != 0) {
+                continue;
+            }
 
             $id = $adminPolicyTpl ? $adminPolicyTpl->get('id') : 3; /* default to object */
             switch ($policy->get('name')) {
@@ -200,7 +204,7 @@ if (!$setting) {
                     if ($policyTpl) {
                         $id = $policyTpl->get('id');
                     } else {
-                        $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find Resource Access Policy Template');
+                        $modx->log(xPDO::LOG_LEVEL_ERROR, 'Could not find Resource Access Policy Template');
                     }
                     break;
                 case 'Element':
@@ -208,7 +212,7 @@ if (!$setting) {
                     if ($policyTpl) {
                         $id = $policyTpl->get('id');
                     } else {
-                        $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find Element Access Policy Template');
+                        $modx->log(xPDO::LOG_LEVEL_ERROR, 'Could not find Element Access Policy Template');
                     }
                     break;
                 case 'Object':
@@ -218,14 +222,14 @@ if (!$setting) {
                     if ($policyTpl) {
                         $id = $policyTpl->get('id');
                     } else {
-                        $modx->log(xPDO::LOG_LEVEL_ERROR,'Could not find Object Access Policy Template');
+                        $modx->log(xPDO::LOG_LEVEL_ERROR, 'Could not find Object Access Policy Template');
                     }
                     break;
                 case 'Administrator':
                 default:
                     break;
             }
-            $modx->log(xPDO::LOG_LEVEL_DEBUG,'Setting template to '.$id.' for standard '.$policy->get('name'));
+            $modx->log(xPDO::LOG_LEVEL_DEBUG, 'Setting template to ' . $id . ' for standard ' . $policy->get('name'));
 
             /* prevent duplicate standard policies */
             $policyExists = $modx->getObject(modAccessPolicy::class, [
@@ -235,13 +239,12 @@ if (!$setting) {
             if ($policyExists) {
                 $policy->remove();
             } else {
-                $policy->set('template',$id);
+                $policy->set('template', $id);
                 $policy->save();
             }
-            unset($policyTpl,$policy,$id,$policyExists);
-
+            unset($policyTpl, $policy, $id, $policyExists);
         } else {
-            $modx->log(xPDO::LOG_LEVEL_DEBUG,'Found non-standard policy: '.$policy->get('name'));
+            $modx->log(xPDO::LOG_LEVEL_DEBUG, 'Found non-standard policy: ' . $policy->get('name'));
             /* non-standard policies */
             if (!$policyTpl = $policy->getOne('Template')) {
                 $policyTpl = $modx->getObject(modAccessPolicyTemplate::class, [
@@ -252,31 +255,37 @@ if (!$setting) {
                 /* array_diff data with standard admin policy */
                 $data = $policy->get('data');
                 $diff = array_diff_key($data, $adminPolicyData);
-                $modx->log(xPDO::LOG_LEVEL_DEBUG,'Diff: '.print_r($diff,true));
+                $modx->log(xPDO::LOG_LEVEL_DEBUG, 'Diff: ' . print_r($diff, true));
 
                 /* if the unknown policy has all the perms and no new perms of the admin
                  * policy, just set its tpl to the admin policy tpl
                  */
                 if (empty($diff) && $adminPolicyTpl) {
-                    $policy->set('template',$adminPolicyTpl->get('id'));
+                    $policy->set('template', $adminPolicyTpl->get('id'));
                     $policy->save();
 
                 /* otherwise create a custom policy tpl */
                 } else {
                     $policyTpl = $modx->newObject(modAccessPolicyTemplate::class);
                     $policyTpl->fromArray([
-                        'name' => $policy->get('name').'Template',
+                        'name' => $policy->get('name') . 'Template',
                         'template_group' => $adminPolicyTplGroup,
                         'description' => $policy->get('description'),
                     ]);
                     $lexicon = $policy->get('lexicon');
                     if (!empty($lexicon)) {
-                        $modx->log(xPDO::LOG_LEVEL_DEBUG,'Setting lexicon to '.$lexicon.' for policy '.$policy->get('name'));
-                        $policyTpl->set('lexicon',$lexicon);
+                        $modx->log(
+                            xPDO::LOG_LEVEL_DEBUG,
+                            'Setting lexicon to ' . $lexicon . ' for policy ' . $policy->get('name')
+                        );
+                        $policyTpl->set('lexicon', $lexicon);
                     }
                     $policyTpl->save();
-                    $modx->log(xPDO::LOG_LEVEL_DEBUG,'Setting template to '.$policyTpl->get('id').' for '.$policy->get('name'));
-                    $policy->set('template',$policyTpl->get('id'));
+                    $modx->log(
+                        xPDO::LOG_LEVEL_DEBUG,
+                        'Setting template to ' . $policyTpl->get('id') . ' for ' . $policy->get('name')
+                    );
+                    $policy->set('template', $policyTpl->get('id'));
                     $policy->save();
 
                     $permissions = $modx->getCollection(modAccessPermission::class, [
@@ -293,20 +302,32 @@ if (!$setting) {
                         if ($permExists) {
                             $permission->remove();
                         } else {
-                            $permission->set('template',$policyTpl->get('id'));
+                            $permission->set('template', $policyTpl->get('id'));
                             $permission->save();
                         }
                     }
-
                 }
             }
         }
     }
-    unset($policy,$permission,$permissions,$policies,$policy,$policyTpl,$adminPolicy,$adminPolicyData,$adminPolicyTpl,$adminPolicyTplGroup,$data);
+    unset(
+        $policy,
+        $permission,
+        $permissions,
+        $policies,
+        $policyTpl,
+        $adminPolicy,
+        $adminPolicyData,
+        $adminPolicyTpl,
+        $adminPolicyTplGroup,
+        $data
+    );
     /* now remove all 0 template permissions */
-    $permissions =$modx->getCollection(modAccessPermission::class, ['template' => 0]);
-    foreach ($permissions as $permission) { $permission->remove(); }
-    unset($permissions,$permission);
+    $permissions = $modx->getCollection(modAccessPermission::class, ['template' => 0]);
+    foreach ($permissions as $permission) {
+        $permission->remove();
+    }
+    unset($permissions, $permission);
 
 
     /* drop policy index from modAccessPermission */
@@ -321,10 +342,10 @@ if (!$setting) {
 
     /* add setting so that this runs only once to prevent errors or goof-ups */
     $setting = $modx->newObject(modSystemSetting::class);
-    $setting->set('key','access_policies_version');
-    $setting->set('namespace','core');
-    $setting->set('area','system');
-    $setting->set('value','1.0');
+    $setting->set('key', 'access_policies_version');
+    $setting->set('namespace', 'core');
+    $setting->set('area', 'system');
+    $setting->set('value', '1.0');
     $setting->save();
 }
 
@@ -344,19 +365,23 @@ if ($provider && $newProvider && $provider->get('id') != $newProvider->get('id')
         ]);
         foreach ($packages as $package) {
             /** @var modTransportPackage $package */
-            $package->set('provider',$newProvider->get('id'));
+            $package->set('provider', $newProvider->get('id'));
             $package->save();
         }
     }
-} else if ($provider && empty($newProvider)) {
-    $provider->set('service_url','https://rest.modx.com/extras/');
+} elseif ($provider && empty($newProvider)) {
+    $provider->set('service_url', 'https://rest.modx.com/extras/');
     $provider->save();
 }
 
 /* Set session_gc_maxlifetime equal to session_cookie_lifetime or session.gc_maxlifetime if empty */
 $setting = $modx->getObject(modSystemSetting::class, ['key' => 'session_gc_maxlifetime']);
 if ($setting && $setting->get('value') == '') {
-    $session_gc_maxlifetime = (int) $modx->getOption('session_cookie_lifetime', null, @ini_get('session.gc_maxlifetime'));
+    $session_gc_maxlifetime = (int) $modx->getOption(
+        'session_cookie_lifetime',
+        null,
+        @ini_get('session.gc_maxlifetime')
+    );
     if ($session_gc_maxlifetime < 1) {
         $session_gc_maxlifetime = 604800;
     }

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -174,11 +174,7 @@ if (!$setting) {
     /* get admin policy and list of standard policies */
     $standards = ['Administrator','Resource','Load Only','Load, List and View','Object','Element'];
     $adminPolicy = $modx->getObject(modAccessPolicy::class, ['name' => 'Administrator']);
-    $adminPolicyData = [];
-    if ($adminPolicy) {
-        $raw = $adminPolicy->get('data');
-        $adminPolicyData = is_array($raw) ? $raw : ($modx->fromJSON($raw, true) ?: []);
-    }
+    $adminPolicyData = $adminPolicy ? $adminPolicy->get('data') : [];
 
     $adminPolicyTpl = $modx->getObject(modAccessPolicyTemplate::class, ['name' => 'AdministratorTemplate']);
     if (!$adminPolicyTpl) {
@@ -255,7 +251,6 @@ if (!$setting) {
             if (!$policyTpl) {
                 /* array_diff data with standard admin policy */
                 $data = $policy->get('data');
-                $data = is_array($data) ? $data : ($modx->fromJSON($data, true) ?: []);
                 $diff = array_diff_key($data, $adminPolicyData);
                 $modx->log(xPDO::LOG_LEVEL_DEBUG,'Diff: '.print_r($diff,true));
 

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -174,7 +174,11 @@ if (!$setting) {
     /* get admin policy and list of standard policies */
     $standards = ['Administrator','Resource','Load Only','Load, List and View','Object','Element'];
     $adminPolicy = $modx->getObject(modAccessPolicy::class, ['name' => 'Administrator']);
-    $adminPolicyData = $adminPolicy ? $adminPolicy->get('data') : [];
+    $adminPolicyData = [];
+    if ($adminPolicy) {
+        $raw = $adminPolicy->get('data');
+        $adminPolicyData = is_array($raw) ? $raw : ($modx->fromJSON($raw, true) ?: []);
+    }
 
     $adminPolicyTpl = $modx->getObject(modAccessPolicyTemplate::class, ['name' => 'AdministratorTemplate']);
     if (!$adminPolicyTpl) {
@@ -251,7 +255,8 @@ if (!$setting) {
             if (!$policyTpl) {
                 /* array_diff data with standard admin policy */
                 $data = $policy->get('data');
-                $diff = array_diff_key($data,$adminPolicyData);
+                $data = is_array($data) ? $data : ($modx->fromJSON($data, true) ?: []);
+                $diff = array_diff_key($data, $adminPolicyData);
                 $modx->log(xPDO::LOG_LEVEL_DEBUG,'Diff: '.print_r($diff,true));
 
                 /* if the unknown policy has all the perms and no new perms of the admin


### PR DESCRIPTION
# Fix: array_diff_key() TypeError in upgrade.install.php (#16825)

## What it does

- **`modAccessPolicy::get()` override** — For key `'data'`, the result is normalized to an array. xPDO’s handling of `phptype` `json` can return a string (e.g. when the value is empty or not decoded) or `null` (e.g. on invalid JSON). The override aligns the model with the `@property array $data` contract.
- **Validation** — A new `JsonArrayValidationRule` ensures the `data` field is either an array or a valid JSON string that decodes to an array; invalid values are rejected with the lexicon key `policy_err_invalid_data`. Validation is wired in the schema and in the MySQL map for `modAccessPolicy`.
- **`setup/includes/upgrade.install.php`** — Uses `$adminPolicy->get('data')` and `$policy->get('data')` directly. The defensive `is_array` / `fromJSON` logic was removed, since the model now guarantees an array. Line length and style were adjusted for phpcs.

## Why it is needed

During upgrade (e.g. MODX 3.12 → 3.20), `modAccessPolicy` `data` can be read from the database as a raw JSON string. Passing that string as the first argument to `array_diff_key()` causes a PHP 8 `TypeError`: `array_diff_key(): Argument #1 ($array) must be of type array, string given`, which breaks the upgrade when non-standard policies (e.g. from MiniShop3) exist.

The fix is applied at the source (the model) and reinforced with validation, as suggested in review.

## How to test

1. Install MODX 3.1.2 and add a component that creates custom access policies (e.g. MiniShop3).
2. Run the upgrade to MODX 3.2.0 via the setup (e.g. `setup/` or CLI).
3. Confirm the upgrade completes without the `array_diff_key()` TypeError and that policies are migrated as expected.

## Related

- Resolves [modx-pro/MiniShop3#100](https://github.com/modx-pro/MiniShop3/issues/100) (reported there; fix is in modxcms/revolution).
- Addresses review: `get('data')` should always return an array (fix at source); invalid `data` is handled with a validator on the field.
