### PR TITLE
fix(core): normalize null path/assets_path in namespace save and transport

### DIFF
--- a/core/src/Revolution/Transport/modPackageBuilder.php
+++ b/core/src/Revolution/Transport/modPackageBuilder.php
@@ -164,6 +164,8 @@ class modPackageBuilder
      */
     public function registerNamespace($ns = 'core', $autoincludes = true, $packageNamespace = true, $path = '', $assetsPath = '')
     {
+        $path = $path === null ? '' : $path;
+        $assetsPath = $assetsPath === null ? '' : $assetsPath;
         if (!($ns instanceof modNamespace)) {
             $namespace = $this->modx->getObject(modNamespace::class, $ns);
             if (!$namespace) {

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -32,6 +32,12 @@ class modNamespace extends modAccessibleObject
 
     public function save($cacheFlag = null)
     {
+        if ($this->get('path') === null) {
+            $this->set('path', '');
+        }
+        if ($this->get('assets_path') === null) {
+            $this->set('assets_path', '');
+        }
         $saved = parent::save();
         if ($saved && !$this->getOption(xPDO::OPT_SETUP)) {
             $this->xpdo->call(modNamespace::class, 'clearCache', [&$this->xpdo]);

--- a/core/src/Revolution/modNamespace.php
+++ b/core/src/Revolution/modNamespace.php
@@ -32,18 +32,23 @@ class modNamespace extends modAccessibleObject
 
     public function save($cacheFlag = null)
     {
-        if ($this->get('path') === null) {
-            $this->set('path', '');
-        }
-        if ($this->get('assets_path') === null) {
-            $this->set('assets_path', '');
-        }
+        $this->normalizePathFields();
         $saved = parent::save();
         if ($saved && !$this->getOption(xPDO::OPT_SETUP)) {
             $this->xpdo->call(modNamespace::class, 'clearCache', [&$this->xpdo]);
         }
 
         return $saved;
+    }
+
+    private function normalizePathFields(): void
+    {
+        if ($this->get('path') === null) {
+            $this->set('path', '');
+        }
+        if ($this->get('assets_path') === null) {
+            $this->set('assets_path', '');
+        }
     }
 
     public function remove(array $ancestors = [])


### PR DESCRIPTION
### What does it do?
Normalizes `path` and `assets_path` from null to empty string in `modNamespace::save()` (via new `normalizePathFields()`) and at the start of `modPackageBuilder::registerNamespace()`. Ensures null is never persisted or passed into `translatePath()`, complementing the existing null-safe `translatePath()` for PHP 8.1+.

### Why is it needed?
When a namespace has `path` or `assets_path` set to null (e.g. some extras), PHP 8.1+ deprecation from `str_replace(..., null)` can be emitted; if that happens in a processor response, the output is not valid JSON and JS breaks. `translatePath()` already returns `''` for null; this change prevents null from being stored or passed in the first place.

### How to test
1. Set a namespace's `assets_path` (or `path`) to null in the DB or via UI where allowed.
2. With `display_errors` on and E_DEPRECATED reported, trigger an ajax call that loads namespaces (e.g. empty cache so namespace cache is rebuilt).
3. Confirm no deprecation warning and valid JSON response.
4. Save the namespace (or create one via transport with null path) and confirm `path`/`assets_path` are stored as empty string, not null.

### Related issue(s)/PR(s)
Resolves #16513