### PR TITLE
Change getVersionData() to use include instead of include_once

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1427,7 +1427,7 @@ class modX extends xPDO {
      */
     public function getVersionData() {
         if ($this->version === null) {
-            $this->version= @ include_once MODX_CORE_PATH . "docs/version.inc.php";
+            $this->version = @ include MODX_CORE_PATH . "docs/version.inc.php";
         }
         return $this->version;
     }


### PR DESCRIPTION
### What does it do?
Replaces `include_once` with `include` in `modX::getVersionData()` so the method always returns the version array. Adds PSR12 spacing (space before `=`) on the changed line.

### Why is it needed?
When the version file was already loaded in the same PHP scope (e.g. in tests with multiple MODX instances), `include_once` returns `true` on the second run. Callers doing `getVersionData()['version']` or `getVersionData()['full_version']` then hit `true['version']`, causing a PHP error (suppressed by `@`), which is hard to track down.

### How to test
1. In a test or script, instantiate MODX (or get `$modx`) and call `$modx->getVersionData()` twice.
2. Assert both returns are arrays with keys `version`, `full_version`, etc.
3. Optionally run existing integration/acceptance tests that create multiple MODX instances.

### Related issue(s)/PR(s)
Resolves #16655