### PR TITLE
fix(sources): keep getObjectContents body when metadata fails

### DIFF
--- a/_build/test/Tests/Model/Sources/MediaSourceGetObjectContentsTest.php
+++ b/_build/test/Tests/Model/Sources/MediaSourceGetObjectContentsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Model\Sources;
+
+use League\Flysystem\Filesystem;
+use League\Flysystem\UnableToRetrieveMetadata;
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Sources\modFileMediaSource;
+use ReflectionProperty;
+
+/**
+ * Regression for #16497: content must survive metadata retrieval failures.
+ *
+ * @group Model
+ * @group Sources
+ * @group modMediaSource
+ */
+class MediaSourceGetObjectContentsTest extends MODxTestCase
+{
+    public function testGetObjectContentsKeepsBodyWhenMimeTypeFails()
+    {
+        /** @var modFileMediaSource $source */
+        $source = $this->modx->newObject(modFileMediaSource::class);
+        $source->fromArray([
+            'name' => 'UnitTestGetObjectContents',
+            'class_key' => modFileMediaSource::class,
+            'properties' => [],
+        ], '', true);
+        $this->assertTrue((bool)$source->save());
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('fileExists')->willReturn(true);
+        $filesystem->method('read')->willReturn('payload-from-s3');
+        $filesystem->method('fileSize')->willReturn(15);
+        $filesystem->method('lastModified')->willReturn(1700000000);
+        $filesystem->method('mimeType')->willThrowException(
+            UnableToRetrieveMetadata::mimeType('demo.jpg')
+        );
+
+        $prop = new ReflectionProperty(modFileMediaSource::class, 'filesystem');
+        $prop->setAccessible(true);
+        $prop->setValue($source, $filesystem);
+
+        try {
+            $result = $source->getObjectContents('demo.jpg');
+            $this->assertNotEmpty($result);
+            $this->assertSame('payload-from-s3', $result['content']);
+            $this->assertSame('application/octet-stream', $result['mime']);
+        } finally {
+            $source->remove();
+        }
+    }
+}

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -592,23 +592,42 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             'trim',
             explode(',', $this->getOption('imageExtensions', $properties, 'jpg,jpeg,png,gif,svg,webp'))
         );
+
+        /*
+         * Read content first; never discard it if metadata calls fail.
+         * S3 (and some other adapters) can throw UnableToRetrieveMetadata for
+         * mimeType/fileSize/lastModified even when the object body is readable (#16497).
+         */
+        $size = false;
+        $lastModified = false;
+        $mime = 'application/octet-stream';
         try {
-            $fa = [
-                'name' => rtrim($path, DIRECTORY_SEPARATOR),
-                'basename' => basename($path),
-                'path' => $path,
-                'size' => $this->filesystem->fileSize($path),
-                'last_accessed' => $this->filesystem->lastModified($path), // We only have lastModified() here.
-                'last_modified' => $this->filesystem->lastModified($path),
-                'content' => $content,
-                'mime' => $this->filesystem->mimeType($path),
-                'image' => $this->isFileImage($path, $imageExtensions),
-            ];
+            $size = $this->filesystem->fileSize($path);
         } catch (FilesystemException | UnableToRetrieveMetadata $e) {
-            $this->addError('file', $this->xpdo->lexicon('file_err_nf'));
-            $this->xpdo->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
-            return [];
+            $this->xpdo->log(modX::LOG_LEVEL_INFO, $e->getMessage());
         }
+        try {
+            $lastModified = $this->filesystem->lastModified($path);
+        } catch (FilesystemException | UnableToRetrieveMetadata $e) {
+            $this->xpdo->log(modX::LOG_LEVEL_INFO, $e->getMessage());
+        }
+        try {
+            $mime = $this->filesystem->mimeType($path);
+        } catch (FilesystemException | UnableToRetrieveMetadata $e) {
+            $this->xpdo->log(modX::LOG_LEVEL_INFO, $e->getMessage());
+        }
+
+        $fa = [
+            'name' => rtrim($path, DIRECTORY_SEPARATOR),
+            'basename' => basename($path),
+            'path' => $path,
+            'size' => $size,
+            'last_accessed' => $lastModified,
+            'last_modified' => $lastModified,
+            'content' => $content,
+            'mime' => $mime,
+            'image' => $this->isFileImage($path, $imageExtensions),
+        ];
         $visibility = $this->visibility_files ? $this->getVisibility($path) : false;
         if ($visibility) {
             $fa['visibility'] = $visibility;


### PR DESCRIPTION
### What does it do?

`modMediaSource::getObjectContents()` still reads the file first. If `fileSize`, `lastModified`, or `mimeType` throw `UnableToRetrieveMetadata`, it keeps the body and fills soft defaults (`size`/`last_modified` false, `mime` `application/octet-stream`) instead of returning an empty array.

The earlier S3-only path-normalization override is removed: Flysystem already normalizes separators, and that change did not address empty content.

### Why is it needed?

On S3, metadata calls often fail even when `read()` succeeds (same class of problem that emptied container listings after the Flysystem v2 migration). Callers then saw `$result['content']` missing because the whole response was `[]` (#16497).

### How to test

1. `phpunit --filter MediaSourceGetObjectContentsTest`
2. With an S3 media source, call `$source->getObjectContents($filePath)` for an existing object and confirm `content` is non-empty even when Content-Type metadata is missing.
3. Filesystem media source: open a normal file in the manager and confirm content/metadata still load.

### Related issue(s)/PR(s)

Resolves #16497