### PR TITLE
fix(manager): passwordless login links not invalidated by link scanners

### DIFF
--- a/_build/test/Tests/Controllers/Security/SecurityLoginControllerTest.php
+++ b/_build/test/Tests/Controllers/Security/SecurityLoginControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -6,6 +7,8 @@
  *
  * For complete copyright and license information, see the COPYRIGHT and LICENSE
  * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
  */
 
 namespace MODX\Revolution\Tests\Controllers\Security;
@@ -47,7 +50,8 @@ class SecurityLoginControllerTest extends MODxControllerTestCase
         parent::setUpFixtures();
 
         $this->testHash = md5(uniqid('magiclink-test-', true));
-        $this->testUser = $this->modx->getObject(modUser::class, ['username' => $this->modx->getOption('modx.test.user.username', null, 'unittestuser')]);
+        $testUsername = $this->modx->getOption('modx.test.user.username', null, 'unittestuser');
+        $this->testUser = $this->modx->getObject(modUser::class, ['username' => $testUsername]);
         if (!$this->testUser) {
             $this->markTestSkipped('Unit test user is not available.');
         }
@@ -94,7 +98,10 @@ class SecurityLoginControllerTest extends MODxControllerTestCase
         $this->controller->handleMagicLoginLink();
 
         $this->assertSame($this->testHash, $this->controller->getPlaceholder('magiclink_pending_hash'));
-        $this->assertNotEmpty($this->readMagicLinkRegistry(false), 'Legacy magiclink GET must show confirmation without consuming the token.');
+        $this->assertNotEmpty(
+            $this->readMagicLinkRegistry(false),
+            'Legacy magiclink GET must show confirmation without consuming the token.'
+        );
     }
 
     public function testBuildMagicLinkPendingUrlUsesPendingParameter()
@@ -120,7 +127,10 @@ class SecurityLoginControllerTest extends MODxControllerTestCase
             'invalid-hash-for-confirm-test',
             $this->controller->getPlaceholder('magiclink_pending_hash')
         );
-        $this->assertNotEmpty($this->readMagicLinkRegistry(false), 'Failed confirm must not remove a different valid token.');
+        $this->assertNotEmpty(
+            $this->readMagicLinkRegistry(false),
+            'Failed confirm must not remove a different valid token.'
+        );
     }
 
     /**

--- a/_build/test/Tests/Controllers/Security/SecurityLoginControllerTest.php
+++ b/_build/test/Tests/Controllers/Security/SecurityLoginControllerTest.php
@@ -1,0 +1,144 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Tests\Controllers\Security;
+
+use MODX\Revolution\modUser;
+use MODX\Revolution\MODxControllerTestCase;
+use MODX\Revolution\Registry\modDbRegister;
+use MODX\Revolution\Registry\modRegistry;
+use ReflectionMethod;
+
+/**
+ * Tests for passwordless magic-link confirmation (issue #16743).
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Controllers
+ * @group Security
+ * @group SecurityLoginController
+ */
+class SecurityLoginControllerTest extends MODxControllerTestCase
+{
+    /** @var \SecurityLoginManagerController $controller */
+    public $controller;
+
+    public $controllerName = 'SecurityLoginManagerController';
+    public $controllerPath = 'security/login';
+
+    /** @var string */
+    private $testHash;
+
+    /** @var modUser|null */
+    private $testUser;
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+
+        $this->testHash = md5(uniqid('magiclink-test-', true));
+        $this->testUser = $this->modx->getObject(modUser::class, ['username' => $this->modx->getOption('modx.test.user.username', null, 'unittestuser')]);
+        if (!$this->testUser) {
+            $this->markTestSkipped('Unit test user is not available.');
+        }
+
+        /** @var modRegistry $registry */
+        $registry = $this->modx->getService('registry', modRegistry::class);
+        /** @var modDbRegister $register */
+        $register = $registry->getRegister('user', modDbRegister::class);
+        $register->connect();
+        $register->subscribe('/pwd/magiclink/');
+        $register->send('/pwd/magiclink/', [
+            $this->testHash => $this->testUser->get('username'),
+        ], [
+            'ttl' => 300,
+        ]);
+
+        unset($_GET['magiclink'], $_GET['magiclink_pending']);
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        unset($_GET['magiclink'], $_GET['magiclink_pending']);
+        if (!empty($this->testHash)) {
+            $this->readMagicLinkRegistry(true);
+        }
+        parent::tearDownFixtures();
+    }
+
+    public function testMagicLinkPendingGetDoesNotConsumeToken()
+    {
+        $_GET['magiclink_pending'] = $this->testHash;
+        $this->controller->handleMagicLoginLink();
+
+        $this->assertSame($this->testHash, $this->controller->getPlaceholder('magiclink_pending_hash'));
+        $this->assertNotEmpty($this->readMagicLinkRegistry(false), 'Pending GET must leave the registry token intact.');
+    }
+
+    public function testLegacyMagicLinkGetDoesNotConsumeToken()
+    {
+        $_GET['magiclink'] = $this->testHash;
+        $this->controller->handleMagicLoginLink();
+
+        $this->assertSame($this->testHash, $this->controller->getPlaceholder('magiclink_pending_hash'));
+        $this->assertNotEmpty($this->readMagicLinkRegistry(false), 'Legacy magiclink GET must show confirmation without consuming the token.');
+    }
+
+    public function testBuildMagicLinkPendingUrlUsesPendingParameter()
+    {
+        $method = new ReflectionMethod($this->controller, 'buildMagicLinkPendingUrl');
+        $method->setAccessible(true);
+        $url = $method->invoke($this->controller, $this->testHash);
+
+        $this->assertStringContainsString('magiclink_pending=' . $this->testHash, $url);
+        $this->assertStringNotContainsString('?magiclink=' . $this->testHash, $url);
+    }
+
+    public function testInvalidConfirmKeepsPendingPlaceholder()
+    {
+        $this->controller->setProperties([
+            'confirm_magiclink' => '1',
+            'magiclink' => 'invalid-hash-for-confirm-test',
+            'login_context' => 'mgr',
+        ]);
+        $this->controller->handlePost();
+
+        $this->assertSame(
+            'invalid-hash-for-confirm-test',
+            $this->controller->getPlaceholder('magiclink_pending_hash')
+        );
+        $this->assertNotEmpty($this->readMagicLinkRegistry(false), 'Failed confirm must not remove a different valid token.');
+    }
+
+    /**
+     * @param bool $remove
+     * @return array
+     */
+    private function readMagicLinkRegistry($remove = false)
+    {
+        /** @var modRegistry $registry */
+        $registry = $this->modx->getService('registry', modRegistry::class);
+        /** @var modDbRegister $register */
+        $register = $registry->getRegister('user', modDbRegister::class);
+        $register->connect();
+        $register->subscribe('/pwd/magiclink/' . $this->testHash);
+
+        return $register->read([
+            'poll_limit' => 1,
+            'remove_read' => $remove,
+        ]);
+    }
+}

--- a/core/lexicon/en/login.inc.php
+++ b/core/lexicon/en/login.inc.php
@@ -39,7 +39,7 @@ $_lang['login_user_inactive'] = 'Your user account has been disabled. Please con
 $_lang['login_email_subject'] = 'Your login details';
 $_lang['login_magiclink_subject'] = 'Your one-time login link';
 $_lang['login_magiclink_err'] = 'Your login link is not valid. Please request a new one.';
-$_lang['login_magiclink_email'] = '<h2>One-time Login Link</h2><p>Here is your link to get logged in to the MODX manager. This link is valid for the next [[+expiration]].</p><p class="center"><a href="[[+url_scheme]][[+http_host]][[+manager_url]]?magiclink=[[+hash]]" class="btn">Log me in</a></p><p class="small">If you did not send this request, please ignore this email.</p>';
+$_lang['login_magiclink_email'] = '<h2>One-time Login Link</h2><p>Here is your link to get logged in to the MODX manager. This link is valid for the next [[+expiration]].</p><p class="center"><a href="[[+magic_login_url]]" class="btn">Log me in</a></p><p class="small">If you did not send this request, please ignore this email.</p>';
 $_lang['login_magiclink_default_msg'] = 'If your email <i>[[+email]]</i> is registered with an account, you’ll receive an email shortly.';
 $_lang['login_magiclink_error_msg'] = 'The system was not able to send a login link via email. Please contact the site administrator if this error is permanent.';
 $_lang['login_forgot_email'] = '<h2>Forgot your password?</h2><p>We received a request to change your MODX Revolution password. You can reset your password by clicking the button below and following the instructions on screen.</p><p class="center"><a href="[[+url_scheme]][[+http_host]][[+manager_url]]?modhash=[[+hash]]" class="btn">Reset my password</a></p><p class="small">If you did not send this request, please ignore this email.</p>';
@@ -52,6 +52,8 @@ $_lang['login_note'] = 'Please log in to access the Manager.';
 $_lang['login_note_passwordless'] = 'Please enter your email address to receive a one-time login link.';
 $_lang['login_magiclink_email_button'] = 'Send me a one-time login link';
 $_lang['login_magiclink_email_placeholder'] = 'Your user account\'s email here';
+$_lang['login_magiclink_confirm_note'] = 'Click the button below to log in to the manager.';
+$_lang['login_magiclink_confirm_button'] = 'Log me in';
 $_lang['login_email'] = 'Email';
 $_lang['login_help_button_text'] = 'Help';
 $_lang['login_help_title'] = 'Get help with MODX';

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -281,59 +281,93 @@ class SecurityLoginManagerController extends modManagerController
     }
 
     /**
-     * Handle a magic login link, if existent.
+     * Build the email URL that opens the confirmation page (does not consume the token).
+     *
+     * @param string $hash Magic link hash
+     * @return string
+     */
+    private function buildMagicLinkPendingUrl($hash)
+    {
+        return $this->modx->getOption('url_scheme', null, MODX_URL_SCHEME) .
+            $this->modx->getOption('http_host', null, MODX_HTTP_HOST) .
+            $this->modx->getOption('manager_url', null, MODX_MANAGER_URL) .
+            '?magiclink_pending=' . $hash;
+    }
+
+    /**
+     * Show confirmation UI for a magic login hash without touching the registry.
+     * Covers new emails (?magiclink_pending=) and legacy emails (?magiclink=).
+     * Token is consumed only after POST confirm_magiclink (see handlePost).
      *
      * @return void
      */
     public function handleMagicLoginLink()
     {
-
-        if (!empty($_GET['magiclink'])) {
+        $hash = '';
+        if (!empty($_GET['magiclink_pending'])) {
+            $hash = $this->modx->sanitizeString($_GET['magiclink_pending']);
+        } elseif (!empty($_GET['magiclink'])) {
             $hash = $this->modx->sanitizeString($_GET['magiclink']);
-            /** @var modDbRegister $registry */
-            $registry = $this->modx->getService('registry', 'registry.modRegistry')
-                ->getRegister('user', 'registry.modDbRegister');
-            $registry->connect();
-            $registry->subscribe('/pwd/magiclink/' . $hash);
+        }
 
-            $record = $registry->read(['poll_limit' => 1, 'remove_read' => false]);
+        if ($hash !== '') {
+            $this->setPlaceholder('magiclink_pending_hash', $hash);
+        }
+    }
 
-            /** @var modUser $user */
-            if (empty($record) || !$user = $this->modx->getObject(modUser::class, ['username' => reset($record)])) {
-                $this->modx->smarty->assign('error_message', $this->modx->lexicon('login_magiclink_err'));
+    /**
+     * Consume a one-time magic login hash and log the user in.
+     *
+     * @param string $hash Sanitized magic link hash
+     * @return void
+     */
+    private function consumeMagicLoginLink($hash)
+    {
+        /** @var modDbRegister $registry */
+        $registry = $this->modx->getService('registry', modRegistry::class)
+            ->getRegister('user', modDbRegister::class);
+        $registry->connect();
+        $registry->subscribe('/pwd/magiclink/' . $hash);
 
-                return;
-            }
+        $record = $registry->read(['poll_limit' => 1, 'remove_read' => false]);
 
-            $this->scriptProperties['passwordgenmethod'] = 's';
-            $this->scriptProperties['passwordnotifymethod'] = 'no';
-            $this->scriptProperties['newPassword'] = true;
-            $this->modx->lexicon->load('core:user');
+        /** @var modUser $user */
+        if (empty($record) || !$user = $this->modx->getObject(modUser::class, ['username' => reset($record)])) {
+            $this->setPlaceholder('magiclink_pending_hash', $hash);
+            $this->modx->smarty->assign('error_message', $this->modx->lexicon('login_magiclink_err'));
 
-            // create a temporary password and immediately use it once to login with the standard method
-            $password = uniqid("tmp-password-", true);
-            $user->set('password', $password);
-            $user->save();
+            return;
+        }
 
-            $this->scriptProperties['username'] = $user->get('username');
-            $this->scriptProperties['password'] = $password;
-            $registry->read(['poll_limit' => 1, 'remove_read' => true]);
+        $this->scriptProperties['passwordgenmethod'] = 's';
+        $this->scriptProperties['passwordnotifymethod'] = 'no';
+        $this->scriptProperties['newPassword'] = true;
+        $this->modx->lexicon->load('core:user');
 
-            /** @var ProcessorResponse $response */
-            $response = $this->modx->runProcessor('security/login', $this->scriptProperties);
-            if (($response instanceof ProcessorResponse)) {
-                if (!$response->isError()) {
-                    $url = !empty($this->scriptProperties['returnUrl'])
-                        ? $this->scriptProperties['returnUrl']
-                        : $this->modx->getOption('manager_url', null, MODX_MANAGER_URL);
-                    $url = $this->modx->getOption('url_scheme', null, MODX_URL_SCHEME) .
-                        $this->modx->getOption('http_host', null, MODX_HTTP_HOST) . rtrim($url, '/');
-                    $this->modx->sendRedirect($url);
-                } else {
-                    $errors = $response->getAllErrors();
-                    $error_message = implode("\n", $errors);
-                    $this->setPlaceholder('error_message', $error_message);
-                }
+        // create a temporary password and immediately use it once to login with the standard method
+        $password = uniqid("tmp-password-", true);
+        $user->set('password', $password);
+        $user->save();
+
+        $this->scriptProperties['username'] = $user->get('username');
+        $this->scriptProperties['password'] = $password;
+        $registry->read(['poll_limit' => 1, 'remove_read' => true]);
+
+        /** @var ProcessorResponse $response */
+        $response = $this->modx->runProcessor('security/login', $this->scriptProperties);
+        if (($response instanceof ProcessorResponse)) {
+            if (!$response->isError()) {
+                $url = !empty($this->scriptProperties['returnUrl'])
+                    ? $this->scriptProperties['returnUrl']
+                    : $this->modx->getOption('manager_url', null, MODX_MANAGER_URL);
+                $url = $this->modx->getOption('url_scheme', null, MODX_URL_SCHEME) .
+                    $this->modx->getOption('http_host', null, MODX_HTTP_HOST) . rtrim($url, '/');
+                $this->modx->sendRedirect($url);
+            } else {
+                $errors = $response->getAllErrors();
+                $error_message = implode("\n", $errors);
+                $this->setPlaceholder('magiclink_pending_hash', $hash);
+                $this->setPlaceholder('error_message', $error_message);
             }
         }
     }
@@ -394,6 +428,8 @@ class SecurityLoginManagerController extends modManagerController
             $this->handleLogin();
         } elseif (!empty($this->scriptProperties['forgotlogin']) && $this->modx->getOption('allow_manager_login_forgot_password', null, true)) {
             $this->handleForgotLogin();
+        } elseif (!empty($this->scriptProperties['confirm_magiclink']) && !empty($this->scriptProperties['magiclink'])) {
+            $this->consumeMagicLoginLink($this->modx->sanitizeString($this->scriptProperties['magiclink']));
         } elseif (!empty($this->scriptProperties['passwordless_login_email']) && $this->modx->getOption('passwordless_activated', null, false)) {
             $this->handlePasswordlessLoginRequest();
         }
@@ -576,6 +612,7 @@ class SecurityLoginManagerController extends modManagerController
 
             // create the magic login hash
             $placeholders['hash'] = $this->setActivationHash($user, $this->modx->getOption('passwordless_expiration'), '/pwd/magiclink/');
+            $placeholders['magic_login_url'] = $this->buildMagicLinkPendingUrl($placeholders['hash']);
             $placeholders['expiration'] = $this->getLifetimeString($this->modx->getOption('passwordless_expiration')); //date('D, d M Y H:i',time() + $this->modx->getOption('passwordless_expiration'));
             $message = $this->modx->lexicon('login_magiclink_email', $placeholders);
 
@@ -587,6 +624,9 @@ class SecurityLoginManagerController extends modManagerController
             $this->modx->getParser()->processElementTags('', $message, true, true, '[[', ']]', [], 10);
             // Then restore previous placeholders to prevent any breakage
             $this->modx->placeholders = $ph;
+
+            // Non-EN lexicons may still hardcode ?magiclink=; rewrite to the pending URL.
+            $message = str_replace('?magiclink=', '?magiclink_pending=', $message);
 
             $this->modx->smarty->assign('config', $this->modx->config);
             $this->modx->smarty->assign('content', $message);

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -32,7 +32,22 @@
 
                 <h1>{$greeting}</h1>
 
-                {if $_config.passwordless_activated}
+                {if $magiclink_pending_hash|default}
+                    {* Confirmation step so email link scanners do not consume the one-time token *}
+                    <form id="modx-magiclink-confirm-form" class="c-form" action="" method="post">
+                        <input type="hidden" name="login_context" value="mgr">
+                        <input type="hidden" name="returnUrl" value="{$returnUrl}">
+                        <input type="hidden" name="magiclink" value="{$magiclink_pending_hash|escape}">
+
+                        <p class="lead">{$_lang.login_magiclink_confirm_note}</p>
+
+                        {if $error_message|default}
+                            <p class="is-error">{$error_message|default}</p>
+                        {/if}
+
+                        <button class="c-button" name="confirm_magiclink" type="submit" value="1" id="modx-magiclink-confirm-btn">{$_lang.login_magiclink_confirm_button}</button>
+                    </form>
+                {elseif $_config.passwordless_activated}
                     {*
                         If we have passwordless login, we don't need a username or a password. Instead we
                         only need the email address of the user to send our login-link.


### PR DESCRIPTION
### What does it do?

Office365 Safe Links (and other mail scanners) hit the passwordless login URL before you do. That used to burn the one-time token, so your real click got "Your login link is not valid."

The mail link now goes to `?magiclink_pending=hash`. You land on a confirmation page and click **Log me in**. Only that POST consumes the token. A plain GET with `magiclink_pending` or the older `magiclink` leaves the registry alone.

The pending URL comes from PHP (`[[+magic_login_url]]`). If a translated email template still hardcodes `?magiclink=`, we rewrite it when sending. Old `?magiclink=` links still work; they just show the same confirm step. Added EN strings for the confirm page and a few controller tests.

### Why is it needed?

People on Office365 (and similar) could not use passwordless login: the scanner spent the link first. Asking for a second click matches what other auth stacks do for this class of bug.

### How to test

1. Turn on `passwordless_activated`.
2. Request a one-time login link from the manager login page.
3. Open the link from the email. You should see the confirmation page.
4. Click **Log me in**. You should end up in the manager.
5. Optional: `curl` the pending URL, then open it in a browser and confirm. Login should still work.
6. Optional: open an old `?magiclink=hash` URL. Confirm page, then login after the button.

### Related issue(s)/PR(s)

Resolves #16743