### PR TITLE
fix(security): Delete user — modAccess error

### DIFF
--- a/_build/test/Tests/Model/Security/PrincipalAclRemoveTest.php
+++ b/_build/test/Tests/Model/Security/PrincipalAclRemoveTest.php
@@ -19,6 +19,7 @@ use MODX\Revolution\modAccessPolicy;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserGroup;
 use MODX\Revolution\MODxTestCase;
+use ReflectionMethod;
 
 /**
  * Regression for #11276: deleting principals must not query abstract modAccess
@@ -174,6 +175,66 @@ class PrincipalAclRemoveTest extends MODxTestCase
         );
 
         $this->modx->setOption('principal_targets', $originalTargets);
+    }
+
+    public function testRemovePrincipalAclsReturnsTrueForUnsavedPrincipal()
+    {
+        /** @var modUser $user */
+        $user = $this->modx->newObject(modUser::class);
+        $method = new ReflectionMethod($user, 'removePrincipalAcls');
+        $method->setAccessible(true);
+
+        $this->assertTrue(
+            $method->invoke($user),
+            'Unsaved principals (id < 1) should skip ACL cleanup successfully.'
+        );
+    }
+
+    public function testGetPrincipalClassNameStripsMysqlDriverNamespace()
+    {
+        /** @var modUserGroup $group */
+        $group = $this->modx->newObject(modUserGroup::class);
+        $group->fromArray(['name' => $this->groupName], '', true, true);
+        $this->assertTrue((bool)$group->save(), 'Could not create user group fixture.');
+
+        // Simulate an xPDO mysql driver instance class name.
+        $group->_class = 'MODX\\Revolution\\mysql\\modUserGroup';
+
+        $method = new ReflectionMethod($group, 'getPrincipalClassName');
+        $method->setAccessible(true);
+
+        $this->assertSame(
+            modUserGroup::class,
+            $method->invoke($group),
+            'Driver subclass names must map back to the package principal_class.'
+        );
+    }
+
+    public function testUserRemoveAbortsWhenAclCleanupFails()
+    {
+        $user = new class ($this->modx) extends modUser {
+            protected function removePrincipalAcls(): bool
+            {
+                return false;
+            }
+        };
+        $user->fromArray([
+            'username' => $this->username,
+            'password' => 'unittest-password',
+            'active' => true,
+            'class_key' => modUser::class,
+        ], '', true, true);
+        $this->assertTrue((bool)$user->save(), 'Could not create user fixture.');
+
+        $this->assertFalse(
+            $user->remove(),
+            'remove() must abort when ACL cleanup fails.'
+        );
+        $this->assertInstanceOf(
+            modUser::class,
+            $this->modx->getObject(modUser::class, ['username' => $this->username]),
+            'User must remain when ACL cleanup fails.'
+        );
     }
 
     /**

--- a/_build/test/Tests/Model/Security/PrincipalAclRemoveTest.php
+++ b/_build/test/Tests/Model/Security/PrincipalAclRemoveTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Model\Security;
+
+use MODX\Revolution\modAccessContext;
+use MODX\Revolution\modAccessMenu;
+use MODX\Revolution\modAccessPolicy;
+use MODX\Revolution\modUser;
+use MODX\Revolution\modUserGroup;
+use MODX\Revolution\MODxTestCase;
+
+/**
+ * Regression for #11276: deleting principals must not query abstract modAccess
+ * and must clear concrete ACL rows (including classes outside principal_targets).
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group Security
+ * @group modPrincipal
+ */
+class PrincipalAclRemoveTest extends MODxTestCase
+{
+    /** @var string */
+    private $username = 'unittest-acl-user';
+
+    /** @var string */
+    private $groupName = 'UnitTestAclGroup';
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        $user = $this->modx->getObject(modUser::class, ['username' => $this->username]);
+        if ($user) {
+            $user->remove();
+        }
+
+        $group = $this->modx->getObject(modUserGroup::class, ['name' => $this->groupName]);
+        if ($group) {
+            $group->remove();
+        }
+
+        parent::tearDownFixtures();
+    }
+
+    public function testUserRemoveClearsAclsWithoutModAccessTableErrors()
+    {
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Administrator']);
+        if (!$policy) {
+            $this->markTestSkipped('Administrator access policy is not available.');
+        }
+
+        /** @var modUser $user */
+        $user = $this->modx->newObject(modUser::class);
+        $user->fromArray([
+            'username' => $this->username,
+            'password' => 'unittest-password',
+            'active' => true,
+            'class_key' => modUser::class,
+        ], '', true, true);
+        $this->assertTrue((bool)$user->save(), 'Could not create user fixture.');
+
+        $principalId = (int)$user->get('id');
+        $this->assertTrue(
+            $this->createContextAcl(modUser::class, $principalId, (int)$policy->get('id')),
+            'Could not create context ACL fixture.'
+        );
+        $this->assertTrue(
+            $this->createMenuAcl(modUser::class, $principalId, (int)$policy->get('id')),
+            'Could not create menu ACL fixture.'
+        );
+
+        $this->assertTrue((bool)$user->remove(), 'User remove() failed.');
+        $this->assertNull(
+            $this->modx->getObject(modUser::class, ['username' => $this->username]),
+            'User row should be gone after remove().'
+        );
+        $this->assertSame(
+            0,
+            $this->modx->getCount(modAccessContext::class, [
+                'principal_class' => modUser::class,
+                'principal' => $principalId,
+            ]),
+            'Context ACL rows must be removed with the user.'
+        );
+        $this->assertSame(
+            0,
+            $this->modx->getCount(modAccessMenu::class, [
+                'principal_class' => modUser::class,
+                'principal' => $principalId,
+            ]),
+            'Menu ACL rows must be removed with the user.'
+        );
+    }
+
+    public function testUserGroupRemoveClearsAcls()
+    {
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Context']);
+        if (!$policy) {
+            $this->markTestSkipped('Context access policy is not available.');
+        }
+
+        /** @var modUserGroup $group */
+        $group = $this->modx->newObject(modUserGroup::class);
+        $group->fromArray([
+            'name' => $this->groupName,
+        ], '', true, true);
+        $this->assertTrue((bool)$group->save(), 'Could not create user group fixture.');
+
+        $principalId = (int)$group->get('id');
+        $this->assertTrue(
+            $this->createContextAcl(modUserGroup::class, $principalId, (int)$policy->get('id')),
+            'Could not create group ACL fixture.'
+        );
+
+        $this->assertTrue((bool)$group->remove(), 'User group remove() failed.');
+        $this->assertSame(
+            0,
+            $this->modx->getCount(modAccessContext::class, [
+                'principal_class' => modUserGroup::class,
+                'principal' => $principalId,
+            ]),
+            'Expected no leftover context ACL rows after group remove.'
+        );
+    }
+
+    public function testUserRemoveClearsAclsOutsidePrincipalTargets()
+    {
+        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Administrator']);
+        if (!$policy) {
+            $this->markTestSkipped('Administrator access policy is not available.');
+        }
+
+        $originalTargets = $this->modx->getOption('principal_targets');
+        $this->modx->setOption('principal_targets', modAccessContext::class);
+
+        /** @var modUser $user */
+        $user = $this->modx->newObject(modUser::class);
+        $user->fromArray([
+            'username' => $this->username,
+            'password' => 'unittest-password',
+            'active' => true,
+            'class_key' => modUser::class,
+        ], '', true, true);
+        $this->assertTrue((bool)$user->save(), 'Could not create user fixture.');
+        $principalId = (int)$user->get('id');
+
+        $this->assertTrue(
+            $this->createMenuAcl(modUser::class, $principalId, (int)$policy->get('id')),
+            'Could not create menu ACL fixture outside principal_targets.'
+        );
+
+        $this->assertTrue((bool)$user->remove(), 'User remove() failed.');
+        $this->assertSame(
+            0,
+            $this->modx->getCount(modAccessMenu::class, [
+                'principal_class' => modUser::class,
+                'principal' => $principalId,
+            ]),
+            'ACL rows outside principal_targets must still be removed.'
+        );
+
+        $this->modx->setOption('principal_targets', $originalTargets);
+    }
+
+    /**
+     * @param string $principalClass
+     * @param int $principalId
+     * @param int $policyId
+     * @return bool
+     */
+    private function createContextAcl(string $principalClass, int $principalId, int $policyId): bool
+    {
+        $acl = $this->modx->newObject(modAccessContext::class);
+        $acl->fromArray([
+            'target' => 'web',
+            'principal_class' => $principalClass,
+            'principal' => $principalId,
+            'authority' => 9999,
+            'policy' => $policyId,
+        ], '', true, true);
+
+        return (bool)$acl->save();
+    }
+
+    /**
+     * @param string $principalClass
+     * @param int $principalId
+     * @param int $policyId
+     * @return bool
+     */
+    private function createMenuAcl(string $principalClass, int $principalId, int $policyId): bool
+    {
+        $acl = $this->modx->newObject(modAccessMenu::class);
+        $acl->fromArray([
+            'target' => '0',
+            'principal_class' => $principalClass,
+            'principal' => $principalId,
+            'authority' => 9999,
+            'policy' => $policyId,
+        ], '', true, true);
+
+        return (bool)$acl->save();
+    }
+}

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -799,7 +799,6 @@
     </object>
 
     <object class="modPrincipal" extends="xPDO\Om\xPDOSimpleObject">
-        <composite alias="Acls" class="modAccess" local="id" foreign="principal" cardinality="many" owner="local" />
     </object>
 
     <object class="modPropertySet" table="property_set" extends="xPDO\Om\xPDOSimpleObject">

--- a/core/src/Revolution/modPrincipal.php
+++ b/core/src/Revolution/modPrincipal.php
@@ -48,7 +48,8 @@ abstract class modPrincipal extends xPDOSimpleObject
     /**
      * Resolve the principal_class value stored on ACL rows for this object.
      *
-     * Users store a class_key (including derivatives); groups use the concrete class name.
+     * Users store a class_key (including derivatives). Groups and other principals
+     * use the package class name, not the mysql driver subclass.
      *
      * @return string
      */
@@ -59,7 +60,12 @@ abstract class modPrincipal extends xPDOSimpleObject
             return $classKey;
         }
 
-        return static::class;
+        $class = !empty($this->_class) ? $this->_class : static::class;
+        if (str_contains($class, '\\mysql\\')) {
+            $class = str_replace('\\mysql\\', '\\', $class);
+        }
+
+        return $class;
     }
 
     /**

--- a/core/src/Revolution/modPrincipal.php
+++ b/core/src/Revolution/modPrincipal.php
@@ -11,8 +11,6 @@ use xPDO\xPDO;
  * {@internal Implement a derivative to define the behavior and attributes of
  * an actual user or system that is intended to access modX or a modX service.}
  *
- * @property modAccess[] $Acls
- *
  * @abstract
  * @package MODX\Revolution
  */
@@ -48,6 +46,78 @@ abstract class modPrincipal extends xPDOSimpleObject
     }
 
     /**
+     * Resolve the principal_class value stored on ACL rows for this object.
+     *
+     * Users store a class_key (including derivatives); groups use the concrete class name.
+     *
+     * @return string
+     */
+    protected function getPrincipalClassName(): string
+    {
+        $classKey = (string)$this->get('class_key');
+        if ($classKey !== '') {
+            return $classKey;
+        }
+
+        return static::class;
+    }
+
+    /**
+     * Delete ACL rows for this principal from every concrete modAccess table.
+     *
+     * modAccess is abstract and has no table, so xPDO cannot cascade through it.
+     * Uses getDescendants(modAccess) so extension packages that register extra ACL
+     * classes are included. Does not use principal_targets (that setting controls
+     * attribute loading, not storage cleanup).
+     *
+     * @return bool False if any table cleanup fails
+     */
+    protected function removePrincipalAcls(): bool
+    {
+        $principalId = (int)$this->get('id');
+        if ($principalId < 1) {
+            return true;
+        }
+
+        $principalClass = $this->getPrincipalClassName();
+        $targets = $this->xpdo->getDescendants(modAccess::class);
+        $success = true;
+
+        foreach ($targets as $target) {
+            if (empty($this->xpdo->getTableName($target))) {
+                continue;
+            }
+            $fields = $this->xpdo->getFields($target);
+            if (
+                !is_array($fields)
+                || !array_key_exists('principal_class', $fields)
+                || !array_key_exists('principal', $fields)
+            ) {
+                continue;
+            }
+
+            $removed = $this->xpdo->removeCollection($target, [
+                'principal_class' => $principalClass,
+                'principal' => $principalId,
+            ]);
+            if ($removed === false) {
+                $success = false;
+                $this->xpdo->log(
+                    xPDO::LOG_LEVEL_ERROR,
+                    sprintf(
+                        '[modPrincipal] Failed removing ACL rows from %s for %s #%d',
+                        $target,
+                        $principalClass,
+                        $principalId
+                    )
+                );
+            }
+        }
+
+        return $success;
+    }
+
+    /**
      * Get the attributes for this principal.
      *
      * @param array   $targets An array of target modAccess classes to load.
@@ -60,9 +130,15 @@ abstract class modPrincipal extends xPDOSimpleObject
     {
         $context = !empty($context) ? $context : $this->xpdo->context->get('key');
         if (!is_array($targets) || empty($targets)) {
-            $targets = explode(',', $this->xpdo->getOption('principal_targets', null,
-                'MODX\\Revolution\\modAccessContext,MODX\\Revolution\\modAccessResourceGroup,MODX\\Revolution\\modAccessCategory,MODX\\Revolution\\Sources\\modAccessMediaSource,MODX\\Revolution\\modAccessNamespace'));
-            array_walk($targets, 'trim');
+            $defaultTargets = implode(',', [
+                modAccessContext::class,
+                modAccessResourceGroup::class,
+                modAccessCategory::class,
+                \MODX\Revolution\Sources\modAccessMediaSource::class,
+                modAccessNamespace::class,
+            ]);
+            $targets = explode(',', $this->xpdo->getOption('principal_targets', null, $defaultTargets));
+            $targets = array_map('trim', $targets);
         }
         $this->loadAttributes($targets, $context, $reload);
 

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -132,6 +132,10 @@ class modUser extends modPrincipal
             ]);
         }
 
+        if (!$this->removePrincipalAcls()) {
+            return false;
+        }
+
         $removed = parent:: remove($ancestors);
 
         if ($this->xpdo instanceof modX) {

--- a/core/src/Revolution/modUserGroup.php
+++ b/core/src/Revolution/modUserGroup.php
@@ -62,22 +62,11 @@ class modUserGroup extends modPrincipal
             ]);
         }
 
-        $removed = parent:: remove($ancestors);
-
-        // delete ACLs for this group
-        $targets = explode(',', $this->xpdo->getOption('principal_targets', null, implode(',', [modAccessContext::class,modAccessResourceGroup::class,modAccessCategory::class])));
-        array_walk($targets, 'trim');
-        foreach ($targets as $target) {
-            $fields = $this->xpdo->getFields($target);
-            if (array_key_exists('principal_class', $fields) && array_key_exists('principal', $fields)) {
-                $tablename = $this->xpdo->getTableName($target);
-                $principal_class_field = $this->xpdo->escape('principal_class');
-                $principal_field = $this->xpdo->escape('principal');
-                if (!empty($tablename)) {
-                    $this->xpdo->query("DELETE FROM {$tablename} WHERE {$principal_class_field} = {$this->xpdo->quote(modUserGroup::class)} AND {$principal_field} = {$this->_fields['id']}");
-                }
-            }
+        if (!$this->removePrincipalAcls()) {
+            return false;
         }
+
+        $removed = parent:: remove($ancestors);
 
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('OnUserGroupRemove', [

--- a/core/src/Revolution/mysql/modPrincipal.php
+++ b/core/src/Revolution/mysql/modPrincipal.php
@@ -22,14 +22,6 @@ class modPrincipal extends \MODX\Revolution\modPrincipal
         ),
         'composites' => 
         array (
-            'Acls' => 
-            array (
-                'class' => 'modAccess',
-                'local' => 'id',
-                'foreign' => 'principal',
-                'cardinality' => 'many',
-                'owner' => 'local',
-            ),
         ),
     );
 


### PR DESCRIPTION
### What does it do?

Deleting a user used to make xPDO cascade through an `Acls` relation on `modPrincipal` that pointed at abstract `modAccess` (no table). You got log spam like `Could not get table class or name for class: modAccess` even though the user disappeared.

This PR drops that composite from the schema, then deletes concrete ACL rows (`access_context`, `access_menus`, … plus package ACL classes from `getDescendants(modAccess)`) with `removeCollection` before `parent::remove()`. Cleanup uses the user’s `class_key` so derivatives still match. `principal_targets` is left alone: it only controls which ACL classes load attributes, not which tables we wipe.

`modUserGroup::remove()` shares the same helper. Regression tests cover user, group, and ACL rows outside a narrowed `principal_targets`.

### Why is it needed?

Bulk delete in Security → Users looked fine in the UI, but the error log filled up and some ACL tables could be left inconsistent. [#11276](https://github.com/modxcms/revolution/issues/11276) has been open since 2014 for that.

### How to test

1. Create a user, give them context / menu (or other) ACL entries.
2. Delete the user (single or bulk).
3. Check the error log: no `modAccess` table errors.
4. Confirm matching rows are gone from the concrete `mod_access_*` tables.
5. Optional: delete a user group with context ACLs the same way.

### Related issue(s)/PR(s)

Resolves #11276