### PR TITLE
Register Smarty date modifier to avoid deprecation warning

### DIFF
--- a/core/src/Revolution/Smarty/modSmarty.php
+++ b/core/src/Revolution/Smarty/modSmarty.php
@@ -67,6 +67,7 @@ class modSmarty extends Smarty
         $this->plugins_dir = [
             $this->modx->getOption('core_path') . 'vendor/smarty/smarty/libs/plugins',
         ];
+        $this->registerPlugin(\Smarty::PLUGIN_MODIFIER, 'date', 'date');
         $this->caching = false;
 
         foreach ($params as $paramKey => $paramValue) {

--- a/setup/includes/parser/modinstallsmarty.class.php
+++ b/setup/includes/parser/modinstallsmarty.class.php
@@ -34,6 +34,7 @@ class modInstallSmarty extends Smarty implements modInstallParser {
         $this->plugins_dir  = [
             MODX_CORE_PATH . 'vendor/smarty/smarty/libs/plugins'
         ];
+        $this->registerPlugin(\Smarty::PLUGIN_MODIFIER, 'date', 'date');
         $this->caching = false;
 
         foreach ($params as $paramKey => $paramValue) {


### PR DESCRIPTION
### What does it do?
Registers the PHP `date` function as a Smarty modifier in `modInstallSmarty` (setup) and `modSmarty` (manager) via `registerPlugin(PLUGIN_MODIFIER, 'date', 'date')`. Templates using `|date` (e.g. `{'Y'|date}`) then work without triggering PHP 8.1+ deprecation.

### Why is it needed?
With Smarty 4, using PHP functions as modifiers without explicit registration is deprecated. During setup/upgrade or on Manager Help, `|date` caused: "Using php-function 'date' as a modifier is deprecated". Explicit registration fixes it.

### How to test
1. Run setup in upgrade mode (or open Manager → Help) with PHP 8.1+ and `display_errors` on.
2. Confirm no deprecation notice; year in footer/help displays correctly.

### Related issue(s)/PR(s)
Resolves #16494