### PR TITLE
Fix quotes breaking grid js

### DIFF
--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -610,6 +610,32 @@ MODx.util.Format = {
             ? string.charAt(0).toUpperCase() + string.substring(1)
             : string
         ;
+    },
+
+    /**
+     * Encodes quotes in given string to their HTML entity equivalents
+     * @param {String} string The string to convert
+     * @param {String} type Specifies which type of quotes to encode (single, double, or both)
+     * @param {Boolean} toTypographicQuotes Whether to convert straight quotes to typographic ones (implementation TBD)
+     * @returns {String}
+     */
+    encodeQuotes: function(string, type = 'single', toTypographicQuotes = false) {
+        if (typeof string !== 'string') {
+            return string;
+        }
+        switch (type) {
+            case 'single':
+                return string.replace(/'/g, '&#39;');
+            case 'double':
+                return string.replace(/"/g, '&#34;');
+            case 'both':
+                return string
+                    .replace(/'/g, '&#39;')
+                    .replace(/"/g, '&#34;')
+                ;
+            default:
+                return string;
+        }
     }
 };
 

--- a/manager/assets/modext/util/utilities.js
+++ b/manager/assets/modext/util/utilities.js
@@ -616,10 +616,9 @@ MODx.util.Format = {
      * Encodes quotes in given string to their HTML entity equivalents
      * @param {String} string The string to convert
      * @param {String} type Specifies which type of quotes to encode (single, double, or both)
-     * @param {Boolean} toTypographicQuotes Whether to convert straight quotes to typographic ones (implementation TBD)
      * @returns {String}
      */
-    encodeQuotes: function(string, type = 'single', toTypographicQuotes = false) {
+    encodeQuotes: function(string, type = 'single') {
         if (typeof string !== 'string') {
             return string;
         }

--- a/manager/assets/modext/widgets/core/modx.grid.js
+++ b/manager/assets/modext/widgets/core/modx.grid.js
@@ -48,12 +48,14 @@ MODx.grid.GridBase = function GridBase(config = {}) {
         });
     }
     if (config.grouping) {
-        const groupingConfig = {
-            forceFit: true,
-            scrollOffset: 0,
-            groupTextTpl: `{text} ({[values.rs.length]} {[values.rs.length > 1 ? '${config.pluralText || _('records')}' : '${config.singleText || _('record')}']})`
-        };
-
+        const
+            titleSingular = MODx.util.Format.encodeQuotes(config.singleText || _('record')),
+            titlePlural = MODx.util.Format.encodeQuotes(config.pluralText || _('records')),
+            groupingConfig = {
+                forceFit: true,
+                scrollOffset: 0,
+                groupTextTpl: `{text} ({[values.rs.length]} {[values.rs.length > 1 ? '${titlePlural}' : '${titleSingular}']})`
+            };
         Ext.applyIf(config.groupingConfig, groupingConfig);
         if (Object.hasOwn(config, 'viewConfig') && Object.hasOwn(config.viewConfig, 'getRowClass')) {
             Ext.applyIf(config.groupingConfig, {


### PR DESCRIPTION
### What does it do?
Added a conversion utility to encode problematic strings with single or double quotes within.

### Why is it needed?
Quotes within certain Lexicon strings that get fed to grids' configs were creating a syntax error and crashing the JS. Crazy enough, after literally 2+ years of developing the revamped grids classes this issue only appeared once non-English users began running into issues in the manager. What are the chances? ;-)

### How to test
This fixes two areas where crashes were reported: The TVs panel (the Properties grid was the one failing) and the ACLs (when editing a Usergroup). Simply visit these areas and verify they work as expected.

### Related issue(s)/PR(s)
Resolves #16823
Resolves #16830
