### PR TITLE
fix(packages): package installer fails with multibyte characters in readme

### DIFF
--- a/_build/test/Tests/Model/Transport/modTransportPackageTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportPackageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -8,11 +9,12 @@
  * files found in the top-level directory of this distribution.
  *
  * @package modx-test
-*/
+ */
+
 namespace MODX\Revolution\Tests\Model\Transport;
 
-
 use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Transport\modTransportPackage;
 
 /**
  * Tests related to the modTransportPackage class.
@@ -23,8 +25,149 @@ use MODX\Revolution\MODxTestCase;
  * @group Transport
  * @group modTransportPackage
  */
-class modTransportPackageTest extends MODxTestCase {
-    public function testExample() {
-        $this->assertTrue(true);
+class modTransportPackageTest extends MODxTestCase
+{
+    /** @var string */
+    private $signature = 'unittest-emoji-0.0.1-pl';
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        modTransportPackage::resetUtf8mb4SupportCache();
+        $existing = $this->modx->getObject(modTransportPackage::class, ['signature' => $this->signature]);
+        if ($existing) {
+            $existing->remove();
+        }
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        $existing = $this->modx->getObject(modTransportPackage::class, ['signature' => $this->signature]);
+        if ($existing) {
+            $existing->remove();
+        }
+        modTransportPackage::resetUtf8mb4SupportCache();
+        parent::tearDownFixtures();
+    }
+
+    public function testSanitizeConvertsSupplementaryPlaneCharactersWithoutMbstringApi()
+    {
+        $package = $this->newForceSanitizingPackage(true);
+        $package->set('metadata', [
+            'readme' => "Intro 🚀 end",
+            'nested' => ['changelog' => "Ship it ✨ and 🎉"],
+        ]);
+
+        $metadata = $package->get('metadata');
+        $this->assertSame('Intro &#x1f680; end', $metadata['readme']);
+        // ✨ is BMP (3-byte UTF-8); only supplementary-plane chars become entities.
+        $this->assertSame('Ship it ✨ and &#x1f389;', $metadata['nested']['changelog']);
+    }
+
+    public function testSanitizeLeavesBmpAndMalformedBytesAlone()
+    {
+        $package = $this->newForceSanitizingPackage(true);
+        $malformed = "ok\xF0\x28broken";
+        $package->set('attributes', [
+            'readme' => "Café ✓",
+            'raw' => $malformed,
+        ]);
+
+        $attributes = $package->get('attributes');
+        $this->assertSame('Café ✓', $attributes['readme']);
+        $this->assertSame($malformed, $attributes['raw']);
+    }
+
+    public function testSanitizeIsIdempotent()
+    {
+        $package = $this->newForceSanitizingPackage(true);
+        $package->set('metadata', ['readme' => '🚀']);
+        $once = $package->get('metadata');
+        $package->set('metadata', $once);
+        $twice = $package->get('metadata');
+
+        $this->assertSame('&#x1f680;', $once['readme']);
+        $this->assertSame($once, $twice);
+    }
+
+    public function testUtf8mb4CapableConnectionPreservesEmoji()
+    {
+        $package = $this->newForceSanitizingPackage(false);
+        $package->set('metadata', ['readme' => 'Hello 🚀']);
+        $metadata = $package->get('metadata');
+        $this->assertSame('Hello 🚀', $metadata['readme']);
+    }
+
+    public function testSaveMetadataWithEmojiOnNonUtf8mb4Database()
+    {
+        $package = $this->modx->newObject(modTransportPackage::class);
+        $package->fromArray([
+            'signature' => $this->signature,
+            'created' => date('Y-m-d H:i:s'),
+            'updated' => null,
+            'installed' => null,
+            'state' => 1,
+            'workspace' => 1,
+            'provider' => 0,
+            'disabled' => false,
+            'source' => $this->signature . '.transport.zip',
+            'package_name' => 'unittest-emoji',
+            'version_major' => 0,
+            'version_minor' => 0,
+            'version_patch' => 1,
+            'release' => 'pl',
+            'release_index' => 0,
+        ], '', true, true);
+        // Use set() so non-utf8mb4 sanitization runs (fromArray rawValues bypasses it).
+        $package->set('metadata', [
+            'name' => 'UnitTest Emoji',
+            'readme' => "Install me 🚀 please",
+        ]);
+        $package->set('attributes', [
+            'readme' => "Local readme with 🎉",
+        ]);
+
+        $this->assertTrue((bool)$package->save(), 'Package with emoji metadata should save on non-utf8mb4.');
+
+        modTransportPackage::resetUtf8mb4SupportCache();
+        /** @var modTransportPackage $reloaded */
+        $reloaded = $this->modx->getObject(modTransportPackage::class, ['signature' => $this->signature]);
+        $this->assertInstanceOf(modTransportPackage::class, $reloaded);
+
+        $metadata = $reloaded->get('metadata');
+        $attributes = $reloaded->get('attributes');
+        $this->assertSame('Install me &#x1f680; please', $metadata['readme']);
+        $this->assertSame('Local readme with &#x1f389;', $attributes['readme']);
+    }
+
+    /**
+     * @param bool $requiresSanitization
+     * @return modTransportPackage
+     */
+    private function newForceSanitizingPackage($requiresSanitization)
+    {
+        $package = new class ($this->modx, $requiresSanitization) extends modTransportPackage {
+            /** @var bool */
+            private $forceRequiresSanitization;
+
+            public function __construct($xpdo, $forceRequiresSanitization)
+            {
+                parent::__construct($xpdo);
+                $this->forceRequiresSanitization = (bool)$forceRequiresSanitization;
+            }
+
+            protected function requiresMultibyteSanitization()
+            {
+                return $this->forceRequiresSanitization;
+            }
+        };
+
+        return $package;
     }
 }

--- a/_build/test/Tests/Model/Transport/modTransportPackageTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportPackageTest.php
@@ -106,14 +106,18 @@ class modTransportPackageTest extends MODxTestCase
 
     public function testSaveMetadataWithEmojiOnNonUtf8mb4Database()
     {
+        $workspace = $this->modx->getObject(\MODX\Revolution\modWorkspace::class, ['active' => true]);
+        if (!$workspace) {
+            $this->markTestSkipped('No active workspace in the test database.');
+        }
+
         $package = $this->modx->newObject(modTransportPackage::class);
         $package->fromArray([
             'signature' => $this->signature,
             'created' => date('Y-m-d H:i:s'),
-            'updated' => null,
             'installed' => null,
             'state' => 1,
-            'workspace' => 1,
+            'workspace' => (int)$workspace->get('id'),
             'provider' => 0,
             'disabled' => false,
             'source' => $this->signature . '.transport.zip',
@@ -132,6 +136,13 @@ class modTransportPackageTest extends MODxTestCase
         $package->set('attributes', [
             'readme' => "Local readme with 🎉",
         ]);
+
+        $metadataBeforeSave = $package->get('metadata');
+        $this->assertSame(
+            'Install me &#x1f680; please',
+            $metadataBeforeSave['readme'],
+            'CI uses charset=utf8; emoji must be entity-encoded before INSERT.'
+        );
 
         $this->assertTrue((bool)$package->save(), 'Package with emoji metadata should save on non-utf8mb4.');
 

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -189,12 +189,16 @@ class modTransportPackage extends xPDOObject
     }
 
     /**
-     * Resolves the effective charset for transport package text columns.
+     * Resolves whether package text storage can accept utf8mb4 end-to-end.
+     * Both the metadata column charset and the connection charset must be utf8mb4;
+     * a utf8mb3 connection still rejects 4-byte characters even if the column is utf8mb4.
      *
-     * @return string|null
+     * @return string|null Lowest-capability charset found, or null if unknown
      */
     protected function resolvePackageTextCharset()
     {
+        $charsets = [];
+
         $tableName = trim((string)$this->xpdo->getTableName(static::class), '`"');
         if ($tableName !== '') {
             $statement = $this->xpdo->query(
@@ -208,7 +212,7 @@ class modTransportPackage extends xPDOObject
             if ($statement) {
                 $columnCharset = $statement->fetchColumn();
                 if (is_string($columnCharset) && $columnCharset !== '') {
-                    return $columnCharset;
+                    $charsets[] = $columnCharset;
                 }
             }
         }
@@ -217,11 +221,21 @@ class modTransportPackage extends xPDOObject
         if ($statement) {
             $connectionCharset = $statement->fetchColumn();
             if (is_string($connectionCharset) && $connectionCharset !== '') {
-                return $connectionCharset;
+                $charsets[] = $connectionCharset;
             }
         }
 
-        return null;
+        if (empty($charsets)) {
+            return null;
+        }
+
+        foreach ($charsets as $charset) {
+            if (stripos($charset, 'utf8mb4') === false) {
+                return $charset;
+            }
+        }
+
+        return $charsets[0];
     }
 
     /**

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -104,8 +104,17 @@ class modTransportPackage extends xPDOObject
     }
 
     /**
+     * Cached per-connection result: whether package text columns can store utf8mb4.
+     *
+     * @var bool|null
+     */
+    private static $supportsUtf8mb4 = null;
+
+    /**
      * Overrides xPDOObject::set. Checks if signature is set, and if so,
      * parses it and sets the source if is a new package.
+     * On databases that cannot store utf8mb4, converts 4-byte UTF-8 characters
+     * in metadata/attributes (e.g. emojis in a package readme) to HTML entities.
      *
      * @param string $k     The key to set
      * @param mixed  $v     The value to set
@@ -115,6 +124,13 @@ class modTransportPackage extends xPDOObject
      */
     public function set($k, $v = null, $vType = '')
     {
+        if (
+            $v !== null
+            && in_array($k, ['metadata', 'attributes'], true)
+            && $this->requiresMultibyteSanitization()
+        ) {
+            $v = $this->sanitizeMultibyteForUtf8($v);
+        }
         $set = parent::set($k, $v, $vType);
         if ($k == 'signature') {
             $this->parseSignature();
@@ -124,6 +140,142 @@ class modTransportPackage extends xPDOObject
         }
 
         return $set;
+    }
+
+    /**
+     * Whether package metadata/attributes must be rewritten for the current DB charset.
+     *
+     * @return bool
+     */
+    protected function requiresMultibyteSanitization()
+    {
+        return !$this->connectionSupportsUtf8mb4();
+    }
+
+    /**
+     * Detects whether the active MySQL connection/column charset can store 4-byte UTF-8.
+     * Result is cached for the request. Non-MySQL drivers are treated as capable.
+     *
+     * @return bool
+     */
+    protected function connectionSupportsUtf8mb4()
+    {
+        if (self::$supportsUtf8mb4 !== null) {
+            return self::$supportsUtf8mb4;
+        }
+
+        // Default to sanitizing when detection is inconclusive (utf8mb3-safe).
+        self::$supportsUtf8mb4 = false;
+        if (!$this->xpdo instanceof xPDO) {
+            return self::$supportsUtf8mb4;
+        }
+
+        try {
+            $driver = (string)$this->xpdo->getOption('dbtype', null, '');
+            if ($driver !== '' && stripos($driver, 'mysql') === false) {
+                self::$supportsUtf8mb4 = true;
+                return self::$supportsUtf8mb4;
+            }
+
+            $charset = $this->resolvePackageTextCharset();
+            if ($charset !== null) {
+                self::$supportsUtf8mb4 = (stripos($charset, 'utf8mb4') !== false);
+            }
+        } catch (Throwable $e) {
+            self::$supportsUtf8mb4 = false;
+        }
+
+        return self::$supportsUtf8mb4;
+    }
+
+    /**
+     * Resolves the effective charset for transport package text columns.
+     *
+     * @return string|null
+     */
+    protected function resolvePackageTextCharset()
+    {
+        $tableName = trim((string)$this->xpdo->getTableName(static::class), '`"');
+        if ($tableName !== '') {
+            $statement = $this->xpdo->query(
+                "SELECT CHARACTER_SET_NAME
+                 FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE()
+                   AND TABLE_NAME = " . $this->xpdo->quote($tableName) . "
+                   AND COLUMN_NAME = 'metadata'
+                 LIMIT 1"
+            );
+            if ($statement) {
+                $columnCharset = $statement->fetchColumn();
+                if (is_string($columnCharset) && $columnCharset !== '') {
+                    return $columnCharset;
+                }
+            }
+        }
+
+        $statement = $this->xpdo->query('SELECT @@character_set_connection');
+        if ($statement) {
+            $connectionCharset = $statement->fetchColumn();
+            if (is_string($connectionCharset) && $connectionCharset !== '') {
+                return $connectionCharset;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Recursively replaces valid 4-byte UTF-8 sequences (U+10000–U+10FFFF) with HTML entities.
+     * Does not require mbstring. Leaves BMP characters and malformed bytes unchanged.
+     *
+     * @param mixed $value String or array of values to sanitize
+     * @return mixed Sanitized value
+     */
+    protected function sanitizeMultibyteForUtf8($value)
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $item) {
+                $value[$key] = $this->sanitizeMultibyteForUtf8($item);
+            }
+
+            return $value;
+        }
+        if (!is_string($value) || $value === '') {
+            return $value;
+        }
+        // Fast path: 4-byte UTF-8 always starts with 0xF0–0xF4.
+        if (!preg_match('/[\xF0-\xF4]/', $value)) {
+            return $value;
+        }
+
+        $sanitized = preg_replace_callback(
+            '/[\xF0-\xF4][\x80-\xBF]{3}/',
+            static function (array $match) {
+                $bytes = unpack('C*', $match[0]);
+                if ($bytes === false || count($bytes) !== 4) {
+                    return $match[0];
+                }
+                $codePoint = (($bytes[1] & 0x07) << 18)
+                    | (($bytes[2] & 0x3F) << 12)
+                    | (($bytes[3] & 0x3F) << 6)
+                    | ($bytes[4] & 0x3F);
+
+                return '&#x' . dechex($codePoint) . ';';
+            },
+            $value
+        );
+
+        return is_string($sanitized) ? $sanitized : $value;
+    }
+
+    /**
+     * Resets the cached utf8mb4 capability flag (for tests).
+     *
+     * @return void
+     */
+    public static function resetUtf8mb4SupportCache()
+    {
+        self::$supportsUtf8mb4 = null;
     }
 
     /**


### PR DESCRIPTION
### What does it do?

Lets Package Management install Extras whose readme or metadata contains emojis (and other characters outside the BMP) on MySQL databases that still use `utf8` / `utf8mb3`.

When the package `metadata` / `attributes` columns cannot store utf8mb4, `modTransportPackage::set()` rewrites only valid 4-byte UTF-8 sequences to HTML entities (for example `🚀` → `&#x1f680;`). utf8mb4 databases are left alone. The conversion does not need `mbstring`.

### Why is it needed?

On non-utf8mb4 sites, download/install fails with:

> Could not download and create transport package with signature: …

Provider metadata and local package attributes both go through `set()`, so one choke point covers remote and uploaded packages. Turning the whole site to utf8mb4 still works; this change is for installs that cannot or have not migrated yet. See [#16725](https://github.com/modxcms/revolution/issues/16725) and the [entity-conversion approach](https://dev.to/nikkimk/converting-utf-including-emoji-to-html-x1f92f-4951#the-completed-utf-including-emoji-to-html-function) linked from the issue.

### How to test

1. Use MySQL with connection/column charset `utf8` or `utf8mb3` (not utf8mb4).
2. Download or upload an Extra with emojis in the readme (for example [modAI 0.11](https://extras.modx.com/package/modai?version=0.11.0-pl)).
3. Confirm the package appears and installs.
4. Open the package details and confirm the readme still shows the emoji (browser renders the entity).
5. On a utf8mb4 site, repeat and confirm the stored value stays real Unicode, not entities.

### Related issue(s)/PR(s)

Resolves #16725