### PR TITLE
feat(system): add "Also in" column to system settings grid

### DIFF
--- a/_build/test/Tests/Processors/System/Settings/SettingsAlsoInGetListTest.php
+++ b/_build/test/Tests/Processors/System/Settings/SettingsAlsoInGetListTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Processors\System\Settings;
+
+use MODX\Revolution\modContextSetting;
+use MODX\Revolution\modSystemSetting;
+use MODX\Revolution\modUserSetting;
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Processors\Security\User\Setting\GetList as UserSettingGetList;
+use MODX\Revolution\Processors\System\Settings\GetList;
+
+/**
+ * Regression for #16472: system settings list marks context/user overrides.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Processors
+ * @group System
+ * @group Settings
+ */
+class SettingsAlsoInGetListTest extends MODxTestCase
+{
+    private const KEY = 'unittest_also_in_setting';
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->cleanupFixtures();
+
+        $system = $this->modx->newObject(modSystemSetting::class);
+        $system->fromArray([
+            'key' => self::KEY,
+            'value' => 'system',
+            'xtype' => 'textfield',
+            'namespace' => 'core',
+            'area' => 'system',
+        ], '', true, true);
+        $this->assertTrue((bool)$system->save());
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        $this->cleanupFixtures();
+        parent::tearDownFixtures();
+    }
+
+    public function testSystemSettingsListMarksContextAndUserOverrides()
+    {
+        $context = $this->modx->newObject(modContextSetting::class);
+        $context->fromArray([
+            'context_key' => 'web',
+            'key' => self::KEY,
+            'value' => 'context',
+            'xtype' => 'textfield',
+            'namespace' => 'core',
+            'area' => 'system',
+        ], '', true, true);
+        $this->assertTrue((bool)$context->save());
+
+        $user = $this->modx->newObject(modUserSetting::class);
+        $user->fromArray([
+            'user' => 1,
+            'key' => self::KEY,
+            'value' => 'user',
+            'xtype' => 'textfield',
+            'namespace' => 'core',
+            'area' => 'system',
+        ], '', true, true);
+        $this->assertTrue((bool)$user->save());
+
+        $result = $this->modx->runProcessor(GetList::class, [
+            'query' => self::KEY,
+            'limit' => 20,
+            'start' => 0,
+        ]);
+        $this->assertTrue($this->checkForSuccess($result));
+
+        $row = $this->findSettingRow($result, self::KEY);
+        $this->assertNotNull($row);
+        $this->assertTrue($row['has_context_override']);
+        $this->assertTrue($row['has_user_override']);
+    }
+
+    public function testSystemSettingsListWithoutOverrides()
+    {
+        $result = $this->modx->runProcessor(GetList::class, [
+            'query' => self::KEY,
+            'limit' => 20,
+            'start' => 0,
+        ]);
+        $this->assertTrue($this->checkForSuccess($result));
+
+        $row = $this->findSettingRow($result, self::KEY);
+        $this->assertNotNull($row);
+        $this->assertFalse($row['has_context_override']);
+        $this->assertFalse($row['has_user_override']);
+    }
+
+    public function testUserSettingsListDoesNotAddAlsoInFlags()
+    {
+        $result = $this->modx->runProcessor(UserSettingGetList::class, [
+            'user' => 1,
+            'limit' => 5,
+            'start' => 0,
+        ]);
+        // May succeed with empty list depending on fixtures; assert no also-in fields when rows exist.
+        if (!$this->checkForSuccess($result)) {
+            $this->markTestSkipped('User setting list processor unavailable in test harness.');
+        }
+
+        $results = $this->getResults($result);
+        foreach ($results as $row) {
+            $this->assertArrayNotHasKey('has_context_override', $row);
+            $this->assertArrayNotHasKey('has_user_override', $row);
+        }
+        $this->assertTrue(true);
+    }
+
+    private function cleanupFixtures(): void
+    {
+        $system = $this->modx->getObject(modSystemSetting::class, ['key' => self::KEY]);
+        if ($system) {
+            $system->remove();
+        }
+
+        $contexts = $this->modx->getCollection(modContextSetting::class, ['key' => self::KEY]);
+        foreach ($contexts as $context) {
+            $context->remove();
+        }
+
+        $users = $this->modx->getCollection(modUserSetting::class, ['key' => self::KEY]);
+        foreach ($users as $user) {
+            $user->remove();
+        }
+    }
+
+    /**
+     * @param mixed $result
+     * @param string $key
+     * @return array|null
+     */
+    private function findSettingRow($result, string $key): ?array
+    {
+        foreach ($this->getResults($result) as $row) {
+            if (($row['oldkey'] ?? $row['key'] ?? null) === $key || ($row['key'] ?? null) === $key) {
+                return $row;
+            }
+        }
+
+        return null;
+    }
+}

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -46,6 +46,7 @@
             <directory>Tests/Processors/Context</directory>
             <directory>Tests/Processors/Element</directory>
             <directory>Tests/Processors/Resource</directory>
+            <directory>Tests/Processors/System</directory>
         </testsuite>
         <testsuite name="Transport">
             <directory>Tests/Transport</directory>

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -55,6 +55,9 @@ $_lang['settings_ui'] = 'Interface &amp; Features';
 $_lang['settings_users'] = 'User';
 $_lang['system_settings'] = 'System Settings';
 $_lang['usergroup'] = 'User Group';
+$_lang['setting_also_in'] = 'Also in';
+$_lang['setting_also_in_context'] = 'Context';
+$_lang['setting_also_in_user'] = 'User';
 
 // user settings
 $_lang['setting_access_category_enabled'] = 'Check Category Access';

--- a/core/src/Revolution/Processors/System/Settings/GetList.php
+++ b/core/src/Revolution/Processors/System/Settings/GetList.php
@@ -12,11 +12,12 @@
 namespace MODX\Revolution\Processors\System\Settings;
 
 use MODX\Revolution\Formatter\modManagerDateFormatter;
+use MODX\Revolution\modContextSetting;
 use MODX\Revolution\modNamespace;
 use MODX\Revolution\modSystemSetting;
+use MODX\Revolution\modUserSetting;
 use MODX\Revolution\Processors\Model\GetListProcessor;
 use xPDO\Om\xPDOObject;
-use xPDO\Om\xPDOQuery;
 
 /**
  * Get a list of system settings
@@ -36,6 +37,12 @@ class GetList extends GetListProcessor
     public $defaultSortField = 'key';
 
     private modManagerDateFormatter $formatter;
+
+    /** @var array<string, bool> Keys that exist in context_setting (overrides) */
+    private array $contextOverrideKeys = [];
+
+    /** @var array<string, bool> Keys that exist in user_settings (overrides) */
+    private array $userOverrideKeys = [];
 
     /**
      * @return bool
@@ -57,6 +64,76 @@ class GetList extends GetListProcessor
     public function prepareCriteria()
     {
         return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     * For system settings only, preload which keys also exist as context/user overrides.
+     */
+    public function iterate(array $data)
+    {
+        if ($this->classKey === modSystemSetting::class) {
+            $keys = [];
+            foreach ($data['results'] as $object) {
+                $key = $object->get('key');
+                if ($key !== null && $key !== '') {
+                    $keys[] = $key;
+                }
+            }
+            $this->loadOverrideKeys(array_values(array_unique($keys)));
+        }
+
+        return parent::iterate($data);
+    }
+
+    /**
+     * Build set maps of override keys without hydrating xPDO objects.
+     *
+     * @param array $keys
+     * @return void
+     */
+    protected function loadOverrideKeys(array $keys)
+    {
+        $this->contextOverrideKeys = [];
+        $this->userOverrideKeys = [];
+        if (empty($keys)) {
+            return;
+        }
+
+        $this->contextOverrideKeys = $this->fetchDistinctSettingKeys(modContextSetting::class, $keys);
+        $this->userOverrideKeys = $this->fetchDistinctSettingKeys(modUserSetting::class, $keys);
+    }
+
+    /**
+     * @param string $class
+     * @param array $keys
+     * @return array<string, bool>
+     */
+    protected function fetchDistinctSettingKeys(string $class, array $keys): array
+    {
+        $table = $this->modx->getTableName($class);
+        if ($table === '' || $table === null) {
+            return [];
+        }
+
+        $quotedKeys = [];
+        foreach ($keys as $key) {
+            $quotedKeys[] = $this->modx->quote((string)$key);
+        }
+
+        $statement = $this->modx->query(
+            'SELECT DISTINCT `key` FROM ' . $table . ' WHERE `key` IN (' . implode(',', $quotedKeys) . ')'
+        );
+        if (!$statement) {
+            return [];
+        }
+
+        $found = $statement->fetchAll(\PDO::FETCH_COLUMN);
+        if (!is_array($found) || empty($found)) {
+            return [];
+        }
+
+        return array_fill_keys($found, true);
     }
 
     /**
@@ -174,6 +251,12 @@ class GetList extends GetListProcessor
             ? $this->formatter->format($editedOn, $customFormat)
             : $this->formatter->formatDateTime($editedOn)
             ;
+
+        if ($this->classKey === modSystemSetting::class) {
+            $settingKey = $object->get('key');
+            $settingArray['has_context_override'] = isset($this->contextOverrideKeys[$settingKey]);
+            $settingArray['has_user_override'] = isset($this->userOverrideKeys[$settingKey]);
+        }
 
         return $settingArray;
     }

--- a/manager/assets/modext/widgets/core/modx.grid.settings.js
+++ b/manager/assets/modext/widgets/core/modx.grid.settings.js
@@ -153,40 +153,67 @@ MODx.grid.SettingsGrid = function(config = {}) {
         )
     );
 
+    const systemSettingsColumns = [
+        this.exp,
+        {
+            header: _('name'),
+            dataIndex: 'name_trans',
+            sortable: true,
+            editable: false,
+            width: 175
+        },
+        {
+            header: _('key'),
+            dataIndex: 'key',
+            sortable: true,
+            editable: false,
+            width: 150
+        }
+    ];
+    if (settingsType === 'system') {
+        systemSettingsColumns.push({
+            header: _('setting_also_in'),
+            dataIndex: 'has_context_override',
+            sortable: false,
+            editable: false,
+            width: 100,
+            renderer: function(value, meta, record) {
+                const ctx = record.get('has_context_override');
+                const usr = record.get('has_user_override');
+                const parts = [];
+                if (ctx) parts.push(_('setting_also_in_context'));
+                if (usr) parts.push(_('setting_also_in_user'));
+                return parts.length ? parts.join(', ') : '';
+            }
+        });
+    }
+    systemSettingsColumns.push(
+        {
+            header: _('value'),
+            dataIndex: 'value',
+            sortable: true,
+            editable: true,
+            renderer: this.renderDynField.createDelegate(this, [this], true),
+            width: 260
+        },
+        {
+            header: _('last_modified'),
+            dataIndex: 'editedon',
+            sortable: true,
+            editable: false,
+            renderer: this.renderLastModDate.createDelegate(this, [this], true),
+            width: 100
+        },
+        {
+            header: _('area'),
+            dataIndex: 'area_text',
+            sortable: true,
+            hidden: true,
+            editable: false
+        }
+    );
     this.cm = new Ext.grid.ColumnModel({
-        columns: [this.exp,{
-            header: _('name')
-            ,dataIndex: 'name_trans'
-            ,sortable: true
-            ,editable: false
-            ,width: 175
-        },{
-            header: _('key')
-            ,dataIndex: 'key'
-            ,sortable: true
-            ,editable: false
-            ,width: 150
-        },{
-            header: _('value')
-            ,dataIndex: 'value'
-            ,sortable: true
-            ,editable: true
-            ,renderer: this.renderDynField.createDelegate(this,[this],true)
-            ,width: 260
-        },{
-            header: _('last_modified')
-            ,dataIndex: 'editedon'
-            ,sortable: true
-            ,editable: false
-            ,renderer: this.renderLastModDate.createDelegate(this,[this],true)
-            ,width: 100
-        },{
-            header: _('area')
-            ,dataIndex: 'area_text'
-            ,sortable: true
-            ,hidden: true
-            ,editable: false
-        }],
+        columns: systemSettingsColumns,
         isCellEditable: function(col, row) {
             var record = config.store.getAt(row);
             if (record.get('xtype') === 'modx-grid-json' || record.get('xtype') === 'grid-json') {
@@ -222,24 +249,28 @@ MODx.grid.SettingsGrid = function(config = {}) {
         }
     });
 
+    const gridFields = [
+        'key',
+        'name',
+        'value',
+        'description',
+        'xtype',
+        'namespace',
+        'area',
+        'area_text',
+        'editedon',
+        'oldkey',
+        'menu',
+        'name_trans',
+        'description_trans'
+    ];
+    if (settingsType === 'system') {
+        gridFields.push('has_context_override', 'has_user_override');
+    }
     Ext.applyIf(config, {
-        cm: this.cm
-        ,fields: [
-            'key',
-            'name',
-            'value',
-            'description',
-            'xtype',
-            'namespace',
-            'area',
-            'area_text',
-            'editedon',
-            'oldkey',
-            'menu',
-            'name_trans',
-            'description_trans'
-        ]
-        ,url: MODx.config.connector_url
+        cm: this.cm,
+        fields: gridFields,
+        url: MODx.config.connector_url
         ,baseParams: {
             action: 'System/Settings/GetList',
             namespace: this.namespaceFilterValue,


### PR DESCRIPTION
### What does it do?

Adds an **Also in** column on **System → System Settings**. For each system key it shows whether the same key also exists as a Context and/or User setting (`Context`, `User`, or both).

The `System/Settings/GetList` processor loads distinct matching keys from context and user setting tables for the current page of results (system settings only — User/Group setting lists do not run this). The ExtJS grid shows the column when `settingsType === 'system'`.

### Why is it needed?

System keys can also be set per context or user, and finding that is easy to miss. #16472 asked for a mark in the system settings table so you can see where else a key lives.

### How to test

1. Open System → System Settings and confirm the Also in column between Key and Value.
2. Add a context setting (or user setting) with the same key as an existing system setting (for example `site_name`).
3. Refresh the system settings list — that row should show Context and/or User.
4. Open User Settings and confirm the Also in column is not there.

### Related issue(s)/PR(s)

Resolves #16472