### PR TITLE
fix(context): Assign TV media source when creating new context

### DIFF
--- a/_build/test/Tests/Processors/Context/ContextCreateMediaSourceTest.php
+++ b/_build/test/Tests/Processors/Context/ContextCreateMediaSourceTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Processors\Context;
+
+use MODX\Revolution\modContext;
+use MODX\Revolution\modTemplateVar;
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Processors\Context\Create;
+use MODX\Revolution\Sources\modFileMediaSource;
+use MODX\Revolution\Sources\modMediaSource;
+use MODX\Revolution\Sources\modMediaSourceElement;
+
+/**
+ * Regression for #9058: context create materializes default TV media source bindings.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Processors
+ * @group Context
+ * @group ContextProcessors
+ */
+class ContextCreateMediaSourceTest extends MODxTestCase
+{
+    /** @var string */
+    private $contextKey = 'unittestmediasrc';
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        $context = $this->modx->getObject(modContext::class, ['key' => $this->contextKey]);
+        if ($context) {
+            $context->remove();
+        }
+
+        $tvs = $this->modx->getCollection(modTemplateVar::class, [
+            'name:LIKE' => '%UnitTestCtxTv%',
+        ]);
+        /** @var modTemplateVar $tv */
+        foreach ($tvs as $tv) {
+            $elements = $this->modx->getCollection(modMediaSourceElement::class, [
+                'object' => $tv->get('id'),
+                'object_class' => modTemplateVar::class,
+            ]);
+            foreach ($elements as $element) {
+                $element->remove();
+            }
+            $tv->remove();
+        }
+
+        $sources = $this->modx->getCollection(modMediaSource::class, [
+            'name:LIKE' => '%UnitTestCtxSource%',
+        ]);
+        /** @var modMediaSource $source */
+        foreach ($sources as $source) {
+            $source->remove();
+        }
+
+        parent::tearDownFixtures();
+    }
+
+    public function testContextCreateAssignsDefaultMediaSourceToTvs()
+    {
+        $defaultSourceId = (int)$this->modx->getOption('default_media_source', null, 1);
+        $defaultSource = $this->modx->getObject(modMediaSource::class, ['id' => $defaultSourceId]);
+        if (!$defaultSource) {
+            $this->markTestSkipped('default_media_source is not available in the test database.');
+        }
+
+        /** @var modMediaSource $customSource */
+        $customSource = $this->modx->newObject(modMediaSource::class);
+        $customSource->fromArray([
+            'name' => 'UnitTestCtxSource',
+            'class_key' => modFileMediaSource::class,
+        ], '', true, true);
+        $this->assertTrue((bool)$customSource->save(), 'Could not create custom media source fixture.');
+        $this->assertNotEquals(
+            $defaultSourceId,
+            (int)$customSource->get('id'),
+            'Custom source fixture must differ from default_media_source.'
+        );
+
+        /** @var modTemplateVar $tv */
+        $tv = $this->modx->newObject(modTemplateVar::class);
+        $tv->fromArray(['name' => 'UnitTestCtxTv'], '', true, true);
+        $this->assertTrue((bool)$tv->save(), 'Could not create TV fixture.');
+
+        foreach (['web', 'mgr'] as $contextKey) {
+            /** @var modMediaSourceElement $binding */
+            $binding = $this->modx->newObject(modMediaSourceElement::class);
+            $binding->fromArray([
+                'source' => $customSource->get('id'),
+                'object_class' => modTemplateVar::class,
+                'object' => $tv->get('id'),
+                'context_key' => $contextKey,
+            ], '', true, true);
+            $this->assertTrue(
+                (bool)$binding->save(),
+                'Could not create media source binding for ' . $contextKey
+            );
+        }
+
+        $result = $this->modx->runProcessor(Create::class, [
+            'key' => $this->contextKey,
+            'description' => 'Context create media source regression',
+        ]);
+        $this->assertTrue(
+            $this->checkForSuccess($result),
+            'Could not create context for media source regression: ' . $result->getMessage()
+        );
+
+        $bindings = $this->modx->getCollection(modMediaSourceElement::class, [
+            'object' => $tv->get('id'),
+            'object_class' => modTemplateVar::class,
+            'context_key' => $this->contextKey,
+        ]);
+        $this->assertCount(1, $bindings, 'Expected exactly one media source binding for the new context.');
+
+        /** @var modMediaSourceElement $created */
+        $created = reset($bindings);
+        $this->assertSame(
+            $defaultSourceId,
+            (int)$created->get('source'),
+            'New context binding must use default_media_source, not a custom source.'
+        );
+        $this->assertNotEquals(
+            (int)$customSource->get('id'),
+            (int)$created->get('source'),
+            'Custom source from existing contexts must not be copied on context create.'
+        );
+    }
+}

--- a/core/src/Revolution/Processors/Context/Create.php
+++ b/core/src/Revolution/Processors/Context/Create.php
@@ -14,8 +14,12 @@ namespace MODX\Revolution\Processors\Context;
 use MODX\Revolution\modAccessContext;
 use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modContext;
-use MODX\Revolution\Processors\Model\CreateProcessor;
+use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\modUserGroup;
+use MODX\Revolution\modX;
+use MODX\Revolution\Processors\Model\CreateProcessor;
+use MODX\Revolution\Sources\modMediaSource;
+use MODX\Revolution\Sources\modMediaSourceElement;
 
 /**
  * Creates a context
@@ -67,6 +71,7 @@ class Create extends CreateProcessor
             $this->enableAnonymousAccess();
         }
         $this->refreshUserACLs();
+        $this->assignDefaultMediaSourceToTvs();
 
         return true;
     }
@@ -142,6 +147,49 @@ class Create extends CreateProcessor
     {
         if ($this->modx->getUser()) {
             $this->modx->user->getAttributes([], '', true);
+        }
+    }
+
+    /**
+     * Materialize default media source bindings for TVs that already have at least one
+     * media_sources_elements row, matching the Manager TV UI fallback for empty contexts.
+     *
+     * Uses one INSERT…SELECT instead of per-TV queries. Does not copy custom sources
+     * (that belongs to Context Duplicate).
+     *
+     * @return void
+     */
+    private function assignDefaultMediaSourceToTvs()
+    {
+        $defaultSourceId = (int)$this->modx->getOption('default_media_source', null, 1);
+        if ($defaultSourceId < 1) {
+            return;
+        }
+        if ($this->modx->getCount(modMediaSource::class, ['id' => $defaultSourceId]) < 1) {
+            return;
+        }
+
+        $contextKey = $this->object->get('key');
+        $table = $this->modx->getTableName(modMediaSourceElement::class);
+        $tvClass = modTemplateVar::class;
+
+        $sql = "INSERT INTO {$table} (`source`, `object_class`, `object`, `context_key`)
+            SELECT DISTINCT ?, mse.`object_class`, mse.`object`, ?
+            FROM {$table} AS mse
+            WHERE mse.`object_class` = ?
+              AND NOT EXISTS (
+                SELECT 1 FROM {$table} AS existing
+                WHERE existing.`object` = mse.`object`
+                  AND existing.`object_class` = mse.`object_class`
+                  AND existing.`context_key` = ?
+              )";
+
+        $stmt = $this->modx->prepare($sql);
+        if (!$stmt || !$stmt->execute([$defaultSourceId, $contextKey, $tvClass, $contextKey])) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                '[Context\\Create] Failed to assign default media sources for context `' . $contextKey . '`.'
+            );
         }
     }
 }


### PR DESCRIPTION
### What does it do?

After you create a new context, TVs that already have a media source in another context looked connected in the Manager, but `media_sources_elements` had no row for the new context. Frontend baseUrl and friends ignored the source until you re-saved the TV.

Context create now inserts a `default_media_source` row for each TV that already has at least one binding. One `INSERT…SELECT` does the work (no per-TV N+1). Custom sources stay where they are; Context Duplicate still copies those.

### Why is it needed?

Without the DB row, the TV UI lied and the new context did not use the media source until a manual re-save. [#9058](https://github.com/modxcms/revolution/issues/9058) has been open since 2012 for that mismatch.

### How to test

1. Assign a media source to a TV in an existing context (e.g. `web`).
2. Create a new context in the Manager.
3. Open the TV: the new context should list the default media source.
4. Use the TV on the frontend of that context without re-saving the TV; baseUrl / source should apply.
5. Optional: confirm a custom source from `web` was not copied; the new row uses `default_media_source`.

### Related issue(s)/PR(s)

Resolves #9058