### PR TITLE
fix(sources): avoid loading mgr Context in MediaSource findPolicy

### DIFF
--- a/_build/test/Tests/Model/Sources/MediaSourceFindPolicyTest.php
+++ b/_build/test/Tests/Model/Sources/MediaSourceFindPolicyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Model\Sources;
+
+use MODX\Revolution\modContext;
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Sources\modFileMediaSource;
+use MODX\Revolution\Sources\modMediaSource;
+
+/**
+ * findPolicy() must keep Media Source ACLs mgr-scoped without loading mgr Context (#16212).
+ *
+ * @group Model
+ * @group Sources
+ * @group modMediaSource
+ */
+class MediaSourceFindPolicyTest extends MODxTestCase
+{
+    public function testFindPolicyKeepsMgrScopeWithoutLoadingMgrContext()
+    {
+        /** @var modMediaSource $source */
+        $source = $this->modx->newObject(modMediaSource::class);
+        $source->fromArray([
+            'name' => 'UnitTestFindPolicySource',
+            'description' => '',
+            'class_key' => modFileMediaSource::class,
+            'properties' => [],
+        ], '', true);
+        $this->assertTrue((bool)$source->save());
+
+        unset($this->modx->contexts['mgr']);
+
+        $web = $this->modx->getObject(modContext::class, ['key' => 'web']);
+        $this->assertNotEmpty($web, 'web context fixture required');
+        $previous = $this->modx->context;
+        $this->modx->context = $web;
+
+        try {
+            $source->findPolicy('web');
+            $this->assertArrayNotHasKey(
+                'mgr',
+                $this->modx->contexts,
+                'findPolicy must not call getContext(mgr) on the frontend'
+            );
+        } finally {
+            $this->modx->context = $previous;
+            $source->remove();
+        }
+    }
+}

--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -13,6 +13,7 @@ namespace MODX\Revolution\Tests\Model\Sources;
 
 
 use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\modContext;
 use MODX\Revolution\Sources\modFileMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
 
@@ -57,5 +58,32 @@ class modMediaSourceTest extends MODxTestCase {
 
     public function testExample() {
         $this->assertTrue(true);
+    }
+
+    /**
+     * Media Source policies stay mgr-scoped; findPolicy must not load the mgr Context
+     * object from a non-mgr request (avoids anonymous INFO ACL noise, #16212).
+     */
+    public function testFindPolicyKeepsMgrScopeWithoutLoadingMgrContext()
+    {
+        $this->source->save();
+        unset($this->modx->contexts['mgr']);
+
+        $web = $this->modx->getObject(modContext::class, ['key' => 'web']);
+        $this->assertNotEmpty($web, 'web context fixture required');
+        $previous = $this->modx->context;
+        $this->modx->context = $web;
+
+        try {
+            $this->source->findPolicy('web');
+            $this->assertArrayNotHasKey(
+                'mgr',
+                $this->modx->contexts,
+                'findPolicy must not call getContext(mgr) on the frontend'
+            );
+        } finally {
+            $this->modx->context = $previous;
+            $this->source->remove();
+        }
     }
 }

--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -13,7 +13,6 @@ namespace MODX\Revolution\Tests\Model\Sources;
 
 
 use MODX\Revolution\MODxTestCase;
-use MODX\Revolution\modContext;
 use MODX\Revolution\Sources\modFileMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
 
@@ -58,32 +57,5 @@ class modMediaSourceTest extends MODxTestCase {
 
     public function testExample() {
         $this->assertTrue(true);
-    }
-
-    /**
-     * Media Source policies stay mgr-scoped; findPolicy must not load the mgr Context
-     * object from a non-mgr request (avoids anonymous INFO ACL noise, #16212).
-     */
-    public function testFindPolicyKeepsMgrScopeWithoutLoadingMgrContext()
-    {
-        $this->source->save();
-        unset($this->modx->contexts['mgr']);
-
-        $web = $this->modx->getObject(modContext::class, ['key' => 'web']);
-        $this->assertNotEmpty($web, 'web context fixture required');
-        $previous = $this->modx->context;
-        $this->modx->context = $web;
-
-        try {
-            $this->source->findPolicy('web');
-            $this->assertArrayNotHasKey(
-                'mgr',
-                $this->modx->contexts,
-                'findPolicy must not call getContext(mgr) on the frontend'
-            );
-        } finally {
-            $this->modx->context = $previous;
-            $this->source->remove();
-        }
     }
 }

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1648,11 +1648,19 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     {
         $policy = [];
         $enabled = true;
-        $context = !empty($context) ? $context : $this->xpdo->context->get('key');
+        /*
+         * Media Source ACLs are manager-scoped (UI always stores context_key=mgr).
+         * Keep that key for policy SQL. Do not call getContext('mgr') from the
+         * frontend just to read access_media_source_enabled — that loads the mgr
+         * Context object and can INFO-log ACL denials for anonymous users (#16212).
+         */
+        $context = 'mgr';
         if ($context === $this->xpdo->context->get('key')) {
             $enabled = (bool)$this->xpdo->getOption('access_media_source_enabled', null, true);
-        } elseif ($obj = $this->xpdo->getContext($context)) {
-            $enabled = (bool)$obj->getOption('access_media_source_enabled', true);
+        } elseif (isset($this->xpdo->contexts[$context])) {
+            $enabled = (bool)$this->xpdo->contexts[$context]->getOption('access_media_source_enabled', true);
+        } else {
+            $enabled = (bool)$this->xpdo->getOption('access_media_source_enabled', null, true);
         }
         if ($enabled) {
             if (empty($this->_policies) || !isset($this->_policies[$context])) {

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1648,7 +1648,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     {
         $policy = [];
         $enabled = true;
-        $context = 'mgr';
+        $context = !empty($context) ? $context : $this->xpdo->context->get('key');
         if ($context === $this->xpdo->context->get('key')) {
             $enabled = (bool)$this->xpdo->getOption('access_media_source_enabled', null, true);
         } elseif ($obj = $this->xpdo->getContext($context)) {


### PR DESCRIPTION
### What does it do?

`modMediaSource::findPolicy()` still looks up Media Source ACLs with `context_key = mgr` (same as the manager UI). It no longer calls `getContext('mgr')` from a frontend request just to read `access_media_source_enabled`.

If the current context is already `mgr`, or `mgr` is already in `$modx->contexts`, that context’s option is used. Otherwise the system option is used.

### Why is it needed?

On the frontend, forcing a load of the `mgr` Context object can INFO-log ACL denials for anonymous users (`Principal 0 does not have permission to load object of class modContext with primary key: mgr`). See #16212.

An earlier approach swapped the hard-coded `mgr` ACL scope for the request context. Maintainers pointed out Media Source ACLs are manager-only (`#16214`, comments from @Mark-H, @theboxer, @smg6511, @opengeek), so that change is not used here.

### How to test

1. Frontend: load a page that touches a media source as an anonymous user. Confirm the log no longer fills with mgr Context load INFO lines from `findPolicy()`.
2. Manager: open Media Sources / file browser as a user with and without source ACL. Access should match previous manager behavior.
3. `phpunit --filter MediaSourceFindPolicyTest`

### Related issue(s)/PR(s)

Resolves #16212  
Supersedes the approach discussed in #16214 for this specific INFO-noise path.