### PR TITLE
Fix: preserve file extension when upload_translit is enabled

### DIFF
--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -14,7 +14,7 @@ namespace MODX\Revolution\Tests\Model\Sources;
 
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Sources\modFileMediaSource;
-use MODX\Revolution\Sources\modMediaSource;
+use ReflectionMethod;
 
 /**
  * Tests related to the modMediaSource class.
@@ -26,8 +26,11 @@ use MODX\Revolution\Sources\modMediaSource;
  * @group modMediaSource
  */
 class modMediaSourceTest extends MODxTestCase {
-    /** @var modMediaSource $source */
+    /** @var modFileMediaSource $source */
     public $source;
+
+    /** @var array Saved options restored after each test */
+    private $savedOptions = [];
 
     /**
      * Setup fixtures before each test.
@@ -37,7 +40,7 @@ class modMediaSourceTest extends MODxTestCase {
     public function setUpFixtures() {
         parent::setUpFixtures();
 
-        $this->source = $this->modx->newObject(modMediaSource::class);
+        $this->source = $this->modx->newObject(modFileMediaSource::class);
         $this->source->fromArray([
             'name' => 'UnitTestSource',
             'description' => '',
@@ -45,6 +48,7 @@ class modMediaSourceTest extends MODxTestCase {
             'properties' => [],
         ],'',true);
     }
+
     /**
      * Tear down fixtures after each test.
      *
@@ -52,10 +56,92 @@ class modMediaSourceTest extends MODxTestCase {
      */
     public function tearDownFixtures() {
         parent::tearDownFixtures();
+        foreach ($this->savedOptions as $key => $value) {
+            $this->modx->setOption($key, $value);
+        }
+        $this->savedOptions = [];
         $this->source = null;
     }
 
-    public function testExample() {
-        $this->assertTrue(true);
+    /**
+     * Remember and override a system option for the duration of the test.
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    private function overrideOption($key, $value) {
+        if (!array_key_exists($key, $this->savedOptions)) {
+            $this->savedOptions[$key] = $this->modx->getOption($key);
+        }
+        $this->modx->setOption($key, $value);
+    }
+
+    /**
+     * Invoke protected applyUploadTranslitToFile and return the resulting file name.
+     *
+     * @param string $name
+     * @return string
+     */
+    private function applyUploadTranslit($name) {
+        $file = ['name' => $name];
+        $method = new ReflectionMethod($this->source, 'applyUploadTranslitToFile');
+        $method->setAccessible(true);
+        $method->invokeArgs($this->source, [&$file, '/']);
+        return $file['name'];
+    }
+
+    /**
+     * #16787: friendly_alias_max_length must not strip the upload file extension.
+     */
+    public function testUploadTranslitPreservesExtensionDespiteMaxLength() {
+        $this->overrideOption('friendly_alias_max_length', 15);
+        $this->overrideOption('friendly_alias_lowercase_only', true);
+        $this->overrideOption('upload_translit_restrict_chars_pattern', '');
+
+        $name = 'verylongfilename.jpg';
+        $this->assertGreaterThan(15, strlen($name));
+
+        // Reproduce the pre-fix failure mode: full-name filter with max_length truncates the extension.
+        $truncated = $this->modx->filterPathSegment($name, []);
+        $this->assertSame('verylongfilenam', $truncated);
+
+        $result = $this->applyUploadTranslit($name);
+        $this->assertSame('verylongfilename.jpg', $result);
+    }
+
+    /**
+     * Upload translit still lowercases the full filename, including the extension.
+     */
+    public function testUploadTranslitLowercasesExtension() {
+        $this->overrideOption('friendly_alias_max_length', 15);
+        $this->overrideOption('friendly_alias_lowercase_only', true);
+        $this->overrideOption('upload_translit_restrict_chars_pattern', '');
+
+        $result = $this->applyUploadTranslit('PHOTO.JPG');
+        $this->assertSame('photo.jpg', $result);
+    }
+
+    /**
+     * Multi-dot names keep the final extension when max_length would otherwise truncate.
+     */
+    public function testUploadTranslitPreservesCompoundExtension() {
+        $this->overrideOption('friendly_alias_max_length', 10);
+        $this->overrideOption('friendly_alias_lowercase_only', true);
+        $this->overrideOption('upload_translit_restrict_chars_pattern', '');
+
+        $result = $this->applyUploadTranslit('archive.backup.tar.gz');
+        $this->assertSame('archive.backup.tar.gz', $result);
+    }
+
+    /**
+     * Names without an extension are still filtered; max_length does not apply.
+     */
+    public function testUploadTranslitWithoutExtension() {
+        $this->overrideOption('friendly_alias_max_length', 5);
+        $this->overrideOption('friendly_alias_lowercase_only', true);
+        $this->overrideOption('upload_translit_restrict_chars_pattern', '');
+
+        $result = $this->applyUploadTranslit('VeryLongName');
+        $this->assertSame('verylongname', $result);
     }
 }

--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -25,7 +25,8 @@ use ReflectionMethod;
  * @group Sources
  * @group modMediaSource
  */
-class modMediaSourceTest extends MODxTestCase {
+class modMediaSourceTest extends MODxTestCase
+{
     /** @var modFileMediaSource $source */
     public $source;
 
@@ -37,7 +38,8 @@ class modMediaSourceTest extends MODxTestCase {
      *
      * @before
      */
-    public function setUpFixtures() {
+    public function setUpFixtures()
+    {
         parent::setUpFixtures();
 
         $this->source = $this->modx->newObject(modFileMediaSource::class);
@@ -54,7 +56,8 @@ class modMediaSourceTest extends MODxTestCase {
      *
      * @after
      */
-    public function tearDownFixtures() {
+    public function tearDownFixtures()
+    {
         parent::tearDownFixtures();
         foreach ($this->savedOptions as $key => $value) {
             $this->modx->setOption($key, $value);
@@ -69,7 +72,8 @@ class modMediaSourceTest extends MODxTestCase {
      * @param string $key
      * @param mixed $value
      */
-    private function overrideOption($key, $value) {
+    private function overrideOption($key, $value)
+    {
         if (!array_key_exists($key, $this->savedOptions)) {
             $this->savedOptions[$key] = $this->modx->getOption($key);
         }
@@ -82,7 +86,8 @@ class modMediaSourceTest extends MODxTestCase {
      * @param string $name
      * @return string
      */
-    private function applyUploadTranslit($name) {
+    private function applyUploadTranslit($name)
+    {
         $file = ['name' => $name];
         $method = new ReflectionMethod($this->source, 'applyUploadTranslitToFile');
         $method->setAccessible(true);
@@ -93,7 +98,8 @@ class modMediaSourceTest extends MODxTestCase {
     /**
      * #16787: friendly_alias_max_length must not strip the upload file extension.
      */
-    public function testUploadTranslitPreservesExtensionDespiteMaxLength() {
+    public function testUploadTranslitPreservesExtensionDespiteMaxLength()
+    {
         $this->overrideOption('friendly_alias_max_length', 15);
         $this->overrideOption('friendly_alias_lowercase_only', true);
         $this->overrideOption('upload_translit_restrict_chars_pattern', '');
@@ -110,33 +116,62 @@ class modMediaSourceTest extends MODxTestCase {
     }
 
     /**
-     * Upload translit still lowercases the full filename, including the extension.
+     * Basename is lowercased; the original extension case is preserved.
      */
-    public function testUploadTranslitLowercasesExtension() {
+    public function testUploadTranslitLowercasesBasenameOnly()
+    {
         $this->overrideOption('friendly_alias_max_length', 15);
         $this->overrideOption('friendly_alias_lowercase_only', true);
         $this->overrideOption('upload_translit_restrict_chars_pattern', '');
 
         $result = $this->applyUploadTranslit('PHOTO.JPG');
+        $this->assertSame('photo.JPG', $result);
+    }
+
+    /**
+     * Alphanumeric FURL restrict replaces dots with the word delimiter on the filtered
+     * string. Filtering the full name would turn photo.jpg into photo-jpg; basename-only
+     * filtering must keep .jpg.
+     */
+    public function testUploadTranslitPreservesExtensionWithAlphanumericRestrict()
+    {
+        $this->overrideOption('friendly_alias_restrict_chars', 'alphanumeric');
+        $this->overrideOption('friendly_alias_word_delimiter', '-');
+        $this->overrideOption('friendly_alias_max_length', 0);
+        $this->overrideOption('friendly_alias_lowercase_only', true);
+        $this->overrideOption('upload_translit_restrict_chars_pattern', '');
+
+        $broken = $this->modx->filterPathSegment('photo.jpg', [
+            'friendly_alias_restrict_chars' => 'alphanumeric',
+            'friendly_alias_word_delimiter' => '-',
+        ]);
+        $this->assertSame('photo-jpg', $broken);
+
+        $result = $this->applyUploadTranslit('photo.jpg');
         $this->assertSame('photo.jpg', $result);
     }
 
     /**
-     * Multi-dot names keep the final extension when max_length would otherwise truncate.
+     * Compound names: dots inside the basename may be rewritten by alphanumeric restrict,
+     * but the final extension stays intact.
      */
-    public function testUploadTranslitPreservesCompoundExtension() {
+    public function testUploadTranslitPreservesFinalExtensionWithAlphanumericRestrict()
+    {
+        $this->overrideOption('friendly_alias_restrict_chars', 'alphanumeric');
+        $this->overrideOption('friendly_alias_word_delimiter', '-');
         $this->overrideOption('friendly_alias_max_length', 10);
         $this->overrideOption('friendly_alias_lowercase_only', true);
         $this->overrideOption('upload_translit_restrict_chars_pattern', '');
 
         $result = $this->applyUploadTranslit('archive.backup.tar.gz');
-        $this->assertSame('archive.backup.tar.gz', $result);
+        $this->assertSame('archive-backup-tar.gz', $result);
     }
 
     /**
-     * Names without an extension are still filtered; max_length does not apply.
+     * Names without an extension are still filtered; max_length does not apply to uploads.
      */
-    public function testUploadTranslitWithoutExtension() {
+    public function testUploadTranslitWithoutExtension()
+    {
         $this->overrideOption('friendly_alias_max_length', 5);
         $this->overrideOption('friendly_alias_lowercase_only', true);
         $this->overrideOption('upload_translit_restrict_chars_pattern', '');

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1148,27 +1148,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             }
 
             if ((bool)$this->xpdo->getOption('upload_translit')) {
-                $uploadRegex = $this->xpdo->getOption('upload_translit_restrict_chars_pattern');
-                $options = !empty($uploadRegex)
-                    ? [
-                        'friendly_alias_restrict_chars' => 'pattern',
-                        'friendly_alias_restrict_chars_pattern' => $uploadRegex
-                    ]
-                    : []
-                    ;
-                $newName = $this->xpdo->filterPathSegment($file['name'], $options);
-
-                // If the file name is different after filtering, call OnFileManagerFileRename
-                // so the change can be tracked by plugins
-                if ($newName !== $file['name']) {
-                    $path = $container . $this->sanitizePath($newName);
-                    $file['name'] = $newName;
-
-                    $this->xpdo->invokeEvent('OnFileManagerFileRename', [
-                        'path' => $path,
-                        'source' => &$this,
-                    ]);
-                }
+                $this->applyUploadTranslitToFile($file, $container);
             }
 
             $newPath = $container . $this->sanitizePath($file['name']);
@@ -1210,6 +1190,44 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         return !$this->hasErrors();
     }
 
+    /**
+     * Applies transliteration to an uploaded file name; updates $file['name'] and may fire OnFileManagerFileRename.
+     *
+     * @param array $file File record (by reference; 'name' may be updated)
+     * @param string $container Target container path
+     */
+    protected function applyUploadTranslitToFile(array &$file, $container)
+    {
+        $uploadRegex = $this->xpdo->getOption('upload_translit_restrict_chars_pattern');
+        $options = !empty($uploadRegex)
+            ? [
+                'friendly_alias_restrict_chars' => 'pattern',
+                'friendly_alias_restrict_chars_pattern' => $uploadRegex,
+            ]
+            : [];
+
+        $pathInfo = pathinfo($file['name']);
+        $basename = $pathInfo['filename'] ?? $pathInfo['basename'];
+        $extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
+
+        $filteredBasename = $this->xpdo->filterFilename($basename, $options);
+        if ($filteredBasename === null || $filteredBasename === '') {
+            return;
+        }
+
+        $newName = $filteredBasename . $extension;
+        if ($newName === $file['name']) {
+            return;
+        }
+
+        $path = $container . $this->sanitizePath($newName);
+        $file['name'] = $newName;
+
+        $this->xpdo->invokeEvent('OnFileManagerFileRename', [
+            'path' => $path,
+            'source' => &$this,
+        ]);
+    }
 
     /**
      * @param string $path ~ relative path of file/directory

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1193,6 +1193,9 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     /**
      * Applies transliteration to an uploaded file name; updates $file['name'] and may fire OnFileManagerFileRename.
      *
+     * Forces friendly_alias_max_length to 0 so FURL alias length limits cannot truncate
+     * the filename (and strip its extension). See #16787.
+     *
      * @param array $file File record (by reference; 'name' may be updated)
      * @param string $container Target container path
      */
@@ -1205,17 +1208,9 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 'friendly_alias_restrict_chars_pattern' => $uploadRegex,
             ]
             : [];
+        $options['friendly_alias_max_length'] = 0;
 
-        $pathInfo = pathinfo($file['name']);
-        $basename = $pathInfo['filename'] ?? $pathInfo['basename'];
-        $extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
-
-        $filteredBasename = $this->xpdo->filterFilename($basename, $options);
-        if ($filteredBasename === null || $filteredBasename === '') {
-            return;
-        }
-
-        $newName = $filteredBasename . $extension;
+        $newName = $this->xpdo->filterPathSegment($file['name'], $options);
         if ($newName === $file['name']) {
             return;
         }

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1193,8 +1193,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     /**
      * Applies transliteration to an uploaded file name; updates $file['name'] and may fire OnFileManagerFileRename.
      *
-     * Forces friendly_alias_max_length to 0 so FURL alias length limits cannot truncate
-     * the filename (and strip its extension). See #16787.
+     * Filters only the basename via filterPathSegment and reattaches the original extension
+     * so FURL rules (max length, alpha/alphanumeric restrict, trim, lowercase) cannot alter
+     * or strip the extension. friendly_alias_max_length is forced to 0 for uploads: FURL
+     * alias length limits do not apply to uploaded file names. See #16787.
      *
      * @param array $file File record (by reference; 'name' may be updated)
      * @param string $container Target container path
@@ -1210,7 +1212,21 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             : [];
         $options['friendly_alias_max_length'] = 0;
 
-        $newName = $this->xpdo->filterPathSegment($file['name'], $options);
+        $pathInfo = pathinfo($file['name']);
+        $basename = isset($pathInfo['filename']) ? $pathInfo['filename'] : $pathInfo['basename'];
+        $extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
+
+        // Dotfiles (e.g. .htaccess) and names that filter to empty keep the original name.
+        if ($basename === '') {
+            return;
+        }
+
+        $filteredBasename = $this->xpdo->filterPathSegment($basename, $options);
+        if ($filteredBasename === null || $filteredBasename === '') {
+            return;
+        }
+
+        $newName = $filteredBasename . $extension;
         if ($newName === $file['name']) {
             return;
         }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1116,33 +1116,6 @@ class modX extends xPDO {
         return $this->call(modResource::class, 'filterPathSegment', [&$this, $string, $options]);
     }
 
-    /**
-     * Filter a string for use as a filename basename (no extension).
-     * Uses the same global transliteration rules as filterPathSegment, with
-     * upload-specific character restriction (upload_translit_restrict_chars_pattern).
-     *
-     * @param string $basename The filename basename to filter (no extension).
-     * @param array $options Optional overrides; friendly_alias_max_length is forced to 0.
-     *
-     * @return string|null Filtered basename safe for use as a filename part, or null on error.
-     */
-    public function filterFilename($basename, array $options = [])
-    {
-        $options['friendly_alias_max_length'] = 0;
-
-        $uploadPattern = $this->getOption('upload_translit_restrict_chars_pattern', $options);
-        $useUploadPattern = !isset($options['friendly_alias_restrict_chars_pattern'])
-            && $uploadPattern !== null
-            && $uploadPattern !== '';
-
-        if ($useUploadPattern) {
-            $options['friendly_alias_restrict_chars'] = 'pattern';
-            $options['friendly_alias_restrict_chars_pattern'] = $uploadPattern;
-        }
-
-        return $this->filterPathSegment($basename, $options);
-    }
-
     public function findResource($uri, $context = '') {
         $resourceId = false;
         if (empty($context) && isset($this->context)) $context = $this->context->get('key');

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1116,6 +1116,33 @@ class modX extends xPDO {
         return $this->call(modResource::class, 'filterPathSegment', [&$this, $string, $options]);
     }
 
+    /**
+     * Filter a string for use as a filename basename (no extension).
+     * Uses the same global transliteration rules as filterPathSegment, with
+     * upload-specific character restriction (upload_translit_restrict_chars_pattern).
+     *
+     * @param string $basename The filename basename to filter (no extension).
+     * @param array $options Optional overrides; friendly_alias_max_length is forced to 0.
+     *
+     * @return string|null Filtered basename safe for use as a filename part, or null on error.
+     */
+    public function filterFilename($basename, array $options = [])
+    {
+        $options['friendly_alias_max_length'] = 0;
+
+        $uploadPattern = $this->getOption('upload_translit_restrict_chars_pattern', $options);
+        $useUploadPattern = !isset($options['friendly_alias_restrict_chars_pattern'])
+            && $uploadPattern !== null
+            && $uploadPattern !== '';
+
+        if ($useUploadPattern) {
+            $options['friendly_alias_restrict_chars'] = 'pattern';
+            $options['friendly_alias_restrict_chars_pattern'] = $uploadPattern;
+        }
+
+        return $this->filterPathSegment($basename, $options);
+    }
+
     public function findResource($uri, $context = '') {
         $resourceId = false;
         if (empty($context) && isset($this->context)) $context = $this->context->get('key');


### PR DESCRIPTION
### What does it do?
With `upload_translit` on, we run FURL filtering on the basename only and put the original extension back on. Alias rules no longer chew through `.jpg`.

`applyUploadTranslitToFile()` does the work: `pathinfo()` split, `friendly_alias_max_length => 0` (upload names ignore the FURL length cap), `filterPathSegment()` on the basename, then rebuild the name and fire `OnFileManagerFileRename` if it changed. Dotfiles like `.htaccess` and empty filter results keep the original name.

`modMediaSourceTest` covers the long-name + max_length case, alphanumeric restrict (`photo.jpg`), compound names, lowercase basename, and names with no extension.

### Why is it needed?
`upload_translit` + `friendly_alias_max_length` used to truncate the whole filename. `verylongfilename.jpg` became `verylongfilenam`, lost the extension, and broke delete / MoreGallery. With `friendly_alias_restrict_chars` set to `alpha` or `alphanumeric`, the same full-name path turned `photo.jpg` into `photo-jpg`.

Fixes #16787.

### How to test
1. Turn on `upload_translit`.
2. Set `friendly_alias_max_length` to something small (15).
3. Upload `verylongfilename.jpg`.
4. Check the stored name is still `verylongfilename.jpg`.
5. Set `friendly_alias_restrict_chars` to `alphanumeric`, upload `photo.jpg`, check it stays `photo.jpg`.
6. Delete the file and confirm that still works.
7. Run `modMediaSourceTest` if you want the automated check.

### Related issue(s)/PR(s)
- #16787