### PR TITLE
feat(manager): add key bindings for Error Log Refresh and Clear buttons

### DIFF
--- a/manager/assets/modext/sections/system/error.log.js
+++ b/manager/assets/modext/sections/system/error.log.js
@@ -17,12 +17,14 @@ MODx.page.ErrorLog = function(config) {
             ,handler: this.refreshLog
             ,scope: this
             ,hidden: config.record.tooLarge
+            ,keys: [{ key: 221, alt: true }]
         },{
             text: _('clear')
             ,id: 'modx-abtn-clear'
             ,handler: this.clear
             ,scope: this
             ,hidden: MODx.hasEraseErrorLog ? false : true
+            ,keys: [{ key: 219, alt: true }]
         },{
             text: _('cancel')
             ,id: 'modx-abtn-cancel'


### PR DESCRIPTION
### What does it do?
Adds keyboard shortcuts to the Error Log page in the Manager: **Alt+]** (or Option+] on macOS) for Refresh and **Alt+[** (or Option+[ on macOS) for Clear. Uses Ext.KeyMap via existing `keys` support on action buttons; keyCode 219/221 so the same physical keys work across Windows and macOS and keyboard layouts.

### Why is it needed?
Frequently using the error log with the keyboard (e.g. during development) is slowed down by having to use the mouse for Refresh and Clear. Shortcuts keep the workflow keyboard-first.

### How to test
1. Open Manager → System → Error Log.
2. Press **Alt+]** (Windows) or **Option+]** (macOS) — log should refresh.
3. Press **Alt+[** (Windows) or **Option+[** (macOS) — log should clear (if you have `error_log_erase` permission).
4. Confirm shortcuts work with focus inside the log textarea.

### Related issue(s)/PR(s)
Resolves #16706