### PR TITLE
fix(browser): allow double dots in filenames, normalize path traversal by segments

### DIFF
--- a/_build/test/Tests/Processors/Browser/BrowserSanitizeTest.php
+++ b/_build/test/Tests/Processors/Browser/BrowserSanitizeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Processors\Browser;
+
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Processors\Browser\File\Remove;
+
+/**
+ * Regression for #16663: Browser::sanitize must keep double dots inside filenames.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Processors
+ * @group BrowserProcessors
+ */
+class BrowserSanitizeTest extends MODxTestCase
+{
+    /** @var Remove */
+    private $processor;
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->processor = new Remove($this->modx);
+    }
+
+    /**
+     * @dataProvider providerSanitize
+     * @param string $input
+     * @param string $expected
+     */
+    public function testSanitizePreservesFilenameDotsAndTrailingSlash($input, $expected)
+    {
+        $this->assertSame($expected, $this->processor->sanitize($input));
+    }
+
+    public function providerSanitize()
+    {
+        return [
+            'double dots in filename' => ['somefile..txt', 'somefile..txt'],
+            'directory plus double-dot file' => ['folder/somefile..txt', 'folder/somefile..txt'],
+            'preserves trailing slash for File/Create' => ['folder/', 'folder/'],
+            'collapses duplicate slashes' => ['folder//file.txt', 'folder/file.txt'],
+            'hidden file leading dot' => ['.htaccess', '.htaccess'],
+            'url-encoded filename' => ['some%20file..txt', 'some file..txt'],
+            'leaves relative parent segment for Flysystem' => ['../escape', '../escape'],
+            'leaves nested parent segment for Flysystem' => ['a/../b', 'a/../b'],
+        ];
+    }
+}

--- a/core/src/Revolution/Processors/Browser/Browser.php
+++ b/core/src/Revolution/Processors/Browser/Browser.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Browser;
-
 
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Sources\modMediaSource;
@@ -135,7 +135,10 @@ abstract class Browser extends Processor
 
 
     /**
-     * @param $file
+     * Soft-sanitize a browser path/filename for media-source operations.
+     * Keeps valid names like somefile..txt. Path traversal is enforced by Flysystem.
+     *
+     * @param string $file
      *
      * @return string
      */
@@ -146,7 +149,6 @@ abstract class Browser extends Processor
         if (strpos($file, '.') === 0) {
             $file = preg_replace('/^(\.)([\s\/]*)(.*)/', '$1$3', $file);
         }
-        $file = preg_replace('/\.(?![\w\-\~\s])/u', '', $file);
         $file = preg_replace('/\/{2,}/', '/', $file);
         $file = strip_tags($file);
 


### PR DESCRIPTION
### What does it do?

Stops `Browser::sanitize()` from rewriting filenames that contain consecutive dots inside a single path segment (for example `somefile..txt`).

The old `preg_replace('/\.(?![\w\-\~\s])/u', '', …)` treated those dots as unsafe and turned the name into `somefile.txt`, so delete/rename/download missed the real file. That pattern is gone. Soft cleanup (URL-decode, strip tags, collapse `//`) stays. Path traversal is still handled by Flysystem’s `WhitespacePathNormalizer` when the media source reads or writes.

### Why is it needed?

`somefile..txt` is a valid name. Users could upload it, then the File Browser could not delete or rename it because sanitize changed the path first. See #16663.

### How to test

1. In Media / File Browser, upload or create `somefile..txt`.
2. Delete it — should succeed.
3. Repeat with rename/download.
4. Confirm `../` style paths still cannot escape the media source root (Flysystem rejects traversal).

### Related issue(s)/PR(s)

Resolves #16663